### PR TITLE
EVG-17010 Fix "host not assigned to run task" errors

### DIFF
--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -170,9 +170,6 @@ func (c *s3copy) Execute(ctx context.Context,
 		return errors.WithStack(err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	errChan := make(chan error)
 	go func() {
 		errChan <- errors.WithStack(c.copyWithRetry(ctx, comm, logger, conf))

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -143,8 +143,7 @@ func (c *s3get) Execute(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "problem connecting to s3")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+
 	if err := c.bucket.Check(ctx); err != nil {
 		return errors.Wrap(err, "invalid pail bucket")
 	}

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -279,8 +279,6 @@ func (s3pc *s3put) Execute(ctx context.Context,
 	if err := s3pc.createPailBucket(httpClient); err != nil {
 		return errors.Wrap(err, "problem connecting to s3")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	if err := s3pc.bucket.Check(ctx); err != nil {
 		return errors.Wrap(err, "invalid bucket")

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-07-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-06-29"
+	AgentVersion = "2022-07-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/service/api.go
+++ b/service/api.go
@@ -159,38 +159,27 @@ func (as *APIServer) requireProject(next http.HandlerFunc) http.HandlerFunc {
 
 func (as *APIServer) requireHost(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		h, _, err := model.ValidateHost(gimlet.GetVars(r)["hostId"], r)
-		UpdateHost(h)
+		h, code, err := model.ValidateHost(gimlet.GetVars(r)["hostId"], r)
 		if err != nil {
-			// validate the host again after update in case the agent and app server were out of sync,
-			// and the update fixed it
-			var code int
-			h, code, err = model.ValidateHost(gimlet.GetVars(r)["hostId"], r)
-			if err != nil {
-				as.LoggedError(w, r, code, errors.Wrap(err, "host not assigned to run task"))
-				return
-			}
-
+			as.LoggedError(w, r, code, errors.Wrap(err, "host not assigned to run task"))
+			return
+		}
+		// update host access time
+		if err := h.UpdateLastCommunicated(); err != nil {
+			grip.Warningf("Could not update host last communication time for %s: %+v", h.Id, err)
+		}
+		// Since the host has contacted the app server, we should prevent the
+		// app server from attempting to deploy agents or agent monitors.
+		// Deciding whether or not we should redeploy agents or agent monitors
+		// is handled within the REST route handler.
+		if h.NeedsNewAgent {
+			grip.Warning(message.WrapError(h.SetNeedsNewAgent(false), "problem clearing host needs new agent"))
+		}
+		if h.NeedsNewAgentMonitor {
+			grip.Warning(message.WrapError(h.SetNeedsNewAgentMonitor(false), "problem clearing host needs new agent monitor"))
 		}
 		r = setAPIHostContext(r, h)
 		next(w, r)
-	}
-}
-
-func UpdateHost(h *host.Host) {
-	// update host access time
-	if err := h.UpdateLastCommunicated(); err != nil {
-		grip.Warningf("Could not update host last communication time for %s: %+v", h.Id, err)
-	}
-	// Since the host has contacted the app server, we should prevent the
-	// app server from attempting to deploy agents or agent monitors.
-	// Deciding whether or not we should redeploy agents or agent monitors
-	// is handled within the REST route handler.
-	if h.NeedsNewAgent {
-		grip.Warning(message.WrapError(h.SetNeedsNewAgent(false), "problem clearing host needs new agent"))
-	}
-	if h.NeedsNewAgentMonitor {
-		grip.Warning(message.WrapError(h.SetNeedsNewAgentMonitor(false), "problem clearing host needs new agent monitor"))
 	}
 }
 
@@ -376,8 +365,7 @@ func (as *APIServer) FetchExpansionsForTask(w http.ResponseWriter, r *http.Reque
 // AttachFiles updates file mappings for a task or build
 func (as *APIServer) AttachFiles(w http.ResponseWriter, r *http.Request) {
 	t := MustHaveTask(r)
-
-	grip.Infof("Attaching files to task:%v", t.Id)
+	grip.Infoln("Attaching files to task:", t.Id)
 
 	entry := &artifact.Entry{
 		TaskId:          t.Id,


### PR DESCRIPTION
[EVG-17010 ](https://jira.mongodb.org/browse/EVG-17010 )

### Description 
The fact that the “host not assigned to run tasks” errors are coming from the /files endpoint is a red herring. Based on both Splunk logs for the host and host event logs, it’s task timeouts that are the Issue: the host ran the older task, timed out, then ran the newer task. The /files endpoint is simply the last thing to run on the task so it’s what was likely running when they timed out.

If the agent has already moved on to a new task we don't want it to keep doing things for a previous task, because that can cause issues for later tasks. We therefore want the agent s3 commands to respect the context passed to them rather than use context.Background(). That way, if it's making requests to the S3 API, the app server won't know that it's doing that, and the agent would have to stop doing it on its own. 
