### PR TITLE
EVG-16839 Only set committer email and name as evergreen on merge-patch

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -751,13 +751,13 @@ func (c *gitFetchProject) getPatchContents(ctx context.Context, comm client.Comm
 // getApplyCommand determines the patch type. If the patch is a mailbox-style
 // patch, it uses git-am (see https://git-scm.com/docs/git-am), otherwise
 // it uses git apply
-func (c *gitFetchProject) getApplyCommand(patchFile string) (string, error) {
+func (c *gitFetchProject) getApplyCommand(patchFile string, conf *internal.TaskConfig) (string, error) {
 	isMBP, err := patch.IsMailbox(patchFile)
 	if err != nil {
 		return "", errors.Wrap(err, "can't check patch type")
 	}
 
-	if isMBP {
+	if isMBP && conf.Task.DisplayName == evergreen.MergeTaskName {
 		committerName := defaultCommitterName
 		committerEmail := defaultCommitterEmail
 		if len(c.CommitterName) > 0 {
@@ -856,7 +856,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 
 		// this applies the patch using the patch files in the temp directory
 		patchCommandStrings := getPatchCommands(patchPart, conf, moduleDir, tempAbsPath)
-		applyCommand, err := c.getApplyCommand(tempAbsPath)
+		applyCommand, err := c.getApplyCommand(tempAbsPath, conf)
 		if err != nil {
 			logger.Execution().Error("Could not to determine patch type")
 			return errors.WithStack(err)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -654,14 +654,17 @@ func (s *GitGetProjectSuite) TestGetApplyCommand() {
 	}
 
 	// regular patch
+	tc := &internal.TaskConfig{
+		Task: &task.Task{},
+	}
 	patchPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test.patch")
-	applyCommand, err := c.getApplyCommand(patchPath)
+	applyCommand, err := c.getApplyCommand(patchPath, tc)
 	s.NoError(err)
 	s.Equal(fmt.Sprintf("git apply --binary --index < '%s'", patchPath), applyCommand)
 
 	// mbox patch
 	patchPath = filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_mbox.patch")
-	applyCommand, err = c.getApplyCommand(patchPath)
+	applyCommand, err = c.getApplyCommand(patchPath, tc)
 	s.NoError(err)
 	s.Equal(fmt.Sprintf(`GIT_COMMITTER_NAME="%s" GIT_COMMITTER_EMAIL="%s" git am --keep-cr --keep < "%s"`, c.CommitterName, c.CommitterEmail, patchPath), applyCommand)
 }


### PR DESCRIPTION
[EVG-16839](https://jira.mongodb.org/browse/EVG-16839)

### Description 
< add description, context, thought process, etc >

### Testing 
Updated existing unit test. Reproduced this issue in staging prior to making the change confirming that each CQ task was running on a separate git environment after running `git am` in `git.get_project`.  Deployed change to staging, re-ran a CQ merge on sandbox and confirmed that only the merge-patch task set the committer email/username.