### PR TITLE
EVG-17133: fix SNS notification detail conversion

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -327,9 +327,7 @@ func (m *podOrHostAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Requ
 		return
 	}
 	if hostID != "" && podID != "" {
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			Message: "host ID and pod ID cannot both be set",
-		}))
+		gimlet.WriteResponse(rw, gimlet.NewJSONErrorResponse("host ID and pod ID cannot both be set"))
 		return
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17133

### Description
Fixed two things:
* I originally used `interface{}` for the detail field because we don't know the actual contents of the detail field until we decode the detail type. However, when a field is of type `interface{}`, `json.Unmarshal` will treat it as a `map[string]interface{}` when unmarshalling. This can't be converted to a struct, so I worked around it by unmarshalling a second time using a `json.RawMessage` so it remains as a `[]byte` until it can be unmarshalled into its actual type.
* Fix an issue where the pod or host auth middleware doesn't return a valid status code with the error response when both pod and host auth headers are given, which caused a panic in local testing.

### Testing 
Updated unit tests.