### PR TITLE
EVG-16679 fix generate tasks retry loop

### DIFF
--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -112,9 +112,12 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 			}
 
 			var generateErr error
-			if len(generateStatus.Errors) > 0 {
+			if generateStatus.Error != "" {
+				generateErr = errors.New(generateStatus.Error)
+			} else if len(generateStatus.Errors) > 0 {
 				generateErr = errors.New(strings.Join(generateStatus.Errors, ", "))
 			}
+
 			if generateStatus.ShouldExit {
 				return false, generateErr
 			}

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -308,9 +308,12 @@ func (ch *CreateHost) Expand(exp *util.Expansions) error {
 }
 
 type GeneratePollResponse struct {
-	Finished   bool     `json:"finished"`
-	ShouldExit bool     `json:"should_exit"`
-	Errors     []string `json:"errors"`
+	Finished   bool   `json:"finished"`
+	ShouldExit bool   `json:"should_exit"`
+	Error      string `json:"error"`
+
+	// TODO: (EVG-16977) Remove the Errors field.
+	Errors []string `json:"errors"`
 }
 
 // DistroView represents the view of data that the agent uses from the distro

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-05-26"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-05-24"
+	AgentVersion = "2022-05-27"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/generate.go
+++ b/model/generate.go
@@ -20,6 +20,8 @@ const (
 	maxGeneratedTasks         = 25000
 )
 
+var DependencyCycleError = errors.New("adding dependencies creates a dependency cycle")
+
 // GeneratedProject is a subset of the Project type, and is generated from the
 // JSON from a `generate.tasks` command.
 type GeneratedProject struct {
@@ -28,7 +30,7 @@ type GeneratedProject struct {
 	Functions     map[string]*YAMLCommandSet `yaml:"functions"`
 	TaskGroups    []parserTaskGroup          `yaml:"task_groups"`
 
-	TaskID string
+	Task *task.Task
 }
 
 // MergeGeneratedProjects takes a slice of generated projects and returns a single, deduplicated project.
@@ -123,7 +125,7 @@ func (g *GeneratedProject) NewVersion(p *Project, pp *ParserProject, v *Version)
 	cachedProject := cacheProjectData(p)
 
 	// We've updated the parser project in a previous iteration of the generator job, so we don't try to update.
-	if utility.StringSliceContains(pp.UpdatedByGenerators, g.TaskID) {
+	if utility.StringSliceContains(pp.UpdatedByGenerators, g.Task.Id) {
 		return p, pp, v, nil
 	}
 	// Validate generated project against original project.
@@ -144,20 +146,22 @@ func (g *GeneratedProject) NewVersion(p *Project, pp *ParserProject, v *Version)
 	return p, newPP, v, nil
 }
 
-func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version, t *task.Task) error {
+func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProject, v *Version) error {
 	// Get task again, to exit early if another generator finished early.
-	t, err := task.FindOneId(g.TaskID)
+	t, err := task.FindOneId(g.Task.Id)
 	if err != nil {
-		return errors.Wrapf(err, "finding task '%s'", g.TaskID)
+		return errors.Wrapf(err, "finding task '%s'", g.Task.Id)
 	}
 	if t == nil {
-		return errors.Errorf("task '%s' not found", g.TaskID)
+		return errors.Errorf("task '%s' not found", g.Task.Id)
 	}
-	if t.GeneratedTasks {
+	g.Task = t
+
+	if g.Task.GeneratedTasks {
 		grip.Debug(message.Fields{
 			"message": "skipping attempting to update parser project because another generator marked the task complete",
-			"task":    t.Id,
-			"version": t.Version,
+			"task":    g.Task.Id,
+			"version": g.Task.Version,
 		})
 		return mongo.ErrNoDocuments
 	}
@@ -166,7 +170,7 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 		return errors.WithStack(err)
 	}
 
-	if err := g.saveNewBuildsAndTasks(ctx, v, p, t); err != nil {
+	if err := g.saveNewBuildsAndTasks(ctx, v, p); err != nil {
 		return errors.Wrap(err, "saving new builds and tasks")
 	}
 	return nil
@@ -210,26 +214,17 @@ func cacheProjectData(p *Project) projectMaps {
 }
 
 // saveNewBuildsAndTasks saves new builds and tasks to the db.
-func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version, p *Project, t *task.Task) error {
+func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version, p *Project) error {
 	// inherit priority from the parent task
 	for i, projBv := range p.BuildVariants {
 		for j := range projBv.Tasks {
-			p.BuildVariants[i].Tasks[j].Priority = t.Priority
+			p.BuildVariants[i].Tasks[j].Priority = g.Task.Priority
 		}
 	}
 	// Only consider batchtime for mainline builds. We should always respect activate if it is set.
-	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester, t)
+	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
 
-	newTVPairs := TaskVariantPairs{}
-	for _, bv := range g.BuildVariants {
-		newTVPairs = appendTasks(newTVPairs, bv, p)
-	}
-	var err error
-	newTVPairs.ExecTasks, err = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester)
-	grip.Warning(message.WrapError(err, message.Fields{
-		"message": "error including dependencies for generator",
-		"task":    g.TaskID,
-	}))
+	newTVPairs := g.getNewTasksWithDependencies(v, p)
 
 	existingBuilds, err := build.Find(build.ByVersion(v.Id))
 	if err != nil {
@@ -275,23 +270,168 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	}
 
 	activatedTasksInExistingBuilds, err := addNewTasks(ctx, activationInfo, v, p, projectRef, newTVPairsForExistingVariants,
-		existingBuilds, syncAtEndOpts, g.TaskID)
+		existingBuilds, syncAtEndOpts, g.Task.Id)
 	if err != nil {
 		return errors.Wrap(err, "adding new tasks")
 	}
 
 	activatedTasksInNewBuilds, err := addNewBuilds(ctx, activationInfo, v, p, newTVPairsForNewVariants,
-		existingBuilds, syncAtEndOpts, projectRef, g.TaskID)
+		existingBuilds, syncAtEndOpts, projectRef, g.Task.Id)
 	if err != nil {
 		return errors.Wrap(err, "adding new builds")
 	}
 
 	// only want to add dependencies to activated tasks
