### PR TITLE
EVG-16679 dependency graph

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -785,6 +785,10 @@ func IsPatchRequester(requester string) bool {
 	return requester == PatchVersionRequester || IsGitHubPatchRequester(requester)
 }
 
+func IsNonPatchRequester(requester string) bool {
+	return utility.StringSliceContains([]string{RepotrackerVersionRequester, TriggerRequester, MergeTestRequester, AdHocRequester}, requester)
+}
+
 func IsGitHubPatchRequester(requester string) bool {
 	return requester == GithubPRRequester || requester == MergeTestRequester
 }

--- a/globals.go
+++ b/globals.go
@@ -512,6 +512,16 @@ const (
 	AdHocRequester              = "ad_hoc"
 )
 
+var AllRequesterTypes = []string{
+	PatchVersionRequester,
+	GithubPRRequester,
+	GitTagRequester,
+	RepotrackerVersionRequester,
+	TriggerRequester,
+	MergeTestRequester,
+	AdHocRequester,
+}
+
 // Constants related to requester types.
 var (
 	SystemVersionRequesterTypes = []string{
@@ -783,10 +793,6 @@ func IsSystemActivator(caller string) bool {
 
 func IsPatchRequester(requester string) bool {
 	return requester == PatchVersionRequester || IsGitHubPatchRequester(requester)
-}
-
-func IsNonPatchRequester(requester string) bool {
-	return utility.StringSliceContains([]string{RepotrackerVersionRequester, TriggerRequester, MergeTestRequester, AdHocRequester}, requester)
 }
 
 func IsGitHubPatchRequester(requester string) bool {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -746,14 +746,8 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 }
 
 func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester string) []BuildVariantTaskUnit {
-	tg := proj.FindTaskGroup(in.Name)
-	if tg == nil {
-		return nil
-	}
-	tasks := proj.TasksFromGroup(in, *tg)
-
 	var willRun []BuildVariantTaskUnit
-	for _, bvt := range tasks {
+	for _, bvt := range proj.tasksFromGroup(in) {
 		if !bvt.IsDisabled() && !bvt.SkipOnRequester(requester) {
 			willRun = append(willRun, bvt)
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -234,9 +234,10 @@ func (bvt *BuildVariantTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error
 }
 
 func (bvt *BuildVariantTaskUnit) SkipOnRequester(requester string) bool {
-	return evergreen.IsPatchRequester(requester) && !bvt.RunsOnPatches() ||
-		evergreen.IsNonPatchRequester(requester) && !bvt.RunsOnNonPatches() ||
-		evergreen.IsGitTagRequester(requester) && !bvt.RunsOnGitTag()
+	return evergreen.IsPatchRequester(requester) && bvt.SkipOnPatchBuild() ||
+		!evergreen.IsPatchRequester(requester) && bvt.SkipOnNonPatchBuild() ||
+		evergreen.IsGitTagRequester(requester) && bvt.SkipOnGitTagBuild() ||
+		!evergreen.IsGitTagRequester(requester) && bvt.SkipOnNonGitTagBuild()
 }
 
 func (bvt *BuildVariantTaskUnit) SkipOnPatchBuild() bool {
@@ -253,18 +254,6 @@ func (bvt *BuildVariantTaskUnit) SkipOnGitTagBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnNonGitTagBuild() bool {
 	return utility.FromBoolPtr(bvt.GitTagOnly)
-}
-
-func (bvt *BuildVariantTaskUnit) RunsOnPatches() bool {
-	return !(bvt.SkipOnPatchBuild() || bvt.SkipOnNonGitTagBuild())
-}
-
-func (bvt *BuildVariantTaskUnit) RunsOnNonPatches() bool {
-	return !(bvt.SkipOnNonPatchBuild() || bvt.SkipOnNonGitTagBuild())
-}
-
-func (bvt *BuildVariantTaskUnit) RunsOnGitTag() bool {
-	return !(bvt.SkipOnNonPatchBuild() || bvt.SkipOnGitTagBuild())
 }
 
 func (bvt *BuildVariantTaskUnit) IsDisabled() bool {

--- a/model/project.go
+++ b/model/project.go
@@ -1955,7 +1955,7 @@ func (p *Project) GetDisplayTask(variant, name string) *patch.DisplayTask {
 // DependencyGraph returns a task.DependencyGraph populated with the tasks in the project.
 func (p *Project) DependencyGraph() task.DependencyGraph {
 	tasks := p.FindAllBuildVariantTasks()
-	g := task.NewDependencyGraph()
+	g := task.NewDependencyGraph(false)
 
 	for _, t := range tasks {
 		g.AddTaskNode(t.ToTaskNode())

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2199,13 +2199,24 @@ func TestSkipOnRequester(t *testing.T) {
 }
 
 func TestDependencyGraph(t *testing.T) {
-	tasks := []BuildVariantTaskUnit{
-		{Name: "compile", Variant: "ubuntu", DependsOn: []TaskUnitDependency{{Name: "setup", Variant: "ubuntu"}}},
-		{Name: "setup", Variant: "ubuntu"},
-		{Name: "compile", Variant: "rhel", DependsOn: []TaskUnitDependency{{Name: "setup", Variant: "rhel"}}},
-		{Name: "setup", Variant: "rhel"},
+	p := Project{
+		BuildVariants: []BuildVariant{
+			{
+				Name: "ubuntu",
+				Tasks: []BuildVariantTaskUnit{
+					{Name: "compile", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
+					{Name: "setup"},
+				},
+			},
+			{
+				Name: "rhel",
+				Tasks: []BuildVariantTaskUnit{
+					{Name: "compile", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
+					{Name: "setup"},
+				},
+			},
+		},
 	}
-	p := Project{BuildVariants: []BuildVariant{{Tasks: tasks}}}
 	depGraph := p.DependencyGraph()
 	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "ubuntu"}, task.TaskNode{Name: "setup", Variant: "ubuntu"}))
 	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "rhel"}, task.TaskNode{Name: "setup", Variant: "rhel"}))

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2242,8 +2242,32 @@ func TestDependencyGraph(t *testing.T) {
 	}
 	p := Project{BuildVariants: []BuildVariant{{Tasks: tasks}}}
 	depGraph := p.DependencyGraph()
-	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "ubuntu"}, task.TaskNode{Name: "compile", Variant: "ubuntu"}))
-	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "rhel"}, task.TaskNode{Name: "compile", Variant: "rhel"}))
+	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "ubuntu"}, task.TaskNode{Name: "setup", Variant: "ubuntu"}))
+	assert.NotNil(t, depGraph.GetDependencyEdge(task.TaskNode{Name: "compile", Variant: "rhel"}, task.TaskNode{Name: "setup", Variant: "rhel"}))
+}
+
+func TestFindAllBuildVariantTasks(t *testing.T) {
+	t.Run("TaskGroup", func(t *testing.T) {
+		tasks := []ProjectTask{
+			{Name: "in_group_0"},
+			{Name: "in_group_1"},
+		}
+		bvTasks := []BuildVariantTaskUnit{{Name: "task_group", IsGroup: true}}
+		groups := []TaskGroup{{Name: bvTasks[0].Name, Tasks: []string{tasks[0].Name, tasks[1].Name}}}
+		p := Project{
+			Tasks:         tasks,
+			BuildVariants: []BuildVariant{{Name: "bv", Tasks: bvTasks}},
+			TaskGroups:    groups,
+		}
+
+		bvts := p.FindAllBuildVariantTasks()
+		require.Len(t, bvts, 2)
+		assert.Equal(t, tasks[0].Name, bvts[0].Name)
+		assert.Equal(t, "bv", bvts[0].Variant)
+
+		assert.Equal(t, tasks[1].Name, bvts[1].Name)
+		assert.Equal(t, "bv", bvts[1].Variant)
+	})
 }
 
 func TestDependenciesForTaskUnit(t *testing.T) {

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -27,7 +27,7 @@ type DependencyGraph struct {
 // If transposed is true, edges point from depended on tasks to the tasks that depend on them.
 func NewDependencyGraph(transposed bool) DependencyGraph {
 	return DependencyGraph{
-		transposed:          true,
+		transposed:          transposed,
 		graph:               multi.NewDirectedGraph(),
 		tasksToNodes:        make(map[TaskNode]graph.Node),
 		nodesToTasks:        make(map[graph.Node]TaskNode),

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -72,13 +72,13 @@ func (t TaskNode) String() string {
 func (g *DependencyGraph) buildFromTasks(tasks []Task) {
 	taskIDToNode := make(map[string]TaskNode)
 	for _, task := range tasks {
-		tNode := task.ToTaskNode()
+		tNode := task.toTaskNode()
 		g.AddTaskNode(tNode)
 		taskIDToNode[task.Id] = tNode
 	}
 
 	for _, task := range tasks {
-		dependentTaskNode := task.ToTaskNode()
+		dependentTaskNode := task.toTaskNode()
 		for _, dep := range task.DependsOn {
 			dependedOnTaskNode := taskIDToNode[dep.TaskId]
 			g.AddEdge(dependentTaskNode, dependedOnTaskNode, dep.Status)

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -1,0 +1,280 @@
+package task
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/multi"
+	"gonum.org/v1/gonum/graph/topo"
+	"gonum.org/v1/gonum/graph/traverse"
+)
+
+// DependencyGraph models task dependency relationships as a directed graph.
+// Use NewDependencyGraph() to initialize a new DependencyGraph.
+type DependencyGraph struct {
+	graph               *multi.DirectedGraph
+	tasksToNodes        map[TaskNode]graph.Node
+	nodesToTasks        map[graph.Node]TaskNode
+	edgesToDependencies map[edgeKey]DependencyEdge
+}
+
+// NewDependencyGraph returns an initialized DependencyGraph.
+func NewDependencyGraph() DependencyGraph {
+	return DependencyGraph{
+		graph:               multi.NewDirectedGraph(),
+		tasksToNodes:        make(map[TaskNode]graph.Node),
+		nodesToTasks:        make(map[graph.Node]TaskNode),
+		edgesToDependencies: make(map[edgeKey]DependencyEdge),
+	}
+}
+
+type edgeKey struct {
+	from TaskNode
+	to   TaskNode
+}
+
+// DependencyEdge is a representation of a dependency in the graph.
+type DependencyEdge struct {
+	// Status is the status specified by the dependency, if any.
+	Status string
+	// From is the node the edge begins from.
+	From TaskNode
+	// To is the node the edge points to.
+	To TaskNode
+}
+
+// TaskNode is the representation of a task in the graph.
+type TaskNode struct {
+	// Name is the display name of the task.
+	Name string
+	// Variant is the build variant of the task.
+	Variant string
+	// ID is the task's ID.
+	ID string
+}
+
+// String represents TaskNode as a string.
+func (t TaskNode) String() string {
+	if t.ID != "" {
+		return t.ID
+	}
+
+	return fmt.Sprintf("%s/%s", t.Variant, t.Name)
+}
+
+// VersionDependencyGraph finds all the tasks from the version given by versionID and constructs a DependencyGraph from them.
+func VersionDependencyGraph(versionID string) (DependencyGraph, error) {
+	tasks, err := FindAllTasksFromVersionWithDependencies(versionID)
+	if err != nil {
+		return DependencyGraph{}, errors.Wrapf(err, "getting tasks for version '%s'", versionID)
+	}
+
+	return taskDependencyGraph(tasks), nil
+}
+
+func taskDependencyGraph(tasks []Task) DependencyGraph {
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, false)
+	return g
+}
+
+// reversedTaskDependencyGraph constructs a DependencyGraph from tasks.
+// Edges in the graph are reversed so they point from depended on tasks to dependent tasks.
+func reversedTaskDependencyGraph(tasks []Task) DependencyGraph {
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, true)
+	return g
+}
+
+func (g *DependencyGraph) buildFromTasks(tasks []Task, reversed bool) {
+	taskIDToNode := make(map[string]TaskNode)
+	for _, task := range tasks {
+		tNode := task.ToTaskNode()
+		g.AddTaskNode(tNode)
+		taskIDToNode[task.Id] = tNode
+	}
+
+	for _, task := range tasks {
+		dependentTaskNode := task.ToTaskNode()
+		for _, dep := range task.DependsOn {
+			dependedOnTaskNode := taskIDToNode[dep.TaskId]
+			if reversed {
+				g.AddReversedEdge(dependentTaskNode, dependedOnTaskNode, dep.Status)
+			} else {
+				g.AddEdge(dependentTaskNode, dependedOnTaskNode, dep.Status)
+			}
+		}
+	}
+}
+
+// AddTaskNode adds a node to the graph.
+func (g *DependencyGraph) AddTaskNode(tNode TaskNode) {
+	if _, ok := g.tasksToNodes[tNode]; ok {
+		return
+	}
+
+	node := g.graph.NewNode()
+	g.graph.AddNode(node)
+	g.tasksToNodes[tNode] = node
+	g.nodesToTasks[node] = tNode
+}
+
+// AddEdge adds an edge from the dependent task to the depended on task.
+// Noop if one of the nodes doesn't exist in the graph.
+func (g *DependencyGraph) AddEdge(dependentTask, dependedOnTask TaskNode, status string) {
+	g.addEdgeToGraph(DependencyEdge{From: dependentTask, To: dependedOnTask, Status: status})
+}
+
+// AddReversedEdge adds an edge from the depended on task to the dependent task.
+// Noops if one of the nodes doesn't exist in the graph.
+func (g *DependencyGraph) AddReversedEdge(dependentTask, dependedOnTask TaskNode, status string) {
+	g.addEdgeToGraph(DependencyEdge{From: dependedOnTask, To: dependentTask, Status: status})
+}
+
+func (g *DependencyGraph) addEdgeToGraph(edge DependencyEdge) {
+	fromNode, fromExists := g.tasksToNodes[edge.From]
+	toNode, toExists := g.tasksToNodes[edge.To]
+	if !(fromExists && toExists) {
+		return
+	}
+
+	line := g.graph.NewLine(fromNode, toNode)
+	g.graph.SetLine(line)
+	g.edgesToDependencies[edgeKey{from: edge.From, to: edge.To}] = edge
+}
+
+// EdgesIntoTask returns all the edges that point to t.
+// For a regular graph these edges are tasks that directly depend on t.
+// If the graph is reversed these edges are tasks t directly depends on.
+func (g *DependencyGraph) EdgesIntoTask(t TaskNode) []DependencyEdge {
+	node := g.tasksToNodes[t]
+	if node == nil {
+		return nil
+	}
+
+	var edges []DependencyEdge
+	nodes := g.graph.To(node.ID())
+	for nodes.Next() {
+		edges = append(edges, g.edgesToDependencies[edgeKey{from: g.nodesToTasks[nodes.Node()], to: t}])
+	}
+
+	return edges
+}
+
+// GetDependencyEdge returns a pointer to the edge from fromNode to toNode.
+// If the edge doesn't exist it returns nil.
+func (g *DependencyGraph) GetDependencyEdge(fromTask, toTask TaskNode) *DependencyEdge {
+	depEdge, ok := g.edgesToDependencies[edgeKey{from: fromTask, to: toTask}]
+	if !ok {
+		return nil
+	}
+
+	return &depEdge
+}
+
+// DependencyCycles is a jagged array of node cycles.
+type DependencyCycles [][]TaskNode
+
+// String represents DependencyCycles as a string.
+func (dc DependencyCycles) String() string {
+	cycles := make([]string, 0, len(dc))
+	for _, cycle := range dc {
+		cycleStrings := make([]string, 0, len(cycle))
+		for _, node := range cycle {
+			cycleStrings = append(cycleStrings, node.String())
+		}
+		cycles = append(cycles, "["+strings.Join(cycleStrings, ", ")+"]")
+	}
+
+	return strings.Join(cycles, ", ")
+}
+
+// Cycles returns cycles in the graph, if any.
+// Self-loops are not included as cycles.
+func (g *DependencyGraph) Cycles() DependencyCycles {
+	var cycles DependencyCycles
+	stronglyConnectedComponenets := topo.TarjanSCC(g.graph)
+	for _, scc := range stronglyConnectedComponenets {
+		if len(scc) <= 1 {
+			continue
+		}
+
+		var cycle []TaskNode
+		for _, node := range scc {
+			taskInCycle := g.nodesToTasks[node]
+			cycle = append(cycle, taskInCycle)
+		}
+		cycles = append(cycles, cycle)
+	}
+
+	return cycles
+}
+
+// DepthFirstSearch begins a DFS from start and returns whether target is reachable.
+// If traverseEdge is not nil an edge is only traversed if traverseEdge returns true on that edge.
+func (g *DependencyGraph) DepthFirstSearch(start, target TaskNode, traverseEdge func(edge DependencyEdge) bool) bool {
+	_, startExists := g.tasksToNodes[start]
+	_, targetExists := g.tasksToNodes[target]
+	if !(startExists && targetExists) {
+		return false
+	}
+
+	traversal := traverse.DepthFirst{
+		Traverse: func(e graph.Edge) bool {
+			if traverseEdge == nil {
+				return true
+			}
+
+			from := g.nodesToTasks[e.From()]
+			to := g.nodesToTasks[e.To()]
+			edge := g.edgesToDependencies[edgeKey{from: from, to: to}]
+
+			return traverseEdge(edge)
+		},
+	}
+
+	return traversal.Walk(g.graph, g.tasksToNodes[start], func(n graph.Node) bool { return g.nodesToTasks[n] == target }) != nil
+}
+
+// TopologicalStableSort sorts the nodes in the graph topologically. It is stable in the sense that when a topological ordering
+// is ambiguous the order the tasks were added to the graph prevails.
+// To sort with all dependent tasks before the tasks they depend on use the default graph.
+// To sort with all depended on tasks before the tasks that depend on them use a reversed graph.
+func (g *DependencyGraph) TopologicalStableSort() ([]TaskNode, error) {
+	sortedNodes, err := topo.SortStabilized(g.graph, nil)
+
+	if err != nil {
+		_, ok := err.(topo.Unorderable)
+		if !ok {
+			return nil, errors.Wrap(err, "sorting the graph")
+		}
+	}
+
+	sortedTasks := make([]TaskNode, 0, len(sortedNodes))
+	for _, node := range sortedNodes {
+		if node != nil {
+			sortedTasks = append(sortedTasks, g.nodesToTasks[node])
+		}
+	}
+
+	return sortedTasks, nil
+}
+
+// reachableFromNode returns all the dependencies recursively depended on by start.
+// In the case of a reversed graph it returns all the dependencies recursively depending on start.
+// The start node is not included in the result.
+func (g *DependencyGraph) reachableFromNode(start TaskNode) []TaskNode {
+	var reachable []TaskNode
+	traversal := traverse.DepthFirst{
+		Visit: func(node graph.Node) {
+			if g.nodesToTasks[node] != start {
+				reachable = append(reachable, g.nodesToTasks[node])
+			}
+		},
+	}
+	_ = traversal.Walk(g.graph, g.tasksToNodes[start], nil)
+
+	return reachable
+}

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -185,7 +185,7 @@ func (dc DependencyCycles) String() string {
 		for _, node := range cycle {
 			cycleStrings = append(cycleStrings, node.String())
 		}
-		cycles = append(cycles, "["+strings.Join(cycleStrings, ", ")+"]")
+		cycles = append(cycles, fmt.Sprintf("[%s]", strings.Join(cycleStrings, ", ")))
 	}
 
 	return strings.Join(cycles, ", ")
@@ -195,8 +195,8 @@ func (dc DependencyCycles) String() string {
 // Self-loops are not included as cycles.
 func (g *DependencyGraph) Cycles() DependencyCycles {
 	var cycles DependencyCycles
-	stronglyConnectedComponenets := topo.TarjanSCC(g.graph)
-	for _, scc := range stronglyConnectedComponenets {
+	stronglyConnectedComponents := topo.TarjanSCC(g.graph)
+	for _, scc := range stronglyConnectedComponents {
 		if len(scc) <= 1 {
 			continue
 		}

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -69,22 +69,6 @@ func (t TaskNode) String() string {
 	return fmt.Sprintf("%s/%s", t.Variant, t.Name)
 }
 
-// VersionDependencyGraph finds all the tasks from the version given by versionID and constructs a DependencyGraph from them.
-func VersionDependencyGraph(versionID string, transposed bool) (DependencyGraph, error) {
-	tasks, err := FindAllTasksFromVersionWithDependencies(versionID)
-	if err != nil {
-		return DependencyGraph{}, errors.Wrapf(err, "getting tasks for version '%s'", versionID)
-	}
-
-	return taskDependencyGraph(tasks, transposed), nil
-}
-
-func taskDependencyGraph(tasks []Task, transposed bool) DependencyGraph {
-	g := NewDependencyGraph(false)
-	g.buildFromTasks(tasks)
-	return g
-}
-
 func (g *DependencyGraph) buildFromTasks(tasks []Task) {
 	taskIDToNode := make(map[string]TaskNode)
 	for _, task := range tasks {
@@ -137,10 +121,10 @@ func (g *DependencyGraph) addEdgeToGraph(edge DependencyEdge) {
 	g.edgesToDependencies[edgeKey{from: edge.From, to: edge.To}] = edge
 }
 
-// EdgesIntoTask returns all the edges that point to t.
+// edgesIntoTask returns all the edges that point to t.
 // For a regular graph these edges are tasks that directly depend on t.
 // If the graph is transposed these edges are tasks t directly depends on.
-func (g *DependencyGraph) EdgesIntoTask(t TaskNode) []DependencyEdge {
+func (g *DependencyGraph) edgesIntoTask(t TaskNode) []DependencyEdge {
 	node := g.tasksToNodes[t]
 	if node == nil {
 		return nil

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -41,40 +41,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
-			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.toTaskNode())
+			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
 		}
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[0].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+			DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[0].toTaskNode(), to: tasks[1].toTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[2].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[2].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[2].ToTaskNode()}],
+			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[2].toTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[3].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[3].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[3].ToTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[3].ToTaskNode()}],
+			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[3].toTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[3].toTaskNode()}],
 		)
 	})
 
@@ -83,40 +83,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
-			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.toTaskNode())
+			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
 		}
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[0].ToTaskNode()}],
+			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[0].toTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[2].ToTaskNode(), To: tasks[1].ToTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[2].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+			DependencyEdge{From: tasks[2].toTaskNode(), To: tasks[1].toTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[2].toTaskNode(), to: tasks[1].toTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[3].ToTaskNode(), To: tasks[1].ToTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[3].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+			DependencyEdge{From: tasks[3].toTaskNode(), To: tasks[1].toTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[3].toTaskNode(), to: tasks[1].toTaskNode()}],
 		)
 	})
 }
