### PR TITLE
EVG-16755 Add debug logging to detect ending of display tasks with no failure details

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1838,6 +1838,13 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		"details":   t.Details,
 	})
 	if detail.Status == "" {
+		grip.Debug(message.Fields{
+			"message":   "detail status was empty, setting to failed",
+			"task_id":   t.Id,
+			"execution": t.Execution,
+			"project":   t.Project,
+			"details":   t.Details,
+		})
 		detail.Status = evergreen.TaskFailed
 	}
 	// record that the task has finished, in memory and in the db

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1703,13 +1703,15 @@ func checkResetDisplayTask(t *task.Task) error {
 			Status: evergreen.TaskFailed,
 		}
 	}
-	grip.Debug(message.Fields{
-		"message":   "resetting display task",
-		"task_id":   t.Id,
-		"execution": t.Execution,
-		"project":   t.Project,
-		"details":   details,
-	})
+	if details.Status == "" {
+		grip.Debug(message.Fields{
+			"message":   "resetting display task",
+			"task_id":   t.Id,
+			"execution": t.Execution,
+			"project":   t.Project,
+			"details":   details,
+		})
+	}
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
 }
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1703,6 +1703,13 @@ func checkResetDisplayTask(t *task.Task) error {
 			Status: evergreen.TaskFailed,
 		}
 	}
+	grip.Debug(message.Fields{
+		"message":   "resetting display task",
+		"task_id":   t.Id,
+		"execution": t.Execution,
+		"project":   t.Project,
+		"details":   details,
+	})
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
 }
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1703,15 +1703,13 @@ func checkResetDisplayTask(t *task.Task) error {
 			Status: evergreen.TaskFailed,
 		}
 	}
-	if details.Status == "" {
-		grip.Debug(message.Fields{
-			"message":   "resetting display task",
-			"task_id":   t.Id,
-			"execution": t.Execution,
-			"project":   t.Project,
-			"details":   details,
-		})
-	}
+	grip.DebugWhen(details.Status == "", message.Fields{
+		"message":   "resetting display task",
+		"task_id":   t.Id,
+		"execution": t.Execution,
+		"project":   t.Project,
+		"details":   details,
+	})
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
 }
 


### PR DESCRIPTION
[EVG-16755](https://jira.mongodb.org/browse/EVG-16755)

### Description 
This is addressing a subset of the issues with [this task](https://spruce.mongodb.com/task/mongodb_mongo_v4.4_windows_display_multiversion_319d8d8145fb5893ab3bf5d077730226f3f2af7c_22_04_06_18_31_56/execution-tasks?execution=0&sortBy=STATUS&sortDir=ASC&sorts=STATUS%3AASC) (a display task that has been generated from its execution task, but the execution task fails/strands on first execution). This PR addresses the fact that despite the display task's execution tasks have system failed, the display task's first execution simply reads `failed` with no relevant failure details.  

What looks like happened is an empty `status_details` got passed into `MarkEnd`, and when this happens we assign the task's status to simply `failed`. I've added a log to track when this happens.  

Secondly I've added a log when we reset a display task's status. I suspect the issue is coming from [this line](https://github.com/evergreen-ci/evergreen/blob/main/model/task_lifecycle.go#L1714) in task lifecycle where we check if `details` is nil but not if it is completely empty.  However I've added a debug log to help us corroborate this, and if we see nil details logging out in the future we can modify the check here.