### PR TITLE
EVG-16797 handle merge conflicts on general section correctly

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -586,7 +586,7 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 		}
 	}
 
-	// Handle each category of aliases as it's own case
+	// Handle each category of aliases as its own case
 	repoAliases, err := FindAliasesForRepo(before.ProjectRef.RepoRefId)
 	catcher.Wrap(err, "finding repo aliases")
 


### PR DESCRIPTION
[EVG-16797](https://jira.mongodb.org/browse/EVG-16797)

### Description 
Testing PR #1 !! Should use the before project ref to test Github conflicts since the UI only passes in general settings. Also fixes copying project with github checks.

### Testing 
Discovered in staging, tested locally.
![image](https://user-images.githubusercontent.com/26798134/171476152-6da7820b-1965-41eb-b731-bfdd6b5bdda4.png)

