### PR TITLE
EVG-17026: add admin setting for ECS capacity providers

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -288,12 +288,12 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts p
 	opts.SetPlacementOptions(*placementOpts)
 
 	for _, cluster := range ecsConfig.Clusters {
-		if string(containerOpts.OS) == string(cluster.Platform) {
+		if string(containerOpts.OS) == string(cluster.OS) {
 			return opts.SetCluster(cluster.Name), nil
 		}
 	}
 
-	return nil, errors.Errorf("pod OS ('%s') did not match any ECS cluster platforms", string(containerOpts.OS))
+	return nil, errors.Errorf("pod OS '%s' did not match any ECS cluster OS", string(containerOpts.OS))
 }
 
 // podAWSOptions creates options to initialize an AWS client for pod management.

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -374,8 +374,8 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 							},
 							Clusters: []evergreen.ECSClusterConfig{
 								{
-									Platform: "linux",
-									Name:     "cluster",
+									OS:   evergreen.ECSOSLinux,
+									Name: "cluster",
 								},
 							},
 						},

--- a/globals.go
+++ b/globals.go
@@ -1088,22 +1088,6 @@ const (
 	LogTypeSystem = "system_log"
 )
 
-type ECSClusterPlatform string
-
-const (
-	ECSClusterPlatformLinux   = "linux"
-	ECSClusterPlatformWindows = "windows"
-)
-
-func (p ECSClusterPlatform) Validate() error {
-	switch p {
-	case ECSClusterPlatformLinux, ECSClusterPlatformWindows:
-		return nil
-	default:
-		return errors.Errorf("unrecognized ECS cluster platform '%s'", p)
-	}
-}
-
 // LogViewer represents recognized viewers for rendering logs.
 type LogViewer string
 

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -16,7 +16,8 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.restartLavender = true;
     $scope.ValidThemes = ["announcement", "information", "warning", "important"];
     $scope.validAuthKinds = ["ldap", "okta", "naive", "only_api", "allow_service_users", "github"];
-    $scope.validECSPlatforms = ["linux", "windows"];
+    $scope.validECSOSes = ["linux", "windows"];
+    $scope.validECSArches = ["amd64", "arm64"];
     $("#restart-modal").on("hidden.bs.modal", $scope.enableSubmit);
   }
 
@@ -418,7 +419,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     }
 
     if (!$scope.validECSCluster($scope.new_ecs_cluster)) {
-      $scope.invalidECSCluster = "ECS cluster name and platform are required.";
+      $scope.invalidECSCluster = "ECS cluster name and OS are required.";
       return
     }
 
