### PR TITLE
EVG-17099: Use Presto test stats for all non-Server projects

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -380,6 +380,13 @@ func (p *ProjectRef) AliasesNeeded() bool {
 	return p.IsGithubChecksEnabled() || p.IsGitTagVersionsEnabled() || p.IsGithubChecksEnabled() || p.IsPRTestingEnabled()
 }
 
+// IsServerResmokeProject returns whether the project is owned by the Server
+// team and uses Resmoke.
+// TODO (PM-2940): Remove this once we migrate Mongo projects to Presto.
+func (p *ProjectRef) IsServerResmokeProject() bool {
+	return strings.HasPrefix("mongodb-mongo-", p.Identifier) || strings.HasPrefix("mongosync", p.Identifier)
+}
+
 const (
 	ProjectRefCollection     = "project_ref"
 	ProjectTriggerLevelTask  = "task"

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -380,13 +380,6 @@ func (p *ProjectRef) AliasesNeeded() bool {
 	return p.IsGithubChecksEnabled() || p.IsGitTagVersionsEnabled() || p.IsGithubChecksEnabled() || p.IsPRTestingEnabled()
 }
 
-// IsServerResmokeProject returns whether the project is owned by the Server
-// team and uses Resmoke.
-// TODO (PM-2940): Remove this once we migrate Mongo projects to Presto.
-func (p *ProjectRef) IsServerResmokeProject() bool {
-	return strings.HasPrefix("mongodb-mongo-", p.Identifier) || strings.HasPrefix("mongosync", p.Identifier)
-}
-
 const (
 	ProjectRefCollection     = "project_ref"
 	ProjectTriggerLevelTask  = "task"
@@ -2689,6 +2682,13 @@ func GetUpstreamProjectName(triggerID, triggerType string) (string, error) {
 		return "", errors.New("upstream project not found")
 	}
 	return upstreamProject.DisplayName, nil
+}
+
+// IsServerResmokeProject returns whether the project is owned by the Server
+// team and uses Resmoke.
+// TODO (PM-2940): Remove this once we migrate Mongo projects to Presto.
+func IsServerResmokeProject(identifier string) bool {
+	return strings.HasPrefix("mongodb-mongo-", identifier) || strings.HasPrefix("mongosync", identifier)
 }
 
 // projectRefPipelineForMatchingTrigger is an aggregation pipeline to find projects that have the projectKey

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2688,7 +2688,7 @@ func GetUpstreamProjectName(triggerID, triggerType string) (string, error) {
 // team and uses Resmoke.
 // TODO (PM-2940): Remove this once we migrate Mongo projects to Presto.
 func IsServerResmokeProject(identifier string) bool {
-	return strings.HasPrefix("mongodb-mongo-", identifier) || strings.HasPrefix("mongosync", identifier)
+	return strings.HasPrefix(identifier, "mongodb-mongo-") || strings.HasPrefix(identifier, "mongosync")
 }
 
 // projectRefPipelineForMatchingTrigger is an aggregation pipeline to find projects that have the projectKey

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2060,3 +2060,44 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.Equal(t, 4, projectRef.ContainerSizes["xlarge"].CPU)
 
 }
+
+func TestIsServerResmokeProject(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		identifier string
+		expected   bool
+	}{
+		{
+			name:       "MongoMaster",
+			identifier: "mongodb-mongo-master",
+			expected:   true,
+		},
+		{
+			name:       "MongoBranch",
+			identifier: "mongodb-mongo-5.0",
+			expected:   true,
+		},
+		{
+			name:       "MongoSync",
+			identifier: "mongosync",
+			expected:   true,
+		},
+		{
+			name:       "MongoSyncCoinbase",
+			identifier: "mongosync-coinbase",
+			expected:   true,
+		},
+		{
+			name:       "Evergreen",
+			identifier: "evergreen",
+		},
+		{
+			name:       "Mongo",
+			identifier: "mongo",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, IsServerResmokeProject(test.identifier))
+		})
+	}
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -54,7 +54,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	editDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsEdit)
 	removeDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsAdmin)
 	editHosts := RequiresDistroPermission(evergreen.PermissionHosts, evergreen.HostsEdit)
-	cedarTestStats := checkCedarTestStats(settings)
 
 	app.AddWrapper(gimlet.WrapperMiddleware(allowCORS))
 
