### PR TITLE
EVG-17318: fix flaky alertrecord test

### DIFF
--- a/model/alertrecord/alert_bookkeeping_test.go
+++ b/model/alertrecord/alert_bookkeeping_test.go
@@ -51,7 +51,7 @@ func (s *alertRecordSuite) TestInsertNewTaskRegressionByTestRecord() {
 	s.Equal("variant", record.Variant)
 	s.Equal("test", record.TestName)
 	s.Equal(5, record.RevisionOrderNumber)
-	s.Equal(time.Now().Round(time.Second), record.AlertTime.Round(time.Second))
+	s.WithinDuration(time.Now(), record.AlertTime, time.Second)
 }
 
 func (s *alertRecordSuite) TestByLastFailureTransition() {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17318

### Description 
I fixed this test. This test is being flaky because the rounded timestamps could be rounded up or down, which could lead to differing timestamps. For example, if the alert time is recorded as 10:25:00.490 and the assertion is checked at 10:25:00.510, the alert time will round down to 10:25:00 and the assertion's `time.Now()` will be rounded up to 10:25:01. The new check correctly verifies that the alert time and `time.Now()` are within a second of each other.

### Testing
N/A
