### PR TITLE
EVG-16882: modify container command to bootstrap using provisioning REST route

### DIFF
--- a/cloud/pod_agent_util_test.go
+++ b/cloud/pod_agent_util_test.go
@@ -1,7 +1,6 @@
 package cloud
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -13,96 +12,45 @@ import (
 func TestAgentScript(t *testing.T) {
 	const workingDir = "/data/mci"
 
-	t.Run("WithoutS3", func(t *testing.T) {
-		settings := &evergreen.Settings{
-			ApiUrl:            "www.test.com",
-			ClientBinariesDir: "clients",
+	settings := &evergreen.Settings{
+		ApiUrl:            "https://example.com",
+		ClientBinariesDir: "clients",
+	}
+
+	t.Run("Linux", func(t *testing.T) {
+		p := &pod.Pod{
+			ID: "id",
+			TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
+				OS:         pod.OSLinux,
+				Arch:       pod.ArchAMD64,
+				WorkingDir: workingDir,
+			},
 		}
+		cmd := bootstrapContainerCommand(settings, p)
+		require.NotZero(t, cmd)
 
-		t.Run("Linux", func(t *testing.T) {
-			p := &pod.Pod{
-				ID: "id",
-				TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-					OS:         pod.OSLinux,
-					Arch:       pod.ArchAMD64,
-					WorkingDir: workingDir,
-				},
-			}
-			cmd := agentScript(settings, p)
-			require.NotZero(t, cmd)
-
-			expected := []string{
-				"bash", "-c",
-				"curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100 && " +
-					"chmod +x evergreen && " +
-					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
-			}
-			assert.Equal(t, expected, cmd)
-		})
-		t.Run("Windows", func(t *testing.T) {
-			p := &pod.Pod{
-				ID: "id",
-				TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-					OS:         pod.OSWindows,
-					Arch:       pod.ArchAMD64,
-					WorkingDir: workingDir,
-				},
-			}
-			cmd := agentScript(settings, p)
-			require.NotZero(t, cmd)
-
-			expected := []string{
-				"cmd.exe", "/c",
-				"curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 && " +
-					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci",
-			}
-			assert.Equal(t, expected, cmd)
-		})
+		expected := []string{
+			"bash", "-c",
+			"curl --retry 10 --retry-max-time 60 -L -H \"Pod-Id: ${POD_ID}\" -H \"Pod-Secret: ${POD_SECRET}\" https://example.com/rest/v2/pods/${POD_ID}/provisioning_script | bash -s",
+		}
+		assert.Equal(t, expected, cmd)
 	})
-
-	t.Run("WithS3", func(t *testing.T) {
-		settings := &evergreen.Settings{
-			ApiUrl:            "www.test.com",
-			PodInit:           evergreen.PodInitConfig{S3BaseURL: "https://foo.com"},
-			ClientBinariesDir: "clients",
+	t.Run("Windows", func(t *testing.T) {
+		p := &pod.Pod{
+			ID: "id",
+			TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
+				OS:         pod.OSWindows,
+				Arch:       pod.ArchAMD64,
+				WorkingDir: workingDir,
+			},
 		}
-		t.Run("Linux", func(t *testing.T) {
-			p := &pod.Pod{
-				ID: "id",
-				TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-					OS:         pod.OSLinux,
-					Arch:       pod.ArchAMD64,
-					WorkingDir: workingDir,
-				},
-			}
-			cmd := agentScript(settings, p)
-			require.NotZero(t, cmd)
+		cmd := bootstrapContainerCommand(settings, p)
+		require.NotZero(t, cmd)
 
-			expected := []string{
-				"bash", "-c",
-				fmt.Sprintf("(curl -fLO https://foo.com/%s/linux_amd64/evergreen --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100) && "+
-					"chmod +x evergreen && "+
-					"./evergreen agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
-			}
-			assert.Equal(t, expected, cmd)
-		})
-		t.Run("Windows", func(t *testing.T) {
-			p := &pod.Pod{
-				ID: "id",
-				TaskContainerCreationOpts: pod.TaskContainerCreationOptions{
-					OS:         pod.OSWindows,
-					Arch:       pod.ArchAMD64,
-					WorkingDir: workingDir,
-				},
-			}
-			cmd := agentScript(settings, p)
-			require.NotZero(t, cmd)
-			expected := []string{
-				"cmd.exe", "/c",
-				fmt.Sprintf("(curl -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100) && "+
-					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/data/mci/agent --working_directory=/data/mci", evergreen.BuildRevision),
-			}
-			assert.Equal(t, expected, cmd)
-		})
+		expected := []string{
+			"powershell.exe", "-noninteractive", "-noprofile", "-Command",
+			"curl.exe --retry 10 --retry-max-time 60 -L -H \"Pod-Id: $env:POD_ID\" -H \"Pod-Secret: $env:POD_SECRET\" https://example.com/rest/v2/pods/$env:POD_ID/provisioning_script | powershell.exe -noprofile -noninteractive -",
+		}
+		assert.Equal(t, expected, cmd)
 	})
 }

--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -229,7 +229,7 @@ func exportECSPodContainerDef(settings *evergreen.Settings, p *pod.Pod) (*cocoa.
 		SetMemoryMB(p.TaskContainerCreationOpts.MemoryMB).
 		SetCPU(p.TaskContainerCreationOpts.CPU).
 		SetWorkingDir(p.TaskContainerCreationOpts.WorkingDir).
-		SetCommand(agentScript(settings, p)).
+		SetCommand(bootstrapContainerCommand(settings, p)).
 		SetEnvironmentVariables(exportPodEnvVars(settings.Providers.AWS.Pod.SecretsManager, p)).
 		AddPortMappings(*cocoa.NewPortMapping().SetContainerPort(agentPort))
 

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -70,7 +69,7 @@ func (h *podProvisioningScript) Run(ctx context.Context) gimlet.Responder {
 
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
-		gimlet.NewTextInternalErrorResponse(errors.Wrap(err, "getting service flags"))
+		return gimlet.NewTextInternalErrorResponse(errors.Wrap(err, "getting service flags"))
 	}
 
 	script := h.agentScript(p, !flags.S3BinaryDownloadsDisabled)
@@ -89,7 +88,18 @@ func (h *podProvisioningScript) agentScript(p *pod.Pod, downloadFromS3 bool) str
 	agentCmd := strings.Join(h.agentCommand(p), " ")
 	scriptCmds = append(scriptCmds, agentCmd)
 
-	return strings.Join(scriptCmds, " && ")
+	if p.TaskContainerCreationOpts.OS == pod.OSLinux {
+		return strings.Join(scriptCmds, " && ")
+	}
+
+	// This chains together the PowerShell commands so that they run in order,
+	// but they also run regardless of whether the previous command succeeded,
+	// which is undesirable. It would be preferable to use pipeline chaining
+	// operators instead (like bash's && and || operators) but they were not
+	// introduced until PowerShell 7. Users may not provide a sufficiently
+	// up-to-date version of PowerShell on their images to use these operators.
+	// Docs: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pipeline_chain_operators
+	return strings.Join(scriptCmds, "; ")
 }
 
 // agentCommand returns the arguments to start the agent in the pod's container.
@@ -106,7 +116,7 @@ func (h *podProvisioningScript) agentCommand(p *pod.Pod) []string {
 		"agent",
 		fmt.Sprintf("--api_server=%s", h.settings.ApiUrl),
 		"--mode=pod",
-		fmt.Sprintf("--log_prefix=%s", filepath.Join(p.TaskContainerCreationOpts.WorkingDir, "agent")),
+		fmt.Sprintf("--log_prefix=%s", strings.Join([]string{p.TaskContainerCreationOpts.WorkingDir, "agent"}, pathSep)),
 		fmt.Sprintf("--working_directory=%s", p.TaskContainerCreationOpts.WorkingDir),
 	}
 }
@@ -120,18 +130,32 @@ func (h *podProvisioningScript) downloadAgentCommands(p *pod.Pod, downloadFromS3
 	)
 	retryArgs := h.curlRetryArgs(curlDefaultNumRetries, curlDefaultMaxSecs)
 
-	var curlCmd string
+	curlExecutable := "curl"
+	if p.TaskContainerCreationOpts.OS == pod.OSWindows {
+		curlExecutable = curlExecutable + ".exe"
+	}
+
 	if downloadFromS3 && h.settings.PodInit.S3BaseURL != "" {
 		// Attempt to download the agent from S3, but fall back to downloading
 		// from the app server if it fails.
 		// Include -f to return an error code from curl if the HTTP request
 		// fails (e.g. it receives 403 Forbidden or 404 Not Found).
-		curlCmd = fmt.Sprintf("(curl -fLO %s %s || curl -fLO %s %s)", h.s3ClientURL(p), retryArgs, h.evergreenClientURL(p), retryArgs)
-	} else {
-		curlCmd = fmt.Sprintf("curl -fLO %s %s", h.evergreenClientURL(p), retryArgs)
+
+		if p.TaskContainerCreationOpts.OS == pod.OSWindows {
+			// PowerShell supports pipeline chaining operators (like bash's ||
+			// operator) as of PowerShell 7. However, users may not provide a
+			// sufficiently up-to-date version of PowerShell on their images to
+			// use these operators. Therefore, use a PowerShell if-else
+			// statement to produce the equivalent functionality.
+			// Docs: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pipeline_chain_operators
+			return fmt.Sprintf("if (%s -fLO %s %s) {} else { %s -fLO %s %s }", curlExecutable, h.s3ClientURL(p), retryArgs, curlExecutable, h.evergreenClientURL(p), retryArgs)
+		}
+
+		return fmt.Sprintf("(%s -fLO %s %s || %s -fLO %s %s)", curlExecutable, h.s3ClientURL(p), retryArgs, curlExecutable, h.evergreenClientURL(p), retryArgs)
+
 	}
 
-	return curlCmd
+	return fmt.Sprintf("%s -fLO %s %s", curlExecutable, h.evergreenClientURL(p), retryArgs)
 }
 
 // evergreenClientURL returns the URL used to get the latest Evergreen client

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -93,7 +93,7 @@ func TestPodProvisioningScript(t *testing.T) {
 				script, ok := resp.Data().(string)
 				require.True(t, ok, "route should return plaintext response")
 
-				expected := "curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 && " +
+				expected := "curl.exe -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100; " +
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/working/dir/agent --working_directory=/working/dir"
 				assert.Equal(t, expected, script)
 			},
@@ -125,7 +125,7 @@ func TestPodProvisioningScript(t *testing.T) {
 				script, ok := resp.Data().(string)
 				require.True(t, ok, "route should return plaintext response")
 
-				expected := fmt.Sprintf("(curl -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100) && "+
+				expected := fmt.Sprintf("if (curl.exe -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100) {} else { curl.exe -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 }; "+
 					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_prefix=/working/dir/agent --working_directory=/working/dir", evergreen.BuildRevision)
 				assert.Equal(t, expected, script)
 			},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16882

### Description 
In order to provision the container, we have to download the agent and start it. Instead of directly downloading the agent from Evergreen using the container command, the container command now asks for the script to run which contains the command to actually download the agent from the REST route (from #5689). This indirection is necessary because as part of the design, we have to cache pod definitions and want them to change as little as possible. This future-proofs the pod definition against future changes so if we ever want to change how the agent is provisioned on the host, we can do so by modifying the REST route's response rather than the container command itself (and therefore prevent the pod definition from changing).

There's also some small but important details about the REST route that I had to change for this to work in Windows, but I'm omitting them because I don't think they'll make sense without a longer explanation of PowerShell and Windows.

* Change container command to download the provisioning script from the REST API instead of directly provisioning the agent.
* Update REST route to work with PowerShell script.
* Fix small bug where a gimlet response isn't returned.

### Testing 
Added unit tests and checked that it works for Windows/Linux pods in staging.