### PR TITLE
EVG-17026: set capacity provider based on container OS/arch

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -247,21 +247,7 @@ func exportECSPodContainerDef(settings *evergreen.Settings, p *pod.Pod) (*cocoa.
 	return def, nil
 }
 
-// podArchToECSArch exports a pod container CPU architecture to an ECS
-// CPU architecture.
-func exportECSPodArch(arch pod.Arch) string {
-	switch arch {
-	case pod.ArchAMD64:
-		return "x86_64"
-	case pod.ArchARM64:
-		return "arm64"
-	default:
-		return ""
-	}
-}
-
 const (
-	ecsCPUArchConstraint           = "attribute:ecs.cpu-architecture"
 	ecsWindowsVersionTagConstraint = "attribute:WindowsVersion"
 )
 
@@ -281,11 +267,19 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts p
 		windowsVersionConstraint := fmt.Sprintf("%s == %s", ecsWindowsVersionTagConstraint, containerOpts.WindowsVersion)
 		placementOpts.AddInstanceFilters(windowsVersionConstraint)
 	}
-	if arch := exportECSPodArch(containerOpts.Arch); arch != "" {
-		archConstraint := fmt.Sprintf("%s == %s", ecsCPUArchConstraint, arch)
-		placementOpts.AddInstanceFilters(archConstraint)
-	}
 	opts.SetPlacementOptions(*placementOpts)
+
+	var foundCapacityProvider bool
+	for _, cp := range ecsConfig.CapacityProviders {
+		if containerOpts.OS.Matches(cp.OS) && containerOpts.Arch.Matches(cp.Arch) {
+			opts.SetCapacityProvider(cp.Name)
+			foundCapacityProvider = true
+			break
+		}
+	}
+	if !foundCapacityProvider {
+		return nil, errors.Errorf("container OS '%s' and arch '%s' did not match any recognized capacity provider", containerOpts.OS, containerOpts.Arch)
+	}
 
 	for _, cluster := range ecsConfig.Clusters {
 		if string(containerOpts.OS) == string(cluster.OS) {
@@ -293,7 +287,7 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts p
 		}
 	}
 
-	return nil, errors.Errorf("pod OS '%s' did not match any ECS cluster OS", string(containerOpts.OS))
+	return nil, errors.Errorf("container OS '%s' did not match any recognized ECS cluster", containerOpts.OS)
 }
 
 // podAWSOptions creates options to initialize an AWS client for pod management.

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -378,6 +378,13 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 									Name: "cluster",
 								},
 							},
