### PR TITLE
EVG-16855 use correct task ID in new UI link

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -387,7 +387,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}
 	newUILink := ""
 	if len(uis.Settings.Ui.UIv2Url) > 0 {
-		newUILink = fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id)
+		newUILink = fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, tId)
 	}
 
 	if uiTask.AbortInfo.TaskID != "" {


### PR DESCRIPTION
[EVG-16855 ](https://jira.mongodb.org/browse/EVG-16855 )

### Description 
Evergreen should use the correct link for redirecting old executions.

### Testing
Tested locally that an old execution now opens in Spruce.