### PR TITLE
EVG-17006 Fetch build ids for deactivating version

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -81,7 +81,7 @@ func SetVersionActivation(versionId string, active bool, caller string) error {
 			q[task.ActivatedByKey] = bson.M{"$in": evergreen.SystemActivators}
 		}
 
-		tasksToModify, err = task.FindAll(db.Query(q).WithFields(task.IdKey, task.ExecutionKey))
+		tasksToModify, err = task.FindAll(db.Query(q).WithFields(task.IdKey, task.ExecutionKey, task.BuildIdKey))
 		if err != nil {
 			return errors.Wrap(err, "getting tasks to deactivate")
 		}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -367,12 +367,12 @@ func TestSetVersionActivation(t *testing.T) {
 	require.NoError(t, db.ClearCollections(build.Collection, task.Collection, VersionCollection))
 
 	vID := "abcdef"
-	v := &Version{Id: vID}
+	v := &Version{Id: vID, BuildIds: []string{"b0", "b1"}}
 	require.NoError(t, v.Insert())
 
 	builds := []build.Build{
-		{Id: "b0", Version: vID, Activated: true},
-		{Id: "b1", Version: vID, Activated: true},
+		{Id: "b0", Version: vID, Activated: true, Tasks: []build.TaskCache{{Id: "t0"}}, Status: evergreen.BuildStarted},
+		{Id: "b1", Version: vID, Activated: true, Tasks: []build.TaskCache{{Id: "t1"}}, Status: evergreen.BuildSucceeded},
 	}
 	for _, build := range builds {
 		require.NoError(t, build.Insert())
@@ -391,6 +391,9 @@ func TestSetVersionActivation(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	for _, b := range builds {
+		if b.Id == "b0" {
+			assert.Equal(t, evergreen.BuildCreated, b.Status)
+		}
 		assert.False(t, b.Activated)
 	}
 


### PR DESCRIPTION
[EVG-17006](https://jira.mongodb.org/browse/EVG-17006)

### Description 
build wasnt being updated when things were being unscheduled 

### Testing 
https://spruce-staging.corp.mongodb.com/version/62e42a31b237363212bb7a51/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
version updated now 

unit test