### PR TITLE
EVG-17370: add option to apply Amboy queue settings for queues matching a regexp

### DIFF
--- a/config_amboy.go
+++ b/config_amboy.go
@@ -46,6 +46,7 @@ type AmboyRetryConfig struct {
 // queues in the Amboy queue group.
 type AmboyNamedQueueConfig struct {
 	Name               string `bson:"name" json:"name" yaml:"name"`
+	Regexp             string `bson:"regexp" json:"regexp" yaml:"regexp"`
 	NumWorkers         int    `bson:"num_workers" json:"num_workers" yaml:"num_workers"`
 	SampleSize         int    `bson:"sample_size" json:"sample_size" yaml:"sample_size"`
 	LockTimeoutSeconds int    `bson:"lock_timeout_seconds" json:"lock_timeout_seconds" yaml:"lock_timeout_seconds"`

--- a/environment.go
+++ b/environment.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -415,9 +416,15 @@ func (e *envState) createRemoteQueueGroup(ctx context.Context) error {
 		Retryable:  &retryOpts,
 	}
 
+	perQueue, regexpQueue, err := e.getNamedRemoteQueueOptions()
+	if err != nil {
+		return errors.Wrap(err, "getting named remote queue options")
+	}
+
 	remoteQueueGroupOpts := queue.MongoDBQueueGroupOptions{
 		DefaultQueue:              queueOpts,
-		PerQueue:                  e.getNamedRemoteQueueOptions(),
+		PerQueue:                  perQueue,
+		RegexpQueue:               regexpQueue,
 		BackgroundCreateFrequency: time.Duration(e.settings.Amboy.GroupBackgroundCreateFrequencyMinutes) * time.Minute,
 		PruneFrequency:            time.Duration(e.settings.Amboy.GroupPruneFrequencyMinutes) * time.Minute,
 		TTL:                       time.Duration(e.settings.Amboy.GroupTTLMinutes) * time.Minute,
@@ -451,9 +458,13 @@ func (e *envState) getRemoteQueueGroupDBOptions() queue.MongoDBOptions {
 	return opts
 }
 
-func (e *envState) getNamedRemoteQueueOptions() map[string]queue.MongoDBQueueOptions {
+func (e *envState) getNamedRemoteQueueOptions() (map[string]queue.MongoDBQueueOptions, []queue.RegexpMongoDBQueueOptions, error) {
 	perQueueOpts := map[string]queue.MongoDBQueueOptions{}
+	var regexpQueueOpts []queue.RegexpMongoDBQueueOptions
 	for _, namedQueue := range e.settings.Amboy.NamedQueues {
+		if namedQueue.Name == "" {
+			continue
+		}
 		dbOpts := e.getRemoteQueueGroupDBOptions()
 		if namedQueue.SampleSize != 0 {
 			dbOpts.SampleSize = namedQueue.SampleSize
@@ -467,12 +478,26 @@ func (e *envState) getNamedRemoteQueueOptions() map[string]queue.MongoDBQueueOpt
 		} else {
 			numWorkers = e.settings.Amboy.GroupDefaultWorkers
 		}
-		perQueueOpts[namedQueue.Name] = queue.MongoDBQueueOptions{
+		queueOpts := queue.MongoDBQueueOptions{
 			NumWorkers: utility.ToIntPtr(numWorkers),
 			DB:         &dbOpts,
 		}
+		if namedQueue.Name != "" {
+			perQueueOpts[namedQueue.Name] = queueOpts
+			continue
+		}
+
+		re, err := regexp.Compile(namedQueue.Regexp)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "invalid regexp '%s'", namedQueue.Regexp)
+		}
+		regexpQueueOpts = append(regexpQueueOpts, queue.RegexpMongoDBQueueOptions{
+			Regexp:  *re,
+			Options: queueOpts,
+		})
 	}
-	return perQueueOpts
+
+	return perQueueOpts, regexpQueueOpts, nil
 }
 
 func (e *envState) createNotificationQueue(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace gopkg.in/20210107192922/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-2021010719292
 require (
 	github.com/99designs/gqlgen v0.14.0
 	github.com/PuerkitoBio/rehttp v1.1.0
-	github.com/aws/aws-sdk-go v1.44.46
+	github.com/aws/aws-sdk-go v1.44.66
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -34,7 +34,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.2
-	github.com/mongodb/amboy v0.0.0-20220714150236-d5bf2dac258e
+	github.com/mongodb/amboy v0.0.0-20220802154347-d8ddbd5cd2cd
 	github.com/mongodb/anser v0.0.0-20220318141853-005b8ead5b8f
 	github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809
 	github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21
@@ -47,8 +47,8 @@ require (
 	github.com/urfave/cli v1.22.9
 	github.com/vektah/gqlparser/v2 v2.2.0
 	github.com/vmware/govmomi v0.27.1
-	go.mongodb.org/mongo-driver v1.9.1
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+	go.mongodb.org/mongo-driver v1.10.0
+	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/tools v0.1.9
 	gonum.org/v1/gonum v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,9 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.43.30/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.46 h1:BsKENvu24eXg7CWQ2wJAjKbDFkGP+hBtxKJIR3UdcB8=
 github.com/aws/aws-sdk-go v1.44.46/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.66 h1:xdH4EvHyUnkm4I8d536ui7yMQKYzrkbSDQ2LvRRHqsg=
+github.com/aws/aws-sdk-go v1.44.66/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0/go.mod h1:6L7zgvqo0idzI7IO8de6ZC051AfXb5ipkIJ7bIA2tGA=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -461,7 +462,6 @@ github.com/go-pdf/fpdf v0.6.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhO
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
@@ -785,8 +785,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mongodb/amboy v0.0.0-20200527191935-07fdffff5b8c/go.mod h1:SfpzZNF2KZUT5zO0/q4eUqW+EQe64MiY8xXmkBHZDqk=
 github.com/mongodb/amboy v0.0.0-20211101161704-2b42087d24e6/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
-github.com/mongodb/amboy v0.0.0-20220714150236-d5bf2dac258e h1:0eHrrBNG2ouO8++tO/vK5hi8eCMyVttnK2cnBvrgGdQ=
-github.com/mongodb/amboy v0.0.0-20220714150236-d5bf2dac258e/go.mod h1:JBI6fZC+Ap0uOwqTW+KzoR/+EBJnUIS53ZmVtLikjo0=
+github.com/mongodb/amboy v0.0.0-20220802154347-d8ddbd5cd2cd h1:ePs+ejYhb6DLGYm96DHHj2l51tdjNGIohlLLhx0X2FM=
+github.com/mongodb/amboy v0.0.0-20220802154347-d8ddbd5cd2cd/go.mod h1:afNDkdWtk9OAqfcxx46Em68wCCn5avNjWRHNb9HuITY=
 github.com/mongodb/anser v0.0.0-20190422213746-1fb43a6d9968/go.mod h1:ESqf0zBEuYrqL0xADbIAFgdEOaBFpwZ4tkzY84ge+QA=
 github.com/mongodb/anser v0.0.0-20211116195831-fdc43007b59f/go.mod h1:jDikxuo5FKbiTMAb8B5AMT3QqFSNrim2+GiRTSCdazU=
 github.com/mongodb/anser v0.0.0-20220318141853-005b8ead5b8f h1:cOPq9/377MrwRdgMGHsj5szvOGCokC7SYly2o5uEdv8=
@@ -804,6 +804,7 @@ github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21/go.mod h1:QfF6CwbaTQx
 github.com/mongodb/jasper v0.0.0-20220214215554-82e5a72cff6b h1:VeoszGUVkmmRmPxwiJIiO/psZbPwz7tc6qbX2xDoQLY=
 github.com/mongodb/jasper v0.0.0-20220214215554-82e5a72cff6b/go.mod h1:ZMsAlwE3H8Yh/L9bc3lliN3EZME41wButVxWpt2e4Io=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 h1:pmpDGKLw4n82EtrNiLqB+xSz/JQwFOaZuMALYUHwX5s=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -1068,10 +1069,12 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
-github.com/xdg-go/scram v1.0.2 h1:akYIkZ28e6A96dkWNJQu3nmCzH3YfwMPQExUYDaRv7w=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
-github.com/xdg-go/stringprep v1.0.2 h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyhBc=
+github.com/xdg-go/scram v1.1.1 h1:VOMT+81stJgXW3CpHyqHN3AXDYIMsx56mEFrB37Mb/E=
+github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
+github.com/xdg-go/stringprep v1.0.3 h1:kdwGpVNwPFtjs98xCGkHjQtGKh86rDcRZN17QEMCOIs=
+github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
@@ -1104,8 +1107,8 @@ go.mongodb.org/mongo-driver v1.8.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCu
 go.mongodb.org/mongo-driver v1.8.2/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.8.4/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
-go.mongodb.org/mongo-driver v1.9.1 h1:m078y9v7sBItkt1aaoe2YlvWEXcD263e1a4E1fBrJ1c=
-go.mongodb.org/mongo-driver v1.9.1/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
+go.mongodb.org/mongo-driver v1.10.0 h1:UtV6N5k14upNp4LTduX0QCufG124fSu25Wz9tu94GLg=
+go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -1141,8 +1144,9 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1249,6 +1253,7 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -514,7 +514,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     }
 
     if (!$scope.validAmboyNamedQueue($scope.new_amboy_named_queue)) {
-      $scope.invalidAmboyNamedQueue = "Amboy queue name is required.";
+      $scope.invalidAmboyNamedQueue = "Amboy queue name or regexp is required.";
       return
     }
 
@@ -524,7 +524,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
   }
 
   $scope.validAmboyNamedQueue = function (queue) {
-    return queue && queue.name;
+    return queue && (queue.name || queue.regexp);
   }
 
   $scope.deleteAmboyNamedQueue = function (index) {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -460,6 +460,7 @@ func (a *APIAmboyRetryConfig) ToService() (interface{}, error) {
 // APIAmboyNamedQueueConfig is the model for named Amboy queue settings.
 type APIAmboyNamedQueueConfig struct {
 	Name               *string `json:"name"`
+	Regexp             *string `json:"regexp"`
 	NumWorkers         int     `json:"num_workers,omitempty"`
 	SampleSize         int     `json:"sample_size,omitempty"`
 	LockTimeoutSeconds int     `json:"lock_timeout_seconds,omitempty"`
@@ -467,6 +468,7 @@ type APIAmboyNamedQueueConfig struct {
 
 func (a *APIAmboyNamedQueueConfig) BuildFromService(h evergreen.AmboyNamedQueueConfig) {
 	a.Name = utility.ToStringPtr(h.Name)
+	a.Regexp = utility.ToStringPtr(h.Regexp)
 	a.NumWorkers = h.NumWorkers
 	a.SampleSize = h.SampleSize
 	a.LockTimeoutSeconds = h.LockTimeoutSeconds
@@ -475,6 +477,7 @@ func (a *APIAmboyNamedQueueConfig) BuildFromService(h evergreen.AmboyNamedQueueC
 func (a *APIAmboyNamedQueueConfig) ToService() evergreen.AmboyNamedQueueConfig {
 	return evergreen.AmboyNamedQueueConfig{
 		Name:               utility.FromStringPtr(a.Name),
+		Regexp:             utility.FromStringPtr(a.Regexp),
 		NumWorkers:         a.NumWorkers,
 		SampleSize:         a.SampleSize,
 		LockTimeoutSeconds: a.LockTimeoutSeconds,

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -105,6 +105,7 @@ func TestModelConversion(t *testing.T) {
 	require.Equal(len(testSettings.Amboy.NamedQueues), len(apiSettings.Amboy.NamedQueues))
 	for i := range testSettings.Amboy.NamedQueues {
 		assert.Equal(testSettings.Amboy.NamedQueues[i].Name, utility.FromStringPtr(apiSettings.Amboy.NamedQueues[i].Name))
+		assert.Equal(testSettings.Amboy.NamedQueues[i].Regexp, utility.FromStringPtr(apiSettings.Amboy.NamedQueues[i].Regexp))
 		assert.Equal(testSettings.Amboy.NamedQueues[i].NumWorkers, apiSettings.Amboy.NamedQueues[i].NumWorkers)
 		assert.Equal(testSettings.Amboy.NamedQueues[i].SampleSize, apiSettings.Amboy.NamedQueues[i].SampleSize)
 		assert.Equal(testSettings.Amboy.NamedQueues[i].LockTimeoutSeconds, apiSettings.Amboy.NamedQueues[i].LockTimeoutSeconds)
@@ -219,6 +220,7 @@ func TestModelConversion(t *testing.T) {
 	require.Equal(len(testSettings.Amboy.NamedQueues), len(dbSettings.Amboy.NamedQueues))
 	for i := range testSettings.Amboy.NamedQueues {
 		assert.Equal(testSettings.Amboy.NamedQueues[i].Name, dbSettings.Amboy.NamedQueues[i].Name)
+		assert.Equal(testSettings.Amboy.NamedQueues[i].Regexp, dbSettings.Amboy.NamedQueues[i].Regexp)
 		assert.Equal(testSettings.Amboy.NamedQueues[i].NumWorkers, dbSettings.Amboy.NamedQueues[i].NumWorkers)
 		assert.Equal(testSettings.Amboy.NamedQueues[i].SampleSize, dbSettings.Amboy.NamedQueues[i].SampleSize)
 		assert.Equal(testSettings.Amboy.NamedQueues[i].LockTimeoutSeconds, dbSettings.Amboy.NamedQueues[i].LockTimeoutSeconds)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1512,15 +1512,19 @@ Admin Settings
 													<label>Name</label>
 													<input type="text" ng-model="queue.name">
 												</md-input-container>
-												<md-input-container class="control" style="width:45%;margin-left:50px;">
+												<md-input-container class="control" style="width:45%;margin-left:50px">
+													<label>Regular Expression</label>
+													<input type="text" ng-model="queue.regexp">
+												</md-input-container>
+												<md-input-container class="control" style="width:45%;">
 													<label>Number of Workers</label>
 													<input type="number" ng-model="queue.num_workers">
 												</md-input-container>
-												<md-input-container class="control" style="width:45%;">
+												<md-input-container class="control" style="width:45%;margin-left:50px;">
 													<label>Sample Size</label>
 													<input type="number" ng-model="queue.sample_size" placeholder="Sample Size">
 												</md-input-container>
-												<md-input-container class="control" style="width:45%;margin-left:50px;">
+												<md-input-container class="control" style="width:45%;">
 													<label>Lock Timeout (Seconds)</label>
 													<input type="number" ng-model="queue.lock_timeout_seconds">
 												</md-input-container>
@@ -1540,14 +1544,18 @@ Admin Settings
 												<input type="text" ng-model="new_amboy_named_queue.name">
 											</md-input-container>
 											<md-input-container class="control" style="width:45%;margin-left:50px;">
+												<label>Regular Expression</label>
+												<input type="text" ng-model="new_amboy_named_queue.regexp">
+											</md-input-container>
+											<md-input-container class="control" style="width:45%;">
 												<label>Number of Workers</label>
 												<input type="number" ng-model="new_amboy_named_queue.num_workers">
 											</md-input-container>
-											<md-input-container class="control" style="width:45%;">
+											<md-input-container class="control" style="width:45%;margin-left:50px;">
 												<label>Sample Size</label>
 												<input type="number" ng-model="new_amboy_named_queue.sample_size" placeholder="Sample Size">
 											</md-input-container>
-											<md-input-container class="control" style="width:45%;margin-left:50px;">
+											<md-input-container class="control" style="width:45%;">
 												<label>Lock Timeout (Seconds)</label>
 												<input type="number" ng-model="new_amboy_named_queue.lock_timeout_seconds">
 											</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -125,6 +125,10 @@ func MockConfig() *evergreen.Settings {
 					Name:       "queue1",
 					SampleSize: 500,
 				},
+				{
+					Regexp:             "^queue2",
+					LockTimeoutSeconds: 50,
+				},
 			},
 		},
 		Api: evergreen.APIConfig{


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17370

### Description 
Add admin settings to apply Amboy queue settings to named queues using a regexp instead of exact name match.

### Testing 
Added admin settings unit tests and tested the settings in local Evergreen.