### PR TITLE
EVG-17297 consider overrideDependencies when checking if task blocked

### DIFF
--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -950,12 +950,29 @@ func TestGetBuildStatus(t *testing.T) {
 	assert.Equal(t, false, allTasksBlocked)
 
 	buildTasks = []task.Task{
-		{Status: evergreen.TaskUndispatched,
-			DependsOn: []task.Dependency{{Unattainable: true}}},
+		{
+			Status:    evergreen.TaskUndispatched,
+			DependsOn: []task.Dependency{{Unattainable: true}},
+			Activated: true,
+		},
 		{Status: evergreen.TaskFailed},
 	}
 	status, allTasksBlocked = getBuildStatus(buildTasks)
 	assert.Equal(t, evergreen.BuildFailed, status)
+	assert.Equal(t, false, allTasksBlocked)
+
+	// Blocked tasks that are overriding dependencies should prevent the build from being completed.
+	buildTasks = []task.Task{
+		{
+			Status:               evergreen.TaskUndispatched,
+			DependsOn:            []task.Dependency{{Unattainable: true}},
+			OverrideDependencies: true,
+			Activated:            true,
+		},
+		{Status: evergreen.TaskSucceeded},
+	}
+	status, allTasksBlocked = getBuildStatus(buildTasks)
+	assert.Equal(t, evergreen.BuildStarted, status)
 	assert.Equal(t, false, allTasksBlocked)
 
 	// Builds with only blocked tasks should stay as created.


### PR DESCRIPTION
[EVG-17297](https://jira.mongodb.org/browse/EVG-17297)

### Description 
Blocked is used all over the place to determine statuses and ordering but doesn't actually consider OverrideDependencies. This results in confusing statuses/API results, and prevented us from scheduling an unblocked task: https://github.com/evergreen-ci/evergreen/blob/799b017d6c69d387981fae3322bfcf0b0854d79c/service/api_task.go#L689-L710

### Testing 
Checking that existing tests pass and added a test for display status that would fail without the change.