-	if err = addDependencies(t, append(activatedTasksInExistingBuilds, activatedTasksInNewBuilds...)); err != nil {
+	if err = g.addDependencies(append(activatedTasksInExistingBuilds, activatedTasksInNewBuilds...)); err != nil {
 		return errors.Wrap(err, "adding dependencies")
 	}
 
 	return nil
+}
+
+// CheckForCycles builds a dependency graph from the existing tasks in the version and simulates
+// adding the generated tasks, their dependencies, and dependencies on the generated tasks to the graph.
+// Returns a DependencyCycleError error if the resultant graph contains dependency cycles.
+func (g *GeneratedProject) CheckForCycles(v *Version, p *Project, projectRef *ProjectRef) error {
+	existingTasksGraph, err := task.VersionDependencyGraph(g.Task.Version, false)
+	if err != nil {
+		return errors.Wrapf(err, "creating dependency graph for version '%s'", g.Task.Version)
+	}
+
+	simulatedGraph, err := g.simulateNewTasks(existingTasksGraph, v, p, projectRef)
+	if err != nil {
+		return errors.Wrap(err, "simulating new tasks")
+	}
+
+	if cycles := simulatedGraph.Cycles(); len(cycles) > 0 {
+		return errors.Wrapf(DependencyCycleError, "'%s'", cycles)
+	}
+
+	return nil
+}
+
+// simulateNewTasks adds the tasks we're planning to add to the version to the graph and
+// adds simulated edges from each task that depends on the generator to each of the generated tasks.
+func (g *GeneratedProject) simulateNewTasks(graph task.DependencyGraph, v *Version, p *Project, projectRef *ProjectRef) (task.DependencyGraph, error) {
+	newTasks := g.getNewTasksWithDependencies(v, p)
+
+	taskIDs, err := getTaskIdTables(v, p, newTasks, projectRef.Identifier)
+	if err != nil {
+		return graph, errors.Wrap(err, "getting task ids")
+	}
+
+	graph = addTasksToGraph(newTasks.ExecTasks, graph, p, taskIDs)
+	return g.addDependencyEdgesToGraph(newTasks.ExecTasks, v, p, graph, taskIDs)
+}
+
+// getNewTasksWithDependencies returns the generated tasks and their recursive dependencies.
+func (g *GeneratedProject) getNewTasksWithDependencies(v *Version, p *Project) TaskVariantPairs {
+	newTVPairs := TaskVariantPairs{}
+	for _, bv := range g.BuildVariants {
+		newTVPairs = appendTasks(newTVPairs, bv, p)
+	}
+
+	var err error
+	newTVPairs.ExecTasks, err = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester)
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message": "error including dependencies for generator",
+		"task":    g.Task.Id,
+	}))
+
+	return newTVPairs
+}
+
+// addTasksToGraph adds tasks to the graph and adds dependency edges from each task to each of its dependencies.
+func addTasksToGraph(tasks TVPairSet, graph task.DependencyGraph, p *Project, taskIDs TaskIdConfig) task.DependencyGraph {
+	for _, newTask := range tasks {
+		graph.AddTaskNode(task.TaskNode{
+			ID:      taskIDs.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName),
+			Name:    newTask.TaskName,
+			Variant: newTask.Variant,
+		})
+	}
+
+	allNodes := graph.Nodes()
+	bvts := make([]BuildVariantTaskUnit, 0, len(allNodes))
+	for _, node := range graph.Nodes() {
+		bvt := p.FindTaskForVariant(node.Name, node.Variant)
+		if bvt != nil {
+			bvts = append(bvts, *bvt)
+		}
+	}
+
+	for _, dep := range dependenciesForTaskUnit(bvts) {
+		dep.From.ID = taskIDs.ExecutionTasks.GetId(dep.From.Variant, dep.From.Name)
+		dep.To.ID = taskIDs.ExecutionTasks.GetId(dep.To.Variant, dep.To.Name)
+		graph.AddEdge(dep.From, dep.To, dep.Status)
+	}
+
+	return graph
+}
+
+// addDependencyEdgesToGraph adds edges from the tasks that depend on the generator to activated generated tasks.
+func (g *GeneratedProject) addDependencyEdgesToGraph(newTasks TVPairSet, v *Version, p *Project, graph task.DependencyGraph, taskIDs TaskIdConfig) (task.DependencyGraph, error) {
+	activatedNewTasks, err := g.filterInactiveTasks(newTasks, v, p)
+	if err != nil {
+		return graph, errors.Wrap(err, "filtering inactive tasks")
+	}
+
+	for _, newTask := range activatedNewTasks {
+		for _, edge := range graph.EdgesIntoTask(g.Task.ToTaskNode()) {
+			graph.AddEdge(edge.From, task.TaskNode{
+				ID:      taskIDs.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName),
+				Name:    newTask.TaskName,
+				Variant: newTask.Variant,
+			}, edge.Status)
+		}
+	}
+
+	return graph, nil
+}
+
+// filterInactiveTasks returns a copy of tasks with the tasks that will not be activated by the generator removed.
+func (g *GeneratedProject) filterInactiveTasks(tasks TVPairSet, v *Version, p *Project) (TVPairSet, error) {
+	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
+	existingBuilds, err := build.Find(build.ByVersion(v.Id))
+	if err != nil {
+		return nil, errors.Wrap(err, "finding builds for version")
+	}
+	existingBuildMap := make(map[string]bool)
+	for _, b := range existingBuilds {
+		existingBuildMap[b.BuildVariant] = true
+	}
+
+	buildSet := make(map[string][]string)
+	for _, t := range tasks {
+		buildSet[t.Variant] = append(buildSet[t.Variant], t.TaskName)
+	}
+
+	activatedTasks := make(TVPairSet, 0, len(tasks))
+	for bv, tasks := range buildSet {
+		if existingBuildMap[bv] {
+			// Existing builds are activated when tasks are added as long as the build isn't specifically not activated.
+			projectBV := p.FindBuildVariant(bv)
+			if projectBV == nil {
+				continue
+			}
+			if !utility.FromBoolTPtr(projectBV.Activate) {
+				continue
+			}
+		} else if activationInfo.variantHasSpecificActivation(bv) {
+			// New builds with specific activation are activated later by ActivateElapsedBuildsAndTasks.
+			// Skip simulating their dependencies because the builds and their tasks are not activated now so will not be adding dependencies.
+			continue
+		}
+
+		for _, t := range tasks {
+			// Tasks with specific activation are activated later by ActivateElapsedBuildsAndTasks and we do not add dependencies for them.
+			if !activationInfo.taskHasSpecificActivation(bv, t) {
+				activatedTasks = append(activatedTasks, TVPair{Variant: bv, TaskName: t})
+			}
+		}
+	}
+
+	return activatedTasks, nil
 }
 
 type specificActivationInfo struct {
@@ -328,7 +468,7 @@ func (b *specificActivationInfo) taskHasSpecificActivation(variant, task string)
 	return utility.StringSliceContains(b.activationTasks[variant], task)
 }
 
