### PR TITLE
EVG-12923 block task group tasks before clearing host's running task

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -180,8 +180,8 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
-	// Call before MarkEnd so the version is marked finished when this is the last task in the version
-	// to finish, and before clearing the running host so later tasks in the group aren't picked up by the host.
+	// Call before MarkEnd so the version is marked finished when this is the last task in the version to finish,
+	// and before clearing the running task from the host so later tasks in the group aren't picked up by the host.
 	if t.IsPartOfSingleHostTaskGroup() && details.Status != evergreen.TaskSucceeded {
 		// BlockTaskGroups is a recursive operation, which
 		// includes updating a large number of task

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -179,7 +179,26 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// clear the running task on the host startPhaseAt that the task has finished
+	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
+	// Call before MarkEnd so the version is marked finished when this is the last task in the version
+	// to finish, and before clearing the running host so later tasks in the group aren't picked up by the host.
+	if t.IsPartOfSingleHostTaskGroup() && details.Status != evergreen.TaskSucceeded {
+		// BlockTaskGroups is a recursive operation, which
+		// includes updating a large number of task
+		// documents.
+		if err := model.BlockTaskGroupTasks(t.Id); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "problem blocking task group tasks",
+				"task_id": t.Id,
+			}))
+		}
+		grip.Debug(message.Fields{
+			"message": "blocked task group tasks for task",
+			"task_id": t.Id,
+		})
+	}
+
+	// Clear the running task on the host now that the task has finished.
 	if err := currentHost.ClearRunningAndSetLastTask(t); err != nil {
 		err = errors.Wrapf(err, "error clearing running task %s for host %s", t.Id, currentHost.Id)
 		grip.Errorf(err.Error())
@@ -194,25 +213,6 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	if projectRef == nil {
 		as.LoggedError(w, r, http.StatusNotFound, fmt.Errorf("empty projectRef for task"))
 		return
-	}
-
-	// For a single-host task group, if a task fails, block and dequeue later tasks in that group.
-	// Call before MarkEnd so the version is marked finished when this is the last task in the version
-	// to finish
-	if t.IsPartOfSingleHostTaskGroup() && details.Status != evergreen.TaskSucceeded {
-		// BlockTaskGroups is a recursive operation, which
-		// includes updating a large number of task
-		// documents.
-		if err = model.BlockTaskGroupTasks(t.Id); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "problem blocking task group tasks",
-				"task_id": t.Id,
-			}))
-		}
-		grip.Debug(message.Fields{
-			"message": "blocked task group tasks for task",
-			"task_id": t.Id,
-		})
 	}
 
 	// mark task as finished


### PR DESCRIPTION
[EVG-12923](https://jira.mongodb.org/browse/EVG-12923)

### Description 
Found this bug through investigating [these logs](https://mongodb.splunkcloud.com/en-US/app/search/search?s=%2FservicesNS%2Fannie.black%2Fsearch%2Fsaved%2Fsearches%2Funblocked%2520dependencies%2520that%2520aren%2527t%2520re-blocked&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&q=search%20index%3Devergreen%20%22message%22%3D%22unblocked%20dependent%20tasks%22%20%22ticket%22%3D%20%22EVG-12923%22&earliest=1651723200&latest=1651896000&sid=1651846628.1336415). If a single host task group task fails, we block all subsequent tasks in the group. However, we clear the host's running task first, so it sometimes picks up the later task group task before it's actually marked as blocked. We should add these dependencies before allowing the host to pick up a new task.

