### PR TITLE
EVG-16103 Remove "Heartbeat ticker canceled, aborting task" from agent logs

### DIFF
--- a/agent/background.go
+++ b/agent/background.go
@@ -50,7 +50,6 @@ func (a *Agent) startHeartbeat(ctx context.Context, cancel context.CancelFunc, t
 				return
 			}
 		case <-ctx.Done():
-			tc.logger.Task().Error("Heartbeat ticker canceled, aborting task")
 			heartbeat <- evergreen.TaskFailed
 			return
 		}

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-04-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-05-04b"
+	AgentVersion = "2022-05-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16103](https://jira.mongodb.org/browse/EVG-16103)

### Description 
Removing log statement that is running at the end of each task and brought up discussion in the [users channel](https://mongodb.slack.com/archives/C0V896UV8/p1651753009912469)