### PR TITLE
EVG-16971 Add Jira Issue and Webhook support to Project Settings mutation

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -338,9 +338,13 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIWebHook
   WebhookHeader:
     model: github.com/evergreen-ci/evergreen/rest/model.APIWebhookHeader
+  WebhookHeaderInput:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIWebhookHeader
   WebhookInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIWebHook
   WebhookSubscriber:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIWebhookSubscriber
+  WebhookSubscriberInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIWebhookSubscriber
   WorkstationConfig:
     model: github.com/evergreen-ci/evergreen/rest/model.APIWorkstationConfig

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -92,6 +92,8 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIJiraField
   JiraIssueSubscriber:
     model: github.com/evergreen-ci/evergreen/rest/model.APIJIRAIssueSubscriber
+  JiraIssueSubscriberInput:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIJIRAIssueSubscriber
   JiraStatus:
     model: github.com/evergreen-ci/evergreen/thirdparty.JiraStatus
   JiraTicket:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -8529,6 +8529,17 @@ type JiraIssueSubscriber {
   issueType: String!
   project: String!
 }
+
+input WebhookSubscriberInput {
+  headers: [WebhookHeaderInput]!
+  secret: String!
+  url: String!
+}
+
+input WebhookHeaderInput {
+  key: String!
+  value: String!
+}
 `, BuiltIn: false},
 	{Name: "graphql/schema/types/project_vars.graphql", Input: `###### INPUTS ######
 input ProjectVarsInput {
@@ -9145,6 +9156,7 @@ input SelectorInput {
 input SubscriberInput {
   target: String!
   type: String!
+  webhookSubscriber: WebhookSubscriberInput
 }
 
 ###### TYPES ######
@@ -41456,6 +41468,14 @@ func (ec *executionContext) unmarshalInputSubscriberInput(ctx context.Context, o
 			if err != nil {
 				return it, err
 			}
+		case "webhookSubscriber":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhookSubscriber"))
+			it.WebhookSubscriber, err = ec.unmarshalOWebhookSubscriberInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookSubscriber(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -42010,6 +42030,37 @@ func (ec *executionContext) unmarshalInputVolumeHost(ctx context.Context, obj in
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputWebhookHeaderInput(ctx context.Context, obj interface{}) (model.APIWebhookHeader, error) {
+	var it model.APIWebhookHeader
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "key":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key"))
+			it.Key, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "value":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			it.Value, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputWebhookInput(ctx context.Context, obj interface{}) (model.APIWebHook, error) {
 	var it model.APIWebHook
 	asMap := map[string]interface{}{}
@@ -42032,6 +42083,45 @@ func (ec *executionContext) unmarshalInputWebhookInput(ctx context.Context, obj 
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("secret"))
 			it.Secret, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputWebhookSubscriberInput(ctx context.Context, obj interface{}) (model.APIWebhookSubscriber, error) {
+	var it model.APIWebhookSubscriber
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "headers":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("headers"))
+			it.Headers, err = ec.unmarshalNWebhookHeaderInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookHeader(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "secret":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("secret"))
+			it.Secret, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "url":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
+			it.URL, err = ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -51822,6 +51912,27 @@ func (ec *executionContext) marshalNWebhookHeader2ᚕgithubᚗcomᚋevergreenᚑ
 	return ret
 }
 
+func (ec *executionContext) unmarshalNWebhookHeaderInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookHeader(ctx context.Context, v interface{}) ([]model.APIWebhookHeader, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]model.APIWebhookHeader, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalOWebhookHeaderInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookHeader(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
 func (ec *executionContext) marshalNWorkstationConfig2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWorkstationConfig(ctx context.Context, sel ast.SelectionSet, v model.APIWorkstationConfig) graphql.Marshaler {
 	return ec._WorkstationConfig(ctx, sel, &v)
 }
@@ -54432,6 +54543,11 @@ func (ec *executionContext) marshalOWebhookHeader2githubᚗcomᚋevergreenᚑci�
 	return ec._WebhookHeader(ctx, sel, &v)
 }
 
+func (ec *executionContext) unmarshalOWebhookHeaderInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookHeader(ctx context.Context, v interface{}) (model.APIWebhookHeader, error) {
+	res, err := ec.unmarshalInputWebhookHeaderInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOWebhookInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebHook(ctx context.Context, v interface{}) (model.APIWebHook, error) {
 	res, err := ec.unmarshalInputWebhookInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -54442,6 +54558,14 @@ func (ec *executionContext) marshalOWebhookSubscriber2ᚖgithubᚗcomᚋevergree
 		return graphql.Null
 	}
 	return ec._WebhookSubscriber(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOWebhookSubscriberInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookSubscriber(ctx context.Context, v interface{}) (*model.APIWebhookSubscriber, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputWebhookSubscriberInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOWorkstationConfigInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWorkstationConfig(ctx context.Context, v interface{}) (model.APIWorkstationConfig, error) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -8540,7 +8540,11 @@ input WebhookHeaderInput {
   key: String!
   value: String!
 }
-`, BuiltIn: false},
+
+input JiraIssueSubscriberInput {
+  issueType: String!
+  project: String!
+}`, BuiltIn: false},
 	{Name: "graphql/schema/types/project_vars.graphql", Input: `###### INPUTS ######
 input ProjectVarsInput {
   adminOnlyVarsList: [String]
@@ -9157,6 +9161,7 @@ input SubscriberInput {
   target: String!
   type: String!
   webhookSubscriber: WebhookSubscriberInput
+  jiraIssueSubscriber: JiraIssueSubscriberInput
 }
 
 ###### TYPES ######
@@ -39776,6 +39781,37 @@ func (ec *executionContext) unmarshalInputJiraFieldInput(ctx context.Context, ob
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputJiraIssueSubscriberInput(ctx context.Context, obj interface{}) (model.APIJIRAIssueSubscriber, error) {
+	var it model.APIJIRAIssueSubscriber
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "issueType":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issueType"))
+			it.IssueType, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "project":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project"))
+			it.Project, err = ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputMainlineCommitsOptions(ctx context.Context, obj interface{}) (MainlineCommitsOptions, error) {
 	var it MainlineCommitsOptions
 	asMap := map[string]interface{}{}
@@ -41473,6 +41509,14 @@ func (ec *executionContext) unmarshalInputSubscriberInput(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhookSubscriber"))
 			it.WebhookSubscriber, err = ec.unmarshalOWebhookSubscriberInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebhookSubscriber(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "jiraIssueSubscriber":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("jiraIssueSubscriber"))
+			it.JiraIssueSubscriber, err = ec.unmarshalOJiraIssueSubscriberInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIJIRAIssueSubscriber(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -53020,6 +53064,14 @@ func (ec *executionContext) marshalOJiraIssueSubscriber2ᚖgithubᚗcomᚋevergr
 		return graphql.Null
 	}
 	return ec._JiraIssueSubscriber(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOJiraIssueSubscriberInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIJIRAIssueSubscriber(ctx context.Context, v interface{}) (*model.APIJIRAIssueSubscriber, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputJiraIssueSubscriberInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOJiraTicket2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐJiraTicket(ctx context.Context, sel ast.SelectionSet, v *thirdparty.JiraTicket) graphql.Marshaler {

--- a/graphql/schema/types/project_subscriber.graphql
+++ b/graphql/schema/types/project_subscriber.graphql
@@ -46,3 +46,14 @@ type JiraIssueSubscriber {
   issueType: String!
   project: String!
 }
+
+input WebhookSubscriberInput {
+  headers: [WebhookHeaderInput]!
+  secret: String!
+  url: String!
+}
+
+input WebhookHeaderInput {
+  key: String!
+  value: String!
+}

--- a/graphql/schema/types/project_subscriber.graphql
+++ b/graphql/schema/types/project_subscriber.graphql
@@ -57,3 +57,8 @@ input WebhookHeaderInput {
   key: String!
   value: String!
 }
+
+input JiraIssueSubscriberInput {
+  issueType: String!
+  project: String!
+}

--- a/graphql/schema/types/user.graphql
+++ b/graphql/schema/types/user.graphql
@@ -65,6 +65,7 @@ input SubscriberInput {
   target: String!
   type: String!
   webhookSubscriber: WebhookSubscriberInput
+  jiraIssueSubscriber: JiraIssueSubscriberInput
 }
 
 ###### TYPES ######

--- a/graphql/schema/types/user.graphql
+++ b/graphql/schema/types/user.graphql
@@ -64,6 +64,7 @@ input SelectorInput {
 input SubscriberInput {
   target: String!
   type: String!
+  webhookSubscriber: WebhookSubscriberInput
 }
 
 ###### TYPES ######

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -12,8 +12,10 @@ import (
 )
 
 type APISubscriber struct {
-	Type   *string     `json:"type"`
-	Target interface{} `json:"target"`
+	Type               *string                `json:"type"`
+	Target             interface{}            `json:"target"`
+	WebhookSubscriber  *APIWebhookSubscriber  `json:"-"`
+	GithubPRSubscriber *APIGithubPRSubscriber `json:"-"`
 }
 
 type APIGithubPRSubscriber struct {
@@ -144,13 +146,19 @@ func (s *APISubscriber) ToService() (interface{}, error) {
 
 	case event.EvergreenWebhookSubscriberType:
 		apiModel := APIWebhookSubscriber{}
-		if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    errors.Wrap(err, "webhook subscriber target is malformed").Error(),
+		if s.WebhookSubscriber != nil {
+			fmt.Println("WebhookSubscriber is not nil")
+			apiModel = *s.WebhookSubscriber
+		} else {
+			if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
+				return nil, gimlet.ErrorResponse{
+					StatusCode: http.StatusBadRequest,
+					Message:    errors.Wrap(err, "webhook subscriber target is malformed").Error(),
+				}
 			}
 		}
 		target, err = apiModel.ToService()
+		fmt.Println(target)
 		if err != nil {
 			return nil, gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -12,10 +12,10 @@ import (
 )
 
 type APISubscriber struct {
-	Type               *string                `json:"type"`
-	Target             interface{}            `json:"target"`
-	WebhookSubscriber  *APIWebhookSubscriber  `json:"-"`
-	GithubPRSubscriber *APIGithubPRSubscriber `json:"-"`
+	Type                *string                 `json:"type"`
+	Target              interface{}             `json:"target"`
+	WebhookSubscriber   *APIWebhookSubscriber   `json:"-"`
+	JiraIssueSubscriber *APIJIRAIssueSubscriber `json:"-"`
 }
 
 type APIGithubPRSubscriber struct {
@@ -147,7 +147,6 @@ func (s *APISubscriber) ToService() (interface{}, error) {
 	case event.EvergreenWebhookSubscriberType:
 		apiModel := APIWebhookSubscriber{}
 		if s.WebhookSubscriber != nil {
-			fmt.Println("WebhookSubscriber is not nil")
 			apiModel = *s.WebhookSubscriber
 		} else {
 			if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
@@ -158,7 +157,6 @@ func (s *APISubscriber) ToService() (interface{}, error) {
 			}
 		}
 		target, err = apiModel.ToService()
-		fmt.Println(target)
 		if err != nil {
 			return nil, gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
@@ -168,10 +166,14 @@ func (s *APISubscriber) ToService() (interface{}, error) {
 
 	case event.JIRAIssueSubscriberType:
 		apiModel := APIJIRAIssueSubscriber{}
-		if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusBadRequest,
-				Message:    errors.Wrap(err, "Jira issue subscriber target is malformed").Error(),
+		if s.JiraIssueSubscriber != nil {
+			apiModel = *s.JiraIssueSubscriber
+		} else {
+			if err = mapstructure.Decode(s.Target, &apiModel); err != nil {
+				return nil, gimlet.ErrorResponse{
+					StatusCode: http.StatusBadRequest,
+					Message:    errors.Wrap(err, "Jira issue subscriber target is malformed").Error(),
+				}
 			}
 		}
 		target, err = apiModel.ToService()


### PR DESCRIPTION
[EVG-16971](https://jira.mongodb.org/browse/EVG-16971)

### Description 
Realized it wasn't possible to set the target for Webhook Subscriptions as well as Jira Issue subscriptions since they had a custom shape. 

The graphql schema for `Target` would expect a string but since Webhook and Jira Issue are complicated shapes we could not simply pass them into `Target`. The legacy UI allowed `Target` to be a freeform shape that would then get decoded into a go struct.  Since graphql doesn't support free form shapes i needed to add a few extra fields to support these inputs.

🎻 
https://github.com/evergreen-ci/evergreen/blob/482b86520f52634eafd76b6fa4bb7b43994c3e4b/model/event/subscribers.go#L46-L47
