### PR TITLE
EVG-16974 Remove null check from annotation update note 

### DIFF
--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -111,9 +111,6 @@ func UpdateAnnotationNote(taskId string, execution int, originalMessage, newMess
 	if err != nil {
 		return errors.Wrap(err, "finding task annotation")
 	}
-	if annotation == nil {
-		return errors.Errorf("annotation for task '%s' and execution %d not found", taskId, execution)
-	}
 
 	if annotation != nil && annotation.Note != nil && annotation.Note.Message != originalMessage {
 		return errors.New("note is out of sync, please try again")


### PR DESCRIPTION
[EVG-16974](https://jira.mongodb.org/browse/EVG-16974)

### Description 
This removes the null check for the annotation update note function. We don't need the null check because if the annotation doesn't exist, one will be created. 

### Testing 
none 
