### PR TITLE
EVG-17241: Fix goroutine leak from the Presto DB client

### DIFF
--- a/mock/environment.go
+++ b/mock/environment.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"database/sql"
 	"math"
 	"runtime"
 	"sync"
@@ -39,6 +40,7 @@ type Environment struct {
 	DBSession               db.Session
 	EvergreenSettings       *evergreen.Settings
 	MongoClient             *mongo.Client
+	PrestoDBClient          *sql.DB
 	mu                      sync.RWMutex
 	DatabaseName            string
 	EnvContext              context.Context
@@ -202,6 +204,8 @@ func (e *Environment) DB() *mongo.Database {
 
 	return e.MongoClient.Database(e.DatabaseName)
 }
+
+func (e *Environment) PrestoDB() *sql.DB { return nil }
 
 func (e *Environment) JasperManager() jasper.Manager {
 	e.mu.RLock()

--- a/model/stats/presto_query.go
+++ b/model/stats/presto_query.go
@@ -100,7 +100,7 @@ func (f *PrestoTestStatsFilter) Validate() error {
 	catcher.ErrorfWhen(f.Limit > MaxQueryLimit, "limit cannot exceed %d", MaxQueryLimit)
 
 	if f.DB == nil {
-		f.DB = evergreen.GetEnvironment().Settings().Presto.DB()
+		f.DB = evergreen.GetEnvironment().PrestoDB()
 	}
 
 	return errors.Wrap(catcher.Resolve(), "invalid Presto test stats filter")

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -168,7 +168,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/revisions/{commit_hash}/tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeTasksByProjectAndCommitHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/task_reliability").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetProjectTaskReliability(opts.URL))
 	app.AddRoute("/projects/{project_id}/task_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskStats(opts.URL))
-	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTestStats(opts.URL, env.Settings().Presto.DB()))
+	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTestStats(opts.URL, env.PrestoDB()))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/tasks/{task_name}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTasksHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases())


### PR DESCRIPTION
EVG-17241: https://jira.mongodb.org/browse/EVG-17241
 
This change sets up the Presto DB client once in the environment, similar to how we set up the Mongo client.

I tested that this works in staging.