### PR TITLE
EVG-17040 Remove pipeline stage looking for tasks without BV display name set

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1039,14 +1039,21 @@ func (r *queryResolver) BuildVariantsForTaskName(ctx context.Context, projectID 
 	}
 	repo, err := model.FindRepository(pid)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting repository for '%s': %s", projectID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting repository for '%s': %s", projectID, err.Error()))
 	}
 	if repo == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", projectID))
 	}
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber)
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber, false)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while getting build variant tasks for task '%s': %s", taskName, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting build variant tasks for task '%s': %s", taskName, err.Error()))
+	}
+	// use legacy lookup pipeline if no results are found
+	if len(taskBuildVariants) == 0 {
+		taskBuildVariants, err = task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber, true)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting build variant tasks using legacy pipeline for task '%s': %s", taskName, err.Error()))
+		}
 	}
 	if taskBuildVariants == nil {
 		return nil, nil

--- a/graphql/tests/buildVariantsForTaskName/data.json
+++ b/graphql/tests/buildVariantsForTaskName/data.json
@@ -4,6 +4,7 @@
             "_id": "t1",
             "display_name" : "test-agent",
             "build_variant": "ubuntu1604",
+            "build_variant_display_name": "Ubuntu 16.04",
             "branch": "evergreen",
             "r": "gitter_request",
             "build_id": "b1",
@@ -13,6 +14,7 @@
             "_id": "t2",
             "display_name" : "dist",
             "build_variant": "ubuntu1604",
+            "build_variant_display_name": "Ubuntu 16.04",
             "branch": "evergreen",
             "r": "gitter_request",
             "build_id": "b1",
@@ -26,12 +28,13 @@
             "r": "gitter_request",
             "build_id": "b1",
             "order": 1
-            
+
         },
         {
             "_id": "t4",
             "display_name" : "test-agent",
             "build_variant": "osx",
+            "build_variant_display_name": "OSX",
             "branch": "evergreen",
             "r": "gitter_request",
             "build_id": "b2",

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -988,49 +988,12 @@ type BuildVariantTuple struct {
 	DisplayName  string `bson:"build_variant_display_name"`
 }
 
-const VersionLimit = 50
-
-// Reusable pipeline stages when finding build variant display names
 var (
-	// sort build variant display names alphabetically
-	sortByVariantDisplayName = bson.M{
-		"$sort": bson.M{
-			"build_variant_display_name": 1,
-		},
-	}
-
-	// cleanup the results
-	projectBvResults = bson.M{
-		"$project": bson.M{
-			"_id":                        0,
-			"build_variant":              "$" + BuildVariantKey,
-			"build_variant_display_name": "$" + BuildVariantDisplayNameKey,
-		},
-	}
-
-	// reorganize the results to get the build variant names and a corresponding build id
-	projectBuildIdAndVariant = bson.M{
-		"$project": bson.M{
-			"_id":                      0,
-			BuildVariantKey:            bsonutil.GetDottedKeyName("$_id", BuildVariantKey),
-			BuildVariantDisplayNameKey: bsonutil.GetDottedKeyName("$_id", BuildVariantDisplayNameKey),
-			BuildIdKey:                 "$" + BuildIdKey,
-		},
-	}
-
-	// group the build variants by unique build variant names and get a build id for each
-	groupByBuildVariant = bson.M{
-		"$group": bson.M{
-			"_id": bson.M{
-				BuildVariantKey:            "$" + BuildVariantKey,
-				BuildVariantDisplayNameKey: "$" + BuildVariantDisplayNameKey,
-			},
-			BuildIdKey: bson.M{
-				"$first": "$" + BuildIdKey,
-			},
-		},
-	}
+	buildVariantTupleVariantKey     = bsonutil.MustHaveTag(BuildVariantTuple{}, "BuildVariant")
+	buildVariantTupleDisplayNameKey = bsonutil.MustHaveTag(BuildVariantTuple{}, "DisplayName")
 )
+
+const VersionLimit = 50
 
 // FindUniqueBuildVariantNamesByTask returns a list of unique build variants names and their display names for a given task name.
 // It attempts to return the most recent display name for each build variant to avoid returning duplicates caused by display names changing.
@@ -1050,9 +1013,47 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 		},
 	}
 
