### PR TITLE
EVG-17099: Make sure we use DB test stats filter for Server projects in test stats route

### DIFF
--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -340,14 +340,12 @@ func (tsh *testStatsHandler) Parse(ctx context.Context, r *http.Request) error {
 	// Evergreen test stats.
 	if dbModel.IsServerResmokeProject(identifier) {
 		tsh.filter = stats.StatsFilter{Project: project}
-		err := tsh.StatsHandler.parseStatsFilter(vals)
+		err := tsh.parseStatsFilter(vals)
 		if err != nil {
 			return errors.Wrap(err, "invalid query parameters")
 		}
-		err = tsh.filter.ValidateForTests()
-		if err != nil {
-			return errors.Wrap(err, "invalid filter")
-		}
+
+		return errors.Wrap(tsh.filter.ValidateForTests(), "invalid filter")
 	}
 
 	return tsh.parsePrestoStatsFilter(project, vals)


### PR DESCRIPTION
EVG-17099: https://jira.mongodb.org/browse/EVG-17099

### Description 
We currently parse the parameters using the legacy test stats filter but use Presto, this returns early from parsing to avoid that.
