### PR TITLE
Update githash for downstream tasks

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -889,6 +889,7 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 				patchDoc.Patches = append(patchDoc.Patches, patch.ModulePatch{
 					ModuleName: intent.ParentAsModule,
 					PatchSet:   p.PatchSet,
+					Githash:    parentPatch.Githash,
 				})
 				break
 			}


### PR DESCRIPTION
[EVG-16678](https://jira.mongodb.org/browse/EVG-16678)

### Description 
add githash
will reenable github trigger pr after merge and deploy 

### Testing 
tested on staging evg using sandbox module 

https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu1604_unit_tests_patch_41a9fa3c35db31e2c7323cbe048b409688f47e7a_6299184d97b1d307abd53ab6_22_06_02_20_06_38/logs?execution=0