### PR TITLE
EVG-16877: handle container instance interrupt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.16
 require (
 	github.com/99designs/gqlgen v0.14.0
 	github.com/PuerkitoBio/rehttp v1.1.0
-	github.com/aws/aws-sdk-go v1.44.4
+	github.com/aws/aws-sdk-go v1.44.25
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20211025210128-7f3409c2b515
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8
+	github.com/evergreen-ci/cocoa v0.0.0-20220606184229-6fe30df91be1
 	github.com/evergreen-ci/gimlet v0.0.0-20220419172609-b882e01673e7
 	github.com/evergreen-ci/go-test2json v0.0.0-20180702150328-5b6cfd2e8cb0
 	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.42.44/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
-github.com/aws/aws-sdk-go v1.44.4 h1:ePN0CVJMdiz2vYUcJH96eyxRrtKGSDMgyhP6rah2OgE=
-github.com/aws/aws-sdk-go v1.44.4/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.25 h1:cJZ4gtEpWAD/StO9GGOAyv6AaAoZ9OJUhu96gF9qaio=
+github.com/aws/aws-sdk-go v1.44.25/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -358,8 +358,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8 h1:aYGYPV4SlBJDEn3SyBN83DJ0r+wtx+we7xh1VVwP/t0=
-github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8/go.mod h1:AjVFiPvAfvSMWEI15f4IuPSWMXBEwJpnfTkGTWpDJ+k=
+github.com/evergreen-ci/cocoa v0.0.0-20220606184229-6fe30df91be1 h1:Igq58kSkb1UqXt3gnCg90r8CFlQjYfygsi/OnAERhaM=
+github.com/evergreen-ci/cocoa v0.0.0-20220606184229-6fe30df91be1/go.mod h1:/3htq2sL7ej1sZ+5AOM0XmKmHlTfeAQ7GG9UZ8gqt2g=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -203,6 +204,36 @@ func (pd *PodDispatcher) dequeue(ctx context.Context, env evergreen.Environment)
 			pd.TaskIDs = oldTaskIDs
 		}
 	}()
+
+	res, err := env.DB().Collection(Collection).UpdateOne(ctx, pd.atomicUpsertQuery(), pd.atomicUpsertUpdate())
+	if err != nil {
+		return errors.Wrap(err, "upserting dispatcher")
+	}
+	if res.ModifiedCount == 0 {
+		return errors.New("dispatcher was not updated")
+	}
+
+	pd.ModificationCount++
+
+	return nil
+}
+
+// removePodsAndTasks removes the given pods and tasks from the dispatcher. If
+// a pod or task is given as a parameter but is not present in the dispatcher,
+// it is ignored.
+// kim: TODO: test
+func (pd *PodDispatcher) removePodsAndTasks(ctx context.Context, env evergreen.Environment, podIDs []string, taskIDs []string) (err error) {
+	oldPodIDs := pd.PodIDs
+	oldTaskIDs := pd.TaskIDs
+	pd.PodIDs, _ = utility.StringSliceSymmetricDifference(pd.PodIDs, podIDs)
+	pd.TaskIDs, _ = utility.StringSliceSymmetricDifference(pd.TaskIDs, taskIDs)
+	defer func() {
+		if err != nil {
+			pd.PodIDs = oldPodIDs
+			pd.TaskIDs = oldTaskIDs
+		}
+	}()
+
 	res, err := env.DB().Collection(Collection).UpdateOne(ctx, pd.atomicUpsertQuery(), pd.atomicUpsertUpdate())
 	if err != nil {
 		return errors.Wrap(err, "upserting dispatcher")
@@ -230,6 +261,38 @@ func (pd *PodDispatcher) dequeueUndispatchableTask(ctx context.Context, env ever
 
 	if err := pd.dequeue(ctx, env); err != nil {
 		return errors.Wrap(err, "dequeueing task")
+	}
+
+	return nil
+}
+
+// RemovePod removes a pod from the dispatcher. If it's the last remaining pod
+// in the dispatcher, it also removes all tasks from the dispatcher and marks
+// those tasks as no longer allocated containers.
+// kim: TODO: test
+func (pd *PodDispatcher) RemovePod(ctx context.Context, env evergreen.Environment, podID string) error {
+	// kim: TODO: make removeUndispatchableTasks for bulk-updating tasks +
+	// clearing the dispatch queue
+
+	if !utility.StringSliceContains(pd.PodIDs, podID) {
+		return errors.Errorf("cannot remove pod '%s' from dispatcher because the pod is not associated with the dispatcher", podID)
+	}
+
+	var tasksToRemove []string
+	if len(pd.PodIDs) == 1 && len(pd.TaskIDs) > 0 {
+		// The last pod is about to be removed, so there will be no pod
+		// remaining to run the tasks still in the dispatch queue. Mark all the
+		// tasks as no longer allocated any container to run them so that they
+		// can be re-allocated.
+		if err := task.MarkContainerDeallocated(ctx, env, pd.TaskIDs); err != nil {
+			return errors.Wrap(err, "marking all tasks in dispatcher as container deallocated")
+		}
+
+		tasksToRemove = pd.TaskIDs
+	}
+
+	if err := pd.removePodsAndTasks(ctx, env, []string{podID}, tasksToRemove); err != nil {
+		return errors.Wrap(err, "removing pod and tasks from dispatcher")
 	}
 
 	return nil

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -536,6 +536,9 @@ func (p *Pod) ClearRunningTask() error {
 	}); err != nil {
 		return errors.Wrap(err, "clearing running task")
 	}
+
+	p.RunningTask = ""
+
 	return nil
 }
 

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -520,6 +520,25 @@ func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, tas
 	return nil
 }
 