@@ -428,11 +429,67 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.validECSCluster = function (item) {
-    return item && item.name && item.platform;
+    return item && item.name && item.os;
   }
 
   $scope.deleteECSCluster = function (index) {
     $scope.Settings.providers.aws.pod.ecs.clusters.splice(index, 1);
+  }
+
+  $scope.addECSCapacityProvider = function () {
+    if ($scope.Settings.providers == null) {
+      $scope.Settings.providers = {
+        "aws": {
+          "pod": {
+            "ecs": {
+              "capacity_providers": []
+            }
+          }
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws == null) {
+      $scope.Settings.providers.aws = {
+        "pod": {
+          "ecs": {
+            "capacity_providers": []
+          }
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws.pod == null) {
+      $scope.Settings.providers.aws.pod = {
+        "ecs": {
+          "capacity_providers": []
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws.pod.ecs == null) {
+      $scope.Settings.providers.aws.pod.ecs = {
+        "capacity_providers": []
+      };
+    }
+
+    if ($scope.Settings.providers.aws.pod.ecs.capacity_providers == null) {
+      $scope.Settings.providers.aws.pod.ecs.capacity_providers = [];
+    }
+
+    if (!$scope.validECSCapacityProvider($scope.new_ecs_capacity_provider)) {
+      $scope.invalidECSCapacityProvider = "ECS capacity provider name, os, and arch are required.";
+      return
+    }
+
+    $scope.Settings.providers.aws.pod.ecs.capacity_providers.push($scope.new_ecs_capacity_provider);
+    $scope.new_ecs_capacity_provider = {};
+    $scope.invalidECSCapacityProvider = "";
+  }
+
+  $scope.validECSCapacityProvider = function (item) {
+    return item && item.name && item.os && item.arch;
+  }
+
+  $scope.deleteECSCapacityProvider = function (index) {
+    $scope.Settings.providers.aws.pod.ecs.capacity_providers.splice(index, 1);
   }
 
   $scope.addAmboyNamedQueue = function () {

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -165,9 +165,15 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.AWSVPC.SecurityGroups, apiSettings.Providers.AWS.Pod.ECS.AWSVPC.SecurityGroups)
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.ExecutionRole, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.ExecutionRole))
 	require.Len(apiSettings.Providers.AWS.Pod.ECS.Clusters, len(testSettings.Providers.AWS.Pod.ECS.Clusters))
-	for i := 0; i < len(testSettings.Providers.AWS.Pod.ECS.Clusters); i++ {
-		assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.Clusters[i].Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Name))
-		assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.Clusters[i].Platform, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Platform))
+	for i, cluster := range testSettings.Providers.AWS.Pod.ECS.Clusters {
+		assert.EqualValues(cluster.Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].Name))
+		assert.EqualValues(cluster.OS, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.Clusters[i].OS))
+	}
+	require.Len(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders, len(testSettings.Providers.AWS.Pod.ECS.CapacityProviders))
+	for i, cp := range testSettings.Providers.AWS.Pod.ECS.CapacityProviders {
+		assert.Equal(cp.Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].Name))
+		assert.EqualValues(cp.OS, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].OS))
+		assert.EqualValues(cp.Arch, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].Arch))
 	}
 	assert.EqualValues(testSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -199,8 +199,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			)
 			rh.env.Settings().Providers.AWS.Pod.ECS.Clusters = []evergreen.ECSClusterConfig{
 				{
-					Name:     clusterID,
-					Platform: evergreen.ECSClusterPlatformLinux,
+					Name: clusterID,
+					OS:   evergreen.ECSOSLinux,
 				},
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
@@ -304,8 +304,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			)
 			rh.env.Settings().Providers.AWS.Pod.ECS.Clusters = []evergreen.ECSClusterConfig{
 				{
-					Name:     clusterID,
-					Platform: evergreen.ECSClusterPlatformLinux,
+					Name: clusterID,
+					OS:   evergreen.ECSOSLinux,
 				},
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
@@ -355,8 +355,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			)
 			rh.env.Settings().Providers.AWS.Pod.ECS.Clusters = []evergreen.ECSClusterConfig{
 				{
-					Name:     clusterID,
-					Platform: evergreen.ECSClusterPlatformLinux,
+					Name: clusterID,
+					OS:   evergreen.ECSOSLinux,
 				},
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1557,7 +1557,7 @@ Admin Settings
 													style="float:left" ng-click="addAmboyNamedQueue()">
 													<i class="fa fa-plus"></i>
 												</button>
-												<label class="control">[[ invalidECSCluster ]]</label>
+												<label class="control">[[ invalidAmboyNamedQueue ]]</label>
 											</div>
 										</md-card-content>
 									</md-card>
@@ -1910,10 +1910,11 @@ Admin Settings
 													</md-input-container>
 													<br />
 													<md-input-container class="control" flex=25>
-														<md-select ng-model="cluster.platform" placeholder="Platform">
-															<md-option ng-repeat="platform in validECSPlatforms" value="[[platform]]">[[platform]]</md-option>
+														<md-select ng-model="cluster.os" placeholder="OS">
+															<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
 														</md-select>
 													</md-input-container>
+
 													<div style="margin-top: 1%;">
 														<button class="btn btn-default btn-danger" type="button"
 															style="float: left" ng-click="deleteECSCluster(index)">
@@ -1929,8 +1930,8 @@ Admin Settings
 												</md-input-container>
 												<br />
 												<md-input-container class="control" flex=25>
-													<md-select ng-model="new_ecs_cluster.platform" placeholder="Platform">
-														<md-option ng-repeat="platform in validECSPlatforms" value="[[platform]]">[[platform]]</md-option>
+													<md-select ng-model="new_ecs_cluster.os" placeholder="OS">
+														<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
 													</md-select>
 												</md-input-container>
 												<div style="margin-top: 1%;">
@@ -1940,6 +1941,68 @@ Admin Settings
 														<i class="fa fa-plus"></i>
 													</button>
 													<label class="control">[[ invalidECSCluster ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
+
+									<md-card>
+										<md-card-title>
+											<md-card-title-text>
+												<span>Pod ECS Capacity Providers</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="ecs-capacity-providers" class="form-group" ng-repeat="(index, capacityProvider) in Settings.providers.aws.pod.ecs.capacity_providers">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="capacityProvider.name" placeholder="Name">
+													</md-input-container>
+													<br />
+													<md-input-container class="control" flex=25>
+														<md-select ng-model="capacityProvider.os" placeholder="OS">
+															<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
+														</md-select>
+													</md-input-container>
+													<br />
+													<md-input-container class="control" flex=25>
+														<md-select ng-model="capacityProvider.arch" placeholder="Arch">
+															<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
+														</md-select>
+													</md-input-container>
+
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteECSCapacityProvider(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="new_ecs_capacity_provider.name"
+														placeholder="Name">
+												</md-input-container>
+												<br />
+												<md-input-container class="control" flex=25>
+													<md-select ng-model="new_ecs_capacity_provider.os" placeholder="OS">
+														<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
+													</md-select>
+												</md-input-container>
+												<br />
+												<md-input-container class="control" flex=25>
+													<md-select ng-model="new_ecs_capacity_provider.arch" placeholder="Arch">
+														<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
+													</md-select>
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!validECSCapacityProvider(new_ecs_capacity_provider)" type="button"
+														style="float: left" ng-click="addECSCapacityProvider()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidECSCapacityProvider ]]</label>
 												</div>
 											</section>
 										</md-card-content>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -282,8 +282,15 @@ func MockConfig() *evergreen.Settings {
 						},
 						Clusters: []evergreen.ECSClusterConfig{
 							{
-								Name:     "cluster_name",
-								Platform: evergreen.ECSClusterPlatformLinux,
+								Name: "cluster_name",
+								OS:   evergreen.ECSOSLinux,
+							},
+						},
+						CapacityProviders: []evergreen.ECSCapacityProvider{
+							{
+								Name: "capacity_provider_name",
+								OS:   evergreen.ECSOSLinux,
+								Arch: evergreen.ECSArchAMD64,
 							},
 						},
 					},

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -198,8 +198,8 @@ func TestPodCreationJob(t *testing.T) {
 			var envClusters []evergreen.ECSClusterConfig
 			for name := range cocoaMock.GlobalECSService.Clusters {
 				envClusters = append(envClusters, evergreen.ECSClusterConfig{
-					Name:     name,
-					Platform: evergreen.ECSClusterPlatformLinux,
+					Name: name,
+					OS:   evergreen.ECSOSLinux,
 				})
 			}
 			env.EvergreenSettings.Providers.AWS.Pod.ECS.Clusters = envClusters


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17026

### Description 
Add admin settings to map a capacity provider name to the OS/arch that it can run. I also renamed a couple fields in the ECS cluster admin settings, which I fixed in staging (the only place using the ECS settings). I'm going to make a follow-up PR to actually set the capacity provider based on the container's required OS/arch.

### Testing 
Added unit tests. Also tested the admin settings page in local-evergreen.
