### PR TITLE
EVG-16755 remove debug logging and modify checkResetDisplayTask

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -172,6 +172,10 @@ type RegistrySettings struct {
 	Password string `mapstructure:"registry_password" json:"registry_password" yaml:"registry_password"`
 }
 
+func (ted *TaskEndDetail) IsEmpty() bool {
+	return ted == nil || ted.Status == ""
+}
+
 func (ch *CreateHost) ValidateDocker() error {
 	catcher := grip.NewBasicCatcher()
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1838,7 +1838,7 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		"project":   t.Project,
 		"details":   t.Details,
 	})
-	if detail.Status == "" {
+	if detail.IsEmpty() {
 		grip.Debug(message.Fields{
 			"message":   "detail status was empty, setting to failed",
 			"task_id":   t.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1781,18 +1781,14 @@ func checkResetDisplayTask(t *task.Task) error {
 		}
 	}
 	details := &t.Details
-	// assign task end details to indicate system failure if we receive no valid details
-	if taskEndDetailsIsEmpty(details) && !t.IsFinished() {
+	// Assign task end details to indicate system failure if we receive no valid details
+	if details.IsEmpty() && !t.IsFinished() {
 		details = &apimodels.TaskEndDetail{
 			Type:   evergreen.CommandTypeSystem,
 			Status: evergreen.TaskFailed,
 		}
 	}
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
-}
-
-func taskEndDetailsIsEmpty(details *apimodels.TaskEndDetail) bool {
-	return details == nil || details.Status == ""
 }
 
 // MarkUnallocatableContainerTasksSystemFailed marks any container task within

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1781,20 +1781,18 @@ func checkResetDisplayTask(t *task.Task) error {
 		}
 	}
 	details := &t.Details
-	if details == nil && !t.IsFinished() {
+	// assign task end details to indicate system failure if we receive no valid details
+	if taskEndDetailsIsEmpty(details) && !t.IsFinished() {
 		details = &apimodels.TaskEndDetail{
 			Type:   evergreen.CommandTypeSystem,
 			Status: evergreen.TaskFailed,
 		}
 	}
-	grip.DebugWhen(details.Status == "", message.Fields{
-		"message":   "resetting display task",
-		"task_id":   t.Id,
-		"execution": t.Execution,
-		"project":   t.Project,
-		"details":   details,
-	})
 	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
+}
+
+func taskEndDetailsIsEmpty(details *apimodels.TaskEndDetail) bool {
+	return details == nil || details.Status == ""
 }
 
 // MarkUnallocatableContainerTasksSystemFailed marks any container task within


### PR DESCRIPTION
[EVG-16755](https://jira.mongodb.org/browse/EVG-16755)

### Description & Testing
There were [a few](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen%22%20%22detail%20status%20was%20empty%2C%20setting%20to%20failed%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&sid=1657039406.1594061) occurrences of the debug statements put in place in [this PR](https://github.com/evergreen-ci/evergreen/pull/5759/files) that caught display tasks ending with a nil `TaskEndDetails` property, resulting in a generic "failed" status shown in API and UI despite the fact that the parent status should be something else. Here is [one such task](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_80_64_bit_multiversion_all_feature_flags_display_change_streams_sharded_collections_multiversion_a372be3c03a6ab0ad96e62c6c241514b6ed699cb_22_06_30_16_01_21/execution-tasks?execution=8&sorts=STATUS%3AASC).  Confirming that this issue is caused by a blank (but non-nil) task end details passing through `MarkEnd`.

Change has been made to:
- remove the debugging log meant to diagnose this issue
- check if details is nil OR empty status when resetting display tasks.

