### PR TITLE
EVG-17126 Do not allow resetting non-complete tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -440,7 +440,7 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 	if len(tasks) == 0 {
 		return nil
 	}
-	return restartTasksForBuild(buildId, tasks, caller)
+	return restartTasksForBuild(tasks, caller)
 }
 
 // RestartAllBuildTasks restarts all the tasks associated with a given build.
@@ -456,10 +456,10 @@ func RestartAllBuildTasks(buildId string, caller string) error {
 	if len(allTasks) == 0 {
 		return nil
 	}
-	return restartTasksForBuild(buildId, allTasks, caller)
+	return restartTasksForBuild(allTasks, caller)
 }
 
-func restartTasksForBuild(buildId string, tasks []task.Task, caller string) error {
+func restartTasksForBuild(tasks []task.Task, caller string) error {
 	// maps task group to a single task in the group so we only check once
 	taskGroupsToCheck := map[string]task.Task{}
 	restartIds := []string{}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1984,7 +1984,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 
 	// test that restarting a task correctly resets the task and archives it
 	assert.NoError(resetTaskData())
-	assert.NoError(resetTask("displayTask", "caller", false))
+	assert.NoError(resetTask("displayTask", "caller"))
 	archivedTasks, err := task.FindOldWithDisplayTasks(nil)
 	assert.NoError(err)
 	assert.Len(archivedTasks, 3)
@@ -2008,7 +2008,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	dt, err := task.FindOneId("displayTask")
 	assert.NoError(err)
 	assert.NoError(dt.SetResetFailedWhenFinished())
-	assert.NoError(resetTask(dt.Id, "caller", false))
+	assert.NoError(resetTask(dt.Id, "caller"))
 	tasks, err = task.FindAll(db.Query(task.ByIds(allTasks)))
 	assert.NoError(err)
 	assert.Len(tasks, 3)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -63,6 +63,7 @@ var (
 	ExecutionKey                   = bsonutil.MustHaveTag(Task{}, "Execution")
 	OldTaskIdKey                   = bsonutil.MustHaveTag(Task{}, "OldTaskId")
 	ArchivedKey                    = bsonutil.MustHaveTag(Task{}, "Archived")
+	CanResetKey                    = bsonutil.MustHaveTag(Task{}, "CanReset")
 	RevisionOrderNumberKey         = bsonutil.MustHaveTag(Task{}, "RevisionOrderNumber")
 	RequesterKey                   = bsonutil.MustHaveTag(Task{}, "Requester")
 	StatusKey                      = bsonutil.MustHaveTag(Task{}, "Status")

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -269,14 +269,14 @@ func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
 	assert.NoError(db.ClearCollections(Collection, OldCollection))
 	taskDoc := Task{
 		Id:        "task",
-		Status:    evergreen.TaskUndispatched,
+		Status:    evergreen.TaskSucceeded,
 		Activated: true,
 	}
 	assert.NoError(taskDoc.Insert())
 	task, err := FindOneIdAndExecutionWithDisplayStatus(taskDoc.Id, utility.ToIntPtr(0))
 	assert.NoError(err)
 	assert.NotNil(task)
-	assert.Equal(task.DisplayStatus, evergreen.TaskWillRun)
+	assert.Equal(task.DisplayStatus, evergreen.TaskSucceeded)
 
 	// Should fetch tasks from the old collection
 	assert.NoError(taskDoc.Archive())
@@ -293,7 +293,7 @@ func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(task)
 	assert.Equal(task.Execution, 1)
-	assert.Equal(task.DisplayStatus, evergreen.TaskWillRun)
+	assert.Equal(task.DisplayStatus, evergreen.TaskSucceeded)
 
 	taskDoc = Task{
 		Id:        "task2",

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2511,7 +2511,7 @@ func (t *Task) Archive() error {
 			},
 			"$inc": bson.M{ExecutionKey: 1},
 		})
-	if err != nil {
+	if err != nil && !adb.ResultsNotFound(err) {
 		return errors.Wrap(err, "updating task")
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1955,27 +1955,26 @@ func (t *Task) Reset() error {
 
 // ResetTasks performs the same DB updates as (*Task).Reset, but resets many
 // tasks instead of a single one.
-func ResetTasks(tasks []Task) (*adb.ChangeInfo, error) {
+func ResetTasks(tasks []Task) error {
 	if len(tasks) == 0 {
-		return nil, nil
+		return nil
 	}
 	var taskIDs []string
 	for _, t := range tasks {
 		taskIDs = append(taskIDs, t.Id)
 	}
 
-	info, err := UpdateAll(
+	if _, err := UpdateAll(
 		bson.M{
 			IdKey:     bson.M{"$in": taskIDs},
 			StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses},
 		},
 		resetTaskUpdate(nil),
-	)
-	if err != nil {
-		return nil, err
+	); err != nil {
+		return err
 	}
 
-	return info, nil
+	return nil
 }
 
 func resetTaskUpdate(t *Task) bson.M {
@@ -2002,6 +2001,7 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.HostCreateDetails = []HostCreateDetail{}
 		t.OverrideDependencies = false
 		t.ContainerAllocationAttempts = 0
+		t.Archived = false
 	}
 	update := bson.M{
 		"$set": bson.M{
@@ -2017,6 +2017,7 @@ func resetTaskUpdate(t *Task) bson.M {
 			TimeTakenKey:                   0,
 			LastHeartbeatKey:               utility.ZeroTime,
 			ContainerAllocationAttemptsKey: 0,
+			ArchivedKey:                    false,
 		},
 		"$unset": bson.M{
 			DetailsKey:                 "",
@@ -2475,7 +2476,7 @@ func (t *Task) Insert() error {
 // considered the latest execution. This task execution is inserted
 // into the old_tasks collection. If this is a display task, its execution tasks
 // are also archived.
-func (t *Task) Archive() (bool, error) {
+func (t *Task) Archive() error {
 	archiveTask := t.makeArchivedTask()
 	err := db.Insert(OldCollection, archiveTask)
 	if err != nil {
@@ -2485,14 +2486,17 @@ func (t *Task) Archive() (bool, error) {
 			"execution":       t.Execution,
 			"display_only":    t.DisplayOnly,
 		}))
-		return false, errors.Wrap(err, "inserting archived task into old tasks")
+		return errors.Wrap(err, "inserting archived task into old tasks")
 	}
-	info, err := UpdateAll(
+	err = UpdateOne(
 		bson.M{
 			IdKey:     t.Id,
 			StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses},
 		},
 		bson.M{
+			"$set": bson.M{
+				ArchivedKey: true,
+			},
 			"$unset": bson.M{
 				AbortedKey:              "",
 				AbortInfoKey:            "",
@@ -2501,23 +2505,20 @@ func (t *Task) Archive() (bool, error) {
 			"$inc": bson.M{ExecutionKey: 1},
 		})
 	if err != nil {
-		return false, errors.Wrap(err, "updating task")
-	}
-	if info.Updated <= 0 {
-		return true, nil
+		return errors.Wrap(err, "updating task")
 	}
 	// only archive execution tasks after we confirm that the task was in a completed state
 	if t.DisplayOnly && len(t.ExecutionTasks) > 0 {
 		execTasks, err := FindAll(db.Query(ByIds(t.ExecutionTasks)))
 		if err != nil {
-			return false, errors.Wrap(err, "retrieving execution tasks")
+			return errors.Wrap(err, "retrieving execution tasks")
 		}
 		if err = ArchiveMany(execTasks); err != nil {
-			return false, errors.Wrap(err, "archiving execution tasks")
+			return errors.Wrap(err, "archiving execution tasks")
 		}
 	}
 	t.Aborted = false
-	return false, nil
+	return nil
 }
 
 func ArchiveMany(tasks []Task) error {
@@ -2581,6 +2582,9 @@ func ArchiveMany(tasks []Task) error {
 			StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses},
 		},
 			bson.M{
+				"$set": bson.M{
+					ArchivedKey: true,
+				},
 				"$unset": bson.M{
 					AbortedKey:   "",
 					AbortInfoKey: "",

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2019,7 +2019,6 @@ func resetTaskUpdate(t *Task) bson.M {
 			TimeTakenKey:                   0,
 			LastHeartbeatKey:               utility.ZeroTime,
 			ContainerAllocationAttemptsKey: 0,
-			ArchivedKey:                    false,
 		},
 		"$unset": bson.M{
 			DetailsKey:                 "",
@@ -2031,6 +2030,7 @@ func resetTaskUpdate(t *Task) bson.M {
 			HostIdKey:                  "",
 			HostCreateDetailsKey:       "",
 			OverrideDependenciesKey:    "",
+			ArchivedKey:                "",
 		},
 	}
 	return update
@@ -2509,7 +2509,7 @@ func (t *Task) Archive() error {
 	if err != nil {
 		return errors.Wrap(err, "updating task")
 	}
-	// only archive execution tasks after we confirm that the task was in a completed state
+
 	if t.DisplayOnly && len(t.ExecutionTasks) > 0 {
 		execTasks, err := FindAll(db.Query(ByIds(t.ExecutionTasks)))
 		if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1451,6 +1451,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 				StatusKey:     evergreen.TaskFailed,
 				FinishTimeKey: t.FinishTime,
 				DetailsKey:    t.Details,
+				CanResetKey:   true,
 			},
 		},
 	)
@@ -1868,6 +1869,7 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 				StartTimeKey:        t.StartTime,
 				LogsKey:             detail.Logs,
 				HasLegacyResultsKey: t.HasLegacyResults,
+				CanResetKey:         true,
 			},
 		})
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -151,6 +151,9 @@ type Task struct {
 	// Set to true if the task should be considered for mainline github checks
 	IsGithubCheck bool `bson:"is_github_check,omitempty" json:"is_github_check,omitempty"`
 
+	// CanReset indicates if the task is in a valid state to be reset.
+	CanReset bool `bson:"can_reset,omitempty" json:"can_reset,omitempty"`
+
 	Execution           int    `bson:"execution" json:"execution"`
 	OldTaskId           string `bson:"old_task_id,omitempty" json:"old_task_id,omitempty"`
 	Archived            bool   `bson:"archived,omitempty" json:"archived,omitempty"`
@@ -1948,7 +1951,7 @@ func (t *Task) Reset() error {
 		bson.M{
 			IdKey:       t.Id,
 			StatusKey:   bson.M{"$in": evergreen.TaskCompletedStatuses},
-			ArchivedKey: true,
+			CanResetKey: true,
 		},
 		resetTaskUpdate(t),
 	)
@@ -1969,7 +1972,7 @@ func ResetTasks(tasks []Task) error {
 		bson.M{
 			IdKey:       bson.M{"$in": taskIDs},
 			StatusKey:   bson.M{"$in": evergreen.TaskCompletedStatuses},
-			ArchivedKey: true,
+			CanResetKey: true,
 		},
 		resetTaskUpdate(nil),
 	); err != nil {
@@ -2003,7 +2006,7 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.HostCreateDetails = []HostCreateDetail{}
 		t.OverrideDependencies = false
 		t.ContainerAllocationAttempts = 0
-		t.Archived = false
+		t.CanReset = false
 	}
 	update := bson.M{
 		"$set": bson.M{
@@ -2030,7 +2033,7 @@ func resetTaskUpdate(t *Task) bson.M {
 			HostIdKey:                  "",
 			HostCreateDetailsKey:       "",
 			OverrideDependenciesKey:    "",
-			ArchivedKey:                "",
+			CanResetKey:                "",
 		},
 	}
 	return update
@@ -2497,7 +2500,7 @@ func (t *Task) Archive() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				ArchivedKey: true,
+				CanResetKey: true,
 			},
 			"$unset": bson.M{
 				AbortedKey:              "",
@@ -2585,7 +2588,7 @@ func ArchiveMany(tasks []Task) error {
 		},
 			bson.M{
 				"$set": bson.M{
-					ArchivedKey: true,
+					CanResetKey: true,
 				},
 				"$unset": bson.M{
 					AbortedKey:   "",

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1946,8 +1946,9 @@ func (t *Task) displayTaskPriority() int {
 func (t *Task) Reset() error {
 	return UpdateOne(
 		bson.M{
-			IdKey:     t.Id,
-			StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses},
+			IdKey:       t.Id,
+			StatusKey:   bson.M{"$in": evergreen.TaskCompletedStatuses},
+			ArchivedKey: true,
 		},
 		resetTaskUpdate(t),
 	)
@@ -1966,8 +1967,9 @@ func ResetTasks(tasks []Task) error {
 
 	if _, err := UpdateAll(
 		bson.M{
-			IdKey:     bson.M{"$in": taskIDs},
-			StatusKey: bson.M{"$in": evergreen.TaskCompletedStatuses},
+			IdKey:       bson.M{"$in": taskIDs},
+			StatusKey:   bson.M{"$in": evergreen.TaskCompletedStatuses},
+			ArchivedKey: true,
 		},
 		resetTaskUpdate(nil),
 	); err != nil {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"strconv"
 	"testing"
 	"time"
@@ -29,10 +28,6 @@ import (
 var (
 	oneMs = time.Millisecond
 )
-
-func init() {
-	testutil.Setup()
-}
 
 var depTaskIds = []Dependency{
 	{TaskId: "td1", Status: evergreen.TaskSucceeded},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"strconv"
 	"testing"
 	"time"
@@ -28,6 +29,10 @@ import (
 var (
 	oneMs = time.Millisecond
 )
+
+func init() {
+	testutil.Setup()
+}
 
 var depTaskIds = []Dependency{
 	{TaskId: "td1", Status: evergreen.TaskSucceeded},
@@ -3110,6 +3115,7 @@ func TestArchiveMany(t *testing.T) {
 	assert.NoError(t, t2.Insert())
 	dt := Task{
 		Id:             "dt",
+		Status:         evergreen.TaskSucceeded,
 		DisplayOnly:    true,
 		ExecutionTasks: []string{"et"},
 		Version:        "v",
@@ -3117,6 +3123,7 @@ func TestArchiveMany(t *testing.T) {
 	assert.NoError(t, dt.Insert())
 	et := Task{
 		Id:      "et",
+		Status:  evergreen.TaskSucceeded,
 		Version: "v",
 	}
 	assert.NoError(t, et.Insert())
@@ -4169,6 +4176,7 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByIdAndExecution() {
 		Id:        "task_1",
 		Execution: 0,
 		BuildId:   "build_1",
+		Status:    evergreen.TaskSucceeded,
 	}
 	s.NoError(testTask1.Insert())
 	for i := 0; i < 10; i++ {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1341,7 +1341,7 @@ func MarkOneTaskReset(t *task.Task) error {
 		}
 	}
 
-	if err := t.Reset(); err != nil {
+	if err := t.Reset(); err != nil && !adb.ResultsNotFound(err) {
 		return errors.Wrap(err, "resetting task in database")
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -294,20 +294,11 @@ func resetTask(taskId, caller string) error {
 	if t.IsPartOfDisplay() {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
-	shouldExit, err := t.Archive()
-	if err != nil {
+	if err = t.Archive(); err != nil {
 		return errors.Wrap(err, "can't restart task because it can't be archived")
 	}
-	if shouldExit {
-		grip.Debug(message.Fields{
-			"message":   "task was not found in completed state, skipping reset",
-			"task_id":   t.Id,
-			"execution": t.Execution,
-		})
-		return nil
-	}
 
-	if err := MarkOneTaskReset(t); err != nil {
+	if err = MarkOneTaskReset(t); err != nil {
 		return errors.WithStack(err)
 	}
 	event.LogTaskRestarted(t.Id, t.Execution, caller)
@@ -1377,12 +1368,8 @@ func MarkTasksReset(taskIds []string) error {
 		return errors.WithStack(err)
 	}
 
-	info, err := task.ResetTasks(tasks)
-	if err != nil {
+	if err = task.ResetTasks(tasks); err != nil {
 		return errors.Wrap(err, "resetting tasks in database")
-	}
-	if info.Updated == 0 {
-		return nil
 	}
 
 	catcher := grip.NewBasicCatcher()


### PR DESCRIPTION
[EVG-17126](https://jira.mongodb.org/browse/EVG-17126)

### Description 
_(This is a boat load of investigation context and I apologize for that)_

We have been seeing occasional [radical spikes](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=verbose&dispatch.sample_ratio=1&q=search%20index%3Devergreen%20metadata.level%20%3E%3D%2070%20%22wrong%20secret%22%0A%7C%20timechart%20count&earliest=1654117800&latest=1657833600&workload_pool=standard_perf&display.page.search.tab=visualizations&display.general.type=visualizations&sid=1658259124.1997534) of 'wrong task secret' error rates on specific days, where the occurrences can reach 100,000+ errors rapidly whereas most other days have far fewer occurrences around 1,000 total.

Looking at the bulk of problematic tasks during these spikes they all show a strange behavior where there are many task executions with the exact same timespan and a final execution that is of a different time, such as [this task](https://spruce.mongodb.com/task/mongo_node_driver_next_macos_1014_fermium_test_6.0_server_3545698bae6ac07dd9edadf0b66afba696eb83fb_22_07_01_17_18_23/logs?execution=5&logtype=task).  Specifically here we see 6 executions where only the first and last execution actually ran, the other clones of the first execution were created as documents but did not execute.

Looking at this task's specific version we can see a [user rapidly restarted the version over and over many times](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=verbose&dispatch.sample_ratio=1&q=search%20index%3Devergreen%20mongo_node_driver_next_3545698bae6ac07dd9edadf0b66afba696eb83fb%20%7C%20spath%20user%20%7C%20search%20user%3D%22neal.beeken%22%7C%20spath%20method%20%7C%20search%20method!%3DGET&earliest=1656705000&latest=1656706200&workload_pool=standard_perf&display.page.search.tab=events&display.general.type=events&sid=1658764665.3058584). We wouldn't normally expect someone spamming the restart button to create a bunch of tasks that never run because logic is currently set up to only restart finished tasks.  However taking a closer look at those user manual requests you can see they took much longer than typical to complete most of them 5-15 minutes to complete the request.

What looks like happened is that due to the combination of user clicking restart rapidly in sequence and the requests taking long to complete, multiple version restarts were accepted as database modifications at the same time since multiple requests were sent in before the first request had updated the version task's DB state, thus evergreen accepted these restarts on the same state of the same version.

The task's event logs corroborate this:
<img width="799" alt="Screen Shot 2022-07-25 at 11 51 53 AM" src="https://user-images.githubusercontent.com/19805673/180824275-c2177ff9-1e4e-45f9-83cf-fa877cea7e50.png">

Multiple consecutive restart event logs should not be possible as far as I've been able to see.  It seems that resetting the tasks is what was bottlenecking the slow requests, so what can happen is many `RestartVersion` invocations begin, the same task is archived many times in a row on each request (which would explain why these tasks have multiple executions with identical timestamps), one of the request successfully resets all of the version's tasks which causes an agent elsewhere to pick up the tasks, but then the other queued version restart requests reset the tasks again after the tasks have already been re-dispatched. You can see this at the bottom of the event logs screenshot where a task gets restarted after it was just dispatched and started.  The timestamp of that last event log lines up right at the time where 'task conflict' errors begin flooding in for this task.  Also, looking at the full event logs in the DB, the conflict errors _stop_ erroring once the last version restart request completes which probably means the task was reset and had its secret was changed for the last time, allowing it to finally complete.

For all of the 'task conflict' spikes shown in the first link, they all line up with versions that have been restarted several times in a row and were all slow to complete which probably caused these race conditions and therefore repeating conflict errors for every task in the restarted version.  If they're big versions, it'd explain the large number of errors we see on the graph.

One way to remedy these issues since it is not obvious why these requests occasionally get slow is to do more to ensure that tasks are only reset if they are in a completed state since that is what these race conditions boil down to. Change I've made here in this PR is taking that approach.

I've removed some unused parameters that I noticed along the way as well.