### PR TITLE
EVG-16371: propagate container options from task to pod

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1111,6 +1111,10 @@ const (
 	WindowsOS ContainerOS = "windows"
 )
 
+// ValidContainerOperatingSystems contains all recognized container operating
+// systems.
+var ValidContainerOperatingSystems = []ContainerOS{LinuxOS, WindowsOS}
+
 // Validate checks that the container OS is recognized.
 func (c ContainerOS) Validate() error {
 	switch c {
@@ -1121,16 +1125,20 @@ func (c ContainerOS) Validate() error {
 	}
 }
 
-// CPUArchitecture represents the architecture necessary to run a container.
-type CPUArchitecture string
+// ContainerArch represents the CPU architecture necessary to run a container.
+type ContainerArch string
 
 const (
-	ArchARM64 CPUArchitecture = "arm64"
-	ArchAMD64 CPUArchitecture = "x86_64"
+	ArchARM64 ContainerArch = "arm64"
+	ArchAMD64 ContainerArch = "x86_64"
 )
 
+// ValidContainerArchitectures contains all recognized container CPU
+// architectures.
+var ValidContainerArchitectures = []ContainerArch{ArchARM64, ArchAMD64}
+
 // Validate checks that the container CPU architecture is recognized.
-func (c CPUArchitecture) Validate() error {
+func (c ContainerArch) Validate() error {
 	switch c {
 	case ArchARM64, ArchAMD64:
 		return nil
@@ -1147,6 +1155,9 @@ const (
 	Windows2019 WindowsVersion = "2019"
 	Windows2016 WindowsVersion = "2016"
 )
+
+// ValidWindowsVersions contains all recognized container Windows versions.
+var ValidWindowsVersions = []WindowsVersion{Windows2016, Windows2019, Windows2022}
 
 // Validate checks that the container Windows version is recognized.
 func (w WindowsVersion) Validate() error {

--- a/model/generate.go
+++ b/model/generate.go
@@ -274,8 +274,8 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		return errors.Errorf("project '%s' not found", p.Identifier)
 	}
 
-	activatedTasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, newTVPairsForExistingVariants,
-		existingBuilds, syncAtEndOpts, projectRef.Identifier, g.TaskID)
+	activatedTasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, projectRef, newTVPairsForExistingVariants,
+		existingBuilds, syncAtEndOpts, g.TaskID)
 	if err != nil {
 		return errors.Wrap(err, "adding new tasks")
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -525,7 +525,7 @@ func RefreshTasksCache(buildId string) error {
 }
 
 // addTasksToBuild creates/activates the tasks for the given build of a project
-func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *Version, taskNames []string,
+func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, pRef *ProjectRef, v *Version, taskNames []string,
 	displayNames []string, activationInfo specificActivationInfo, generatedBy string, tasksInBuild []task.Task,
 	syncAtEndOpts patch.SyncAtEndOptions, distroAliases map[string][]string, taskIds TaskIdConfig) (*build.Build, task.Tasks, error) {
 	// find the build variant for this project/build
@@ -541,27 +541,17 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 		return nil, nil, errors.Wrapf(err, "getting create time for tasks in version '%s'", v.Id)
 	}
 
-	var pRef *ProjectRef
 	var githubCheckAliases ProjectAliases
-	if v.Requester == evergreen.RepotrackerVersionRequester {
-		pRef, err = FindMergedProjectRef(project.Identifier, v.Id, true)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "finding project ref")
-		}
-		if pRef == nil {
-			return nil, nil, errors.Errorf("project '%s' not found", project.Identifier)
-		}
-		if pRef.IsGithubChecksEnabled() {
-			githubCheckAliases, err = FindAliasInProjectRepoOrConfig(v.Identifier, evergreen.GithubChecksAlias)
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":            "error getting github check aliases when adding tasks to build",
-				"project":            v.Identifier,
-				"project_identifier": pRef.Identifier,
-				"version":            v.Id,
-			}))
-		}
+	if v.Requester == evergreen.RepotrackerVersionRequester && pRef.IsGithubChecksEnabled() {
+		githubCheckAliases, err = FindAliasInProjectRepoOrConfig(v.Identifier, evergreen.GithubChecksAlias)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":            "error getting github check aliases when adding tasks to build",
+			"project":            v.Identifier,
+			"project_identifier": pRef.Identifier,
+			"version":            v.Id,
+		}))
 	}
-	tasks, err := createTasksForBuild(project, buildVariant, b, v, taskIds, taskNames, displayNames, activationInfo,
+	tasks, err := createTasksForBuild(project, pRef, buildVariant, b, v, taskIds, taskNames, displayNames, activationInfo,
 		generatedBy, tasksInBuild, syncAtEndOpts, distroAliases, createTime, githubCheckAliases)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "creating tasks for build '%s'", b.Id)
@@ -587,15 +577,6 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 
 	batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 	tasksWithActivationTime := activationInfo.getActivationTasks(b.BuildVariant)
