### PR TITLE
EVG-16784: Return partial error from copyProject

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -20,6 +20,8 @@ const (
 	// InputValidationError conveys that the given input is not formatted properly
 	InputValidationError GqlError = "INPUT_VALIDATION_ERROR"
 	ServiceUnavailable   GqlError = "SERVICE_UNAVAILABLE"
+	// PartialError conveys that the request succeeded, but there were nonfatal errors that may be communicated to users
+	PartialError GqlError = "PARTIAL_ERROR"
 )
 
 // Send sends a gql error to the client formatted with
@@ -35,6 +37,8 @@ func (err GqlError) Send(ctx context.Context, message string) *gqlerror.Error {
 		return formError(ctx, message, InputValidationError)
 	case ServiceUnavailable:
 		return formError(ctx, message, ServiceUnavailable)
+	case PartialError:
+		return formError(ctx, message, PartialError)
 	default:
 		return gqlerror.ErrorPathf(graphql.GetFieldContext(ctx).Path(), message)
 	}

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -157,6 +157,9 @@ func CopyProjectVars(oldProjectId, newProjectId string) error {
 	if err != nil {
 		return errors.Wrapf(err, "finding variables for project '%s'", oldProjectId)
 	}
+	if vars == nil {
+		vars = &ProjectVars{}
+	}
 	vars.Id = newProjectId
 	_, err = vars.Upsert()
 	return errors.Wrapf(err, "inserting variables for project '%s", newProjectId)

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -77,6 +77,7 @@ func CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProje
 	if err := model.UpdateAdminRoles(projectToCopy, projectToCopy.Admins, nil); err != nil {
 		catcher.Wrapf(err, "updating admin DB for project '%s'", opts.NewProjectIdentifier)
 	}
+	// Since the errors above are nonfatal and still permit copying the project, return both the new project and any errors that were encountered.
 	return apiProjectRef, catcher.Resolve()
 }
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -63,20 +63,21 @@ func CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProje
 	}
 
 	// copy variables, aliases, and subscriptions
+	catcher := grip.NewBasicCatcher()
 	if err := model.CopyProjectVars(oldId, projectToCopy.Id); err != nil {
-		return nil, errors.Wrapf(err, "error copying project vars from project '%s'", oldIdentifier)
+		catcher.Wrapf(err, "copying project vars from project '%s'", oldIdentifier)
 	}
 	if err := model.CopyProjectAliases(oldId, projectToCopy.Id); err != nil {
-		return nil, errors.Wrapf(err, "error copying aliases from project '%s'", oldIdentifier)
+		catcher.Wrapf(err, "copying aliases from project '%s'", oldIdentifier)
 	}
 	if err := event.CopyProjectSubscriptions(oldId, projectToCopy.Id); err != nil {
-		return nil, errors.Wrapf(err, "error copying subscriptions from project '%s'", oldIdentifier)
+		catcher.Wrapf(err, "copying subscriptions from project '%s'", oldIdentifier)
 	}
 	// set the same admin roles from the old project on the newly copied project.
 	if err := model.UpdateAdminRoles(projectToCopy, projectToCopy.Admins, nil); err != nil {
-		return nil, errors.Wrapf(err, "Database error updating admins for project '%s'", opts.NewProjectIdentifier)
+		catcher.Wrapf(err, "updating admin DB for project '%s'", opts.NewProjectIdentifier)
 	}
-	return apiProjectRef, nil
+	return apiProjectRef, catcher.Resolve()
 }
 
 // SaveProjectSettingsForSection saves the given UI page section and logs it for the given user. If isRepo is true, uses


### PR DESCRIPTION
[EVG-16784](https://jira.mongodb.org/browse/EVG-16784)

### Description
- When a project has successfully copied but some fields were unable to be copied, return both data _and_ error from the `copyProject` resolver. This enables us to redirect the user to the new project, but still warn them that some errors were encountered.
- Add new `PartialError` GraphQL error type

### Testing 
- Add unit test, tested in GraphQL playground