### PR TITLE
EVG-16789 Use DisplayTaskId instead of DisplayTask.Id for task-end-stats

### DIFF
--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/utility"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -130,8 +131,8 @@ func (j *collectTaskEndDataJob) Run(ctx context.Context) {
 		"version":              j.task.Version,
 	}
 
-	if j.task.DisplayTask != nil {
-		msg["display_task_id"] = j.task.DisplayTask.Id
+	if utility.FromStringPtr(j.task.DisplayTaskId) != "" {
+		msg["display_task_id"] = j.task.DisplayTaskId
 	}
 
 	pRef, err := model.FindBranchProjectRef(j.task.Project)

--- a/units/stats_task_end.go
+++ b/units/stats_task_end.go
@@ -3,13 +3,13 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/utility"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"


### PR DESCRIPTION
[EVG-16789](https://jira.mongodb.org/browse/EVG-16789)

### Description 
task-end-stats were not properly logging out display task IDs as a part of the implementation done in https://jira.mongodb.org/browse/EVG-14823.  The log statement was referencing DisplayTask instead of DisplayTaskId on the passed in task.  Since the task end stats job re-retrieves the task from DB at runtime, DisplayTask will be nil because GetDisplayTask() only saves DisplayTaskId to DB.
### Testing 
Tested in staging