### PR TITLE
EVG-17926: Sort private and admin only vars

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1300,8 +1300,8 @@ type ProjectSubscriberResolver interface {
 	Subscriber(ctx context.Context, obj *model.APISubscriber) (*Subscriber, error)
 }
 type ProjectVarsResolver interface {
-	AdminOnlyVars(ctx context.Context, obj *model.APIProjectVars) ([]*string, error)
-	PrivateVars(ctx context.Context, obj *model.APIProjectVars) ([]*string, error)
+	AdminOnlyVars(ctx context.Context, obj *model.APIProjectVars) ([]string, error)
+	PrivateVars(ctx context.Context, obj *model.APIProjectVars) ([]string, error)
 }
 type QueryResolver interface {
 	BbGetCreatedTickets(ctx context.Context, taskID string) ([]*thirdparty.JiraTicket, error)
@@ -8521,8 +8521,8 @@ input ProjectVarsInput {
 
 ###### TYPES ######
 type ProjectVars {
-  adminOnlyVars: [String]
-  privateVars: [String]
+  adminOnlyVars: [String!]!
+  privateVars: [String!]!
   vars: StringMap
 }
 `, BuiltIn: false},
@@ -25001,11 +25001,14 @@ func (ec *executionContext) _ProjectVars_adminOnlyVars(ctx context.Context, fiel
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]*string)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalOString2ᚕᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ProjectVars_privateVars(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectVars) (ret graphql.Marshaler) {
@@ -25033,11 +25036,14 @@ func (ec *executionContext) _ProjectVars_privateVars(ctx context.Context, field 
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]*string)
+	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalOString2ᚕᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ProjectVars_vars(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectVars) (ret graphql.Marshaler) {
@@ -45339,6 +45345,9 @@ func (ec *executionContext) _ProjectVars(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._ProjectVars_adminOnlyVars(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			})
 		case "privateVars":
@@ -45350,6 +45359,9 @@ func (ec *executionContext) _ProjectVars(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._ProjectVars_privateVars(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			})
 		case "vars":

--- a/graphql/project_vars_resolver.go
+++ b/graphql/project_vars_resolver.go
@@ -5,28 +5,30 @@ package graphql
 
 import (
 	"context"
+	"sort"
 
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/utility"
 )
 
-func (r *projectVarsResolver) AdminOnlyVars(ctx context.Context, obj *restModel.APIProjectVars) ([]*string, error) {
-	res := []*string{}
+func (r *projectVarsResolver) AdminOnlyVars(ctx context.Context, obj *restModel.APIProjectVars) ([]string, error) {
+	res := []string{}
 	for varAlias, isAdminOnly := range obj.AdminOnlyVars {
 		if isAdminOnly {
-			res = append(res, utility.ToStringPtr(varAlias))
+			res = append(res, varAlias)
 		}
 	}
+	sort.Strings(res)
 	return res, nil
 }
 
-func (r *projectVarsResolver) PrivateVars(ctx context.Context, obj *restModel.APIProjectVars) ([]*string, error) {
-	res := []*string{}
+func (r *projectVarsResolver) PrivateVars(ctx context.Context, obj *restModel.APIProjectVars) ([]string, error) {
+	res := []string{}
 	for privateAlias, isPrivate := range obj.PrivateVars {
 		if isPrivate {
-			res = append(res, utility.ToStringPtr(privateAlias))
+			res = append(res, privateAlias)
 		}
 	}
+	sort.Strings(res)
 	return res, nil
 }
 

--- a/graphql/schema/types/project_vars.graphql
+++ b/graphql/schema/types/project_vars.graphql
@@ -7,7 +7,7 @@ input ProjectVarsInput {
 
 ###### TYPES ######
 type ProjectVars {
-  adminOnlyVars: [String]
-  privateVars: [String]
+  adminOnlyVars: [String!]!
+  privateVars: [String!]!
   vars: StringMap
 }


### PR DESCRIPTION
[EVG-17926](https://jira.mongodb.org/browse/EVG-17926)

### Description 
The `PrivateVars` and `AdminOnlyVars` resolvers construct lists from [maps](https://github.com/evergreen-ci/evergreen/blob/1c0d68ff52d836fd7fcca4df84beb745afd1db10/rest/model/project_event.go#L39-L40) to return to the front end. This results in no guaranteed order, with a differently ordered list sent in each `ProjectEventLogs` request. This change in ordering caused privateVars updates to appear in every event log entry.

To fix, return alphabetically sorted private and admin only vars so that we do not inaccurately report an event.

Before:
<img width="932" alt="image" src="https://user-images.githubusercontent.com/9298431/179026857-367d8593-e226-43d7-b043-65ae133ac764.png">

After:
<img width="941" alt="image" src="https://user-images.githubusercontent.com/9298431/179026401-f1e55608-07d9-47d4-b9ac-136e7071b181.png">

### Testing 
- Tested updated backend with current `main` branch of Spruce in staging