### PR TITLE
EVG-14878: Remove checkbox to enable Cedar test results from project settings page

### DIFF
--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -481,7 +481,6 @@ mciModule.controller(
             admin_only_vars: $scope.adminOnlyVars,
             display_name: $scope.projectRef.display_name,
             default_logger: $scope.projectRef.default_logger,
-            cedar_test_results_enabled: $scope.projectRef.cedar_test_results_enabled,
             remote_path: $scope.projectRef.remote_path,
             spawn_host_script_path: $scope.projectRef.spawn_host_script_path,
             batch_time: $scope.projectRef.batch_time,

--- a/service/project.go
+++ b/service/project.go
@@ -255,45 +255,44 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	origProjectRef := *projectRef
 
 	responseRef := struct {
-		Id                      string                         `json:"id"`
-		Identifier              string                         `json:"identifier"`
-		DisplayName             string                         `json:"display_name"`
-		RemotePath              string                         `json:"remote_path"`
-		SpawnHostScriptPath     string                         `json:"spawn_host_script_path"`
-		BatchTime               int                            `json:"batch_time"`
-		DeactivatePrevious      bool                           `json:"deactivate_previous"`
-		Branch                  string                         `json:"branch_name"`
-		ProjVarsMap             map[string]string              `json:"project_vars"`
-		GitHubPRAliases         []model.ProjectAlias           `json:"github_pr_aliases,omitempty"`
-		GithubChecksAliases     []model.ProjectAlias           `json:"github_checks_aliases,omitempty"`
-		CommitQueueAliases      []model.ProjectAlias           `json:"commit_queue_aliases,omitempty"`
-		PatchAliases            []model.ProjectAlias           `json:"patch_aliases,omitempty"`
-		GitTagAliases           []model.ProjectAlias           `json:"git_tag_aliases,omitempty"`
-		DeleteAliases           []string                       `json:"delete_aliases"`
-		DefaultLogger           string                         `json:"default_logger"`
-		CedarTestResultsEnabled bool                           `json:"cedar_test_results_enabled"`
-		PrivateVars             map[string]bool                `json:"private_vars"`
-		AdminOnlyVars           map[string]bool                `json:"admin_only_vars"`
-		Enabled                 bool                           `json:"enabled"`
-		Private                 bool                           `json:"private"`
-		Restricted              bool                           `json:"restricted"`
-		Owner                   string                         `json:"owner_name"`
-		Repo                    string                         `json:"repo_name"`
-		Admins                  []string                       `json:"admins"`
-		GitTagAuthorizedUsers   []string                       `json:"git_tag_authorized_users,omitempty"`
-		GitTagAuthorizedTeams   []string                       `json:"git_tag_authorized_teams,omitempty"`
-		PRTestingEnabled        bool                           `json:"pr_testing_enabled"`
-		ManualPRTestingEnabled  bool                           `json:"manual_pr_testing_enabled"`
-		GithubChecksEnabled     bool                           `json:"github_checks_enabled"`
-		GitTagVersionsEnabled   bool                           `json:"git_tag_versions_enabled"`
-		Hidden                  bool                           `json:"hidden"`
-		CommitQueue             restModel.APICommitQueueParams `json:"commit_queue"`
-		TaskSync                restModel.APITaskSyncOptions   `json:"task_sync"`
-		PatchingDisabled        bool                           `json:"patching_disabled"`
-		RepotrackerDisabled     bool                           `json:"repotracker_disabled"`
-		DispatchingDisabled     bool                           `json:"dispatching_disabled"`
-		VersionControlEnabled   bool                           `json:"version_control_enabled"`
-		AlertConfig             map[string][]struct {
+		Id                     string                         `json:"id"`
+		Identifier             string                         `json:"identifier"`
+		DisplayName            string                         `json:"display_name"`
+		RemotePath             string                         `json:"remote_path"`
+		SpawnHostScriptPath    string                         `json:"spawn_host_script_path"`
+		BatchTime              int                            `json:"batch_time"`
+		DeactivatePrevious     bool                           `json:"deactivate_previous"`
+		Branch                 string                         `json:"branch_name"`
+		ProjVarsMap            map[string]string              `json:"project_vars"`
+		GitHubPRAliases        []model.ProjectAlias           `json:"github_pr_aliases,omitempty"`
+		GithubChecksAliases    []model.ProjectAlias           `json:"github_checks_aliases,omitempty"`
+		CommitQueueAliases     []model.ProjectAlias           `json:"commit_queue_aliases,omitempty"`
+		PatchAliases           []model.ProjectAlias           `json:"patch_aliases,omitempty"`
+		GitTagAliases          []model.ProjectAlias           `json:"git_tag_aliases,omitempty"`
+		DeleteAliases          []string                       `json:"delete_aliases"`
+		DefaultLogger          string                         `json:"default_logger"`
+		PrivateVars            map[string]bool                `json:"private_vars"`
+		AdminOnlyVars          map[string]bool                `json:"admin_only_vars"`
+		Enabled                bool                           `json:"enabled"`
+		Private                bool                           `json:"private"`
+		Restricted             bool                           `json:"restricted"`
+		Owner                  string                         `json:"owner_name"`
+		Repo                   string                         `json:"repo_name"`
+		Admins                 []string                       `json:"admins"`
+		GitTagAuthorizedUsers  []string                       `json:"git_tag_authorized_users,omitempty"`
+		GitTagAuthorizedTeams  []string                       `json:"git_tag_authorized_teams,omitempty"`
+		PRTestingEnabled       bool                           `json:"pr_testing_enabled"`
+		ManualPRTestingEnabled bool                           `json:"manual_pr_testing_enabled"`
+		GithubChecksEnabled    bool                           `json:"github_checks_enabled"`
+		GitTagVersionsEnabled  bool                           `json:"git_tag_versions_enabled"`
+		Hidden                 bool                           `json:"hidden"`
+		CommitQueue            restModel.APICommitQueueParams `json:"commit_queue"`
+		TaskSync               restModel.APITaskSyncOptions   `json:"task_sync"`
+		PatchingDisabled       bool                           `json:"patching_disabled"`
+		RepotrackerDisabled    bool                           `json:"repotracker_disabled"`
+		DispatchingDisabled    bool                           `json:"dispatching_disabled"`
+		VersionControlEnabled  bool                           `json:"version_control_enabled"`
+		AlertConfig            map[string][]struct {
 			Provider string                 `json:"provider"`
 			Settings map[string]interface{} `json:"settings"`
 		} `json:"alert_config"`
@@ -619,7 +618,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.Branch = responseRef.Branch
 	projectRef.Enabled = &responseRef.Enabled
 	projectRef.DefaultLogger = responseRef.DefaultLogger
-	projectRef.CedarTestResultsEnabled = &responseRef.CedarTestResultsEnabled
 	projectRef.Private = &responseRef.Private
 	projectRef.Restricted = &responseRef.Restricted
 	projectRef.Owner = responseRef.Owner

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -318,19 +318,6 @@ Evergreen Projects
     <div class="variables">
       <div class="form-group">
         <div class="col-header col-lg-8 form-control-static">
-          <h3>Test Results</h3>
-        </div>
-      </div>
-      <div id="enable-cedar-test-results" class="form-group">
-        <div class="col-lg-6">
-          <input type="checkbox" id="enable-cedar-test-results-checkbox" ng-model="settingsFormData.cedar_test_results_enabled"/>
-          <label for="enable-cedar-test-results-checkbox">Enable Cedar Test Results</label>
-        </div>
-      </div>
-    </div>
-    <div class="variables">
-      <div class="form-group">
-        <div class="col-header col-lg-8 form-control-static">
           <h3>Version Control</h3>
         </div>
       </div>


### PR DESCRIPTION
EVG-14878: https://jira.mongodb.org/browse/EVG-14878

We will now be forcing all projects  except for the mongodb-mongo-* projects to use Cedar test results.
I checked in staging and the Test Results section is no longer on the page.
