### PR TITLE
EVG-17331: Use proper sort key in FindFirstProjectRef.

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1141,27 +1141,27 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 }
 
 func FindFirstProjectRef() (*ProjectRef, error) {
-	projectRefSlice := &[]ProjectRef{}
+	projectRefSlice := []ProjectRef{}
 	pipeline := projectRefPipelineForValueIsBool(ProjectRefPrivateKey, RepoRefPrivateKey, false)
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{ProjectRefPrivateKey: -1}}, bson.M{"$limit": 1})
 	err := db.Aggregate(
 		ProjectRefCollection,
 		pipeline,
-		projectRefSlice,
+		&projectRefSlice,
 	)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating project ref")
 	}
 
-	if len(*projectRefSlice) == 0 {
+	if len(projectRefSlice) == 0 {
 		return nil, errors.New("No project found in FindFirstProjectRef")
 	}
-	projectRef := &(*projectRefSlice)[0]
+	projectRef := projectRefSlice[0]
 
 	projectRef.checkDefaultLogger()
 
-	return projectRef, nil
+	return &projectRef, nil
 }
 
 // FindAllMergedTrackedProjectRefs returns all project refs in the db

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1143,7 +1143,7 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 func FindFirstProjectRef() (*ProjectRef, error) {
 	projectRefSlice := []ProjectRef{}
 	pipeline := projectRefPipelineForValueIsBool(ProjectRefPrivateKey, RepoRefPrivateKey, false)
-	pipeline = append(pipeline, bson.M{"$sort": bson.M{ProjectRefPrivateKey: -1}}, bson.M{"$limit": 1})
+	pipeline = append(pipeline, bson.M{"$sort": bson.M{ProjectRefDisplayNameKey: -1}}, bson.M{"$limit": 1})
 	err := db.Aggregate(
 		ProjectRefCollection,
 		pipeline,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1141,18 +1141,24 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 }
 
 func FindFirstProjectRef() (*ProjectRef, error) {
-	projectRef := &ProjectRef{}
+	projectRefSlice := &[]ProjectRef{}
 	pipeline := projectRefPipelineForValueIsBool(ProjectRefPrivateKey, RepoRefPrivateKey, false)
-	pipeline = append(pipeline, bson.M{"$sort": "-" + ProjectRefDisplayNameKey}, bson.M{"$limit": 1})
+	pipeline = append(pipeline, bson.M{"$sort": bson.M{ProjectRefPrivateKey: -1}}, bson.M{"$limit": 1})
 	err := db.Aggregate(
 		ProjectRefCollection,
 		pipeline,
-		projectRef,
+		projectRefSlice,
 	)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating project ref")
 	}
+
+	if len(*projectRefSlice) == 0 {
+		return nil, errors.New("No project found in FindFirstProjectRef")
+	}
+	projectRef := &(*projectRefSlice)[0]
+
 	projectRef.checkDefaultLogger()
 
 	return projectRef, nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1847,6 +1847,25 @@ func TestGetProjectSetupCommands(t *testing.T) {
 	assert.Contains(t, cmds[1].String(), "c1")
 }
 
+func TestFindFirstProjectRef(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(ProjectRefCollection))
+
+	_, err := FindFirstProjectRef()
+	assert.Error(t, err, "Should return error and not panic if there are no matching projects")
+
+	projectRef := ProjectRef{
+		Id:        "p1",
+		RepoRefId: "my_repo",
+		Private:   utility.FalsePtr(),
+	}
+
+	assert.NoError(t, projectRef.Insert())
+
+	resultRef, err := FindFirstProjectRef()
+	assert.NoError(t, err)
+	assert.Equal(t, "p1", resultRef.Id)
+}
+
 func TestFindPeriodicProjects(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection))
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1850,8 +1850,11 @@ func TestGetProjectSetupCommands(t *testing.T) {
 func TestFindFirstProjectRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection))
 
-	_, err := FindFirstProjectRef()
-	assert.Error(t, err, "Should return error and not panic if there are no matching projects")
+	var err error
+	assert.NotPanics(t, func() {
+		_, err = FindFirstProjectRef()
+	}, "Should not panic if there are no matching projects")
+	assert.Error(t, err, "Should return error if there are no matching projects")
 
 	projectRef := ProjectRef{
 		Id:        "p1",


### PR DESCRIPTION
[EVG-17331](https://jira.mongodb.org/browse/EVG-17331)

### Description 
I discovered this during local setup, since local setup's development fixtures don't set a default project. This occurs for anonymous users without any cookies hitting the waterfall endpoint

### Testing 
Added unit tests to verify that the function doesn't fail. Also verified locally by clearing cookies and hitting localhost:9090