+// ClearRunningTask clears the current task dispatched to the pod.
+func (p *Pod) ClearRunningTask() error {
+	if p.RunningTask == "" {
+		return nil
+	}
+
+	if err := UpdateOne(bson.M{
+		IDKey:          p.ID,
+		RunningTaskKey: p.RunningTask,
+	}, bson.M{
+		"$unset": bson.M{
+			RunningTaskKey: 1,
+		},
+	}); err != nil {
+		return errors.Wrap(err, "clearing running task")
+	}
+	return nil
+}
+
 // SetAgentStartTime sets the time when the pod's agent started.
 func (p *Pod) SetAgentStartTime() error {
 	ts := utility.BSONTime(time.Now())

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -592,6 +592,7 @@ func TestClearRunningTask(t *testing.T) {
 			require.NoError(t, p.Insert())
 			require.NoError(t, p.ClearRunningTask())
 
+			assert.Zero(t, p.RunningTask)
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
@@ -602,6 +603,7 @@ func TestClearRunningTask(t *testing.T) {
 			require.NoError(t, p.Insert())
 			require.NoError(t, p.ClearRunningTask())
 
+			assert.Zero(t, p.RunningTask)
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
@@ -613,6 +615,7 @@ func TestClearRunningTask(t *testing.T) {
 			p.RunningTask = ""
 			require.NoError(t, p.ClearRunningTask())
 
+			assert.Zero(t, p.RunningTask)
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2357,10 +2357,7 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
 		assert.False(t, dbTask.ContainerAllocated)
-		assert.True(t, utility.IsZeroTime(dbTask.DispatchTime))
-		assert.True(t, utility.IsZeroTime(dbTask.LastHeartbeat))
 		assert.True(t, utility.IsZeroTime(dbTask.ContainerAllocatedTime))
-		assert.Zero(t, dbTask.AgentVersion)
 	}
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task){
@@ -2372,6 +2369,12 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 		},
 		"FailsWithUnallocatedTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
 			tsk.ContainerAllocated = false
+			require.NoError(t, tsk.Insert())
+
+			assert.Error(t, tsk.MarkAsContainerDeallocated(ctx, env))
+		},
+		"FailsWithHostTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformHost
 			require.NoError(t, tsk.Insert())
 
 			assert.Error(t, tsk.MarkAsContainerDeallocated(ctx, env))
@@ -2403,12 +2406,123 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 				Status:                 evergreen.TaskUndispatched,
 				ContainerAllocated:     true,
 				ContainerAllocatedTime: time.Now(),
-				DispatchTime:           time.Now(),
-				LastHeartbeat:          time.Now(),
 				ExecutionPlatform:      ExecutionPlatformContainer,
 			}
 
 			tCase(tctx, t, env, tsk)
