### PR TITLE
EVG-16749: Fix incorrect logic for fetching old execution tasks

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -948,15 +948,29 @@ func FindByExecutionTasksAndMaxExecution(taskIds []*string, execution int) ([]Ta
 			},
 		}
 		oldTaskPipeline = append(oldTaskPipeline, match)
+
+		// If there are multiple previous executions, matching on $lte will return duplicate tasks.
+		// We sort and group to find and return the old task with the most recent execution.
+		oldTaskPipeline = append(oldTaskPipeline, bson.M{
+			"$sort": bson.D{bson.E{Key: ExecutionKey, Value: -1}},
+		})
+		oldTaskPipeline = append(oldTaskPipeline, bson.M{
+			"$group": bson.M{
+				"_id":  "$" + OldTaskIdKey,
+				"root": bson.M{"$first": "$$ROOT"},
+			},
+		})
+		oldTaskPipeline = append(oldTaskPipeline, bson.M{"$replaceRoot": bson.M{"newRoot": "$root"}})
+
 		if err := db.Aggregate(OldCollection, oldTaskPipeline, &oldTasks); err != nil {
 			return nil, errors.Wrap(err, "finding old tasks")
 		}
-
 		result = append(result, oldTasks...)
 	}
 	if len(result) == 0 {
 		return nil, nil
 	}
+
 	return result, nil
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -949,8 +949,8 @@ func FindByExecutionTasksAndMaxExecution(taskIds []*string, execution int) ([]Ta
 		}
 		oldTaskPipeline = append(oldTaskPipeline, match)
 
-		// If there are multiple previous executions, matching on $lte will return duplicate tasks.
-		// We sort and group to find and return the old task with the most recent execution.
+		// If there are multiple previous executions, matching on non-zero executions with $lte will return
+		// duplicate tasks. We sort and group to find and return the old task with the most recent execution.
 		oldTaskPipeline = append(oldTaskPipeline, bson.M{
 			"$sort": bson.D{bson.E{Key: ExecutionKey, Value: -1}},
 		})

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3858,8 +3858,10 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		assertTasksAreEqual(t, t1, tasks[0], 2)
 		assertTasksAreEqual(t, t2, tasks[1], 1)
 	})
-	t.Run("Fetching older executions with same execution", func(t *testing.T) {
+	t.Run("Fetching old executions when there are even older executions", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(Collection, OldCollection))
+
+		// Both tasks have 2 previous executions.
 		t1 := Task{
 			Id:        "t1",
 			Version:   "v1",
@@ -3873,6 +3875,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot1 = *ot1.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot1))
 
+		ot1 = t1
 		ot1.Execution = 0
 		ot1 = *ot1.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot1))
@@ -3881,7 +3884,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 			Id:        "t2",
 			Version:   "v1",
 			Execution: 2,
-			Status:    evergreen.TaskSucceeded,
+			Status:    evergreen.TaskFailed,
 		}
 		assert.NoError(t, db.Insert(Collection, t2))
 
@@ -3890,6 +3893,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
 
+		ot2 = t2
 		ot2.Execution = 0
 		ot2 = *ot2.makeArchivedTask()
 		assert.NoError(t, db.Insert(OldCollection, ot2))
@@ -3898,57 +3902,9 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 		tasks = convertOldTasksIntoTasks(tasks)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(tasks))
-		assertTasksAreEqual(t, t1, tasks[0], 1)
-		assertTasksAreEqual(t, t2, tasks[1], 1)
-	})
-	t.Run("Fetching old executions when there are even older executions", func(t *testing.T) {
-		require.NoError(t, db.ClearCollections(Collection, OldCollection))
-
-		// Both tasks have two previous executions.
-		t1 := Task{
-			Id:        "t1",
-			Version:   "v1",
-			Execution: 2,
-			Status:    evergreen.TaskSucceeded,
-		}
-		assert.NoError(t, db.Insert(Collection, t1))
-
-		ot1_execution1 := t1
-		ot1_execution1.Execution = 1
-		ot1_execution1 = *ot1_execution1.makeArchivedTask()
-		assert.NoError(t, db.Insert(OldCollection, ot1_execution1))
-
-		ot1_execution0 := t1
-		ot1_execution0.Execution = 0
-		ot1_execution0 = *ot1_execution0.makeArchivedTask()
-		assert.NoError(t, db.Insert(OldCollection, ot1_execution0))
-
-		t2 := Task{
-			Id:        "t2",
-			Version:   "v1",
-			Execution: 2,
-			Status:    evergreen.TaskSucceeded,
-		}
-		assert.NoError(t, db.Insert(Collection, t2))
-
-		ot2_execution1 := t2
-		ot2_execution1.Execution = 1
-		ot2_execution1 = *ot2_execution1.makeArchivedTask()
-		assert.NoError(t, db.Insert(OldCollection, ot2_execution1))
-
-		ot2_execution0 := t2
-		ot2_execution0.Execution = 0
-		ot2_execution0 = *ot2_execution0.makeArchivedTask()
-		assert.NoError(t, db.Insert(OldCollection, ot2_execution0))
-
-		tasks, err := FindByExecutionTasksAndMaxExecution(tasksToFetch, 1)
-		tasks = convertOldTasksIntoTasks(tasks)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, len(tasks))
 		assert.Equal(t, tasks[0].Execution, 1)
 		assert.Equal(t, tasks[1].Execution, 1)
 	})
-
 }
 
 type TaskConnectorFetchByIdSuite struct {


### PR DESCRIPTION
[EVG-16749](https://jira.mongodb.org/browse/EVG-16749)

### Description 
This PR fixes an issue where the execution tasks were being returned incorrectly. You can see in the video below that when I go through different executions in this [version](https://spruce.mongodb.com/task/mongodb_mongo_v4.4_windows_display_multiversion_319d8d8145fb5893ab3bf5d077730226f3f2af7c_22_04_06_18_31_56/execution-tasks?execution=0&sortBy=STATUS&sortDir=ASC&sorts=STATUS%3AASC), I start getting multiple copies of the execution tasks (there should only ever be four). 

https://user-images.githubusercontent.com/47064971/167049541-b0c120ed-b52e-442d-b8c5-dd1cd2fcd966.mov

The reason this happens is that there is an error in the query for fetching execution tasks. Specifically, the problem comes from the fact that we find old tasks by matching on `{ execution: { $lte: specified_execution } }`.

In the video above there are three executions of the task, which means there is one task in the `Tasks` collection, and two older tasks in the `OldTasks` collection. If we want execution 2, then we'll need to query the `OldTasks` collection, but since we get all executions _less than or equal to_ execution 2, we'll end up also getting the tasks from execution 1. That's why the duplicates appear.

Since we only want one copy of each execution task, I modified the pipeline so that we return the task with the most recent execution.

### Testing 
- Added test for untested case in `TestByExecutionTasksAndMaxExecution`
- Checked functionality on staging
