### PR TITLE
EVG-15858 Add subscription and event ID to email notifications

### DIFF
--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -189,6 +189,26 @@ const emailTaskFailTemplate = `
           </span>
         </td>
       </tr>
+      <tr>
+	     <td colspan="2"><span style="font-family:Arial,sans-serif;font-weight:bold;font-size:10px;color:#999999" class="label">SUBSCRIPTION ID</span></td>
+	  </tr>
+      <tr>
+        <td colspan="2">
+          <span style="font-family:Arial,sans-serif;font-weight:bold;font-size:36px;color:#333333" class="subscription">
+            {{ .SubscriptionID }}
+          </span>
+        </td>
+      </tr>
+      <tr>
+	     <td colspan="2"><span style="font-family:Arial,sans-serif;font-weight:bold;font-size:10px;color:#999999" class="label">EVENT ID</span></td>
+	  </tr>
+      <tr>
+        <td colspan="2">
+          <span style="font-family:Arial,sans-serif;font-weight:bold;font-size:36px;color:#333333" class="event">
+            {{ .EventID }}
+          </span>
+        </td>
+      </tr>
     </table>
   </td>
   <td width="20"></td>
@@ -203,6 +223,8 @@ const emailDefaultContentTemplateString = `{{ define "content"}}
 
 <p>Your Evergreen {{ .Object }} in '{{ .Project }}' <a href="{{ .URL }}">{{ .DisplayName }}</a> has {{ .PastTenseStatus }}.</p>
 <p>{{ .Description }}</p>
+
+<p>Subscription: {{ .SubscriptionID }}; Event: {{ .EventID }} </p>
 {{ end }}`
 
 var emailDefaultContentTemplate = template.Must(template.New("content").Parse(emailDefaultContentTemplateString))

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -49,6 +49,8 @@ func (s *payloadSuite) SetupTest() {
 		DisplayName:     "display-1234",
 		Object:          "patch",
 		Project:         "test",
+		EventID:         "ABC123",
+		SubscriptionID:  "DFE456",
 		URL:             s.url,
 		PastTenseStatus: s.status,
 		Headers:         headers,
@@ -65,6 +67,8 @@ func (s *payloadSuite) TestEmailWithNilContent() {
 	s.Contains(m.Body, "> has failed.")
 	s.Contains(m.Body, `href="`+s.url+`"`)
 	s.Contains(m.Body, "X-Evergreen-test:something")
+	s.Contains(m.Body, "Subscription: DFE456")
+	s.Contains(m.Body, "Event: ABC123")
 }
 
 func (s *payloadSuite) TestEmailWithTaskContent() {
@@ -102,6 +106,8 @@ func (s *payloadSuite) TestEmailWithTaskContent() {
 	s.Contains(m.Body, "display_test1")
 	s.Contains(m.Body, "theproject")
 	s.Contains(m.Body, "buildname")
+	s.Contains(m.Body, "DFE456")
+	s.Contains(m.Body, "ABC123")
 
 	s.t.Task.DisplayTask = &task.Task{
 		DisplayName: "thedisplaytask",


### PR DESCRIPTION
[EVG-15858](https://jira.mongodb.org/browse/EVG-15858)

### Description 
Slack notifications includes the subscription and event ID in the footer, this PR adds them to the email notifications as well.

### Testing 
Unit tests and screenshots (to be added after draft)