### PR TITLE
EVG-16858 include display tasks when checking existing generated tasks

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1867,7 +1867,7 @@ func (h *Host) IsIdleParent() (bool, error) {
 	if !h.HasContainers {
 		return false, nil
 	}
-	// sanity check so that hosts not immediately decommissioned
+	// Verify that hosts are not immediately decommissioned.
 	if h.IdleTime() < idleTimeCutoff {
 		return false, nil
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -746,15 +746,15 @@ func createTasksForBuild(project *Project, pRef *ProjectRef, buildVariant *Build
 	tasksInBuild []task.Task, syncAtEndOpts patch.SyncAtEndOptions, distroAliases map[string][]string, createTime time.Time,
 	githubChecksAliases ProjectAliases) (task.Tasks, error) {
 
-	// the list of tasks we should create.  if tasks are passed in, then
-	// use those, else use the default set
+	// The list of tasks we should create.
+	// If tasks are passed in, then use those, otherwise use the default set.
 	tasksToCreate := []BuildVariantTaskUnit{}
 
 	createAll := false
 	if len(taskNames) == 0 && len(displayNames) == 0 {
 		createAll = true
 	}
-	// tables includes only new and existing tasks
+	// Tables includes only new and existing tasks.
 	execTable := taskIds.ExecutionTasks
 	displayTable := taskIds.DisplayTasks
 
@@ -764,7 +764,7 @@ func createTasksForBuild(project *Project, pRef *ProjectRef, buildVariant *Build
 	}
 
 	for _, task := range buildVariant.Tasks {
-		// sanity check that the config isn't malformed
+		// Verify that the config isn't malformed.
 		if task.Name != "" && !task.IsGroup {
 			if task.IsDisabled() || task.SkipOnRequester(b.Requester) {
 				continue
@@ -1678,8 +1678,8 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 	activatedTasks := []task.Task{}
 	for _, b := range existingBuilds {
 		wasActivated := b.Activated
-		// Find the set of task names that already exist for the given build
-		tasksInBuild, err := task.FindWithFields(task.ByBuildId(b.Id), task.DisplayNameKey, task.ActivatedKey)
+		// Find the set of task names that already exist for the given build, including display tasks.
+		tasksInBuild, err := task.FindAll(db.Query(task.ByBuildId(b.Id)).WithFields(task.DisplayNameKey, task.ActivatedKey))
 		if err != nil {
 			return nil, err
 		}
@@ -1693,21 +1693,21 @@ func addNewTasks(ctx context.Context, activationInfo specificActivationInfo, v *
 			b.Activated = utility.FromBoolTPtr(projectBV.Activate) // activate unless explicitly set otherwise
 		}
 
-		// build a list of tasks that haven't been created yet for the given variant, but have
+		// Build a list of tasks that haven't been created yet for the given variant, but have
 		// a record in the TVPairSet indicating that it should exist
 		tasksToAdd := []string{}
-		for _, taskname := range pairs.ExecTasks.TaskNames(b.BuildVariant) {
-			if ok := existingTasksIndex[taskname]; ok {
+		for _, taskName := range pairs.ExecTasks.TaskNames(b.BuildVariant) {
+			if ok := existingTasksIndex[taskName]; ok {
 				continue
 			}
-			tasksToAdd = append(tasksToAdd, taskname)
+			tasksToAdd = append(tasksToAdd, taskName)
 		}
 		displayTasksToAdd := []string{}
-		for _, taskname := range pairs.DisplayTasks.TaskNames(b.BuildVariant) {
-			if ok := existingTasksIndex[taskname]; ok {
+		for _, taskName := range pairs.DisplayTasks.TaskNames(b.BuildVariant) {
+			if ok := existingTasksIndex[taskName]; ok {
 				continue
 			}
-			displayTasksToAdd = append(displayTasksToAdd, taskname)
+			displayTasksToAdd = append(displayTasksToAdd, taskName)
 		}
 		if len(tasksToAdd) == 0 && len(displayTasksToAdd) == 0 { // no tasks to add, so we do nothing.
 			continue

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -1419,7 +1419,7 @@ Examples:
 			},
 			cli.BoolTFlag{
 				Name:  sanityChecksFlagName,
-				Usage: "perform basic sanity checks for common sources of error (ignored on dry runs) (default: true)",
+				Usage: "perform basic checks for common sources of error (ignored on dry runs) (default: true)",
 			},
 			cli.BoolFlag{
 				Name:  joinFlagNames(dryRunFlagName, "n"),
@@ -1467,7 +1467,7 @@ Examples:
 			}
 
 			if doSanityCheck && !dryRun {
-				ok := sanityCheckRsync(localPath, remotePath, pull)
+				ok := verifyRsync(localPath, remotePath, pull)
 				if !ok {
 					fmt.Println("Refusing to perform rsync, exiting")
 					return nil
@@ -1620,11 +1620,11 @@ func getUserAndHostname(ctx context.Context, hostID, confPath string) (user, hos
 	return "", "", errors.Errorf("could not find host '%s' in user's spawn hosts", hostID)
 }
 
-// sanityCheckRsync performs some basic sanity checks for the common case in
+// verifyRsync performs some basic validation for the common case in
 // which you want to mirror two directories. The trailing slash means to
 // overwrite all of the contents of the destination directory, so we check that
 // they really want to do this.
-func sanityCheckRsync(localPath, remotePath string, pull bool) bool {
+func verifyRsync(localPath, remotePath string, pull bool) bool {
 	localPathIsDir := strings.HasSuffix(localPath, "/")
 	remotePathIsDir := strings.HasSuffix(remotePath, "/")
 

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -714,7 +714,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
 	}
-	if err = sanityCheckOrderNum(v.RevisionOrderNumber, projectInfo.Ref.Id, metadata.Revision.Revision); err != nil {
+	if err = verifyOrderNum(v.RevisionOrderNumber, projectInfo.Ref.Id, metadata.Revision.Revision); err != nil {
 		return nil, errors.Wrap(err, "inconsistent version order")
 	}
 
@@ -890,18 +890,16 @@ func makeVersionIdWithTag(project, tag, id string) string {
 }
 
 // Verifies that the given revision order number is higher than the latest number stored for the project.
-func sanityCheckOrderNum(revOrderNum int, projectId, revision string) error {
+func verifyOrderNum(revOrderNum int, projectId, revision string) error {
 	latest, err := model.VersionFindOne(model.VersionByMostRecentSystemRequester(projectId))
 	if err != nil || latest == nil {
 		return errors.Wrap(err, "Error getting latest version")
 	}
 
-	// When there are no versions in the db yet, sanity check is moot
-	if latest != nil {
-		if revOrderNum <= latest.RevisionOrderNumber {
-			return errors.Errorf("Commit order number isn't greater than last stored version's: %v <= %v",
-				revOrderNum, latest.RevisionOrderNumber)
-		}
+	// When there are no versions in the db yet, verification is moot.
+	if revOrderNum <= latest.RevisionOrderNumber {
+		return errors.Errorf("Commit order number isn't greater than last stored version's: %v <= %v",
+			revOrderNum, latest.RevisionOrderNumber)
 	}
 	return nil
 }

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -279,7 +279,6 @@ func (j *cloudHostReadyJob) setDNSName(ctx context.Context, cloudMgr cloud.Manag
 		return errors.Wrapf(err, "error checking DNS name for host %s", h.Id)
 	}
 
-	// sanity check for the host DNS name
 	if hostDNS == "" {
 		// DNS name not required if IP address set
 		if h.IP != "" {


### PR DESCRIPTION
[EVG-16858](https://jira.mongodb.org/browse/EVG-16858)

### Description 
Alas, Find omits display tasks, which means the check for existing display tasks at 1705 - 1707 never works. 

I also noticed we still have "sanity check" used throughout the codebase, which is not super PC these days so I went ahead and changed those.
