### PR TITLE
EVG-16730 add debugging to understand long unschedule times

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -374,21 +374,18 @@ func modifyVersionHandler(ctx context.Context, patchID string, modification mode
 		return mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}
 
-	if evergreen.IsPatchRequester(v.Requester) {
-		// Restart is handled through graphql because we need the user to specify
-		// which downstream tasks they want to restart.
-		if modification.Action != evergreen.RestartAction {
-			// Only modify the child patch if it is finalized.
-			childPatchIds, err := patch.GetFinalizedChildPatchIdsForPatch(patchID)
-			if err != nil {
-				return ResourceNotFound.Send(ctx, err.Error())
+	// Restart is handled through graphql because we need the user to specify
+	// which downstream tasks they want to restart.
+	if evergreen.IsPatchRequester(v.Requester) && modification.Action != evergreen.RestartAction {
+		// Only modify the child patch if it is finalized.
+		childPatchIds, err := patch.GetFinalizedChildPatchIdsForPatch(patchID)
+		if err != nil {
+			return ResourceNotFound.Send(ctx, err.Error())
+		}
+		for _, childPatchId := range childPatchIds {
+			if err = modifyVersionHandler(ctx, childPatchId, modification); err != nil {
+				return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("modifying child patch '%s'", childPatchId))
 			}
-			for _, childPatchId := range childPatchIds {
-				if err = modifyVersionHandler(ctx, childPatchId, modification); err != nil {
-					return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("modifying child patch '%s'", childPatchId))
-				}
-			}
-
 		}
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2413,19 +2413,22 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 		// if the aborting task is part of a display task, we also don't want to mark it as aborted
 		q[ExecutionTasksKey] = bson.M{"$ne": reason.TaskID}
 	}
+	now := time.Now()
 	ids, err := findAllTaskIDs(db.Query(q))
 	if err != nil {
 		return errors.Wrap(err, "finding updated tasks")
 	}
-
+	grip.DebugWhen(reason.User != "", message.Fields{
+		"ticket":        "EVG-16730",
+		"step":          "finding tasks to abort",
+		"version_id":    versionId,
+		"time_taken_ms": time.Since(now).Milliseconds(),
+	})
 	if len(ids) == 0 {
-		grip.Info(message.Fields{
-			"message": "no tasks aborted for version",
-			"buildId": versionId,
-		})
 		return nil
 	}
 
+	now = time.Now()
 	_, err = UpdateAll(
 		bson.M{IdKey: bson.M{"$in": ids}},
 		bson.M{"$set": bson.M{
@@ -2433,12 +2436,24 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 			AbortInfoKey: reason,
 		}},
 	)
+	grip.DebugWhen(reason.User != "", message.Fields{
+		"ticket":        "EVG-16730",
+		"step":          "updating aborted tasks",
+		"version_id":    versionId,
+		"time_taken_ms": time.Since(now).Milliseconds(),
+	})
 	if err != nil {
 		return errors.Wrap(err, "setting aborted statuses")
 	}
 
+	now = time.Now()
 	event.LogManyTaskAbortRequests(ids, reason.User)
-
+	grip.DebugWhen(reason.User != "", message.Fields{
+		"ticket":        "EVG-16730",
+		"step":          "logging aborted tasks",
+		"version_id":    versionId,
+		"time_taken_ms": time.Since(now).Milliseconds(),
+	})
 	return nil
 }
 

--- a/model/version_modification.go
+++ b/model/version_modification.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
@@ -39,9 +40,16 @@ func ModifyVersion(version Version, user user.DBUser, modifications VersionModif
 		if version.Requester == evergreen.MergeTestRequester && modifications.Active {
 			return http.StatusBadRequest, errors.New("commit queue merges cannot be manually scheduled")
 		}
+		now := time.Now()
 		if err := SetVersionActivation(version.Id, modifications.Active, user.Id); err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "activating patch")
 		}
+		grip.Debug(message.Fields{
+			"ticket":        "EVG-16730",
+			"step":          "setting version activation",
+			"version_id":    version.Id,
+			"time_taken_ms": time.Since(now).Milliseconds(),
+		})
 		// abort after deactivating the version so we aren't bombarded with failing tasks while
 		// the deactivation is in progress
 		if modifications.Abort {


### PR DESCRIPTION
[EVG-16730](https://jira.mongodb.org/browse/EVG-16730 )

### Description 
UnschedulePatchTasks follows a pretty simple/reused path so it's not clear to me why this is reported to occasionally take 15 minutes for large patches. It looks like this only seems to happen for aborted tasks also. I've added some logging to try and pinpoint what part is causing an issue.
