### PR TITLE
EVG-17208 Remove macOS agent before downloading

### DIFF
--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -285,9 +285,7 @@ func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.
 	if runtime.GOOS == "darwin" {
 		_, err := os.Stat(m.clientPath)
 		if err == nil {
-			if err := os.Remove(m.clientPath); err != nil {
-				grip.Error(errors.Wrap(err, "deleting client"))
-			}
+			grip.Error(errors.Wrap(os.Remove(m.clientPath), "deleting client"))
 		} else {
 			grip.ErrorWhen(!errors.Is(err, os.ErrNotExist), errors.Wrap(err, "checking if client exists"))
 		}

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -283,12 +283,7 @@ func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.
 	// downloading prevents this from occurring. See
 	// https://apple.stackexchange.com/questions/258623/how-to-fix-killed-9-error-in-mac-os/428388#428388
 	if runtime.GOOS == "darwin" {
-		_, err := os.Stat(m.clientPath)
-		if err == nil {
-			grip.Error(errors.Wrap(os.Remove(m.clientPath), "deleting client"))
-		} else {
-			grip.ErrorWhen(!errors.Is(err, os.ErrNotExist), errors.Wrap(err, "checking if client exists"))
-		}
+		grip.Error(errors.Wrap(os.RemoveAll(m.clientPath), "deleting client"))
 	}
 
 	for _, url := range urls {

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -283,16 +283,13 @@ func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.
 	// downloading prevents this from occurring. See
 	// https://apple.stackexchange.com/questions/258623/how-to-fix-killed-9-error-in-mac-os/428388#428388
 	if runtime.GOOS == "darwin" {
-		if _, err := os.Stat(m.clientPath); err != nil {
-			// It is significant toil to investigate a host, so
-			// log an error but but don't return if there is a
-			// problem checking whether the client exists, and try
-			// to download a client anyway.
-			grip.ErrorWhen(!errors.Is(err, os.ErrNotExist), errors.Wrap(err, "checking if client exists"))
-		} else {
+		_, err := os.Stat(m.clientPath)
+		if err == nil {
 			if err := os.Remove(m.clientPath); err != nil {
 				grip.Error(errors.Wrap(err, "deleting client"))
 			}
+		} else {
+			grip.ErrorWhen(!errors.Is(err, os.ErrNotExist), errors.Wrap(err, "checking if client exists"))
 		}
 	}
 

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -276,6 +277,25 @@ func handleMonitorSignals(ctx context.Context, serviceCancel context.CancelFunc)
 func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.RetryOptions) error {
 	var downloaded bool
 	catcher := grip.NewBasicCatcher()
+
+	// macOS caches signatures, which means that a newly downloaded
+	// evergreen agent can fail to start. Removing the agent before
+	// downloading prevents this from occurring. See
+	// https://apple.stackexchange.com/questions/258623/how-to-fix-killed-9-error-in-mac-os/428388#428388
+	if runtime.GOOS == "darwin" {
+		if _, err := os.Stat(m.clientPath); err != nil {
+			// It is significant toil to investigate a host, so
+			// log an error but but don't return if there is a
+			// problem checking whether the client exists, and try
+			// to download a client anyway.
+			grip.ErrorWhen(!errors.Is(err, os.ErrNotExist), errors.Wrap(err, "checking if client exists"))
+		} else {
+			if err := os.Remove(m.clientPath); err != nil {
+				grip.Error(errors.Wrap(err, "deleting client"))
+			}
+		}
+	}
+
 	for _, url := range urls {
 		info := options.Download{
 			URL:         url,


### PR DESCRIPTION
[EVG-17208](https://jira.mongodb.org/browse/EVG-17208)

### Description 
macOS caches signatures, which means that a newly downloaded evergreen agent can fail to start. Removing the agent before downloading prevents this from occurring. See https://apple.stackexchange.com/questions/258623/how-to-fix-killed-9-error-in-mac-os/428388#428388.

This PR deliberately does this only on macOS to reduce the amount of work to deploy this, since otherwise every static distro would have to be manually redeployed.

### Testing 
This will require manual testing.