### PR TITLE
EVG-16848 handle Github conflicts in more places

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -411,6 +411,8 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 	if p.Id == "" {
 		p.Id = mgobson.NewObjectId().Hex()
 	}
+	// Ensure that any new project is originally explicitly disabled.
+	p.Enabled = utility.FalsePtr()
 
 	// if a hidden project exists for this configuration, use that ID
 	if p.Owner != "" && p.Repo != "" && p.Branch != "" {
@@ -436,7 +438,7 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 	if err != nil {
 		return errors.Wrap(err, "inserting project ref")
 	}
-	return p.AddPermissions(creator)
+	return p.addPermissions(creator)
 }
 
 func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerDefinition, bool) {
@@ -486,30 +488,9 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 	return err
 }
 
-// AttachToRepo adds the branch to the relevant repo scopes, and updates the project to point to the repo.
-// Any values that previously were unset will now use the repo value.
-// If no repo ref currently exists, the user attaching it will be added as the repo ref admin.
-func (p *ProjectRef) AttachToRepo(u *user.DBUser) error {
-	before, err := GetProjectSettingsById(p.Id, false)
-	if err != nil {
-		return errors.Wrap(err, "getting before project settings event")
-	}
-	if err := p.AddToRepoScope(u); err != nil {
-		return err
-	}
-	err = db.UpdateId(ProjectRefCollection, p.Id, bson.M{
-		"$set": bson.M{
-			ProjectRefRepoRefIdKey: p.RepoRefId, // this is set locally in AddToRepoScope
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "attaching repo to scope")
-	}
-	return GetAndLogProjectModified(p.Id, u.Id, false, before)
-}
-
-// AddToRepoScope adds the branch to the unrestricted branches under repo scope, adds repo view permission for
-// branch admins, and adds branch edit access for repo admins.
+// AddToRepoScope validates that the branch can be attached to the matching repo,
+// adds the branch to the unrestricted branches under repo scope, and
+// adds repo view permission for branch admins, and adds branch edit access for repo admins.
 func (p *ProjectRef) AddToRepoScope(u *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
 	repoRef, err := FindRepoRefByOwnerAndRepo(p.Owner, p.Repo)
@@ -526,17 +507,17 @@ func (p *ProjectRef) AddToRepoScope(u *user.DBUser) error {
 		p.RepoRefId = repoRef.Id
 	}
 
-	// add the project to the repo admin scope
+	// Add the project to the repo admin scope.
 	if err := rm.AddResourceToScope(GetRepoAdminScope(p.RepoRefId), p.Id); err != nil {
 		return errors.Wrapf(err, "adding resource to repo '%s' admin scope", p.RepoRefId)
 	}
-	// only give branch admins view access if the repo isn't restricted
+	// Only give branch admins view access if the repo isn't restricted.
 	if !repoRef.IsRestricted() {
 		if err := addViewRepoPermissionsToBranchAdmins(p.RepoRefId, p.Admins); err != nil {
 			return errors.Wrapf(err, "giving branch '%s' admins view permission for repo '%s'", p.Id, p.RepoRefId)
 		}
 	}
-	// if the branch is unrestricted, add it to this scope so users who requested all-repo permissions have access
+	// If the branch is unrestricted, add it to this scope so users who requested all-repo permissions have access.
 	if !p.IsRestricted() {
 		if err := rm.AddResourceToScope(GetUnrestrictedBranchProjectsScope(p.RepoRefId), p.Id); err != nil {
 			return errors.Wrap(err, "adding resource to unrestricted branches scope")
@@ -635,6 +616,34 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 	return catcher.Resolve()
 }
 
+// AttachToRepo adds the branch to the relevant repo scopes, and updates the project to point to the repo.
+// Any values that previously were unset will now use the repo value, unless this would introduce
+// a Github project conflict. If no repo ref currently exists, the user attaching it will be added as the repo ref admin.
+func (p *ProjectRef) AttachToRepo(u *user.DBUser) error {
+	before, err := GetProjectSettingsById(p.Id, false)
+	if err != nil {
+		return errors.Wrap(err, "getting before project settings event")
+	}
+	if err := p.AddToRepoScope(u); err != nil {
+		return err
+	}
+	update := bson.M{
+		ProjectRefRepoRefIdKey: p.RepoRefId, // This is set locally in AddToRepoScope
+	}
+	update = p.addGithubConflictsToUpdate(update)
+	err = db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+		"$set": update,
+	})
+	if err != nil {
+		return errors.Wrap(err, "attaching repo to scope")
+	}
+
+	return GetAndLogProjectModified(p.Id, u.Id, false, before)
+}
+
+// AttachToNewRepo modifies the project's owner/repo, updates the old and new repo scopes (if relevant), and
+// updates the project to point to the new repo. Any Github project conflicts are disabled.
+// If no repo ref currently exists for the new repo, the user attaching it will be added as the repo ref admin.
 func (p *ProjectRef) AttachToNewRepo(u *user.DBUser) error {
 	before, err := GetProjectSettingsById(p.Id, false)
 	if err != nil {
@@ -654,17 +663,58 @@ func (p *ProjectRef) AttachToNewRepo(u *user.DBUser) error {
 			return errors.Wrap(err, "adding project to new repo scope")
 		}
 	}
+
 	update := bson.M{
-		"$set": bson.M{
-			ProjectRefOwnerKey:     p.Owner,
-			ProjectRefRepoKey:      p.Repo,
-			ProjectRefRepoRefIdKey: p.RepoRefId,
-		},
+		ProjectRefOwnerKey:     p.Owner,
+		ProjectRefRepoKey:      p.Repo,
+		ProjectRefRepoRefIdKey: p.RepoRefId,
 	}
-	if err := db.UpdateId(ProjectRefCollection, p.Id, update); err != nil {
+	update = p.addGithubConflictsToUpdate(update)
+	err = db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+		"$set": update,
+	})
+	if err != nil {
 		return errors.Wrap(err, "updating owner/repo in the DB")
 	}
 	return GetAndLogProjectModified(p.Id, u.Id, false, before)
+}
+
+// addGithubConflictsToUpdate turns off any settings that may introduce conflicts by
+// adding fields to the given update and returning them.
+func (p *ProjectRef) addGithubConflictsToUpdate(update bson.M) bson.M {
+	// If the project ref doesn't default to repo, will just return the original project.
+	mergedProject, err := GetProjectRefMergedWithRepo(*p)
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":            "unable to merge project with attached repo",
+			"project_id":         p.Id,
+			"project_identifier": p.Identifier,
+			"repo_id":            p.RepoRefId,
+		}))
+		return update
+	}
+	if mergedProject.IsEnabled() {
+		conflicts, err := mergedProject.GetGithubProjectConflicts()
+		if err != nil {
+			grip.Debug(message.WrapError(err, message.Fields{
+				"message":            "unable to get github project conflicts",
+				"project_id":         p.Id,
+				"project_identifier": p.Identifier,
+				"repo_id":            mergedProject.RepoRefId,
+			}))
+			return update
+		}
+		if len(conflicts.CommitQueueIdentifiers) > 0 {
+			update[bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey)] = false
+		}
+		if len(conflicts.CommitCheckIdentifiers) > 0 {
+			update[projectRefGithubChecksEnabledKey] = false
+		}
+		if len(conflicts.PRTestingIdentifiers) > 0 {
+			update[projectRefPRTestingEnabledKey] = false
+		}
+	}
+	return update
 }
 
 // RemoveFromRepoScope removes the branch from the unrestricted branches under repo scope, removes repo view permission
