### PR TITLE
EVG-17340 Update status code for task already generated error

### DIFF
--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -23,6 +23,7 @@ func GenerateTasks(taskID string, jsonBytes []json.RawMessage, group amboy.Queue
 	}
 
 	// Don't continue if the generator has already run
+	// Return status code 400 to prevent retries
 	if t.GeneratedTasks {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -3,9 +3,11 @@ package data
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/amboy"
 	"github.com/pkg/errors"
 )
@@ -22,7 +24,10 @@ func GenerateTasks(taskID string, jsonBytes []json.RawMessage, group amboy.Queue
 
 	// Don't continue if the generator has already run
 	if t.GeneratedTasks {
-		return errors.New(evergreen.TasksAlreadyGeneratedError)
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    evergreen.TasksAlreadyGeneratedError,
+		}
 	}
 
 	if err = t.SetGeneratedJSON(jsonBytes); err != nil {


### PR DESCRIPTION
[EVG-17340](https://jira.mongodb.org/browse/EVG-17340)

### Description 
doesnt repeat because it returns 400 instead of 500

### Testing 
https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%20nothing_here_release_my_first_generator_patch_edc6cd0b9f8a1b8481bcf14bc75f0a819a71aa7a_62f42d929dbe3237cc395d3f_22_08_10_22_13_44%20bynnbynn&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1660240440&latest=1660240500&sid=1660240751.6284612

doesnt repeat 

and is sucessful 

https://spruce-staging.corp.mongodb.com/task/nothing_here_release_my_first_generator_patch_edc6cd0b9f8a1b8481bcf14bc75f0a819a71aa7a_62f42d929dbe3237cc395d3f_22_08_10_22_13_44/logs?execution=1