+		})
+	}
+}
+
+func TestMarkManyContainerDeallocated(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.Clear(Collection))
+	}()
+
+	checkTasksUnallocated := func(t *testing.T, taskIDs []string) {
+		for _, taskID := range taskIDs {
+			dbTask, err := FindOneId(taskID)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.False(t, dbTask.ContainerAllocated)
+			assert.True(t, utility.IsZeroTime(dbTask.ContainerAllocatedTime))
+		}
+	}
+
+	for tName, tCase := range map[string]func(t *testing.T, tasks []Task){
+		"Succeeds": func(t *testing.T, tasks []Task) {
+			var taskIDs []string
+			for _, tsk := range tasks {
+				require.NoError(t, tsk.Insert())
+				taskIDs = append(taskIDs, tsk.Id)
+			}
+
+			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			checkTasksUnallocated(t, taskIDs)
+		},
+		"NoopsWithHostTask": func(t *testing.T, tasks []Task) {
+			tasks[0].ExecutionPlatform = ExecutionPlatformHost
+			var taskIDs []string
+			for _, tsk := range tasks {
+				require.NoError(t, tsk.Insert())
+				taskIDs = append(taskIDs, tsk.Id)
+			}
+
+			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			checkTasksUnallocated(t, taskIDs[1:])
+			dbHostTask, err := FindOneId(tasks[0].Id)
+			require.NoError(t, err)
+			assert.Equal(t, tasks[0].ContainerAllocated, dbHostTask.ContainerAllocated, "host task should not be updated")
+			assert.NotZero(t, dbHostTask.LastHeartbeat, "host task should not be updated")
+			assert.NotZero(t, dbHostTask.DispatchTime, "host task should not be updated")
+		},
+		"UpdatesTaskThatIsAlreadyContainerUnallocated": func(t *testing.T, tasks []Task) {
+			tasks[0].ContainerAllocated = false
+			var taskIDs []string
+			for _, tsk := range tasks {
+				require.NoError(t, tsk.Insert())
+				taskIDs = append(taskIDs, tsk.Id)
+			}
+
+			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			checkTasksUnallocated(t, taskIDs)
+		},
+		"DoesNotUpdateNonexistentTask": func(t *testing.T, tasks []Task) {
+			taskIDs := []string{tasks[0].Id}
+			for _, tsk := range tasks[1:] {
+				require.NoError(t, tsk.Insert())
+				taskIDs = append(taskIDs, tsk.Id)
+			}
+
+			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			checkTasksUnallocated(t, taskIDs[1:])
+
+			dbTask, err := FindOneId(tasks[0].Id)
+			assert.NoError(t, err)
+			assert.Zero(t, dbTask)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.Clear(Collection))
+			ts := utility.BSONTime(time.Now())
+			tasks := []Task{
+				{
+					Id:                     utility.RandomString(),
+					Activated:              true,
+					ActivatedTime:          time.Now(),
+					Status:                 evergreen.TaskUndispatched,
+					ContainerAllocated:     true,
+					ContainerAllocatedTime: ts,
+					DispatchTime:           ts,
+					LastHeartbeat:          ts,
+					ExecutionPlatform:      ExecutionPlatformContainer,
+				},
+				{
+					Id:                     utility.RandomString(),
+					Activated:              true,
+					ActivatedTime:          ts,
+					Status:                 evergreen.TaskDispatched,
+					ContainerAllocated:     true,
+					ContainerAllocatedTime: ts,
+					DispatchTime:           ts,
+					LastHeartbeat:          ts,
+					ExecutionPlatform:      ExecutionPlatformContainer,
+				},
+				{
+					Id:                     utility.RandomString(),
+					Activated:              true,
+					ActivatedTime:          ts,
+					Status:                 evergreen.TaskStarted,
+					ContainerAllocated:     true,
+					ContainerAllocatedTime: ts,
+					DispatchTime:           ts,
+					StartTime:              ts,
+					LastHeartbeat:          ts,
+					ExecutionPlatform:      ExecutionPlatformContainer,
+				},
+			}
+
+			tCase(t, tasks)
 		})
 	}
 }

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3251,7 +3251,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	assert.Len(e, 4)
 }
 
-func TestClearAndResetStrandedTask(t *testing.T) {
+func TestClearAndResetStrandedHostTask(t *testing.T) {
 	require.NoError(t, db.ClearCollections(host.Collection, task.Collection, task.OldCollection, build.Collection, VersionCollection))
 	assert := assert.New(t)
 
@@ -3281,7 +3281,7 @@ func TestClearAndResetStrandedTask(t *testing.T) {
 	}
 	assert.NoError(v.Insert())
 
-	assert.NoError(ClearAndResetStrandedTask(h))
+	assert.NoError(ClearAndResetStrandedHostTask(h))
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, runningTask.Status)
@@ -3367,7 +3367,7 @@ func TestClearAndResetStaleStrandedTask(t *testing.T) {
 	b := build.Build{Id: "b"}
 	assert.NoError(b.Insert())
 
-	assert.NoError(ClearAndResetStrandedTask(h))
+	assert.NoError(ClearAndResetStrandedHostTask(h))
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, runningTask.Status)
@@ -3415,7 +3415,7 @@ func TestClearAndResetExecTask(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 
-	assert.NoError(t, ClearAndResetStrandedTask(h))
+	assert.NoError(t, ClearAndResetStrandedHostTask(h))
 	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -2,13 +2,10 @@ package data
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
 
@@ -86,49 +83,4 @@ func FindPodByID(id string) (*model.APIPod, error) {
 		}
 	}
 	return &apiPod, nil
-}
-
-// FindPodByExternalID finds a pod by its external identifier. It returns a nil
-// result if no such pod is found.
-func FindPodByExternalID(id string) (*model.APIPod, error) {
-	p, err := pod.FindOneByExternalID(id)
-	if err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "finding pod with external ID '%s'", id).Error(),
-		}
-	}
-	if p == nil {
-		return nil, nil
-	}
-
-	var apiPod model.APIPod
-	if err := apiPod.BuildFromService(p); err != nil {
-		return nil, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "converting pod to API model").Error(),
-		}
-	}
-	return &apiPod, nil
-}
-
-// UpdatePodStatus updates the pod status from the current status to the updated
-// one.
-func UpdatePodStatus(id string, apiCurrent, apiUpdated restModel.APIPodStatus) error {
-	current, err := apiCurrent.ToService()
-	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "converting current status to service model").Error(),
-		}
-	}
-	updated, err := apiUpdated.ToService()
-	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "converting current status to service model").Error(),
-		}
-	}
-
-	return pod.UpdateOneStatus(id, *current, *updated, utility.BSONTime(time.Now()))
 }

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -64,53 +64,6 @@ func TestPodConnector(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, apiPod)
 		},