@@ -166,9 +166,9 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
 		assert.Equal(t, 2, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 2)
 	})
 
@@ -178,7 +178,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -189,7 +189,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: TaskNode{ID: "t3"}})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: TaskNode{ID: "t3"}})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -200,11 +200,11 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode()})
 		assert.Equal(t, 3, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 3)
 	})
 }
@@ -219,19 +219,19 @@ func TestGetDependencyEdge(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("ExistingEdgeWithStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[1].ToTaskNode(), tasks[2].ToTaskNode())
+		edge := g.GetDependencyEdge(tasks[1].toTaskNode(), tasks[2].toTaskNode())
 		require.NotNil(t, edge)
 		assert.Equal(t, evergreen.TaskSucceeded, edge.Status)
 	})
 
 	t.Run("ExistingEdgeNoStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[0].ToTaskNode(), tasks[1].ToTaskNode())
+		edge := g.GetDependencyEdge(tasks[0].toTaskNode(), tasks[1].toTaskNode())
 		require.NotNil(t, edge)
 		assert.Empty(t, edge.Status)
 	})
 
 	t.Run("NonexistentEdge", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[2].ToTaskNode(), tasks[0].ToTaskNode())
+		edge := g.GetDependencyEdge(tasks[2].toTaskNode(), tasks[0].toTaskNode())
 		assert.Nil(t, edge)
 	})
 }
