### PR TITLE
EVG-17726: specify Windows version for capacity providers

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -247,10 +247,6 @@ func exportECSPodContainerDef(settings *evergreen.Settings, p *pod.Pod) (*cocoa.
 	return def, nil
 }
 
-const (
-	ecsWindowsVersionTagConstraint = "attribute:WindowsVersion"
-)
-
 // exportECSPodExecutionOptions exports the ECS configuration into
 // cocoa.ECSPodExecutionOptions.
 func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts pod.TaskContainerCreationOptions) (*cocoa.ECSPodExecutionOptions, error) {
@@ -262,15 +258,11 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts p
 			SetSecurityGroups(ecsConfig.AWSVPC.SecurityGroups))
 	}
 
-	placementOpts := cocoa.NewECSPodPlacementOptions()
-	if containerOpts.WindowsVersion != "" {
-		windowsVersionConstraint := fmt.Sprintf("%s == %s", ecsWindowsVersionTagConstraint, containerOpts.WindowsVersion)
-		placementOpts.AddInstanceFilters(windowsVersionConstraint)
-	}
-	opts.SetPlacementOptions(*placementOpts)
-
 	var foundCapacityProvider bool
 	for _, cp := range ecsConfig.CapacityProviders {
+		if containerOpts.OS == pod.OSWindows && !containerOpts.WindowsVersion.Matches(cp.WindowsVersion) {
+			continue
+		}
 		if containerOpts.OS.Matches(cp.OS) && containerOpts.Arch.Matches(cp.Arch) {
 			opts.SetCapacityProvider(cp.Name)
 			foundCapacityProvider = true
@@ -278,6 +270,9 @@ func exportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts p
 		}
 	}
 	if !foundCapacityProvider {
+		if containerOpts.OS == pod.OSWindows {
+			return nil, errors.Errorf("container OS '%s' with Windows version '%s' and arch '%s' did not match any recognized capacity provider", containerOpts.OS, containerOpts.WindowsVersion, containerOpts.Arch)
+		}
 		return nil, errors.Errorf("container OS '%s' and arch '%s' did not match any recognized capacity provider", containerOpts.OS, containerOpts.Arch)
 	}
 

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -402,6 +402,21 @@ func (v WindowsVersion) Validate() error {
 	}
 }
 
+// Matches returns whether or not the pod Windows Version matches the given
+// Evergreen ECS config Windows version.
+func (v WindowsVersion) Matches(other evergreen.ECSWindowsVersion) bool {
+	switch v {
+	case WindowsVersionServer2016:
+		return other == evergreen.ECSWindowsServer2016
+	case WindowsVersionServer2019:
+		return other == evergreen.ECSWindowsServer2019
+	case WindowsVersionServer2022:
+		return other == evergreen.ECSWindowsServer2022
+	default:
+		return false
+	}
+}
+
 // ImportWindowsVersion converts the container Windows version into its
 // equivalent pod Windows version.
 func ImportWindowsVersion(winVer evergreen.WindowsVersion) (WindowsVersion, error) {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -18,6 +18,11 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.validAuthKinds = ["ldap", "okta", "naive", "only_api", "allow_service_users", "github"];
     $scope.validECSOSes = ["linux", "windows"];
     $scope.validECSArches = ["amd64", "arm64"];
+    $scope.validECSWindowsVersions = {
+      "Windows Server 2016": "windows_server_2016",
+      "Windows Server 2019": "windows_server_2019",
+      "Windows Server 2022": "windows_server_2022"
+    };
     $("#restart-modal").on("hidden.bs.modal", $scope.enableSubmit);
   }
 
@@ -475,7 +480,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     }
 
     if (!$scope.validECSCapacityProvider($scope.new_ecs_capacity_provider)) {
-      $scope.invalidECSCapacityProvider = "ECS capacity provider name, os, and arch are required.";
+      $scope.invalidECSCapacityProvider = "ECS capacity provider name, OS (and Windows version if Windows), and arch are required.";
       return
     }
 