+							CapacityProviders: []evergreen.ECSCapacityProvider{
+								{
+									Name: "capacity_provider",
+									OS:   evergreen.ECSOSLinux,
+									Arch: evergreen.ECSArchAMD64,
+								},
+							},
 						},
 						SecretsManager: evergreen.SecretsManagerConfig{
 							SecretPrefix: "secret_prefix",
@@ -405,8 +412,7 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 		assert.Equal(t, settings.Providers.AWS.Pod.ECS.AWSVPC.Subnets, opts.ExecutionOpts.AWSVPCOpts.Subnets)
 		assert.Equal(t, settings.Providers.AWS.Pod.ECS.AWSVPC.SecurityGroups, opts.ExecutionOpts.AWSVPCOpts.SecurityGroups)
 		require.NotZero(t, opts.ExecutionOpts.PlacementOpts)
-		require.Len(t, opts.ExecutionOpts.PlacementOpts.InstanceFilters, 1)
-		assert.Equal(t, "attribute:ecs.cpu-architecture == x86_64", opts.ExecutionOpts.PlacementOpts.InstanceFilters[0])
+		assert.Equal(t, settings.Providers.AWS.Pod.ECS.CapacityProviders[0].Name, utility.FromStringPtr(opts.ExecutionOpts.CapacityProvider))
 
 		assert.True(t, strings.HasPrefix(utility.FromStringPtr(opts.Name), settings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
 		assert.Contains(t, utility.FromStringPtr(opts.Name), p.ID)
@@ -487,9 +493,16 @@ func TestExportECSPodCreationOptions(t *testing.T) {
 		require.NotZero(t, err)
 		assert.Zero(t, opts)
 	})
-	t.Run("FailsWithNoClusters", func(t *testing.T) {
+	t.Run("FailsWithNoMatchingCluster", func(t *testing.T) {
 		settings := validSettings()
-		settings.Providers.AWS.Pod.ECS.Clusters = nil
+		settings.Providers.AWS.Pod.ECS.Clusters[0].OS = evergreen.ECSOSWindows
+		opts, err := ExportECSPodCreationOptions(settings, &pod.Pod{})
+		assert.Error(t, err)
+		assert.Zero(t, opts)
+	})
+	t.Run("FailsWithNoMatchingCapacityProvider", func(t *testing.T) {
+		settings := validSettings()
+		settings.Providers.AWS.Pod.ECS.CapacityProviders[0].Arch = evergreen.ECSArchARM64
 		opts, err := ExportECSPodCreationOptions(settings, &pod.Pod{})
 		assert.Error(t, err)
 		assert.Zero(t, opts)

--- a/go.mod
+++ b/go.mod
@@ -5,14 +5,14 @@ go 1.16
 require (
 	github.com/99designs/gqlgen v0.14.0
 	github.com/PuerkitoBio/rehttp v1.1.0
-	github.com/aws/aws-sdk-go v1.44.4
+	github.com/aws/aws-sdk-go v1.44.25
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20211025210128-7f3409c2b515
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8
+	github.com/evergreen-ci/cocoa v0.0.0-20220610175551-2ddb1b6e0758
 	github.com/evergreen-ci/gimlet v0.0.0-20220419172609-b882e01673e7
 	github.com/evergreen-ci/go-test2json v0.0.0-20180702150328-5b6cfd2e8cb0
 	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.42.44/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
 github.com/aws/aws-sdk-go v1.44.4 h1:ePN0CVJMdiz2vYUcJH96eyxRrtKGSDMgyhP6rah2OgE=
 github.com/aws/aws-sdk-go v1.44.4/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.25 h1:cJZ4gtEpWAD/StO9GGOAyv6AaAoZ9OJUhu96gF9qaio=
+github.com/aws/aws-sdk-go v1.44.25/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -360,6 +362,8 @@ github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxz
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
 github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8 h1:aYGYPV4SlBJDEn3SyBN83DJ0r+wtx+we7xh1VVwP/t0=
 github.com/evergreen-ci/cocoa v0.0.0-20220524172555-fbc120d1cbf8/go.mod h1:AjVFiPvAfvSMWEI15f4IuPSWMXBEwJpnfTkGTWpDJ+k=
+github.com/evergreen-ci/cocoa v0.0.0-20220610175551-2ddb1b6e0758 h1:ut9eiV6eS2n9aNF1UM0fFZYlOwo9DFRHD7/y/oy/EcQ=
+github.com/evergreen-ci/cocoa v0.0.0-20220610175551-2ddb1b6e0758/go.mod h1:/3htq2sL7ej1sZ+5AOM0XmKmHlTfeAQ7GG9UZ8gqt2g=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -301,6 +301,19 @@ func (os OS) Validate() error {
 	}
 }
 
+// Matches returns whether or not the pod OS matches the given Evergreen ECS
+// config OS.
+func (os OS) Matches(other evergreen.ECSOS) bool {
+	switch os {
+	case OSLinux:
+		return other == evergreen.ECSOSLinux
+	case OSWindows:
+		return other == evergreen.ECSOSWindows
+	default:
+		return false
+	}
+}
+
 // ImportOS converts the container OS into its equivalent pod OS.
 func ImportOS(os evergreen.ContainerOS) (OS, error) {
 	switch os {
@@ -331,6 +344,19 @@ func (a Arch) Validate() error {
 		return nil
 	default:
 		return errors.Errorf("unrecognized pod architecture '%s'", a)
+	}
+}
+
+// Matches returns whether or not the pod CPU architecture matches the given
+// Evergreen ECS config CPU architecture.
+func (a Arch) Matches(arch evergreen.ECSArch) bool {
+	switch a {
+	case ArchAMD64:
+		return arch == evergreen.ECSArchAMD64
+	case ArchARM64:
+		return arch == evergreen.ECSArchARM64
+	default:
+		return false
 	}
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17026

### Description 
Instead of setting a placement constraint for the architecture, specify the capacity provider that will run the pod in an instance with the desired OS/arch.

### Testing 
Updated the existing unit test. We can't verify that this in an e2e way until [BUILD-15127](https://jira.mongodb.org/browse/BUILD-15127) fixes the staging AWS IAM role structure (because it prevents us from making ECS/Secrets Manager API calls), but setting the capacity provider worked as expected when I did the load test.