### PR TITLE
EVG-16304 authorize dependabot patches

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	patchIntentJobName = "patch-intent-processor"
+	patchIntentJobName   = "patch-intent-processor"
+	githubDependabotUser = "dependabot[bot]"
 )
 
 func init() {
@@ -947,20 +948,34 @@ func (j *patchIntentProcessor) authAndFetchPRMergeBase(ctx context.Context, patc
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	isMember, err := thirdparty.GithubUserInOrganization(ctx, githubOauthToken, requiredOrganization, githubUser)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"job":          j.ID(),
-			"message":      "Failed to authenticate github PR",
-			"source":       "patch intents",
-			"creator":      githubUser,
-			"required_org": requiredOrganization,
-			"base_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
-			"head_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),
-			"pr_number":    patchDoc.GithubPatchData.PRNumber,
-		}))
-		return false, err
-
+	isMember := false
+	var err error
+	//
+	if githubUser == githubDependabotUser {
+		grip.Info(message.Fields{
+			"job":       j.ID(),
+			"message":   fmt.Sprintf("authorizing patch from %s", githubDependabotUser),
+			"source":    "patch intents",
+			"base_repo": fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
+			"head_repo": fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),
+			"pr_number": patchDoc.GithubPatchData.PRNumber,
+		})
+		isMember = true
+	} else {
+		isMember, err = thirdparty.GithubUserInOrganization(ctx, githubOauthToken, requiredOrganization, githubUser)
+		if err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"job":          j.ID(),
+				"message":      "Failed to authenticate github PR",
+				"source":       "patch intents",
+				"creator":      githubUser,
+				"required_org": requiredOrganization,
+				"base_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
+				"head_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),
+				"pr_number":    patchDoc.GithubPatchData.PRNumber,
+			}))
+			return false, err
+		}
 	}
 
 	hash, err := thirdparty.GetPullRequestMergeBase(ctx, githubOauthToken, patchDoc.GithubPatchData)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -950,7 +950,7 @@ func (j *patchIntentProcessor) authAndFetchPRMergeBase(ctx context.Context, patc
 
 	isMember := false
 	var err error
-	//
+	// Github Dependabot patches should be automatically authorized.
 	if githubUser == githubDependabotUser {
 		grip.Info(message.Fields{
 			"job":       j.ID(),


### PR DESCRIPTION
[EVG-16304 ](https://jira.mongodb.org/browse/EVG-16304 )

### Description 
Dependabot patches should be automatically authorized. I was torn about whether to make dependabot a constant, or have this be definable via admin settings. However, dependabot is something of a special case, and we aren't intending to allow any other non-members to be authorized, so I think making this an editable admin setting field would be misleading.

### Testing 
Don't have a good way to test this; may make an alert for myself on the new log message and will close when it triggers (i.e. the code is validated).