### PR TITLE
EVG-16615 use most recent base revision for PRs

### DIFF
--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -141,6 +141,9 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy string, pr *github.Pull
 	if pr.Head.GetSHA() == "" {
 		return nil, errors.New("head hash must not be empty")
 	}
+	if pr.Base.GetSHA() == "" {
+		return nil, errors.New("base hash must not be empty")
+	}
 	if pr.GetTitle() == "" {
 		return nil, errors.New("PR title must not be empty")
 	}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -67,6 +67,9 @@ type githubIntent struct {
 	// commit.
 	HeadHash string `bson:"head_hash"`
 
+	// BaseHash is the base hash of the commit.
+	BaseHash string `bson:"base_hash"`
+
 	// Title is the title of the Github PR
 	Title string `bson:"Title"`
 
@@ -158,6 +161,7 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy string, pr *github.Pull
 		User:         patchOwner,
 		UID:          int(pr.User.GetID()),
 		HeadHash:     pr.Head.GetSHA(),
+		BaseHash:     pr.Base.GetSHA(),
 		Title:        pr.GetTitle(),
 		IntentType:   GithubIntentType,
 		PushedAt:     pr.Head.Repo.PushedAt.Time.UTC(),
@@ -254,6 +258,7 @@ func (g *githubIntent) NewPatch() *Patch {
 		Author:      evergreen.GithubPatchUser,
 		Status:      evergreen.PatchCreated,
 		CreateTime:  g.PushedAt,
+		Githash:     g.BaseHash,
 		GithubPatchData: thirdparty.GithubPatch{
 			PRNumber:   g.PRNumber,
 			BaseOwner:  baseRepo[0],

--- a/testutil/github.go
+++ b/testutil/github.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-github/v34/github"
 )
 
-func NewGithubPR(prNumber int, baseRepoName, headRepoName, headHash, user, title string) *github.PullRequest {
+func NewGithubPR(prNumber int, baseRepoName, baseHash, headRepoName, headHash, user, title string) *github.PullRequest {
 	return &github.PullRequest{
 		Title:  github.String(title),
 		Number: github.Int(prNumber),
@@ -19,6 +19,7 @@ func NewGithubPR(prNumber int, baseRepoName, headRepoName, headHash, user, title
 		},
 		Base: &github.PullRequestBranch{
 			Ref: github.String("main"),
+			SHA: github.String(baseHash),
 			Repo: &github.Repository{
 				FullName: github.String(baseRepoName),
 			},

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -166,7 +166,7 @@ func (s *githubStatusUpdateSuite) TestForDeleteFromCommitQueue() {
 
 func (s *githubStatusUpdateSuite) TestForProcessingError() {
 	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(448,
-		"evergreen-ci/evergreen", "tychoish/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "tychoish", "Title"))
+		"evergreen-ci/evergreen", "7c38f3f63c05675329518c148d3a176e1da6ec2d", "tychoish/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "tychoish", "Title"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -978,22 +978,25 @@ func (j *patchIntentProcessor) authAndFetchPRMergeBase(ctx context.Context, patc
 		}
 	}
 
-	hash, err := thirdparty.GetPullRequestMergeBase(ctx, githubOauthToken, patchDoc.GithubPatchData)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"job":          j.ID(),
-			"message":      "Failed to authenticate github PR",
-			"source":       "patch intents",
-			"creator":      githubUser,
-			"required_org": requiredOrganization,
-			"base_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
-			"head_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),
-			"pr_number":    patchDoc.GithubPatchData.PRNumber,
-		}))
-		return isMember, err
-	}
+	// Maintain for backwards compatibility; remove after deploy of EVG-16615.
+	if patchDoc.Githash == "" {
+		hash, err := thirdparty.GetPullRequestMergeBase(ctx, githubOauthToken, patchDoc.GithubPatchData)
+		if err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"job":          j.ID(),
+				"message":      "Failed to authenticate github PR",
+				"source":       "patch intents",
+				"creator":      githubUser,
+				"required_org": requiredOrganization,
+				"base_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
+				"head_repo":    fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),
+				"pr_number":    patchDoc.GithubPatchData.PRNumber,
+			}))
+			return isMember, err
+		}
 
-	patchDoc.Githash = hash
+		patchDoc.Githash = hash
+	}
 
 	return isMember, nil
 }

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -37,6 +37,7 @@ type PatchIntentUnitsSuite struct {
 	prNumber        int
 	user            string
 	hash            string
+	baseHash        string
 	diffURL         string
 	desc            string
 	project         string
@@ -141,6 +142,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 	s.prNumber = 5290
 	s.user = evergreen.GithubPatchUser
 	s.hash = "8b9b7ee42ef46d40e391910e3afd00e187a9dae8"
+	s.baseHash = "7c38f3f63c05675329518c148d3a176e1da6ec2d"
 	s.diffURL = "https://github.com/evergreen-ci/evergreen/pull/5290.diff"
 	s.githubPatchData = thirdparty.GithubPatch{
 		PRNumber:   448,
@@ -506,7 +508,7 @@ func (s *PatchIntentUnitsSuite) TestRunInDegradedModeWithGithubIntent() {
 	}
 	s.NoError(evergreen.SetServiceFlags(flags))
 
-	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.headRepo, s.hash, "tychoish", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.baseHash, s.headRepo, s.hash, "tychoish", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -537,7 +539,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	}
 	s.Require().NoError(evergreen.SetServiceFlags(flags))
 
-	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())


### PR DESCRIPTION
[EVG-16615 ](https://jira.mongodb.org/browse/EVG-16615 )

### Description 
Right now we purposefully use the first commit's base hash as the base commit. This seems really misleading since future commits can be rebased on a new HEAD, so their base commits should reflect that.

### Testing 
I created this PR: https://github.com/evergreen-ci/commit-queue-sandbox/pull/349
The 1st commit is a control; the base revision is correctly [a2139a208d](https://spruce-staging.corp.mongodb.com/version/sandbox_a2139a208d54a9a11b2911c72ba24d0bc438163a/tasks).
The second commit is without my changes; you can see that even though we've merged HEAD, the base revision doesn't change.
(The 3rd commit had a bug so skipping it)
The 4th commit is with my changes; now the base revision is correctly the new revision, [c4787485e2](https://spruce-staging.corp.mongodb.com/version/sandbox_c4787485e232c0696e773fb3ffb02fa878db9a19/tasks).
The last commit proves that, even though new commits have been merged, I haven't merged them into my branch so the base revision stays the same.