### PR TITLE
EVG-17120 Update POST /task/{taskid}/restart to accept failedOnly parameter

### DIFF
--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1017,12 +1018,19 @@ func TestTaskResetPrepare(t *testing.T) {
 	Convey("With handler and a project context and user", t, func() {
 		trh := &taskRestartHandler{}
 
+		testTask := task.Task{
+			Id:           "testTaskId",
+			Activated:    false,
+			Secret:       "initialSecret",
+			DispatchTime: time.Now(),
+			BuildId:      "b0",
+			Version:      "v1",
+			Status:       evergreen.TaskSucceeded,
+			Priority:     0,
+		}
+
 		projCtx := serviceModel.Context{
-			Task: &task.Task{
-				Id:        "testTaskId",
-				Priority:  0,
-				Activated: false,
-			},
+			Task: &testTask,
 		}
 		u := user.DBUser{
 			Id: "testUser",
@@ -1053,6 +1061,41 @@ func TestTaskResetPrepare(t *testing.T) {
 			}
 
 			So(err, ShouldResemble, expectedErr)
+		})
+
+		projCtx.ProjectRef = &serviceModel.ProjectRef{
+			Id:         "project_1",
+			Identifier: "project_identifier",
+		}
+
+		failedOnlyTest := func(failedOnly bool) {
+			projCtx.Task = &testTask
+			req, err := http.NewRequest(http.MethodPost, "task/testTaskId/restart?failedOnly="+strconv.FormatBool(failedOnly), &bytes.Buffer{})
+			So(err, ShouldBeNil)
+			ctx = gimlet.AttachUser(ctx, &u)
+			ctx = context.WithValue(ctx, RequestContext, &projCtx)
+			err = trh.Parse(ctx, req)
+			So(err, ShouldBeNil)
+			So(trh.failedOnly, ShouldEqual, failedOnly)
+		}
+
+		Convey("should register true valued failedOnly parameter", func() {
+			failedOnlyTest(true)
+		})
+
+		Convey("should register false valued failedOnly parameter", func() {
+			failedOnlyTest(false)
+		})
+
+		Convey("should have default false failedOnly", func() {
+			projCtx.Task = &testTask
+			req, err := http.NewRequest(http.MethodPost, "task/testTaskId/restart", &bytes.Buffer{})
+			So(err, ShouldBeNil)
+			ctx = gimlet.AttachUser(ctx, &u)
+			ctx = context.WithValue(ctx, RequestContext, &projCtx)
+			err = trh.Parse(ctx, req)
+			So(err, ShouldBeNil)
+			So(trh.failedOnly, ShouldEqual, false)
 		})
 	})
 }
@@ -1145,14 +1188,51 @@ func TestTaskResetExecute(t *testing.T) {
 			Status:       evergreen.TaskSucceeded,
 		}
 		So(testTask.Insert(), ShouldBeNil)
+
+		testTask2 := task.Task{
+			Id:           "testTaskId2",
+			Activated:    false,
+			Secret:       "initialSecret",
+			DispatchTime: timeNow,
+			BuildId:      "b0",
+			Version:      "v1",
+			Status:       evergreen.TaskFailed,
+		}
+		So(testTask2.Insert(), ShouldBeNil)
+
+		testTask3 := task.Task{
+			Id:           "testTaskId3",
+			Activated:    false,
+			Secret:       "initialSecret",
+			DispatchTime: timeNow,
+			BuildId:      "b0",
+			Version:      "v1",
+			Status:       evergreen.TaskSucceeded,
+		}
+		So(testTask3.Insert(), ShouldBeNil)
+
+		displayTask := &task.Task{
+			Id:             "displayTask",
+			DisplayName:    "displayTask",
+			BuildId:        "b0",
+			Version:        "v1",
+			Activated:      false,
+			DisplayOnly:    true,
+			ExecutionTasks: []string{testTask2.Id, testTask3.Id},
+			Status:         evergreen.TaskFailed,
+			DispatchTime:   time.Now(),
+		}
+		So(displayTask.Insert(), ShouldBeNil)
+
 		v := &serviceModel.Version{Id: "v1"}
 		So(v.Insert(), ShouldBeNil)
 		b := build.Build{Id: "b0", Version: "v1", Activated: true}
 		So(b.Insert(), ShouldBeNil)
