### PR TITLE
EVG-16940 match on display status before aggregation lookup

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3897,6 +3897,14 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		// Add a field for the display status of each task
 		addDisplayStatus,
 	)
+	// Filter on the computed display status before continuing to add additional fields.
+	if len(opts.Statuses) > 0 {
+		pipeline = append(pipeline, bson.M{
+			"$match": bson.M{
+				DisplayStatusKey: bson.M{"$in": opts.Statuses},
+			},
+		})
+	}
 	if opts.IncludeBaseTasks {
 		baseCommitMatch := []bson.M{
 			{"$eq": []string{"$" + BuildVariantKey, "$$" + BuildVariantKey}},
@@ -3952,13 +3960,6 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	// Add the build variant display name to the returned subset of results if it wasn't added earlier
 	if len(opts.Variants) == 0 && opts.IncludeBuildVariantDisplayName {
 		pipeline = append(pipeline, AddBuildVariantDisplayName...)
-	}
-	if len(opts.Statuses) > 0 {
-		pipeline = append(pipeline, bson.M{
-			"$match": bson.M{
-				DisplayStatusKey: bson.M{"$in": opts.Statuses},
-			},
-		})
 	}
 
 	if opts.IncludeBaseTasks && len(opts.BaseStatuses) > 0 {


### PR DESCRIPTION
[EVG-16940](https://jira.mongodb.org/browse/EVG-16940)

### Description 
Came across his while looking at other things; we can match on display status after we calculate it so we don't need to include base tasks and other info for unneeded tasks.

### Testing 
Existing tests pass.