### PR TITLE
EVG-17171 Added testing for the description field in patch aliases

### DIFF
--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -306,7 +306,7 @@ patch_aliases:
     variant: "^ubuntu1604$"
     task: "^test.*$"
     remote_path: ""
-	description: "Test Description"
+    description: "Test Description"
 `
 	projectAliases, err := FindAliasInProjectRepoOrPatchedConfig("", "test", projYml)
 	s.NoError(err)

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -306,11 +306,13 @@ patch_aliases:
     variant: "^ubuntu1604$"
     task: "^test.*$"
     remote_path: ""
+	description: "Test Description"
 `
 	projectAliases, err := FindAliasInProjectRepoOrPatchedConfig("", "test", projYml)
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 	s.Equal("^ubuntu1604$", projectAliases[0].Variant)
+	s.Equal("Test Description", projectAliases[0].Description)
 }
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -27,10 +27,11 @@ func (s *ProjectAliasSuite) SetupTest() {
 	s.aliases = []ProjectAlias{}
 	for i := 0; i < 10; i++ {
 		s.aliases = append(s.aliases, ProjectAlias{
-			ProjectID: fmt.Sprintf("project-%d", i),
-			Alias:     fmt.Sprintf("alias-%d", i),
-			Variant:   fmt.Sprintf("variant-%d", i),
-			Task:      fmt.Sprintf("task-%d", i),
+			ProjectID:   fmt.Sprintf("project-%d", i),
+			Alias:       fmt.Sprintf("alias-%d", i),
+			Variant:     fmt.Sprintf("variant-%d", i),
+			Task:        fmt.Sprintf("task-%d", i),
+			Description: fmt.Sprintf("description-%d", i),
 		})
 	}
 }
@@ -48,6 +49,7 @@ func (s *ProjectAliasSuite) TestInsertTaskAndVariantWithNoTags() {
 		s.Equal(a.Alias, out.Alias)
 		s.Equal(a.Variant, out.Variant)
 		s.Equal(a.Task, out.Task)
+		s.Equal(a.Description, out.Description)
 	}
 }
 
@@ -70,6 +72,7 @@ func (s *ProjectAliasSuite) TestInsertTagsAndNoTask() {
 		s.Empty(out.VariantTags)
 		s.Equal("", out.Task)
 		s.Equal(tags, out.TaskTags)
+		s.Equal(a.Description, out.Description)
 	}
 }
 
@@ -138,6 +141,7 @@ func (s *ProjectAliasSuite) TestInsertTagsAndNoVariant() {
 		s.Empty(out.TaskTags)
 		s.Equal("", out.Variant)
 		s.Equal(tags, out.VariantTags)
+		s.Equal(a.Description, out.Description)
 	}
 }
 

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -45,11 +45,12 @@ func getMockProjectSettings() ProjectSettings {
 			AdminOnlyVars: map[string]bool{},
 		},
 		Aliases: []ProjectAlias{ProjectAlias{
-			ID:        mgobson.ObjectIdHex("5bedc72ee4055d31f0340b1d"),
-			ProjectID: projectId,
-			Alias:     "alias1",
-			Variant:   "ubuntu",
-			Task:      "subcommand",
+			ID:          mgobson.ObjectIdHex("5bedc72ee4055d31f0340b1d"),
+			ProjectID:   projectId,
+			Alias:       "alias1",
+			Variant:     "ubuntu",
+			Task:        "subcommand",
+			Description: "Description Here",
 		},
 		},
 		Subscriptions: []event.Subscription{event.Subscription{


### PR DESCRIPTION
[EVG-17171](https://jira.mongodb.org/browse/EVG-17171)

### Description 
In ticket [EVG-15871](https://jira.mongodb.org/browse/EVG-15871), a description field to patch aliases was added. This ticket adds that description field to tests.

### Testing 
Unit testing inside of patch_aliases_test.go (adding proper description(s) and testing for its existence after parsing and usage of certain methods). In the 'project_event_test.go', the test compares the aliases and compares the description through it as well.