-		"FindPodByExternalIDSucceeds": func(t *testing.T) {
-			p := pod.Pod{
-				ID:     "id",
-				Type:   pod.TypeAgent,
-				Status: pod.StatusRunning,
-				Resources: pod.ResourceInfo{
-					ExternalID: "external_id",
-				},
-			}
-			require.NoError(t, p.Insert())
-
-			apiPod, err := FindPodByExternalID(p.Resources.ExternalID)
-			require.NoError(t, err)
-			require.NotZero(t, apiPod)
-
-			assert.Equal(t, p.ID, utility.FromStringPtr(apiPod.ID))
-			assert.EqualValues(t, p.Type, apiPod.Type)
-			assert.EqualValues(t, p.Status, apiPod.Status)
-		},
-		"FindPodByExternalIDReturnsNilWithNonexistentPod": func(t *testing.T) {
-			apiPod, err := FindPodByExternalID("nonexistent")
-			assert.NoError(t, err)
-			assert.Zero(t, apiPod)
-		},
-		"UpdatePodStatusSucceeds": func(t *testing.T) {
-			p := pod.Pod{
-				ID:     "id",
-				Type:   pod.TypeAgent,
-				Status: pod.StatusRunning,
-			}
-			require.NoError(t, p.Insert())
-
-			var current model.APIPodStatus
-			require.NoError(t, current.BuildFromService(p.Status))
-			updated := model.PodStatusTerminated
-			require.NoError(t, UpdatePodStatus(p.ID, current, updated))
-
-			apiPod, err := FindPodByID(p.ID)
-			require.NoError(t, err)
-			require.NotZero(t, apiPod)
-
-			require.NotZero(t, apiPod.Status)
-			assert.Equal(t, updated, apiPod.Status)
-		},
-		"UpdatePodStatusFailsWithNonexistentPod": func(t *testing.T) {
-			assert.Error(t, UpdatePodStatus("nonexistent", model.PodStatusRunning, model.PodStatusTerminated))
-		},
 		"CheckPodSecret": func(t *testing.T) {
 			secretVal := "secret_value"
 			p := pod.Pod{

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -416,13 +416,11 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 			}
 		}
 	case ecsContainerInstanceStateChangeType:
-		// kim: TODO: test
 		detail, ok := notification.Detail.(ecsContainerInstanceEventDetail)
 		if !ok {
 			return errors.New("notification details should be ECS task event details")
 		}