@@ -485,7 +490,13 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.validECSCapacityProvider = function (item) {
-    return item && item.name && item.os && item.arch;
+    if (!item || !item.name || !item.os || !item.arch) {
+      return false
+    }
+    if (item.os == "windows" && !item.windows_version) {
+      return false
+    }
+    return true
   }
 
   $scope.deleteECSCapacityProvider = function (index) {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -19,9 +19,9 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.validECSOSes = ["linux", "windows"];
     $scope.validECSArches = ["amd64", "arm64"];
     $scope.validECSWindowsVersions = {
-      "Windows Server 2016": "windows_server_2016",
-      "Windows Server 2019": "windows_server_2019",
-      "Windows Server 2022": "windows_server_2022"
+      "Server 2016": "windows_server_2016",
+      "Server 2019": "windows_server_2019",
+      "Server 2022": "windows_server_2022"
     };
     $("#restart-modal").on("hidden.bs.modal", $scope.enableSubmit);
   }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1739,15 +1739,17 @@ func (a *APIECSClusterConfig) ToService() (*evergreen.ECSClusterConfig, error) {
 // APIECSCapacityProvider represents configuration options for a capacity
 // provider within an ECS cluster.
 type APIECSCapacityProvider struct {
-	Name *string `json:"name"`
-	OS   *string `json:"os"`
-	Arch *string `json:"arch"`
+	Name           *string `json:"name"`
+	OS             *string `json:"os"`
+	Arch           *string `json:"arch"`
+	WindowsVersion *string `json:"windows_version"`
 }
 
 func (a *APIECSCapacityProvider) BuildFromService(cp evergreen.ECSCapacityProvider) {
 	a.Name = utility.ToStringPtr(cp.Name)
 	a.OS = utility.ToStringPtr(string(cp.OS))
 	a.Arch = utility.ToStringPtr(string(cp.Arch))
+	a.WindowsVersion = utility.ToStringPtr(string(cp.WindowsVersion))
 }
 
 func (a *APIECSCapacityProvider) ToService() (*evergreen.ECSCapacityProvider, error) {
@@ -1759,10 +1761,17 @@ func (a *APIECSCapacityProvider) ToService() (*evergreen.ECSCapacityProvider, er
 	if err := arch.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid arch")
 	}
+	winVer := evergreen.ECSWindowsVersion(utility.FromStringPtr(a.WindowsVersion))
+	if winVer != "" {
+		if err := winVer.Validate(); err != nil {
+			return nil, errors.Wrap(err, "invalid Windows version")
+		}
+	}
 	return &evergreen.ECSCapacityProvider{
-		Name: utility.FromStringPtr(a.Name),
-		OS:   os,
-		Arch: arch,
+		Name:           utility.FromStringPtr(a.Name),
+		OS:             os,
+		Arch:           arch,
+		WindowsVersion: winVer,
 	}, nil
 }
 

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -174,6 +174,7 @@ func TestModelConversion(t *testing.T) {
 		assert.Equal(cp.Name, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].Name))
 		assert.EqualValues(cp.OS, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].OS))
 		assert.EqualValues(cp.Arch, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].Arch))
