### PR TITLE
EVG-17390: Add Presto admin settings to the UI

### DIFF
--- a/config_presto.go
+++ b/config_presto.go
@@ -18,27 +18,25 @@ import (
 // PrestoConfig represents configuration information for the application level
 // Presto DB connection.
 type PrestoConfig struct {
-	BaseURI           string            `bson:"base_uri" json:"base_uri" yaml:"base_uri"`
-	Port              int               `bson:"port" json:"port" yaml:"port"`
-	TLS               bool              `bson:"tls" json:"tls" yaml:"tls"`
-	Username          string            `bson:"username" json:"username" yaml:"username"`
-	Password          string            `bson:"password" json:"password" yaml:"password"`
-	Source            string            `bson:"source" json:"source" yaml:"source"`
-	Catalog           string            `bson:"catalog" json:"catalog" yaml:"catalog"`
-	Schema            string            `bson:"schema" json:"schema" yaml:"schema"`
-	SessionProperties map[string]string `bson:"session_properties" json:"session_properties" yaml:"session_properties"`
+	BaseURI  string `bson:"base_uri" json:"base_uri" yaml:"base_uri"`
+	Port     int    `bson:"port" json:"port" yaml:"port"`
+	TLS      bool   `bson:"tls" json:"tls" yaml:"tls"`
+	Username string `bson:"username" json:"username" yaml:"username"`
+	Password string `bson:"password" json:"password" yaml:"password"`
+	Source   string `bson:"source" json:"source" yaml:"source"`
+	Catalog  string `bson:"catalog" json:"catalog" yaml:"catalog"`
+	Schema   string `bson:"schema" json:"schema" yaml:"schema"`
 }
 
 var (
-	PrestoConfigBaseURIKey           = bsonutil.MustHaveTag(PrestoConfig{}, "BaseURI")
-	PrestoConfigPortKey              = bsonutil.MustHaveTag(PrestoConfig{}, "Port")
-	PrestoConfigTLSKey               = bsonutil.MustHaveTag(PrestoConfig{}, "TLS")
-	PrestoConfigUsernameKey          = bsonutil.MustHaveTag(PrestoConfig{}, "Username")
-	PrestoConfigPasswordKey          = bsonutil.MustHaveTag(PrestoConfig{}, "Password")
-	PrestoConfigSourceKey            = bsonutil.MustHaveTag(PrestoConfig{}, "Source")
-	PrestoConfigCatalogKey           = bsonutil.MustHaveTag(PrestoConfig{}, "Catalog")
-	PrestoConfigSchemaKey            = bsonutil.MustHaveTag(PrestoConfig{}, "Schema")
-	PrestoConfigSessionPropertiesKey = bsonutil.MustHaveTag(PrestoConfig{}, "SessionProperties")
+	PrestoConfigBaseURIKey  = bsonutil.MustHaveTag(PrestoConfig{}, "BaseURI")
+	PrestoConfigPortKey     = bsonutil.MustHaveTag(PrestoConfig{}, "Port")
+	PrestoConfigTLSKey      = bsonutil.MustHaveTag(PrestoConfig{}, "TLS")
+	PrestoConfigUsernameKey = bsonutil.MustHaveTag(PrestoConfig{}, "Username")
+	PrestoConfigPasswordKey = bsonutil.MustHaveTag(PrestoConfig{}, "Password")
+	PrestoConfigSourceKey   = bsonutil.MustHaveTag(PrestoConfig{}, "Source")
+	PrestoConfigCatalogKey  = bsonutil.MustHaveTag(PrestoConfig{}, "Catalog")
+	PrestoConfigSchemaKey   = bsonutil.MustHaveTag(PrestoConfig{}, "Schema")
 )
 
 func (*PrestoConfig) SectionId() string { return "presto" }
@@ -78,11 +76,10 @@ func (*PrestoConfig) ValidateAndDefault() error { return nil }
 
 func (c *PrestoConfig) setupDB(ctx context.Context) (*sql.DB, error) {
 	dsnConfig := trino.Config{
-		ServerURI:         c.formatURI(),
-		Source:            c.Source,
-		Catalog:           c.Catalog,
-		Schema:            c.Schema,
-		SessionProperties: c.SessionProperties,
+		ServerURI: c.formatURI(),
+		Source:    c.Source,
+		Catalog:   c.Catalog,
+		Schema:    c.Schema,
 	}
 	dsn, err := dsnConfig.FormatDSN()
 	if err != nil {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -32,6 +32,7 @@ func NewConfigModel() *APIAdminSettings {
 		Notify:            &APINotifyConfig{},
 		Plugins:           map[string]map[string]interface{}{},
 		PodInit:           &APIPodInitConfig{},
+		Presto:            &APIPrestoConfig{},
 		Providers:         &APICloudProviders{},
 		RepoTracker:       &APIRepoTrackerConfig{},
 		Scheduler:         &APISchedulerConfig{},
@@ -78,6 +79,7 @@ type APIAdminSettings struct {
 	Plugins             map[string]map[string]interface{} `json:"plugins,omitempty"`
 	PodInit             *APIPodInitConfig                 `json:"pod_init,omitempty"`
 	PprofPort           *string                           `json:"pprof_port,omitempty"`
+	Presto              *APIPrestoConfig                  `json:"presto,omitempty"`
 	Providers           *APICloudProviders                `json:"providers,omitempty"`
 	RepoTracker         *APIRepoTrackerConfig             `json:"repotracker,omitempty"`
 	Scheduler           *APISchedulerConfig               `json:"scheduler,omitempty"`
@@ -1192,6 +1194,48 @@ func (a *APINotifyConfig) ToService() (interface{}, error) {
 		BufferTargetPerInterval: a.BufferTargetPerInterval,
 		BufferIntervalSeconds:   a.BufferIntervalSeconds,
 		SMTP:                    smtp.(evergreen.SMTPConfig),
+	}, nil
+}
+
+type APIPrestoConfig struct {
+	BaseURI  *string `json:"base_uri"`
+	Port     int     `json:"port"`
+	TLS      bool    `json:"tls"`
+	Username *string `json:"username"`
+	Password *string `json:"password"`
+	Source   *string `json:"source"`
+	Catalog  *string `json:"catalog"`
+	Schema   *string `json:"schema"`
+}
+
+func (a *APIPrestoConfig) BuildFromService(h interface{}) error {
+	switch v := h.(type) {
+	case evergreen.PrestoConfig:
+		a.BaseURI = utility.ToStringPtr(v.BaseURI)
+		a.Port = v.Port
+		a.TLS = v.TLS
+		a.Username = utility.ToStringPtr(v.Username)
+		a.Password = utility.ToStringPtr(v.Password)
+		a.Source = utility.ToStringPtr(v.Source)
+		a.Catalog = utility.ToStringPtr(v.Catalog)
+		a.Schema = utility.ToStringPtr(v.Schema)
+	default:
+		return errors.Errorf("programmatic error: expected Presto config but got type %T", h)
+	}
+
+	return nil
+}
+
+func (a *APIPrestoConfig) ToService() (interface{}, error) {
+	return evergreen.PrestoConfig{
+		BaseURI:  utility.FromStringPtr(a.BaseURI),
+		Port:     a.Port,
+		TLS:      a.TLS,
+		Username: utility.FromStringPtr(a.Username),
+		Password: utility.FromStringPtr(a.Password),
+		Source:   utility.FromStringPtr(a.Source),
+		Catalog:  utility.FromStringPtr(a.Catalog),
+		Schema:   utility.FromStringPtr(a.Schema),
 	}, nil
 }
 
@@ -2384,8 +2428,6 @@ func (rtr *RestartResponse) ToService() (interface{}, error) {
 	return nil, errors.New("ToService not implemented for RestartTasksResponse")
 }
 
-const prestoConfigId = "presto"
-
 func AdminDbToRestModel(in evergreen.ConfigSection) (Model, error) {
 	id := in.SectionId()
 	var out Model
@@ -2395,8 +2437,6 @@ func AdminDbToRestModel(in evergreen.ConfigSection) (Model, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if id == prestoConfigId { // TODO PM-2940: Remove presto check
-		return nil, nil
 	} else {
 		structVal := reflect.ValueOf(*NewConfigModel())
 		for i := 0; i < structVal.NumField(); i++ {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -80,6 +80,7 @@ Admin Settings
 						<li class="link" ng-click="scrollTo('splunk')">Splunk</li>
 						<li class="link" ng-click="scrollTo('newrelic')">New Relic</li>
 						<li class="link" ng-click="scrollTo('cedar')">Cedar</li>
+						<li class="link" ng-click="scrollTo('cedar')">Presto</li>
 						<div>Background Processing</div>
 						<li class="link" ng-click="scrollTo('amboy')">Amboy</li>
 						<li class="link" ng-click="scrollTo('logger_config')">Logger Config</li>
@@ -616,7 +617,6 @@ Admin Settings
 						</section>
 
 						<section layout="row" flex>
-
 							<md-card flex=50 id="hostinit">
 								<md-card-title>
 									<md-card-title-text>
@@ -1382,6 +1382,9 @@ Admin Settings
 									</md-input-container>
 								</md-card-content>
 							</md-card>
+                                                </section>
+
+						<section layout="row" flex>
 							<md-card flex=50 id="cedar" style="height:auto">
 								<md-card-title>
 									<md-card-title-text>
@@ -1407,6 +1410,49 @@ Admin Settings
 									<md-input-container class="control" style="width:45%;">
 										<label>API Key</label>
 										<input type="text" ng-model="Settings.cedar.api_key">
+									</md-input-container>
+								</md-card-content>
+							</md-card>
+							<md-card flex=50 id="presto" style="height:auto">
+								<md-card-title>
+									<md-card-title-text>
+										<span>Presto</span>
+									</md-card-title-text>
+									<md-button ng-click="clearSection('presto')">
+										<i class="fa fa-trash"></i>
+									</md-button>
+								</md-card-title>
+								<md-card-content>
+									<md-input-container class="control" style="width:45%;">
+										<label>Base URI</label>
+										<input type="text" ng-model="Settings.presto.base_uri">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Port</label>
+										<input type="number" ng-model="Settings.presto.port">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+                                                                                <md-checkbox ng-model="Settings.presto.tls">TLS</md-checkbox>
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Username</label>
+										<input type="text" ng-model="Settings.presto.username">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Password</label>
+										<input type="text" ng-model="Settings.presto.password">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Source</label>
+										<input type="text" ng-model="Settings.presto.source">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Catalog</label>
+										<input type="text" ng-model="Settings.presto.catalog">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Schema</label>
+										<input type="text" ng-model="Settings.presto.schema">
 									</md-input-container>
 								</md-card-content>
 							</md-card>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -80,7 +80,7 @@ Admin Settings
 						<li class="link" ng-click="scrollTo('splunk')">Splunk</li>
 						<li class="link" ng-click="scrollTo('newrelic')">New Relic</li>
 						<li class="link" ng-click="scrollTo('cedar')">Cedar</li>
-						<li class="link" ng-click="scrollTo('cedar')">Presto</li>
+						<li class="link" ng-click="scrollTo('presto')">Presto</li>
 						<div>Background Processing</div>
 						<li class="link" ng-click="scrollTo('amboy')">Amboy</li>
 						<li class="link" ng-click="scrollTo('logger_config')">Logger Config</li>


### PR DESCRIPTION
EVG-17390: https://jira.mongodb.org/browse/EVG-17390

### Description 
This fixes a bug that was causing the presto config section to be wiped in the DB every time the admin settings were updated. 
- Add the Presto settings to the UI and the API settings model.
- Remove the field `SessionProperties` since it was not being used / not needed and just made the UI more complicated.
- Remove[ Bynn's workaround](https://github.com/bynn/evergreen/blob/766a2deb8469c1f6b627991f2dad615dd0a2a16a/rest/model/admin.go#L2393-L2394) to skip the Presto config section when updating the admin events page.

### Testing 
I tested that the Presto settings both load correctly and are updated in the UI in staging.
