### PR TITLE
EVG-16797 add stepback resolver and removed field

### DIFF
--- a/graphql/resolvers.go
+++ b/graphql/resolvers.go
@@ -2482,6 +2482,14 @@ func (r *mutationResolver) ForceRepotrackerRun(ctx context.Context, projectID st
 	return true, nil
 }
 
+func (r *mutationResolver) DeactivateStepbackTasks(ctx context.Context, projectID string) (bool, error) {
+	usr := mustHaveUser(ctx)
+	if err := task.DeactivateStepbackTasksForProject(projectID, usr.Username()); err != nil {
+		return false, InternalServerError.Send(ctx, fmt.Sprintf("deactivating current stepback tasks: %s", err.Error()))
+	}
+	return true, nil
+}
+
 func (r *mutationResolver) SetTaskPriority(ctx context.Context, taskID string, priority int) (*restModel.APITask, error) {
 	t, err := task.FindOneId(taskID)
 	if err != nil {

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -226,6 +226,14 @@ Evergreen Projects
             </label> <br>
             <label class="muted col-lg-offset-1">Anyone can see this project.</label>
           </div>
+          <div class="form-group">
+            <div class="col-lg-8">
+              <label class="control-label">Restricted Project&nbsp;&nbsp;
+                <input type="checkbox" ng-model="settingsFormData.restricted"/>
+              </label>
+              <div class="muted small">Logged-in users by default will not be able to access this project. Access must be granted manually.</div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1124,7 +1132,7 @@ Evergreen Projects
               <label for="disable-stats-cache">Disable caching</label>
             </div>
           </div>
-          <div class="muted small">Comma-separated list of regular expression patterns that specify test filenames to ignore when caching test and task history.</div>
+          <div class="muted small">List of regular expression patterns that specify test filenames to ignore when caching test and task history.</div>
           <div class="form-group">
             <div class="col-lg-5 col-header">
               <label class="control-label">File patterns to ignore</label>


### PR DESCRIPTION
[EVG-16797](https://jira.mongodb.org/browse/EVG-16797)

### Description 
Two things found while testing:
1) Added back in the restricted option to the legacy page, which was removed accidentally in https://github.com/evergreen-ci/evergreen/commit/c55a71bdcc27f5f94d485f58cdbc9483f80f172e (cc @bynn )
2) Stepback on save doesn't exist on the new UI so I added the resolver; the front end can be done in https://jira.mongodb.org/browse/EVG-17044 but should be v simple
