### PR TITLE
EVG-17250 remove error logging for assign next task

### DIFF
--- a/service/api_task.go
+++ b/service/api_task.go
@@ -1007,8 +1007,6 @@ func (as *APIServer) NextTask(w http.ResponseWriter, r *http.Request) {
 		// assign the task to a host and retrieve the task
 		nextTask, shouldRunTeardown, err = assignNextAvailableTask(ctx, taskQueue, as.taskDispatcher, h, details)
 		if err != nil {
-			err = errors.WithStack(err)
-			grip.Error(err)
 			gimlet.WriteResponse(w, gimlet.MakeJSONErrorResponder(err))
 			return
 		}


### PR DESCRIPTION
[EVG-17250](https://jira.mongodb.org/browse/EVG-17250)

### Description 
I'm not sure why we had this logging to begin with but stack is large to log, and this route hasn't been a problem area where we've needed to see logging for so we should remove it.