### PR TITLE
EVG-16818 Refactor aborted collective status

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -3937,43 +3937,13 @@ func (r *versionResolver) PreviousVersion(ctx context.Context, obj *restModel.AP
 }
 
 func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion) (string, error) {
-	status, err := evergreen.VersionStatusToPatchStatus(*obj.Status)
+	collectiveStatusArray, err := getCollectiveStatusArray(*obj)
 	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("An error occurred when converting a version status: %s", err.Error()))
-	}
-	isAborted := utility.FromBoolPtr(obj.Aborted)
-	nonAbortedStatuses := []string{}
-	if !isAborted {
-		nonAbortedStatuses = append(nonAbortedStatuses, status)
-	}
-	if evergreen.IsPatchRequester(*obj.Requester) {
-		p, err := data.FindPatchById(*obj.Id)
-		if err != nil {
-			return status, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch Patch %s: %s", *obj.Id, err.Error()))
-		}
-		if len(p.ChildPatches) > 0 {
-			for _, cp := range p.ChildPatches {
-				cpVersion, err := model.VersionFindOneId(*cp.Version)
-				if err != nil {
-					return "", InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch version for patch: %s ", err.Error()))
-				}
-				if cpVersion == nil {
-					continue
-				}
-				if cpVersion.Aborted {
-					isAborted = true
-				} else {
-					nonAbortedStatuses = append(nonAbortedStatuses, *cp.Status)
-				}
-			}
-			status = patch.GetCollectiveStatus(nonAbortedStatuses)
-		}
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("getting collective status array: %s", err.Error()))
 	}
 
-	// If theres an aborted task we should set the patch status to aborted if there are no other failures
-	if isAborted && !utility.StringSliceContains(nonAbortedStatuses, evergreen.PatchFailed) {
-		status = evergreen.PatchAborted
-	}
+	status := patch.GetCollectiveStatus(collectiveStatusArray)
+
 	return status, nil
 }
 

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -3,10 +3,18 @@ package graphql
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/user"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -46,4 +54,27 @@ func TestFilterGeneralSubscriptions(t *testing.T) {
 		filteredSubIDs := removeGeneralSubscriptions(usr, subs)
 		assert.ElementsMatch(t, []string{"123456"}, filteredSubIDs)
 	})
+}
+
+func TestCollectiveStatusArray(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(model.VersionCollection, patch.Collection))
+	patchId := bson.NewObjectId()
+	version := &restModel.APIVersion{
+		Id:        utility.ToStringPtr(patchId.Hex()),
+		Aborted:   utility.ToBoolPtr(true),
+		Status:    utility.ToStringPtr(evergreen.PatchFailed),
+		Requester: utility.ToStringPtr("patch_request"),
+	}
+
+	assert.NoError(t, db.Insert(model.VersionCollection, version))
+
+	p := &patch.Patch{
+		Id:     patchId,
+		Status: evergreen.PatchFailed,
+	}
+	require.NoError(t, p.Insert())
+
+	statusArray, err := getCollectiveStatusArray(*version)
+	require.NoError(t, err)
+	assert.Equal(t, evergreen.PatchAborted, statusArray[0])
 }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -1049,6 +1049,7 @@ func GetCollectiveStatus(statuses []string) string {
 	hasCreated := false
 	hasFailure := false
 	hasSuccess := false
+	hasAborted := false
 
 	for _, s := range statuses {
 		switch s {
@@ -1060,10 +1061,12 @@ func GetCollectiveStatus(statuses []string) string {
 			hasFailure = true
 		case evergreen.PatchSucceeded:
 			hasSuccess = true
+		case evergreen.PatchAborted:
+			hasAborted = true
 		}
 	}
 
-	if !(hasCreated || hasFailure || hasSuccess) {
+	if !(hasCreated || hasFailure || hasSuccess || hasAborted) {
 		grip.Critical(message.Fields{
 			"message":  "An unknown patch status was found",
 			"cause":    "Programmer error: new statuses should be added to patch.getCollectiveStatus().",
@@ -1077,6 +1080,8 @@ func GetCollectiveStatus(statuses []string) string {
 		return evergreen.PatchCreated
 	} else if hasFailure {
 		return evergreen.PatchFailed
+	} else if hasAborted {
+		return evergreen.PatchAborted
 	} else if hasSuccess {
 		return evergreen.PatchSucceeded
 	}


### PR DESCRIPTION
[EVG-16818](https://jira.mongodb.org/browse/EVG-16818)

### Description 
This refactors calculating collective statuses with aborted to avoid passing an empty array. 

### Testing 
Tested on staging and added a unit test
