### PR TITLE
EVG-16125 Accept project identifier rather than project id in 'tasksByProjectHandler'

### DIFF
--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -53,6 +53,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 		}
 	}
 
+	opts.Project = projectId
 	pipeline := task.TasksByProjectAndCommitPipeline(opts)
 
 	res := []task.Task{}

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -365,7 +365,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 					},
 				}
 				handler := &tasksByProjectHandler{
-					project:    projectName,
+					project:    projectId,
 					commitHash: commit,
 					key:        fmt.Sprintf("%dtask_%d", prefix, taskToStartAt),
 					limit:      limit,
@@ -448,7 +448,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				}
 				prefix = int(math.Log10(float64(taskToStartAt)))
 				handler := &tasksByProjectHandler{
-					project:    projectName,
+					project:    projectId,
 					commitHash: commit,
 					key:        fmt.Sprintf("%dtask_%d", prefix, taskToStartAt),
 					limit:      limit,

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -305,13 +305,14 @@ func TestHostPaginator(t *testing.T) {
 
 func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 	numTasks := 300
-	projectName := "project_1"
+	projectId := "project_1"
+	projectName := "project_identifier"
 	commit := "commit_1"
 	Convey("When paginating with a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, serviceModel.ProjectRefCollection))
 		p := &serviceModel.ProjectRef{
-			Id:         "project_1",
-			Identifier: "project_1",
+			Id:         projectId,
+			Identifier: projectName,
 		}
 		assert.NoError(t, p.Insert())
 		Convey("and there are tasks to be found", func() {
@@ -324,7 +325,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				nextTask := task.Task{
 					Id:       fmt.Sprintf("%dtask_%d", prefix, i),
 					Revision: commit,
-					Project:  projectName,
+					Project:  projectId,
 				}
 				cachedTasks = append(cachedTasks, nextTask)
 			}
@@ -345,7 +346,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 					serviceTask := &task.Task{
 						Id:       fmt.Sprintf("%dtask_%d", prefix, i),
 						Revision: commit,
-						Project:  projectName,
+						Project:  projectId,
 					}
 					nextModelTask := &model.APITask{}
 					err := nextModelTask.BuildFromArgs(serviceTask, &model.APITaskArgs{LogURL: "http://evergreen.example.net", IncludeProjectIdentifier: true})
@@ -386,7 +387,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 					serviceTask := &task.Task{
 						Id:       fmt.Sprintf("%dtask_%d", prefix, i),
 						Revision: commit,
-						Project:  projectName,
+						Project:  projectId,
 					}
 					nextModelTask := &model.APITask{}
 					err := nextModelTask.BuildFromArgs(serviceTask, &model.APITaskArgs{LogURL: "http://evergreen.example.net", IncludeProjectIdentifier: true})
@@ -427,7 +428,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 					serviceTask := &task.Task{
 						Id:       fmt.Sprintf("%dtask_%d", prefix, i),
 						Revision: commit,
-						Project:  projectName,
+						Project:  projectId,
 					}
 					nextModelTask := &model.APITask{}
 					err := nextModelTask.BuildFromArgs(serviceTask, &model.APITaskArgs{LogURL: "http://evergreen.example.net", IncludeProjectIdentifier: true})
@@ -469,7 +470,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 					serviceTask := &task.Task{
 						Id:       fmt.Sprintf("%dtask_%d", prefix, i),
 						Revision: commit,
-						Project:  projectName,
+						Project:  projectId,
 					}
 					nextModelTask := &model.APITask{}
 					err := nextModelTask.BuildFromArgs(serviceTask, &model.APITaskArgs{LogURL: "http://evergreen.example.net", IncludeProjectIdentifier: true})


### PR DESCRIPTION
[EVG-16125](https://jira.mongodb.org/browse/EVG-16125)

### Description 
[This slack thread](https://mongodb.slack.com/archives/C0V896UV8/p1653473341506469) raised the issue that our endpoint to [list tasks by commit](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#list-tasks-by-project-and-commit) no longer works when putting a project identifier in its path, but rather expects the project id itself which for many projects is distinct from the identifier. Change has been made to modify the options passed into the DB function for this route to lookup project id from its identifier passed into the path.

### Testing 
Modified unit tests to use separate project identifiers and project id when testing this route.