### PR TITLE
EVG-15871 Added description output to the CLI and description to the backend API

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -22,6 +22,7 @@ var (
 	gitTagKey      = bsonutil.MustHaveTag(ProjectAlias{}, "GitTag")
 	remotePathKey  = bsonutil.MustHaveTag(ProjectAlias{}, "RemotePath")
 	variantKey     = bsonutil.MustHaveTag(ProjectAlias{}, "Variant")
+	descriptionKey = bsonutil.MustHaveTag(ProjectAlias{}, "Description")
 	taskKey        = bsonutil.MustHaveTag(ProjectAlias{}, "Task")
 	variantTagsKey = bsonutil.MustHaveTag(ProjectAlias{}, "VariantTags")
 	taskTagsKey    = bsonutil.MustHaveTag(ProjectAlias{}, "TaskTags")
@@ -61,6 +62,7 @@ type ProjectAlias struct {
 	ProjectID   string           `bson:"project_id" json:"project_id" yaml:"project_id"`
 	Alias       string           `bson:"alias" json:"alias" yaml:"alias"`
 	Variant     string           `bson:"variant,omitempty" json:"variant" yaml:"variant"`
+	Description string           `bson:"description" json:"description" yaml:"description"`
 	GitTag      string           `bson:"git_tag" json:"git_tag" yaml:"git_tag"`
 	RemotePath  string           `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
 	VariantTags []string         `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
@@ -374,6 +376,7 @@ func (p *ProjectAlias) Upsert() error {
 		remotePathKey:  p.RemotePath,
 		projectIDKey:   p.ProjectID,
 		variantKey:     p.Variant,
+		descriptionKey: p.Description,
 		variantTagsKey: p.VariantTags,
 		taskTagsKey:    p.TaskTags,
 		taskKey:        p.Task,

--- a/operations/list.go
+++ b/operations/list.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/cheynewallace/tabby"
@@ -305,15 +306,9 @@ func listPatchAliases(ctx context.Context, confPath, project string) error {
 	}
 
 	for _, alias := range aliases {
-		fmt.Printf("%+v\n", alias)
 		if !utility.StringSliceContains(evergreen.InternalAliases, alias.Alias) {
-			// OG printing:
-			//fmt.Printf("%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, strings.Join(alias.VariantTags, ","),
-			//	alias.Task, strings.Join(alias.TaskTags, ", "))
-
-			// Debug printing
-			fmt.Printf("HEYHEYHEY ---- test")
-			fmt.Printf("\n\n%s\n\n%s\n\n", alias.Alias, alias.Description)
+			fmt.Printf("%s\t%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Description, alias.Variant, strings.Join(alias.VariantTags, ","),
+				alias.Task, strings.Join(alias.TaskTags, ", "))
 		}
 	}
 

--- a/operations/list.go
+++ b/operations/list.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/cheynewallace/tabby"
@@ -306,9 +305,15 @@ func listPatchAliases(ctx context.Context, confPath, project string) error {
 	}
 
 	for _, alias := range aliases {
+		fmt.Printf("%+v\n", alias)
 		if !utility.StringSliceContains(evergreen.InternalAliases, alias.Alias) {
-			fmt.Printf("%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, strings.Join(alias.VariantTags, ","),
-				alias.Task, strings.Join(alias.TaskTags, ", "))
+			// OG printing:
+			//fmt.Printf("%s\t%s\t%s\t%s\t%s\n", alias.Alias, alias.Variant, strings.Join(alias.VariantTags, ","),
+			//	alias.Task, strings.Join(alias.TaskTags, ", "))
+
+			// Debug printing
+			fmt.Printf("HEYHEYHEY ---- test")
+			fmt.Printf("\n\n%s\n\n%s\n\n", alias.Alias, alias.Description)
 		}
 	}
 

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -49,6 +49,7 @@ type APIProjectAlias struct {
 	Alias       *string   `json:"alias"`
 	GitTag      *string   `json:"git_tag"`
 	Variant     *string   `json:"variant"`
+	Description *string   `json:"description"`
 	Task        *string   `json:"task"`
 	RemotePath  *string   `json:"remote_path"`
 	VariantTags []*string `json:"variant_tags,omitempty"`
@@ -161,6 +162,7 @@ func (a *APIProjectAlias) ToService() (interface{}, error) {
 		Alias:       utility.FromStringPtr(a.Alias),
 		Task:        utility.FromStringPtr(a.Task),
 		Variant:     utility.FromStringPtr(a.Variant),
+		Description: utility.FromStringPtr(a.Description),
 		GitTag:      utility.FromStringPtr(a.GitTag),
 		RemotePath:  utility.FromStringPtr(a.RemotePath),
 		TaskTags:    utility.FromStringPtrSlice(a.TaskTags),
@@ -180,6 +182,7 @@ func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 
 		a.Alias = utility.ToStringPtr(v.Alias)
 		a.Variant = utility.ToStringPtr(v.Variant)
+		a.Description = utility.ToStringPtr(v.Description)
 		a.GitTag = utility.ToStringPtr(v.GitTag)
 		a.RemotePath = utility.ToStringPtr(v.RemotePath)
 		a.Task = utility.ToStringPtr(v.Task)
@@ -192,6 +195,7 @@ func (a *APIProjectAlias) BuildFromService(h interface{}) error {
 
 		a.Alias = utility.ToStringPtr(v.Alias)
 		a.Variant = utility.ToStringPtr(v.Variant)
+		a.Description = utility.ToStringPtr(v.Description)
 		a.GitTag = utility.ToStringPtr(v.GitTag)
 		a.RemotePath = utility.ToStringPtr(v.RemotePath)
 		a.Task = utility.ToStringPtr(v.Task)
@@ -211,6 +215,7 @@ func dbProjectAliasesToRestModel(aliases []model.ProjectAlias) []APIProjectAlias
 			ID:          utility.ToStringPtr(alias.ID.String()),
 			Alias:       utility.ToStringPtr(alias.Alias),
 			Variant:     utility.ToStringPtr(alias.Variant),
+			Description: utility.ToStringPtr(alias.Description),
 			Task:        utility.ToStringPtr(alias.Task),
 			RemotePath:  utility.ToStringPtr(alias.RemotePath),
 			GitTag:      utility.ToStringPtr(alias.GitTag),

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -666,3 +666,13 @@ buildvariants:
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
+
+## Patch alias testing
+
+patch_aliases:
+  - alias: "test_patch_1"
+    variant: "^ubuntu1604$"
+    task: "^test.*$"
+    variant_tags: ["pr_check", "pr_check_all"]
+    tags: ["pr_check"]
+    description: "Hey I am a string"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -666,13 +666,3 @@ buildvariants:
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
-
-## Patch alias testing
-
-patch_aliases:
-  - alias: "test_patch_1"
-    variant: "^ubuntu1604$"
-    task: "^test.*$"
-    variant_tags: ["pr_check", "pr_check_all"]
-    tags: ["pr_check"]
-    description: "Hey I am a string"


### PR DESCRIPTION
[EVG-15871](https://jira.mongodb.org/browse/EVG-15871)

### Description 
Users have external descriptions of their aliases and instead they should be able to view descriptions set to aliases. The backend was modified to accept descriptions in to the struct (defaulting to an empty string) and in the CLI, to output this description.

### Testing 
As of now, a user cannot create a patch alias with a description. To test, a description was added to the database inside the alias record in the staging database. Then running the command using the staging configuration, you are able to see the description put in. As well, the description shows up nicely on the rest API.

(Please excuse the commits, I had to cherry-pick them from my branches and I'm still getting used to handling them!)
