### PR TITLE
EVG-16655 Add gp3 to existing valid volume types

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -244,6 +244,7 @@ const (
 const (
 	VolumeTypeStandard = "standard"
 	VolumeTypeIo2      = "io1"
+	VolumeTypeGp3      = "gp3"
 	VolumeTypeGp2      = "gp2"
 	VolumeTypeSc1      = "sc1"
 	VolumeTypeSt1      = "st1"
@@ -253,6 +254,7 @@ var (
 	ValidVolumeTypes = []string{
 		VolumeTypeStandard,
 		VolumeTypeIo2,
+		VolumeTypeGp3,
 		VolumeTypeGp2,
 		VolumeTypeSc1,
 		VolumeTypeSt1,


### PR DESCRIPTION
[EVG-16655](https://jira.mongodb.org/browse/EVG-16655)

### Description 
Workstations currently don't allow gp3, to use gp3 as a volume type, it can be added to the volume types. The Spruce UI still needs compatibility, I made a ticket linked to this one relating to it.

### Testing 
Deployed on staging and made a volume with gp3 as the type (before this change, gp3 would result in an error message and a list of valid types. Now it is allowed and invalid types are responded with an error message including gp3). I added screenshot on JIRA ticket as showing of the test.
