### PR TITLE
EVG-17395 Fix verify owner/repo 

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2122,12 +2122,18 @@ func (p *ProjectRef) GetGithubProjectConflicts() (GithubProjectConflicts, error)
 }
 
 func (p *ProjectRef) ValidateOwnerAndRepo(validOrgs []string) error {
+	// if the project doesn't have an owner, we want to verify the repo's owner instead
+	projectWithRepo, err := GetProjectRefMergedWithRepo(*p)
+	if err != nil {
+		return errors.Wrap(err, "getting the merged project ref")
+	}
+
 	// verify input and webhooks
-	if p.Owner == "" || p.Repo == "" {
+	if projectWithRepo.Owner == "" || projectWithRepo.Repo == "" {
 		return errors.New("no owner/repo specified")
 	}
 
-	return validateOwner(p.Owner, validOrgs)
+	return validateOwner(projectWithRepo.Owner, validOrgs)
 }
 
 func validateOwner(owner string, validOrgs []string) error {


### PR DESCRIPTION
[EVG-17395](https://jira.mongodb.org/browse/EVG-17395)

### Description 
Duplicate project didn't work because verifyOwner would make sure that the owner and repo weren't nil, which wasn't true if a project was defaulted to the repo. I updated the function to also check the repo. 

### Testing 
Tested on staging

