### PR TITLE
EVG-15869 Fix Redirect to the new Evergreen UI loses task execution number

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -216,7 +216,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	// Build a struct containing the subset of task data needed for display in the UI
 	tId := projCtx.Task.Id
 	totalExecutions := projCtx.Task.Execution
-
+	taskExecution := projCtx.Task.Execution
 	if archived {
 		tId = projCtx.Task.OldTaskId
 
@@ -244,7 +244,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		BuildVariant:         projCtx.Task.BuildVariant,
 		BuildId:              projCtx.Task.BuildId,
 		Activated:            projCtx.Task.Activated,
-		Execution:            projCtx.Task.Execution,
+		Execution:            taskExecution,
 		Requester:            projCtx.Task.Requester,
 		CreateTime:           projCtx.Task.CreateTime,
 		IngestTime:           projCtx.Task.IngestTime,
@@ -385,7 +385,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}
 	newUILink := ""
 	if len(uis.Settings.Ui.UIv2Url) > 0 {
-		newUILink = fmt.Sprintf("%s/task/%s", uis.Settings.Ui.UIv2Url, tId)
+		newUILink = fmt.Sprintf("%s/task/%s?execution=%d", uis.Settings.Ui.UIv2Url, tId, taskExecution)
 	}
 
 	if uiTask.AbortInfo.TaskID != "" {


### PR DESCRIPTION
[EVG-15869](https://jira.mongodb.org/browse/EVG-15869)

### Description 
This adds the execution to the url that task links with redirect_spruce_users=true redirects to. While I was at it, I also fixed the button on the legacy task page. 
![image](https://user-images.githubusercontent.com/13104717/177834346-b89bfc85-a848-45dd-805b-fca320711ad4.png)

### Testing 
Tested on staging 