@@ -244,8 +244,8 @@ func TestTasksDependingOnTask(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	assert.Empty(t, g.edgesIntoTask(tasks[0].ToTaskNode()))
-	edges := g.edgesIntoTask(tasks[1].ToTaskNode())
+	assert.Empty(t, g.edgesIntoTask(tasks[0].toTaskNode()))
+	edges := g.edgesIntoTask(tasks[1].toTaskNode())
 	require.Len(t, edges, 1)
 	assert.Equal(t, tasks[0].Id, edges[0].From.ID)
 }
@@ -261,18 +261,18 @@ func TestReachableFromNode(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	reachable := g.reachableFromNode(tasks[0].ToTaskNode())
+	reachable := g.reachableFromNode(tasks[0].toTaskNode())
 	assert.Len(t, reachable, 4)
-	assert.Contains(t, reachable, tasks[1].ToTaskNode())
-	assert.Contains(t, reachable, tasks[2].ToTaskNode())
-	assert.Contains(t, reachable, tasks[3].ToTaskNode())
-	assert.Contains(t, reachable, tasks[4].ToTaskNode())
+	assert.Contains(t, reachable, tasks[1].toTaskNode())
+	assert.Contains(t, reachable, tasks[2].toTaskNode())
+	assert.Contains(t, reachable, tasks[3].toTaskNode())
+	assert.Contains(t, reachable, tasks[4].toTaskNode())
 
-	reachable = g.reachableFromNode(tasks[1].ToTaskNode())
+	reachable = g.reachableFromNode(tasks[1].toTaskNode())
 	assert.Len(t, reachable, 1)
-	assert.Contains(t, reachable, tasks[3].ToTaskNode())
+	assert.Contains(t, reachable, tasks[3].toTaskNode())
 
-	reachable = g.reachableFromNode(tasks[3].ToTaskNode())
+	reachable = g.reachableFromNode(tasks[3].toTaskNode())
 	assert.Empty(t, reachable)
 }
 
@@ -367,14 +367,14 @@ func TestDepthFirstSearch(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("NilTraverseEdge", func(t *testing.T) {
-		assert.True(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[1].ToTaskNode(), tasks[0].ToTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[3].ToTaskNode(), tasks[0].ToTaskNode(), nil))
+		assert.True(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[1].toTaskNode(), tasks[0].toTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[3].toTaskNode(), tasks[0].toTaskNode(), nil))
 	})
 
 	t.Run("TraversalBlockedAtNode", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
-			if edge.To == tasks[1].ToTaskNode() {
+		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
+			if edge.To == tasks[1].toTaskNode() {
 				return false
 			}
 			return true
@@ -382,7 +382,7 @@ func TestDepthFirstSearch(t *testing.T) {
 	})
 
 	t.Run("TraversalBlockedAtEdge", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
+		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
 			if edge.Status == evergreen.TaskSucceeded {
 				return true
 			}
@@ -391,11 +391,11 @@ func TestDepthFirstSearch(t *testing.T) {
 	})
 
 	t.Run("StartMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].toTaskNode(), nil))
 	})
 
 	t.Run("TargetMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), TaskNode{ID: "t4"}, nil))
+		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), TaskNode{ID: "t4"}, nil))
 	})
 }
 
