### PR TITLE
EVG-16772 don't set display task start time for exec tasks that have zero start time

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1583,7 +1583,7 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 		timeTaken += execTask.TimeTaken
 
 		// set the start/end time of the display task as the earliest/latest task
-		if execTask.StartTime.Before(startTime) {
+		if execTask.StartTime != utility.ZeroTime && execTask.StartTime.Before(startTime) {
 			startTime = execTask.StartTime
 		}
 		if execTask.FinishTime.After(endTime) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1583,7 +1583,7 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 		timeTaken += execTask.TimeTaken
 
 		// set the start/end time of the display task as the earliest/latest task
-		if execTask.StartTime != utility.ZeroTime && execTask.StartTime.Before(startTime) {
+		if !utility.IsZeroTime(execTask.StartTime) && execTask.StartTime.Before(startTime) {
 			startTime = execTask.StartTime
 		}
 		if execTask.FinishTime.After(endTime) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3724,12 +3724,13 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	}
 	assert.NoError(dt2.Insert())
 	dt3 := task.Task{
-		Id:          "dt2",
+		Id:          "dt3",
 		DisplayOnly: true,
 		Status:      evergreen.TaskUndispatched,
 		Activated:   false,
 		ExecutionTasks: []string{
 			"task11",
+			"task12",
 		},
 	}
 	assert.NoError(dt3.Insert())
@@ -3886,6 +3887,7 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	dbTask, err = task.FindOne(db.Query(task.ById(dt3.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
+	assert.Equal(task12.StartTime, dbTask.StartTime)
 	assert.Equal(time.Date(2000, 0, 0, 0, 44, 0, 0, time.Local), dbTask.StartTime)
 }
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3888,7 +3888,6 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(task12.StartTime, dbTask.StartTime)
-	assert.Equal(time.Date(2000, 0, 0, 0, 44, 0, 0, time.Local), dbTask.StartTime)
 }
 
 func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {


### PR DESCRIPTION
[EVG-16772](https://jira.mongodb.org/browse/EVG-16772)

### Description 
Although I was not able to emulate this error in staging I have noticed some logic in `UpdateDisplayTaskForTask` where the display task's start time is set to the lowest value of all of its execution tasks' start times. What seems to be happening is some execution tasks have nil / zero start time set are being detected as the "lowest" start time and updating the display task as such. Small change has been made to not update the display task's start time if the execution task we are inspecting has a nil / zero start time.
### Testing 
Added case to unit test for `UpdateDisplayTaskForTask`