### PR TITLE
EVG-16803: log statistics for container task pipeline performance

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
@@ -51,6 +53,7 @@ func (q *ContainerTaskQueue) Len() int {
 }
 
 func (q *ContainerTaskQueue) populate() error {
+	startAt := time.Now()
 	candidates, err := task.FindNeedsContainerAllocation()
 	if err != nil {
 		return errors.Wrap(err, "finding candidate container tasks for allocation")
@@ -60,6 +63,13 @@ func (q *ContainerTaskQueue) populate() error {
 	if err != nil {
 		return errors.Wrap(err, "filtering candidate container tasks for allocation by project ref settings")
 	}
+
+	grip.Info(message.Fields{
+		"message":    "generated container task queue",
+		"candidates": len(candidates),
+		"queue":      len(readyForAllocation),
+		"duration":   time.Since(startAt),
+	})
 
 	q.queue = readyForAllocation
 

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -35,6 +35,7 @@ var (
 	TimeInfoInitializingKey     = bsonutil.MustHaveTag(TimeInfo{}, "Initializing")
 	TimeInfoStartingKey         = bsonutil.MustHaveTag(TimeInfo{}, "Starting")
 	TimeInfoLastCommunicatedKey = bsonutil.MustHaveTag(TimeInfo{}, "LastCommunicated")
+	TimeInfoAgentStartedKey     = bsonutil.MustHaveTag(TimeInfo{}, "AgentStarted")
 
 	ResourceInfoExternalIDKey   = bsonutil.MustHaveTag(ResourceInfo{}, "ExternalID")
 	ResourceInfoDefinitionIDKey = bsonutil.MustHaveTag(ResourceInfo{}, "DefinitionID")

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -74,6 +74,17 @@ func FindOneByGroupID(groupID string) (*PodDispatcher, error) {
 	return FindOne(db.Query(ByGroupID(groupID)))
 }
 
+// FindOneByPodID finds the dispatcher that manages the given pod by ID.
+func FindOneByPodID(podID string) (*PodDispatcher, error) {
+	return FindOne(db.Query(byPodID(podID)))
+}
+
+func byPodID(podID string) bson.M {
+	return bson.M{
+		PodIDsKey: podID,
+	}
+}
+
 // Allocate sets up the given intent pod to the given task for dispatching.
 func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *pod.Pod) (*PodDispatcher, error) {
 	mongoClient := env.Client()

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"context"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -144,6 +145,15 @@ func (pd *PodDispatcher) AssignNextTask(ctx context.Context, env evergreen.Envir
 				return nil, errors.Wrap(err, "updating parent display task")
 			}
 		}
+
+		grip.Info(message.Fields{
+			"message":                    "successfully dispatched task to pod",
+			"task":                       t.Id,
+			"pod":                        p.ID,
+			"secs_since_task_activation": time.Since(t.ActivatedTime).Seconds(),
+			"secs_since_pod_allocation":  time.Since(p.TimeInfo.Initializing).Seconds(),
+			"secs_since_pod_creation":    time.Since(p.TimeInfo.Starting).Seconds(),
+		})
 
 		return t, nil
 	}

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -477,3 +477,47 @@ func TestSetRunningTask(t *testing.T) {
 		})
 	}
 }
+
+func TestSetAgentStartTime(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
+			require.NoError(t, p.Insert())
+			require.NoError(t, p.SetAgentStartTime())
+
+			dbPod, err := FindOneByID(p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.NotZero(t, dbPod.TimeInfo.AgentStarted)
+			assert.Equal(t, p.TimeInfo.AgentStarted, dbPod.TimeInfo.AgentStarted)
+		},
+		"FailsWithNonexistentPod": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
+			assert.Error(t, p.SetAgentStartTime())
+
+			dbPod, err := FindOneByID(p.ID)
+			assert.NoError(t, err)
+			assert.Zero(t, dbPod)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+
+			require.NoError(t, db.ClearCollections(Collection))
+
+			p := Pod{
+				ID: "id",
+			}
+			tCase(tctx, t, env, p)
+		})
+	}
+}

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -13,6 +14,8 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -118,32 +121,16 @@ func (h *podAgentNextTask) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
-	p, err := pod.FindOneByID(h.podID)
+	p, err := h.findPod()
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "finding pod").Error(),
-		})
-	}
-	if p == nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("pod '%s' not found", h.podID),
-		})
+		return gimlet.MakeJSONErrorResponder(err)
 	}
 
