### PR TITLE
EVG-14769 Add instance role to admin settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,6 +61,7 @@ type Settings struct {
 	Api                 APIConfig               `yaml:"api" bson:"api" json:"api" id:"api"`
 	ApiUrl              string                  `yaml:"api_url" bson:"api_url" json:"api_url"`
 	AuthConfig          AuthConfig              `yaml:"auth" bson:"auth" json:"auth" id:"auth"`
+	AWSInstanceRole     string                  `yaml:"aws_instance_role" bson:"aws_instance_role" json:"aws_instance_role"`
 	Banner              string                  `bson:"banner" json:"banner" yaml:"banner"`
 	BannerTheme         BannerTheme             `bson:"banner_theme" json:"banner_theme" yaml:"banner_theme"`
 	Cedar               CedarConfig             `bson:"cedar" json:"cedar" yaml:"cedar" id:"cedar"`
@@ -140,6 +141,7 @@ func (c *Settings) Set() error {
 	_, err := coll.UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
 			apiUrlKey:             c.ApiUrl,
+			awsInstanceRoleKey:    c.AWSInstanceRole,
 			bannerKey:             c.Banner,
 			bannerThemeKey:        c.BannerTheme,
 			clientBinariesDirKey:  c.ClientBinariesDir,

--- a/config_db.go
+++ b/config_db.go
@@ -20,6 +20,7 @@ var (
 	serviceFlagsKey       = bsonutil.MustHaveTag(Settings{}, "ServiceFlags")
 	configDirKey          = bsonutil.MustHaveTag(Settings{}, "ConfigDir")
 	apiUrlKey             = bsonutil.MustHaveTag(Settings{}, "ApiUrl")
+	awsInstanceRoleKey    = bsonutil.MustHaveTag(Settings{}, "AWSInstanceRole")
 	cedarKey              = bsonutil.MustHaveTag(Settings{}, "Cedar")
 	clientBinariesDirKey  = bsonutil.MustHaveTag(Settings{}, "ClientBinariesDir")
 	hostJasperKey         = bsonutil.MustHaveTag(Settings{}, "HostJasper")

--- a/config_test.go
+++ b/config_test.go
@@ -143,6 +143,7 @@ func (s *AdminSuite) TestBanner() {
 func (s *AdminSuite) TestBaseConfig() {
 	config := Settings{
 		ApiUrl:              "api",
+		AWSInstanceRole:     "role",
 		Banner:              "banner",
 		BannerTheme:         Important,
 		ClientBinariesDir:   "bin_dir",
@@ -167,6 +168,7 @@ func (s *AdminSuite) TestBaseConfig() {
 	s.NoError(err)
 	s.NotNil(settings)
 	s.Equal(config.ApiUrl, settings.ApiUrl)
+	s.Equal(config.AWSInstanceRole, settings.AWSInstanceRole)
 	s.Equal(config.Banner, settings.Banner)
 	s.Equal(config.BannerTheme, settings.BannerTheme)
 	s.Equal(config.ClientBinariesDir, settings.ClientBinariesDir)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -50,6 +50,7 @@ type APIAdminSettings struct {
 	Amboy               *APIAmboyConfig                   `json:"amboy,omitempty"`
 	Api                 *APIapiConfig                     `json:"api,omitempty"`
 	ApiUrl              *string                           `json:"api_url,omitempty"`
+	AWSInstanceRole     *string                           `json:"aws_instance_role,omitempty"`
 	AuthConfig          *APIAuthConfig                    `json:"auth,omitempty"`
 	Banner              *string                           `json:"banner,omitempty"`
 	BannerTheme         *string                           `json:"banner_theme,omitempty"`
@@ -119,6 +120,7 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 			}
 		}
 		as.ApiUrl = &v.ApiUrl
+		as.AWSInstanceRole = utility.ToStringPtr(v.AWSInstanceRole)
 		as.Banner = &v.Banner
 		tmp := string(v.BannerTheme)
 		as.BannerTheme = &tmp
@@ -186,6 +188,9 @@ func (as *APIAdminSettings) ToService() (interface{}, error) {
 	}
 	if as.ApiUrl != nil {
 		settings.ApiUrl = *as.ApiUrl
+	}
+	if as.AWSInstanceRole != nil {
+		settings.AWSInstanceRole = *as.AWSInstanceRole
 	}
 	if as.Banner != nil {
 		settings.Banner = *as.Banner

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -54,6 +54,7 @@ func TestModelConversion(t *testing.T) {
 	// test converting from a db model to an API model
 	assert.NoError(apiSettings.BuildFromService(testSettings))
 	assert.Equal(testSettings.ApiUrl, *apiSettings.ApiUrl)
+	assert.Equal(testSettings.AWSInstanceRole, *apiSettings.AWSInstanceRole)
 	assert.Equal(testSettings.Banner, *apiSettings.Banner)
 	assert.EqualValues(testSettings.BannerTheme, *apiSettings.BannerTheme)
 	assert.Equal(testSettings.ClientBinariesDir, *apiSettings.ClientBinariesDir)

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -165,6 +165,7 @@ func MockConfig() *evergreen.Settings {
 			PreferredType:           evergreen.AuthLDAPKey,
 			BackgroundReauthMinutes: 60,
 		},
+		AWSInstanceRole:   "role",
 		Banner:            "banner",
 		BannerTheme:       "important",
 		ClientBinariesDir: "bin_dir",


### PR DESCRIPTION
[EVG-14769](https://jira.mongodb.org/browse/EVG-1469)

### Description 
added instance role section on the admin settings 
not adding to the legacy ui (we can add it to the new admin page later)

### Testing 
unit tests