@@ -689,7 +739,9 @@ func (p *ProjectRef) RemoveFromRepoScope() error {
 	return nil
 }
 
-func (p *ProjectRef) AddPermissions(creator *user.DBUser) error {
+// addPermissions adds the project ref to the general scope (and repo scope if applicable) and
+// gives the inputted creator admin permissions.
+func (p *ProjectRef) addPermissions(creator *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
 	parentScope := evergreen.UnrestrictedProjectsScope
 	if p.IsRestricted() {
@@ -788,7 +840,7 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 		}
 		pRef, err = mergeBranchAndRepoSettings(pRef, repoRef)
 		if err != nil {
-			return nil, errors.Wrapf(err, "merging repo ref '%s' for project '%s'", repoRef.RepoRefId, pRef.Identifier)
+			return nil, errors.Wrapf(err, "merging repo ref '%s' for project '%s'", repoRef.RepoRefId, identifier)
 		}
 	}
 	if includeProjectConfig && pRef.IsVersionControlEnabled() {
@@ -800,30 +852,19 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 	return pRef, nil
 }
 
-// GetProjectRefMergedWithRepo merges the project with the repo that matches it, if one exists.
+// GetProjectRefMergedWithRepo merges the project with the repo, if one exists.
 // Otherwise, it will return the project as given.
 func GetProjectRefMergedWithRepo(pRef ProjectRef) (*ProjectRef, error) {
 	if !pRef.UseRepoSettings() {
 		return &pRef, nil
 	}
-	if pRef.RepoRefId != "" {
-		repoRef, err := FindOneRepoRef(pRef.RepoRefId)
-		if err != nil {
-			return nil, errors.Wrapf(err, "finding repo ref '%s'", pRef.RepoRefId)
-		}
-		if repoRef == nil {
-			return nil, errors.Errorf("repo ref '%s' does not exist", pRef.RepoRefId)
-		}
-		return mergeBranchAndRepoSettings(&pRef, repoRef)
-	}
-	repoRef, err := FindRepoRefByOwnerAndRepo(pRef.Owner, pRef.Repo)
+	repoRef, err := FindOneRepoRef(pRef.RepoRefId)
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding repo ref for repo '%s/%s'", pRef.Owner, pRef.Repo)
+		return nil, errors.Wrapf(err, "finding repo ref '%s'", pRef.RepoRefId)
 	}
 	if repoRef == nil {
-		return &pRef, nil
+		return nil, errors.Errorf("repo ref '%s' does not exist", pRef.RepoRefId)
 	}
-	pRef.RepoRefId = repoRef.Id
 	return mergeBranchAndRepoSettings(&pRef, repoRef)
 }
 