-	pd, err := dispatcher.FindOneByPodID(h.podID)
+	h.setAgentFirstContactTime(p)
+
+	pd, err := h.findDispatcher()
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "finding dispatcher").Error(),
-		})
-	}
-	if pd == nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("dispatcher for pod '%s' not found", h.podID),
-		})
+		return gimlet.MakeJSONErrorResponder(err)
 	}
 
 	nextTask, err := pd.AssignNextTask(ctx, h.env, p)
@@ -164,4 +151,61 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return gimlet.NewJSONResponse(apimodels.NextTaskResponse{})
+}
+
+func (h *podAgentNextTask) findPod() (*pod.Pod, error) {
+	p, err := pod.FindOneByID(h.podID)
+	if err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "finding pod").Error(),
+		}
+	}
+	if p == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("pod '%s' not found", h.podID),
+		}
+	}
+
+	return p, nil
+}
+
+func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {
+	if !p.TimeInfo.Initializing.IsZero() {
+		return
+	}
+
+	if err := p.SetAgentStartTime(); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "could not update pod's agent first contact time",
+			"pod":     p.ID,
+		}))
+		return
+	}
+
+	grip.Info(message.Fields{
+		"message":                   "pod initiated first contact with application server",
+		"pod":                       p.ID,
+		"secs_since_pod_allocation": time.Since(p.TimeInfo.Initializing).Seconds(),
+		"secs_since_pod_creation":   time.Since(p.TimeInfo.Starting).Seconds(),
+	})
+}
+
+func (h *podAgentNextTask) findDispatcher() (*dispatcher.PodDispatcher, error) {
+	pd, err := dispatcher.FindOneByPodID(h.podID)
+	if err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "finding dispatcher").Error(),
+		}
+	}
+	if pd == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("dispatcher for pod '%s' not found", h.podID),
+		}
+	}
+
+	return pd, nil
 }

--- a/units/crons.go
+++ b/units/crons.go
@@ -1303,6 +1303,12 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 		if err != nil {
 			return errors.Wrap(err, "counting initializing pods")
 		}
+
+		grip.Info(message.Fields{
+			"message":          "tracking statistics for number of parallel pods being requested",
+			"num_initializing": numInitializing,
+		})
+
 		settings, err := evergreen.GetConfig()
 		if err != nil {
 			return errors.Wrap(err, "loading admin settings")

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -116,7 +116,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		"message":                    "successfully allocated pod for container task",
 		"task":                       j.task.Id,
 		"pod":                        intentPod.ID,
-		"time_since_task_activation": time.Since(j.task.ActivatedTime),
+		"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
 	})
 }
 

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -111,6 +111,13 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		j.AddRetryableError(errors.Wrap(err, "allocating pod for task dispatch"))
 		return
 	}
+
+	grip.Info(message.Fields{
+		"message":                    "successfully allocated pod for container task",
+		"task":                       j.task.Id,
+		"pod":                        intentPod.ID,
+		"time_since_task_activation": time.Since(j.task.ActivatedTime),
+	})
 }
 
 func (j *podAllocatorJob) canAllocate() (shouldAllocate bool, err error) {

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -212,7 +212,7 @@ func (j *podCreationJob) logTaskTimingStats() error {
 
 	if tsk != nil {
 		msg["is_for_task_group"] = false
-		msg["time_since_task_activation"] = time.Since(tsk.ActivatedTime)
+		msg["secs_since_task_activation"] = time.Since(tsk.ActivatedTime).Seconds()
 	} else {
 		// The dispatcher group will not be associated with a single task if
 		// it's a task group. Task groups don't have a single activation time,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16803

### Description 
I had to plug in the dispatcher to the pod next task route since it was necessary for logging. It doesn't actually make the agent run the task for now, but it does log that the necessary DB changes were made to indicate the task is considered dispatched.

We're most interested in timing how long each step takes from the moment the task starts waiting to run (when it's activated) to when it actually run. I changed it to log timing statistics when:
* Container task queue is generated.
* Pod allocation jobs are being enqueued (so we know how many parallel pod requests there are currently).
* Task is allocated a pod.
* Task's pod is actually requested from the cloud provider.
* Agent makes first contact with the app server.
* Task is dispatched to the agent.

### Testing 
Tested the new DB functions and updated pod next task tests.