### PR TITLE
EVG-17362 Fix project disappearing when defaulting to repo 

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1772,6 +1772,7 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 	switch section {
 	case ProjectPageGeneralSection:
 		setUpdate := bson.M{
+			ProjectRefEnabledKey:                 p.Enabled,
 			ProjectRefBranchKey:                  p.Branch,
 			ProjectRefBatchTimeKey:               p.BatchTime,
 			ProjectRefRemotePathKey:              p.RemotePath,
@@ -1787,12 +1788,11 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 			ProjectRefDisabledStatsCacheKey:      p.DisabledStatsCache,
 			ProjectRefFilesIgnoredFromCacheKey:   p.FilesIgnoredFromCache,
 		}
-		if !isRepo && !p.UseRepoSettings() && !defaultToRepo {
+		if !isRepo && !p.UseRepoSettings() {
 			setUpdate[ProjectRefOwnerKey] = p.Owner
 			setUpdate[ProjectRefRepoKey] = p.Repo
 		}
 		if !defaultToRepo {
-			setUpdate[ProjectRefEnabledKey] = p.Enabled
 			setUpdate[ProjectRefDisplayNameKey] = p.DisplayName
 			setUpdate[ProjectRefIdentifierKey] = p.Identifier
 		}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1792,6 +1792,7 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 			setUpdate[ProjectRefOwnerKey] = p.Owner
 			setUpdate[ProjectRefRepoKey] = p.Repo
 		}
+		// some fields shouldn't be set to nil when defaulting to the repo
 		if !defaultToRepo {
 			setUpdate[ProjectRefDisplayNameKey] = p.DisplayName
 			setUpdate[ProjectRefIdentifierKey] = p.Identifier

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -761,6 +761,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 
 			pRef := ProjectRef{
 				Id:                    "my_project",
+				Identifier:            "my_identifier",
 				Owner:                 "candy",
 				Repo:                  "land",
 				BatchTime:             10,

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -649,6 +649,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
+			assert.NotEqual(t, pRefFromDb.Identifier, "")
 			assert.Equal(t, pRefFromDb.BatchTime, 0)
 			assert.Nil(t, pRefFromDb.RepotrackerDisabled)
 			assert.Nil(t, pRefFromDb.DeactivatePrevious)


### PR DESCRIPTION
[EVG-17362](https://jira.mongodb.org/browse/EVG-17362)

### Description 
Because the function set the project to an empty struct when defaulting to repo, it ended up resetting the identifier, display name, and disabled field as well. This adds some casing to avoid that. 

### Testing 
Added to unit test and tested on staging. 
