### PR TITLE
EVG-17169: transition pod state and fix dispatch idempotency during next task

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -522,6 +522,13 @@ func (p *Pod) GetSecret() (*Secret, error) {
 
 // SetRunningTask sets the task to dispatch to the pod.
 func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, taskID string) error {
+	if p.RunningTask == taskID {
+		return nil
+	}
+	if p.RunningTask != "" {
+		return errors.Errorf("cannot set running task to '%s' when it is already set to '%s'", taskID, p.RunningTask)
+	}
+
 	query := bson.M{
 		IDKey:          p.ID,
 		StatusKey:      StatusRunning,

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -548,12 +548,23 @@ func TestSetRunningTask(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, taskID, dbPod.RunningTask)
 		},
+		"NoopsWithPodAlreadyRunningSameTask": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
+			const taskID = "task"
+			p.RunningTask = taskID
+			require.NoError(t, p.Insert())
+			assert.NoError(t, p.SetRunningTask(ctx, env, taskID))
+
+			dbPod, err := FindOneByID(p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Equal(t, taskID, dbPod.RunningTask)
+		},
 		"FailsWithNonRunningPod": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
 			p.Status = StatusDecommissioned
 			require.NoError(t, p.Insert())
 			assert.Error(t, p.SetRunningTask(ctx, env, "task"))
 		},
-		"FailsWithPodAlreadyRunningTask": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
+		"FailsWithPodAlreadyRunningDifferentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
 			p.RunningTask = "some-other-task"
 			require.NoError(t, p.Insert())
 			assert.Error(t, p.SetRunningTask(ctx, env, "task"))

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -245,6 +245,10 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 
+	if err := h.transitionStartingToRunning(p); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "marking pod as running"))
+	}
+
 	h.setAgentFirstContactTime(p)
 
 	pd, err := h.findDispatcher()
@@ -288,6 +292,16 @@ func (h *podAgentNextTask) findPod() (*pod.Pod, error) {
 	}
 
 	return p, nil
+}
+
+// transitionStartingToRunning transitions the pod that is still starting up to
+// indicate that it is running and ready to accept tasks.
+func (h *podAgentNextTask) transitionStartingToRunning(p *pod.Pod) error {
+	if p.Status != pod.StatusStarting {
+		return nil
+	}
+
+	return p.UpdateStatus(pod.StatusRunning)
 }
 
 func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -16,10 +16,11 @@ import (
 	"github.com/evergreen-ci/evergreen/model/pod/dispatcher"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy/queue"
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestPodProvisioningScript(t *testing.T) {
@@ -230,7 +231,7 @@ func TestPodAgentNextTask(t *testing.T) {
 	}()
 	getPod := func() pod.Pod {
 		return pod.Pod{
-			ID:     utility.RandomString(),
+			ID:     primitive.NewObjectID().Hex(),
 			Status: pod.StatusStarting,
 		}
 	}
@@ -284,6 +285,28 @@ func TestPodAgentNextTask(t *testing.T) {
 			stats := env.RemoteQueue().Stats(ctx)
 			assert.Equal(t, 1, stats.Total)
 		},
+		"RunUpdatesStartingPodToRunning": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
+			// Close the remote queue so that it doesn't actually try to run the
+			// pod termination job when there's no task to run.
+			env.RemoteQueue().Close(ctx)
+
+			p := getPod()
+			require.NoError(t, p.Insert())
+			assert.Equal(t, pod.StatusStarting, p.Status, "initial pod status should be starting")
+			rh.podID = p.ID
+
+			pd := dispatcher.NewPodDispatcher("group", []string{}, []string{p.ID})
+			require.NoError(t, pd.Insert())
+
+			resp := rh.Run(ctx)
+			assert.Equal(t, http.StatusOK, resp.Status())
+
+			dbPod, err := pod.FindOneByID(p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.NotZero(t, dbPod.TimeInfo.AgentStarted)
+			assert.Equal(t, pod.StatusRunning, dbPod.Status)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -291,6 +314,11 @@ func TestPodAgentNextTask(t *testing.T) {
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
+			// Don't use the default local limited size remote queue from the
+			// mock env because it does not accept jobs when it's not active.
+			rq, err := queue.NewLocalLimitedSizeSerializable(1, 1)
+			require.NoError(t, err)
+			env.Remote = rq
 
 			require.NoError(t, db.ClearCollections(task.Collection, pod.Collection, dispatcher.Collection, event.AllLogCollection))
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17169

### Description 
I couldn't reproduce the issue where the agent would not check into the app server. When I tested with a container task, it successfully started the agent and asked for the next task. Since the container task lifecycle seems to be working as expected (up until the task actually runs on the agent), I did some small improvements for the next task route. Only the first one is actually necessary from a correctness perspective, but the second one is a nice to have.

* Set the pod status to running once the agent requests the next task.
* Ensure that setting the running task is a no-op if that task has already been assigned to the pod.

### Testing 
Tested that [a container task](https://spruce-staging.corp.mongodb.com/task/evg_lint_generate_lint_patch_353be1934dd2fe13f111bdf94c907f0e606b0385_62b4a1679dbe323902b0b330_22_06_23_17_23_06/logs?execution=0) successfully started an agent and performed the necessary updates to dispatch the container task. Also updated unit tests.
