### PR TITLE
EVG-17242 Use DisplayTaskId field for showing end task stats in splunk

### DIFF
--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -527,7 +527,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if t.IsPartOfDisplay() {
-		msg["display_task_id"] = t.DisplayTask.Id
+		msg["display_task_id"] = t.DisplayTaskId
 	}
 
 	grip.Info(msg)

--- a/service/api_task.go
+++ b/service/api_task.go
@@ -311,7 +311,7 @@ func (as *APIServer) EndTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if t.IsPartOfDisplay() {
-		msg["display_task_id"] = t.DisplayTask.Id
+		msg["display_task_id"] = t.DisplayTaskId
 	}
 
 	grip.Info(msg)


### PR DESCRIPTION
[EVG-17242](https://jira.mongodb.org/browse/EVG-17242)

### Description 
Changes in [this PR](https://github.com/evergreen-ci/evergreen/pull/5737) were made to use `IsPartOfDisplay` to reduce the amount of DB calls used when retrieving display task info for ending tasks, because it will only call `GetDisplayTask` for older tasks that have a nil `DisplayTaskId`.

However in cases where `DisplayTaskId` is set but `DisplayTask` is nil, this code may panic. Changed code to no longer make use of `DisplayTask`.
