### PR TITLE
EVG-15622 Take activated as starting time for builds that have restarted once or more

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -267,11 +267,7 @@ func TryMarkStarted(buildId string, startTime time.Time) error {
 func (b *Build) MarkFinished(status string, finishTime time.Time) error {
 	b.Status = status
 	b.FinishTime = finishTime
-	if b.ActivatedTime.Before(b.StartTime) {
-		b.TimeTaken = finishTime.Sub(b.StartTime)
-	} else {
-		b.TimeTaken = finishTime.Sub(b.ActivatedTime)
-	}
+	b.TimeTaken = finishTime.Sub(b.StartTime)
 	return UpdateOne(
 		bson.M{IdKey: b.Id},
 		bson.M{

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -267,7 +267,11 @@ func TryMarkStarted(buildId string, startTime time.Time) error {
 func (b *Build) MarkFinished(status string, finishTime time.Time) error {
 	b.Status = status
 	b.FinishTime = finishTime
-	b.TimeTaken = finishTime.Sub(b.StartTime)
+	if b.ActivatedTime.Before(b.StartTime) {
+		b.TimeTaken = finishTime.Sub(b.StartTime)
+	} else {
+		b.TimeTaken = finishTime.Sub(b.ActivatedTime)
+	}
 	return UpdateOne(
 		bson.M{IdKey: b.Id},
 		bson.M{

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -299,7 +299,10 @@ func SetBuildStartedForTasks(tasks []task.Task, caller string) error {
 	// Set the build status for all the builds containing the tasks that we touched
 	_, err := UpdateAllBuilds(
 		bson.M{IdKey: bson.M{"$in": buildIdList}},
-		bson.M{"$set": bson.M{StatusKey: evergreen.BuildStarted}},
+		bson.M{"$set": bson.M{
+			StatusKey:    evergreen.BuildStarted,
+			StartTimeKey: time.Now(),
+		}},
 	)
 	catcher.Wrap(err, "setting builds to started")
 	// update activation for all the builds

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -634,8 +634,9 @@ func TestBuildMarkFinished(t *testing.T) {
 
 		startTime := time.Now()
 		b := &build.Build{
-			Id:        "build",
-			StartTime: startTime,
+			Id:            "build",
+			StartTime:     startTime,
+			ActivatedTime: startTime,
 		}
 		So(b.Insert(), ShouldBeNil)
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1894,10 +1894,14 @@ func TestVersionRestart(t *testing.T) {
 
 	// test that restarting a version restarts its tasks
 	taskIds := []string{"task1", "task3", "task4"}
+	buildIds := []string{"build1", "build2"}
 	assert.NoError(RestartVersion("version", taskIds, false, "test"))
 	tasks, err := task.Find(task.ByIds(taskIds))
 	assert.NoError(err)
 	assert.NotEmpty(tasks)
+	builds, err := build.Find(build.ByIds(buildIds))
+	assert.NoError(err)
+	assert.NotEmpty(builds)
 	for _, t := range tasks {
 		assert.Equal(evergreen.TaskUndispatched, t.Status)
 		assert.True(t.Activated)
@@ -1907,6 +1911,9 @@ func TestVersionRestart(t *testing.T) {
 			assert.Equal("task1", t.DependsOn[0].TaskId)
 			assert.False(t.DependsOn[0].Finished, "restarting task1 should have marked dependency as unfinished")
 		}
+	}
+	for _, b := range builds {
+		assert.False(b.StartTime.IsZero())
 	}
 	dbTask5, err := task.FindOneId("task5")
 	require.NoError(err)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -64,12 +64,12 @@ type Task struct {
 	Secret string `bson:"secret" json:"secret"`
 
 	// time information for task
-	// Create - the creation time for the task, derived from the commit time or the patch creation time.
-	// Dispatch - the time the task runner starts up the agent on the host.
-	// Scheduled - the time the task is scheduled.
-	// Start - the time the agent starts the task on the host after spinning it up.
-	// Finish - the time the task was completed on the remote host.
-	// Activated - the time the task was marked as available to be scheduled, automatically or by a developer.
+	// CreateTime - the creation time for the task, derived from the commit time or the patch creation time.
+	// DispatchTime - the time the task runner starts up the agent on the host.
+	// ScheduledTime - the time the task is scheduled.
+	// StartTime - the time the agent starts the task on the host after spinning it up.
+	// FinishTime - the time the task was completed on the remote host.
+	// ActivatedTime - the time the task was marked as available to be scheduled, automatically or by a developer.
 	// DependenciesMet - for tasks that have dependencies, the time all dependencies are met.
 	// ContainerAllocated - for tasks that run on containers, the time the container was allocated.
 	CreateTime             time.Time `bson:"create_time" json:"create_time"`


### PR DESCRIPTION
[EVG-15622](https://jira.mongodb.org/browse/EVG-15622)

### Description 
Builds have an issue where the time taken is derived as (finish time -  start time).  However start time does not update with each restart of a build, hence some builds that have multiple restarts over a few days have far too high `time_taken_ms`.

Change has been made such that if a build has been restarted, then calculate time taken as (finish time - activated time) since activated time keeps up with each restart. Otherwise we still calculate time taken as (finish time - start time).
### Testing 
Updated existing unit test. Added cases