@@ -412,9 +412,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("StableSortWithDependencies", func(t *testing.T) {
@@ -429,9 +429,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("Cycle", func(t *testing.T) {
@@ -446,7 +446,7 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 1)
-		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[0])
 	})
 
 	t.Run("EmptyGraph", func(t *testing.T) {

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -244,8 +244,8 @@ func TestTasksDependingOnTask(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	assert.Empty(t, g.EdgesIntoTask(tasks[0].ToTaskNode()))
-	edges := g.EdgesIntoTask(tasks[1].ToTaskNode())
+	assert.Empty(t, g.edgesIntoTask(tasks[0].ToTaskNode()))
+	edges := g.edgesIntoTask(tasks[1].ToTaskNode())
 	require.Len(t, edges, 1)
 	assert.Equal(t, tasks[0].Id, edges[0].From.ID)
 }

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -1,0 +1,459 @@
+package task
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskNodeString(t *testing.T) {
+	assert.Equal(t, "t0", TaskNode{ID: "t0", Name: "task0", Variant: "BV0"}.String())
+	assert.Equal(t, "BV0/task0", TaskNode{Name: "task0", Variant: "BV0"}.String())
+}
+
+func TestBuildFromTasks(t *testing.T) {
+	tasks := []Task{
+		{
+			Id: "t0",
+			DependsOn: []Dependency{
+				{
+					TaskId: "t1",
+					Status: evergreen.TaskSucceeded,
+				},
+			},
+		},
+		{
+			Id: "t1",
+			DependsOn: []Dependency{
+				{TaskId: "t2"},
+				{TaskId: "t3"},
+			},
+		},
+		{Id: "t2"},
+		{Id: "t3"},
+	}
+
+	t.Run("ForwardEdges", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+
+		for _, task := range tasks {
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
+		}
+
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+
+		assert.Len(t, g.edgesToDependencies, 3)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[0].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+		)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[2].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[2].ToTaskNode()}],
+		)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[3].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[3].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[3].ToTaskNode()}],
+		)
+	})
+
+	t.Run("ReversedEdges", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, true)
+
+		for _, task := range tasks {
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
+		}
+
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+
+		assert.Len(t, g.edgesToDependencies, 3)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[0].ToTaskNode()}],
+		)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[2].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[2].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+		)
+
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.Equal(t,
+			DependencyEdge{From: tasks[3].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[3].ToTaskNode(), to: tasks[1].ToTaskNode()}],
+		)
+	})
+}
+
+func TestAddTaskNode(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0"},
+	}
+
+	t.Run("NewNode", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Len(t, g.nodesToTasks, 1)
+		assert.Len(t, g.tasksToNodes, 1)
+		assert.Equal(t, 1, g.graph.Nodes().Len())
+
+		g.AddTaskNode(TaskNode{ID: "t1"})
+		assert.Len(t, g.nodesToTasks, 2)
+		assert.Len(t, g.tasksToNodes, 2)
+		assert.Equal(t, 2, g.graph.Nodes().Len())
+	})
+
+	t.Run("PreexistingNode", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Len(t, g.nodesToTasks, 1)
+		assert.Len(t, g.tasksToNodes, 1)
+		assert.Equal(t, 1, g.graph.Nodes().Len())
+
+		g.AddTaskNode(TaskNode{ID: "t0"})
+		assert.Len(t, g.nodesToTasks, 1)
+		assert.Len(t, g.tasksToNodes, 1)
+		assert.Equal(t, 1, g.graph.Nodes().Len())
+	})
+}
+
+func TestAddEdgeToGraph(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0"},
+		{Id: "t1", DependsOn: []Dependency{{TaskId: "t2"}}},
+		{Id: "t2"},
+	}
+
+	t.Run("NewEdge", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
+		assert.Equal(t, 2, g.graph.Edges().Len())
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.Len(t, g.edgesToDependencies, 2)
+	})
+
+	t.Run("PreexistingEdge", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()})
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+	})
+
+	t.Run("EdgeToMissingNode", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: TaskNode{ID: "t3"}})
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+	})
+
+	t.Run("Cyclic", func(t *testing.T) {
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+		assert.Equal(t, 1, g.graph.Edges().Len())
+		assert.Len(t, g.edgesToDependencies, 1)
+
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode()})
+		assert.Equal(t, 3, g.graph.Edges().Len())
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
+		assert.Len(t, g.edgesToDependencies, 3)
+	})
+}
+
+func TestGetDependencyEdge(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+		{Id: "t1", DependsOn: []Dependency{{TaskId: "t2", Status: evergreen.TaskSucceeded}}},
+		{Id: "t2"},
+	}
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, false)
+
+	t.Run("ExistingEdgeWithStatus", func(t *testing.T) {
+		edge := g.GetDependencyEdge(tasks[1].ToTaskNode(), tasks[2].ToTaskNode())
+		require.NotNil(t, edge)
+		assert.Equal(t, evergreen.TaskSucceeded, edge.Status)
+	})
+
+	t.Run("ExistingEdgeNoStatus", func(t *testing.T) {
+		edge := g.GetDependencyEdge(tasks[0].ToTaskNode(), tasks[1].ToTaskNode())
+		require.NotNil(t, edge)
+		assert.Empty(t, edge.Status)
+	})
+
+	t.Run("NonexistentEdge", func(t *testing.T) {
+		edge := g.GetDependencyEdge(tasks[2].ToTaskNode(), tasks[0].ToTaskNode())
+		assert.Nil(t, edge)
+	})
+}
+
+func TestTasksDependingOnTask(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+		{Id: "t1"},
+	}
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, false)
+
+	assert.Empty(t, g.EdgesIntoTask(tasks[0].ToTaskNode()))
+	edges := g.EdgesIntoTask(tasks[1].ToTaskNode())
+	require.Len(t, edges, 1)
+	assert.Equal(t, tasks[0].Id, edges[0].From.ID)
+}
+
+func TestReachableFromNode(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}, {TaskId: "t2"}}},
+		{Id: "t1", DependsOn: []Dependency{{TaskId: "t3"}}},
+		{Id: "t2", DependsOn: []Dependency{{TaskId: "t4"}}},
+		{Id: "t3"},
+		{Id: "t4"},
+	}
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, false)
+
+	reachable := g.reachableFromNode(tasks[0].ToTaskNode())
+	assert.Len(t, reachable, 4)
+	assert.Contains(t, reachable, tasks[1].ToTaskNode())
+	assert.Contains(t, reachable, tasks[2].ToTaskNode())
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
+	assert.Contains(t, reachable, tasks[4].ToTaskNode())
+
+	reachable = g.reachableFromNode(tasks[1].ToTaskNode())
+	assert.Len(t, reachable, 1)
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
+
+	reachable = g.reachableFromNode(tasks[3].ToTaskNode())
+	assert.Empty(t, reachable)
+}
+
+func TestCycles(t *testing.T) {
+	t.Run("EmptyGraph", func(t *testing.T) {
+		g := NewDependencyGraph()
+		assert.Empty(t, g.Cycles())
+	})
+
+	t.Run("NoCycles", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+			{Id: "t1"},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+
+		assert.Empty(t, g.Cycles())
+	})
+
+	t.Run("Loops", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t0"}}},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+
+		assert.Empty(t, g.Cycles())
+	})
+
+	t.Run("TwoConnectedCycles", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+			{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t2"}}},
+			{Id: "t2", DependsOn: []Dependency{{TaskId: "t3"}}},
+			{Id: "t3", DependsOn: []Dependency{{TaskId: "t2"}}},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+
+		cycles := g.Cycles()
+		assert.Len(t, cycles, 2)
+	})
+
+	t.Run("TwoDisconnectedCycles", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+			{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}},
+			{Id: "t2", DependsOn: []Dependency{{TaskId: "t3"}}},
+			{Id: "t3", DependsOn: []Dependency{{TaskId: "t2"}}},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, false)
+
+		cycles := g.Cycles()
+		assert.Len(t, cycles, 2)
+	})
+}
+
+func TestDependencyCyclesString(t *testing.T) {
+	t.Run("NoCycles", func(t *testing.T) {
+		dc := DependencyCycles{}
+		assert.Empty(t, dc.String())
+	})
+
+	t.Run("OneCycle", func(t *testing.T) {
+		ids := []string{"t0", "t1"}
+		dc := DependencyCycles{
+			{{ID: ids[0]}, {ID: ids[1]}},
+		}
+		assert.Equal(t, fmt.Sprintf("[%s, %s]", ids[0], ids[1]), dc.String())
+	})
+
+	t.Run("TwoCycles", func(t *testing.T) {
+		ids := []string{"t0", "t1", "t2", "t3"}
+		dc := DependencyCycles{
+			{{ID: ids[0]}, {ID: ids[1]}},
+			{{ID: ids[2]}, {ID: ids[3]}},
+		}
+		assert.Equal(t, fmt.Sprintf("[%s, %s], [%s, %s]", ids[0], ids[1], ids[2], ids[3]), dc.String())
+	})
+}
+
+func TestDepthFirstSearch(t *testing.T) {
+	tasks := []Task{
+		{Id: "t0", DependsOn: []Dependency{{TaskId: "t1", Status: evergreen.TaskSucceeded}}},
+		{Id: "t1", DependsOn: []Dependency{{TaskId: "t2"}}},
+		{Id: "t2"},
+		{Id: "t3"},
+	}
+	g := NewDependencyGraph()
+	g.buildFromTasks(tasks, false)
+
+	t.Run("NilTraverseEdge", func(t *testing.T) {
+		assert.True(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[1].ToTaskNode(), tasks[0].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[3].ToTaskNode(), tasks[0].ToTaskNode(), nil))
+	})
+
+	t.Run("TraversalBlockedAtNode", func(t *testing.T) {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
+			if edge.To == tasks[1].ToTaskNode() {
+				return false
+			}
+			return true
+		}))
+	})
+
+	t.Run("TraversalBlockedAtEdge", func(t *testing.T) {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
+			if edge.Status == evergreen.TaskSucceeded {
+				return true
+			}
+			return false
+		}))
+	})
+
+	t.Run("StartMissingFromGraph", func(t *testing.T) {
+		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].ToTaskNode(), nil))
+	})
+
+	t.Run("TargetMissingFromGraph", func(t *testing.T) {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), TaskNode{ID: "t4"}, nil))
+	})
+}
+
+func TestTopologicalStableSort(t *testing.T) {
+	t.Run("StableSortNoDependencies", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0"},
+			{Id: "t1"},
+			{Id: "t2"},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, true)
+
+		sortedNodes, err := g.TopologicalStableSort()
+		assert.NoError(t, err)
+		require.Len(t, sortedNodes, 3)
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
+	})
+
+	t.Run("StableSortWithDependencies", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+			{Id: "t1"},
+			{Id: "t2"},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, true)
+
+		sortedNodes, err := g.TopologicalStableSort()
+		assert.NoError(t, err)
+		require.Len(t, sortedNodes, 3)
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
+	})
+
+	t.Run("Cycle", func(t *testing.T) {
+		tasks := []Task{
+			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
+			{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}},
+			{Id: "t2"},
+		}
+		g := NewDependencyGraph()
+		g.buildFromTasks(tasks, true)
+
+		sortedNodes, err := g.TopologicalStableSort()
+		assert.NoError(t, err)
+		require.Len(t, sortedNodes, 1)
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[0])
+	})
+
+	t.Run("EmptyGraph", func(t *testing.T) {
+		g := NewDependencyGraph()
+
+		sortedNodes, err := g.TopologicalStableSort()
+		assert.NoError(t, err)
+		assert.Empty(t, sortedNodes)
+	})
+}

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -37,8 +37,8 @@ func TestBuildFromTasks(t *testing.T) {
 	}
 
 	t.Run("ForwardEdges", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
 			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
@@ -79,8 +79,8 @@ func TestBuildFromTasks(t *testing.T) {
 	})
 
 	t.Run("ReversedEdges", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, true)
+		g := NewDependencyGraph(true)
+		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
 			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
