### PR TITLE
EVG-17370: do not skip queue regexp settings

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -489,9 +489,10 @@ func (e *envState) getNamedRemoteQueueOptions() (map[string]queue.MongoDBQueueOp
 	perQueueOpts := map[string]queue.MongoDBQueueOptions{}
 	var regexpQueueOpts []queue.RegexpMongoDBQueueOptions
 	for _, namedQueue := range e.settings.Amboy.NamedQueues {
-		if namedQueue.Name == "" {
+		if namedQueue.Name == "" && namedQueue.Regexp == "" {
 			continue
 		}
+
 		dbOpts := e.getRemoteQueueGroupDBOptions()
 		if namedQueue.SampleSize != 0 {
 			dbOpts.SampleSize = namedQueue.SampleSize


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17370

### Description 
I drive-by noticed a small bug while doing outage things (which has nothing to do with the outage). This should properly apply the queue options when using a regexp instead of a name to match the queue.

### Testing 
N/A
