### PR TITLE
EVG-17086 Add Support for Periodic Build requester to MainlineCommits Query

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -509,7 +509,7 @@ const (
 	RepotrackerVersionRequester = "gitter_request"
 	TriggerRequester            = "trigger_request"
 	MergeTestRequester          = "merge_test" // commit queue
-	AdHocRequester              = "ad_hoc"
+	AdHocRequester              = "ad_hoc"     // periodic build
 )
 
 var AllRequesterTypes = []string{
@@ -528,6 +528,7 @@ var (
 		RepotrackerVersionRequester,
 		TriggerRequester,
 		GitTagRequester,
+		AdHocRequester,
 	}
 )
 

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -838,13 +838,6 @@ func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metada
 		if metadata.Message != "" {
 			v.Message = metadata.Message
 		}
-		if metadata.User != nil {
-			num, err := metadata.User.IncPatchNumber()
-			if err != nil {
-				return nil, errors.Wrap(err, "error incrementing patch number")
-			}
-			v.RevisionOrderNumber = num
-		}
 	} else if metadata.GitTag.Tag != "" {
 		if !ref.IsGitTagVersionsEnabled() {
 			return nil, errors.Errorf("git tag versions are not enabled for project '%s'", ref.Id)

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -312,7 +312,7 @@ func TestCreateVersionFromConfig(t *testing.T) {
 	assert.Equal("my message", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)
 	assert.Equal(ref.Id, newVersion.Identifier)
-	assert.Equal(6, newVersion.RevisionOrderNumber)
+	assert.Equal(1, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
 	assert.Empty(newVersion.Config)
 
@@ -358,7 +358,7 @@ tasks:
 	assert.Equal("message 2", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)
 	assert.Equal(ref.Id, newVersion.Identifier)
-	assert.Equal(7, newVersion.RevisionOrderNumber)
+	assert.Equal(2, newVersion.RevisionOrderNumber)
 	assert.Equal(evergreen.AdHocRequester, newVersion.Requester)
 	assert.Empty(newVersion.Config)
 


### PR DESCRIPTION
[EVG-17086](https://jira.mongodb.org/browse/EVG-17086)

### Description 
This adds the Periodic Build requester to MainlineCommits query so that it can be viewed on the UI. 

### Testing 
[Tested on staging](http://localhost:3000/commits/mci?requester=all,gitter_request,git_tag_request,trigger_request,ad_hoc&skipOrderNumber=7828) on the mci project. 

### Spruce PR 
[1340](https://github.com/evergreen-ci/spruce/pull/1340)