@@ -1994,8 +2035,8 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 	return defaultRes, nil
 }
 
-// GetGithubProjectConflicts returns any potential conflicts; i.e. regardless of whether or not p has something enabled,
-// returns the project identifiers that it _would_ conflict with if it did.
+// GetGithubProjectConflicts returns any potential conflicts; i.e. regardless of whether or not
+// p has something enabled, returns the project identifiers that it _would_ conflict with if it did.
 func (p *ProjectRef) GetGithubProjectConflicts() (GithubProjectConflicts, error) {
 	res := GithubProjectConflicts{}
 	// return early for projects that don't need to consider conflicts

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -41,7 +41,7 @@ func (r *RepoRef) Add(creator *user.DBUser) error {
 	if err != nil {
 		return errors.Wrap(err, "upserting repo ref")
 	}
-	return r.AddPermissions(creator)
+	return r.addPermissions(creator)
 }
 
 // Insert is included here so ProjectRef.Insert() isn't mistakenly used.
@@ -92,7 +92,9 @@ func FindRepoRefByOwnerAndRepo(owner, repoName string) (*RepoRef, error) {
 	}))
 }
 
-func (r *RepoRef) AddPermissions(creator *user.DBUser) error {
+// addPermissions adds the repo ref to the general scope and gives the inputted creator admin permissions
+// for the repo and branches, and gives branch admins permission to view the repo.
+func (r *RepoRef) addPermissions(creator *user.DBUser) error {
 	rm := evergreen.GetEnvironment().RoleManager()
 
 	adminScope := gimlet.Scope{
@@ -288,10 +290,12 @@ func GetRepoAdminScope(repoId string) string {
 	return fmt.Sprintf("admin_repo_%s", repoId)
 }
 
+// GetRepoAdminRole returns the repo admin role ID for the given repo.
 func GetRepoAdminRole(repoId string) string {
 	return fmt.Sprintf("admin_repo_%s", repoId)
 }
 
+// GetViewRepoRole returns the role ID to view the given repo.
 func GetViewRepoRole(repoId string) string {
 	return fmt.Sprintf("view_repo_%s", repoId)
 }

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -85,7 +85,6 @@ func CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProje
 // RepoRef related functions and collection instead of ProjectRef.
 func SaveProjectSettingsForSection(ctx context.Context, projectId string, changes *restModel.APIProjectSettings,
 	section model.ProjectPageSection, isRepo bool, userId string) (*restModel.APIProjectSettings, error) {
-	// TODO: this function should only be called after project setting changes have been validated in the resolver or by the front end
 	before, err := model.GetProjectSettingsById(projectId, isRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting before project settings event")
@@ -284,6 +283,7 @@ func handleIdentifierConflict(pRef *model.ProjectRef) error {
 	return nil
 }
 
+// handleGithubConflicts returns an error containing any potential Github project conflicts.
 func handleGithubConflicts(pRef *model.ProjectRef, reason string) error {
 	if !pRef.IsPRTestingEnabled() && !pRef.CommitQueue.IsEnabled() && !pRef.IsGithubChecksEnabled() {
 		return nil // if nothing is toggled on, then there's no reason to look for conflicts


### PR DESCRIPTION
[EVG-16848](https://jira.mongodb.org/browse/EVG-16848)

### Description 
We want to try to make sure that a project doesn't get attached or change owner/repo and suddenly introduce project conflicts on the UI that prevent the page from being usable, and makes it ambiguous in the backend which project is being used. 

I had this silently update conflicts. For AttachToRepo this definitely makes sense, since any new conflicts would be due to defaulting to repo, so explicitly setting to false is pretty much the same as what they had before. For AttachToNewRepo this may not be clear, however I don't anticipate this being used often (if at all) except to rename existing repos, and returning an error in the conflict case would require some refactoring and also may not be clear anyway. (I can change this if there are objections though.)

Also added comments and did some refactor tweaking while I was poking around.

### Testing 
Added to unit test.
