### PR TITLE
EVG-12923 consider in nextTask if a task is currently blocked

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -207,13 +207,13 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		if j.host.LastGroup != "" {
 			lastTask, err := task.FindOneId(j.host.LastTask)
 			if err != nil {
-				j.AddError(errors.Wrapf(err, "error finding last task '%s'", j.host.LastTask))
+				j.AddError(errors.Wrapf(err, "finding last task '%s'", j.host.LastTask))
 			}
 			// Only try to restart the task group if it was successful and should have continued executing.
 			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() && lastTask.Status == evergreen.TaskSucceeded {
 				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildId, lastTask.TaskGroup)
 				if err != nil {
-					j.AddError(errors.Wrapf(err, "can't get task group for task '%s'", lastTask.Id))
+					j.AddError(errors.Wrapf(err, "getting task group for task '%s'", lastTask.Id))
 					return
 				}
 				if len(tasks) == 0 {


### PR DESCRIPTION
[EVG-12923](https://jira.mongodb.org/browse/EVG-12923)

### Description 
Gave myself a headache reading through scheduler code to think through this:
I think blocking task group tasks isn't quite enough because we depend on the task queue to handle removing unattainable dependencies. However, we only refresh the task queue on hosts [every one minute](https://github.com/evergreen-ci/evergreen/blob/bbef382d237202a8074f0113bdf5214abb21c386/service/api.go#L60). So even later task group tasks are blocked and dequeued, this will only take affect for hosts [once they refresh their task queues](https://github.com/evergreen-ci/evergreen/blob/5e8f49dfb8a290050cdc226571c2a02922c7d367/model/task_queue.go#L753-L756). 



PS: I believe the reason regular tasks don't hit this is because they already _have_ the dependencies and so the dependencies not being finished is considered by the scheduler already, so this might again be fixed by https://jira.mongodb.org/browse/EVG-16826, although it isn't certain still if this can be done. 