### PR TITLE
EVG-17195: deallocate stranded container task during pod termination

### DIFF
--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -314,7 +314,7 @@ func (pd *PodDispatcher) RemovePod(ctx context.Context, env evergreen.Environmen
 			return errors.Wrap(err, "marking unallocatable container tasks as system-failed")
 		}
 
-		if err := task.MarkManyContainerDeallocated(pd.TaskIDs); err != nil {
+		if err := task.MarkTasksAsContainerDeallocated(pd.TaskIDs); err != nil {
 			return errors.Wrap(err, "marking all tasks in dispatcher as container deallocated")
 		}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1142,9 +1142,9 @@ func (t *Task) MarkAsContainerDeallocated(ctx context.Context, env evergreen.Env
 	return nil
 }
 
-// MarkManyContainerDeallocated marks multiple container tasks as no longer
+// MarkTasksAsContainerDeallocated marks multiple container tasks as no longer
 // allocated containers.
-func MarkManyContainerDeallocated(taskIDs []string) error {
+func MarkTasksAsContainerDeallocated(taskIDs []string) error {
 	if len(taskIDs) == 0 {
 		return nil
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2428,7 +2428,7 @@ func TestMarkAsContainerDeallocated(t *testing.T) {
 	}
 }
 
-func TestMarkManyContainerDeallocated(t *testing.T) {
+func TestMarkTasksAsContainerDeallocated(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.Clear(Collection))
 	}()
@@ -2451,7 +2451,7 @@ func TestMarkManyContainerDeallocated(t *testing.T) {
 				taskIDs = append(taskIDs, tsk.Id)
 			}
 
-			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			require.NoError(t, MarkTasksAsContainerDeallocated(taskIDs))
 			checkTasksUnallocated(t, taskIDs)
 		},
 		"NoopsWithHostTask": func(t *testing.T, tasks []Task) {
@@ -2462,7 +2462,7 @@ func TestMarkManyContainerDeallocated(t *testing.T) {
 				taskIDs = append(taskIDs, tsk.Id)
 			}
 
-			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			require.NoError(t, MarkTasksAsContainerDeallocated(taskIDs))
 			checkTasksUnallocated(t, taskIDs[1:])
 			dbHostTask, err := FindOneId(tasks[0].Id)
 			require.NoError(t, err)
@@ -2478,7 +2478,7 @@ func TestMarkManyContainerDeallocated(t *testing.T) {
 				taskIDs = append(taskIDs, tsk.Id)
 			}
 
-			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			require.NoError(t, MarkTasksAsContainerDeallocated(taskIDs))
 			checkTasksUnallocated(t, taskIDs)
 		},
 		"DoesNotUpdateNonexistentTask": func(t *testing.T, tasks []Task) {
@@ -2488,7 +2488,7 @@ func TestMarkManyContainerDeallocated(t *testing.T) {
 				taskIDs = append(taskIDs, tsk.Id)
 			}
 
-			require.NoError(t, MarkManyContainerDeallocated(taskIDs))
+			require.NoError(t, MarkTasksAsContainerDeallocated(taskIDs))
 			checkTasksUnallocated(t, taskIDs[1:])
 
 			dbTask, err := FindOneId(tasks[0].Id)

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -205,25 +205,25 @@ func (j *podTerminationJob) fixStrandedTasks(ctx context.Context) error {
 	if j.pod.RunningTask != "" {
 		// A stranded task will need to be re-allocated to ensure that it
 		// dispatches to a new pod after this one is terminated.
-		if err := task.MarkManyContainerDeallocated([]string{j.pod.RunningTask}); err != nil {
-			return errors.Wrapf(err, "marking stranded container task '%s' running on pod as deallocated", j.pod.RunningTask)
+		if err := task.MarkTasksAsContainerDeallocated([]string{j.pod.RunningTask}); err != nil {
+			return errors.Wrapf(err, "marking stranded container task '%s' running on pod '%s' as deallocated", j.pod.RunningTask, j.pod.ID)
 		}
 
 		if err := model.ClearAndResetStrandedContainerTask(j.pod); err != nil {
-			return errors.Wrapf(err, "resetting stranded container task '%s' running on pod", j.pod.RunningTask)
+			return errors.Wrapf(err, "resetting stranded container task '%s' running on pod '%s'", j.pod.RunningTask, j.pod.ID)
 		}
 	}
 
 	disp, err := dispatcher.FindOneByPodID(j.pod.ID)
 	if err != nil {
-		return errors.Wrap(err, "finding dispatcher associated with pod")
+		return errors.Wrapf(err, "finding dispatcher associated with pod '%s'", j.pod.ID)
 	}
 	if disp == nil {
 		return nil
 	}
 
 	if err := disp.RemovePod(ctx, j.env, j.pod.ID); err != nil {
-		return errors.Wrap(err, "removing pod from dispatcher")
+		return errors.Wrapf(err, "removing pod '%s' from dispatcher '%s'", j.pod.ID, disp.ID)
 	}
 
 	return nil

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -125,16 +125,18 @@ func TestPodTerminationJob(t *testing.T) {
 			}
 			require.NoError(t, v.Insert())
 			tsk := task.Task{
-				Id:            "task_id",
-				Execution:     1,
-				BuildId:       b.Id,
-				Version:       v.Id,
-				Status:        evergreen.TaskStarted,
-				Activated:     true,
-				ActivatedTime: time.Now(),
-				DispatchTime:  time.Now(),
-				StartTime:     time.Now(),
-				LastHeartbeat: time.Now(),
+				Id:                 "task_id",
+				Execution:          1,
+				BuildId:            b.Id,
+				Version:            v.Id,
+				ExecutionPlatform:  task.ExecutionPlatformContainer,
+				Status:             evergreen.TaskStarted,
+				Activated:          true,
+				ActivatedTime:      time.Now(),
+				DispatchTime:       time.Now(),
+				StartTime:          time.Now(),
+				LastHeartbeat:      time.Now(),
+				ContainerAllocated: true,
 			}
 			require.NoError(t, tsk.Insert())
 			j.pod.RunningTask = tsk.Id
@@ -156,7 +158,7 @@ func TestPodTerminationJob(t *testing.T) {
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbTask)
-			assert.Equal(t, evergreen.TaskUndispatched, dbTask.Status, "stranded task should have been restarted")
+			assert.True(t, dbTask.ShouldAllocateContainer(), "stranded task should have been restarted to re-attempt allocation")
 
 			dbBuild, err := build.FindOneId(b.Id)
 			require.NoError(t, err)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17195

### Description 
When a pod is about to terminate, tasks that are waiting to be dispatched to that pod are de-allocated to indicate that they need a new pod to run them. However, in the case that a pod is about to be terminated but it has already been dispatched to the pod, that stranded container task also has to be de-allocated so that when it restarts with a new execution, it gets allocated a new container to run it. I added some logic to ensure that the stranded task is re-allocated when the pod is abruptly terminated.

### Testing 
Added unit test.
