### PR TITLE
EVG-17014 use correct task to determine test results type

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -1796,7 +1796,11 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 
 	baseTestStatusMap := map[string]string{}
 	if baseTask != nil {
-		baseTestResults, _ := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{TaskID: baseTask.Id, Execution: baseTask.Execution})
+		baseTestResults, _ := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{
+			TaskID:         baseTask.Id,
+			Execution:      baseTask.Execution,
+			ExecutionTasks: baseTask.ExecutionTasks,
+		})
 		for _, t := range baseTestResults {
 			baseTestStatusMap[t.TestFile] = t.Status
 		}
@@ -1806,15 +1810,16 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 		sortDir = -1
 	}
 	filteredTestResults, err := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{
-		TaskID:    taskID,
-		Execution: dbTask.Execution,
-		TestName:  utility.FromStringPtr(testName),
-		Statuses:  statuses,
-		SortBy:    sortBy,
-		SortDir:   sortDir,
-		GroupID:   utility.FromStringPtr(groupID),
-		Limit:     limitNum,
-		Page:      utility.FromIntPtr(page),
+		TaskID:         taskID,
+		Execution:      dbTask.Execution,
+		ExecutionTasks: dbTask.ExecutionTasks,
+		TestName:       utility.FromStringPtr(testName),
+		Statuses:       statuses,
+		SortBy:         sortBy,
+		SortDir:        sortDir,
+		GroupID:        utility.FromStringPtr(groupID),
+		Limit:          limitNum,
+		Page:           utility.FromIntPtr(page),
 	})
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
@@ -1891,14 +1896,15 @@ func (r *queryResolver) TaskTestSample(ctx context.Context, tasks []string, test
 		regexFilter := strings.Join(filters, "|")
 		for _, t := range dbTasks {
 			filteredTestResults, err := r.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{
-				TaskID:    t.Id,
-				Execution: t.Execution,
-				TestName:  regexFilter,
-				Statuses:  []string{evergreen.TestFailedStatus},
-				SortBy:    testresult.TaskIDKey,
-				Limit:     testSampleLimit,
-				SortDir:   1,
-				Page:      0,
+				TaskID:         t.Id,
+				Execution:      t.Execution,
+				ExecutionTasks: t.ExecutionTasks,
+				TestName:       regexFilter,
+				Statuses:       []string{evergreen.TestFailedStatus},
+				SortBy:         testresult.TaskIDKey,
+				Limit:          testSampleLimit,
+				SortDir:        1,
+				Page:           0,
 			})
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting test results sample: %s", err))

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -22,6 +22,8 @@ type FindTestsByTaskIdOpts struct {
 	Statuses []string
 	// TaskID is the only required field.
 	TaskID string
+	// ExecutionTasks is required for display tasks.
+	ExecutionTasks []string
 	// TestID matches all IDs >= TestID.
 	TestID   string
 	TestName string

--- a/rest/data/test.go
+++ b/rest/data/test.go
@@ -39,26 +39,10 @@ func FindTestById(id string) ([]testresult.TestResult, error) {
 }
 
 func (tc *DBTestConnector) FindTestsByTaskId(opts FindTestsByTaskIdOpts) ([]testresult.TestResult, error) {
-	t, err := task.FindOneIdNewOrOld(opts.TaskID)
-	if err != nil {
-		return []testresult.TestResult{}, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    errors.Wrapf(err, "finding task '%s'", opts.TaskID).Error(),
-		}
+	taskIDs := []string{opts.TaskID}
+	if len(opts.ExecutionTasks) > 0 {
+		taskIDs = opts.ExecutionTasks
 	}
-	if t == nil {
-		return []testresult.TestResult{}, gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("task '%s' not found", opts.TaskID),
-		}
-	}
-	var taskIDs []string
-	if t.DisplayOnly {
-		taskIDs = t.ExecutionTasks
-	} else {
-		taskIDs = []string{opts.TaskID}
-	}
-
 	res, err := testresult.TestResultsFilterSortPaginate(testresult.TestResultsFilterSortPaginateOpts{
 		TestID:    opts.TestID,
 		TaskIDs:   taskIDs,

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -310,10 +310,10 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 		ExecutionTasks: []string{},
 	}
 	assert.NoError(displayTaskWithoutTasks.Insert())
-	foundTests, err := serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "with_tasks"})
+	foundTests, err := serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "with_tasks", ExecutionTasks: displayTaskWithTasks.ExecutionTasks})
 	assert.NoError(err)
 	assert.Len(foundTests, 20)
-	foundTests, err = serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "without_tasks"})
+	foundTests, err = serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "without_tasks", ExecutionTasks: displayTaskWithoutTasks.ExecutionTasks})
 	assert.Error(err)
 	assert.Len(foundTests, 0)
 }

