### PR TITLE
EVG-16810 Add error with activated_by to check_blocked_tasks

### DIFF
--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -126,6 +126,12 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 
 	dependenciesMet, err := t.DependenciesMet(dependencyCaches)
 	if err != nil {
+		grip.Error(message.Fields{
+			"message":      "checking if dependencies met for task",
+			"task_id":      t.Id,
+			"activated_by": t.ActivatedBy,
+			"depends_on":   t.DependsOn,
+		})
 		return 0, errors.Wrapf(err, "checking if dependencies met for task '%s'", t.Id)
 	}
 	if dependenciesMet {

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -126,7 +126,7 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 
 	dependenciesMet, err := t.DependenciesMet(dependencyCaches)
 	if err != nil {
-		grip.Error(message.Fields{
+		grip.Debug(message.Fields{
 			"message":      "checking if dependencies met for task",
 			"task_id":      t.Id,
 			"activated_by": t.ActivatedBy,


### PR DESCRIPTION
[EVG-16810](https://jira.mongodb.org/browse/EVG-16810)

### Description 
There are tasks with dependencies that don't exist that are hard to identify or reproduce. It looks like they all belong to one user. This PR adds the user to the logging so that we can filter on it. 


Will add a splunk alert once this is merged. 