-	if len(tasksWithActivationTime) > 0 && pRef == nil {
-		pRef, err = FindMergedProjectRef(project.Identifier, v.Id, true)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "finding project ref")
-		}
-		if pRef == nil {
-			return nil, nil, errors.Errorf("project '%s' not found", project.Identifier)
-		}
-	}
 	batchTimeCatcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
 		if !utility.StringSliceContains(tasksWithActivationTime, t.DisplayName) {
@@ -629,10 +610,10 @@ func addTasksToBuild(ctx context.Context, b *build.Build, project *Project, v *V
 	return b, tasks, nil
 }
 
-// BuildCreateArgs is the set of parameters used in CreateBuildFromVersionNoInsert
+// BuildCreateArgs is the set of parameters used in CreateBuildFromVersionNoInsert.
 type BuildCreateArgs struct {
 	Project             Project                 // project to create the build for
-	ProjectIdentifier   string                  // the readable project identifier, used to create new IDs
+	ProjectRef          ProjectRef              // project ref associated with the build
 	Version             Version                 // the version the build belong to
 	TaskIDs             TaskIdConfig            // pre-generated IDs for the tasks to be created
 	BuildName           string                  // name of the buildvariant
@@ -677,7 +658,7 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 
 	// create a new build id
 	buildId := fmt.Sprintf("%s_%s_%s_%s",
-		args.ProjectIdentifier,
+		args.ProjectRef.Identifier,
 		args.BuildName,
 		rev,
 		args.Version.CreateTime.Format(build.IdTimeLayout))
@@ -718,7 +699,7 @@ func CreateBuildFromVersionNoInsert(args BuildCreateArgs) (*build.Build, task.Ta
 	b.BuildNumber = strconv.FormatUint(buildNumber, 10)
 
 	// create all of the necessary tasks for the build
-	tasksForBuild, err := createTasksForBuild(&args.Project, buildVariant, b, &args.Version, args.TaskIDs,
+	tasksForBuild, err := createTasksForBuild(&args.Project, &args.ProjectRef, buildVariant, b, &args.Version, args.TaskIDs,
 		args.TaskNames, args.DisplayNames, args.ActivationInfo, args.GeneratedBy,
 		nil, args.SyncAtEndOpts, args.DistroAliases, args.TaskCreateTime, args.GithubChecksAliases)
 	if err != nil {
@@ -791,7 +772,7 @@ func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester stri
 // The slice of tasks will be in the same order as the project's specified tasks
 // appear in the specified build variant.
 // If tasksToActivate is nil, then all tasks will be activated.
-func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.Build, v *Version,
+func createTasksForBuild(project *Project, pRef *ProjectRef, buildVariant *BuildVariant, b *build.Build, v *Version,
 	taskIds TaskIdConfig, taskNames []string, displayNames []string, activationInfo specificActivationInfo, generatedBy string,
 	tasksInBuild []task.Task, syncAtEndOpts patch.SyncAtEndOptions, distroAliases map[string][]string, createTime time.Time,
 	githubChecksAliases ProjectAliases) (task.Tasks, error) {
@@ -860,7 +841,7 @@ func createTasksForBuild(project *Project, buildVariant *BuildVariant, b *build.
 	taskMap := make(map[string]*task.Task)
 	for _, t := range tasksToCreate {
 		id := execTable.GetId(b.BuildVariant, t.Name)
-		newTask, err := createOneTask(id, t, project, buildVariant, b, v, distroAliases, createTime, activationInfo, githubChecksAliases)
+		newTask, err := createOneTask(id, t, project, pRef, buildVariant, b, v, distroAliases, createTime, activationInfo, githubChecksAliases)
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating task '%s'", id)
 		}
@@ -1203,7 +1184,7 @@ func getTaskCreateTime(projectId string, v *Version) (time.Time, error) {
 }
 
 // createOneTask is a helper to create a single task.
-func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Project, buildVariant *BuildVariant,
+func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Project, pRef *ProjectRef, buildVariant *BuildVariant,
 	b *build.Build, v *Version, dat distro.AliasLookupTable, createTime time.Time, activationInfo specificActivationInfo,
 	githubChecksAliases ProjectAliases) (*task.Task, error) {
 
@@ -1266,7 +1247,7 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		IsGithubCheck:       isGithubCheck,
 		DisplayTaskId:       utility.ToStringPtr(""), // this will be overridden if the task is an execution task
 	}
-	// is running in a host or container.
+
 	t.ExecutionPlatform = shouldRunOnContainer(buildVarTask.RunOn, buildVariant.RunOn, project.Containers)
 	if t.IsContainerTask() {
 		flags, err := evergreen.GetServiceFlags()
@@ -1276,10 +1257,16 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		if flags.ContainerConfigurationsDisabled {
 			return nil, errors.Errorf("container configurations are disabled; task '%s' cannot run", t.DisplayName)
 		}
+
 		t.Container, err = getContainerFromRunOn(id, buildVarTask, buildVariant)
 		if err != nil {
 			return nil, err
 		}
+		opts, err := getContainerOptions(project, pRef, t.Container)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting container options")
+		}
+		t.ContainerOpts = *opts
 	} else {
 		distroID, distroAliases, err := getDistrosFromRunOn(id, buildVarTask, buildVariant, project, v)
 		if err != nil {
@@ -1288,11 +1275,13 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 		t.DistroId = distroID
 		t.DistroAliases = distroAliases
 	}
+
 	if isStepback {
 		t.ActivatedBy = evergreen.StepbackTaskActivator
 	} else if t.Activated {
 		t.ActivatedBy = v.Author
 	}
+
 	if buildVarTask.IsGroup {
 		tg := project.FindTaskGroup(buildVarTask.GroupName)
 		if tg == nil {
@@ -1301,6 +1290,7 @@ func createOneTask(id string, buildVarTask BuildVariantTaskUnit, project *Projec
 
 		tg.InjectInfo(t)
 	}
+
 	return t, nil
 }
 
@@ -1353,6 +1343,42 @@ func getContainerFromRunOn(id string, buildVarTask BuildVariantTaskUnit, buildVa
 		return "", errors.Errorf("task '%s' on buildvariant '%s' is not runnable as there is no container specified", id, buildVariant.Name)
 	}
 	return container, nil
+}
+
+// getContainerOptions resolves the task's container configuration based on the
+// task's container name and the container definitions available to the project.
+func getContainerOptions(project *Project, pRef *ProjectRef, container string) (*task.ContainerOptions, error) {
+	for _, c := range project.Containers {
+		if c.Name != container {
+			continue
+		}
+
+		opts := task.ContainerOptions{
+			WorkingDir:     c.WorkingDir,
+			Image:          c.Image,
+			OS:             c.System.OperatingSystem,
+			Arch:           c.System.CPUArchitecture,
+			WindowsVersion: c.System.WindowsVersion,
+		}
+
+		if c.Resources != nil {
+			opts.CPU = c.Resources.CPU
+			opts.MemoryMB = c.Resources.MemoryMB
+			return &opts, nil
+		}
+
+		for name, size := range pRef.ContainerSizes {
+			if name == c.Size {
+				opts.CPU = size.CPU
+				opts.MemoryMB = size.MemoryMB
+				return &opts, nil
+			}
+		}
+
+		return nil, errors.Errorf("container size '%s' not found", c.Size)
+	}
+
+	return nil, errors.Errorf("definition for container '%s' not found", container)
 }
 
 func createDisplayTask(id string, displayName string, execTasks []string, bv *BuildVariant, b *build.Build,
@@ -1563,18 +1589,18 @@ func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v 
 		displayNames := tasks.DisplayTasks.TaskNames(pair.Variant)
 		activateVariant := !activationInfo.variantHasSpecificActivation(pair.Variant)
 		buildArgs := BuildCreateArgs{
-			Project:           *p,
-			Version:           *v,
-			TaskIDs:           taskIdTables,
-			BuildName:         pair.Variant,
-			ActivateBuild:     activateVariant,
-			TaskNames:         taskNames,
-			DisplayNames:      displayNames,
-			ActivationInfo:    activationInfo,
-			GeneratedBy:       generatedBy,
-			TaskCreateTime:    createTime,
-			SyncAtEndOpts:     syncAtEndOpts,
-			ProjectIdentifier: projectRef.Identifier,
+			Project:        *p,
+			ProjectRef:     *projectRef,
+			Version:        *v,
+			TaskIDs:        taskIdTables,
+			BuildName:      pair.Variant,
+			ActivateBuild:  activateVariant,
+			TaskNames:      taskNames,
+			DisplayNames:   displayNames,
+			ActivationInfo: activationInfo,
+			GeneratedBy:    generatedBy,
+			TaskCreateTime: createTime,
+			SyncAtEndOpts:  syncAtEndOpts,
 		}
 
 		grip.Info(message.Fields{
@@ -1664,8 +1690,8 @@ func addNewBuilds(ctx context.Context, activationInfo specificActivationInfo, v 
 
 // Given a version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds. Returns activated task IDs.
-func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project, pairs TaskVariantPairs,
-	existingBuilds []build.Build, syncAtEndOpts patch.SyncAtEndOptions, projectIdentifier string, generatedBy string) ([]string, error) {
+func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *Version, p *Project, pRef *ProjectRef, pairs TaskVariantPairs,
+	existingBuilds []build.Build, syncAtEndOpts patch.SyncAtEndOptions, generatedBy string) ([]string, error) {
 	if v.BuildIds == nil {
 		return nil, nil
 	}
@@ -1675,7 +1701,7 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 		return nil, err
 	}
 
-	taskIdTables, err := getTaskIdTables(v, p, pairs, projectIdentifier)
+	taskIdTables, err := getTaskIdTables(v, p, pairs, pRef.Identifier)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting table of task IDs")
 	}
@@ -1729,7 +1755,7 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 			continue
 		}
 		// Add the new set of tasks to the build.
-		_, tasks, err := addTasksToBuild(ctx, &b, p, v, tasksToAdd, displayTasksToAdd, activationInfo,
+		_, tasks, err := addTasksToBuild(ctx, &b, p, pRef, v, tasksToAdd, displayTasksToAdd, activationInfo,
 			generatedBy, tasksInBuild, syncAtEndOpts, distroAliases, taskIdTables)
 		if err != nil {
 			return nil, err

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1367,15 +1367,14 @@ func getContainerOptions(project *Project, pRef *ProjectRef, container string) (
 			return &opts, nil
 		}
 
-		for name, size := range pRef.ContainerSizes {
-			if name == c.Size {
-				opts.CPU = size.CPU
-				opts.MemoryMB = size.MemoryMB
-				return &opts, nil
-			}
+		size, ok := pRef.ContainerSizes[c.Size]
+		if !ok {
+			return nil, errors.Errorf("container size '%s' not found", c.Size)
 		}
 
-		return nil, errors.Errorf("container size '%s' not found", c.Size)
+		opts.CPU = size.CPU
+		opts.MemoryMB = size.MemoryMB
+		return &opts, nil
 	}
 
 	return nil, errors.Errorf("definition for container '%s' not found", container)

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -721,13 +721,23 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			DisplayName: "Build Variant 4",
 			RunOn:       []string{"container1"},
 			Tasks: parserBVTaskUnits{
-				{Name: "taskA"}, {Name: "taskB"}, {Name: "taskC"}, {Name: "taskE"},
+				{Name: "taskA"}, {Name: "taskB"}, {Name: "taskC"}, {
+					Name:  "taskE",
+					RunOn: parserStringSlice{"container2"},
+				},
 			},
 		}
 
+		smallContainerSize := ContainerResources{
+			MemoryMB: 128,
+			CPU:      256,
+		}
 		pref := &ProjectRef{
 			Id:         "projectId",
 			Identifier: "projectName",
+			ContainerSizes: map[string]ContainerResources{
+				"small": smallContainerSize,
+			},
 		}
 		So(pref.Insert(), ShouldBeNil)
 
@@ -735,6 +745,30 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			Variant: ".*"}
 		So(alias.Upsert(), ShouldBeNil)
 		mustHaveResults := true
+		container1 := Container{
+			Name:       "container1",
+			WorkingDir: "/data",
+			Image:      "ubuntu",
+			Resources: &ContainerResources{
+				MemoryMB: 1024,
+				CPU:      512,
+			},
+			System: ContainerSystem{
+				OperatingSystem: evergreen.LinuxOS,
+				CPUArchitecture: evergreen.ArchARM64,
+			},
+		}
+		container2 := Container{
+			Name:       "container2",
+			WorkingDir: "/dir",
+			Image:      "windows",
+			Size:       "small",
+			System: ContainerSystem{
+				OperatingSystem: evergreen.WindowsOS,
+				CPUArchitecture: evergreen.ArchAMD64,
+				WindowsVersion:  evergreen.Windows2019,
+			},
+		}
 		parserProject := &ParserProject{
 			Identifier: utility.ToStringPtr("projectId"),
 			Tasks: []parserTask{
@@ -779,11 +813,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 					},
 				},
 			},
-			Containers: []Container{
-				{
-					Name: "container1",
-				},
-			},
+			Containers:    []Container{container1, container2},
 			BuildVariants: []parserBV{buildVar1, buildVar2, buildVar3, buildVar4},
 		}
 
@@ -847,6 +877,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     "blecch",
@@ -864,6 +895,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -890,6 +922,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -909,6 +942,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			batchTimeTasks := []string{"taskA", "taskB"}
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -935,6 +969,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar2.Name,
@@ -952,6 +987,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -967,9 +1003,10 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 		})
 
-		Convey("execution mode should be populated for execution tasks", func() {
+		Convey("host execution mode should be populated for execution tasks running on a distro", func() {
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -987,11 +1024,55 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			}
 		})
 
+		Convey("execution platform should be set to containers and container options should be populated when run_on contains a container name", func() {
+			args := BuildCreateArgs{
+				Project:       *project,
+				ProjectRef:    *pref,
+				Version:       *v,
+				TaskIDs:       table,
+				BuildName:     buildVar4.Name,
+				ActivateBuild: false,
+				TaskNames:     []string{},
+			}
+			build, tasks, err := CreateBuildFromVersionNoInsert(args)
+			So(err, ShouldBeNil)
+			So(build.Id, ShouldNotEqual, "")
+			So(len(build.Tasks), ShouldEqual, 4)
+
+			bvContainerOpts := task.ContainerOptions{
+				CPU:        container1.Resources.CPU,
+				MemoryMB:   container1.Resources.MemoryMB,
+				WorkingDir: container1.WorkingDir,
+				Image:      container1.Image,
+				OS:         container1.System.OperatingSystem,
+				Arch:       container1.System.CPUArchitecture,
+			}
+			taskContainerOpts := task.ContainerOptions{
+				CPU:        smallContainerSize.CPU,
+				MemoryMB:   smallContainerSize.MemoryMB,
+				WorkingDir: container2.WorkingDir,
+				Image:      container2.Image,
+				OS:         container2.System.OperatingSystem,
+				Arch:       container2.System.CPUArchitecture,
+			}
+			for _, tsk := range tasks[:3] {
+				So(tsk.ExecutionPlatform, ShouldEqual, task.ExecutionPlatformContainer)
+				if tsk.Id != "taskE" {
+					So(tsk.Container, ShouldEqual, container1.Name)
+					So(tsk.ContainerOpts, ShouldResemble, bvContainerOpts)
+				} else {
+					So(tsk.Container, ShouldEqual, container2.Name)
+					So(tsk.ContainerOpts, ShouldResemble, taskContainerOpts)
+				}
+			}
+		})
+
 		Convey("the build should contain task caches that correspond exactly"+
 			" to the tasks created", func() {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar2.Name,
@@ -1012,30 +1093,10 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			So(build.Tasks[3].Id, ShouldContainSubstring, "taskE")
 		})
 
-		Convey("execution platform should be set to containers when run_on contains a container name", func() {
-			args := BuildCreateArgs{
-				Project:       *project,
-				Version:       *v,
-				TaskIDs:       table,
-				BuildName:     buildVar4.Name,
-				ActivateBuild: false,
-				TaskNames:     []string{},
-			}
-			build, tasks, err := CreateBuildFromVersionNoInsert(args)
-			So(err, ShouldBeNil)
-			So(build.Id, ShouldNotEqual, "")
-			So(len(build.Tasks), ShouldEqual, 4)
-
-			// make sure the task execution platforms are correct
-			So(tasks[0].ExecutionPlatform, ShouldEqual, task.ExecutionPlatformContainer)
-			So(tasks[1].ExecutionPlatform, ShouldEqual, task.ExecutionPlatformContainer)
-			So(tasks[2].ExecutionPlatform, ShouldEqual, task.ExecutionPlatformContainer)
-			So(tasks[3].ExecutionPlatform, ShouldEqual, task.ExecutionPlatformContainer)
-		})
-
 		Convey("a task cache should not contain execution tasks that are part of a display task", func() {
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -1064,6 +1125,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -1130,6 +1192,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -1160,6 +1223,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -1256,6 +1320,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 				args := BuildCreateArgs{
 					Project:        *project,
+					ProjectRef:     *pref,
 					Version:        *v,
 					TaskIDs:        table,
 					BuildName:      buildVar1.Name,
@@ -1338,6 +1403,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 		Convey("the 'must have test results' flag should be set", func() {
 			args := BuildCreateArgs{
 				Project:       *project,
+				ProjectRef:    *pref,
 				Version:       *v,
 				TaskIDs:       table,
 				BuildName:     buildVar1.Name,
@@ -1401,7 +1467,8 @@ func TestCreateTaskGroup(t *testing.T) {
   `
 	proj := &Project{}
 	ctx := context.Background()
-	_, err := LoadProjectInto(ctx, []byte(projYml), nil, "test", proj)
+	const projectIdentifier = "test"
+	_, err := LoadProjectInto(ctx, []byte(projYml), nil, projectIdentifier, proj)
 	assert.NotNil(proj)
 	assert.NoError(err)
 	v := &Version{
@@ -1418,10 +1485,15 @@ func TestCreateTaskGroup(t *testing.T) {
 		},
 		Config: projYml,
 	}
+	pRef := ProjectRef{
+		Id:         "projectId",
+		Identifier: projectIdentifier,
+	}
 	table := NewTaskIdTable(proj, v, "", "")
 
 	args := BuildCreateArgs{
 		Project:       *proj,
+		ProjectRef:    pRef,
 		Version:       *v,
 		TaskIDs:       table,
 		BuildName:     "bv",

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -100,10 +100,10 @@ func addNewTasksAndBuildsForPatch(ctx context.Context, syncOpts patch.SyncAtEndO
 	}
 	_, err = addNewBuilds(ctx, specificActivationInfo{}, patchVersion, project, pairs, existingBuilds, syncOpts, pRef, "")
 	if err != nil {
-		return errors.Wrap(err, "can't add new builds")
+		return errors.Wrap(err, "adding new builds")
 	}
-	_, err = addNewTasks(ctx, specificActivationInfo{}, patchVersion, project, pairs, existingBuilds, syncOpts, pRef.Identifier, "")
-	return errors.Wrap(err, "can't add new tasks")
+	_, err = addNewTasks(ctx, specificActivationInfo{}, patchVersion, project, pRef, pairs, existingBuilds, syncOpts, "")
+	return errors.Wrap(err, "adding new tasks")
 }
 
 type PatchUpdate struct {
@@ -154,7 +154,7 @@ func ConfigurePatch(ctx context.Context, p *patch.Patch, version *Version, proj 
 	if p.Version != "" {
 		// This patch has already been finalized, just add the new builds and tasks
 		if version == nil {
-			return http.StatusInternalServerError, errors.Errorf("finding patch for version '%v'", p.Version)
+			return http.StatusInternalServerError, errors.Errorf("finding patch for version '%s'", p.Version)
 		}
 
 		if version.Message != patchUpdateReq.Description {
@@ -499,17 +499,17 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		}
 		taskNames := tasks.ExecTasks.TaskNames(vt.Variant)
 		buildArgs := BuildCreateArgs{
-			Project:           *project,
-			Version:           *patchVersion,
-			TaskIDs:           taskIds,
-			BuildName:         vt.Variant,
-			ActivateBuild:     true,
-			TaskNames:         taskNames,
-			DisplayNames:      displayNames,
-			DistroAliases:     distroAliases,
-			TaskCreateTime:    createTime,
-			SyncAtEndOpts:     p.SyncAtEndOpts,
-			ProjectIdentifier: projectRef.Identifier,
+			Project:        *project,
+			ProjectRef:     *projectRef,
+			Version:        *patchVersion,
+			TaskIDs:        taskIds,
+			BuildName:      vt.Variant,
+			ActivateBuild:  true,
+			TaskNames:      taskNames,
+			DisplayNames:   displayNames,
+			DistroAliases:  distroAliases,
+			TaskCreateTime: createTime,
+			SyncAtEndOpts:  p.SyncAtEndOpts,
 		}
 		var build *build.Build
 		var tasks task.Tasks

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -695,7 +695,7 @@ func TestAddNewPatch(t *testing.T) {
 	assert.NotNil(dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
 
-	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, ref.Identifier, "")
+	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, &ref, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, "")
 	assert.NoError(err)
 	dbTasks, err := task.FindAll(db.Query(task.ByBuildId(dbBuild.Id)))
 	assert.NoError(err)
@@ -775,7 +775,7 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 	assert.NotNil(dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
 
-	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, ref.Identifier, "")
+	_, err = addNewTasks(context.Background(), specificActivationInfo{}, v, proj, &ref, tasks, []build.Build{*dbBuild}, p.SyncAtEndOpts, "")
 	assert.NoError(err)
 	dbTasks, err := task.FindAll(db.Query(task.ByBuildId(dbBuild.Id)))
 	assert.NoError(err)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -194,7 +194,7 @@ type TimeInfo struct {
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (i TimeInfo) IsZero() bool {
-	return i.Initializing.IsZero() && i.Starting.IsZero() && i.LastCommunicated.IsZero()
+	return i == TimeInfo{}
 }
 
 // ResourceInfo represents information about external resources associated with
@@ -284,6 +284,9 @@ const (
 	OSWindows OS = "windows"
 )
 
+// validOperatingSystems contains all the recognized pod operating systems.
+var validOperatingSystems = []OS{OSLinux, OSWindows}
+
 // Validate checks that the pod OS is recognized.
 func (os OS) Validate() error {
 	switch os {
@@ -294,13 +297,28 @@ func (os OS) Validate() error {
 	}
 }
 
+// ImportOS converts the container OS into its equivalent pod OS.
+func ImportOS(os evergreen.ContainerOS) (OS, error) {
+	switch os {
+	case evergreen.LinuxOS:
+		return OSLinux, nil
+	case evergreen.WindowsOS:
+		return OSWindows, nil
+	default:
+		return "", errors.Errorf("unrecognized OS '%s'", os)
+	}
+}
+
 // Arch represents recognized architectures for pods.
 type Arch string
 
 const (
-	ArchAMD64 = "amd64"
-	ArchARM64 = "arm64"
+	ArchAMD64 Arch = "amd64"
+	ArchARM64 Arch = "arm64"
 )
+
+// validArchitectures contains all the recognized pod CPU architectures.
+var validArchitectures = []Arch{ArchAMD64, ArchARM64}
 
 // Validate checks that the pod architecture is recognized.
 func (a Arch) Validate() error {
@@ -312,8 +330,21 @@ func (a Arch) Validate() error {
 	}
 }
 
-// WindowsVersion represents specific version of Windows that a pod is allowed
-// to run on.
+// ImportArch converts the container CPU architecture into its equivalent pod
+// CPU architecture.
+func ImportArch(arch evergreen.ContainerArch) (Arch, error) {
+	switch arch {
+	case evergreen.ArchAMD64:
+		return ArchAMD64, nil
+	case evergreen.ArchARM64:
+		return ArchARM64, nil
+	default:
+		return "", errors.Errorf("unrecognized CPU architecture '%s'", arch)
+	}
+}
+
+// WindowsVersion represents a specific version of Windows that a pod is allowed
+// to run on. This only applies to pods running Windows containers.
 type WindowsVersion string
 
 const (
@@ -328,6 +359,9 @@ const (
 	WindowsVersionServer2022 WindowsVersion = "SERVER_2022"
 )
 
+// validWindowsVersions contains all the recognized pod Windows versions.
+var validWindowsVersions = []WindowsVersion{WindowsVersionServer2016, WindowsVersionServer2019, WindowsVersionServer2022}
+
 // Validate checks that the pod Windows version is recognized.
 func (v WindowsVersion) Validate() error {
 	switch v {
@@ -338,10 +372,25 @@ func (v WindowsVersion) Validate() error {
 	}
 }
 
+// ImportWindowsVersion converts the container Windows version into its
+// equivalent pod Windows version.
+func ImportWindowsVersion(winVer evergreen.WindowsVersion) (WindowsVersion, error) {
+	switch winVer {
+	case evergreen.Windows2016:
+		return WindowsVersionServer2016, nil
+	case evergreen.Windows2019:
+		return WindowsVersionServer2019, nil
+	case evergreen.Windows2022:
+		return WindowsVersionServer2022, nil
+	default:
+		return "", errors.Errorf("unrecognized Windows version '%s'", winVer)
+	}
+}
+
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (o TaskContainerCreationOptions) IsZero() bool {
-	return o.Image == "" && o.MemoryMB == 0 && o.CPU == 0 && o.OS == "" && o.Arch == "" && len(o.EnvVars) == 0 && len(o.EnvSecrets) == 0
+	return o.MemoryMB == 0 && o.CPU == 0 && o.OS == "" && o.Arch == "" && o.WindowsVersion == "" && o.Image == "" && o.RepoUsername == "" && o.RepoPassword == "" && o.WorkingDir == "" && len(o.EnvVars) == 0 && len(o.EnvSecrets) == 0
 }
 
 // Secret is a sensitive secret that a pod can access. The secret is managed
@@ -368,7 +417,7 @@ type Secret struct {
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
 // zero value for BSON marshalling.
 func (s Secret) IsZero() bool {
-	return s.Name == "" && s.ExternalID == "" && s.Value == "" && s.Exists == nil && s.Owned == nil
+	return s == Secret{}
 }
 
 // Insert inserts a new pod into the collection. This relies on the global Anser

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -17,6 +18,108 @@ import (
 
 func init() {
 	testutil.Setup()
+}
+
+func TestOSValidate(t *testing.T) {
+	t.Run("SucceedsForValidOperatingSystems", func(t *testing.T) {
+		for _, os := range validOperatingSystems {
+			assert.NoError(t, os.Validate())
+		}
+	})
+	t.Run("FailsWithInvalidOperatingSystem", func(t *testing.T) {
+		assert.Error(t, OS("invalid").Validate())
+	})
+	t.Run("FailsWithEmptyOperatingSystem", func(t *testing.T) {
+		assert.Error(t, OS("").Validate())
+	})
+}
+
+func TestImportOS(t *testing.T) {
+	t.Run("SucceedsForValidContainerOperatingSystems", func(t *testing.T) {
+		for _, os := range evergreen.ValidContainerOperatingSystems {
+			imported, err := ImportOS(os)
+			require.NoError(t, err)
+			assert.NotZero(t, imported)
+		}
+	})
+	t.Run("FailsWithInvalidContainerOperatingSystem", func(t *testing.T) {
+		imported, err := ImportOS(evergreen.ContainerOS("invalid"))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
+	t.Run("FailsWithEmptyOperatingSystem", func(t *testing.T) {
+		imported, err := ImportOS(evergreen.ContainerOS(""))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
+}
+
+func TestArchValidate(t *testing.T) {
+	t.Run("SucceedsForValidArchitectures", func(t *testing.T) {
+		for _, arch := range validArchitectures {
+			assert.NoError(t, arch.Validate())
+		}
+	})
+	t.Run("FailsWithInvalidArchitecture", func(t *testing.T) {
+		assert.Error(t, Arch("invalid").Validate())
+	})
+	t.Run("FailsWithEmptyArchitecture", func(t *testing.T) {
+		assert.Error(t, Arch("").Validate())
+	})
+}
+
+func TestImportArch(t *testing.T) {
+	t.Run("SucceedsForValidContainerArchitecture", func(t *testing.T) {
+		for _, arch := range evergreen.ValidContainerArchitectures {
+			imported, err := ImportArch(arch)
+			require.NoError(t, err)
+			assert.NotZero(t, imported)
+		}
+	})
+	t.Run("FailsWithInvalidContainerArchitecture", func(t *testing.T) {
+		imported, err := ImportArch(evergreen.ContainerArch("invalid"))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
+	t.Run("FailsWithEmptyArchitecture", func(t *testing.T) {
+		imported, err := ImportArch(evergreen.ContainerArch(""))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
+}
+
+func TestWindowsVersionValidate(t *testing.T) {
+	t.Run("SucceedsForValidWindowsVersions", func(t *testing.T) {
+		for _, winVer := range validWindowsVersions {
+			assert.NoError(t, winVer.Validate())
+		}
+	})
+	t.Run("FailsWithInvalidWindowsVersion", func(t *testing.T) {
+		assert.Error(t, WindowsVersion("invalid").Validate())
+	})
+	t.Run("FailsWithEmptyWindowsVersion", func(t *testing.T) {
+		assert.Error(t, WindowsVersion("").Validate())
+	})
+}
+
+func TestImportWindowsVersion(t *testing.T) {
+	t.Run("SucceedsWithValidContainerWindowsVersions", func(t *testing.T) {
+		for _, winVer := range evergreen.ValidWindowsVersions {
+			imported, err := ImportWindowsVersion(winVer)
+			require.NoError(t, err)
+			assert.NotZero(t, imported)
+		}
+	})
+	t.Run("FailsWithInvalidContainerWindowsVersion", func(t *testing.T) {
+		imported, err := ImportWindowsVersion(evergreen.WindowsVersion("invalid"))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
+	t.Run("FailsWithEmptyArchitecture", func(t *testing.T) {
+		imported, err := ImportWindowsVersion(evergreen.WindowsVersion(""))
+		assert.Error(t, err)
+		assert.Zero(t, imported)
+	})
 }
 
 func TestInsertAndFindOneByID(t *testing.T) {

--- a/model/project.go
+++ b/model/project.go
@@ -313,9 +313,9 @@ type Container struct {
 
 // ContainerSystem specifies the architecture and OS for the running container to use.
 type ContainerSystem struct {
-	CPUArchitecture evergreen.CPUArchitecture `yaml:"cpu_architecture,omitempty" bson:"cpu_architecture"`
-	OperatingSystem evergreen.ContainerOS     `yaml:"operating_system,omitempty" bson:"operating_system"`
-	WindowsVersion  evergreen.WindowsVersion  `yaml:"windows_version,omitempty" bson:"windows_version"`
+	CPUArchitecture evergreen.ContainerArch  `yaml:"cpu_architecture,omitempty" bson:"cpu_architecture"`
+	OperatingSystem evergreen.ContainerOS    `yaml:"operating_system,omitempty" bson:"operating_system"`
+	WindowsVersion  evergreen.WindowsVersion `yaml:"windows_version,omitempty" bson:"windows_version"`
 }
 
 type Module struct {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -108,7 +108,7 @@ type Task struct {
 	ContainerAllocated bool `bson:"container_allocated" json:"container_allocated"`
 
 	BuildId  string `bson:"build_id" json:"build_id"`
-	DistroId string `bson:"distro,omitempty" json:"distro"`
+	DistroId string `bson:"distro" json:"distro"`
 	// Container is the name of the container configuration for running a
 	// container task.
 	Container string `bson:"container,omitempty" json:"container,omitempty"`

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -108,7 +108,7 @@ type Task struct {
 	ContainerAllocated bool `bson:"container_allocated" json:"container_allocated"`
 
 	BuildId  string `bson:"build_id" json:"build_id"`
-	DistroId string `bson:"distro" json:"distro"`
+	DistroId string `bson:"distro,omitempty" json:"distro"`
 	// Container is the name of the container configuration for running a
 	// container task.
 	Container string `bson:"container,omitempty" json:"container,omitempty"`

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -107,14 +107,19 @@ type Task struct {
 	// container to run it. It only applies to tasks running in containers.
 	ContainerAllocated bool `bson:"container_allocated" json:"container_allocated"`
 
-	BuildId                 string       `bson:"build_id" json:"build_id"`
-	DistroId                string       `bson:"distro" json:"distro"`
-	Container               string       `bson:"container,omitempty" json:"container,omitempty"`
-	BuildVariant            string       `bson:"build_variant" json:"build_variant"`
-	BuildVariantDisplayName string       `bson:"build_variant_display_name" json:"-"`
-	DependsOn               []Dependency `bson:"depends_on" json:"depends_on"`
-	NumDependents           int          `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
-	OverrideDependencies    bool         `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
+	BuildId  string `bson:"build_id" json:"build_id"`
+	DistroId string `bson:"distro" json:"distro"`
+	// Container is the name of the container configuration for running a
+	// container task.
+	Container string `bson:"container,omitempty" json:"container,omitempty"`
+	// ContainerOpts contains the options to configure the container that will
+	// run the task.
+	ContainerOpts           ContainerOptions `bson:"container_options,omitempty" json:"container_options,omitempty"`
+	BuildVariant            string           `bson:"build_variant" json:"build_variant"`
+	BuildVariantDisplayName string           `bson:"build_variant_display_name" json:"-"`
+	DependsOn               []Dependency     `bson:"depends_on" json:"depends_on"`
+	NumDependents           int              `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
+	OverrideDependencies    bool             `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
 
 	// DistroAliases refer to the optional secondary distros that can be
 	// associated with a task. This is used for running tasks in case there are
@@ -241,6 +246,23 @@ const (
 	// ExecutionPlatformContainer indicates that the task runs in a container.
 	ExecutionPlatformContainer ExecutionPlatform = "container"
 )
+
+// ContainerOptions represent options to create the container to run a task.
+type ContainerOptions struct {
+	CPU            int
+	MemoryMB       int
+	WorkingDir     string
+	Image          string
+	OS             evergreen.ContainerOS
+	Arch           evergreen.ContainerArch
+	WindowsVersion evergreen.WindowsVersion
+}
+
+// IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
+// zero value for BSON marshalling.
+func (o ContainerOptions) IsZero() bool {
+	return o == ContainerOptions{}
+}
 
 func (t *Task) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(t) }
 func (t *Task) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, t) }

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1004,6 +1004,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}))
 		args := model.BuildCreateArgs{
 			Project:             *projectInfo.Project,
+			ProjectRef:          *projectInfo.Ref,
 			Version:             *v,
 			TaskIDs:             taskIds,
 			TaskNames:           taskNames,
@@ -1015,7 +1016,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			DistroAliases:       distroAliases,
 			TaskCreateTime:      v.CreateTime,
 			GithubChecksAliases: aliasesMatchingVariant,
-			ProjectIdentifier:   projectInfo.Ref.Identifier,
 		}
 
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(args)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -481,9 +481,15 @@ func validateProjectConfigAliases(pc *model.ProjectConfig) ValidationErrors {
 
 func validateProjectConfigContainers(pc *model.ProjectConfig) ValidationErrors {
 	errs := ValidationErrors{}
-	for _, containerResource := range pc.ContainerSizes {
-		err := containerResource.Validate()
-		if err != nil {
+	for name, containerResource := range pc.ContainerSizes {
+		if name == "" {
+			errs = append(errs, ValidationError{
+				Message: "container size name cannot be empty",
+				Level:   Error,
+			})
+		}
+
+		if err := containerResource.Validate(); err != nil {
 			errs = append(errs,
 				ValidationError{
 					Message: errors.Wrap(err, "error validating container resources").Error(),

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1646,6 +1646,55 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 	})
 }
 
+func TestValidateProjectConfigContainers(t *testing.T) {
+	t.Run("SucceedsWithValidContainers", func(t *testing.T) {
+		pc := model.ProjectConfig{
+			ProjectConfigFields: model.ProjectConfigFields{
+				ContainerSizes: map[string]model.ContainerResources{
+					"small": {
+						CPU:      128,
+						MemoryMB: 128,
+					},
+					"large": {
+						CPU:      2048,
+						MemoryMB: 2048,
+					},
+				},
+			},
+		}
+		errs := validateProjectConfigContainers(&pc)
+		assert.Empty(t, errs)
+	})
+	t.Run("FailsWithInvalidContainerResources", func(t *testing.T) {
+		pc := model.ProjectConfig{
+			ProjectConfigFields: model.ProjectConfigFields{
+				ContainerSizes: map[string]model.ContainerResources{
+					"invalid": {
+						CPU:      -10,
+						MemoryMB: -5,
+					},
+				},
+			},
+		}
+		errs := validateProjectConfigContainers(&pc)
+		assert.NotEmpty(t, errs)
+	})
+	t.Run("FailsWithUnnamedContainerSize", func(t *testing.T) {
+		pc := model.ProjectConfig{
+			ProjectConfigFields: model.ProjectConfigFields{
+				ContainerSizes: map[string]model.ContainerResources{
+					"": {
+						CPU:      128,
+						MemoryMB: 128,
+					},
+				},
+			},
+		}
+		errs := validateProjectConfigContainers(&pc)
+		assert.NotEmpty(t, errs)
+	})
+}
+
 func TestValidatePluginCommands(t *testing.T) {
 	Convey("When validating a project", t, func() {
 		Convey("an error should be thrown if a referenced plugin for a task does not exist", func() {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16371

### Description 
* Resolve the task's container config when creating the DB task. The container config cannot be changed once the task is created.
    * This is necessary to avoid some extra work later on. The container definitions only exist in the `model.Project` (the YAML model) and not in a DB model. Therefore, resolving the container options when creating the DB task avoids the need to re-read the whole YAML into a `model.Project` to get the container definitions in the pod lifecycle.
    * Resolving the container options at task creation time also has an implication for container sizes - since container sizes can be defined in the project ref, they can change dynamically. I decided that it's better to snapshot the container size at task creation time and disallow dynamically changing the task's container size after the task is already created (e.g. when restarting a task), since that would make the container parameters unstable across different executions. For example, if a user defined the task's container size as "small" with memoryMB=128 and cpu=128 in the project settings page, then ran a task with the "small" size, then updated the container size to be memoryMB=256 and cpu=256 on the project settings page, then restarted the task, the newer execution of the "small" task will still use the original "small" parameters (memoryMB=128 and cpu=128).
    * Plumb the project ref down to `createOneTask` to minimize the number of times we fetch the project ref. Doing this also removes some unnecessary re-fetching of the project ref in some of the task creation helper functions.
* Populate the intent pods using the task's container options.
* Add a small validation for the container size name to ensure it's non-empty.

### Testing 
Added unit tests for container task creation, the pod allocator, and project validation.