### PR TITLE
EVG-16863: populate host termination reason from note

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -105,9 +105,13 @@ func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue ambo
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}
 
+		reason := notes
+		if reason == "" {
+			reason = fmt.Sprintf("terminated by user '%s'", u.Username())
+		}
 		if err := amboy.EnqueueUniqueJob(ctx, queue, units.NewHostTerminationJob(env, h, units.HostTerminationOptions{
 			TerminateIfBusy:   true,
-			TerminationReason: fmt.Sprintf("terminated by %s", u.Username()),
+			TerminationReason: reason,
 		})); err != nil {
 			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
 		}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16863

### Description 
If the user terminates the host with a note from the host event page, the note should eventually show up in the event logs.

### Testing 
Didn't seem that critical enough to test, and I didn't feel like unit testing all this existing untested code.