### PR TITLE
EVG-16762 add revision to periodic builds

### DIFF
--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -41,12 +41,21 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	j.ProjectID = sampleProject.Id
 	j.DefinitionID = "abc"
 
+	prevVersion := model.Version{
+		Id:         "version",
+		Identifier: sampleProject.Id,
+		Requester:  evergreen.RepotrackerVersionRequester,
+		Revision:   "88dcc12106a40cb4917f552deab7574ececd9a3e",
+	}
+	assert.NoError(prevVersion.Insert())
+
 	// test that a version is created when the job runs
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	createdVersion, err := model.FindLastPeriodicBuild(sampleProject.Id, sampleProject.PeriodicBuilds[0].ID)
 	assert.NoError(err)
 	assert.Equal(evergreen.AdHocRequester, createdVersion.Requester)
+	assert.Equal(prevVersion.Revision, createdVersion.Revision)
 	tasks, err := task.Find(task.ByVersion(createdVersion.Id))
 	assert.NoError(err)
 	assert.True(tasks[0].Activated)


### PR DESCRIPTION
[EVG-16762](https://jira.mongodb.org/browse/EVG-16762)

### Description 
Add revision to periodic build using the latest revision (this is what using branch does anyway, but using revision throughout also makes this more consistent, in case a new version is pushed while we're still adding included files).

### Testing 
Tested on staging: https://evergreen-staging.corp.mongodb.com/rest/v2/versions/62729bffb2373669f3e4715c
