### PR TITLE
EVG-16650 send task scheduled events to Splunk instead of the db

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2036,6 +2036,7 @@ func (r *taskLogsResolver) EventLogs(ctx context.Context, obj *TaskLogs) ([]*res
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Unable to find EventLogs for task %s: %s", obj.TaskID, err.Error()))
 	}
 
+	// TODO (EVG-16969) remove once TaskScheduled events TTL
 	// remove all scheduled events except the youngest and push to filteredEvents
 	filteredEvents := []event.EventLogEntry{}
 	foundScheduled := false

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -310,6 +310,60 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
+func (s *PlannerSettings) ShouldGroupVersions() bool {
+	return utility.FromBoolPtr(s.GroupVersions)
+}
+
+func (s *PlannerSettings) GetPatchFactor() int64 {
+	if s.PatchFactor <= 0 {
+		return 1
+	}
+	return s.PatchFactor
+}
+
+func (s *PlannerSettings) GetPatchTimeInQueueFactor() int64 {
+	if s.PatchTimeInQueueFactor <= 0 {
+		return 1
+	}
+	return s.PatchTimeInQueueFactor
+}
+
+func (s *PlannerSettings) GetCommitQueueFactor() int64 {
+	if s.CommitQueueFactor <= 0 {
+		return 1
+	}
+	return s.CommitQueueFactor
+}
+
+func (s *PlannerSettings) GetGenerateTaskFactor() int64 {
+	if s.GenerateTaskFactor <= 0 {
+		return 1
+	}
+	return s.GenerateTaskFactor
+}
+
+func (s *PlannerSettings) GetMainlineTimeInQueueFactor() int64 {
+	if s.MainlineTimeInQueueFactor <= 0 {
+		return 1
+	}
+	return s.MainlineTimeInQueueFactor
+}
+
+func (s *PlannerSettings) GetStepbackTaskFactor() int64 {
+	if s.StepbackTaskFactor <= 0 {
+		return 1
+	}
+	return s.StepbackTaskFactor
+}
+
+func (s *PlannerSettings) GetExpectedRuntimeFactor() int64 {
+	if s.ExpectedRuntimeFactor <= 0 {
+		return 1
+	}
+
+	return s.ExpectedRuntimeFactor
+}
+
 // GenerateName generates a unique instance name for a host in a distro.
 func (d *Distro) GenerateName() string {
 	switch d.Provider {
@@ -336,64 +390,6 @@ func (d *Distro) GenerateName() string {
 	}
 
 	return name
-}
-
-func (d *Distro) ShouldGroupVersions() bool {
-	if d.PlannerSettings.GroupVersions == nil {
-		return false
-	}
-
-	return *d.PlannerSettings.GroupVersions
-}
-
-func (d *Distro) GetPatchFactor() int64 {
-	if d.PlannerSettings.PatchFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.PatchFactor
-}
-
-func (d *Distro) GetPatchTimeInQueueFactor() int64 {
-	if d.PlannerSettings.PatchTimeInQueueFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.PatchTimeInQueueFactor
-}
-
-func (d *Distro) GetCommitQueueFactor() int64 {
-	if d.PlannerSettings.CommitQueueFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.CommitQueueFactor
-}
-
-func (d *Distro) GetGenerateTaskFactor() int64 {
-	if d.PlannerSettings.GenerateTaskFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.GenerateTaskFactor
-}
-
-func (d *Distro) GetMainlineTimeInQueueFactor() int64 {
-	if d.PlannerSettings.MainlineTimeInQueueFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.MainlineTimeInQueueFactor
-}
-
-func (d *Distro) GetStepbackTaskFactor() int64 {
-	if d.PlannerSettings.StepbackTaskFactor <= 0 {
-		return 1
-	}
-	return d.PlannerSettings.StepbackTaskFactor
-}
-
-func (d *Distro) GetExpectedRuntimeFactor() int64 {
-	if d.PlannerSettings.ExpectedRuntimeFactor <= 0 {
-		return 1
-	}
-
-	return d.PlannerSettings.ExpectedRuntimeFactor
 }
 
 func (d *Distro) MaxDurationPerHost() time.Duration {

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -30,12 +30,14 @@ const (
 	TaskActivated              = "TASK_ACTIVATED"
 	TaskDeactivated            = "TASK_DEACTIVATED"
 	TaskAbortRequest           = "TASK_ABORT_REQUEST"
-	TaskScheduled              = "TASK_SCHEDULED"
 	ContainerAllocated         = "CONTAINER_ALLOCATED"
 	TaskPriorityChanged        = "TASK_PRIORITY_CHANGED"
 	TaskJiraAlertCreated       = "TASK_JIRA_ALERT_CREATED"
 	TaskDependenciesOverridden = "TASK_DEPENDENCIES_OVERRIDDEN"
 	MergeTaskUnscheduled       = "MERGE_TASK_UNSCHEDULED"
+
+	// TODO (EVG-16969) remove once TaskScheduled events TTL
+	TaskScheduled = "TASK_SCHEDULED"
 )
 
 // implements Data

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -173,11 +173,6 @@ func LogManyTaskAbortRequests(taskIds []string, userId string) {
 		TaskEventData{UserId: userId})
 }
 
-func LogTaskScheduled(taskId string, execution int, scheduledTime time.Time) {
-	logTaskEvent(taskId, TaskScheduled,
-		TaskEventData{Execution: execution, Timestamp: scheduledTime})
-}
-
 func LogTaskContainerAllocated(taskId string, execution int, containerAllocatedTime time.Time) {
 	logTaskEvent(taskId, ContainerAllocated,
 		TaskEventData{Execution: execution, Timestamp: containerAllocatedTime})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1251,7 +1251,7 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 			ids = append(ids, utility.FromStringPtr(tasks[i].DisplayTaskId))
 		}
 	}
