### PR TITLE
EVG-13262 Add check for CLI version string update

### DIFF
--- a/scripts/verify-client-version-update.sh
+++ b/scripts/verify-client-version-update.sh
@@ -32,5 +32,5 @@ if [[ "${last_commit_client_version_updated}" == "000000000000000000000000000000
 fi
 
 echo -e "Files affected by client version update:\n${files_changed}" >&2
-echo "Operations has been changed but client version has not been updated. Please update the client version." >&2
+echo "Evergreen CLI has been changed but client version has not been updated. Please update the client version." >&2
 exit 1

--- a/scripts/verify-client-version-update.sh
+++ b/scripts/verify-client-version-update.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [[ "${BRANCH_NAME}" == "" ]]; then
+    BRANCH_NAME=main;
+fi
+
+# Find the common ancestor between the current set of changes and the upstream branch, then see if any source code files
+# have changed in the operations directory.
+common_ancestor=$(git merge-base ${BRANCH_NAME}@{upstream} HEAD);
+files_changed="$(git diff --name-only "${common_ancestor}" -- 'operations/**.go')"
+if [[ "${files_changed}" == "" ]]; then
+    exit 0;
+fi
+
+# Get the list of commit revisions.
+committed_changes=$(git log --format=%H ${common_ancestor}..);
+
+# Find the latest commit when the client version was updated.
+client_version_line_num=$(git grep -n -e "ClientVersion =" config.go | cut -d ':' -f 2);
+last_commit_client_version_updated=$(git blame -l -L ${client_version_line_num},${client_version_line_num} config.go | cut -d ' ' -f 1);
+
+# Check if the last commit when the client version was updated is in the list of committed changes.
+if [[ "${committed_changes}" =~ "${last_commit_client_version_updated}" ]]; then
+    exit 0;
+fi
+
+# If the client version was updated but not committed yet, it still counts as a change.
+if [[ "${last_commit_client_version_updated}" == "0000000000000000000000000000000000000000" ]]; then
+    exit 0;
+fi
+
+echo -e "Files affected by client version update:\n${files_changed}" >&2
+echo "Operations has been changed but client version has not been updated. Please update the client version." >&2
+exit 1

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -290,6 +290,15 @@ functions:
         env:
           BRANCH_NAME: ${branch_name}
 
+  verify-client-version-update:
+    - command: subprocess.exec
+      params:
+        working_dir: evergreen
+        binary: bash
+        args: ["scripts/verify-client-version-update.sh"]
+        env:
+          BRANCH_NAME: ${branch_name}
+
   verify-merge-function-update:
     - command: subprocess.exec
       params:
@@ -537,6 +546,12 @@ tasks:
     commands:
       - func: get-project-and-modules
       - func: verify-agent-version-update
+  - name: verify-client-version-update
+    tags: ["linter"]
+    patch_only: true
+    commands:
+      - func: get-project-and-modules
+      - func: verify-client-version-update
   - name: verify-mod-tidy
     tags: ["linter"]
     commands:


### PR DESCRIPTION
[EVG-13262](https://jira.mongodb.org/browse/EVG-13262)

### Description 
linter now checks that we change the client version when something in the operations package is edited 

### Testing 

made a patch with a change in operations and agent and verified that both checks failed 

https://spruce.mongodb.com/version/62c4515f7742ae4c1f3580ec/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC