### PR TITLE
EVG-16986 Rewrite GetNextTask to support containers

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -994,6 +994,37 @@ func (t *Task) cacheExpectedDuration() error {
 	)
 }
 
+// MarkAsContainerDispatched marks that the container task has been dispatched
+// to a pod.
+func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Environment, agentVersion string) error {
+	dispatchedAt := time.Now()
+	query := isContainerTaskScheduledQuery()
+	query[StatusKey] = evergreen.TaskUndispatched
+	query[ContainerAllocatedKey] = true
+	update := bson.M{
+		"$set": bson.M{
+			StatusKey:        evergreen.TaskDispatched,
+			DispatchTimeKey:  dispatchedAt,
+			LastHeartbeatKey: dispatchedAt,
+			AgentVersionKey:  agentVersion,
+		},
+	}
+	res, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update)
+	if err != nil {
+		return errors.Wrap(err, "updating task")
+	}
+	if res.ModifiedCount == 0 {
+		return errors.New("task was not updated")
+	}
+
+	t.Status = evergreen.TaskDispatched
+	t.DispatchTime = dispatchedAt
+	t.LastHeartbeat = dispatchedAt
+	t.AgentVersion = agentVersion
+
+	return nil
+}
+
 // MarkAsHostDispatched marks that the task has been dispatched onto a
 // particular host. If the task is part of a display task, the display task is
 // also marked as dispatched to a host. Returns an error if any of the database
@@ -1155,37 +1186,6 @@ func MarkManyContainerDeallocated(taskIDs []string) error {
 	}, containerDeallocatedUpdate()); err != nil {
 		return errors.Wrap(err, "updating tasks")
 	}
-
-	return nil
-}
-
-// MarkAsContainerDispatched marks that the container task has been dispatched
-// to a pod.
-func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Environment, agentVersion string) error {
-	dispatchedAt := time.Now()
-	query := isContainerTaskScheduledQuery()
-	query[StatusKey] = evergreen.TaskUndispatched
-	query[ContainerAllocatedKey] = true
-	update := bson.M{
-		"$set": bson.M{
-			StatusKey:        evergreen.TaskDispatched,
-			DispatchTimeKey:  dispatchedAt,
-			LastHeartbeatKey: dispatchedAt,
-			AgentVersionKey:  agentVersion,
-		},
-	}
-	res, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update)
-	if err != nil {
-		return errors.Wrap(err, "updating task")
-	}
-	if res.ModifiedCount == 0 {
-		return errors.New("task was not updated")
-	}
-
-	t.Status = evergreen.TaskDispatched
-	t.DispatchTime = dispatchedAt
-	t.LastHeartbeat = dispatchedAt
-	t.AgentVersion = agentVersion
 
 	return nil
 }
@@ -1478,6 +1478,14 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 			},
 		},
 	)
+}
+
+func SetNextTask(t *Task, response *apimodels.NextTaskResponse) {
+	response.TaskId = t.Id
+	response.TaskSecret = t.Secret
+	response.TaskGroup = t.TaskGroup
+	response.Version = t.Version
+	response.Build = t.BuildId
 }
 
 // SetHasCedarResults sets the HasCedarResults field of the task to

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -1242,6 +1243,22 @@ func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 	}
 
 	event.LogHostTaskDispatched(t.Id, t.Execution, h.Id)
+
+	if t.IsPartOfDisplay() {
+		return UpdateDisplayTaskForTask(t)
+	}
+
+	return nil
+}
+
+// MarkContainerTaskDispatched marks a task as being dispatched to the pod. If it's
+// part of a display task, update the display task as necessary.
+func MarkContainerTaskDispatched(ctx context.Context, env evergreen.Environment, t *task.Task, p *pod.Pod) error {
+	if err := t.MarkAsContainerDispatched(ctx, env, p.AgentVersion); err != nil {
+		return errors.Wrapf(err, "marking task '%s' as dispatched on pod '%s'", t.Id, p.ID)
+	}
+
+	event.LogContainerTaskDispatched(t.Id, t.Execution, p.ID)
 
 	if t.IsPartOfDisplay() {
 		return UpdateDisplayTaskForTask(t)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -1136,7 +1136,7 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(err))
 		return
 	}
-	setNextTask(nextTask, &response)
+	task.SetNextTask(nextTask, &response)
 	gimlet.WriteJSON(w, response)
 }
 
@@ -1327,7 +1327,7 @@ func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w ht
 	}
 	// if the task is activated return that task
 	if t.Activated {
-		setNextTask(t, &response)
+		task.SetNextTask(t, &response)
 		gimlet.WriteJSON(w, response)
 		return
 	}
@@ -1348,12 +1348,4 @@ func sendBackRunningTask(h *host.Host, response apimodels.NextTaskResponse, w ht
 		"task_id": t.Id,
 	})
 	gimlet.WriteJSON(w, response)
-}
-
-func setNextTask(t *task.Task, response *apimodels.NextTaskResponse) {
-	response.TaskId = t.Id
-	response.TaskSecret = t.Secret
-	response.TaskGroup = t.TaskGroup
-	response.Version = t.Version
-	response.Build = t.BuildId
 }


### PR DESCRIPTION
[EVG-16986](https://jira.mongodb.org/browse/EVG-16986)

### Description 
This implementation works off of the existing boilerplate container task dispatching functionality that has been implemented as a part of [PM-2615](https://jira.mongodb.org/browse/PM-2615).  More checks and logic were added that base themselves off of containerized assumptions. These include:

- Ensuring that the task dispatch flag is enabled
- Error handling a non-nil next task
- Checking that the container is in a state where it can accept tasks
- Dispatching the existing task on the pod if it has not been dispatched yet

### Testing 
Added more cases to existing next task pod unit tests.