### PR TITLE
EVG-16831 activate dependencies for activated tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1750,7 +1750,9 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dependencies for activated tasks")
 	}
-	task.ActivateTasks(activatedTaskDependencies, time.Now(), true, evergreen.User)
+	if err = task.ActivateTasks(activatedTaskDependencies, time.Now(), true, evergreen.User); err != nil {
+		return nil, errors.Wrap(err, "activating existing dependencies for new tasks")
+	}
 
 	return activatedTaskIds, nil
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1675,6 +1675,7 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 	}
 
 	activatedTaskIds := []string{}
+	activatedTasks := []task.Task{}
 	for _, b := range existingBuilds {
 		wasActivated := b.Activated
 		// Find the set of task names that already exist for the given build
@@ -1682,15 +1683,10 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 		if err != nil {
 			return nil, err
 		}
-		// build an index to keep track of which tasks already exist, and their activation
-		type taskInfo struct {
-			id        string
-			activated bool
-		}
-		existingTasksIndex := map[string]taskInfo{}
+
+		existingTasksIndex := map[string]bool{}
 		for _, t := range tasksInBuild {
-			info := taskInfo{id: t.Id, activated: t.Activated}
-			existingTasksIndex[t.DisplayName] = info
+			existingTasksIndex[t.DisplayName] = true
 		}
 		projectBV := p.FindBuildVariant(b.BuildVariant)
 		if projectBV != nil {
@@ -1701,20 +1697,14 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 		// a record in the TVPairSet indicating that it should exist
 		tasksToAdd := []string{}
 		for _, taskname := range pairs.ExecTasks.TaskNames(b.BuildVariant) {
-			if info, ok := existingTasksIndex[taskname]; ok {
-				// if activating build, update task activation for dependencies that already exist, regardless of batchtime
-				if b.Activated && !info.activated {
-					if err = SetActiveStateById(info.id, evergreen.User, true); err != nil {
-						return nil, errors.Wrapf(err, "updating active state for existing task '%s'", info.id)
-					}
-				}
+			if ok := existingTasksIndex[taskname]; ok {
 				continue
 			}
 			tasksToAdd = append(tasksToAdd, taskname)
 		}
 		displayTasksToAdd := []string{}
 		for _, taskname := range pairs.DisplayTasks.TaskNames(b.BuildVariant) {
-			if _, ok := existingTasksIndex[taskname]; ok {
+			if ok := existingTasksIndex[taskname]; ok {
 				continue
 			}
 			displayTasksToAdd = append(displayTasksToAdd, taskname)
@@ -1732,6 +1722,7 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 		for _, t := range tasks {
 			if t.Activated {
 				activatedTaskIds = append(activatedTaskIds, t.Id)
+				activatedTasks = append(activatedTasks, *t)
 				b.Activated = true
 			}
 			if t.Activated && activationInfo.isStepbackTask(t.BuildVariant, t.DisplayName) {
@@ -1754,6 +1745,12 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 	if err = v.SetActivated(); err != nil {
 		return nil, errors.Wrap(err, "setting version activation to true")
 	}
+
+	activatedTaskDependencies, err := task.GetRecursiveDependenciesUp(activatedTasks, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting dependencies for activated tasks")
+	}
+	task.ActivateTasks(activatedTaskDependencies, time.Now(), true, evergreen.User)
 
 	return activatedTaskIds, nil
 }


### PR DESCRIPTION
[EVG-16831](https://jira.mongodb.org/browse/EVG-16831)

### Description 
[We intend](https://github.com/evergreen-ci/evergreen/pull/3896) that when a generated task is activated the tasks it depends on should also be activated. I think maybe later when we added [task level activation](https://github.com/evergreen-ci/evergreen/pull/4679) we didn't also update this logic. So currently if a generated task is `activate: false` but its build isn't its dependencies are still activated.

The changes here should activate just the dependencies for activated generated tasks.

### Testing 
I contrived a set of tasks on the sandbox project. [inactivated_task0](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu1604_inactivated_task0_patch_a2139a208d54a9a11b2911c72ba24d0bc438163a_627d7466b237364e8395eac5_22_05_12_20_56_11) is a dependency for an `activate: false`  generated task. Without the changes [it was was activated](https://spruce-staging.corp.mongodb.com/version/627d504597b1d3589b6c8b09/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and with the changes [it was not](https://spruce-staging.corp.mongodb.com/version/627d7466b237364e8395eac5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
