### PR TITLE
EVG-16958: Add webhook documents

### DIFF
--- a/testdata/local/github_hooks.json
+++ b/testdata/local/github_hooks.json
@@ -1,0 +1,2 @@
+{"_id":{"$oid":"628ce40875c5071247ec564d"},"hook_id":0,"owner":"evergreen-ci","repo":"evergreen"}
+{"_id":{"$oid":"628ce6d275c5071247ec564e"},"hook_id":1,"owner":"evergreen-ci","repo":"spruce"}


### PR DESCRIPTION
[EVG-16958](https://jira.mongodb.org/browse/EVG-16958)

### Description 
- Add github_hooks collection so that local projects have webhooks enabled for testing

### Testing 
- Verified in local dev environment that `githubWebhooksEnabled` field is returned as true for evergreen-ci/evergreen and evergreen-ci/spruce projects