### PR TITLE
EVG-16679 validate new dependency graph

### DIFF
--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -69,16 +69,32 @@ func (t TaskNode) String() string {
 	return fmt.Sprintf("%s/%s", t.Variant, t.Name)
 }
 
+// VersionDependencyGraph finds all the tasks from the version given by versionID and constructs a DependencyGraph from them.
+func VersionDependencyGraph(versionID string, transposed bool) (DependencyGraph, error) {
+	tasks, err := FindWithFields(ByVersion(versionID), DependsOnKey, BuildVariantKey, DisplayNameKey)
+	if err != nil {
+		return DependencyGraph{}, errors.Wrapf(err, "getting tasks for version '%s'", versionID)
+	}
+
+	return taskDependencyGraph(tasks, transposed), nil
+}
+
+func taskDependencyGraph(tasks []Task, transposed bool) DependencyGraph {
+	g := NewDependencyGraph(transposed)
+	g.buildFromTasks(tasks)
+	return g
+}
+
 func (g *DependencyGraph) buildFromTasks(tasks []Task) {
 	taskIDToNode := make(map[string]TaskNode)
 	for _, task := range tasks {
-		tNode := task.toTaskNode()
+		tNode := task.ToTaskNode()
 		g.AddTaskNode(tNode)
 		taskIDToNode[task.Id] = tNode
 	}
 
 	for _, task := range tasks {
-		dependentTaskNode := task.toTaskNode()
+		dependentTaskNode := task.ToTaskNode()
 		for _, dep := range task.DependsOn {
 			dependedOnTaskNode := taskIDToNode[dep.TaskId]
 			g.AddEdge(dependentTaskNode, dependedOnTaskNode, dep.Status)
@@ -121,10 +137,10 @@ func (g *DependencyGraph) addEdgeToGraph(edge DependencyEdge) {
 	g.edgesToDependencies[edgeKey{from: edge.From, to: edge.To}] = edge
 }
 
-// edgesIntoTask returns all the edges that point to t.
+// EdgesIntoTask returns all the edges that point to t.
 // For a regular graph these edges are tasks that directly depend on t.
 // If the graph is transposed these edges are tasks t directly depends on.
-func (g *DependencyGraph) edgesIntoTask(t TaskNode) []DependencyEdge {
+func (g *DependencyGraph) EdgesIntoTask(t TaskNode) []DependencyEdge {
 	node := g.tasksToNodes[t]
 	if node == nil {
 		return nil

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -41,40 +41,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.toTaskNode())
-			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
 		}
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
-		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[0].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[0].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[2].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[2].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[2].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[2].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[3].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[3].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[3].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[3].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[3].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[3].ToTaskNode()}],
 		)
 	})
 
@@ -83,40 +83,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.toTaskNode())
-			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
 		}
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[0].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[0].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[2].toTaskNode(), To: tasks[1].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[2].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[2].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[2].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[3].toTaskNode(), To: tasks[1].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[3].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[3].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[3].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 	})
 }
@@ -166,9 +166,9 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
 		assert.Equal(t, 2, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 2)
 	})
 
@@ -178,7 +178,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -189,7 +189,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: TaskNode{ID: "t3"}})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: TaskNode{ID: "t3"}})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -200,11 +200,11 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode()})
 		assert.Equal(t, 3, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 3)
 	})
 }
@@ -219,19 +219,19 @@ func TestGetDependencyEdge(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("ExistingEdgeWithStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[1].toTaskNode(), tasks[2].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[1].ToTaskNode(), tasks[2].ToTaskNode())
 		require.NotNil(t, edge)
 		assert.Equal(t, evergreen.TaskSucceeded, edge.Status)
 	})
 
 	t.Run("ExistingEdgeNoStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[0].toTaskNode(), tasks[1].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[0].ToTaskNode(), tasks[1].ToTaskNode())
 		require.NotNil(t, edge)
 		assert.Empty(t, edge.Status)
 	})
 
 	t.Run("NonexistentEdge", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[2].toTaskNode(), tasks[0].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[2].ToTaskNode(), tasks[0].ToTaskNode())
 		assert.Nil(t, edge)
 	})
 }
@@ -244,8 +244,8 @@ func TestTasksDependingOnTask(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	assert.Empty(t, g.edgesIntoTask(tasks[0].toTaskNode()))
-	edges := g.edgesIntoTask(tasks[1].toTaskNode())
+	assert.Empty(t, g.EdgesIntoTask(tasks[0].ToTaskNode()))
+	edges := g.EdgesIntoTask(tasks[1].ToTaskNode())
 	require.Len(t, edges, 1)
 	assert.Equal(t, tasks[0].Id, edges[0].From.ID)
 }
@@ -261,18 +261,18 @@ func TestReachableFromNode(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	reachable := g.reachableFromNode(tasks[0].toTaskNode())
+	reachable := g.reachableFromNode(tasks[0].ToTaskNode())
 	assert.Len(t, reachable, 4)
-	assert.Contains(t, reachable, tasks[1].toTaskNode())
-	assert.Contains(t, reachable, tasks[2].toTaskNode())
-	assert.Contains(t, reachable, tasks[3].toTaskNode())
-	assert.Contains(t, reachable, tasks[4].toTaskNode())
+	assert.Contains(t, reachable, tasks[1].ToTaskNode())
+	assert.Contains(t, reachable, tasks[2].ToTaskNode())
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
+	assert.Contains(t, reachable, tasks[4].ToTaskNode())
 
-	reachable = g.reachableFromNode(tasks[1].toTaskNode())
+	reachable = g.reachableFromNode(tasks[1].ToTaskNode())
 	assert.Len(t, reachable, 1)
-	assert.Contains(t, reachable, tasks[3].toTaskNode())
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
 
-	reachable = g.reachableFromNode(tasks[3].toTaskNode())
+	reachable = g.reachableFromNode(tasks[3].ToTaskNode())
 	assert.Empty(t, reachable)
 }
 
