### PR TITLE
EVG-16040 Update test endpoint to return latest execution

### DIFF
--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -69,6 +69,8 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 				StatusCode: http.StatusBadRequest,
 			}
 		}
+	} else {
+		tgh.testExecution = projCtx.Task.Execution
 	}
 
 	if status := vals.Get("status"); status != "" {

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -31,6 +31,7 @@ type testGetHandler struct {
 	key           string
 	limit         int
 	sc            data.Connector
+	latest        bool
 }
 
 func makeFetchTestsForTask(sc data.Connector) gimlet.RouteHandler {
@@ -60,8 +61,15 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	var err error
 	vals := r.URL.Query()
 	execution := vals.Get("execution")
+	tgh.latest = vals.Get("latest") == "true"
 
 	if execution != "" {
+		if tgh.latest {
+			return gimlet.ErrorResponse{
+				Message:    "cannot specify both latest and execution",
+				StatusCode: http.StatusBadRequest,
+			}
+		}
 		tgh.testExecution, err = strconv.Atoi(execution)
 		if err != nil {
 			return gimlet.ErrorResponse{
@@ -69,7 +77,7 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 				StatusCode: http.StatusBadRequest,
 			}
 		}
-	} else {
+	} else if tgh.latest {
 		tgh.testExecution = projCtx.Task.Execution
 	}
 


### PR DESCRIPTION
[EVG-16040](https://jira.mongodb.org/browse/EVG-16040)

### Description 
adding latest=true will give the most recent execution and default behavior is not modified
only works if execution is not specified 

### Testing 
staging
![image](https://user-images.githubusercontent.com/26491602/167004418-98c403cb-dee2-401f-902c-63585a2f1bb4.png)

https://evergreen-staging.corp.mongodb.com/rest/v2/tasks/evg_race_detector_test_model_pod_4a1ed094bee959b235b34f3a2cffd71a43586e02_22_05_04_14_10_29/tests?latest=true