### PR TITLE
EVG-17060 Remove un-needed high volume debug statements

### DIFF
--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -57,12 +57,6 @@ func ActivateElapsedBuildsAndTasks(v *Version) (bool, error) {
 
 		isElapsedBuild := bv.ShouldActivate(now)
 		if !isElapsedBuild && len(readyTasks) == 0 {
-			grip.Debug(message.Fields{
-				"message":          "not activating build",
-				"ignore_tasks":     ignoreTasks,
-				"is_elapsed_build": isElapsedBuild,
-				"build_variant":    bv.BuildId,
-			})
 			continue
 		}
 		hasActivated = true

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -11,8 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 )
 
 // UnitCache stores an unordered collection of schedulable units. The
@@ -315,13 +313,6 @@ func (unit *Unit) RankValue() int64 {
 
 	info := unit.info()
 	unit.cachedValue = info.value()
-
-	grip.Info(message.Fields{
-		"message":   "prioritized distro unit",
-		"distro":    unit.distro.Id,
-		"value":     unit.cachedValue,
-		"unit_info": info,
-	})
 
 	return unit.cachedValue
 }

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -106,19 +106,6 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 			numChecksThatUpdatedTasks++
 		}
 	}
-	grip.Debug(message.Fields{
-		"message":             "finished check blocked tasks job",
-		"len_queue":           lenQueue,
-		"len_alias_queue":     lenAliasQueue,
-		"len_tasks":           len(tasksToCheck),
-		"len_task_ids":        len(taskIds),
-		"task_ids":            taskIds,
-		"num_tasks_modified":  numTasksModified,
-		"num_updating_checks": numChecksThatUpdatedTasks,
-		"job":                 j.ID(),
-		"source":              checkBlockedTasks,
-		"distro":              j.DistroId,
-	})
 }
 
 func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) (int, error) {

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -150,7 +150,6 @@ func (j *idleHostJob) Run(ctx context.Context) {
 			"num_idle_hosts":                 len(info.IdleHosts),
 			"min_num_idle_hosts_to_evaluate": minNumHostsToEvaluate,
 			"num_idle_hosts_to_evaluate":     len(hostsToEvaluateForTermination),
-			"idle_hosts_to_evaluate":         hostsToEvaluateForTermination,
 		})
 	}
 }

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 )
 
@@ -138,19 +137,6 @@ func (j *idleHostJob) Run(ctx context.Context) {
 			hostsToEvaluateForTermination = append(hostsToEvaluateForTermination, info.IdleHosts[i])
 			j.AddError(j.checkAndTerminateHost(ctx, &info.IdleHosts[i], currentDistro))
 		}
-
-		grip.InfoWhen(sometimes.Percent(10), message.Fields{
-			"id":                             j.ID(),
-			"job_type":                       idleHostJobName,
-			"runner":                         "monitor",
-			"op":                             "dispatcher",
-			"distro_id":                      info.DistroID,
-			"minimum_hosts":                  minimumHostsForDistro,
-			"num_running_hosts":              info.RunningHostsCount,
-			"num_idle_hosts":                 len(info.IdleHosts),
-			"min_num_idle_hosts_to_evaluate": minNumHostsToEvaluate,
-			"num_idle_hosts_to_evaluate":     len(hostsToEvaluateForTermination),
-		})
 	}
 }
 


### PR DESCRIPTION
[EVG-17060](https://jira.mongodb.org/browse/EVG-17060)

### Description 
Reviewed and removed all of the debug statements. 
Removed
[not activating builds](https://github.com/evergreen-ci/evergreen/blob/8cc324c7d913b08af7e46d433dfd63301e515bd1/model/version_activation.go#L60-L65)
[finished check blocked tasks job](https://github.com/evergreen-ci/evergreen/blob/73aeda1957e70c0f4b7f5ca4eaf0044e8a4ea7a5/units/check_blocked_tasks.go#L109-L121)
[prioritized distro unit](https://github.com/evergreen-ci/evergreen/blob/main/scheduler/planner.go#L320)
[idle_hosts_to_evaluate](https://github.com/evergreen-ci/evergreen/blob/1d229b273bb8f680e8fa06cd56053c825c74702b/units/host_monitoring_idle_termination.go#L142-L154) to simply remove the `idle_hosts_to_evaluate` field and just log the length of the hosts since that is what is causing bloat.

Keeping [github hook](https://github.com/evergreen-ci/evergreen/blob/74e6be38155f11e5dfc1a3d83772e3ac9dcdf311/rest/route/github.go#L199-L206) because it doesn't hit as frequently and provides helpful insight to GitHub PRs for debugging purposes.