--- a/rest/data/test_test.go
+++ b/rest/data/test_test.go
@@ -16,7 +16,6 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
-	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -193,11 +192,8 @@ func TestFindTestsByTaskId(t *testing.T) {
 	assert.Len(foundTests, 1)
 
 	foundTests, err = serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "fake_task", TestName: "", Statuses: []string{}, SortBy: "duration", GroupID: "", SortDir: 1, Page: 0, Limit: 0, Execution: 0})
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Len(foundTests, 0)
-	apiErr, ok := err.(gimlet.ErrorResponse)
-	assert.True(ok)
-	assert.Equal(http.StatusNotFound, apiErr.StatusCode)
 
 	foundTests, err = serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "task_0", TestName: "", Statuses: []string{"pass", "fail"}, SortBy: "duration", GroupID: "group_0", SortDir: 1, Page: 0, Limit: 0, Execution: 0})
 	assert.NoError(err)
@@ -305,7 +301,7 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 	}
 	assert.NoError(displayTaskWithTasks.Insert())
 	displayTaskWithoutTasks := &task.Task{
-		Id:             "no_tasks",
+		Id:             "without_tasks",
 		DisplayOnly:    true,
 		ExecutionTasks: []string{},
 	}
@@ -313,8 +309,9 @@ func TestFindTestsByDisplayTaskId(t *testing.T) {
 	foundTests, err := serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "with_tasks", ExecutionTasks: displayTaskWithTasks.ExecutionTasks})
 	assert.NoError(err)
 	assert.Len(foundTests, 20)
+
 	foundTests, err = serviceContext.FindTestsByTaskId(FindTestsByTaskIdOpts{TaskID: "without_tasks", ExecutionTasks: displayTaskWithoutTasks.ExecutionTasks})
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Len(foundTests, 0)
 }
 

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -742,9 +742,13 @@ func TestTestPaginator(t *testing.T) {
 				}
 				nextTest := testresult.TestResult{
 					ID:     mgobson.ObjectId(fmt.Sprintf("object_id_%d_", i)),
+					TaskID: "myTask",
 					Status: status,
 				}
 				cachedTests = append(cachedTests, nextTest)
+			}
+			myTask := task.Task{
+				Id: "myTask",
 			}
 			serviceContext.CachedTests = cachedTests
 			Convey("then finding a key in the middle of the set should produce"+
@@ -773,6 +777,7 @@ func TestTestPaginator(t *testing.T) {
 					limit: limit,
 					key:   fmt.Sprintf("object_id_%d_", testToStartAt),
 					sc:    &serviceContext,
+					task:  &myTask,
 				}
 
 				validatePaginatedResponse(t, handler, expectedTests, expectedPages)
@@ -803,6 +808,7 @@ func TestTestPaginator(t *testing.T) {
 					limit: 50,
 					key:   fmt.Sprintf("object_id_%d_", testToStartAt),
 					sc:    &serviceContext,
+					task:  &myTask,
 				}
 
 				validatePaginatedResponse(t, handler, expectedTests, expectedPages)
@@ -833,6 +839,7 @@ func TestTestPaginator(t *testing.T) {
 					key:   fmt.Sprintf("object_id_%d_", testToStartAt),
 					limit: limit,
 					sc:    &serviceContext,
+					task:  &myTask,
 				}
 
 				validatePaginatedResponse(t, handler, expectedTests, expectedPages)
@@ -863,6 +870,7 @@ func TestTestPaginator(t *testing.T) {
 					key:   fmt.Sprintf("object_id_%d_", testToStartAt),
 					sc:    &serviceContext,
 					limit: limit,
+					task:  &myTask,
 				}
 
 				validatePaginatedResponse(t, handler, expectedTests, expectedPages)

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/evergreen-ci/evergreen/model/task"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/testresult"
@@ -21,17 +23,16 @@ import (
 // GET /tasks/{task_id}/tests
 
 type testGetHandler struct {
-	taskID        string
-	displayTask   bool
-	cedarResults  bool
-	testStatus    []string
-	testID        string
-	testName      string
-	testExecution int
-	key           string
-	limit         int
-	sc            data.Connector
-	latest        bool
+	taskID     string
+	testStatus []string
+	testID     string
+	testName   string
+	key        string
+	limit      int
+	sc         data.Connector
+	latest     bool
+
+	task *task.Task
 }
 
 func makeFetchTestsForTask(sc data.Connector) gimlet.RouteHandler {
@@ -50,35 +51,49 @@ func (tgh *testGetHandler) Parse(ctx context.Context, r *http.Request) error {
 	projCtx := MustHaveProjectContext(ctx)
 	if projCtx.Task == nil {
 		return gimlet.ErrorResponse{
-			Message:    "task not found",
 			StatusCode: http.StatusNotFound,
 		}
 	}
-	tgh.taskID = projCtx.Task.Id
-	tgh.displayTask = projCtx.Task.DisplayOnly
-	tgh.cedarResults = projCtx.Task.HasCedarResults
+	tgh.taskID = gimlet.GetVars(r)["task_id"]
 
 	var err error
 	vals := r.URL.Query()
-	execution := vals.Get("execution")
+	executionStr := vals.Get("execution")
 	tgh.latest = vals.Get("latest") == "true"
 
-	if execution != "" {
-		if tgh.latest {
-			return gimlet.ErrorResponse{
-				Message:    "cannot specify both latest and execution",
-				StatusCode: http.StatusBadRequest,
-			}
-		}
-		tgh.testExecution, err = strconv.Atoi(execution)
-		if err != nil {
-			return gimlet.ErrorResponse{
-				Message:    "invalid execution",
-				StatusCode: http.StatusBadRequest,
-			}
+	if tgh.latest && executionStr != "" {
+		return gimlet.ErrorResponse{
+			Message:    "cannot specify both latest and execution",
+			StatusCode: http.StatusBadRequest,
 		}
 	} else if tgh.latest {
-		tgh.testExecution = projCtx.Task.Execution
+		tgh.task = projCtx.Task
+	} else {
+
+		execution := 0 // Default to first execution unless latest is specified to maintain backwards compatibility.
+		if executionStr != "" {
+			execution, err = strconv.Atoi(executionStr)
+			if err != nil {
+				return gimlet.ErrorResponse{
+					Message:    "invalid execution",
+					StatusCode: http.StatusBadRequest,
+				}
+			}
+		}
+		taskByExecution, err := task.FindOneIdAndExecution(tgh.taskID, execution)
+		if err != nil {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    errors.Wrapf(err, "finding execution '%d' for task '%s'", execution, tgh.taskID).Error(),
+			}
+		}
+		if taskByExecution == nil {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("task '%s' not found", tgh.taskID),
+			}
+		}
+		tgh.task = taskByExecution
 	}
 
 	if status := vals.Get("status"); status != "" {
@@ -98,7 +113,7 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 	var err error
 	var key string
 
-	if tgh.cedarResults {
+	if tgh.task.HasCedarResults {
 		var page int
 		if tgh.key != "" {
 			page, err = strconv.Atoi(tgh.key)
@@ -110,8 +125,8 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 		cedarTestResults, status, err := apimodels.GetCedarTestResults(ctx, apimodels.GetCedarTestResultsOptions{
 			BaseURL:     evergreen.GetEnvironment().Settings().Cedar.BaseURL,
 			TaskID:      tgh.taskID,
-			Execution:   utility.ToIntPtr(tgh.testExecution),
-			DisplayTask: tgh.displayTask,
+			Execution:   utility.ToIntPtr(tgh.task.Execution),
+			DisplayTask: tgh.task.DisplayOnly,
 			TestName:    tgh.testName,
 			Statuses:    tgh.testStatus,
 			Limit:       tgh.limit,
@@ -140,14 +155,16 @@ func (tgh *testGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))
 		}
 	} else {
+
 		// we're going in here, and we've provided nothing so the limit is 101
 		tests, err = tgh.sc.FindTestsByTaskId(data.FindTestsByTaskIdOpts{
-			Execution: tgh.testExecution,
-			Limit:     tgh.limit + 1,
-			Statuses:  tgh.testStatus, // we haven't provided a status or execution or test name
-			TaskID:    tgh.taskID,
-			TestID:    tgh.key, // TESTID IS KEY
-			TestName:  tgh.testName,
+			Execution:      tgh.task.Execution,
+			Limit:          tgh.limit + 1,
+			Statuses:       tgh.testStatus, // we haven't provided a status or execution or test name
+			TaskID:         tgh.taskID,
+			TestID:         tgh.key, // TESTID IS KEY
+			TestName:       tgh.testName,
+			ExecutionTasks: tgh.task.ExecutionTasks,
 		})
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "database error"))


### PR DESCRIPTION
[EVG-17014](https://jira.mongodb.org/browse/EVG-17014)

### Description 
Right now, we check if we're using cedarResults using the task from the project context, rather than the correct task for that task/execution pair. If we're querying an old execution and the newest execution is running, then the projCtx.Task.CedarResults returns false, which means we query using the legacy method for old tasks (which correctly would've had CedarResults set to true if we used the right document).

Refactored so we'd only ever need to query the task document once.

### Testing 
Tested on staging; https://evergreen-staging.corp.mongodb.com/rest/v2/tasks/evg_ubuntu1604_test_model_manifest_78708dfdbd1f5c4e517a61ebc5734f9b54de1323_22_05_31_21_59_52/tests?execution=0 didn't work after restarting before changes, and did work after restarting after changes.