-func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester string, generatorTask *task.Task) specificActivationInfo {
+func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester string) specificActivationInfo {
 	res := newSpecificActivationInfo()
 	for _, bv := range g.BuildVariants {
 		// only consider batchtime for certain requesters
@@ -340,7 +480,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 		// regardless of whether the build variant has batchtime, there may be tasks with different batchtime
 		batchTimeTasks := []string{}
 		for _, bvt := range bv.Tasks {
-			if isStepbackTask(generatorTask, bv.Name, bvt.Name) {
+			if isStepbackTask(g.Task, bv.Name, bvt.Name) {
 				res.stepbackTasks[bv.Name] = append(res.stepbackTasks[bv.Name], bvt.Name)
 				continue // don't consider batchtime/activation if we're stepping back this generated task
 			}
@@ -367,11 +507,11 @@ func isStepbackTask(generatorTask *task.Task, variant, taskName string) bool {
 	return false
 }
 
-func addDependencies(t *task.Task, newTaskIds []string) error {
+func (g *GeneratedProject) addDependencies(newTaskIds []string) error {
 	statuses := []string{evergreen.TaskSucceeded, task.AllStatuses}
 	for _, status := range statuses {
-		if err := t.UpdateDependsOn(status, newTaskIds); err != nil {
-			return errors.Wrapf(err, "updating tasks depending on '%s'", t.Id)
+		if err := g.Task.UpdateDependsOn(status, newTaskIds); err != nil {
+			return errors.Wrapf(err, "updating tasks depending on '%s'", g.Task.Id)
 		}
 	}
 

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -614,7 +615,7 @@ func (s *GenerateSuite) TestAddGeneratedProjectToConfig() {
 }
 
 func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
-	genTask := task.Task{
+	genTask := &task.Task{
 		Id:       "task_that_called_generate_task",
 		Project:  "proj",
 		Version:  "version_that_called_generate_task",
@@ -671,13 +672,13 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	s.NoError(v.Insert())
 
 	g := sampleGeneratedProject
-	g.TaskID = "task_that_called_generate_task"
+	g.Task = genTask
 
 	projectInfo, err := LoadProjectForVersion(v, "proj", false)
 	s.Require().NoError(err)
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.Require().NoError(err)
-	s.NoError(g.Save(context.Background(), p, pp, v, &genTask))
+	s.NoError(g.Save(context.Background(), p, pp, v))
 
 	// verify we stopped saving versions
 	v, err = VersionFindOneId(v.Id)
@@ -728,7 +729,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 }
 
 func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
-	generatorTask := task.Task{
+	generatorTask := &task.Task{
 		Id:      "generator",
 		BuildId: "generate_build",
 		Version: "version_that_called_generate_task",
@@ -762,7 +763,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	s.NoError(err)
 
 	g := partiallyGeneratedProject
-	g.TaskID = generatorTask.Id
+	g.Task = generatorTask
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.NoError(err)
 	pp.UpdatedByGenerators = []string{generatorTask.Id}
@@ -773,7 +774,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	s.NoError(err)
 	s.Len(pp.UpdatedByGenerators, 1) // Not modified again.
 
-	s.NoError(g.Save(context.Background(), p, pp, v, &generatorTask))
+	s.NoError(g.Save(context.Background(), p, pp, v))
 
 	tasks := []task.Task{}
 	taskQuery := db.Query(bson.M{task.GeneratedByKey: "generator"}).Sort([]string{task.CreateTimeKey})
@@ -838,12 +839,12 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	s.NoError(v.Insert())
 
 	g := sampleGeneratedProjectAddToBVOnly
-	g.TaskID = "task_that_called_generate_task"
+	g.Task = &tasksThatExist[0]
 	projectInfo, err := LoadProjectForVersion(v, "", false)
 	s.Require().NoError(err)
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, pp, v, &tasksThatExist[0]))
+	s.NoError(g.Save(context.Background(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)
 	s.NoError(err)
@@ -872,7 +873,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 }
 
 func (s *GenerateSuite) TestSaveNewTasksWithCrossVariantDependencies() {
-	t1 := task.Task{
+	t1 := &task.Task{
 		Id:      "generator",
 		BuildId: "b1",
 		Version: "v1",
@@ -904,7 +905,7 @@ buildvariants:
 	s.NoError(v.Insert())
 
 	g := GeneratedProject{
-		TaskID: t1.Id,
+		Task: t1,
 		Tasks: []parserTask{
 			{
 				Name: "task_that_has_dependencies",
@@ -937,7 +938,7 @@ buildvariants:
 	s.Require().NoError(err)
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.NoError(err)
-	s.NoError(g.Save(context.Background(), p, pp, v, &t1))
+	s.NoError(g.Save(context.Background(), p, pp, v))
 
 	// the depended-on task is created in the existing variant
 	saySomething := task.Task{}
@@ -980,12 +981,12 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.NoError(v.Insert())
 
 	g := smallGeneratedProject
-	g.TaskID = "task_that_called_generate_task"
+	g.Task = &taskThatExists
 	projectInfo, err := LoadProjectForVersion(v, "", false)
 	s.Require().NoError(err)
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	s.Require().NoError(err)
-	s.NoError(g.Save(context.Background(), p, pp, v, &taskThatExists))
+	s.NoError(g.Save(context.Background(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)
 	s.NoError(err)
@@ -1004,6 +1005,269 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{"display_name": "my_display_task"}), &tasks))
 	s.Len(tasks, 1)
 	s.Len(tasks[0].ExecutionTasks, 1)
+}
+
+func TestSimulateNewDependencyGraph(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.Clear(task.Collection))
+	}()
+	require.NoError(t, db.Clear(task.Collection))
+
+	v := &Version{Id: "v0"}
+	generatorTask := task.Task{Id: "mci_bv0_generator__01_01_01_00_00_00", Version: v.Id, BuildVariant: "bv0", DisplayName: "generator"}
+	require.NoError(t, generatorTask.Insert())
+
+	t.Run("CreatesCycle", func(t *testing.T) {
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
+					{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
+					{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generator"},
+				}},
+			},
+			Tasks: []ProjectTask{
+				{Name: "generated"},
+				{Name: "dependedOn"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+				},
+			},
+		}
+		assert.Error(t, g.CheckForCycles(v, project, &ProjectRef{Identifier: "mci"}))
+	})
+
+	t.Run("CreatesLoop", func(t *testing.T) {
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
+					{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generator"},
+				}},
+			},
+			Tasks: []ProjectTask{
+				{Name: "generated"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+				},
+			},
+		}
+
+		assert.Error(t, g.CheckForCycles(v, project, &ProjectRef{Identifier: "mci"}))
+	})
+
+	t.Run("NoCycles", func(t *testing.T) {
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{
+					Name: "bv0",
+					Tasks: []BuildVariantTaskUnit{
+						{Name: "generated"},
+						{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+						{Name: "generator"},
+					},
+				},
+			},
+			Tasks: []ProjectTask{
+				{Name: "generated"},
+				{Name: "dependedOn"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+				},
+			},
+		}
+		assert.NoError(t, g.CheckForCycles(v, project, &ProjectRef{Identifier: "mci"}))
+	})
+
+	t.Run("InactiveBuild", func(t *testing.T) {
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{
+					Name: "bv0",
+					Tasks: []BuildVariantTaskUnit{
+						{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
+						{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+						{Name: "generator"},
+					},
+				},
+			},
+			Tasks: []ProjectTask{
+				{Name: "generated"},
+				{Name: "dependedOn"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+					Activate: utility.FalsePtr(),
+				},
+			},
+		}
+		assert.NoError(t, g.CheckForCycles(v, project, &ProjectRef{Identifier: "mci"}))
+	})
+}
+
+func TestFilterInactiveTasks(t *testing.T) {
+	v := &Version{Requester: evergreen.PatchVersionRequester}
+
+	t.Run("ActiveNonExistentBuild", func(t *testing.T) {
+		g := GeneratedProject{
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+				},
+			},
+			Task: &task.Task{},
+		}
+
+		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		assert.NoError(t, err)
+		assert.Len(t, tasks, 1)
+	})
+
+	t.Run("InactiveNonExistentBuild", func(t *testing.T) {
+		g := GeneratedProject{
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "generated"},
+					},
+					Activate: utility.FalsePtr(),
+				},
+			},
+			Task: &task.Task{},
+		}
+
+		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		assert.NoError(t, err)
+		assert.Empty(t, tasks)
+	})
+
+	t.Run("ActiveExistingBuild", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, db.Clear(build.Collection))
+		}()
+		assert.NoError(t, db.Clear(build.Collection))
+		assert.NoError(t, (&build.Build{DisplayName: "bv0"}).Insert())
+
+		g := GeneratedProject{
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{
+							Name: "generated",
+						},
+					},
+				},
+			},
+			Task: &task.Task{},
+		}
+
+		p := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0"},
+			},
+		}
+
+		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
+		assert.NoError(t, err)
+		assert.Len(t, tasks, 1)
+	})
+
+	t.Run("InactiveExistingBuild", func(t *testing.T) {
+		defer func() {
+			assert.NoError(t, db.Clear(build.Collection))
+		}()
+		assert.NoError(t, db.Clear(build.Collection))
+		assert.NoError(t, (&build.Build{BuildVariant: "bv0"}).Insert())
+
+		g := GeneratedProject{
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{
+							Name: "generated",
+						},
+					},
+				},
+			},
+			Task: &task.Task{},
+		}
+
+		p := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0", Activate: utility.FalsePtr()},
+			},
+		}
+
+		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
+		assert.NoError(t, err)
+		assert.Empty(t, tasks)
+	})
+
+	t.Run("InactiveTask", func(t *testing.T) {
+		g := GeneratedProject{
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{
+							Name:     "generated",
+							Activate: utility.FalsePtr(),
+						},
+					},
+				},
+			},
+			Task: &task.Task{},
+		}
+
+		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		assert.NoError(t, err)
+		assert.Empty(t, tasks)
+	})
 }
 
 func (s *GenerateSuite) TestMergeGeneratedProjectsWithNoTasks() {
@@ -1088,7 +1352,8 @@ func TestAddDependencies(t *testing.T) {
 		assert.NoError(t, task.Insert())
 	}
 
-	assert.NoError(t, addDependencies(&task.Task{Id: "generator"}, []string{"t3"}))
+	g := GeneratedProject{Task: &task.Task{Id: "generator"}}
+	assert.NoError(t, g.addDependencies([]string{"t3"}))
 
 	t1, err := task.FindOneId("t1")
 	assert.NoError(t, err)

--- a/model/task/dependency_graph.go
+++ b/model/task/dependency_graph.go
@@ -69,21 +69,47 @@ func (t TaskNode) String() string {
 	return fmt.Sprintf("%s/%s", t.Variant, t.Name)
 }
 
+// VersionDependencyGraph finds all the tasks from the version given by versionID and constructs a DependencyGraph from them.
+func VersionDependencyGraph(versionID string, transposed bool) (DependencyGraph, error) {
+	tasks, err := FindWithFields(ByVersion(versionID), DependsOnKey, BuildVariantKey, DisplayNameKey)
+	if err != nil {
+		return DependencyGraph{}, errors.Wrapf(err, "getting tasks for version '%s'", versionID)
+	}
+
+	return taskDependencyGraph(tasks, transposed), nil
+}
+
+func taskDependencyGraph(tasks []Task, transposed bool) DependencyGraph {
+	g := NewDependencyGraph(transposed)
+	g.buildFromTasks(tasks)
+	return g
+}
+
 func (g *DependencyGraph) buildFromTasks(tasks []Task) {
 	taskIDToNode := make(map[string]TaskNode)
 	for _, task := range tasks {
-		tNode := task.toTaskNode()
+		tNode := task.ToTaskNode()
 		g.AddTaskNode(tNode)
 		taskIDToNode[task.Id] = tNode
 	}
 
 	for _, task := range tasks {
-		dependentTaskNode := task.toTaskNode()
+		dependentTaskNode := task.ToTaskNode()
 		for _, dep := range task.DependsOn {
 			dependedOnTaskNode := taskIDToNode[dep.TaskId]
 			g.AddEdge(dependentTaskNode, dependedOnTaskNode, dep.Status)
 		}
 	}
+}
+
+// Nodes returns a slice of all the task nodes in the graph.
+func (g *DependencyGraph) Nodes() []TaskNode {
+	tNodes := make([]TaskNode, 0, len(g.tasksToNodes))
+	for tNode := range g.tasksToNodes {
+		tNodes = append(tNodes, tNode)
+	}
+
+	return tNodes
 }
 
 // AddTaskNode adds a node to the graph.
@@ -121,10 +147,10 @@ func (g *DependencyGraph) addEdgeToGraph(edge DependencyEdge) {
 	g.edgesToDependencies[edgeKey{from: edge.From, to: edge.To}] = edge
 }
 
-// edgesIntoTask returns all the edges that point to t.
+// EdgesIntoTask returns all the edges that point to t.
 // For a regular graph these edges are tasks that directly depend on t.
 // If the graph is transposed these edges are tasks t directly depends on.
-func (g *DependencyGraph) edgesIntoTask(t TaskNode) []DependencyEdge {
+func (g *DependencyGraph) EdgesIntoTask(t TaskNode) []DependencyEdge {
 	node := g.tasksToNodes[t]
 	if node == nil {
 		return nil
@@ -168,21 +194,23 @@ func (dc DependencyCycles) String() string {
 }
 
 // Cycles returns cycles in the graph, if any.
-// Self-loops are not included as cycles.
+// Self-loops are also considered cycles.
 func (g *DependencyGraph) Cycles() DependencyCycles {
 	var cycles DependencyCycles
 	stronglyConnectedComponents := topo.TarjanSCC(g.graph)
 	for _, scc := range stronglyConnectedComponents {
-		if len(scc) <= 1 {
-			continue
+		if len(scc) == 1 {
+			if g.graph.HasEdgeBetween(scc[0].ID(), scc[0].ID()) {
+				cycles = append(cycles, []TaskNode{g.nodesToTasks[scc[0]], g.nodesToTasks[scc[0]]})
+			}
+		} else {
+			var cycle []TaskNode
+			for _, node := range scc {
+				taskInCycle := g.nodesToTasks[node]
+				cycle = append(cycle, taskInCycle)
+			}
+			cycles = append(cycles, cycle)
 		}
-
-		var cycle []TaskNode
-		for _, node := range scc {
-			taskInCycle := g.nodesToTasks[node]
-			cycle = append(cycle, taskInCycle)
-		}
-		cycles = append(cycles, cycle)
 	}
 
 	return cycles

--- a/model/task/dependency_graph_test.go
+++ b/model/task/dependency_graph_test.go
@@ -41,40 +41,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.toTaskNode())
-			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
 		}
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
-		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[0].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[0].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[2].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[2].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[2].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[2].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[3].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[3].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[3].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[3].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[3].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[3].ToTaskNode()}],
 		)
 	})
 
