### PR TITLE
EVG-16908: create model for container secrets

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -369,10 +369,13 @@ func (r *mutationResolver) AttachProjectToRepo(ctx context.Context, projectID st
 }
 
 func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.APIProjectRef) (*restModel.APIProjectRef, error) {
-	dbProjectRef := project.ToService()
+	dbProjectRef, err := project.ToService()
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error converting project ref to service model: %s", err.Error()))
+	}
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 
-	if err := data.CreateProject(&dbProjectRef, u); err != nil {
+	if err := data.CreateProject(dbProjectRef, u); err != nil {
 		apiErr, ok := err.(gimlet.ErrorResponse)
 		if ok {
 			if apiErr.StatusCode == http.StatusBadRequest {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1540,6 +1540,36 @@ func TestValidatePeriodicBuildDefinition(t *testing.T) {
 	}
 }
 
+func TestContainerSecretValidate(t *testing.T) {
+	t.Run("SucceedsWithStoredSecret", func(t *testing.T) {
+		cs := ContainerSecret{
+			Type:  ContainerSecretRepoCred,
+			Value: `{"username": "cool_user", "password": "very_secure_password_waow"}`,
+		}
+		assert.NoError(t, cs.Validate())
+	})
+	t.Run("SucceedsWithSecretNeedingToBeCreated", func(t *testing.T) {
+		cs := ContainerSecret{
+			Type:  ContainerSecretPodSecret,
+			Value: "pod_secret",
+		}
+		assert.NoError(t, cs.Validate())
+	})
+	t.Run("FailsWithInvalidSecretType", func(t *testing.T) {
+		cs := ContainerSecret{
+			Type:       "",
+			ExternalID: "external_id",
+		}
+		assert.Error(t, cs.Validate())
+	})
+	t.Run("FailsWithoutExternalIDOrValueForNewSecret", func(t *testing.T) {
+		cs := ContainerSecret{
+			Type: ContainerSecretRepoCred,
+		}
+		assert.Error(t, cs.Validate())
+	})
+}
+
 func TestGetPatchTriggerAlias(t *testing.T) {
 	projRef := ProjectRef{
 		PatchTriggerAliases: []patch.PatchTriggerDefinition{{Alias: "a0"}},
@@ -2104,7 +2134,6 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, projectRef)
 	assert.Equal(t, 4, projectRef.ContainerSizes["xlarge"].CPU)
-
 }
 
 func TestIsServerResmokeProject(t *testing.T) {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -313,10 +313,13 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 		}
 	}
 
-	newProjectRef := requestProjectRef.ToService()
+	newProjectRef, err := requestProjectRef.ToService()
+	if err != nil {
+		return errors.Wrap(err, "converting new project to service model")
+	}
 	newProjectRef.RepoRefId = oldProject.RepoRefId // this can't be modified by users
 
-	h.newProjectRef = &newProjectRef
+	h.newProjectRef = newProjectRef
 	h.originalProject = oldProject
 	h.apiNewProjectRef = requestProjectRef // needed for the delete fields
 	return nil

--- a/rest/route/repo.go
+++ b/rest/route/repo.go
@@ -126,8 +126,11 @@ func (h *repoIDPatchHandler) Parse(ctx context.Context, r *http.Request) error {
 	}
 
 	// read the new changes onto it
-	pRef := h.apiNewRepoRef.ToService()
-	h.newRepoRef = &dbModel.RepoRef{ProjectRef: pRef}
+	pRef, err := h.apiNewRepoRef.ToService()
+	if err != nil {
+		return errors.Wrap(err, "converting new repo ref to service model")
+	}
+	h.newRepoRef = &dbModel.RepoRef{ProjectRef: *pRef}
 	return nil
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -303,23 +303,23 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 			Provider string                 `json:"provider"`
 			Settings map[string]interface{} `json:"settings"`
 		} `json:"alert_config"`
-		NotifyOnBuildFailure    bool                                        `json:"notify_on_failure"`
-		ForceRepotrackerRun     bool                                        `json:"force_repotracker_run"`
-		DeactivateStepbackTasks bool                                        `json:"deactivate_stepback_tasks"`
-		Subscriptions           []restModel.APISubscription                 `json:"subscriptions,omitempty"`
-		DeleteSubscriptions     []string                                    `json:"delete_subscriptions"`
-		Triggers                []model.TriggerDefinition                   `json:"triggers,omitempty"`
-		PatchTriggerAliases     []patch.PatchTriggerDefinition              `json:"patch_trigger_aliases,omitempty"`
-		GithubTriggerAliases    []string                                    `json:"github_trigger_aliases,omitempty"`
-		FilesIgnoredFromCache   []string                                    `json:"files_ignored_from_cache,omitempty"`
-		DisabledStatsCache      bool                                        `json:"disabled_stats_cache"`
-		PeriodicBuilds          []*model.PeriodicBuildDefinition            `json:"periodic_builds,omitempty"`
-		WorkstationConfig       restModel.APIWorkstationConfig              `json:"workstation_config"`
-		PerfEnabled             bool                                        `json:"perf_enabled"`
-		BuildBaronSettings      restModel.APIBuildBaronSettings             `json:"build_baron_settings"`
-		TaskAnnotationSettings  restModel.APITaskAnnotationSettings         `json:"task_annotation_settings"`
-		ContainerSizes          map[string]restModel.APIContainerResources  `json:"container_sizes"`
-		ContainerCredentials    map[string]restModel.APIContainerCredential `json:"container_credentials"`
+		NotifyOnBuildFailure    bool                                       `json:"notify_on_failure"`
+		ForceRepotrackerRun     bool                                       `json:"force_repotracker_run"`
+		DeactivateStepbackTasks bool                                       `json:"deactivate_stepback_tasks"`
+		Subscriptions           []restModel.APISubscription                `json:"subscriptions,omitempty"`
+		DeleteSubscriptions     []string                                   `json:"delete_subscriptions"`
+		Triggers                []model.TriggerDefinition                  `json:"triggers,omitempty"`
+		PatchTriggerAliases     []patch.PatchTriggerDefinition             `json:"patch_trigger_aliases,omitempty"`
+		GithubTriggerAliases    []string                                   `json:"github_trigger_aliases,omitempty"`
+		FilesIgnoredFromCache   []string                                   `json:"files_ignored_from_cache,omitempty"`
+		DisabledStatsCache      bool                                       `json:"disabled_stats_cache"`
+		PeriodicBuilds          []*model.PeriodicBuildDefinition           `json:"periodic_builds,omitempty"`
+		WorkstationConfig       restModel.APIWorkstationConfig             `json:"workstation_config"`
+		PerfEnabled             bool                                       `json:"perf_enabled"`
+		BuildBaronSettings      restModel.APIBuildBaronSettings            `json:"build_baron_settings"`
+		TaskAnnotationSettings  restModel.APITaskAnnotationSettings        `json:"task_annotation_settings"`
+		ContainerSizes          map[string]restModel.APIContainerResources `json:"container_sizes"`
+		ContainerSecrets        map[string]restModel.APIContainerSecret    `json:"container_secrets"`
 	}{}
 
 	if err = utility.ReadJSON(utility.NewRequestReader(r), &responseRef); err != nil {
@@ -549,14 +549,12 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 
 	containerSizes := map[string]model.ContainerResources{}
 	for key, apiContainerResource := range responseRef.ContainerSizes {
-		containerResource := apiContainerResource.ToService()
-		containerSizes[key] = containerResource
+		containerSizes[key] = apiContainerResource.ToService()
 	}
 
-	containerCredentials := map[string]model.ContainerCredential{}
-	for key, apiContainerCredential := range responseRef.ContainerCredentials {
-		containerCredential := apiContainerCredential.ToService()
-		containerCredentials[key] = containerCredential
+	containerSecrets := map[string]model.ContainerSecret{}
+	for key, apiContainerSecret := range responseRef.ContainerSecrets {
+		containerSecrets[key] = apiContainerSecret.ToService()
 	}
 
 	catcher := grip.NewSimpleCatcher()
@@ -571,10 +569,12 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		catcher.Wrapf(buildDef.Validate(), "invalid periodic build definition on line %d", i+1)
 	}
 	for size, containerResource := range containerSizes {
+		catcher.NewWhen(size == "", "container size name cannot be empty")
 		catcher.Wrapf(containerResource.Validate(), "invalid container size '%s'", size)
 	}
-	for name, containerCredential := range containerCredentials {
-		catcher.Wrapf(containerCredential.Validate(), "invalid container credential '%s'", name)
+	for name, containerSecret := range containerSecrets {
+		catcher.NewWhen(name == "", "container secret's name cannot be empty")
+		catcher.Wrapf(containerSecret.Validate(), "invalid container secret '%s'", name)
 	}
 	if catcher.HasErrors() {
 		uis.LoggedError(w, r, http.StatusBadRequest, catcher.Resolve())
@@ -621,7 +621,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.PeriodicBuilds = []model.PeriodicBuildDefinition{}
 	projectRef.PerfEnabled = &responseRef.PerfEnabled
 	projectRef.ContainerSizes = containerSizes
-	projectRef.ContainerCredentials = containerCredentials
+	projectRef.ContainerSecrets = containerSecrets
 	projectRef.WorkstationConfig = responseRef.WorkstationConfig.ToService()
 	if hook != nil {
 		projectRef.TracksPushEvents = utility.TruePtr()
@@ -630,7 +630,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		projectRef.PeriodicBuilds = append(projectRef.PeriodicBuilds, *periodicBuild)
 	}
 
-	if containerCredentials != nil {
+	if containerSecrets != nil {
 		// TODO: store / update these credentials in Secrets Manager if applicable
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -552,12 +552,17 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		containerSizes[key] = apiContainerResource.ToService()
 	}
 
+	catcher := grip.NewSimpleCatcher()
 	containerSecrets := map[string]model.ContainerSecret{}
 	for key, apiContainerSecret := range responseRef.ContainerSecrets {
-		containerSecrets[key] = apiContainerSecret.ToService()
+		secret, err := apiContainerSecret.ToService()
+		if err != nil {
+			catcher.Wrapf(err, "converting secret '%s' to service model", key)
+			continue
+		}
+		containerSecrets[key] = *secret
 	}
 
-	catcher := grip.NewSimpleCatcher()
 	for i := range responseRef.Triggers {
 		catcher.Add(responseRef.Triggers[i].Validate(id))
 	}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16908

### Description 
This updates the model for container secrets so that they're suitable for Secrets Manager. They don't actually store the secrets in Secrets Manager until [EVG-16913](https://jira.mongodb.org/browse/EVG-16913).

The gist of how it's going to work is that, through the REST model, the user can either send Evergreen a secret to store or ask Evergreen to give them their secret in plaintext. If they ask us to store a repo cred, this is a special case because it must be stored in Secrets Manager as a JSON-encoded string. The JSON-encoded credentials will then be stored (in [EVG-16913](https://jira.mongodb.org/browse/EVG-16913)) in Secrets Manager. After it's stored, if Evergreen ever needs to retrieve the secret value in plaintext to give back to the user, it queries Secrets Manager to get the JSON-encoded string, which gets decoded into a more nicely formatted REST response containing the username/password.

### Testing 
Updated existing unit tests and added some more validation unit tests.