-	info, err := UpdateAll(
+	_, err := UpdateAll(
 		bson.M{
 			IdKey: bson.M{
 				"$in": ids,
@@ -1270,11 +1270,6 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 		return err
 	}
 
-	if info.Updated > 0 {
-		for _, t := range tasks {
-			event.LogTaskScheduled(t.Id, t.Execution, scheduledTime)
-		}
-	}
 	return nil
 }
 

--- a/public/static/js/task.js
+++ b/public/static/js/task.js
@@ -744,6 +744,7 @@ mciModule.controller('TaskLogCtrl', ['$scope', '$timeout', '$http', '$location',
     $http.get('/json/task_log/' + $scope.taskId + '/' + $scope.task.execution + '?type=' + $scope.currentLogs).then(
       function (resp) {
         $scope.buildlogger = false;
+        // TODO (EVG-16969) remove once TaskScheduled events TTL
         var taskScheduledStatus = "TASK_SCHEDULED";
         var data = resp.data;
         if ($scope.currentLogs == $scope.eventLogs) {

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -186,15 +186,15 @@ type unitInfo struct {
 	// NumDeps is the total number of tasks depending on tasks in the unit.
 	NumDeps int64 `json:"num_deps"`
 	// ContainsInCommitQueue indicates if the unit contains any tasks that are part of a commit queue version.
-	ContainsInCommitQueue bool `json:"in_commit_queue"`
+	ContainsInCommitQueue bool `json:"contains_in_commit_queue"`
 	// ContainsInPatch indicates if the unit contains any tasks that are part of a patch.
-	ContainsInPatch bool `json:"in_patch"`
+	ContainsInPatch bool `json:"contains_in_patch"`
 	// ContainsNonGroupTasks indicates if the unit contains any tasks that are not part of a task group.
-	ContainsNonGroupTasks bool `json:"any_non_group_tasks"`
+	ContainsNonGroupTasks bool `json:"contains_non_group_tasks"`
 	// ContainsGenerateTask indicates if the unit contains generator task.
-	ContainsGenerateTask bool `json:"generate_task"`
+	ContainsGenerateTask bool `json:"contains_generate_task"`
 	// ContainsStepbackTask indicates if the unit contains task activated by stepback.
-	ContainsStepbackTask bool `json:"stepback_task"`
+	ContainsStepbackTask bool `json:"contains_stepback_task"`
 }
 
 func (u *unitInfo) value() int64 {

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -178,9 +178,9 @@ type unitInfo struct {
 	// Settings are the planner settings for the unit's distro.
 	Settings distro.PlannerSettings `json:"settings"`
 	// ExpectedRuntime is the sum of the durations the tasks in the unit are expected to take.
-	ExpectedRuntime time.Duration `json:"expected_runtime"`
+	ExpectedRuntime time.Duration `json:"expected_runtime_ns"`
 	// TimeInQueue is the sum of the durations the tasks in the unit have been waiting in the queue.
-	TimeInQueue time.Duration `json:"time_in_queue"`
+	TimeInQueue time.Duration `json:"time_in_queue_ns"`
 	// TotalPriority is the sum of the priority values of all the tasks in the unit.
 	TotalPriority int64 `json:"total_priority"`
 	// NumDeps is the total number of tasks depending on tasks in the unit.


### PR DESCRIPTION
[EVG-16650](https://jira.mongodb.org/browse/EVG-16650)

### Description 
In order to whittle down the event_log collection I'm going to open a few PRs to reduce the daily write volume to the collection. [We've set a 90 day TTL on the events with a TASK r_type](https://jira.mongodb.org/browse/EVG-15227), but even with the TTL task events are still a significant part of the bulk of the collection. The bulk of these are TASK_SCHEDULED events which don't really need to be in the db. Logging these to Splunk instead will reduce the size of the collection over time.

Once we're already logging to Splunk, include additional information about the parameters that determined each task's position in the queue. This way we'll finally have visibility into why a particular task ranked before another task in the queue. Given two task ids you can answer why one had a higher priority in the queue (see [EVG-15554](https://jira.mongodb.org/browse/EVG-15554))

There's a risk that this will result in too much logging to Splunk. I can't think of a good way to know apriori. We'll get alerted by the Splunk alert if that's the case.

### Testing 
When this was deployed to staging I got the logging [here](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen-staging%20%22prioritizated%20distro%20unit%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1653496500&latest=1653496800&sid=1653497588.1802084).