@@ -83,40 +83,40 @@ func TestBuildFromTasks(t *testing.T) {
 		g.buildFromTasks(tasks)
 
 		for _, task := range tasks {
-			require.Contains(t, g.tasksToNodes, task.toTaskNode())
-			assert.Equal(t, task.toTaskNode(), g.nodesToTasks[g.tasksToNodes[task.toTaskNode()]])
+			require.Contains(t, g.tasksToNodes, task.ToTaskNode())
+			assert.Equal(t, task.ToTaskNode(), g.nodesToTasks[g.tasksToNodes[task.ToTaskNode()]])
 		}
 
-		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
-		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].toTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.To(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.From(g.tasksToNodes[tasks[0].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].toTaskNode()].ID()).Len())
+		assert.Equal(t, 2, g.graph.To(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[1].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[2].ToTaskNode()].ID()).Len())
 
-		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
-		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].toTaskNode()].ID()).Len())
+		assert.Equal(t, 0, g.graph.To(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
+		assert.Equal(t, 1, g.graph.From(g.tasksToNodes[tasks[3].ToTaskNode()].ID()).Len())
 
 		assert.Len(t, g.edgesToDependencies, 3)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode(), Status: evergreen.TaskSucceeded},
-			g.edgesToDependencies[edgeKey{from: tasks[1].toTaskNode(), to: tasks[0].toTaskNode()}],
+			DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode(), Status: evergreen.TaskSucceeded},
+			g.edgesToDependencies[edgeKey{from: tasks[1].ToTaskNode(), to: tasks[0].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[2].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[2].toTaskNode(), To: tasks[1].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[2].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[2].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[2].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[3].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Equal(t,
-			DependencyEdge{From: tasks[3].toTaskNode(), To: tasks[1].toTaskNode()},
-			g.edgesToDependencies[edgeKey{from: tasks[3].toTaskNode(), to: tasks[1].toTaskNode()}],
+			DependencyEdge{From: tasks[3].ToTaskNode(), To: tasks[1].ToTaskNode()},
+			g.edgesToDependencies[edgeKey{from: tasks[3].ToTaskNode(), to: tasks[1].ToTaskNode()}],
 		)
 	})
 }