@@ -127,8 +127,8 @@ func TestAddTaskNode(t *testing.T) {
 	}
 
 	t.Run("NewNode", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Len(t, g.nodesToTasks, 1)
 		assert.Len(t, g.tasksToNodes, 1)
 		assert.Equal(t, 1, g.graph.Nodes().Len())
@@ -140,8 +140,8 @@ func TestAddTaskNode(t *testing.T) {
 	})
 
 	t.Run("PreexistingNode", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Len(t, g.nodesToTasks, 1)
 		assert.Len(t, g.tasksToNodes, 1)
 		assert.Equal(t, 1, g.graph.Nodes().Len())
@@ -161,8 +161,8 @@ func TestAddEdgeToGraph(t *testing.T) {
 	}
 
 	t.Run("NewEdge", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
@@ -173,8 +173,8 @@ func TestAddEdgeToGraph(t *testing.T) {
 	})
 
 	t.Run("PreexistingEdge", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
@@ -184,8 +184,8 @@ func TestAddEdgeToGraph(t *testing.T) {
 	})
 
 	t.Run("EdgeToMissingNode", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
@@ -195,8 +195,8 @@ func TestAddEdgeToGraph(t *testing.T) {
 	})
 
 	t.Run("Cyclic", func(t *testing.T) {
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
@@ -215,8 +215,8 @@ func TestGetDependencyEdge(t *testing.T) {
 		{Id: "t1", DependsOn: []Dependency{{TaskId: "t2", Status: evergreen.TaskSucceeded}}},
 		{Id: "t2"},
 	}
-	g := NewDependencyGraph()
-	g.buildFromTasks(tasks, false)
+	g := NewDependencyGraph(false)
+	g.buildFromTasks(tasks)
 
 	t.Run("ExistingEdgeWithStatus", func(t *testing.T) {
 		edge := g.GetDependencyEdge(tasks[1].ToTaskNode(), tasks[2].ToTaskNode())
@@ -241,8 +241,8 @@ func TestTasksDependingOnTask(t *testing.T) {
 		{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
 		{Id: "t1"},
 	}
-	g := NewDependencyGraph()
-	g.buildFromTasks(tasks, false)
+	g := NewDependencyGraph(false)
+	g.buildFromTasks(tasks)
 
 	assert.Empty(t, g.EdgesIntoTask(tasks[0].ToTaskNode()))
 	edges := g.EdgesIntoTask(tasks[1].ToTaskNode())
@@ -258,8 +258,8 @@ func TestReachableFromNode(t *testing.T) {
 		{Id: "t3"},
 		{Id: "t4"},
 	}
-	g := NewDependencyGraph()
-	g.buildFromTasks(tasks, false)
+	g := NewDependencyGraph(false)
+	g.buildFromTasks(tasks)
 
 	reachable := g.reachableFromNode(tasks[0].ToTaskNode())
 	assert.Len(t, reachable, 4)
@@ -278,7 +278,7 @@ func TestReachableFromNode(t *testing.T) {
 
 func TestCycles(t *testing.T) {
 	t.Run("EmptyGraph", func(t *testing.T) {
-		g := NewDependencyGraph()
+		g := NewDependencyGraph(false)
 		assert.Empty(t, g.Cycles())
 	})
 
@@ -287,8 +287,8 @@ func TestCycles(t *testing.T) {
 			{Id: "t0", DependsOn: []Dependency{{TaskId: "t1"}}},
 			{Id: "t1"},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 
 		assert.Empty(t, g.Cycles())
 	})
@@ -297,8 +297,8 @@ func TestCycles(t *testing.T) {
 		tasks := []Task{
 			{Id: "t0", DependsOn: []Dependency{{TaskId: "t0"}}},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 
 		assert.Empty(t, g.Cycles())
 	})
@@ -310,8 +310,8 @@ func TestCycles(t *testing.T) {
 			{Id: "t2", DependsOn: []Dependency{{TaskId: "t3"}}},
 			{Id: "t3", DependsOn: []Dependency{{TaskId: "t2"}}},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 
 		cycles := g.Cycles()
 		assert.Len(t, cycles, 2)
@@ -324,8 +324,8 @@ func TestCycles(t *testing.T) {
 			{Id: "t2", DependsOn: []Dependency{{TaskId: "t3"}}},
 			{Id: "t3", DependsOn: []Dependency{{TaskId: "t2"}}},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, false)
+		g := NewDependencyGraph(false)
+		g.buildFromTasks(tasks)
 
 		cycles := g.Cycles()
 		assert.Len(t, cycles, 2)
@@ -363,8 +363,8 @@ func TestDepthFirstSearch(t *testing.T) {
 		{Id: "t2"},
 		{Id: "t3"},
 	}
-	g := NewDependencyGraph()
-	g.buildFromTasks(tasks, false)
+	g := NewDependencyGraph(false)
+	g.buildFromTasks(tasks)
 
 	t.Run("NilTraverseEdge", func(t *testing.T) {
 		assert.True(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), nil))
@@ -406,8 +406,8 @@ func TestTopologicalStableSort(t *testing.T) {
 			{Id: "t1"},
 			{Id: "t2"},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, true)
+		g := NewDependencyGraph(true)
+		g.buildFromTasks(tasks)
 
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
@@ -423,8 +423,8 @@ func TestTopologicalStableSort(t *testing.T) {
 			{Id: "t1"},
 			{Id: "t2"},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, true)
+		g := NewDependencyGraph(true)
+		g.buildFromTasks(tasks)
 
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
@@ -440,8 +440,8 @@ func TestTopologicalStableSort(t *testing.T) {
 			{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}},
 			{Id: "t2"},
 		}
-		g := NewDependencyGraph()
-		g.buildFromTasks(tasks, true)
+		g := NewDependencyGraph(true)
+		g.buildFromTasks(tasks)
 
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
@@ -450,7 +450,7 @@ func TestTopologicalStableSort(t *testing.T) {
 	})
 
 	t.Run("EmptyGraph", func(t *testing.T) {
-		g := NewDependencyGraph()
+		g := NewDependencyGraph(true)
 
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3301,6 +3301,14 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	return FindAll(query)
 }
 
+func (t *Task) ToTaskNode() TaskNode {
+	return TaskNode{
+		Name:    t.DisplayName,
+		Variant: t.BuildVariant,
+		ID:      t.Id,
+	}
+}
+
 func AnyActiveTasks(tasks []Task) bool {
 	for _, t := range tasks {
 		if t.Activated {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3301,7 +3301,7 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	return FindAll(query)
 }
 
-func (t *Task) ToTaskNode() TaskNode {
+func (t *Task) toTaskNode() TaskNode {
 	return TaskNode{
 		Name:    t.DisplayName,
 		Variant: t.BuildVariant,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/command"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
@@ -353,27 +354,19 @@ func validateContainers(project *model.Project, ref *model.ProjectRef, _ bool) V
 	return errs
 }
 
-// Makes sure that the dependencies for the tasks in the project form a
-// valid dependency graph (no cycles).
+// validateDependencyGraph returns a non-nil ValidationErrors if the dependency graph contains cycles.
 func validateDependencyGraph(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
-
-	tvToTaskUnit := tvToTaskUnit(project)
-	visited := map[model.TVPair]bool{}
-	allNodes := []model.TVPair{}
-
-	for node := range tvToTaskUnit {
-		visited[node] = false
-		allNodes = append(allNodes, node)
-	}
-
-	for node := range tvToTaskUnit {
-		if err := dependencyCycleExists(node, allNodes, visited, tvToTaskUnit); err != nil {
-			errs = append(errs, ValidationError{
-				Level:   Error,
-				Message: fmt.Sprintf("dependency error for '%s' task: %s", node.TaskName, err.Error()),
-			})
+	graph := project.DependencyGraph()
+	for _, cycle := range graph.Cycles() {
+		var nodeStrings []string
+		for _, task := range cycle {
+			nodeStrings = append(nodeStrings, task.String())
 		}
+		errs = append(errs, ValidationError{
+			Level:   Error,
+			Message: fmt.Sprintf("tasks [%s] form a dependency cycle", strings.Join(nodeStrings, ", ")),
+		})
 	}
 
 	return errs
@@ -411,41 +404,6 @@ func tvToTaskUnit(p *model.Project) map[model.TVPair]model.BuildVariantTaskUnit 
 		}
 	}
 	return tasksByNameAndVariant
-}
-
-// Helper for checking the dependency graph for cycles.
-func dependencyCycleExists(node model.TVPair, allNodes []model.TVPair, visited map[model.TVPair]bool,
-	tasksByNameAndVariant map[model.TVPair]model.BuildVariantTaskUnit) error {
-
-	v, ok := visited[node]
-	// if the node does not exist, the deps are broken
-	if !ok {
-		return errors.Errorf("dependency %s is not present in the project config", node)
-	}
-	// if the task has already been visited, then a cycle certainly exists
-	if v {
-		return errors.Errorf("dependency %s is part of a dependency cycle", node)
-	}
-
-	visited[node] = true
-
-	task := tasksByNameAndVariant[node]
-
-	depsToNodes := dependenciesForTaskUnit(node, task, allNodes)
-	for _, depNodes := range depsToNodes {
-		// For each of the task's dependencies, recursively check for cycles.
-		for _, dn := range depNodes {
-			if err := dependencyCycleExists(dn, allNodes, visited, tasksByNameAndVariant); err != nil {
-				return err
-			}
-		}
-	}
-
-	// remove the task from the visited map so that higher-level calls do not see it
-	visited[node] = false
-
-	// no cycle found
-	return nil
 }
 
 func validateProjectConfigPeriodicBuilds(pc *model.ProjectConfig) ValidationErrors {
@@ -1787,10 +1745,6 @@ func validateTaskSyncCommands(p *model.Project, runLong bool) ValidationErrors {
 			Message: fmt.Sprintf("too many commands using '%s' to check dependencies by default", evergreen.S3PullCommandName),
 		})
 	}
-	var taskDefMapping map[model.TVPair]model.BuildVariantTaskUnit
-	if checkDependencies {
-		taskDefMapping = tvToTaskUnit(p)
-	}
 	for bv, taskCmds := range bvToTaskCmds {
 		for task, cmds := range taskCmds {
 			for _, cmd := range cmds {
@@ -1818,7 +1772,7 @@ func validateTaskSyncCommands(p *model.Project, runLong bool) ValidationErrors {
 				s3PushTaskNode := model.TVPair{TaskName: s3PushTaskName, Variant: s3PushBVName}
 				if checkDependencies {
 					s3PullTaskNode := model.TVPair{TaskName: task, Variant: bv}
-					if err := validateTVDependsOnTV(s3PullTaskNode, s3PushTaskNode, taskDefMapping); err != nil {
+					if err := validateTVDependsOnTV(s3PullTaskNode, s3PushTaskNode, []string{"", evergreen.TaskSucceeded}, p); err != nil {
 						errs = append(errs, ValidationError{
 							Level: Error,
 							Message: fmt.Sprintf("problem validating that task running command '%s' depends on task running command '%s': %s",
@@ -1850,178 +1804,68 @@ func validateTaskSyncCommands(p *model.Project, runLong bool) ValidationErrors {
 	return errs
 }
 
-// validateTVDependsOnTV checks that the task in the given build variant has a
-// dependency on the task in the given build variant.
-func validateTVDependsOnTV(source, target model.TVPair, tvToTaskUnit map[model.TVPair]model.BuildVariantTaskUnit) error {
-	if source == target {
-		return errors.Errorf("task '%s' in build variant '%s' cannot depend on itself",
-			source.TaskName, source.Variant)
-	}
-	visited := map[model.TVPair]bool{}
-	var allTVs []model.TVPair
-	for tv := range tvToTaskUnit {
-		visited[tv] = false
-		allTVs = append(allTVs, tv)
+// validateTVDependsOnTV checks that the dependent task always has a dependency on the depended on task.
+// The dependedOnTask and every other task along the path must run on all the same requester types as the dependentTask
+// and the dependency on the dependedOnTask must be with a status in statuses, if provided.
+func validateTVDependsOnTV(dependentTask, dependedOnTask model.TVPair, statuses []string, project *model.Project) error {
+	g := project.DependencyGraph()
+	tvTaskUnitMap := tvToTaskUnit(project)
+
+	dependentNode := task.TaskNode{Name: dependentTask.TaskName, Variant: dependentTask.Variant}
+	dependedOnNode := task.TaskNode{Name: dependedOnTask.TaskName, Variant: dependedOnTask.Variant}
+	traversal := func(edge task.DependencyEdge) bool {
+		dependent := edge.From
+		dependedOn := edge.To
+
+		dependentTaskUnit := tvTaskUnitMap[model.TVPair{TaskName: dependent.Name, Variant: dependent.Variant}]
+		dependedOnTaskUnit := tvTaskUnitMap[model.TVPair{TaskName: dependedOn.Name, Variant: dependedOn.Variant}]
+
+		var dep model.TaskUnitDependency
+		for _, dependency := range dependentTaskUnit.DependsOn {
+			if dependency.Name == dependedOn.Name && dependency.Variant == dependedOn.Variant {
+				dep = dependency
+			}
+		}
+
+		if dependentTaskUnit.RunsOnPatches() && (!dependedOnTaskUnit.RunsOnPatches() || dep.PatchOptional) {
+			return false
+		}
+		if dependentTaskUnit.RunsOnNonPatches() && !dependedOnTaskUnit.RunsOnNonPatches() {
+			return false
+		}
+		if dependentTaskUnit.RunsOnGitTag() && !dependedOnTaskUnit.RunsOnGitTag() {
+			return false
+		}
+
+		if statuses != nil && dependedOn == dependedOnNode {
+			return utility.StringSliceContains(statuses, dep.Status)
+		}
+
+		return true
 	}
 
-	sourceTask, ok := tvToTaskUnit[source]
-	if !ok {
-		return errors.Errorf("could not find task '%s' in build variant '%s'",
-			source.TaskName, source.Variant)
-	}
-
-	// patches and mainline builds shouldn't depend on anything that's git tag only,
-	// while something that could run in a git tag build can't depend on something that's patchOnly.
-	// requireOnNonGitTag is just requireOnPatches & requireOnNonPatches so we don't consider this case.
-	depReqs := dependencyRequirements{
-		lastDepNeedsSuccess: true,
-		requireOnPatches:    !sourceTask.SkipOnPatchBuild() && !sourceTask.SkipOnNonGitTagBuild(),
-		requireOnNonPatches: !sourceTask.SkipOnNonPatchBuild() && !sourceTask.SkipOnNonGitTagBuild(),
-		requireOnGitTag:     !sourceTask.SkipOnNonPatchBuild() && !sourceTask.SkipOnGitTagBuild(),
-	}
-	depFound, err := dependencyMustRun(target, source, depReqs, allTVs, visited, tvToTaskUnit)
-	if err != nil {
-		return errors.Wrapf(err, "error searching for dependency of task '%s' in build variant '%s'"+
-			" on task '%s' in build variant '%s'",
-			source.TaskName, source.Variant,
-			target.TaskName, target.Variant)
-	}
-	if !depFound {
-		errMsg := "task '%s' on build variant '%s' must depend on" +
-			" task '%s' in build variant '%s' running and succeeding"
-		if depReqs.requireOnPatches && depReqs.requireOnNonPatches {
+	if found := g.DepthFirstSearch(dependentNode, dependedOnNode, traversal); !found {
+		dependentBVTask := tvTaskUnitMap[dependentTask]
+		errMsg := "task '%s' in build variant '%s' must depend on" +
+			" task '%s' in build variant '%s' completing"
+		if dependentBVTask.RunsOnPatches() && dependentBVTask.RunsOnNonPatches() {
 			errMsg += " for both patches and non-patches"
-		} else if depReqs.requireOnPatches {
+		} else if dependentBVTask.RunsOnPatches() {
 			errMsg += " for patches"
-		} else if depReqs.requireOnNonPatches {
+		} else if dependentBVTask.RunsOnNonPatches() {
 			errMsg += " for non-patches"
-		} else if depReqs.requireOnGitTag {
+		} else if dependentBVTask.RunsOnGitTag() {
 			errMsg += " for git-tag builds"
 		}
-		return errors.Errorf(errMsg, source.TaskName, source.Variant, target.TaskName, target.Variant)
+		errMsg = fmt.Sprintf(errMsg, dependentTask.TaskName, dependentTask.Variant, dependedOnTask.TaskName, dependedOnTask.Variant)
+
+		if statuses != nil {
+			errMsg = fmt.Sprintf(errMsg+" with status in [%s]", strings.Join(statuses, ", "))
+		}
+
+		return errors.New(errMsg)
 	}
 	return nil
-}
-
-type dependencyRequirements struct {
-	lastDepNeedsSuccess bool
-	requireOnPatches    bool
-	requireOnNonPatches bool
-	requireOnGitTag     bool
-}
-
-// dependencyMustRun checks whether or not the current task in a build
-// variant depends on the success of the target task in the build variant.
-func dependencyMustRun(target model.TVPair, current model.TVPair, depReqs dependencyRequirements, allNodes []model.TVPair, visited map[model.TVPair]bool, tvToTaskUnit map[model.TVPair]model.BuildVariantTaskUnit) (bool, error) {
-	isVisited, ok := visited[current]
-	// If the node is missing, the dependency graph is malformed.
-	if !ok {
-		return false, errors.Errorf("dependency '%s' in variant '%s' is not defined", current.TaskName, current.Variant)
-	}
-	// If a node is revisited on this DFS, the dependency graph cannot be
-	// checked because it has a cycle.
-	if isVisited {
-		return false, errors.Errorf("dependency '%s' in variant '%s' is in a dependency cycle", current.TaskName, current.Variant)
-	}
-
-	taskUnit := tvToTaskUnit[current]
-	// Even if current depends on target according to the dependency graph, if
-	// the current task will not run in the same cases as the source (e.g. the
-	// source task runs on patches but current task does not, or if the current task
-	// is only available to git tag builds), the dependency is
-	// not reachable from this branch.
-	if depReqs.requireOnPatches && (taskUnit.SkipOnPatchBuild() || taskUnit.SkipOnNonGitTagBuild()) {
-		return false, nil
-	}
-	if depReqs.requireOnNonPatches && (taskUnit.SkipOnNonPatchBuild() || taskUnit.SkipOnNonGitTagBuild()) {
-		return false, nil
-	}
-	if depReqs.requireOnGitTag && (taskUnit.SkipOnNonPatchBuild() || taskUnit.SkipOnGitTagBuild()) {
-		return false, nil
-	}
-
-	if current == target {
-		return depReqs.lastDepNeedsSuccess, nil
-	}
-
-	visited[current] = true
-
-	depsToNodes := dependenciesForTaskUnit(current, taskUnit, allNodes)
-	for dep, depNodes := range depsToNodes {
-		// If the task must run on patches but this dependency is optional on
-		// patches, we cannot traverse this dependency branch.
-		if depReqs.requireOnPatches && dep.PatchOptional {
-			continue
-		}
-		depReqs.lastDepNeedsSuccess = dep.Status == "" || dep.Status == evergreen.TaskSucceeded
-
-		for _, depNode := range depNodes {
-			reachable, err := dependencyMustRun(target, depNode, depReqs, allNodes, visited, tvToTaskUnit)
-			if err != nil {
-				return false, errors.Wrap(err, "dependency graph has problems")
-			}
-			if reachable {
-				return true, nil
-			}
-		}
-	}
-
-	visited[current] = false
-
-	return false, nil
-}
-
-// dependenciesForTaskUnit returns a map of this task unit's dependencies to
-// and all the task-build variant pairs the task unit depends on.
-func dependenciesForTaskUnit(tv model.TVPair, taskUnit model.BuildVariantTaskUnit, allTVs []model.TVPair) map[model.TaskUnitDependency][]model.TVPair {
-	depsToNodes := map[model.TaskUnitDependency][]model.TVPair{}
-	for _, dep := range taskUnit.DependsOn {
-		if dep.Variant != model.AllVariants {
-			// Handle dependencies with one variant.
-
-			depTV := model.TVPair{TaskName: dep.Name, Variant: dep.Variant}
-			if depTV.Variant == "" {
-				// Use the current variant if none is specified.
-				depTV.Variant = tv.Variant
-			}
-
-			if depTV.TaskName == model.AllDependencies {
-				// Handle dependencies with all-dependencies by adding all the
-				// variant's tasks except the current one.
-				for _, currTV := range allTVs {
-					if currTV.TaskName != tv.TaskName && currTV.Variant == depTV.Variant {
-						depsToNodes[dep] = append(depsToNodes[dep], currTV)
-					}
-				}
-			} else {
-				// Normal case: just append the dependency with its task and
-				// variant.
-				depsToNodes[dep] = append(depsToNodes[dep], depTV)
-			}
-		} else {
-			// Handle dependencies with all-variants.
-
-			if dep.Name != model.AllDependencies {
-				// Handle dependencies with all-variants by adding the task from
-				// all variants except the current task-variant.
-				for _, currTV := range allTVs {
-					if currTV.TaskName == dep.Name && (currTV != tv) {
-						depsToNodes[dep] = append(depsToNodes[dep], currTV)
-					}
-				}
-			} else {
-				// Handle dependencies with all-variants and all-dependencies by
-				// adding all the tasks except the current one.
-				for _, currTV := range allTVs {
-					if currTV != tv {
-						depsToNodes[dep] = append(depsToNodes[dep], currTV)
-					}
-				}
-			}
-		}
-	}
-
-	return depsToNodes
 }
 
 // parseS3PullParameters returns the parameters from the s3.pull command that

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1820,14 +1820,14 @@ func validateTVDependsOnTV(dependentTask, dependedOnTask model.TVPair, statuses 
 		dependentTaskUnit := tvTaskUnitMap[model.TVPair{TaskName: dependent.Name, Variant: dependent.Variant}]
 		dependedOnTaskUnit := tvTaskUnitMap[model.TVPair{TaskName: dependedOn.Name, Variant: dependedOn.Variant}]
 
-		var dep model.TaskUnitDependency
+		var edgeInfo model.TaskUnitDependency
 		for _, dependency := range dependentTaskUnit.DependsOn {
 			if dependency.Name == dependedOn.Name && dependency.Variant == dependedOn.Variant {
-				dep = dependency
+				edgeInfo = dependency
 			}
 		}
 
-		if dependentTaskUnit.RunsOnPatches() && (!dependedOnTaskUnit.RunsOnPatches() || dep.PatchOptional) {
+		if dependentTaskUnit.RunsOnPatches() && (!dependedOnTaskUnit.RunsOnPatches() || edgeInfo.PatchOptional) {
 			return false
 		}
 		if dependentTaskUnit.RunsOnNonPatches() && !dependedOnTaskUnit.RunsOnNonPatches() {
@@ -1837,8 +1837,9 @@ func validateTVDependsOnTV(dependentTask, dependedOnTask model.TVPair, statuses 
 			return false
 		}
 
+		// If statuses is specified we need to check the edge's status when the edge points to the target node.
 		if statuses != nil && dependedOn == dependedOnNode {
-			return utility.StringSliceContains(statuses, dep.Status)
+			return utility.StringSliceContains(statuses, edgeInfo.Status)
 		}
 
 		return true
@@ -1860,7 +1861,7 @@ func validateTVDependsOnTV(dependentTask, dependedOnTask model.TVPair, statuses 
 		errMsg = fmt.Sprintf(errMsg, dependentTask.TaskName, dependentTask.Variant, dependedOnTask.TaskName, dependedOnTask.Variant)
 
 		if statuses != nil {
-			errMsg = fmt.Sprintf(errMsg+" with status in [%s]", strings.Join(statuses, ", "))
+			errMsg = fmt.Sprintf("%s with status in [%s]", errMsg, strings.Join(statuses, ", "))
 		}
 
 		return errors.New(errMsg)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1829,12 +1829,12 @@ func validateTVDependsOnTV(dependentTask, dependedOnTask model.TVPair, statuses 
 			}
 		}
 
-		// PatchOptional dependencies are skipped when the edge.From task is running on a patch.
+		// PatchOptional dependencies are skipped when the fromTaskUnit task is running on a patch.
 		if edgeInfo.PatchOptional && !(fromTaskUnit.SkipOnPatchBuild() || fromTaskUnit.SkipOnNonGitTagBuild()) {
 			return false
 		}
 
-		// The dependency is skipped if edge.To doesn't run on all the same requester types that edge.From runs on.
+		// The dependency is skipped if toTaskUnit doesn't run on all the same requester types that fromTaskUnit runs on.
 		for _, rType := range evergreen.AllRequesterTypes {
 			if !fromTaskUnit.SkipOnRequester(rType) && toTaskUnit.SkipOnRequester(rType) {
 				return false

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -187,20 +187,6 @@ func TestValidateDependencyGraph(t *testing.T) {
 	Convey("When checking a project's dependency graph", t, func() {
 		Convey("cycles in the dependency graph should cause error to be returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name:      "compile",
-						DependsOn: []model.TaskUnitDependency{{Name: "testOne"}},
-					},
-					{
-						Name:      "testOne",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-					},
-					{
-						Name:      "testTwo",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv",
@@ -221,23 +207,13 @@ func TestValidateDependencyGraph(t *testing.T) {
 					},
 				},
 			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 3)
+			errs := validateDependencyGraph(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
 		})
 
 		Convey("task wildcard cycles in the dependency graph should return an error", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name:      "testOne",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "testTwo"}},
-					},
-					{
-						Name:      "testTwo",
-						DependsOn: []model.TaskUnitDependency{{Name: model.AllDependencies}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv",
@@ -255,49 +231,14 @@ func TestValidateDependencyGraph(t *testing.T) {
 					},
 				},
 			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 2)
-		})
 
-		Convey("nonexisting nodes in the dependency graph should return an error", func() {
-			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name:      "testOne",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "hamSteak"}},
-					},
-				},
-				BuildVariants: []model.BuildVariant{
-					{
-						Name: "bv",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}, {Name: "hamSteak"}}}}},
-				},
-			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 1)
+			errs := validateDependencyGraph(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
 		})
 
 		Convey("cross-variant cycles in the dependency graph should return an error", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name: "compile",
-					},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile"},
-							{Name: "testSpecial", Variant: "bv2"},
-						},
-					},
-					{
-						Name:      "testSpecial",
-						DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: "bv1"}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -320,64 +261,14 @@ func TestValidateDependencyGraph(t *testing.T) {
 					},
 				},
 			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 2)
-		})
 
-		Convey("cycles/errors from overwriting the dependency graph should return an error", func() {
-			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name: "compile",
-					},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile"},
-						},
-					},
-				},
-				BuildVariants: []model.BuildVariant{
-					{
-						Name: "bv1",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile", DependsOn: []model.TaskUnitDependency{{Name: "testOne"}}},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{{Name: "compile"}}},
-						},
-					},
-				},
-			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 2)
-
-			project.BuildVariants[0].Tasks[0].DependsOn = nil
-			project.BuildVariants[0].Tasks[1].DependsOn = []model.TaskUnitDependency{{Name: "NOPE"}}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 1)
-
-			project.BuildVariants[0].Tasks[1].DependsOn = []model.TaskUnitDependency{{Name: "compile", Variant: "bvNOPE"}}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 1)
+			errs := validateDependencyGraph(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
 		})
 
 		Convey("variant wildcard cycles in the dependency graph should return an error", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name: "compile",
-					},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile"},
-							{Name: "testSpecial", Variant: "bv2"},
-						},
-					},
-					{
-						Name:      "testSpecial",
-						DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: model.AllVariants}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -414,28 +305,14 @@ func TestValidateDependencyGraph(t *testing.T) {
 					},
 				},
 			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 4)
+
+			errs := validateDependencyGraph(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
 		})
 
 		Convey("cycles in a ** dependency graph should return an error", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile", Variant: model.AllVariants},
-							{Name: "testTwo"},
-						},
-					},
-					{
-						Name: "testTwo",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: model.AllDependencies, Variant: model.AllVariants},
-						},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -475,23 +352,14 @@ func TestValidateDependencyGraph(t *testing.T) {
 				},
 			}
 
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 3)
+			errs := validateDependencyGraph(project)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
 		})
 
