### PR TITLE
EVG-16386: Set HttpOnly flags for evergreen cookies

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -87,13 +87,16 @@ func NewUIServer(env evergreen.Environment, queue amboy.Queue, home string, fo T
 		Functions:    MakeTemplateFuncs(fo),
 	}
 
+	cookieStore := sessions.NewCookieStore([]byte(settings.Ui.Secret))
+	cookieStore.Options.HttpOnly = true
+
 	uis := &UIServer{
 		Settings:     *settings,
 		env:          env,
 		queue:        queue,
 		Home:         home,
 		clientConfig: evergreen.GetEnvironment().ClientConfig(),
-		CookieStore:  sessions.NewCookieStore([]byte(settings.Ui.Secret)),
+		CookieStore:  cookieStore,
 		render:       gimlet.NewHTMLRenderer(ropts),
 		renderText:   gimlet.NewTextRenderer(ropts),
 		jiraHandler:  thirdparty.NewJiraHandler(*settings.Jira.Export()),


### PR DESCRIPTION
[EVG-16386](https://jira.mongodb.org/browse/EVG-16386)

### Description 
These code changes set httpOnly true for the `mci-session-cookie` which is used for legacy ui banners. `mci-project` cannot be set to httpOnly because it's accessed manipulated by spruce js. [newrelic](https://newrelic.com/termsandconditions/cookie-policy/cookie-table) 3rd party cookies can be disabled only. AWS 3rd party cookies can be [configured](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application) from the aws cli if necessary. 

### Testing
Tested by making sure a banner appears when stopping a host locally and in staging. 

