### PR TITLE
EVG-17047 Redirect users to spruce UI in BF ticket links

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
 	"github.com/evergreen-ci/utility"
@@ -38,6 +39,16 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 	u := MustHaveUser(r)
 
 	id := gimlet.GetVars(r)["host_id"]
+
+	if r.FormValue("redirect_spruce_users") == "true" {
+		if u := gimlet.GetUser(r.Context()); u != nil {
+			usr, ok := u.(*user.DBUser)
+			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
+				http.Redirect(w, r, fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id), http.StatusTemporaryRedirect)
+				return
+			}
+		}
+	}
 
 	h, err := host.FindOneByIdOrTag(id)
 	if err != nil {

--- a/service/host.go
+++ b/service/host.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
 	"github.com/evergreen-ci/utility"
@@ -41,12 +40,10 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["host_id"]
 
 	if r.FormValue("redirect_spruce_users") == "true" {
-		if u := gimlet.GetUser(r.Context()); u != nil {
-			usr, ok := u.(*user.DBUser)
-			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
-				http.Redirect(w, r, fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id), http.StatusTemporaryRedirect)
-				return
-			}
+		user := MustHaveUser(r)
+		if user.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id), http.StatusTemporaryRedirect)
+			return
 		}
 	}
 

--- a/service/task.go
+++ b/service/task.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/plugin"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
@@ -151,12 +150,10 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 
 	if r.FormValue("redirect_spruce_users") == "true" {
-		if u := gimlet.GetUser(r.Context()); u != nil {
-			usr, ok := u.(*user.DBUser)
-			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
-				http.Redirect(w, r, fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id), http.StatusTemporaryRedirect)
-				return
-			}
+		user := MustHaveUser(r)
+		if user.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, projCtx.Task.Id), http.StatusTemporaryRedirect)
+			return
 		}
 	}
 

--- a/service/version.go
+++ b/service/version.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/plugin"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -21,18 +20,17 @@ import (
 func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
+
 	if err != nil || project == nil || projCtx.Version == nil {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 
 	if r.FormValue("redirect_spruce_users") == "true" {
-		if u := gimlet.GetUser(r.Context()); u != nil {
-			usr, ok := u.(*user.DBUser)
-			if ok && usr.Settings.UseSpruceOptions.SpruceV1 {
-				http.Redirect(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id), http.StatusTemporaryRedirect)
-				return
-			}
+		user := MustHaveUser(r)
+		if user.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id), http.StatusTemporaryRedirect)
+			return
 		}
 	}
 

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -623,6 +623,17 @@ func waterfallDataAdaptor(vvData versionVariantData, project *model.Project, ski
 func (uis *UIServer) waterfallPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
+
+	if r.FormValue("redirect_spruce_users") == "true" {
+		if u := gimlet.GetUser(r.Context()); u != nil {
+			usr, ok := u.(*user.DBUser)
+			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
+				http.Redirect(w, r, fmt.Sprintf("%s/commits/%s", uis.Settings.Ui.UIv2Url, project.Identifier), http.StatusTemporaryRedirect)
+				return
+			}
+		}
+	}
+
 	if err != nil || project == nil {
 		uis.ProjectNotFound(w, r)
 		return

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -625,12 +625,10 @@ func (uis *UIServer) waterfallPage(w http.ResponseWriter, r *http.Request) {
 	project, err := projCtx.GetProject()
 
 	if r.FormValue("redirect_spruce_users") == "true" {
-		if u := gimlet.GetUser(r.Context()); u != nil {
-			usr, ok := u.(*user.DBUser)
-			if ok && usr != nil && usr.Settings.UseSpruceOptions.SpruceV1 {
-				http.Redirect(w, r, fmt.Sprintf("%s/commits/%s", uis.Settings.Ui.UIv2Url, project.Identifier), http.StatusTemporaryRedirect)
-				return
-			}
+		user := MustHaveUser(r)
+		if user.Settings.UseSpruceOptions.SpruceV1 {
+			http.Redirect(w, r, fmt.Sprintf("%s/commits/%s", uis.Settings.Ui.UIv2Url, project.Identifier), http.StatusTemporaryRedirect)
+			return
 		}
 	}
 

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -466,6 +466,6 @@ func versionLink(i versionLinkInput) string {
 }
 
 func hostLink(uiBase string, hostID string) string {
-	return fmt.Sprintf("%s/host/%s", uiBase, hostID)
+	return fmt.Sprintf("%s/host/%s?redirect_spruce_users=true", uiBase, hostID)
 
 }

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -53,7 +53,7 @@ func getHostMetadata(data *jiraTemplateData) string {
 		return "N/A"
 	}
 
-	return fmt.Sprintf("[%s|%s/host/%s]", data.Host.Host, data.UIRoot, url.PathEscape(data.Host.Id))
+	return fmt.Sprintf("[%s|%s/host/%s?redirect_spruce_users=true]", data.Host.Host, data.UIRoot, url.PathEscape(data.Host.Id))
 }
 
 func getTaskURL(data *jiraTemplateData) (string, error) {

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -22,7 +22,7 @@ import (
 const descriptionTemplateString = `
 h2. [{{.Task.DisplayName}} failed on {{.Build.DisplayName}}|{{taskurl .}}]
 Host: {{host .}}
-Project: [{{.Project.DisplayName}}|{{.UIRoot}}/waterfall/{{.Project.Id}}]
+Project: [{{.Project.DisplayName}}|{{.UIRoot}}/waterfall/{{.Project.Id}}?redirect_spruce_users=true]
 Commit: [diff|https://github.com/{{.Project.Owner}}/{{.Project.Repo}}/commit/{{.Version.Revision}}]: {{.Version.Message}} | {{.Task.CreateTime | formatAsTimestamp}}
 Evergreen Subscription: {{.SubscriptionID}}; Evergreen Event: {{.EventID}}
 {{range .Tests}}*{{.Name}}* - [Logs|{{.URL}}] | [History|{{.HistoryURL}}]
@@ -339,7 +339,7 @@ func (j *jiraBuilder) makeCustomFields(customFields []evergreen.JIRANotification
 
 // historyURL provides a full URL to the test's task history page.
 func historyURL(t *task.Task, testName, uiRoot string) string {
-	return fmt.Sprintf("%s/task_history/%s/%s?revision=%s#/%s=fail",
+	return fmt.Sprintf("%s/task_history/%s/%s?revision=%s&redirect_spruce_users=true#/%s=fail",
 		uiRoot, url.PathEscape(t.Project), url.PathEscape(t.DisplayName), t.Revision, url.QueryEscape(testName))
 }
 


### PR DESCRIPTION
[EVG-17047](https://jira.mongodb.org/browse/EVG-17047)

### Description 
BF tickets don't redirect with every link to the spruce UI. This adds the parameter to the BF ticket links to redirect to the spruce UI and adds the redirection logic to the pages associated that did not have it. As well, updated redirection logic to be consistent with new methods.

### Testing 
Created a BF ticket and tested all the links that should have changed (host, project- waterfall/project health, task history). [This is the BF created in testing.](https://jira.mongodb.org/browse/EVG-17188)
