### PR TITLE
EVG-16635: Update EC2 spot instance creation to handle UnfulfillableCapacity Errors

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -690,8 +690,8 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 				"distro":        h.Distro.Id,
 			}))
 			if h.ShouldFallbackToOnDemand() && (strings.Contains(err.Error(), EC2InsufficientCapacity) || strings.Contains(err.Error(), EC2UnfulfillableCapacity)) {
-				// Spot creation failed due to an InsufficientCapacity error.
-				// Try to spawn the host as OnDemand instead of Spot
+				// Spot creation fails relatively frequently due to InsufficientCapacity or UnfulfillableCapacity,
+				// so we fall back to OnDemand if requested since that is more consistently reliable.
 				event.LogHostFallback(h.Id)
 				grip.Info(message.Fields{
 					"message":  "could not spawn spot instance, falling back to on-demand",
@@ -709,7 +709,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 						"host_provider": h.Distro.Provider,
 						"distro":        h.Distro.Id,
 					}))
-					return nil, errors.Wrapf(err, "fallback to on-demand failed for host '%s'", h.Id)
+					return nil, errors.Wrapf(err, "spawning on-demand host '%s'", h.Id)
 				}
 				grip.Debug(message.Fields{
 					"message":       "spawned on-demand host",

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -13,6 +14,7 @@ import (
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -687,6 +689,36 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 				"host_provider": h.Distro.Provider,
 				"distro":        h.Distro.Id,
 			}))
+			if strings.Contains(err.Error(), EC2InsufficientCapacity) && h.ShouldFallbackToOnDemand() {
+				// Spot creation failed due to an InsufficientCapacity error.
+				// Try to spawn the host as OnDemand instead of Spot
+				event.LogHostFallback(h.Id)
+				grip.Info(message.Fields{
+					"message":  "fallback to on-demand",
+					"host_id":  h.Id,
+					"host_tag": h.Tag,
+					"distro":   h.Distro.Id,
+					"provider": h.Provider,
+				})
+				h.Provider = evergreen.ProviderNameEc2OnDemand
+				h.Distro.Provider = evergreen.ProviderNameEc2OnDemand
+				if err = m.spawnOnDemandHost(ctx, h, ec2Settings, blockDevices); err != nil {
+					msg := "error spawning on-demand host"
+					grip.Error(message.WrapError(err, message.Fields{
+						"message":       msg,
+						"host_id":       h.Id,
+						"host_provider": h.Distro.Provider,
+						"distro":        h.Distro.Id,
+					}))
+					return nil, errors.Wrapf(err, "error falling back to on-demand for host '%s'", h.Id)
+				}
+				grip.Debug(message.Fields{
+					"message":       "spawned on-demand host",
+					"host_id":       h.Id,
+					"host_provider": h.Distro.Provider,
+					"distro":        h.Distro.Id,
+				})
+			}
 			return nil, errors.Wrap(err, msg)
 		}
 		grip.Debug(message.Fields{

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -718,6 +718,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 					"host_provider": h.Distro.Provider,
 					"distro":        h.Distro.Id,
 				})
+				return h, nil
 			}
 			return nil, errors.Wrap(err, msg)
 		}

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -689,7 +689,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 				"host_provider": h.Distro.Provider,
 				"distro":        h.Distro.Id,
 			}))
