### PR TITLE
EVG-8072 Added computed field time_taken_ms generated field

### DIFF
--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -120,7 +120,7 @@ func (apiBuild *APIBuild) SetTaskCache(tasks []task.Task) {
 			StatusDetails: t.Details,
 			StartTime:     ToTimePtr(t.StartTime),
 			TimeTaken:     t.TimeTaken,
-			TimeTakenMs:   t.TimeTaken / 1000,
+			TimeTakenMs:   APIDuration(t.TimeTaken.Nanoseconds() / 1000),
 			Activated:     t.Activated,
 		})
 		apiBuild.StatusCounts.IncrementStatus(t.Status, t.Details)
@@ -139,9 +139,9 @@ type APITaskCache struct {
 	StatusDetails   apimodels.TaskEndDetail `json:"task_end_details"`
 	StartTime       *time.Time              `json:"start_time"`
 	TimeTaken       time.Duration           `json:"time_taken"`
-	TimeTakenMs     APIDuration
-	Activated       bool     `json:"activated"`
-	FailedTestNames []string `json:"failed_test_names,omitempty"`
+	TimeTakenMs     APIDuration             `json:"time_taken_ms"`
+	Activated       bool                    `json:"activated"`
+	FailedTestNames []string                `json:"failed_test_names,omitempty"`
 }
 
 type APIVariantTasks struct {

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -120,7 +120,7 @@ func (apiBuild *APIBuild) SetTaskCache(tasks []task.Task) {
 			StatusDetails: t.Details,
 			StartTime:     ToTimePtr(t.StartTime),
 			TimeTaken:     t.TimeTaken,
-			TimeTakenMs:   APIDuration(t.TimeTaken.Nanoseconds() / 1000),
+			TimeTakenMs:   APIDuration(t.TimeTaken.Milliseconds()),
 			Activated:     t.Activated,
 		})
 		apiBuild.StatusCounts.IncrementStatus(t.Status, t.Details)

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -120,6 +120,7 @@ func (apiBuild *APIBuild) SetTaskCache(tasks []task.Task) {
 			StatusDetails: t.Details,
 			StartTime:     ToTimePtr(t.StartTime),
 			TimeTaken:     t.TimeTaken,
+			TimeTakenMs:   t.TimeTaken / 1000,
 			Activated:     t.Activated,
 		})
 		apiBuild.StatusCounts.IncrementStatus(t.Status, t.Details)
@@ -138,8 +139,9 @@ type APITaskCache struct {
 	StatusDetails   apimodels.TaskEndDetail `json:"task_end_details"`
 	StartTime       *time.Time              `json:"start_time"`
 	TimeTaken       time.Duration           `json:"time_taken"`
-	Activated       bool                    `json:"activated"`
-	FailedTestNames []string                `json:"failed_test_names,omitempty"`
+	TimeTakenMs     APIDuration
+	Activated       bool     `json:"activated"`
+	FailedTestNames []string `json:"failed_test_names,omitempty"`
 }
 
 type APIVariantTasks struct {


### PR DESCRIPTION
[EVG-8072](https://jira.mongodb.org/browse/EVG-8072)

### Description 
When querying a build#, the task cache will return a field labeled "time_taken" in nanoseconds when sent as a resp. To not break possible code that depends on this, a new entry "time_taken_ms" that is in milliseconds was added in the response (API struct for task cache).

### Testing 
Querying a build# via the rest API and seeing a new entry "time_taken_ms" with proper numbers.
