### PR TITLE
EVG-16490: Don't return 500s when getting test results fails.

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -333,7 +333,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	testResults := uis.getTestResults(w, r, projCtx, &uiTask)
+	testResults := uis.getTestResults(projCtx, &uiTask)
 	if projCtx.Patch != nil {
 		var taskOnBaseCommit *task.Task
 		var testResultsOnBaseCommit []task.TestResult
@@ -891,9 +891,12 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 	uis.render.Stream(w, http.StatusOK, data, "base", "task_log.html")
 }
 
-func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, projCtx projectContext, uiTask *uiTaskData) []task.TestResult {
+func (uis *UIServer) getTestResults(projCtx projectContext, uiTask *uiTaskData) []task.TestResult {
 	if err := projCtx.Task.PopulateTestResults(); err != nil {
-		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		grip.Error(message.WrapError(err, message.Fields{
+			"task_id": projCtx.Task.Id,
+			"message": "fetching test results for task",
+		}))
 		return nil
 	}
 
@@ -911,7 +914,11 @@ func (uis *UIServer) getTestResults(w http.ResponseWriter, r *http.Request, proj
 				et, err = task.FindOneId(t)
 			}
 			if err != nil {
-				uis.LoggedError(w, r, http.StatusInternalServerError, err)
+				grip.Error(message.Fields{
+					"message": "fetching execution task",
+					"task":    t,
+					"parent":  projCtx.Task.Id,
+				})
 				return nil
 			}
 			if et == nil {

--- a/service/task.go
+++ b/service/task.go
@@ -915,17 +915,17 @@ func (uis *UIServer) getTestResults(projCtx projectContext, uiTask *uiTaskData) 
 			}
 			if err != nil {
 				grip.Error(message.Fields{
-					"message": "fetching execution task",
-					"task":    t,
-					"parent":  projCtx.Task.Id,
+					"message":        "fetching test results for execution task",
+					"task_id":        t,
+					"parent_task_id": projCtx.Task.Id,
 				})
 				return nil
 			}
 			if et == nil {
 				grip.Error(message.Fields{
-					"message": "execution task not found",
-					"task":    t,
-					"parent":  projCtx.Task.Id,
+					"message":        "execution task not found",
+					"task_id":        t,
+					"parent_task_id": projCtx.Task.Id,
 				})
 				continue
 			}

--- a/service/task_test.go
+++ b/service/task_test.go
@@ -16,7 +16,7 @@ func TestGetTestResults(t *testing.T) {
 
 	testutil.Setup()
 
-	db.ClearCollections(task.Collection)
+	require.NoError(t, db.ClearCollections(task.Collection))
 
 	newTask := task.Task{
 		HasCedarResults: true,

--- a/service/task_test.go
+++ b/service/task_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTestResults(t *testing.T) {
+
+	testutil.Setup()
+
+	db.ClearCollections(task.Collection)
+
+	newTask := task.Task{
+		HasCedarResults: true,
+		Id:              "test_task_id",
+		Status:          evergreen.TaskSucceeded,
+	}
+	err := newTask.Insert()
+	require.NoError(t, err)
+	uis := UIServer{hostCache: make(map[string]hostCacheItem)}
+	projectContext := projectContext{
+		Context: model.Context{
+			Task: &newTask,
+		},
+	}
+	uiTask := uiTaskData{}
+	results := uis.getTestResults(projectContext, &uiTask)
+	var expected []task.TestResult = nil
+	assert.Equal(t, expected, results)
+}

--- a/service/task_test.go
+++ b/service/task_test.go
@@ -33,6 +33,5 @@ func TestGetTestResults(t *testing.T) {
 	}
 	uiTask := uiTaskData{}
 	results := uis.getTestResults(projectContext, &uiTask)
-	var expected []task.TestResult = nil
-	assert.Equal(t, expected, results)
+	assert.Nil(t, results)
 }


### PR DESCRIPTION
Currently we don't return the error, but we also send an error
response globally, causing this to 500 in the event of a Cedar
outage. This changes the logic so that we will return no test
results if Cedar is down but otherwise continue to process the
response.

[EVG-16490](https://jira.mongodb.org/browse/EVG-16490)

### Description 
This updates getTestResults to not send a 500 response if for some reason Cedar is down. It now silently logs the error and the request continues to process normally.

### Testing 
  I added testing to make sure that we do in fact return a nil list of results if Cedar is unavailable. Also, the function no longer has access to the response and request objects so it is impossible for it to send a 500 response code header.
