### PR TITLE
EVG-16930 Deprecate goreleaser

### DIFF
--- a/makefile
+++ b/makefile
@@ -188,7 +188,7 @@ coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).
 $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 	@touch $@
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 120 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1 && touch $@
+	@curl --retry 10 --retry-max-time 120 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1 && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	$(gobin) build -ldflags "-w" -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
[EVG-16930](https://jira.mongodb.org/browse/EVG-16930)

### Description 
install lint directly instead of using goreleaser 
will be making this change in these repos 
<img width="350" alt="image" src="https://user-images.githubusercontent.com/26491602/169395271-d4ec4718-ae56-44a1-973b-ddb904d91210.png">
<img width="318" alt="image" src="https://user-images.githubusercontent.com/26491602/169395298-360cd1db-a92f-4a0b-be9f-3c39938240c3.png">


### Testing 
https://spruce.mongodb.com/version/6286971132f4175495e7282e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC