### PR TITLE
EVG-17386: ensure compilation make recipe depends on go module files

### DIFF
--- a/makefile
+++ b/makefile
@@ -110,13 +110,13 @@ smokeFile := $(if $(SMOKE_TEST_FILE),--test-file $(SMOKE_TEST_FILE),)
 
 # start rules for building services and clients
 ifeq ($(OS),Windows_NT)
-localClientBinary := $(clientBuildDir)/$(goos)_$(goarch)/evergreen.exe
+localClientBinary := $(clientBuildDir)/$(goos)_$(goarch)/$(windowsBinaryBasename)
 else
-localClientBinary := $(clientBuildDir)/$(goos)_$(goarch)/evergreen
+localClientBinary := $(clientBuildDir)/$(goos)_$(goarch)/$(unixBinaryBasename)
 endif
 cli:$(localClientBinary)
 clis:$(clientBinaries)
-$(clientBuildDir)/%/evergreen $(clientBuildDir)/%/evergreen.exe:$(buildDir)/build-cross-compile $(srcFiles)
+$(clientBuildDir)/%/$(unixBinaryBasename) $(clientBuildDir)/%/$(windowsBinaryBasename):$(buildDir)/build-cross-compile $(srcFiles) go.mod go.sum
 	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -goBinary="$(gobin)" -directory=$(clientBuildDir) -source=$(clientSource) -output=$@
 # Targets to upload the CLI binaries to S3.
 $(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17386

### Description 
Allow re-compiling if the Go module dependency files are changed. I also did some small tidying up of make variables.

I'm going to also apply this same change to all the PLT repos that use Go modules once it's approved.

### Testing 
I re-compiled and it depended on modifications to go.mod/go.sum.