### PR TITLE
EVG-17366 Don't set repo identifier

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -940,6 +940,7 @@ func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err err
 	// some fields shouldn't be set from projects
 	repoRef.Id = mgobson.NewObjectId().Hex()
 	repoRef.RepoRefId = ""
+	repoRef.Identifier = ""
 	// set explicitly in case no project is enabled
 	repoRef.Owner = p.Owner
 	repoRef.Repo = p.Repo

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -950,6 +950,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, doc1.Insert())
 	doc2 := &ProjectRef{
 		Id:                    "id2",
+		Identifier:            "identifier",
 		Owner:                 "mongodb",
 		Repo:                  "mongo",
 		Branch:                "mci2",
@@ -1074,6 +1075,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.True(t, repoRef.IsEnabled())
 	assert.True(t, repoRef.IsPRTestingEnabled())
 	assert.Equal(t, "evergreen.yml", repoRef.RemotePath)
+	assert.Equal(t, "", repoRef.Identifier)
 	assert.Nil(t, repoRef.NotifyOnBuildFailure)
 	assert.Nil(t, repoRef.GithubChecksEnabled)
 	assert.Equal(t, "my message", repoRef.CommitQueue.Message)


### PR DESCRIPTION
[EVG-17366](https://jira.mongodb.org/browse/EVG-17366)

### Description 
We don't want to set the repo identifier to the project's identifier. 

### Testing 
Added to existing unit test. 
