### PR TITLE
EVG-16880: system-fail tasks that try to exceed the container allocation limit

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -99,6 +99,9 @@ const (
 	TaskDescriptionHeartbeat = "heartbeat"
 	TaskDescriptionStranded  = "stranded"
 	TaskDescriptionNoResults = "expected test results, but none attached"
+	// TaskDescriptionContainerUnallocatable indicates that the reason a
+	// container task failed is because it cannot be allocated a container.
+	TaskDescriptionContainerUnallocatable = "container task cannot be allocated"
 
 	// Task Statuses that are currently used only by the UI, and in tests
 	// (these may be used in old tasks as actual task statuses rather than just

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -309,6 +309,11 @@ func (pd *PodDispatcher) RemovePod(ctx context.Context, env evergreen.Environmen
 	if len(pd.PodIDs) == 1 && len(pd.TaskIDs) > 0 {
 		// The last pod is about to be removed, so there will be no pod
 		// remaining to run the tasks still in the dispatch queue.
+
+		if err := model.MarkUnallocatableContainerTasksSystemFailed(pd.TaskIDs); err != nil {
+			return errors.Wrap(err, "marking unallocatable container tasks as system-failed")
+		}
+
 		if err := task.MarkManyContainerDeallocated(pd.TaskIDs); err != nil {
 			return errors.Wrap(err, "marking all tasks in dispatcher as container deallocated")
 		}

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -480,13 +481,27 @@ func TestRemovePod(t *testing.T) {
 				ContainerAllocatedTime: time.Now(),
 			}
 			require.NoError(t, t0.Insert())
+
+			v := model.Version{
+				Id:     "version_id",
+				Status: evergreen.BuildStarted,
+			}
+			require.NoError(t, v.Insert())
+			b := build.Build{
+				Id:      "build_id",
+				Version: v.Id,
+			}
+			require.NoError(t, b.Insert())
 			t1 := task.Task{
-				Id:                     "task_id1",
-				ExecutionPlatform:      task.ExecutionPlatformContainer,
-				Status:                 evergreen.TaskUndispatched,
-				Activated:              true,
-				ContainerAllocated:     true,
-				ContainerAllocatedTime: time.Now(),
+				Id:                          "task_id1",
+				BuildId:                     b.Id,
+				Version:                     v.Id,
+				ExecutionPlatform:           task.ExecutionPlatformContainer,
+				Status:                      evergreen.TaskUndispatched,
+				Activated:                   true,
+				ContainerAllocated:          true,
+				ContainerAllocatedTime:      time.Now(),
+				ContainerAllocationAttempts: 100,
 			}
 			require.NoError(t, t1.Insert())
 
@@ -506,11 +521,24 @@ func TestRemovePod(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask0)
 			assert.False(t, dbTask0.ContainerAllocated)
+			assert.True(t, dbTask0.ShouldAllocateContainer(), "task should be able to allocate another container")
 
 			dbTask1, err := task.FindOneId(t1.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
+			assert.False(t, dbTask1.ShouldAllocateContainer(), "task should not be able to allocate another container because it has no remaining attempts")
+			assert.True(t, dbTask1.IsFinished(), "task should be finished because it has used up all of its container allocation attempts")
 			assert.False(t, dbTask1.ContainerAllocated)
+
+			dbBuild, err := build.FindOneId(b.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbBuild)
+			assert.True(t, dbBuild.IsFinished(), "build should be updated after its task is finished")
+
+			dbVersion, err := model.VersionFindOneId(v.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVersion)
+			assert.Equal(t, evergreen.VersionFailed, dbVersion.Status, "version should be updated after its task is finished")
 		},
 		"FailsWhenPodIsNotInTheDispatcher": func(ctx context.Context, env evergreen.Environment, t *testing.T) {
 			pd := NewPodDispatcher("group_id", []string{"task_id"}, []string{"pod_id"})
@@ -556,7 +584,7 @@ func TestRemovePod(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
 			defer tcancel()
 
-			require.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection))
+			require.NoError(t, db.ClearCollections(Collection, pod.Collection, task.Collection, build.Collection, model.VersionCollection))
 
 			tCase(tctx, env, t)
 		})

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1729,3 +1729,44 @@ func checkResetDisplayTask(t *task.Task) error {
 	}
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
 }
+
+// MarkUnallocatableContainerTasksSystemFailed marks any container task within
+// the candidate task IDs that needs to re-allocate a container but has used up
+// all of its container allocation attempts as finished due to system failure.
+func MarkUnallocatableContainerTasksSystemFailed(candidateTaskIDs []string) error {
+	var unallocatableTasks []task.Task
+	for _, taskID := range candidateTaskIDs {
+		tsk, err := task.FindOneId(taskID)
+		if err != nil {
+			return errors.Wrapf(err, "finding task '%s'", taskID)
+		}
+		if tsk == nil {
+			continue
+		}
+		if !tsk.IsContainerTask() {
+			continue
+		}
+		if !tsk.ContainerAllocated {
+			continue
+		}
+		if tsk.RemainingContainerAllocationAttempts() > 0 {
+			continue
+		}
+
+		unallocatableTasks = append(unallocatableTasks, *tsk)
+	}
+
+	catcher := grip.NewBasicCatcher()
+	for _, tsk := range unallocatableTasks {
+		details := apimodels.TaskEndDetail{
+			Status:      evergreen.TaskFailed,
+			Type:        evergreen.CommandTypeSystem,
+			Description: evergreen.TaskDescriptionContainerUnallocatable,
+		}
+		if err := MarkEnd(&tsk, evergreen.APIServerTaskActivator, time.Now(), &details, false); err != nil {
+			catcher.Wrapf(err, "marking task '%s' as a failure due to inability to allocate", tsk.Id)
+		}
+	}
+
+	return catcher.Resolve()
+}

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -92,7 +92,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		// A task that has used up all of its container allocation attempts
 		// should not try to allocate again.
 		if err := model.MarkUnallocatableContainerTasksSystemFailed([]string{j.TaskID}); err != nil {
-			j.AddRetryableError(errors.Wrap(err, "marking container task as unable to allocate"))
+			j.AddRetryableError(errors.Wrap(err, "marking unallocatable container task as system-failed"))
 		}
 
 		return


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16880

### Description 
This is a follow-on to #5720, which added a counter to track each task's number of allocation attempts. When a pod is being terminated and cleaned up, we have to re-allocate new pods for any task that it was supposed to run but could not. However, we don't want to try allocating a container for a task past a certain number of failed attempts, so mark tasks that try to exceed that limit as system-failed. Since we don't support task groups yet, each task gets its own dedicated pod to run it (i.e. there's a 1:1 mapping between container tasks and pods). The implication of this assumption is that if a pod gets terminated (for whatever reason) before it finishes running the task, the one task it was allocated for needs to have at least one more container allocation attempt in order to retry.

### Testing 
Added unit tests.