@@ -166,9 +166,9 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
 		assert.Equal(t, 2, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 2)
 	})
 
@@ -178,7 +178,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[2].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[2].ToTaskNode()})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -189,7 +189,7 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: TaskNode{ID: "t3"}})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: TaskNode{ID: "t3"}})
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 	})
@@ -200,11 +200,11 @@ func TestAddEdgeToGraph(t *testing.T) {
 		assert.Equal(t, 1, g.graph.Edges().Len())
 		assert.Len(t, g.edgesToDependencies, 1)
 
-		g.addEdgeToGraph(DependencyEdge{From: tasks[0].toTaskNode(), To: tasks[1].toTaskNode()})
-		g.addEdgeToGraph(DependencyEdge{From: tasks[1].toTaskNode(), To: tasks[0].toTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[0].ToTaskNode(), To: tasks[1].ToTaskNode()})
+		g.addEdgeToGraph(DependencyEdge{From: tasks[1].ToTaskNode(), To: tasks[0].ToTaskNode()})
 		assert.Equal(t, 3, g.graph.Edges().Len())
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].toTaskNode()].ID(), g.tasksToNodes[tasks[1].toTaskNode()].ID()))
-		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].toTaskNode()].ID(), g.tasksToNodes[tasks[0].toTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[0].ToTaskNode()].ID(), g.tasksToNodes[tasks[1].ToTaskNode()].ID()))
+		assert.True(t, g.graph.HasEdgeFromTo(g.tasksToNodes[tasks[1].ToTaskNode()].ID(), g.tasksToNodes[tasks[0].ToTaskNode()].ID()))
 		assert.Len(t, g.edgesToDependencies, 3)
 	})
 }