-		Convey("if any task has itself as a dependency, an error should be"+
+		Convey("if any task has itself as a dependency, no error should be"+
 			" returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name:      "compile",
-						DependsOn: []model.TaskUnitDependency{},
-					},
-					{
-						Name:      "testOne",
-						DependsOn: []model.TaskUnitDependency{{Name: "testOne"}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv",
@@ -502,34 +370,12 @@ func TestValidateDependencyGraph(t *testing.T) {
 					},
 				},
 			}
-			So(validateDependencyGraph(project), ShouldNotResemble, ValidationErrors{})
-			So(len(validateDependencyGraph(project)), ShouldEqual, 1)
+			So(validateDependencyGraph(project), ShouldResemble, ValidationErrors{})
 		})
 
 		Convey("if there is no cycle in the dependency graph, no error should"+
 			" be returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name:      "compile",
-						DependsOn: []model.TaskUnitDependency{},
-					},
-					{
-						Name:      "testOne",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-					},
-					{
-						Name:      "testTwo",
-						DependsOn: []model.TaskUnitDependency{{Name: "compile"}},
-					},
-					{
-						Name: "push",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "testOne"},
-							{Name: "testTwo"},
-						},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv",
@@ -546,21 +392,6 @@ func TestValidateDependencyGraph(t *testing.T) {
 		Convey("if there is no cycle in the cross-variant dependency graph, no error should"+
 			" be returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile", Variant: "bv2"},
-						},
-					},
-					{
-						Name: "testSpecial",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile"},
-							{Name: "testOne", Variant: "bv1"}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -593,19 +424,6 @@ func TestValidateDependencyGraph(t *testing.T) {
 
 		Convey("if there is no cycle in the * dependency graph, no error should be returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile", Variant: model.AllVariants},
-						},
-					},
-					{
-						Name:      "testTwo",
-						DependsOn: []model.TaskUnitDependency{{Name: model.AllDependencies}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -633,19 +451,6 @@ func TestValidateDependencyGraph(t *testing.T) {
 
 		Convey("if there is no cycle in the ** dependency graph, no error should be returned", func() {
 			project := &model.Project{
-				Tasks: []model.ProjectTask{
-					{Name: "compile"},
-					{
-						Name: "testOne",
-						DependsOn: []model.TaskUnitDependency{
-							{Name: "compile", Variant: model.AllVariants},
-						},
-					},
-					{
-						Name:      "testTwo",
-						DependsOn: []model.TaskUnitDependency{{Name: model.AllDependencies, Variant: model.AllVariants}},
-					},
-				},
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "bv1",
@@ -3418,685 +3223,545 @@ func TestTVToTaskUnit(t *testing.T) {
 	}
 }
 
-func TestDependenciesForTaskUnit(t *testing.T) {
+func TestValidateTVDependsOnTV(t *testing.T) {
 	for testName, testCase := range map[string]struct {
-		expectedDepsToTVs map[model.TaskUnitDependency][]model.TVPair
-		tv                model.TVPair
-		taskUnit          model.BuildVariantTaskUnit
-		allTVs            []model.TVPair
-	}{
-		"WithExplicitVariants": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name:    "setup",
-						Variant: "rhel",
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: "setup", Variant: "rhel"}: []model.TVPair{
-					{TaskName: "setup", Variant: "rhel"},
-				},
-			},
-		},
-		"WithDependencyVariantsBasedOnTaskUnit": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name: "setup",
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "rhel"},
-				{TaskName: "setup", Variant: "ubuntu"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: "setup"}: []model.TVPair{
-					{TaskName: "setup", Variant: "ubuntu"},
-				},
-			},
-		},
-		"WithOneTaskAndAllVariants": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name:    "setup",
-						Variant: model.AllVariants,
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "rhel"},
-				{TaskName: "setup", Variant: "ubuntu"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: "setup", Variant: model.AllVariants}: []model.TVPair{
-					{TaskName: "setup", Variant: "rhel"},
-					{TaskName: "setup", Variant: "ubuntu"},
-				},
-			},
-		},
-		"WithAllTasksAndOneVariant": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name:    model.AllDependencies,
-						Variant: "rhel",
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "rhel"},
-				{TaskName: "setup", Variant: "ubuntu"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: model.AllDependencies, Variant: "rhel"}: []model.TVPair{
-					{TaskName: "setup", Variant: "rhel"},
-				},
-			},
-		},
-		"WithAllTasksAndOneVariantBasedOnTaskUnit": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name: model.AllDependencies,
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "rhel"},
-				{TaskName: "setup", Variant: "ubuntu"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: model.AllDependencies}: []model.TVPair{
-					{TaskName: "setup", Variant: "ubuntu"},
-				},
-			},
-		},
-		"WithAllTasksAndAllVariants": {
-			tv: model.TVPair{
-				TaskName: "compile",
-				Variant:  "ubuntu",
-			},
-			taskUnit: model.BuildVariantTaskUnit{
-				Name:    "compile",
-				Variant: "ubuntu",
-				DependsOn: []model.TaskUnitDependency{
-					{
-						Name:    model.AllDependencies,
-						Variant: model.AllVariants,
-					},
-				},
-			},
-			allTVs: []model.TVPair{
-				{TaskName: "setup", Variant: "rhel"},
-				{TaskName: "compile", Variant: "rhel"},
-				{TaskName: "setup", Variant: "ubuntu"},
-				{TaskName: "compile", Variant: "ubuntu"},
-			},
-			expectedDepsToTVs: map[model.TaskUnitDependency][]model.TVPair{
-				model.TaskUnitDependency{Name: model.AllDependencies, Variant: model.AllVariants}: []model.TVPair{
-					{TaskName: "setup", Variant: "rhel"},
-					{TaskName: "compile", Variant: "rhel"},
-					{TaskName: "setup", Variant: "ubuntu"},
-				},
-			},
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			depsToTVs := dependenciesForTaskUnit(testCase.tv, testCase.taskUnit, testCase.allTVs)
-			assert.Len(t, depsToTVs, len(testCase.expectedDepsToTVs))
-			for expectedDep, expectedTVs := range testCase.expectedDepsToTVs {
-				assert.Contains(t, depsToTVs, expectedDep)
-				assert.Equal(t, expectedTVs, depsToTVs[expectedDep])
-			}
-		})
-	}
-}
-
-func TestDependencyMustRun(t *testing.T) {
-	for testName, testCase := range map[string]struct {
-		source                model.TVPair
-		target                model.TVPair
-		depReqs               dependencyRequirements
-		tvToTaskUnit          map[model.TVPair]model.BuildVariantTaskUnit
-		expectDependencyFound bool
+		dependedOnTask model.TVPair
+		dependentTask  model.TVPair
+		statuses       []string
+		buildVariants  []model.BuildVariant
+		expectError    bool
 	}{
 		"FindsDependency": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B"},
+							},
+						},
+						{Name: "B"},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"FindsDependencyWithoutExplicitBV": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
 						{Name: "B"},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"FindsDependencyTransitively": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