+
 		ctx := context.Background()
 		Convey("and an error from the service function", func() {
-			testTask2 := task.Task{
-				Id:           "testTaskId2",
+			testTask4 := task.Task{
+				Id:           "testTaskId4",
 				Activated:    false,
 				Secret:       "initialSecret",
 				DispatchTime: timeNow,
@@ -1160,9 +1240,9 @@ func TestTaskResetExecute(t *testing.T) {
 				Version:      "v1",
 				Status:       evergreen.TaskStarted,
 			}
-			So(testTask2.Insert(), ShouldBeNil)
+			So(testTask4.Insert(), ShouldBeNil)
 			trh := &taskRestartHandler{
-				taskId:   "testTaskId2",
+				taskId:   "testTaskId4",
 				username: "testUser",
 			}
 			resp := trh.Run(ctx)
@@ -1173,7 +1253,7 @@ func TestTaskResetExecute(t *testing.T) {
 
 		})
 
-		Convey("calling TryReset should reset the task", func() {
+		Convey("calling TaskRestartHandler should reset the task", func() {
 			trh := &taskRestartHandler{
 				taskId:   "testTaskId",
 				username: "testUser",
@@ -1188,6 +1268,29 @@ func TestTaskResetExecute(t *testing.T) {
 			dbTask, err := task.FindOneId("testTaskId")
 			So(err, ShouldBeNil)
 			So(dbTask.Secret, ShouldNotResemble, "initialSecret")
+		})
+
+		Convey("calling TaskRestartHandler should reset the task with failedonly", func() {
+			trh := &taskRestartHandler{
+				taskId:     "displayTask",
+				username:   "testUser",
+				failedOnly: true,
+			}
+
+			res := trh.Run(ctx)
+			So(res.Status(), ShouldEqual, http.StatusOK)
+			resTask, ok := res.Data().(*model.APITask)
+			So(ok, ShouldBeTrue)
+			So(resTask.Activated, ShouldBeTrue)
+			So(resTask.DispatchTime, ShouldEqual, nil)
+			dbTask2, err := task.FindOneId("testTaskId2")
+			So(err, ShouldBeNil)
+			So(dbTask2.Secret, ShouldNotResemble, "initialSecret")
+			So(dbTask2.Status, ShouldEqual, evergreen.TaskUndispatched)
+			dbTask3, err := task.FindOneId("testTaskId3")
+			So(err, ShouldBeNil)
+			So(dbTask3.Secret, ShouldResemble, "initialSecret")
+			So(dbTask3.Status, ShouldEqual, evergreen.TaskSucceeded)
 		})
 	})
 

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -17,8 +17,9 @@ import (
 // fetches the needed task and project and calls the service function to
 // set the proper fields when reseting the task.
 type taskRestartHandler struct {
-	taskId   string
-	username string
+	taskId     string
+	username   string
+	failedOnly bool
 }
 
 func makeTaskRestartHandler() gimlet.RouteHandler {
@@ -54,7 +55,7 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 // Execute calls the data ResetTask function and returns the refreshed
 // task from the service.
 func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
-	err := resetTask(trh.taskId, trh.username)
+	err := resetTask(trh.taskId, trh.username, trh.failedOnly)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -80,7 +81,7 @@ func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
 
 // resetTask sets the task to be in an unexecuted state and prepares it to be run again.
 // If given an execution task, marks the display task for reset.
-func resetTask(taskId, username string) error {
+func resetTask(taskId, username string, failedOnly bool) error {
 	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return gimlet.ErrorResponse{
@@ -95,5 +96,5 @@ func resetTask(taskId, username string) error {
 		}
 	}
 	// TODO EVG-17120 handle failedOnly
-	return errors.Wrapf(serviceModel.ResetTaskOrDisplayTask(t, username, evergreen.RESTV2Package, false, nil), "resetting task '%s'", taskId)
+	return errors.Wrapf(serviceModel.ResetTaskOrDisplayTask(t, username, evergreen.RESTV2Package, failedOnly, nil), "resetting task '%s'", taskId)
 }

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
@@ -46,9 +47,22 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 			StatusCode: http.StatusNotFound,
 		}
 	}
+	paramsFailedOnly := r.URL.Query().Get("failedOnly")
+	failedOnly := false
+	if paramsFailedOnly != "" {
+		var err error
+		failedOnly, err = strconv.ParseBool(paramsFailedOnly)
+		if err != nil {
+			return gimlet.ErrorResponse{
+				Message:    "failedOnly can only be true/false, True/False, 1/0, or T/F.",
+				StatusCode: http.StatusUnprocessableEntity,
+			}
+		}
+	}
 	trh.taskId = projCtx.Task.Id
 	u := MustHaveUser(ctx)
 	trh.username = u.DisplayName()
+	trh.failedOnly = failedOnly
 	return nil
 }
 


### PR DESCRIPTION
[EVG-17120](https://jira.mongodb.org/browse/EVG-17120)

### Description 
In [PR 5726](https://github.com/evergreen-ci/evergreen/pull/5726) ([EVG-16979](https://jira.mongodb.org/browse/EVG-16979)) there was added functionality "failedOnly" which should only restart failed tasks and should not restart successful ones. This exposes this functionality to the route /task/{taskid}/restart to accept a parameter (?failedOnly=true/false) to decide the functionality. By default, it is the original behavior of false.

### Testing 
Adjusted tests to include explicit testing for the parsing/detection of the failedOnly parameter. Added tests that restart a displaytask, with two tasks inside. One task is successful, one task is failed. Then restarting that displaytask with failedOnly as true, does not adjust/reschedule the first task, but it does for the second task (since it is failed).
