### PR TITLE
EVG-16713 refactor handling of nonexistent containers

### DIFF
--- a/cloud/cloud_status.go
+++ b/cloud/cloud_status.go
@@ -31,6 +31,9 @@ const (
 
 	// StatusTerminated indicates that the instance is deleted.
 	StatusTerminated
+
+	// StatusNonExistent indicates that the instance doesn't exist.
+	StatusNonExistent
 )
 
 func (stat CloudStatus) String() string {

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -142,6 +142,9 @@ func (m *dockerManager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cl
 		if client.IsErrConnectionFailed(err) {
 			return StatusTerminated, nil
 		}
+		if client.IsErrNotFound(err) {
+			return StatusNonExistent, nil
+		}
 		return StatusUnknown, errors.Wrapf(err, "Failed to get container information for host '%s'", h.Id)
 	}
 	return toEvgStatus(container.State), nil

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -427,8 +427,7 @@ func (c *dockerClientImpl) GetDockerStatus(ctx context.Context, containerID stri
 	}
 	container, err := c.GetContainer(ctx, parent, containerID)
 	if err != nil {
-		if strings.Contains(err.Error(), "No such container") ||
-			strings.Contains(err.Error(), "Is the docker daemon running?") {
+		if docker.IsErrNotFound(err) || docker.IsErrConnectionFailed(err) {
 			return &ContainerStatus{HasStarted: false}, nil
 		}
 		return nil, errors.Wrapf(err, "Error getting container %s", containerID)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1027,14 +1027,8 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 
 	instance, err := m.client.GetInstanceInfo(ctx, id)
 	if err != nil {
-		// terminate an unknown host in the db
 		if err == noReservationError {
-			grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is unknown to AWS"), message.Fields{
-				"message":       "can't mark instance as terminated",
-				"host_id":       h.Id,
-				"host_provider": h.Distro.Provider,
-				"distro":        h.Distro.Id,
-			}))
+			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting instance info",

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -237,10 +237,6 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	return statuses, nil
 }
 
-// ErrInstanceNotFound indicates that no matching instance could be found for a
-// particular host.
-var ErrInstanceNotFound = errors.New("no such instance")
-
 func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (CloudStatus, error) {
 	status := StatusUnknown
 
@@ -258,7 +254,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 			"distro":        h.Distro.Id,
 		}))
 		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
-			return status, ErrInstanceNotFound
+			return StatusNonExistent, nil
 		}
 		return status, errors.Wrap(err, "error getting instance info")
 	}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -141,7 +141,7 @@ clientsLoop:
 				j.AddError(errors.Wrapf(err, "error checking instance status of host %s", h.Id))
 				continue clientsLoop
 			}
-			if cloudStatus == cloud.StatusUnknown {
+			if cloudStatus == cloud.StatusNonExistent {
 				// Terminate unknown host in the DB.
 				grip.Error(message.WrapError(h.Terminate(evergreen.User, "host does not exist"), message.Fields{
 					"message":       "can't mark instance as terminated",

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -141,6 +141,16 @@ clientsLoop:
 				j.AddError(errors.Wrapf(err, "error checking instance status of host %s", h.Id))
 				continue clientsLoop
 			}
+			if cloudStatus == cloud.StatusUnknown {
+				// Terminate unknown host in the DB.
+				grip.Error(message.WrapError(h.Terminate(evergreen.User, "host does not exist"), message.Fields{
+					"message":       "can't mark instance as terminated",
+					"host_id":       h.Id,
+					"host_provider": h.Distro.Provider,
+					"distro":        h.Distro.Id,
+				}))
+				continue clientsLoop
+			}
 			j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, h, cloudStatus), "setting instance status for host '%s'", h.Id))
 		}
 	}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -356,7 +356,7 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 		}
 		return catcher.Resolve()
 	}
-	if cloudStatus == cloud.StatusUnknown {
+	if cloudStatus == cloud.StatusNonExistent {
 		return j.host.Terminate(evergreen.User, "cloud host does not exist")
 	}
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -134,13 +134,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	}
 
 	if err = j.host.DeleteJasperCredentials(ctx, j.env); err != nil {
-		j.AddError(err)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":  "problem deleting Jasper credentials",
-			"host_id":  j.host.Id,
-			"provider": j.host.Distro.Provider,
-			"job":      j.ID(),
-		}))
+		j.AddError(errors.Wrapf(err, "deleting Jasper credentials for host '%s'", j.host.Id))
 		return
 	}
 
