### PR TITLE
EVG-16945 clear SIGN_MACOS for staging dist

### DIFF
--- a/makefile
+++ b/makefile
@@ -241,9 +241,8 @@ $(clientBuildDir)/%/.signed:$(buildDir)/sign-executable $(clientBuildDir)/%/$(un
 	./$< sign --client $(buildDir)/macnotary --executable $(@D)/$(unixBinaryBasename) --server-url $(NOTARY_SERVER_URL) --bundle-id $(EVERGREEN_BUNDLE_ID)
 	touch $@
 
-dist-staging: export STAGING_ONLY := 1
 dist-staging:
-	make dist
+	STAGING_ONLY=1 SIGN_MACOS= $(MAKE) dist
 dist:$(buildDir)/dist.tar.gz
 $(buildDir)/dist.tar.gz:$(buildDir)/make-tarball $(clientBinaries) $(uiFiles) $(if $(SIGN_MACOS),$(foreach platform,$(macOSPlatforms),$(clientBuildDir)/$(platform)/.signed))
 	./$< --name $@ --prefix $(name) $(foreach item,$(distContents),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"


### PR DESCRIPTION
[EVG-16945](https://jira.mongodb.org/browse/EVG-16945)

### Description 
When you run `dist-staging` it's always to build a dist for staging. Since no one should be downloading the executable from staging it makes sense to skip signing on staging.

Separately, switch the explicit make invocation for $(MAKE) since that's what [the docs](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable:~:text=Recursive%20make%20commands%20should%20always%20use%20the%20variable%20MAKE%2C%20not%20the%20explicit%20command%20name%20%E2%80%98make%E2%80%99) recommend.

### Testing 
Running
```
SIGN_MACOS=1 make dist-staging
```
Does not attempt to sign the executable. It continues to only build the staging platforms.