### PR TITLE
EVG-16832 Make JIRA BF ticket endpoint grab ticket by taskID and execution

### DIFF
--- a/rest/data/build_baron.go
+++ b/rest/data/build_baron.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
@@ -29,7 +28,7 @@ type FailingTaskData struct {
 // BbFileTicket creates a JIRA ticket for a task with the given test failures.
 func BbFileTicket(context context.Context, taskId string, execution int) (int, error) {
 	// Find information about the task
-	t, err := task.FindOne(db.Query(task.ById(taskId)))
+	t, err := task.FindOneIdAndExecution(taskId, execution)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
[EVG-16832](https://jira.mongodb.org/browse/EVG-16832)

### Description 
When JIRA BF tickets are generated through the UI, an endpoint is called that goes through the process of generating the JIRA ticket and posting it. Then the corresponding ticket would always be generated with information and links that are for the newest execution. This was because when finding the ticket, evergreen would search for tasks based on only taskID- thus getting the newest entry by default in MongoDB. Replacing the ticket query with one that finds one by taskID and execution solves the issue of incorrectly generated BF tickets.

One thing to note is that links are still generated to the old UI, but have a redirection in the URL causing it to go to the spruce UI. When transferring from the old UI to the spruce UI, the execution number is not preserved.

### Testing 
Generated fake BF and ensured they had information relating to the corresponding execution (host, build status, links- by coping them and removing the redirection parameter in the URL).