@@ -367,14 +367,14 @@ func TestDepthFirstSearch(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("NilTraverseEdge", func(t *testing.T) {
-		assert.True(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[1].toTaskNode(), tasks[0].toTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[3].toTaskNode(), tasks[0].toTaskNode(), nil))
+		assert.True(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[1].ToTaskNode(), tasks[0].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[3].ToTaskNode(), tasks[0].ToTaskNode(), nil))
 	})
 
 	t.Run("TraversalBlockedAtNode", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
-			if edge.To == tasks[1].toTaskNode() {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
+			if edge.To == tasks[1].ToTaskNode() {
 				return false
 			}
 			return true
@@ -382,7 +382,7 @@ func TestDepthFirstSearch(t *testing.T) {
 	})
 
 	t.Run("TraversalBlockedAtEdge", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
 			if edge.Status == evergreen.TaskSucceeded {
 				return true
 			}
@@ -391,11 +391,11 @@ func TestDepthFirstSearch(t *testing.T) {
 	})
 
 	t.Run("StartMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].toTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].ToTaskNode(), nil))
 	})
 
 	t.Run("TargetMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), TaskNode{ID: "t4"}, nil))
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), TaskNode{ID: "t4"}, nil))
 	})
 }
 
@@ -412,9 +412,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("StableSortWithDependencies", func(t *testing.T) {
@@ -429,9 +429,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("Cycle", func(t *testing.T) {
@@ -446,7 +446,7 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 1)
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[0])
 	})
 
 	t.Run("EmptyGraph", func(t *testing.T) {

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -300,7 +300,8 @@ func TestCycles(t *testing.T) {
 		g := NewDependencyGraph(false)
 		g.buildFromTasks(tasks)
 
-		assert.Empty(t, g.Cycles())
+		cycles := g.Cycles()
+		assert.Len(t, cycles, 1)
 	})
 
 	t.Run("TwoConnectedCycles", func(t *testing.T) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3323,7 +3323,7 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	return FindAll(query)
 }
 
-func (t *Task) toTaskNode() TaskNode {
+func (t *Task) ToTaskNode() TaskNode {
 	return TaskNode{
 		Name:    t.DisplayName,
 		Variant: t.BuildVariant,

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -103,7 +104,7 @@ func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
 	shouldExit := false
 	if len(jobErrs) > 0 { // exit early if we know the error will keep recurring
 		jobErr := errors.New(strings.Join(jobErrs, ", "))
-		shouldExit = db.IsDocumentLimit(jobErr)
+		shouldExit = db.IsDocumentLimit(jobErr) || strings.Contains(jobErr.Error(), model.DependencyCycleError.Error())
 	}
 	return gimlet.NewJSONResponse(&apimodels.GeneratePollResponse{
 		Finished:   finished,

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -179,6 +179,11 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
+
+	if err := g.SimulateNewDependencyGraph(v, p, pref); err != nil {
+		return errors.Wrap(err, "simulating adding dependencies on generated tasks")
+	}
+
 	start = time.Now()
 
 	// Don't use the job's context, because it's better to finish than to exit early after a

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -143,9 +143,9 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if err != nil {
 		return errors.Wrap(err, "error merging generated projects")
 	}
-	start = time.Now()
-	g.TaskID = j.TaskID
+	g.Task = t
 
+	start = time.Now()
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
@@ -183,7 +183,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 
 	// Don't use the job's context, because it's better to finish than to exit early after a
 	// SIGTERM from a deploy. This should maybe be a context with timeout.
-	err = g.Save(context.Background(), p, pp, v, t)
+	err = g.Save(context.Background(), p, pp, v)
 
 	// If the version or parser project has changed there was a race. Another generator will try again.
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -180,9 +180,19 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"version":       t.Version,
 	})
 
+	start = time.Now()
 	if err := g.SimulateNewDependencyGraph(v, p, pref); err != nil {
 		return errors.Wrap(err, "simulating adding dependencies on generated tasks")
 	}
+	grip.Debug(message.Fields{
+		"message":       "generate.tasks timing",
+		"function":      "generate",
+		"operation":     "SimulateNewDependencyGraph",
+		"duration_secs": time.Since(start).Seconds(),
+		"task":          t.Id,
+		"job":           j.ID(),
+		"version":       t.Version,
+	})
 
 	start = time.Now()
 


### PR DESCRIPTION
[EVG-16679](https://jira.mongodb.org/browse/EVG-16679)

### Description 
This PR was what I originally had in mind for the DependencyGraph added in #5628. The idea is to be able to simulate the dependency graph before we actually add the new dependencies. If making the generator's dependencies depend on the generated tasks would create a dependency cycle the dependencies are not added and the generator fails.

If adding dependencies would create a cycle it's not going to change based on other generators so there's no point in retrying. The error string was added to the errors we check when deciding whether to exit immediately.

### Testing 
I created [a patch on staging](https://spruce-staging.corp.mongodb.com/version/6287f1149dbe323642ca0db2/tasks) where one generator (bad_generator) generates a task that creates a dependency cycle and another generator (good_generator) generates a task that does not create a dependency cycle. The bad_generator fails while the good_generator succeeds.