### PR TITLE
EVG-12923 remove re-computing dependencies and reset last running task

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -518,25 +518,10 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		return errors.Wrap(err, "marking task finished")
 	}
 
-	unblockedIds, err := UpdateUnblockedDependencies(t)
-	if err != nil {
-		return errors.Wrap(err, "updating unblocked dependencies")
-	}
 	blockedIds, err := UpdateBlockedDependencies(t)
 	if err != nil {
 		return errors.Wrap(err, "updating blocked dependencies")
 	}
-
-	permanentlyUnblockedIds, _ := utility.StringSliceSymmetricDifference(unblockedIds, blockedIds)
-	// The question to determine here is: do we ever unblock dependencies that don't immediately get re-blocked?
-	grip.DebugWhen(len(permanentlyUnblockedIds) > 0, message.Fields{
-		"message":                   "unblocked dependent tasks",
-		"ticket":                    "EVG-12923",
-		"is_task_group":             t.IsPartOfSingleHostTaskGroup(),
-		"permanently_unblocked_ids": permanentlyUnblockedIds,
-		"task":                      t.Id,
-		"caller":                    caller,
-	})
 
 	if err = t.MarkDependenciesFinished(true); err != nil {
 		return errors.Wrap(err, "updating dependency met status")

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4270,21 +4270,17 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	assert.NoError(execTask.Insert())
 	assert.NoError(b.Insert())
 
-	ids, err := UpdateBlockedDependencies(&tasks[0])
-	assert.NoError(err)
-	assert.Len(ids, 4)
+	assert.NoError(UpdateBlockedDependencies(&tasks[0]))
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)
 	assert.Len(dbTask1.DependsOn, 2)
 	assert.True(dbTask1.DependsOn[0].Unattainable)
 	assert.True(dbTask1.DependsOn[1].Unattainable) // this task has duplicates which are also marked
-	assert.Contains(ids, dbTask1.Id)
 
 	dbTask2, err := task.FindOneId(tasks[2].Id)
 	assert.NoError(err)
 	assert.True(dbTask2.DependsOn[0].Unattainable)
-	assert.Contains(ids, dbTask2.Id)
 
 	dbTask3, err := task.FindOneId(tasks[3].Id)
 	assert.NoError(err)
@@ -4299,12 +4295,10 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	dbTask5, err := task.FindOneId(tasks[5].Id)
 	assert.NoError(err)
 	assert.True(dbTask5.DependsOn[0].Unattainable)
-	assert.Contains(ids, dbTask5.Id)
 
 	dbExecTask, err := task.FindOneId(execTask.Id)
 	assert.NoError(err)
 	assert.True(dbExecTask.DependsOn[0].Unattainable)
-	assert.Contains(ids, dbExecTask.Id)
 
 	// one event inserted for every updated task
 	events, err := event.Find(event.AllLogCollection, db.Q{})
@@ -4375,21 +4369,17 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	}
 	assert.NoError(b.Insert())
 
-	ids, err := UpdateUnblockedDependencies(&tasks[0])
-	assert.NoError(err)
-	assert.Len(ids, 2)
+	assert.NoError(UpdateUnblockedDependencies(&tasks[0]))
 
 	// this task should still be marked blocked because t1 is unattainable
 	dbTask2, err := task.FindOneId(tasks[2].Id)
 	assert.NoError(err)
 	assert.False(dbTask2.DependsOn[0].Unattainable)
 	assert.True(dbTask2.DependsOn[1].Unattainable)
-	assert.Contains(ids, dbTask2.Id)
 
 	dbTask3, err := task.FindOneId(tasks[3].Id)
 	assert.NoError(err)
 	assert.False(dbTask3.DependsOn[0].Unattainable)
-	assert.Contains(ids, dbTask3.Id)
 
 	dbTask4, err := task.FindOneId(tasks[4].Id)
 	assert.NoError(err)

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -281,8 +281,7 @@ func BlockTaskGroupTasks(taskID string) error {
 		catcher.AddWhen(!adb.ResultsNotFound(err), err) // it's not an error if the task already isn't on the queue
 		// this operation is recursive, maybe be refactorable
 		// to use some kind of cache.
-		_, err = UpdateBlockedDependencies(&taskToBlock)
-		catcher.Add(err)
+		catcher.Add(UpdateBlockedDependencies(&taskToBlock))
 	}
 	return catcher.Resolve()
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -97,10 +97,7 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 			err = foundHost.SetStatus(status.Status, user.Id, fmt.Sprintf("changed by %s from API", user.Id))
 		}
 		if err != nil {
-			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusInternalServerError,
-				Message:    err.Error(),
-			})
+			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
 
 		host := &model.APIHost{}

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -138,7 +138,7 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 	if err == nil {
 		for _, blockingTask := range blockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			_, err = model.UpdateBlockedDependencies(&blockingTask)
+			err = model.UpdateBlockedDependencies(&blockingTask)
 			catcher.Wrapf(err, "updating blocked dependencies for '%s'", blockingTask.Id)
 		}
 	}


### PR DESCRIPTION
[EVG-12923](https://jira.mongodb.org/browse/EVG-12923)

### Description 

The couple of times we run into this now seem valid; we don't 100% guarantee that task group tasks will run on the same host (for example, if something happens to host1, then everything else can try to run on host2). That means sometimes funny races will happen. One I've found is when host1 is running a task group but is quarantined, host2 will start running the task group, but then the quarantined host starts running again and thinks it can continue with the task group since that was its last running task, even though host2 has now taken over (headache yet?).

Whereas before improvements were made we hit this error many times a day, we now only hit it a couple of times a week, and always for cases like the above where it makes sense for later task group tasks to be blocked since the task wasn't supposed to run in the first place. I think it's time we removed this re-computation. 