+	// group the build variants by unique build variant names and get a build id for each
+	groupByBuildVariant := bson.M{
+		"$group": bson.M{
+			"_id": bson.M{
+				BuildVariantKey:            "$" + BuildVariantKey,
+				BuildVariantDisplayNameKey: "$" + BuildVariantDisplayNameKey,
+			},
+			BuildIdKey: bson.M{
+				"$first": "$" + BuildIdKey,
+			},
+		},
+	}
 	pipeline = append(pipeline, groupByBuildVariant)
+
+	// reorganize the results to get the build variant names and a corresponding build id
+	projectBuildIdAndVariant := bson.M{
+		"$project": bson.M{
+			"_id":                      0,
+			BuildVariantKey:            bsonutil.GetDottedKeyName("$_id", BuildVariantKey),
+			BuildVariantDisplayNameKey: bsonutil.GetDottedKeyName("$_id", BuildVariantDisplayNameKey),
+			BuildIdKey:                 "$" + BuildIdKey,
+		},
+	}
 	pipeline = append(pipeline, projectBuildIdAndVariant)
+
+	// cleanup the results
+	projectBvResults := bson.M{
+		"$project": bson.M{
+			"_id":                           0,
+			buildVariantTupleVariantKey:     "$" + BuildVariantKey,
+			buildVariantTupleDisplayNameKey: "$" + BuildVariantDisplayNameKey,
+		},
+	}
 	pipeline = append(pipeline, projectBvResults)
