### PR TITLE
EVG-17062 Remove legacy cedar config route

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-06-07"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-06-22"
+	AgentVersion = "2022-06-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-06-07"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-06-17"
+	AgentVersion = "2022-06-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/service/api.go
+++ b/service/api.go
@@ -727,15 +727,6 @@ func (as *APIServer) LoggedError(w http.ResponseWriter, r *http.Request, code in
 	gimlet.WriteResponse(w, resp)
 }
 
-func (as *APIServer) Cedar(w http.ResponseWriter, r *http.Request) {
-	gimlet.WriteJSON(w, &apimodels.CedarConfig{
-		BaseURL:  as.Settings.Cedar.BaseURL,
-		RPCPort:  as.Settings.Cedar.RPCPort,
-		Username: as.Settings.Cedar.User,
-		APIKey:   as.Settings.Cedar.APIKey,
-	})
-}
-
 // GetSettings returns the global evergreen settings.
 func (as *APIServer) GetSettings() evergreen.Settings {
 	return as.Settings
@@ -794,7 +785,6 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	// legacy routes.
 	app.Route().Version(2).Route("/agent/setup").Wrap(requireHost).Handler(as.agentSetup).Get()
 	app.Route().Version(2).Route("/agent/next_task").Wrap(requireHost).Handler(as.NextTask).Get()
-	app.Route().Version(2).Route("/agent/cedar_config").Wrap(requireHost).Handler(as.Cedar).Get()
 	app.Route().Version(2).Route("/task/{taskId}/end").Wrap(requireTaskSecret, requireHost).Handler(as.EndTask).Post()
 	app.Route().Version(2).Route("/task/{taskId}/start").Wrap(requireTaskSecret, requireHost).Handler(as.StartTask).Post()
 	app.Route().Version(2).Route("/task/{taskId}/log").Wrap(requireTaskSecret, requireHost).Handler(as.AppendTaskLog).Post()


### PR DESCRIPTION
[EVG-17062](https://jira.mongodb.org/browse/EVG-17062)

### Description 
Waited some time for agents to roll over before removing this route after the default cedar config route was migrated to v2. Removing the v1 route would not have been backwards compatible with agents on hosts that were started before [this commit](https://github.com/evergreen-ci/evergreen/pull/5707) was deployed.