@@ -219,19 +219,19 @@ func TestGetDependencyEdge(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("ExistingEdgeWithStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[1].toTaskNode(), tasks[2].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[1].ToTaskNode(), tasks[2].ToTaskNode())
 		require.NotNil(t, edge)
 		assert.Equal(t, evergreen.TaskSucceeded, edge.Status)
 	})
 
 	t.Run("ExistingEdgeNoStatus", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[0].toTaskNode(), tasks[1].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[0].ToTaskNode(), tasks[1].ToTaskNode())
 		require.NotNil(t, edge)
 		assert.Empty(t, edge.Status)
 	})
 
 	t.Run("NonexistentEdge", func(t *testing.T) {
-		edge := g.GetDependencyEdge(tasks[2].toTaskNode(), tasks[0].toTaskNode())
+		edge := g.GetDependencyEdge(tasks[2].ToTaskNode(), tasks[0].ToTaskNode())
 		assert.Nil(t, edge)
 	})
 }
@@ -244,8 +244,8 @@ func TestTasksDependingOnTask(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	assert.Empty(t, g.edgesIntoTask(tasks[0].toTaskNode()))
-	edges := g.edgesIntoTask(tasks[1].toTaskNode())
+	assert.Empty(t, g.EdgesIntoTask(tasks[0].ToTaskNode()))
+	edges := g.EdgesIntoTask(tasks[1].ToTaskNode())
 	require.Len(t, edges, 1)
 	assert.Equal(t, tasks[0].Id, edges[0].From.ID)
 }