@@ -161,14 +155,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	switch j.host.Status {
 	case evergreen.HostUninitialized, evergreen.HostBuildingFailed:
 		if err := j.host.Terminate(evergreen.User, j.TerminationReason); err != nil {
-			j.AddError(errors.Wrap(err, "terminating intent host in DB"))
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":  "problem terminating intent host in DB",
-				"host_id":  j.host.Id,
-				"provider": j.host.Distro.Provider,
-				"job_type": j.Type().Name,
-				"job":      j.ID(),
-			}))
+			j.AddError(errors.Wrapf(err, "terminating intent host '%s' in DB", j.host.Id))
 		}
 		return
 	case evergreen.HostTerminated:
@@ -283,14 +270,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		}
 		if parent == nil || parent.Status == evergreen.HostTerminated {
 			if err = j.host.Terminate(evergreen.User, "parent was already terminated"); err != nil {
-				j.AddError(errors.Wrap(err, "problem terminating container in db"))
-				grip.Error(message.WrapError(err, message.Fields{
-					"host_id":  j.host.Id,
-					"provider": j.host.Distro.Provider,
-					"job_type": j.Type().Name,
-					"job":      j.ID(),
-					"message":  "problem terminating container in db",
-				}))
+				j.AddError(errors.Wrapf(err, "terminating container '%s' in db", j.host.Id))
 			}
 			return
 		}
@@ -305,14 +285,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			if adb.ResultsNotFound(err) {
 				return
 			}
-			j.AddError(errors.Wrap(err, "problem terminating intent host in db"))
-			grip.Error(message.WrapError(err, message.Fields{
-				"host_id":  j.host.Id,
-				"provider": j.host.Distro.Provider,
-				"job_type": j.Type().Name,
-				"job":      j.ID(),
-				"message":  "problem terminating intent host in db",
-			}))
+			j.AddError(errors.Wrapf(err, "terminating intent host '%s' in db", j.host.Id))
 		}
 
 		return
@@ -325,13 +298,6 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 
 	if err := j.checkAndTerminateCloudHost(ctx, prevStatus); err != nil {
 		j.AddError(err)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":  "failed to check and terminate cloud host",
-			"host_id":  j.host.Id,
-			"provider": j.host.Distro.Provider,
-			"job_type": j.Type().Name,
-			"job":      j.ID(),
-		}))
 		return
 	}
 
@@ -382,9 +348,6 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 		if utility.IsContextError(errors.Cause(err)) {
 			return errors.Wrap(err, "checking cloud host status")
 		}
-		if err == cloud.ErrInstanceNotFound {
-			return j.host.Terminate(evergreen.User, "corresponding cloud host instance does not exist")
-		}
 
 		catcher := grip.NewBasicCatcher()
 		catcher.Add(errors.Wrap(err, "getting cloud host instance status"))
@@ -392,6 +355,9 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 			catcher.Wrap(j.host.Terminate(evergreen.User, "unable to get cloud status for host"), "marking host as terminated")
 		}
 		return catcher.Resolve()
+	}
+	if cloudStatus == cloud.StatusUnknown {
+		return j.host.Terminate(evergreen.User, "cloud host does not exist")
 	}
 
 	if cloudStatus == cloud.StatusTerminated {


### PR DESCRIPTION
[EVG-16713](https://jira.mongodb.org/browse/EVG-16713)

### Description 
Discovered two things in this ticket:
1) We double log everything that we both grip and add to the job's errors, so I reduced this so we only log once.
2) We have special handling for EC2 instances not being found, but not for docker. It's weird to do this for an interface also, since docker has errors formatted differently, so I thought a new status could make sense, and I looked at usages of GetInstanceStatus to verify terminations would still happen where needed. 

If this seems like an issue, I could change it to case on EC2 errors _or_ docker errors but I think it makes sense to move that logic out.

### Testing 
Not sure how to test besides putting in staging and doing some things and verifying no breakage.