### PR TITLE
EVG-16888 Refactor addBuildVariantDisplayName to use cached field if it exists

### DIFF
--- a/graphql/tests/mainlineCommits/data.json
+++ b/graphql/tests/mainlineCommits/data.json
@@ -118,7 +118,7 @@
             "build_variant": "enterprise-ubuntu1604-64",
             "display_name": "Ubuntu 16.04"
         },
-                        {
+        {
             "_id": "evergreen_version5_build",
             "build_variant": "enterprise-ubuntu1604-64",
             "display_name": "Ubuntu 16.04"

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1037,7 +1037,8 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 	groupByBuildVariant := bson.M{
 		"$group": bson.M{
 			"_id": bson.M{
-				BuildVariantKey: "$" + BuildVariantKey,
+				BuildVariantKey:            "$" + BuildVariantKey,
+				BuildVariantDisplayNameKey: "$" + BuildVariantDisplayNameKey,
 			},
 			BuildIdKey: bson.M{
 				"$first": "$" + BuildIdKey,
@@ -1050,9 +1051,10 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 	// reorganize the results to get the build variant names and a corresponding build id
 	projectBuildId := bson.M{
 		"$project": bson.M{
-			"_id":           0,
-			BuildVariantKey: bsonutil.GetDottedKeyName("$_id", BuildVariantKey),
-			BuildIdKey:      "$" + BuildIdKey,
+			"_id":                      0,
+			BuildVariantKey:            bsonutil.GetDottedKeyName("$_id", BuildVariantKey),
+			BuildVariantDisplayNameKey: bsonutil.GetDottedKeyName("$_id", BuildVariantDisplayNameKey),
+			BuildIdKey:                 "$" + BuildIdKey,
 		},
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3881,14 +3881,14 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	}
 	match[VersionKey] = versionID
 	pipeline := []bson.M{}
+	pipeline = append(pipeline,
+		bson.M{"$match": match},
+	)
 	// Add BuildVariantDisplayName to all the results if it we need to match on the entire set of results
 	// This is an expensive operation so we only want to do it if we have to
 	if len(opts.Variants) > 0 && opts.IncludeBuildVariantDisplayName {
 		pipeline = append(pipeline, AddBuildVariantDisplayName...)
 	}
-	pipeline = append(pipeline,
-		bson.M{"$match": match},
-	)
 
 	if !opts.IncludeExecutionTasks {
 		const tempParentKey = "_parent"

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3668,6 +3668,9 @@ type GroupedTaskStatusCount struct {
 }
 
 func GetGroupedTaskStatsByVersion(versionID string, opts GetTasksByVersionOptions) ([]*GroupedTaskStatusCount, error) {
+	if opts.Variants != nil {
+		opts.IncludeBuildVariantDisplayName = true
+	}
 	pipeline := getTasksByVersionPipeline(versionID, opts)
 	project := bson.M{"$project": bson.M{
 		BuildVariantKey:            "$" + BuildVariantKey,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3860,17 +3860,8 @@ func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, err
 func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) []bson.M {
 	var match bson.M = bson.M{}
 
-	// Allow searching by either variant name or variant display
-	if len(opts.Variants) > 0 {
-		variantsAsRegex := strings.Join(opts.Variants, "|")
+	match[VersionKey] = versionID
 
-		match = bson.M{
-			"$or": []bson.M{
-				{BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-				{BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-			},
-		}
-	}
 	if len(opts.TaskNames) > 0 {
 		taskNamesAsRegex := strings.Join(opts.TaskNames, "|")
 		match[DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
@@ -3879,15 +3870,24 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	if !opts.IncludeEmptyActivation {
 		match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	}
-	match[VersionKey] = versionID
-	pipeline := []bson.M{}
-	pipeline = append(pipeline,
-		bson.M{"$match": match},
-	)
+	pipeline := []bson.M{
+		{"$match": match},
+	}
+
 	// Add BuildVariantDisplayName to all the results if it we need to match on the entire set of results
 	// This is an expensive operation so we only want to do it if we have to
 	if len(opts.Variants) > 0 && opts.IncludeBuildVariantDisplayName {
 		pipeline = append(pipeline, AddBuildVariantDisplayName...)
+
+		// Allow searching by either variant name or variant display
+		variantsAsRegex := strings.Join(opts.Variants, "|")
+		match = bson.M{
+			"$or": []bson.M{
+				{BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+				{BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+			},
+		}
+		pipeline = append(pipeline, bson.M{"$match": match})
 	}
 
 	if !opts.IncludeExecutionTasks {

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -47,21 +47,17 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t2.Insert())
-	b3 := build.Build{
-		Id:          "b3",
-		DisplayName: "Windows 64 bit",
-	}
-	assert.NoError(t, b3.Insert())
 	t3 := task.Task{
-		Id:                  "t3",
-		Status:              evergreen.TaskSucceeded,
-		BuildVariant:        "windows",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b3",
-		CreateTime:          time.Now().Add(-time.Hour),
-		RevisionOrderNumber: 1,
+		Id:                      "t3",
+		Status:                  evergreen.TaskSucceeded,
+		BuildVariant:            "windows",
+		BuildVariantDisplayName: "Windows 64 bit",
+		DisplayName:             "test-agent",
+		Project:                 "evergreen",
+		Requester:               evergreen.RepotrackerVersionRequester,
+		BuildId:                 "b3",
+		CreateTime:              time.Now().Add(-time.Hour),
+		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t3.Insert())
 	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)


### PR DESCRIPTION
[EVG-16888](https://jira.mongodb.org/browse/EVG-16888)

### Description 
Refactors AddBuildVariantDisplayName to use the cached value in the task struct that was introduced in #5715 if it exists. If the field does not exist (On older task documents) We will use the `$lookup` method to get the build variant display name.
### Testing 
Tested locally and staging and as a stand alone db query. Old unit tests should be sufficient as well.