@@ -261,18 +261,18 @@ func TestReachableFromNode(t *testing.T) {
 	g := NewDependencyGraph(false)
 	g.buildFromTasks(tasks)
 
-	reachable := g.reachableFromNode(tasks[0].toTaskNode())
+	reachable := g.reachableFromNode(tasks[0].ToTaskNode())
 	assert.Len(t, reachable, 4)
-	assert.Contains(t, reachable, tasks[1].toTaskNode())
-	assert.Contains(t, reachable, tasks[2].toTaskNode())
-	assert.Contains(t, reachable, tasks[3].toTaskNode())
-	assert.Contains(t, reachable, tasks[4].toTaskNode())
+	assert.Contains(t, reachable, tasks[1].ToTaskNode())
+	assert.Contains(t, reachable, tasks[2].ToTaskNode())
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
+	assert.Contains(t, reachable, tasks[4].ToTaskNode())
 
-	reachable = g.reachableFromNode(tasks[1].toTaskNode())
+	reachable = g.reachableFromNode(tasks[1].ToTaskNode())
 	assert.Len(t, reachable, 1)
-	assert.Contains(t, reachable, tasks[3].toTaskNode())
+	assert.Contains(t, reachable, tasks[3].ToTaskNode())
 
-	reachable = g.reachableFromNode(tasks[3].toTaskNode())
+	reachable = g.reachableFromNode(tasks[3].ToTaskNode())
 	assert.Empty(t, reachable)
 }
 
@@ -300,7 +300,8 @@ func TestCycles(t *testing.T) {
 		g := NewDependencyGraph(false)
 		g.buildFromTasks(tasks)
 
-		assert.Empty(t, g.Cycles())
+		cycles := g.Cycles()
+		assert.Len(t, cycles, 1)
 	})
 
 	t.Run("TwoConnectedCycles", func(t *testing.T) {
@@ -367,29 +368,29 @@ func TestDepthFirstSearch(t *testing.T) {
 	g.buildFromTasks(tasks)
 
 	t.Run("NilTraverseEdge", func(t *testing.T) {
-		assert.True(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[1].toTaskNode(), tasks[0].toTaskNode(), nil))
-		assert.False(t, g.DepthFirstSearch(tasks[3].toTaskNode(), tasks[0].toTaskNode(), nil))
+		assert.True(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[1].ToTaskNode(), tasks[0].ToTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(tasks[3].ToTaskNode(), tasks[0].ToTaskNode(), nil))
 	})
 
 	t.Run("TraversalBlockedAtNode", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
-			return edge.To != tasks[1].toTaskNode()
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
+			return edge.To != tasks[1].ToTaskNode()
 		}))
 	})
 
 	t.Run("TraversalBlockedAtEdge", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), tasks[2].toTaskNode(), func(edge DependencyEdge) bool {
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), tasks[2].ToTaskNode(), func(edge DependencyEdge) bool {
 			return edge.Status == evergreen.TaskSucceeded
 		}))
 	})
 
 	t.Run("StartMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].toTaskNode(), nil))
+		assert.False(t, g.DepthFirstSearch(TaskNode{ID: "t4"}, tasks[0].ToTaskNode(), nil))
 	})
 
 	t.Run("TargetMissingFromGraph", func(t *testing.T) {
-		assert.False(t, g.DepthFirstSearch(tasks[0].toTaskNode(), TaskNode{ID: "t4"}, nil))
+		assert.False(t, g.DepthFirstSearch(tasks[0].ToTaskNode(), TaskNode{ID: "t4"}, nil))
 	})
 }
 
