### PR TITLE
EVG-16866 Allow finalize flag with regex tasks/variants

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-06-07"
+	ClientVersion = "2022-07-06"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-06-24"

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -249,14 +249,15 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	if params.BaseGitHash == "" {
 		return nil, errors.New("no base hash provided")
 	}
-	if params.Finalize {
-		if params.Alias == "" {
-			if len(params.Variants) == 0 && len(params.RegexVariants) == 0 {
-				return nil, errors.New("no variants provided")
-			}
-			if len(params.Tasks) == 0 && len(params.RegexTasks) == 0 {
-				return nil, errors.New("no tasks provided")
-			}
+	if params.Finalize && params.Alias == "" && !params.RepeatFailed && !params.RepeatDefinition {
+		if len(params.Variants)+len(params.RegexVariants)+len(params.Tasks)+len(params.RegexTasks) == 0 {
+			return nil, errors.New("no tasks or variants provided")
+		}
+		if len(params.Variants)+len(params.RegexVariants) == 0 {
+			return nil, errors.New("no variants provided")
+		}
+		if len(params.Tasks)+len(params.RegexTasks) == 0 {
+			return nil, errors.New("no tasks provided")
 		}
 	}
 	if len(params.SyncParams.BuildVariants) != 0 && len(params.SyncParams.Tasks) == 0 {

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -251,10 +251,10 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	}
 	if params.Finalize {
 		if params.Alias == "" {
-			if len(params.Variants) == 0 {
+			if len(params.Variants) == 0 && len(params.RegexVariants) == 0 {
 				return nil, errors.New("no variants provided")
 			}
-			if len(params.Tasks) == 0 {
+			if len(params.Tasks) == 0 && len(params.RegexTasks) == 0 {
 				return nil, errors.New("no tasks provided")
 			}
 		}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -271,15 +271,10 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		}
 	}
 
-	if !p.Finalize || p.Alias != "" {
-		return ref, nil
-	}
-
-	if len(p.Tasks) == 0 && len(p.RegexTasks) == 0 {
-		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing (No task specified).")
-	}
-	if len(p.Variants) == 0 && len(p.RegexVariants) == 0 {
-		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing (No variants specified).")
+	if p.Finalize && p.Alias != "" {
+		if len(p.Variants)+len(p.RegexVariants) == 0 || len(p.Tasks)+len(p.RegexTasks) == 0 {
+			return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing")
+		}
 	}
 
 	return ref, nil

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -271,7 +271,7 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		}
 	}
 
-	if p.Finalize && p.Alias != "" {
+	if p.Finalize && p.Alias == "" && !p.RepeatFailed && !p.RepeatDefinition {
 		if len(p.Variants)+len(p.RegexVariants) == 0 || len(p.Tasks)+len(p.RegexTasks) == 0 {
 			return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing")
 		}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -271,8 +271,15 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		}
 	}
 
-	if (len(p.Tasks) == 0 || len(p.Variants) == 0) && p.Alias == "" && p.Finalize {
-		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing.")
+	if !p.Finalize || p.Alias != "" {
+		return ref, nil
+	}
+
+	if len(p.Tasks) == 0 && len(p.RegexTasks) == 0 {
+		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing (No task specified).")
+	}
+	if len(p.Variants) == 0 && len(p.RegexVariants) == 0 {
+		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing (No variants specified).")
 	}
 
 	return ref, nil


### PR DESCRIPTION
[EVG-16866](https://jira.mongodb.org/browse/EVG-16866)

### Description 
Enables users to use the finalize flag with regex tasks/variants and mixing regex tasks with a list of variants or regex variants with a list of tasks.

### Testing 
Running `evergreen patch --rv '.*' --rt '.*' -f` results in an error saying that no tasks/variants are listed. After these commits, running the same command will give a patch link that has all the tasks on all variants to be ran (the regex provided is all). If you run `evergreen patch -t generate-lint --rv lint -f` works and schedules the task 'generate-lint' on the 'lint' variant.
