### PR TITLE
EVG-16693 Remove project param from delete CQ route

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-05-24"
+	ClientVersion = "2022-05-25"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-05-23"

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-04-20"
+	ClientVersion = "2022-05-24"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-05-23"

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/manifest"
-	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -1116,28 +1115,17 @@ func (c *communicatorImpl) GetCommitQueue(ctx context.Context, projectID string)
 }
 
 func (c *communicatorImpl) DeleteCommitQueueItem(ctx context.Context, item string) error {
-	// TODO (EVG-16693): doing a DB query on the Evergreen client side seems
-	// wrong.
-	requestedPatch, err := patch.FindOneId(item)
-	if err != nil {
-		return errors.Wrapf(err, "finding commit queue item '%s'", item)
-	}
-	if requestedPatch == nil {
-		return errors.New("commit queue item not found")
-	}
-	projectID := requestedPatch.Project
 	info := requestInfo{
 		method: http.MethodDelete,
-		path:   fmt.Sprintf("/commit_queue/%s/%s", projectID, item),
+		path:   fmt.Sprintf("/commit_queue/%s", item),
 	}
-
 	resp, err := c.request(ctx, info, "")
 	if err != nil {
-		return errors.Wrapf(err, "deleting item '%s' from commit queue for project '%s'", item, projectID)
+		return errors.Wrapf(err, "deleting item '%s' from commit queue", item)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		return utility.RespErrorf(resp, "deleting item '%s' from commit queue for project '%s'", item, projectID)
+		return utility.RespErrorf(resp, "deleting item '%s' from commit queue", item)
 	}
 
 	return nil

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -71,9 +71,15 @@ func (cq commitQueueDeleteItemHandler) Factory() gimlet.RouteHandler {
 
 func (cq *commitQueueDeleteItemHandler) Parse(ctx context.Context, r *http.Request) error {
 	vars := gimlet.GetVars(r)
-	cq.project = vars["project_id"]
 	cq.item = vars["item"]
-
+	requestedPatch, err := patch.FindOneId(cq.item)
+	if err != nil {
+		return errors.Wrapf(err, "finding commit queue item '%s'", cq.item)
+	}
+	if requestedPatch == nil {
+		return errors.New("commit queue item not found")
+	}
+	cq.project = requestedPatch.Project
 	return nil
 }
 

--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -71,7 +71,7 @@ func (cq commitQueueDeleteItemHandler) Factory() gimlet.RouteHandler {
 
 func (cq *commitQueueDeleteItemHandler) Parse(ctx context.Context, r *http.Request) error {
 	vars := gimlet.GetVars(r)
-	cq.item = vars["item"]
+	cq.item = vars["patch_id"]
 	requestedPatch, err := patch.FindOneId(cq.item)
 	if err != nil {
 		return errors.Wrapf(err, "finding commit queue item '%s'", cq.item)

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -120,7 +120,7 @@ func (s *CommitQueueSuite) TestDeleteItem() {
 	route.project = "not_here"
 	route.item = "2"
 	response = route.Run(ctx)
-	s.Equal(404, response.Status())
+	s.Equal(500, response.Status())
 }
 
 func (s *CommitQueueSuite) TestClearAll() {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -82,7 +82,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/builds/{build_id}/tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchTasksByBuild(opts.URL))
 	app.AddRoute("/builds/{build_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByBuild())
 	app.AddRoute("/commit_queue/{project_id}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetCommitQueueItems())
-	app.AddRoute("/commit_queue/{project_id}/{item}").Version(2).Delete().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(env))
+	app.AddRoute("/commit_queue/{item}").Version(2).Delete().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(env))
 	app.AddRoute("/commit_queue/{patch_id}").Version(2).Put().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeCommitQueueEnqueueItem())
 	app.AddRoute("/commit_queue/{patch_id}/additional").Version(2).Get().Wrap(requireTask).RouteHandler(makeCommitQueueAdditionalPatches())
 	app.AddRoute("/commit_queue/{patch_id}/conclude_merge").Version(2).Post().Wrap(requireTask).RouteHandler(makeCommitQueueConcludeMerge())

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -82,7 +82,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/builds/{build_id}/tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchTasksByBuild(opts.URL))
 	app.AddRoute("/builds/{build_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByBuild())
 	app.AddRoute("/commit_queue/{project_id}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetCommitQueueItems())
-	app.AddRoute("/commit_queue/{item}").Version(2).Delete().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(env))
+	app.AddRoute("/commit_queue/{patch_id}").Version(2).Delete().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(env))
 	app.AddRoute("/commit_queue/{patch_id}").Version(2).Put().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeCommitQueueEnqueueItem())
 	app.AddRoute("/commit_queue/{patch_id}/additional").Version(2).Get().Wrap(requireTask).RouteHandler(makeCommitQueueAdditionalPatches())
 	app.AddRoute("/commit_queue/{patch_id}/conclude_merge").Version(2).Post().Wrap(requireTask).RouteHandler(makeCommitQueueConcludeMerge())


### PR DESCRIPTION
[EVG-16693](https://jira.mongodb.org/browse/EVG-16693)

### Description 
Modification to the commit queue delete route, making it accept just a single commit queue item and do a project DB lookup on the server side rather than on the client side where it is currently invalid.
### Testing 
Testing in staging env (attached)