@@ -406,9 +407,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("StableSortWithDependencies", func(t *testing.T) {
@@ -423,9 +424,9 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 3)
-		assert.Equal(t, tasks[1].toTaskNode(), sortedNodes[0])
-		assert.Equal(t, tasks[0].toTaskNode(), sortedNodes[1])
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[2])
+		assert.Equal(t, tasks[1].ToTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[0].ToTaskNode(), sortedNodes[1])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[2])
 	})
 
 	t.Run("Cycle", func(t *testing.T) {
@@ -440,7 +441,7 @@ func TestTopologicalStableSort(t *testing.T) {
 		sortedNodes, err := g.TopologicalStableSort()
 		assert.NoError(t, err)
 		require.Len(t, sortedNodes, 1)
-		assert.Equal(t, tasks[2].toTaskNode(), sortedNodes[0])
+		assert.Equal(t, tasks[2].ToTaskNode(), sortedNodes[0])
 	})
 
 	t.Run("EmptyGraph", func(t *testing.T) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3323,7 +3323,7 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	return FindAll(query)
 }
 
-func (t *Task) toTaskNode() TaskNode {
+func (t *Task) ToTaskNode() TaskNode {
 	return TaskNode{
 		Name:    t.DisplayName,
 		Variant: t.BuildVariant,

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -33,18 +33,14 @@ func GenerateTasks(ctx context.Context, taskID string, jsonBytes []json.RawMessa
 }
 
 // GeneratePoll checks to see if a `generate.tasks` job has finished.
-func GeneratePoll(ctx context.Context, taskID string, group amboy.QueueGroup) (bool, []string, error) {
+func GeneratePoll(ctx context.Context, taskID string, group amboy.QueueGroup) (bool, string, error) {
 	t, err := task.FindOneId(taskID)
 	if err != nil {
-		return false, nil, errors.Wrapf(err, "finding task '%s'", taskID)
+		return false, "", errors.Wrapf(err, "finding task '%s'", taskID)
 	}
 	if t == nil {
-		return false, nil, errors.Errorf("task '%s' not found", taskID)
+		return false, "", errors.Errorf("task '%s' not found", taskID)
 	}
 
-	var errs []string
-	if t.GenerateTasksError != "" {
-		errs = []string{t.GenerateTasksError}
-	}
-	return t.GeneratedTasks, errs, nil
+	return t.GeneratedTasks, t.GenerateTasksError, nil
 }

--- a/rest/data/generate_test.go
+++ b/rest/data/generate_test.go
@@ -59,6 +59,6 @@ func TestGeneratePoll(t *testing.T) {
 
 	finished, generateErrs, err = GeneratePoll(context.Background(), "task-3", q)
 	assert.True(t, finished)
-	assert.Equal(t, []string{"this is an error"}, generateErrs)
+	assert.Equal(t, "this is an error", generateErrs)
 	assert.NoError(t, err)
 }

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -92,7 +93,7 @@ func (h *generatePollHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
-	finished, jobErrs, err := data.GeneratePoll(ctx, h.taskID, h.queue)
+	finished, jobErr, err := data.GeneratePoll(ctx, h.taskID, h.queue)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error polling for generated tasks",
@@ -100,14 +101,15 @@ func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
 		}))
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
-	shouldExit := false
-	if len(jobErrs) > 0 { // exit early if we know the error will keep recurring
-		jobErr := errors.New(strings.Join(jobErrs, ", "))
-		shouldExit = db.IsDocumentLimit(jobErr)
-	}
+
+	// Exit early if we know the error will keep recurring.
+	// If the parser project is already too big it's not going to get smaller.
+	// If new tasks create a dependency cycle it's going to persist across retries.
+	shouldExit := db.IsDocumentLimit(errors.New(jobErr)) || strings.Contains(jobErr, model.DependencyCycleError.Error())
+
 	return gimlet.NewJSONResponse(&apimodels.GeneratePollResponse{
 		Finished:   finished,
 		ShouldExit: shouldExit,
-		Errors:     jobErrs,
+		Errors:     []string{jobErr},
 	})
 }

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -116,5 +116,6 @@ func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
 		Finished:   finished,
 		ShouldExit: shouldExit,
 		Errors:     errors,
+		Error:      jobErr,
 	})
 }

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -107,9 +107,14 @@ func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
 	// If new tasks create a dependency cycle it's going to persist across retries.
 	shouldExit := db.IsDocumentLimit(errors.New(jobErr)) || strings.Contains(jobErr, model.DependencyCycleError.Error())
 
+	var errors []string
+	if len(jobErr) > 0 {
+		errors = append(errors, jobErr)
+	}
+
 	return gimlet.NewJSONResponse(&apimodels.GeneratePollResponse{
 		Finished:   finished,
 		ShouldExit: shouldExit,
-		Errors:     []string{jobErr},
+		Errors:     errors,
 	})
 }

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -143,9 +143,9 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if err != nil {
 		return errors.Wrap(err, "error merging generated projects")
 	}
-	start = time.Now()
-	g.TaskID = j.TaskID
+	g.Task = t
 
+	start = time.Now()
 	p, pp, v, err := g.NewVersion(projectInfo.Project, projectInfo.IntermediateProject, v)
 	if err != nil {
 		return j.handleError(pp, v, errors.WithStack(err))
@@ -179,11 +179,27 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		"job":           j.ID(),
 		"version":       t.Version,
 	})
+
+	start = time.Now()
+	if err := g.CheckForCycles(v, p, pref); err != nil {
+		return errors.Wrap(err, "checking new dependency graph for cycles")
+	}
+
+	grip.Debug(message.Fields{
+		"message":       "generate.tasks timing",
+		"function":      "generate",
+		"operation":     "SimulateNewDependencyGraph",
+		"duration_secs": time.Since(start).Seconds(),
+		"task":          t.Id,
+		"job":           j.ID(),
+		"version":       t.Version,
+	})
+
 	start = time.Now()
 
 	// Don't use the job's context, because it's better to finish than to exit early after a
 	// SIGTERM from a deploy. This should maybe be a context with timeout.
-	err = g.Save(context.Background(), p, pp, v, t)
+	err = g.Save(context.Background(), p, pp, v)
 
 	// If the version or parser project has changed there was a race. Another generator will try again.
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {


### PR DESCRIPTION
[EVG-16679](https://jira.mongodb.org/browse/EVG-16679)

### Description 
Cherry pick the changes from #5677 that were reverted and fix the problem.
The fix is just the second commit (https://github.com/evergreen-ci/evergreen/commit/78270ed7918252620792cd480953cd29b2cb768c)

### Testing 
Generate tasks [works in staging](https://spruce-staging.corp.mongodb.com/version/6290ff22b237364300b7b73f/tasks). Without the fix this would have also been broken.
