### PR TITLE
EVG-16293 Add return so that loading a project doesn't panic 

### DIFF
--- a/service/patch.go
+++ b/service/patch.go
@@ -53,6 +53,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	variantsAndTasksFromProject, err := model.GetVariantsAndTasksFromProject(r.Context(), projCtx.Patch.PatchedParserProject, projCtx.Patch.Project)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
 	}
 
 	commitQueuePosition := 0
@@ -61,6 +62,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 		// still display patch page if problem finding commit queue
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error finding commit queue"))
+			return
 		}
 		if cq != nil {
 			commitQueuePosition = cq.FindItem(projCtx.Patch.Id.Hex())

--- a/service/patch.go
+++ b/service/patch.go
@@ -62,7 +62,6 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 		// still display patch page if problem finding commit queue
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error finding commit queue"))
-			return
 		}
 		if cq != nil {
 			commitQueuePosition = cq.FindItem(projCtx.Patch.Id.Hex())


### PR DESCRIPTION
[EVG-16293](https://jira.mongodb.org/browse/EVG-16293)

### Description 
We currently panic  [here](https://github.com/evergreen-ci/evergreen/blob/fa0e2d13b1a7065724e7ebfe36e8d36c298ce382/service/patch.go#L81) if we've hit an error [here](https://github.com/evergreen-ci/evergreen/blob/fa0e2d13b1a7065724e7ebfe36e8d36c298ce382/graphql/util.go#L361-L363). This fixes it. 

