### PR TITLE
EVG-16833 improving moving a host from stopping to stopped

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -36,6 +36,7 @@ const (
 var (
 	validUpdateToStatuses = []string{
 		evergreen.HostRunning,
+		evergreen.HostStopped,
 		evergreen.HostQuarantined,
 		evergreen.HostDecommissioned,
 		evergreen.HostTerminated,

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -233,8 +233,9 @@ const (
 )
 
 const (
-	checkSuccessAttempts   = 10
+	checkSuccessAttempts   = 12
 	checkSuccessInitPeriod = 2 * time.Second
+	checkSuccessMaxDelay   = 2 * time.Minute
 )
 
 const (
@@ -1221,6 +1222,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		}, utility.RetryOptions{
 			MaxAttempts: checkSuccessAttempts,
 			MinDelay:    checkSuccessInitPeriod,
+			MaxDelay:    checkSuccessMaxDelay,
 		})
 	if err != nil {
 		return errors.Wrap(err, "checking if spawn host stopped")

--- a/public/static/js/hosts_admin.js
+++ b/public/static/js/hosts_admin.js
@@ -1,6 +1,6 @@
 mciModule.controller('AdminOptionsCtrl', ['$scope', '$filter', 'mciHostsRestService', 'notificationService', function($scope, $filter, hostsRestService, notifier) {
   $scope.modalTitle = 'Modify Hosts';
-  $scope.validHostStatuses = ["running", "decommissioned", "quarantined", "terminated"];
+  $scope.validHostStatuses = ["running", "decommissioned", "quarantined", "terminated", "stopped"];
   $scope.newStatus = $scope.validHostStatuses[0];
   $scope.notes={};
 


### PR DESCRIPTION
[EVG-16833](https://jira.mongodb.org/browse/EVG-16833)

### Description 
Increases retries but adds a max delay since I think multiple minutes in between checks causes user experiences such as what Jason mentioned [here](https://mongodb.slack.com/archives/C0V896UV8/p1653489578489349?thread_ts=1653488793.700029&cid=C0V896UV8) (I looked at his host a few minutes prior and it had already been moved to stopping in AWS. Let me know if this seems like the wrong approach or limit.

I also added Stopped to the host panel (and will open a corresponding spruce PR) so that we can edit host statuses more easily. 
![image](https://user-images.githubusercontent.com/26798134/170294356-8ba6ffca-bda5-4ae1-b39e-8b144638327e.png)