+
+	// sort build variant display names alphabetically
+	sortByVariantDisplayName := bson.M{
+		"$sort": bson.M{
+			buildVariantTupleDisplayNameKey: 1,
+		},
+	}
 	pipeline = append(pipeline, sortByVariantDisplayName)
 
 	result := []*BuildVariantTuple{}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1044,6 +1044,7 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 			"$and": []bson.M{
 				{RevisionOrderNumberKey: bson.M{"$gte": repoOrderNumber - VersionLimit}},
 				{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
+				{BuildVariantDisplayNameKey: bson.M{"$exists": true, "$ne": ""}},
 			},
 		},
 		},

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -13,6 +13,11 @@ import (
 
 func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
+	b1 := build.Build{
+		Id:          "b1",
+		DisplayName: "Ubuntu 16.04 from builds collection",
+	}
+	assert.NoError(t, b1.Insert())
 	t1 := task.Task{
 		Id:                      "t1",
 		Status:                  evergreen.TaskSucceeded,
@@ -26,6 +31,11 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t1.Insert())
+	b2 := build.Build{
+		Id:          "b2",
+		DisplayName: "OSX from builds collection",
+	}
+	assert.NoError(t, b2.Insert())
 	t2 := task.Task{
 		Id:                      "t2",
 		Status:                  evergreen.TaskSucceeded,
@@ -39,6 +49,11 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t2.Insert())
+	b3 := build.Build{
+		Id:          "b3",
+		DisplayName: "Windows 64 bit from builds collection",
+	}
+	assert.NoError(t, b3.Insert())
 	t3 := task.Task{
 		Id:                      "t3",
 		Status:                  evergreen.TaskSucceeded,
@@ -52,6 +67,11 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t3.Insert())
+	b4 := build.Build{
+		Id:          "b4",
+		DisplayName: "Race Detector from builds collection",
+	}
+	assert.NoError(t, b4.Insert())
 	t4 := task.Task{
 		Id:                  "t4",
 		Status:              evergreen.TaskSucceeded,
@@ -64,11 +84,20 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, t4.Insert())
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1, false)
 	assert.NoError(t, err)
 	assert.Equal(t, []*task.BuildVariantTuple{
 		{DisplayName: "OSX", BuildVariant: "osx"},
 		{DisplayName: "Ubuntu 16.04", BuildVariant: "ubuntu1604"},
 		{DisplayName: "Windows 64 bit", BuildVariant: "windows"},
+	}, taskBuildVariants)
+
+	taskBuildVariants, err = task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1, true)
+	assert.NoError(t, err)
+	assert.Equal(t, []*task.BuildVariantTuple{
+		{DisplayName: "OSX from builds collection", BuildVariant: "osx"},
+		{DisplayName: "Race Detector from builds collection", BuildVariant: "race-detector"},
+		{DisplayName: "Ubuntu 16.04 from builds collection", BuildVariant: "ubuntu1604"},
+		{DisplayName: "Windows 64 bit from builds collection", BuildVariant: "windows"},
 	}, taskBuildVariants)
 }

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -52,6 +52,18 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t3.Insert())
+	t4 := task.Task{
+		Id:                  "t4",
+		Status:              evergreen.TaskSucceeded,
+		BuildVariant:        "race-detector",
+		DisplayName:         "test-agent",
+		Project:             "evergreen",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildId:             "b4",
+		CreateTime:          time.Now().Add(-time.Hour),
+		RevisionOrderNumber: 1,
+	}
+	assert.NoError(t, t4.Insert())
 	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, []*task.BuildVariantTuple{

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -13,55 +13,43 @@ import (
 
 func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
-	b1 := build.Build{
-		Id:          "b1",
-		DisplayName: "Ubuntu 16.04",
-	}
-	assert.NoError(t, b1.Insert())
 	t1 := task.Task{
-		Id:                  "t1",
-		Status:              evergreen.TaskSucceeded,
-		BuildVariant:        "ubuntu1604",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b1",
-		CreateTime:          time.Now().Add(-time.Hour),
-		RevisionOrderNumber: 1,
+		Id:                      "t1",
+		Status:                  evergreen.TaskSucceeded,
+		BuildVariant:            "ubuntu1604",
+		BuildVariantDisplayName: "Ubuntu 16.04",
+		DisplayName:             "test-agent",
+		Project:                 "evergreen",
+		Requester:               evergreen.RepotrackerVersionRequester,
+		BuildId:                 "b1",
+		CreateTime:              time.Now().Add(-time.Hour),
+		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t1.Insert())
-	b2 := build.Build{
-		Id:          "b2",
-		DisplayName: "OSX",
-	}
-	assert.NoError(t, b2.Insert())
 	t2 := task.Task{
-		Id:                  "t2",
-		Status:              evergreen.TaskSucceeded,
-		BuildVariant:        "osx",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b2",
-		CreateTime:          time.Now().Add(-time.Hour),
-		RevisionOrderNumber: 1,
+		Id:                      "t2",
+		Status:                  evergreen.TaskSucceeded,
+		BuildVariant:            "osx",
+		BuildVariantDisplayName: "OSX",
+		DisplayName:             "test-agent",
+		Project:                 "evergreen",
+		Requester:               evergreen.RepotrackerVersionRequester,
+		BuildId:                 "b2",
+		CreateTime:              time.Now().Add(-time.Hour),
+		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t2.Insert())
-	b3 := build.Build{
-		Id:          "b3",
-		DisplayName: "Windows 64 bit",
-	}
-	assert.NoError(t, b3.Insert())
 	t3 := task.Task{
-		Id:                  "t3",
-		Status:              evergreen.TaskSucceeded,
-		BuildVariant:        "windows",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b3",
-		CreateTime:          time.Now().Add(-time.Hour),
-		RevisionOrderNumber: 1,
+		Id:                      "t3",
+		Status:                  evergreen.TaskSucceeded,
+		BuildVariant:            "windows",
+		BuildVariantDisplayName: "Windows 64 bit",
+		DisplayName:             "test-agent",
+		Project:                 "evergreen",
+		Requester:               evergreen.RepotrackerVersionRequester,
+		BuildId:                 "b3",
+		CreateTime:              time.Now().Add(-time.Hour),
+		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t3.Insert())
 	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)


### PR DESCRIPTION
[EVG-17040](https://jira.mongodb.org/browse/EVG-17040)

### Description 
Given that `FindUniqueBuildVariantNamesByTask` looks back no more than 50 versions and build variant display names have been cached in structs for the past 30 days, it seems appropriate now to directly read the `BuildVariantDisplayName` on a task when reading variant data for the task history page rather than performing a facet/lookup combination.
### Testing 
Augmented existing unit tests given new assumptions when retrieving BV display name, and tested in staging that task history page remains accurate.