-			if strings.Contains(err.Error(), EC2InsufficientCapacity) && h.ShouldFallbackToOnDemand() {
+			if h.ShouldFallbackToOnDemand() && (strings.Contains(err.Error(), EC2InsufficientCapacity) || strings.Contains(err.Error(), EC2UnfulfillableCapacity)) {
 				// Spot creation failed due to an InsufficientCapacity error.
 				// Try to spawn the host as OnDemand instead of Spot
 				event.LogHostFallback(h.Id)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -694,7 +694,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 				// Try to spawn the host as OnDemand instead of Spot
 				event.LogHostFallback(h.Id)
 				grip.Info(message.Fields{
-					"message":  "fallback to on-demand",
+					"message":  "could not spawn spot instance, falling back to on-demand",
 					"host_id":  h.Id,
 					"host_tag": h.Tag,
 					"distro":   h.Distro.Id,
@@ -703,14 +703,13 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 				h.Provider = evergreen.ProviderNameEc2OnDemand
 				h.Distro.Provider = evergreen.ProviderNameEc2OnDemand
 				if err = m.spawnOnDemandHost(ctx, h, ec2Settings, blockDevices); err != nil {
-					msg := "error spawning on-demand host"
 					grip.Error(message.WrapError(err, message.Fields{
-						"message":       msg,
+						"message":       "spawning on-demand host",
 						"host_id":       h.Id,
 						"host_provider": h.Distro.Provider,
 						"distro":        h.Distro.Id,
 					}))
-					return nil, errors.Wrapf(err, "error falling back to on-demand for host '%s'", h.Id)
+					return nil, errors.Wrapf(err, "fallback to on-demand failed for host '%s'", h.Id)
 				}
 				grip.Debug(message.Fields{
 					"message":       "spawned on-demand host",

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1203,6 +1203,7 @@ type awsClientMock struct { //nolint
 	*ec2.StopInstancesInput
 	*ec2.StartInstancesInput
 	*ec2.RequestSpotInstancesInput
+	requestSpotInstancesError error
 	*ec2.DescribeSpotInstanceRequestsInput
 	*ec2.CancelSpotInstanceRequestsInput
 	*ec2.CreateVolumeInput
@@ -1357,6 +1358,11 @@ func (c *awsClientMock) StartInstances(ctx context.Context, input *ec2.StartInst
 // RequestSpotInstances is a mock for ec2.RequestSpotInstances.
 func (c *awsClientMock) RequestSpotInstances(ctx context.Context, input *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error) {
 	c.RequestSpotInstancesInput = input
+
+	if c.requestSpotInstancesError != nil {
+		return nil, c.requestSpotInstancesError
+	}
+
 	return &ec2.RequestSpotInstancesOutput{
 		SpotInstanceRequests: []*ec2.SpotInstanceRequest{
 			&ec2.SpotInstanceRequest{

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -548,8 +548,6 @@ func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	s.Equal(base64OfSomeUserData, *runInput.UserData)
 }
 
-// Test that the ec2 spot instance cloud manager falls back to on demand when it receives
-// an UnfulfillableCapacity error.
 func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
 	h := &host.Host{}
 	h.Distro.Id = "distro_id"

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -517,8 +517,10 @@ func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
 	mock.requestSpotInstancesError = awserr.New(EC2InsufficientCapacity, "Test error for Insufficient Capacity", nil)
 
-	_, err := s.spotManager.SpawnHost(ctx, h)
+	returnedHost, err := s.spotManager.SpawnHost(ctx, h)
 	s.NoError(err)
+	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Provider, "Provider should have been changed to OnDemand on fallback")
+	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Distro.Provider, "Provider should have been changed to OnDemand on fallback")
 
 	// Check that we have made a request for a spot instance
 	s.Require().NotNil(mock.RequestSpotInstancesInput)
@@ -583,8 +585,10 @@ func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
 	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
 	mock.requestSpotInstancesError = awserr.New(EC2UnfulfillableCapacity, "Test error for Unfulfillable Capacity", nil)
 
-	_, err := s.spotManager.SpawnHost(ctx, h)
+	returnedHost, err := s.spotManager.SpawnHost(ctx, h)
 	s.NoError(err)
+	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Provider, "Provider should have been changed to OnDemand on fallback")
+	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Distro.Provider, "Provider should have been changed to OnDemand on fallback")
 
 	// Check that we have made a request for a spot instance
 	s.Require().NotNil(mock.RequestSpotInstancesInput)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -482,8 +482,6 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
 }
 
-// Test that the ec2 spot instance cloud manager falls back to on demand when it receives
-// an InsufficientCapacity error.
 func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	h := &host.Host{}
 	h.Distro.Id = "distro_id"

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -484,7 +484,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 
 // Test that the ec2 spot instance cloud manager falls back to on demand when it receives
 // an InsufficientCapacity error.
-func (s *EC2Suite) TestSpawnHostClassicSpotFallback() {
+func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	h := &host.Host{}
 	h.Distro.Id = "distro_id"
 	h.Distro.Provider = evergreen.ProviderNameEc2Spot
@@ -516,6 +516,72 @@ func (s *EC2Suite) TestSpawnHostClassicSpotFallback() {
 
 	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
 	mock.requestSpotInstancesError = awserr.New(EC2InsufficientCapacity, "Test error for Insufficient Capacity", nil)
+
+	_, err := s.spotManager.SpawnHost(ctx, h)
+	s.NoError(err)
+
+	// Check that we have made a request for a spot instance
+	s.Require().NotNil(mock.RequestSpotInstancesInput)
+	requestInput := *mock.RequestSpotInstancesInput
+	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
+	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
+	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
+	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
+	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
+	s.Equal("sg-123456", *requestInput.LaunchSpecification.SecurityGroups[0])
+	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
+	s.Nil(requestInput.LaunchSpecification.SubnetId)
+	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
+
+	// Check that we have made a fallback request for an on demand instance
+	s.Require().NotNil(mock.RunInstancesInput, "On Demand Instance Fallback was not called")
+	runInput := *mock.RunInstancesInput
+	s.Equal("ami", *runInput.ImageId)
+	s.Equal("instanceType", *runInput.InstanceType)
+	s.Equal("keyName", *runInput.KeyName)
+	s.Require().Len(runInput.BlockDeviceMappings, 1)
+	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
+	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)
+	s.Equal("sg-123456", *runInput.SecurityGroups[0])
+	s.Nil(runInput.SecurityGroupIds)
+	s.Nil(runInput.SubnetId)
+	s.Equal(base64OfSomeUserData, *runInput.UserData)
+}
+
+// Test that the ec2 spot instance cloud manager falls back to on demand when it receives
+// an UnfulfillableCapacity error.
+func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
+	h := &host.Host{}
+	h.Distro.Id = "distro_id"
+	h.Distro.Provider = evergreen.ProviderNameEc2Spot
+	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
+		birch.EC.String("ami", "ami"),
+		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("key_name", "keyName"),
+		birch.EC.String("subnet_id", "subnet-123456"),
+		birch.EC.String("user_data", someUserData),
+		birch.EC.String("region", evergreen.DefaultEC2Region),
+		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
+		birch.EC.Array("mount_points", birch.NewArray(
+			birch.VC.Document(birch.NewDocument(
+				birch.EC.String("device_name", "device"),
+				birch.EC.String("virtual_name", "virtual"),
+			)),
+		)),
+		birch.EC.Boolean("fallback", true),
+	)}
+	s.Require().NoError(h.Insert())
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	manager, ok := s.spotManager.(*ec2Manager)
+	s.True(ok)
+	mock, ok := manager.client.(*awsClientMock)
+	s.True(ok)
+
+	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
+	mock.requestSpotInstancesError = awserr.New(EC2UnfulfillableCapacity, "Test error for Unfulfillable Capacity", nil)
 
 	_, err := s.spotManager.SpawnHost(ctx, h)
 	s.NoError(err)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -26,13 +26,14 @@ import (
 )
 
 const (
-	EC2ErrorNotFound        = "InvalidInstanceID.NotFound"
-	EC2DuplicateKeyPair     = "InvalidKeyPair.Duplicate"
-	EC2InsufficientCapacity = "InsufficientInstanceCapacity"
-	EC2InvalidParam         = "InvalidParameterValue"
-	EC2VolumeNotFound       = "InvalidVolume.NotFound"
-	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
-	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
+	EC2ErrorNotFound         = "InvalidInstanceID.NotFound"
+	EC2DuplicateKeyPair      = "InvalidKeyPair.Duplicate"
+	EC2InsufficientCapacity  = "InsufficientInstanceCapacity"
+	EC2UnfulfillableCapacity = "UnfulfillableCapacity"
+	EC2InvalidParam          = "InvalidParameterValue"
+	EC2VolumeNotFound        = "InvalidVolume.NotFound"
+	EC2VolumeResizeRate      = "VolumeModificationRateExceeded"
+	ec2TemplateNameExists    = "InvalidLaunchTemplateName.AlreadyExistsException"
 )
 
 var (

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -328,7 +328,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
-		return errors.Wrapf(err, "error spawning host '%s'", j.host.Id)
+		return errors.Wrapf(err, "spawning host '%s'", j.host.Id)
 	}
 	// Don't mark containers as starting. SpawnHost already marks containers as
 	// running.

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -329,36 +328,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
-		if strings.Contains(err.Error(), cloud.EC2InsufficientCapacity) && j.host.ShouldFallbackToOnDemand() {
-			event.LogHostFallback(j.host.Id)
-			grip.Info(message.Fields{
-				"message":  "fallback to on-demand",
-				"host_id":  j.host.Id,
-				"host_tag": j.host.Tag,
-				"distro":   j.host.Distro.Id,
-				"provider": j.host.Provider,
-			})
-
-			// create a new cloud manager for on demand, and re-attempt to spawn
-			j.host.Provider = evergreen.ProviderNameEc2OnDemand
-			j.host.Distro.Provider = evergreen.ProviderNameEc2OnDemand
-			mgrOpts.Provider = j.host.Provider
-			cloudManager, err = cloud.GetManager(ctx, j.env, mgrOpts)
-			if err != nil {
-				grip.Warning(message.WrapError(err, message.Fields{
-					"message":   "problem getting cloud provider for host",
-					"operation": "fallback to EC2 on-demand",
-					"host_id":   j.host.Id,
-					"job":       j.ID(),
-				}))
-				return errors.Wrapf(errIgnorableCreateHost, "problem getting cloud provider for host '%s' [%s]", j.host.Id, err.Error())
-			}
-			if _, err = cloudManager.SpawnHost(ctx, j.host); err != nil {
-				return errors.Wrapf(err, "error falling back to on-demand for host '%s'", j.host.Id)
-			}
-		} else {
-			return errors.Wrapf(err, "error spawning host '%s'", j.host.Id)
-		}
+		return errors.Wrapf(err, "error spawning host '%s'", j.host.Id)
 	}
 	// Don't mark containers as starting. SpawnHost already marks containers as
 	// running.


### PR DESCRIPTION
[EVG-16635](https://jira.mongodb.org/browse/EVG-16635)

### Description 
This change updates our spot instance creation creation fallback logic in order to handle UnfulfillableCapacity errors that we sometimes get back from spot instance creation requests. It also refactors the code to pull the fallback logic into the EC2 cloud manager, so that we don't mix levels of abstraction in provisioning_create_host.go. 

### Testing 
Primarily I added the ability to return errors to our awsClientMock, so that when I pulled the code into our ec2 cloud manager, we could verify that we made the appropriate calls when an error was returned from our AWS client.