-		// kim: TODO: replace with Cocoa constant.
-		if detail.Status != "DRAINING" {
+		if ecs.ContainerInstanceStatus(detail.Status) != ecs.ContainerInstanceStatusDraining {
 			return nil
 		}
 

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -8,14 +8,15 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
-	"github.com/evergreen-ci/evergreen/rest/data"
-	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -36,7 +37,8 @@ const (
 	interruptionWarningType = "EC2 Spot Instance Interruption Warning"
 	instanceStateChangeType = "EC2 Instance State-change Notification"
 
-	ecsTaskStateChangeType = "ECS Task State Change"
+	ecsTaskStateChangeType              = "ECS Task State Change"
+	ecsContainerInstanceStateChangeType = "ECS Container Instance State Change"
 )
 
 type baseSNS struct {
@@ -296,16 +298,23 @@ type ecsSNS struct {
 }
 
 type ecsEventBridgeNotification struct {
-	DetailType string         `json:"detail-type"`
-	Detail     ecsEventDetail `json:"detail"`
+	DetailType string      `json:"detail-type"`
+	Detail     interface{} `json:"detail"`
 }
 
-type ecsEventDetail struct {
+type ecsTaskEventDetail struct {
 	TaskARN       string `json:"taskArn"`
 	ClusterARN    string `json:"clusterArn"`
 	LastStatus    string `json:"lastStatus"`
 	DesiredStatus string `json:"desiredStatus"`
 	StoppedReason string `json:"stoppedReason"`
+}
+
+type ecsContainerInstanceEventDetail struct {
+	ContainerInstanceARN string `json:"containerInstanceArn"`
+	ClusterARN           string `json:"clusterArn"`
+	Status               string `json:"status"`
+	StatusReason         string `json:"statusReason"`
 }
 
 func makeECSSNS(env evergreen.Environment, queue amboy.Queue) gimlet.RouteHandler {
@@ -360,27 +369,31 @@ func (sns *ecsSNS) Run(ctx context.Context) gimlet.Responder {
 func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEventBridgeNotification) error {
 	switch notification.DetailType {
 	case ecsTaskStateChangeType:
-		p, err := data.FindPodByExternalID(notification.Detail.TaskARN)
+		detail, ok := notification.Detail.(ecsTaskEventDetail)
+		if !ok {
+			return errors.New("notification details should be ECS task event details")
+		}
+		p, err := pod.FindOneByExternalID(detail.TaskARN)
 		if err != nil {
 			return err
 		}
 		if p == nil {
 			grip.Info(message.Fields{
 				"message":        "found unexpected ECS task that did not match any known pod in Evergreen",
-				"task":           notification.Detail.TaskARN,
-				"cluster":        notification.Detail.ClusterARN,
-				"last_status":    notification.Detail.LastStatus,
-				"desired_status": notification.Detail.DesiredStatus,
+				"task":           detail.TaskARN,
+				"cluster":        detail.ClusterARN,
+				"last_status":    detail.LastStatus,
+				"desired_status": detail.DesiredStatus,
 				"route":          "/hooks/aws/ecs",
 			})
-			if err := sns.cleanupUnrecognizedPod(ctx, notification.Detail); err != nil {
-				return errors.Wrapf(err, "cleaning up unrecognized pod '%s'", notification.Detail.TaskARN)
+			if err := sns.cleanupUnrecognizedPod(ctx, detail); err != nil {
+				return errors.Wrapf(err, "cleaning up unrecognized pod '%s'", detail.TaskARN)
 			}
 
 			return nil
 		}
 
-		status := ecs.TaskStatus(notification.Detail.LastStatus).ToCocoaStatus()
+		status := ecs.TaskStatus(detail.LastStatus).ToCocoaStatus()
 		switch status {
 		case cocoa.StatusStarting, cocoa.StatusRunning:
 			// No-op because the pod is not considered running until the agent
@@ -391,7 +404,7 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 			// stopped.
 			return nil
 		case cocoa.StatusStopped:
-			reason := notification.Detail.StoppedReason
+			reason := detail.StoppedReason
 			if reason == "" {
 				reason = "stopped due to unknown reason"
 			}
@@ -399,9 +412,57 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 		default:
 			return gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
-				Message:    fmt.Sprintf("unrecognized status '%s'", notification.Detail.LastStatus),
+				Message:    fmt.Sprintf("unrecognized status '%s'", detail.LastStatus),
 			}
 		}
+	case ecsContainerInstanceStateChangeType:
+		// kim: TODO: test
+		detail, ok := notification.Detail.(ecsContainerInstanceEventDetail)
+		if !ok {
+			return errors.New("notification details should be ECS task event details")
+		}
+		// kim: TODO: replace with Cocoa constant.
+		if detail.Status != "DRAINING" {
+			return nil
+		}
+
+		grip.Info(message.Fields{
+			"message":            "got notification for draining container instance",
+			"container_instance": detail.ContainerInstanceARN,
+			"cluster":            detail.ClusterARN,
+			"reason":             detail.StatusReason,
+		})
+
+		taskARNs, err := sns.listECSTasks(ctx, detail)
+		if err != nil {
+			return errors.Wrapf(err, "listing ECS tasks associated with container instance '%s'", detail.ContainerInstanceARN)
+		}
+		for _, taskARN := range taskARNs {
+			p, err := pod.FindOneByExternalID(taskARN)
+			if err != nil {
+				return errors.Wrapf(err, "finding pod with external ID '%s'", taskARN)
+			}
+			if p == nil {
+				grip.Error(message.Fields{
+					"message": "Found an ECS task running in a draining container instance, but it's not associated with any known pod." +
+						" This isn't supposed to happen, so this may be due to a race (i.e. the ECS task started before we could track it in the DB) or a bug (i.e. failing to properly track a pod that we started).",
+					"task":               taskARN,
+					"container_instance": detail.ContainerInstanceARN,
+					"cluster":            detail.ClusterARN,
+				})
+				continue
+			}
+			var reason string
+			if detail.StatusReason != "" {
+				reason = detail.StatusReason
+			} else {
+				reason = "container instance is draining"
+			}
+			if err := sns.handleStoppedPod(ctx, p, reason); err != nil {
+				return errors.Wrapf(err, "handling pods on draining container instance '%s'", detail.ContainerInstanceARN)
+			}
+		}
+		return nil
 	default:
 		grip.Error(message.Fields{
 			"message":         "received an unknown notification detail type",
@@ -421,20 +482,19 @@ func (sns *ecsSNS) handleNotification(ctx context.Context, notification ecsEvent
 
 // handleStoppedPod handles an SNS notification that a pod has been stopped in
 // ECS.
-func (sns *ecsSNS) handleStoppedPod(ctx context.Context, p *model.APIPod, reason string) error {
-	if p.Status == model.PodStatusDecommissioned || p.Status == model.PodStatusTerminated {
+func (sns *ecsSNS) handleStoppedPod(ctx context.Context, p *pod.Pod, reason string) error {
+	if p.Status == pod.StatusDecommissioned || p.Status == pod.StatusTerminated {
 		return nil
 	}
-	id := utility.FromStringPtr(p.ID)
 
-	if err := data.UpdatePodStatus(id, p.Status, model.PodStatusDecommissioned); err != nil {
+	if err := p.UpdateStatus(pod.StatusDecommissioned); err != nil {
 		return err
 	}
 
-	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, units.NewPodTerminationJob(id, reason, utility.RoundPartOfMinute(0))); err != nil {
+	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, units.NewPodTerminationJob(p.ID, reason, utility.RoundPartOfMinute(0))); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":    "could not enqueue job to terminate pod from SNS notification",
-			"pod_id":     id,
+			"pod_id":     p.ID,
 			"pod_status": p.Status,
 			"route":      "/hooks/aws/ecs",
 		}))
@@ -443,8 +503,8 @@ func (sns *ecsSNS) handleStoppedPod(ctx context.Context, p *model.APIPod, reason
 	return nil
 }
 
-func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, details ecsEventDetail) error {
-	status := ecs.TaskStatus(details.DesiredStatus).ToCocoaStatus()
+func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, detail ecsTaskEventDetail) error {
+	status := ecs.TaskStatus(detail.DesiredStatus).ToCocoaStatus()
 	if status == cocoa.StatusStopping || status == cocoa.StatusStopped {
 		// The unrecognized pod is already cleaning up, so no-op.
 		return nil
@@ -462,7 +522,7 @@ func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, details ecsEventD
 	// Evergreen-owned cluster.
 	var isInManagedCluster bool
 	for _, c := range sns.env.Settings().Providers.AWS.Pod.ECS.Clusters {
-		if strings.Contains(details.ClusterARN, c.Name) {
+		if strings.Contains(detail.ClusterARN, c.Name) {
 			isInManagedCluster = true
 			break
 		}
@@ -478,8 +538,8 @@ func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, details ecsEventD
 	defer c.Close(ctx)
 
 	resources := cocoa.NewECSPodResources().
-		SetCluster(details.ClusterARN).
-		SetTaskID(details.TaskARN)
+		SetCluster(detail.ClusterARN).
+		SetTaskID(detail.TaskARN)
 
 	statusInfo := cocoa.NewECSPodStatusInfo().SetStatus(status)
 
@@ -499,12 +559,64 @@ func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, details ecsEventD
 
 	grip.Info(message.Fields{
 		"message":        "successfully cleaned up unrecognized pod",
-		"task":           details.TaskARN,
-		"cluster":        details.ClusterARN,
-		"last_status":    details.LastStatus,
-		"desired_status": details.DesiredStatus,
+		"task":           detail.TaskARN,
+		"cluster":        detail.ClusterARN,
+		"last_status":    detail.LastStatus,
+		"desired_status": detail.DesiredStatus,
 		"route":          "/hooks/aws/ecs",
 	})
 
 	return nil
+}
+
+// listECSTasks returns the ARNs of all ECS tasks running in the container
+// instance associated with the event.
+func (sns *ecsSNS) listECSTasks(ctx context.Context, details ecsContainerInstanceEventDetail) ([]string, error) {
+	// Spot check that the notification is actually for a pod in an
+	// Evergreen-owned cluster.
+	var isInManagedCluster bool
+	for _, c := range sns.env.Settings().Providers.AWS.Pod.ECS.Clusters {
+		if strings.Contains(details.ClusterARN, c.Name) {
+			isInManagedCluster = true
+			break
+		}
+	}
+	if !isInManagedCluster {
+		return nil, nil
+	}
+
+	c, err := sns.makeECSClient(sns.env.Settings())
+	if err != nil {
+		return nil, errors.Wrap(err, "getting ECS client")
+	}
+	defer c.Close(ctx)
+
+	var token *string
+	var taskARNs []string
+
+	for {
+		resp, err := c.ListTasks(ctx, &awsECS.ListTasksInput{
+			Cluster:           aws.String(details.ClusterARN),
+			ContainerInstance: aws.String(details.ContainerInstanceARN),
+			NextToken:         token,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "listing ECS tasks")
+		}
+		if resp == nil {
+			return nil, errors.New("listing ECS tasks returned no response")
+		}
+
+		for _, arn := range resp.TaskArns {
+			if arn == nil {
+				continue
+			}
+			taskARNs = append(taskARNs, utility.FromStringPtr(arn))
+		}
+
+		token = resp.NextToken
+		if token == nil {
+			return taskARNs, nil
+		}
+	}
 }

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -185,7 +185,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task":     j.host.RunningTask,
 			})
 
-			j.AddError(model.ClearAndResetStrandedTask(j.host))
+			j.AddError(model.ClearAndResetStrandedHostTask(j.host))
 		} else {
 			return
 		}
@@ -252,7 +252,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task":     j.host.RunningTask,
 			})
 
-			j.AddError(model.ClearAndResetStrandedTask(j.host))
+			j.AddError(model.ClearAndResetStrandedHostTask(j.host))
 		} else {
 			return
 		}

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -195,18 +195,11 @@ func (j *podTerminationJob) populateIfUnset(ctx context.Context) error {
 	return nil
 }
 
-// kim: TODO: check if this pod is currently running a task or is part of a
-// pod group to decide if the tasks need resetting.
-// If it's the last pod running in a dispatch queue and there are still
-// tasks in the dispatch queue, reset all tasks in the dispatch queue to
-// need reallocation. If it's running a task, reset that one task to need
-// reallocation.
-
 // fixStrandedTasks fixes tasks that are in an invalid state due to termination
 // of this pod. If the pod is already running a task, that task is reset so that
-// it can re-run. If the pod is part of a dispatcher that will have no pods left
-// to run tasks after this one is terminated, it marks the tasks in the
-// dispatcher as needing re-allocation.
+// it can re-run if possible. If the pod is part of a dispatcher that will have
+// no pods remaining to run tasks after this one is terminated, it marks the
+// tasks in the dispatcher as needing re-allocation.
 func (j *podTerminationJob) fixStrandedTasks(ctx context.Context) error {
 	if j.pod.RunningTask != "" {
 		if err := model.ClearAndResetStrandedContainerTask(j.pod); err != nil {
@@ -222,16 +215,6 @@ func (j *podTerminationJob) fixStrandedTasks(ctx context.Context) error {
 		return nil
 	}
 
-	// kim: TODO: update dispatcher to remove pod and tasks, and mark tasks as
-	// needing re-allocation. Maybe need transaction to do this safely. But
-	// given that the task re-allocation update just sets
-	// ContainerAllocated=false, it might not be necessary? It might be
-	// sufficient to use an atomic update on the task collection with the IDs
-	// and possibly check the other keys to make sure that they're still in a
-	// needs-dispatch state. Since ContainerAllocated can only be set by pod
-	// allocation and a pod allocation should not be happening right now (since
-	// we have only one pod in the dispatch queue for now), it should be safe to
-	// clear the field since there cannot be a race.
 	if err := disp.RemovePod(ctx, j.env, j.pod.ID); err != nil {
 		return errors.Wrap(err, "removing pod from dispatcher")
 	}

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -3,14 +3,20 @@ package units
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/cocoa/mock"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/evergreen-ci/evergreen/model/pod/dispatcher"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,6 +34,10 @@ func TestNewPodTerminationJob(t *testing.T) {
 }
 
 func TestPodTerminationJob(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(pod.Collection, task.Collection, task.OldCollection, build.Collection, model.VersionCollection, dispatcher.Collection, event.AllLogCollection))
+	}()
+
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *podTerminationJob){
 		"TerminatesAndDeletesResourcesForRunningPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
 			require.NoError(t, j.pod.Insert())
@@ -103,15 +113,107 @@ func TestPodTerminationJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
 		},
+		"TerminatesPodAndResetsTaskStrandedOnPod": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
+			b := build.Build{
+				Id:     "build_id",
+				Status: evergreen.BuildStarted,
+			}
+			require.NoError(t, b.Insert())
+			v := model.Version{
+				Id:     "version_id",
+				Status: evergreen.VersionStarted,
+			}
+			require.NoError(t, v.Insert())
+			tsk := task.Task{
+				Id:            "task_id",
+				Execution:     1,
+				BuildId:       b.Id,
+				Version:       v.Id,
+				Status:        evergreen.TaskStarted,
+				Activated:     true,
+				ActivatedTime: time.Now(),
+				DispatchTime:  time.Now(),
+				StartTime:     time.Now(),
+				LastHeartbeat: time.Now(),
+			}
+			require.NoError(t, tsk.Insert())
+			j.pod.RunningTask = tsk.Id
+			require.NoError(t, j.pod.Insert())
+
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			assert.Equal(t, cocoa.StatusDeleted, j.ecsPod.StatusInfo().Status)
+			dbPod, err := pod.FindOneByID(j.pod.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
+
+			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
+			require.NoError(t, err)
+			assert.Equal(t, evergreen.TaskFailed, dbArchivedTask.Status, "stranded task should have failed")
+
+			dbTask, err := task.FindOneId(tsk.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.Equal(t, evergreen.TaskUndispatched, dbTask.Status, "stranded task should have been restarted")
+
+			dbBuild, err := build.FindOneId(b.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbBuild)
+			assert.Equal(t, evergreen.BuildCreated, dbBuild.Status, "build should have been updated after resetting stranded task")
+
+			dbVersion, err := model.VersionFindOneId(v.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVersion)
+			assert.Equal(t, evergreen.VersionCreated, dbVersion.Status, "version should have been updated after resetting stranded task")
+		},
+		"RemovesPodFromDispatcher": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
+			pd := dispatcher.NewPodDispatcher("group_id", []string{"task_id"}, []string{j.pod.ID, "another_pod_id"})
+			require.NoError(t, pd.Insert())
+			require.NoError(t, j.pod.Insert())
+
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			assert.Equal(t, cocoa.StatusDeleted, j.ecsPod.StatusInfo().Status)
+			dbPod, err := pod.FindOneByID(j.pod.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
+
+			dbDisp, err := dispatcher.FindOneByID(pd.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisp)
+			assert.Equal(t, dbDisp.PodIDs, []string{"another_pod_id"}, "pod should have been removed from dispatcher's set of pods")
+			assert.Equal(t, dbDisp.TaskIDs, []string{"task_id"}, "tasks being dispatched should be unaffected")
+		},
+		"ClearsDispatcherTasksWhenPodIsOnlyRemainingOne": func(ctx context.Context, t *testing.T, j *podTerminationJob) {
+			pd := dispatcher.NewPodDispatcher("group_id", []string{"task_id"}, []string{j.pod.ID})
+			require.NoError(t, pd.Insert())
+			require.NoError(t, j.pod.Insert())
+
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			assert.Equal(t, cocoa.StatusDeleted, j.ecsPod.StatusInfo().Status)
+			dbPod, err := pod.FindOneByID(j.pod.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Equal(t, pod.StatusTerminated, dbPod.Status)
+
+			dbDisp, err := dispatcher.FindOneByID(pd.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisp)
+			assert.Empty(t, dbDisp.PodIDs, "terminated pod should have been removed from dispatcher")
+			assert.Empty(t, dbDisp.TaskIDs, "tasks should have been cleared from the dispatcher since there are no remaining pods to run them")
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			require.NoError(t, db.ClearCollections(pod.Collection, event.AllLogCollection))
-			defer func() {
-				assert.NoError(t, db.ClearCollections(pod.Collection, event.AllLogCollection))
-			}()
+			require.NoError(t, db.ClearCollections(pod.Collection, task.Collection, task.OldCollection, build.Collection, model.VersionCollection, dispatcher.Collection, event.AllLogCollection))
 
 			cluster := "cluster"
 

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -69,7 +69,7 @@ func (j *taskStrandedCleanupJob) Run(ctx context.Context) {
 		taskIDs = append(taskIDs, h.RunningTask)
 		hostIDs = append(hostIDs, h.Id)
 
-		j.AddError(model.ClearAndResetStrandedTask(&h))
+		j.AddError(model.ClearAndResetStrandedHostTask(&h))
 	}
 
 	tasks, err := task.FindStuckDispatching()

--- a/units/util.go
+++ b/units/util.go
@@ -55,7 +55,7 @@ func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment
 		return errors.Wrap(err, "enqueueing decohost notify job")
 	}
 
-	return model.ClearAndResetStrandedTask(h)
+	return model.ClearAndResetStrandedHostTask(h)
 }
 
 // EnqueueHostReprovisioningJob enqueues a job to reprovision a host. For hosts


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16877

### Description 
This adds support . The general behavior should be something like this:
* AWS tells Evergreen via SNS that the container instance is going to be spot instance interrupted (i.e. drained).
* Find the pods that will are about to be stopped due to the interrupt and enqueue the job to terminate them.
* When terminating them, fix any task lifecycle issues caused by abrupt termination. If the task is already running in the pod, mark it as system failed and restart it. If there are any tasks still waiting to run on this pod and it's the only one left that can run them, mark those tasks as needing another container allocated to them.

### Testing 
Added unit tests.

I couldn't test this in staging with AWS because we can't actually run container tasks yet and we can't simulate draining containers until [BUILD-14978](https://jira.mongodb.org/browse/BUILD-14978) is done.