### PR TITLE
EVG-16815 Reference repo credentials in YAML from credentials set on the ProjectRef

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -322,6 +322,7 @@ type Container struct {
 	WorkingDir string              `yaml:"working_dir,omitempty" bson:"working_dir"`
 	Image      string              `yaml:"image" bson:"image"`
 	Size       string              `yaml:"size,omitempty" bson:"size"`
+	Credential string              `yaml:"credential,omitempty" bson:"credential"`
 	Resources  *ContainerResources `yaml:"resources,omitempty" bson:"resources"`
 	System     ContainerSystem     `yaml:"system,omitempty" bson:"system"`
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2504,18 +2504,18 @@ func ValidateContainers(pRef *ProjectRef, containers []Container) error {
 	catcher := grip.NewSimpleCatcher()
 	for _, container := range containers {
 		catcher.Add(container.System.Validate())
+		if container.Resources != nil {
+			catcher.Add(container.Resources.Validate())
+		}
 		size, ok := pRef.ContainerSizes[container.Size]
 		if ok {
 			catcher.Add(size.Validate())
 		}
+		catcher.ErrorfWhen(container.Size != "" && !ok, "size '%s' is not defined anywhere", container.Size)
 		credential, ok := pRef.ContainerCredentials[container.Credential]
 		if ok {
 			catcher.Add(credential.Validate())
 		}
-		if container.Resources != nil {
-			catcher.Add(container.Resources.Validate())
-		}
-		catcher.ErrorfWhen(container.Size != "" && !ok, "size '%s' is not defined anywhere", container.Size)
 		catcher.ErrorfWhen(container.Credential != "" && !ok, "credential '%s' is not defined anywhere", container.Credential)
 		catcher.NewWhen(container.Size != "" && container.Resources != nil, "size and resources cannot both be defined")
 		catcher.NewWhen(container.Size == "" && container.Resources == nil, "either size or resources must be defined")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2512,10 +2512,7 @@ func ValidateContainers(pRef *ProjectRef, containers []Container) error {
 			catcher.Add(size.Validate())
 		}
 		catcher.ErrorfWhen(container.Size != "" && !ok, "size '%s' is not defined anywhere", container.Size)
-		credential, ok := pRef.ContainerCredentials[container.Credential]
-		if ok {
-			catcher.Add(credential.Validate())
-		}
+		_, ok = pRef.ContainerCredentials[container.Credential]
 		catcher.ErrorfWhen(container.Credential != "" && !ok, "credential '%s' is not defined anywhere", container.Credential)
 		catcher.NewWhen(container.Size != "" && container.Resources != nil, "size and resources cannot both be defined")
 		catcher.NewWhen(container.Size == "" && container.Resources == nil, "either size or resources must be defined")

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -521,7 +521,7 @@ mciModule.controller(
             periodic_builds: data.ProjectRef.periodic_builds,
             container_sizes: data.ProjectRef.container_sizes || {},
             container_credentials: data.ProjectRef.container_credentials || {},
-            use_repo_settings: false,
+            use_repo_settings: !!$scope.projectRef.repo_ref_id,
             build_baron_settings: data.ProjectRef.build_baron_settings || {},
             task_annotation_settings: data.ProjectRef.task_annotation_settings || {},
             perf_enabled: data.ProjectRef.perf_enabled || false,

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -520,7 +520,8 @@ mciModule.controller(
             disabled_stats_cache: data.ProjectRef.disabled_stats_cache,
             periodic_builds: data.ProjectRef.periodic_builds,
             container_sizes: data.ProjectRef.container_sizes || {},
-            use_repo_settings: !!$scope.projectRef.repo_ref_id,
+            container_credentials: data.ProjectRef.container_credentials || {},
+            use_repo_settings: false,
             build_baron_settings: data.ProjectRef.build_baron_settings || {},
             task_annotation_settings: data.ProjectRef.task_annotation_settings || {},
             perf_enabled: data.ProjectRef.perf_enabled || false,
@@ -653,6 +654,10 @@ mciModule.controller(
 
       if ($scope.container_size) {
         $scope.addContainerSize();
+      }
+
+      if ($scope.container_credential) {
+        $scope.addContainerCredential();
       }
 
       $scope.settingsFormData.subscriptions = _.filter(
@@ -812,6 +817,21 @@ mciModule.controller(
       $scope.invalidContainerSizeMessage = "";
     };
 
+    $scope.addContainerCredential = function () {
+      if (!$scope.validContainerCredential($scope.container_credential)) {
+          $scope.invalidContainerCredentialMessage =
+              "A valid container credential must have a valid username and password.";
+          return;
+      }
+      var item = Object.assign({}, $scope.container_credential);
+      $scope.settingsFormData.container_credentials[item.name] = {
+          "username": item.username,
+          "password": item.password,
+      }
+      delete $scope.container_credential;
+      $scope.invalidContainerCredentialMessage = "";
+    };
+
     $scope.addWorkstationCommand = function () {
       if (!$scope.settingsFormData.workstation_config) {
         $scope.settingsFormData.workstation_config = {};
@@ -885,6 +905,13 @@ mciModule.controller(
       $scope.removeContainerSize = function (name) {
           if ($scope.settingsFormData.container_sizes[name]) {
               delete $scope.settingsFormData.container_sizes[name]
+          }
+          $scope.isDirty = true;
+      };
+
+      $scope.removeContainerCredential = function (name) {
+          if ($scope.settingsFormData.container_credentials[name]) {
+              delete $scope.settingsFormData.container_credentials[name]
           }
           $scope.isDirty = true;
       };
@@ -1118,6 +1145,11 @@ mciModule.controller(
     $scope.validContainerSize = function (container_size) {
       return container_size && container_size.cpu && container_size.memory_mb
           && container_size.cpu > 0 && container_size.memory_mb > 0;
+    };
+
+    $scope.validContainerCredential = function (containter_credential) {
+      return containter_credential && containter_credential.username && containter_credential.password
+        && containter_credential.username !== "" && containter_credential.password !== "";
     };
 
     $scope.validWorkstationCommand = function (obj) {

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -1147,9 +1147,9 @@ mciModule.controller(
           && container_size.cpu > 0 && container_size.memory_mb > 0;
     };
 
-    $scope.validContainerCredential = function (containter_credential) {
-      return containter_credential && containter_credential.username && containter_credential.password
-        && containter_credential.username !== "" && containter_credential.password !== "";
+    $scope.validContainerCredential = function (container_credential) {
+      return container_credential && container_credential.username && container_credential.password
+        && container_credential.username !== "" && container_credential.password !== "";
     };
 
     $scope.validWorkstationCommand = function (obj) {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -367,6 +367,23 @@ type APIWorkstationConfig struct {
 	GitClone      *bool                        `bson:"git_clone" json:"git_clone"`
 }
 
+type APIContainerCredential struct {
+	Username *string `bson:"username" json:"username"`
+	Password *string `bson:"password" json:"password"`
+}
+
+func (cr *APIContainerCredential) BuildFromService(h model.ContainerCredential) {
+	cr.Username = utility.ToStringPtr(h.Username)
+	cr.Password = utility.ToStringPtr(h.Password)
+}
+
+func (cr *APIContainerCredential) ToService() model.ContainerCredential {
+	return model.ContainerCredential{
+		Username: utility.FromStringPtr(cr.Username),
+		Password: utility.FromStringPtr(cr.Password),
+	}
+}
+
 type APIContainerResources struct {
 	MemoryMB *int `bson:"memory_mb" json:"memory_mb"`
 	CPU      *int `bson:"cpu" json:"cpu"`

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -1016,6 +1016,54 @@ Evergreen Projects
           </div>
         </div>
       </div>
+      <!-- Container credentials used for private image repos -->
+      <div class="variables">
+        <div class="form-group">
+          <div class="col-header col-lg-6 form-control-static">
+            <h3>Container Credentials</h3>
+            <div class="muted small">Set username/password pairs to be used for authentication when interacting with private image repositories.</div>
+          </div>
+        </div>
+        <div id="container-credentials-list-header" class="form-group">
+          <div class="col-lg-2"> <label class="control-label"> Name </label> </div>
+          <div class="col-lg-2"> <label class="control-label"> Username </label> </div>
+          <div class="col-lg-2"> <label class="control-label"> Password </label> </div>
+          <div class="col-lg-2"></div>
+        </div>
+        <div id="container-credentials-list" class="form-group" ng-repeat="(name, obj) in settingsFormData.container_credentials track by $index">
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="name" type="text" placeholder="name">
+          </div>
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="obj.username" type="text" placeholder="username">
+          </div>
+          <div class="col-lg-2">
+            <input class="form-control" ng-model="obj.password" type="text" placeholder="password">
+          </div>
+          <div class="col-lg-2">
+            <button class="btn btn-default btn-danger" type="button" ng-click="removeContainerCredential(name)">
+              <i class="fa fa-trash"></i>
+            </button>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-lg-2">
+            <input ng-model="container_credential.name" class="form-control" type="text" placeholder="name">
+          </div>
+          <div class="col-lg-2">
+            <input ng-model="container_credential.username" class="form-control" type="text" placeholder="username">
+          </div>
+          <div class="col-lg-2">
+            <input ng-model="container_credential.password" class="form-control" type="text" placeholder="password">
+          </div>
+          <div class="col-lg-2">
+            <button class="plus-button btn btn-primary " ng-disabled="!validContainerCredential(container_credential)" type="button" ng-click="addContainerCredential()">
+              <i class="fa fa-plus"></i>
+            </button>
+            <label class="distro-error">[[invalidContainerCredentialMessage]]</label>
+          </div>
+        </div>
+      </div>
       <!-- Commands for Virtual Workstations -->
       <div class="variables">
         <div class="form-group">

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2849,10 +2849,6 @@ func TestValidateVersionControl(t *testing.T) {
 }
 
 func TestValidateContainers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := tu.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(model.ProjectRefCollection))
 	ref := &model.ProjectRef{
 		Identifier: "proj",


### PR DESCRIPTION
[EVG-16815](https://jira.mongodb.org/browse/EVG-16815)

### Description 
The ProjectRef now has a section to set username/password pairs as credentials to a private image repository and give them a name which can then be referenced in the project YAML. Upon submitting these new credentials to the ProjectRef, we will later implement a change to store these credentials in AWS Secrets Manager at the time they are submitted as changes on the ProjectRef. This will allow projects to reuse the same credential over and over for every pod it creates in the future rather than having to generate a new credential each time a pod is created (which would be expensive and breach API limits).

### Testing 
Tested modify project route in staging to confirm credentials were properly set. Updated unit tests for validating credential configs.