### PR TITLE
EVG-16879: fix test-model-pod-dispatcher

### DIFF
--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -330,7 +330,24 @@ func (pd *PodDispatcher) removePodsAndTasks(ctx context.Context, env evergreen.E
 	oldPodIDs := pd.PodIDs
 	oldTaskIDs := pd.TaskIDs
 	pd.PodIDs, _ = utility.StringSliceSymmetricDifference(pd.PodIDs, podIDs)
-	pd.TaskIDs, _ = utility.StringSliceSymmetricDifference(pd.TaskIDs, taskIDs)
+
+	taskIDsSet := map[string]struct{}{}
+	for _, taskID := range taskIDs {
+		taskIDsSet[taskID] = struct{}{}
+	}
+	// Don't use StringSliceSymmetricDifference here, because the order of tasks
+	// in the dispatch queue matters and StringSliceSymmetricDifference is not
+	// guaranteed to return strings in the same order as they were originally
+	// ordered in the slice. Iterate in reverse so that removing elements during
+	// iteration doesn't change the cursor position.
+	for i := len(pd.TaskIDs) - 1; i >= 0; i-- {
+		if _, ok := taskIDsSet[pd.TaskIDs[i]]; !ok {
+			continue
+		}
+
+		pd.TaskIDs = append(pd.TaskIDs[:i], pd.TaskIDs[i+1:]...)
+	}
+
 	defer func() {
 		if err != nil {
 			pd.PodIDs = oldPodIDs

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -455,7 +455,7 @@ func TestRemovePod(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbDisp)
 			assert.Empty(t, dbDisp.TaskIDs)
-			assert.Equal(t, dbDisp.PodIDs, []string{"other_pod_id", "another_pod_id"})
+			assert.ElementsMatch(t, dbDisp.PodIDs, []string{"other_pod_id", "another_pod_id"})
 		},
 		"SucceedsWhenTheLastPodIsBeingRemovedWithoutAnyTasks": func(ctx context.Context, env evergreen.Environment, t *testing.T) {
 			const podID = "pod_id"


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16879

### Description 
This fixes two issues with `removePodsAndTasks`.

1. The [RemovePod test](https://github.com/evergreen-ci/evergreen/blob/8918ac1aae8755d218c8a5ef252e91cc56916cb4/model/pod/dispatcher/dispatcher_test.go#L458) is flaky because [utility.StringSliceSymmetricDifference](https://github.com/evergreen-ci/evergreen/blob/8918ac1aae8755d218c8a5ef252e91cc56916cb4/model/pod/dispatcher/dispatcher.go#L332) is not stable, meaning that when we remove pods/tasks using it, the pods/tasks might be returned in a different order. Since the pods are a set and order in the slice doesn't matter for them, I changed the test to use `assert.ElementsMatch` so it checks set equality instead of slice order equality.
2. Because `utility.StringSliceSymmetricDifference` is not stable with regards to ordering, we can't use it for the task IDs because the order of the task IDs determines the order of dispatch. I changed it to manually iterate and remove task IDs.

### Testing 
Updated unit test.