+						{Name: "B", DependsOn: []model.TaskUnitDependency{{Name: "C", Variant: "rhel"}}},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel"},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: true,
+			expectError: false,
+		},
+		"FailsForNoDependency": {
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A"},
+					},
+				},
+			},
+			expectError: true,
 		},
 		"FailsIfDependencySkipsPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B", Variant: "ubuntu"}}},
+						{Name: "B", Patchable: utility.FalsePtr()},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"FailsIfIntermediateDependencySkipsPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
+						{
+							Name:      "B",
+							Variant:   "ubuntu",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel"},
+							},
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel"},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"FailsIfDependencySkipsNonPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B", Variant: "ubuntu"}}},
+						{Name: "B", Patchable: utility.FalsePtr()},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"FailsIfIntermediateDependencySkipsNonPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
+						{
+							Name:      "B",
+							PatchOnly: utility.TruePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel"},
+							},
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel"},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"FailsIfDependencyIsPatchOptional": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name:          "B",
-							Variant:       "ubuntu",
-							PatchOptional: true,
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name:          "B",
+									Variant:       "ubuntu",
+									PatchOptional: true,
+								},
+							},
 						},
+						{Name: "B"},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"FailsIfIntermediateDependencyIsPatchOptional": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
-					},
-				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel", PatchOptional: true},
-					},
-				},
-				{TaskName: "C", Variant: "rhel"}: {},
-			},
-			expectDependencyFound: false,
-		},
-		"OnlyLastDependencyRequiresSuccessStatus": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Status: evergreen.TaskFailed},
-					},
-				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel"},
-					},
-				},
-				{TaskName: "C", Variant: "rhel"}: {},
-			},
-			expectDependencyFound: true,
-		},
-		"FailsIfDependencyDoesNotRequireSuccessStatus": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name:    "B",
-							Variant: "ubuntu",
-							Status:  evergreen.TaskFailed,
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name: "B",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel", PatchOptional: true},
+							},
 						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