+		assert.EqualValues(cp.WindowsVersion, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].WindowsVersion))
 	}
 	assert.EqualValues(testSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1970,6 +1970,12 @@ Admin Settings
 															<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
 														</md-select>
 													</md-input-container>
+													<br />
+													<md-input-container class="control" flex=25>
+														<md-select ng-model="capacityProvider.windows_version" placeholder="Windows version">
+															<md-option ng-repeat="(displayWinVer, winVer) in validECSWindowsVersions" value="[[winVer]]">[[displayWinVer]]</md-option>
+														</md-select>
+													</md-input-container>
 
 													<div style="margin-top: 1%;">
 														<button class="btn btn-default btn-danger" type="button"
@@ -1994,6 +2000,12 @@ Admin Settings
 												<md-input-container class="control" flex=25>
 													<md-select ng-model="new_ecs_capacity_provider.arch" placeholder="Arch">
 														<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
+													</md-select>
+												</md-input-container>
+												<br />
+												<md-input-container class="control" flex=25>
+													<md-select ng-model="new_ecs_capacity_provider.windows_version" placeholder="Windows version">
+														<md-option ng-repeat="(displayWinVer, winVer) in validECSWindowsVersions" value="[[winVer]]">[[displayWinVer]]</md-option>
 													</md-select>
 												</md-input-container>
 												<div style="margin-top: 1%;">

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -496,7 +496,7 @@ Admin Settings
 												</button>
 											</section>
 										</div>
-									</div> 
+									</div>
 								</md-card-content>
 							</md-card>
 
@@ -1958,22 +1958,19 @@ Admin Settings
 													<md-input-container class="control" flex=25>
 														<input class="control" type="text" ng-model="capacityProvider.name" placeholder="Name">
 													</md-input-container>
-													<br />
 													<md-input-container class="control" flex=25>
 														<md-select ng-model="capacityProvider.os" placeholder="OS">
 															<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
 														</md-select>
 													</md-input-container>
-													<br />
-													<md-input-container class="control" flex=25>
-														<md-select ng-model="capacityProvider.arch" placeholder="Arch">
-															<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
-														</md-select>
-													</md-input-container>
-													<br />
 													<md-input-container class="control" flex=25>
 														<md-select ng-model="capacityProvider.windows_version" placeholder="Windows version">
 															<md-option ng-repeat="(displayWinVer, winVer) in validECSWindowsVersions" value="[[winVer]]">[[displayWinVer]]</md-option>
+														</md-select>
+													</md-input-container>
+													<md-input-container class="control" flex=25>
+														<md-select ng-model="capacityProvider.arch" placeholder="Arch">
+															<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
 														</md-select>
 													</md-input-container>
 
@@ -1990,22 +1987,19 @@ Admin Settings
 													<input class="control" type="text" ng-model="new_ecs_capacity_provider.name"
 														placeholder="Name">
 												</md-input-container>
-												<br />
 												<md-input-container class="control" flex=25>
 													<md-select ng-model="new_ecs_capacity_provider.os" placeholder="OS">
 														<md-option ng-repeat="os in validECSOSes" value="[[os]]">[[os]]</md-option>
 													</md-select>
 												</md-input-container>
-												<br />
-												<md-input-container class="control" flex=25>
-													<md-select ng-model="new_ecs_capacity_provider.arch" placeholder="Arch">
-														<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
-													</md-select>
-												</md-input-container>
-												<br />
 												<md-input-container class="control" flex=25>
 													<md-select ng-model="new_ecs_capacity_provider.windows_version" placeholder="Windows version">
 														<md-option ng-repeat="(displayWinVer, winVer) in validECSWindowsVersions" value="[[winVer]]">[[displayWinVer]]</md-option>
+													</md-select>
+												</md-input-container>
+												<md-input-container class="control" flex=25>
+													<md-select ng-model="new_ecs_capacity_provider.arch" placeholder="Arch">
+														<md-option ng-repeat="arch in validECSArches" value="[[arch]]">[[arch]]</md-option>
 													</md-select>
 												</md-input-container>
 												<div style="margin-top: 1%;">

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -282,15 +282,25 @@ func MockConfig() *evergreen.Settings {
 						},
 						Clusters: []evergreen.ECSClusterConfig{
 							{
-								Name: "cluster_name",
+								Name: "linux_cluster_name",
+								OS:   evergreen.ECSOSLinux,
+							},
+							{
+								Name: "windows_cluster_name",
 								OS:   evergreen.ECSOSLinux,
 							},
 						},
 						CapacityProviders: []evergreen.ECSCapacityProvider{
 							{
-								Name: "capacity_provider_name",
+								Name: "linux_capacity_provider_name",
 								OS:   evergreen.ECSOSLinux,
 								Arch: evergreen.ECSArchAMD64,
+							},
+							{
+								Name:           "windows_capacity_provider_name",
+								OS:             evergreen.ECSOSWindows,
+								Arch:           evergreen.ECSArchAMD64,
+								WindowsVersion: evergreen.ECSWindowsServer2022,
 							},
 						},
 					},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17226

### Description 
Originally, we used placement constraints to specify that the container had to run on a host that ran a particular Windows version because [Windows containers have to be compatible with their host OS version](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility). However, the ECS infrastructure was changed so instead, we now have to specify a capacity provider that maps to a particular Windows version. For example, all Windows server 2022 containers have to run in the one capacity provider that runs Windows server 2022 hosts.

* Add admin setting for setting the Windows version for a capacity provider.
* Remove placement constraint for Windows version and replace with capacity provider.

### Testing 
Added unit tests and tested in local-evergreen that the admin settings work correctly.
