### PR TITLE
EVG-17007 Removed confusing error message about expansions

### DIFF
--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -117,13 +117,9 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 	logger.Execution().Debug("Preparing script...")
 
 	var err error
-	originalScript := c.Script
 	if err = c.doExpansions(conf.Expansions); err != nil {
 		logger.Execution().Warning(err.Error())
 		return errors.WithStack(err)
-	}
-	if originalScript != c.Script {
-		logger.Task().Info("`${SHELL_EXPANSION}` syntax will only work for Evergreen expansions.")
 	}
 
 	logger.Execution().WarningWhen(filepath.IsAbs(c.WorkingDir) && !strings.HasPrefix(c.WorkingDir, conf.WorkDir),

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-06-07"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-06-13_a"
+	AgentVersion = "2022-06-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-17007](https://jira.mongodb.org/browse/EVG-17007)

### Description 
remove the expansion warning 
adding a message for only the cases when it doesn't find an expansion is more refactoring than it seems to be worth 

### Testing 