+					},
+				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
+		},
+		"OnlyLastDependencyRequiresSuccessStatus": {
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			statuses: []string{
+				evergreen.TaskSucceeded,
+				"",
+			},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Status: evergreen.TaskFailed},
+							},
+						},
+						{
+							Name: "B",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel"},
+							},
+						},
+					},
+				},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		"FailsIfDependencyDoesNotRequireSuccessStatus": {
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			statuses: []string{
+				evergreen.TaskSucceeded,
+				"",
+			},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name:    "B",
+									Variant: "ubuntu",
+									Status:  evergreen.TaskFailed,
+								},
+							},
+						},
+						{Name: "B"},
+					},
+				},
+			},
+			expectError: true,
 		},
 		"FailsIfLastDependencyDoesNotRequireSuccessStatus": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: true,
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			statuses: []string{
+				evergreen.TaskSucceeded,
+				"",
 			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B"},
+							},
+						},
+						{
+							Name: "B",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
+							},
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"DependencyCanSkipPatchesIfSourceSkipsPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:      "B",
+							Patchable: utility.FalsePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-				},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"IntermediateDependencyCanSkipPatchesIfSourceSkipsPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B"},
+							},
+						},
+						{
+							Name:      "B",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
+							},
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: false,
+			expectError: false,
 		},
 		"DependencyCanSkipNonPatchesIfSourceSkipsNonPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: false,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							PatchOnly: utility.TruePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:      "B",
+							PatchOnly: utility.TruePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-				},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"IntermediateDependencyCanSkipNonPatchesIfSourceSkipsNonPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "C", Variant: "rhel"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: false,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "C", Variant: "rhel"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							PatchOnly: utility.TruePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B"},
+							},
+						},
+						{
+							Name:      "B",
+							PatchOnly: utility.TruePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "C", Variant: "rhel"},
+							},
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "C", Variant: "rhel"},
+				{
+					Name: "rhel",
+					Tasks: []model.BuildVariantTaskUnit{
+						{Name: "C"},
 					},
 				},
-				{TaskName: "C", Variant: "rhel"}: {},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"DependencySkipsGitTagsIfSourceRequiresPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    true,
-				requireOnNonPatches: false,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							PatchOnly: utility.TruePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:       "B",
+							GitTagOnly: utility.TruePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					GitTagOnly: utility.TruePtr(),
-				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"DependencySkipsGitTagsIfSourceRequiresNonPatches": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:       "B",
+							GitTagOnly: utility.TruePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					GitTagOnly: utility.TruePtr(),
-				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"DependencySkipsGitTagsIfNotAllowedForGitTags": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: false,
-				requireOnGitTag:     true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					Patchable: utility.FalsePtr(),
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name:      "A",
+							Patchable: utility.FalsePtr(),
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:           "B",
+							AllowForGitTag: utility.FalsePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					AllowForGitTag: utility.FalsePtr(),
-				},
 			},
-			expectDependencyFound: false,
+			expectError: true,
 		},
 		"DependencyIncludesGitTagsIfAllowed": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: false,
-				requireOnGitTag:     true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:           "B",
+							AllowForGitTag: utility.TruePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					AllowForGitTag: utility.TruePtr(),
-				},
 			},
-			expectDependencyFound: true,
+			expectError: false,
 		},
 		"DependencySkipsPatchIfSourceIncludesGitTags": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: false,
-				requireOnGitTag:     true,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
+			dependentTask:  model.TVPair{TaskName: "A", Variant: "ubuntu"},
+			dependedOnTask: model.TVPair{TaskName: "B", Variant: "ubuntu"},
+			buildVariants: []model.BuildVariant{
+				{
+					Name: "ubuntu",
+					Tasks: []model.BuildVariantTaskUnit{
+						{
+							Name: "A",
+							DependsOn: []model.TaskUnitDependency{
+								{Name: "B", Variant: "ubuntu"},
+							},
+						},
+						{
+							Name:      "B",
+							PatchOnly: utility.TruePtr(),
+						},
 					},
 				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					PatchOnly: utility.TruePtr(),
-				},
 			},
-			expectDependencyFound: false,
-		},
-		"DependencyIncludesGitTagsWithGitTagOnly": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			depReqs: dependencyRequirements{
-				lastDepNeedsSuccess: true,
-				requireOnPatches:    false,
-				requireOnNonPatches: false,
-			},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "ubuntu"},
-					},
-				},
-				{TaskName: "B", Variant: "ubuntu"}: {
-					GitTagOnly: utility.TruePtr(),
-				},
-			},
-			expectDependencyFound: true,
+			expectError: true,
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			visited := map[model.TVPair]bool{}
-			allNodes := []model.TVPair{}
-
-			for tv := range testCase.tvToTaskUnit {
-				visited[tv] = false
-				allNodes = append(allNodes, tv)
+			err := validateTVDependsOnTV(
+				testCase.dependentTask,
+				testCase.dependedOnTask,
+				testCase.statuses,
+				&model.Project{BuildVariants: testCase.buildVariants},
+			)
+			if testCase.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-
-			dependencyFound, err := dependencyMustRun(testCase.target, testCase.source, testCase.depReqs, allNodes, visited, testCase.tvToTaskUnit)
-			require.NoError(t, err)
-			assert.Equal(t, testCase.expectDependencyFound, dependencyFound)
 		})
 	}
 }
@@ -5094,67 +4759,6 @@ func TestBVsWithTasksThatCallCommand(t *testing.T) {
 			})
 		}
 	})
-}
-
-func TestValidateTVDependsOnTV(t *testing.T) {
-	for testName, testCase := range map[string]struct {
-		source       model.TVPair
-		target       model.TVPair
-		tvToTaskUnit map[model.TVPair]model.BuildVariantTaskUnit
-		expectError  bool
-	}{
-		"PassesForValidDependency": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "rhel"},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B", Variant: "rhel"},
-					},
-				},
-				{TaskName: "B", Variant: "rhel"}: {},
-			},
-			expectError: false,
-		},
-		"PassesForValidDependencyImplicitlyInSameBuildVariant": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {
-					DependsOn: []model.TaskUnitDependency{
-						{Name: "B"},
-					},
-				},
-				{TaskName: "B", Variant: "ubuntu"}: {},
-			},
-			expectError: false,
-		},
-		"FailsForDependencyOnSelf": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {},
-			},
-			expectError: true,
-		},
-		"FailsForNoDependency": {
-			source: model.TVPair{TaskName: "A", Variant: "ubuntu"},
-			target: model.TVPair{TaskName: "B", Variant: "ubuntu"},
-			tvToTaskUnit: map[model.TVPair]model.BuildVariantTaskUnit{
-				{TaskName: "A", Variant: "ubuntu"}: {},
-			},
-			expectError: true,
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			err := validateTVDependsOnTV(testCase.source, testCase.target, testCase.tvToTaskUnit)
-			if testCase.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }
 
 func TestValidationErrorsAtLevel(t *testing.T) {


### PR DESCRIPTION
[EVG-16679](https://jira.mongodb.org/browse/EVG-16679)

### Description 
When I was looking to validate that generate tasks doesn't create dependency cycles I wrote a thing to abstract away the graph computer sciencey stuff and used it to simulate the new dependency graph before actually adding the dependencies. The case to use the DependencyGraph in other places seemed compelling so I began refactoring other places to use it too. 

This PR includes the DependencyGraph itself and applying it to two problems in the project validator. Future PRs will use it to validate adding dependencies on generated tasks, getRecursiveDependencies (down and up), and for the DAG dispatcher.

### Testing 
Unit testing