### PR TITLE
EVG-16977 remove errors field

### DIFF
--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -114,8 +114,6 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 			var generateErr error
 			if generateStatus.Error != "" {
 				generateErr = errors.New(generateStatus.Error)
-			} else if len(generateStatus.Errors) > 0 {
-				generateErr = errors.New(strings.Join(generateStatus.Errors, ", "))
 			}
 
 			if generateStatus.ShouldExit {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -469,7 +469,6 @@ func (c *Mock) GenerateTasksPoll(ctx context.Context, td TaskData) (*apimodels.G
 	return &apimodels.GeneratePollResponse{
 		Finished:   true,
 		ShouldExit: false,
-		Errors:     []string{},
 	}, nil
 }
 

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -311,9 +311,6 @@ type GeneratePollResponse struct {
 	Finished   bool   `json:"finished"`
 	ShouldExit bool   `json:"should_exit"`
 	Error      string `json:"error"`
-
-	// TODO: (EVG-16977) Remove the Errors field.
-	Errors []string `json:"errors"`
 }
 
 // DistroView represents the view of data that the agent uses from the distro

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-06-07"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-06-27"
+	AgentVersion = "2022-06-29"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -102,15 +102,9 @@ func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
 	// If new tasks create a dependency cycle it's going to persist across retries.
 	shouldExit := db.IsDocumentLimit(errors.New(jobErr)) || strings.Contains(jobErr, model.DependencyCycleError.Error())
 
-	var errors []string
-	if len(jobErr) > 0 {
-		errors = append(errors, jobErr)
-	}
-
 	return gimlet.NewJSONResponse(&apimodels.GeneratePollResponse{
 		Finished:   finished,
 		ShouldExit: shouldExit,
-		Errors:     errors,
 		Error:      jobErr,
 	})
 }


### PR DESCRIPTION
[EVG-16977](https://jira.mongodb.org/browse/EVG-16977)

### Description 
#5693 replaced the `Errors` field with an `Error` field. Now that that's been live for a while (it was deployed 6/14) it's a (near?) certainty that there are no hosts still running a task with the old agent.