@@ -169,7 +168,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/revisions/{commit_hash}/tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeTasksByProjectAndCommitHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/task_reliability").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetProjectTaskReliability(opts.URL))
 	app.AddRoute("/projects/{project_id}/task_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskStats(opts.URL))
-	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks, cedarTestStats).RouteHandler(makeGetProjectTestStats(opts.URL, env.Settings().Presto.DB()))
+	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTestStats(opts.URL, env.Settings().Presto.DB()))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/tasks/{task_name}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTasksHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases())

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -328,23 +328,17 @@ func (tsh *testStatsHandler) Parse(ctx context.Context, r *http.Request) error {
 	project := gimlet.GetVars(r)["project_id"]
 	vals := r.URL.Query()
 
-	projectRef, err := dbModel.FindBranchProjectRef(project)
+	identifier, err := dbModel.GetIdentifierForProject(project)
 	if err != nil {
 		return gimlet.ErrorResponse{
-			Message:    fmt.Sprintf("finding project ref '%s'", project),
+			Message:    fmt.Sprintf("getting project identifier for '%s'", project),
 			StatusCode: http.StatusInternalServerError,
-		}
-	}
-	if projectRef == nil {
-		return gimlet.ErrorResponse{
-			Message:    fmt.Sprintf("project ref '%s' not found", project),
-			StatusCode: http.StatusNotFound,
 		}
 	}
 
 	// If this project is owned by Server and uses Resmoke, we need to use
 	// Evergreen test stats.
-	if projectRef.IsServerResmokeProject() {
+	if dbModel.IsServerResmokeProject(identifier) {
 		tsh.filter = stats.StatsFilter{Project: project}
 		err := tsh.StatsHandler.parseStatsFilter(vals)
 		if err != nil {

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -14,13 +13,11 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/stats"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -331,21 +328,35 @@ func (tsh *testStatsHandler) Parse(ctx context.Context, r *http.Request) error {
 	project := gimlet.GetVars(r)["project_id"]
 	vals := r.URL.Query()
 
-	if vals.Get("presto") == "true" {
-		return tsh.parsePrestoStatsFilter(project, vals)
+	projectRef, err := dbModel.FindBranchProjectRef(project)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			Message:    fmt.Sprintf("finding project ref '%s'", project),
+			StatusCode: http.StatusInternalServerError,
+		}
+	}
+	if projectRef == nil {
+		return gimlet.ErrorResponse{
+			Message:    fmt.Sprintf("project ref '%s' not found", project),
+			StatusCode: http.StatusNotFound,
+		}
 	}
 
-	tsh.filter = stats.StatsFilter{Project: project}
-	err := tsh.StatsHandler.parseStatsFilter(vals)
-	if err != nil {
-		return errors.Wrap(err, "invalid query parameters")
-	}
-	err = tsh.filter.ValidateForTests()
-	if err != nil {
-		return errors.Wrap(err, "invalid filter")
+	// If this project is owned by Server and uses Resmoke, we need to use
+	// Evergreen test stats.
+	if projectRef.IsServerResmokeProject() {
+		tsh.filter = stats.StatsFilter{Project: project}
+		err := tsh.StatsHandler.parseStatsFilter(vals)
+		if err != nil {
+			return errors.Wrap(err, "invalid query parameters")
+		}
+		err = tsh.filter.ValidateForTests()
+		if err != nil {
+			return errors.Wrap(err, "invalid filter")
+		}
 	}
 
-	return nil
+	return tsh.parsePrestoStatsFilter(project, vals)
 }
 
 func (tsh *testStatsHandler) parsePrestoStatsFilter(project string, vals url.Values) error {
@@ -579,61 +590,4 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return resp
-}
-
-type cedarTestStatsMiddleware struct {
-	settings *evergreen.Settings
-}
-
-func checkCedarTestStats(settings *evergreen.Settings) gimlet.Middleware {
-	return &cedarTestStatsMiddleware{
-		settings: settings,
-	}
-}
-
-func (m *cedarTestStatsMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-	ctx := r.Context()
-
-	if r.URL.Query().Get("presto") != "true" {
-		newURL := fmt.Sprintf(
-			"https://%s/rest/v1/historical_test_data/%s?%s",
-			m.settings.Cedar.BaseURL,
-			gimlet.GetVars(r)["project_id"],
-			r.URL.RawQuery,
-		)
-		req, err := http.NewRequest(http.MethodGet, newURL, nil)
-		if err != nil {
-			gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating Cedar test stats request")))
-			return
-		}
-		req = req.WithContext(ctx)
-
-		c := utility.GetHTTPClient()
-		defer utility.PutHTTPClient(c)
-
-		resp, err := c.Do(req)
-		if err != nil {
-			gimlet.WriteResponse(rw, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "sending test stats request to Cedar")))
-			return
-		}
-		defer func() {
-			_ = resp.Body.Close()
-		}()
-		if resp.StatusCode == http.StatusOK {
-			for key, vals := range resp.Header {
-				for _, val := range vals {
-					rw.Header().Add(key, val)
-				}
-			}
-			_, err = io.Copy(rw, resp.Body)
-			grip.Error(message.WrapError(err, message.Fields{
-				"route":      "/projects/{project_id}/test_stats",
-				"message":    "problem copying Cedar test stats",
-				"project_id": gimlet.GetVars(r)["project_id"],
-			}))
-			return
-		}
-	}
-
-	next(rw, r)
 }

--- a/rest/route/stats_test.go
+++ b/rest/route/stats_test.go
@@ -436,7 +436,6 @@ func TestParsePrestoStatsFilter(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			test.vals["presto"] = []string{"true"}
 			handler := testStatsHandler{db: db}
 
 			err := handler.parsePrestoStatsFilter("project", test.vals)


### PR DESCRIPTION
EVG-17099: https://jira.mongodb.org/browse/EVG-17099

- Remove the Cedar test stats middleware.
- Remove the `presto` query parameter from the test stats route.
- Add temporary method that returns if a given identifier is a Server/Resmoke project (anything that beings with `mongodb-mongo-` or `mongosync`).
- Use the Presto client to fetch all non-Server/Resmoke projects.

I tested that this works in staging.