### PR TITLE
EVG-16918 Fix Build Variant display names not being resolved in HasMatchingTasks query.

### DIFF
--- a/graphql/tests/mainlineCommits/queries/variant-displayname.graphql
+++ b/graphql/tests/mainlineCommits/queries/variant-displayname.graphql
@@ -1,0 +1,23 @@
+{
+  mainlineCommits(options: { projectID: "evergreen" }, buildVariantOptions: {variants: ["Ubuntu 16.04"]}) {
+    versions {
+      version {
+        id
+        author
+        buildVariants(options: { variants: ["Ubuntu 16.04"]}) {
+          variant
+          displayName
+          tasks {
+            id
+            displayName
+            status
+          }
+        }
+      }
+      rolledUpVersions {
+        id
+        activated
+      }
+    }
+  }
+}

--- a/graphql/tests/mainlineCommits/results.json
+++ b/graphql/tests/mainlineCommits/results.json
@@ -601,6 +601,100 @@
                      }
                   }
       }
+      },
+      {
+         "query_file": "variant-displayname.graphql",
+                  "result": {
+            "data": {
+               "mainlineCommits": {
+                  "versions": [
+        {
+          "version": {
+            "id": "evergreen_version5",
+            "author": "mohamed.khelif",
+            "buildVariants": [
+              {
+                "variant": "enterprise-ubuntu1604-64",
+                "displayName": "Ubuntu 16.04",
+                "tasks": [
+                  {
+                    "id": "task_5",
+                    "displayName": "Some Other Task",
+                    "status": "success"
+                  }
+                ]
+              }
+            ]
+          },
+          "rolledUpVersions": null
+        },
+        {
+          "version": null,
+          "rolledUpVersions": [
+            {
+              "id": "evergreen_version4",
+              "activated": false
+            },
+            {
+              "id": "evergreen_version3",
+              "activated": false
+            }
+          ]
+        },
+        {
+          "version": {
+            "id": "evergreen_version2",
+            "author": "mohamed.khelif",
+            "buildVariants": [
+              {
+                "variant": "enterprise-ubuntu1604-64",
+                "displayName": "Ubuntu 16.04",
+                "tasks": [
+                  {
+                    "id": "task_4",
+                    "displayName": "Some Other Task",
+                    "status": "success"
+                  },
+                  {
+                    "id": "task_3",
+                    "displayName": "Some Task",
+                    "status": "failed"
+                  }
+                ]
+              }
+            ]
+          },
+          "rolledUpVersions": null
+        },
+        {
+          "version": {
+            "id": "evergreen_version1",
+            "author": "mohamed.khelif",
+            "buildVariants": [
+              {
+                "variant": "enterprise-ubuntu1604-64",
+                "displayName": "Ubuntu 16.04",
+                "tasks": [
+                  {
+                    "id": "task_2",
+                    "displayName": "Some Other Task",
+                    "status": "success"
+                  },
+                  {
+                    "id": "task_1",
+                    "displayName": "Some Task",
+                    "status": "success"
+                  }
+                ]
+              }
+            ]
+          },
+          "rolledUpVersions": null
+        }
+      ]
+               }
+            }
+            }
       }
    ]
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3708,9 +3708,10 @@ type HasMatchingTasksOptions struct {
 // HasMatchingTasks returns true if the version has tasks with the given statuses
 func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, error) {
 	options := GetTasksByVersionOptions{
-		TaskNames: opts.TaskNames,
-		Variants:  opts.Variants,
-		Statuses:  opts.Statuses,
+		TaskNames:                      opts.TaskNames,
+		Variants:                       opts.Variants,
+		Statuses:                       opts.Statuses,
+		IncludeBuildVariantDisplayName: true,
 	}
 	pipeline := getTasksByVersionPipeline(versionID, options)
 	pipeline = append(pipeline, bson.M{"$count": "count"})

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3748,9 +3748,10 @@ func TestHasMatchingTasks(t *testing.T) {
 		Status:       evergreen.TaskFailed,
 	}
 	// TODO: Reenable this test once https://jira.mongodb.org/browse/EVG-16918 is complete
-	// bv1 := BuildVariant{
-	// 	Name:        "bv1",
-	// 	DisplayName: "Build Variant 1",
+	// bv1 := build.Build{
+	// 	Id:           "bv1",
+	// 	BuildVariant: "bv1",
+	// 	DisplayName:  "Build Variant 1",
 	// }
 	t3 := Task{
 		Id:           "t3",
@@ -3766,9 +3767,10 @@ func TestHasMatchingTasks(t *testing.T) {
 		Execution:    1,
 		Status:       evergreen.TaskFailed,
 	}
-	// bv2 := BuildVariant{
-	// 	Name:        "bv2",
-	// 	DisplayName: "Build Variant 2",
+	// bv2 := build.Build{
+	// 	Id:           "bv2",
+	// 	BuildVariant: "bv2",
+	// 	DisplayName:  "Build Variant 2",
 	// }
 	t5 := Task{
 		Id:           "t5",
@@ -3784,9 +3786,10 @@ func TestHasMatchingTasks(t *testing.T) {
 		Execution:    2,
 		Status:       evergreen.TaskFailed,
 	}
-	// bv3 := BuildVariant{
-	// 	Name:        "bv3",
-	// 	DisplayName: "Build Variant 3",
+	// bv3 := build.Build{
+	// 	Id:           "bv3",
+	// 	BuildVariant: "bv3",
+	// 	DisplayName:  "Build Variant 3",
 	// }
 	// assert.NoError(t, db.InsertMany("build", bv1, bv2, bv3))
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4, t5, t6))

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3734,41 +3734,61 @@ func compareGroupedTaskStatusCounts(t *testing.T, expected, actual []*GroupedTas
 func TestHasMatchingTasks(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
 	t1 := Task{
-		Id:        "t1",
-		Version:   "v1",
-		Execution: 0,
-		Status:    evergreen.TaskSucceeded,
+		Id:           "t1",
+		Version:      "v1",
+		BuildVariant: "bv1",
+		Execution:    0,
+		Status:       evergreen.TaskSucceeded,
 	}
 	t2 := Task{
-		Id:        "t2",
-		Version:   "v1",
-		Execution: 0,
-		Status:    evergreen.TaskFailed,
+		Id:           "t2",
+		Version:      "v1",
+		BuildVariant: "bv1",
+		Execution:    0,
+		Status:       evergreen.TaskFailed,
 	}
+	// TODO: Reenable this test once https://jira.mongodb.org/browse/EVG-16918 is complete
+	// bv1 := BuildVariant{
+	// 	Name:        "bv1",
+	// 	DisplayName: "Build Variant 1",
+	// }
 	t3 := Task{
-		Id:        "t3",
-		Version:   "v1",
-		Execution: 1,
-		Status:    evergreen.TaskSucceeded,
+		Id:           "t3",
+		Version:      "v1",
+		BuildVariant: "bv2",
+		Execution:    1,
+		Status:       evergreen.TaskSucceeded,
 	}
 	t4 := Task{
-		Id:        "t4",
-		Version:   "v1",
-		Execution: 1,
-		Status:    evergreen.TaskFailed,
+		Id:           "t4",
+		Version:      "v1",
+		BuildVariant: "bv2",
+		Execution:    1,
+		Status:       evergreen.TaskFailed,
 	}
+	// bv2 := BuildVariant{
+	// 	Name:        "bv2",
+	// 	DisplayName: "Build Variant 2",
+	// }
 	t5 := Task{
-		Id:        "t5",
-		Version:   "v1",
-		Execution: 2,
-		Status:    evergreen.TaskStatusPending,
+		Id:           "t5",
+		Version:      "v1",
+		BuildVariant: "bv3",
+		Execution:    2,
+		Status:       evergreen.TaskStatusPending,
 	}
 	t6 := Task{
-		Id:        "t6",
-		Version:   "v1",
-		Execution: 2,
-		Status:    evergreen.TaskFailed,
+		Id:           "t6",
+		Version:      "v1",
+		BuildVariant: "bv3",
+		Execution:    2,
+		Status:       evergreen.TaskFailed,
 	}
+	// bv3 := BuildVariant{
+	// 	Name:        "bv3",
+	// 	DisplayName: "Build Variant 3",
+	// }
+	// assert.NoError(t, db.InsertMany("build", bv1, bv2, bv3))
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4, t5, t6))
 	opts := HasMatchingTasksOptions{
 		Statuses: []string{evergreen.TaskFailed},
@@ -3779,6 +3799,24 @@ func TestHasMatchingTasks(t *testing.T) {
 
 	opts.Statuses = []string{evergreen.TaskWillRun}
 
+	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	assert.NoError(t, err)
+	assert.False(t, hasMatchingTasks)
+
+	opts = HasMatchingTasksOptions{
+		Variants: []string{"bv1"},
+	}
+	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	assert.NoError(t, err)
+	assert.True(t, hasMatchingTasks)
+
+	// TODO: Reenable this test once https://jira.mongodb.org/browse/EVG-16918 is complete
+	// opts.Variants = []string{"Build Variant 2"}
+	// hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	// assert.NoError(t, err)
+	// assert.True(t, hasMatchingTasks)
+
+	opts.Variants = []string{"DNE"}
 	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
 	assert.NoError(t, err)
 	assert.False(t, hasMatchingTasks)


### PR DESCRIPTION
[EVG-16918>](https://jira.mongodb.org/browse/EVG-16918)

### Description 
Build Variant Display Names were not included in this query which broke matching on them.
### Testing 
Tested in staging.
I was unable to write a unit test for this function due to a dep cycle. But i wrote  a graphql test