### PR TITLE
EVG-17574: use `T.TempDir` to create temporary test directory

### DIFF
--- a/agent/agent_command_test.go
+++ b/agent/agent_command_test.go
@@ -44,8 +44,7 @@ func (s *CommandSuite) SetupTest() {
 	s.mockCommunicator = s.a.comm.(*client.Mock)
 
 	var err error
-	s.tmpDirName, err = ioutil.TempDir("", "agent-command-suite-")
-	s.Require().NoError(err)
+	s.tmpDirName = s.T().TempDir()
 	s.a.jasper, err = jasper.NewSynchronizedManager(false)
 	s.Require().NoError(err)
 
@@ -56,10 +55,6 @@ func (s *CommandSuite) SetupTest() {
 		taskModel:  &task.Task{},
 		oomTracker: &mock.OOMTracker{},
 	}
-}
-
-func (s *CommandSuite) TearDownTest() {
-	s.Require().NoError(os.RemoveAll(s.tmpDirName))
 }
 
 func (s *CommandSuite) TestShellExec() {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3,8 +3,6 @@ package agent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -74,8 +72,7 @@ func (s *AgentSuite) SetupTest() {
 	factory, ok := command.GetCommandFactory("setup.initial")
 	s.True(ok)
 	s.tc.setCurrentCommand(factory())
-	s.tmpDirName, err = ioutil.TempDir("", "agent-command-suite-")
-	s.Require().NoError(err)
+	s.tmpDirName = s.T().TempDir()
 	s.tc.taskDirectory = s.tmpDirName
 	sender, err := s.a.GetSender(ctx, evergreen.LocalLoggingOverride)
 	s.Require().NoError(err)
@@ -84,7 +81,6 @@ func (s *AgentSuite) SetupTest() {
 
 func (s *AgentSuite) TearDownTest() {
 	s.canceler()
-	s.Require().NoError(os.RemoveAll(s.tmpDirName))
 }
 
 func (s *AgentSuite) TestNextTaskResponseShouldExit() {

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -42,8 +42,7 @@ func (s *TimeoutSuite) SetupTest() {
 	s.mockCommunicator = s.a.comm.(*client.Mock)
 	var err error
 
-	s.tmpDirName, err = ioutil.TempDir("", "agent-timeout-suite-")
-	s.Require().NoError(err)
+	s.tmpDirName = s.T().TempDir()
 	s.tmpFile, err = ioutil.TempFile(s.tmpDirName, "timeout")
 	s.Require().NoError(err)
 
@@ -56,7 +55,6 @@ func (s *TimeoutSuite) SetupTest() {
 
 func (s *TimeoutSuite) TearDownTest() {
 	s.Require().NoError(os.Remove(s.tmpFileName))
-	s.Require().NoError(os.RemoveAll(s.tmpDirName))
 }
 
 // TestExecTimeoutProject tests exec_timeout_secs set on a project.

--- a/agent/command/archive_auto_extract_test.go
+++ b/agent/command/archive_auto_extract_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,8 +35,7 @@ func TestAutoExtractSuite(t *testing.T) {
 
 func (s *AutoExtractSuite) SetupTest() {
 	var err error
-	s.targetLocation, err = ioutil.TempDir("", "auto-extract-suite")
-	s.Require().NoError(err)
+	s.targetLocation = s.T().TempDir()
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
@@ -51,7 +49,6 @@ func (s *AutoExtractSuite) SetupTest() {
 
 func (s *AutoExtractSuite) TearDownTest() {
 	s.cancel()
-	s.Require().NoError(os.RemoveAll(s.targetLocation))
 }
 
 func (s *AutoExtractSuite) TestNilArguments() {

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -107,11 +107,7 @@ func TestTarGzCommandMakeArchive(t *testing.T) {
 					assert.NoError(t, os.RemoveAll(target.Name()))
 				}()
 				require.NoError(t, target.Close())
-				outputDir, err := ioutil.TempDir("", "archive_targz_output")
-				require.NoError(t, err)
-				defer func() {
-					assert.NoError(t, os.RemoveAll(outputDir))
-				}()
+				outputDir := t.TempDir()
 
 				params := map[string]interface{}{
 					"target":        target.Name(),

--- a/agent/command/archive_tarball_extract_test.go
+++ b/agent/command/archive_tarball_extract_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,8 +35,7 @@ func TestTarballExtractSuite(t *testing.T) {
 
 func (s *TarballExtractSuite) SetupTest() {
 	var err error
-	s.targetLocation, err = ioutil.TempDir("", "tarball-extract-suite")
-	s.Require().NoError(err)
+	s.targetLocation = s.T().TempDir()
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
@@ -51,7 +49,6 @@ func (s *TarballExtractSuite) SetupTest() {
 
 func (s *TarballExtractSuite) TearDownTest() {
 	s.cancel()
-	s.Require().NoError(os.RemoveAll(s.targetLocation))
 }
 
 func (s *TarballExtractSuite) TestNilArguments() {

--- a/agent/command/archive_zip_create_test.go
+++ b/agent/command/archive_zip_create_test.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,8 +34,7 @@ func TestZipCreateSuite(t *testing.T) {
 
 func (s *ZipCreateSuite) SetupTest() {
 	var err error
-	s.targetLocation, err = ioutil.TempDir("", "zip-create-suite")
-	s.Require().NoError(err)
+	s.targetLocation = s.T().TempDir()
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
@@ -51,7 +48,6 @@ func (s *ZipCreateSuite) SetupTest() {
 
 func (s *ZipCreateSuite) TearDownTest() {
 	s.cancel()
-	s.Require().NoError(os.RemoveAll(s.targetLocation))
 }
 
 func (s *ZipCreateSuite) TestNilArguments() {

--- a/agent/command/archive_zip_extract_test.go
+++ b/agent/command/archive_zip_extract_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,8 +35,7 @@ func TestZipExtractSuite(t *testing.T) {
 
 func (s *ZipExtractSuite) SetupTest() {
 	var err error
-	s.targetLocation, err = ioutil.TempDir("", "zip-extract-suite")
-	s.Require().NoError(err)
+	s.targetLocation = s.T().TempDir()
 
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
@@ -51,7 +49,6 @@ func (s *ZipExtractSuite) SetupTest() {
 
 func (s *ZipExtractSuite) TearDownTest() {
 	s.cancel()
-	s.Require().NoError(os.RemoveAll(s.targetLocation))
 }
 
 func (s *ZipExtractSuite) TestNilArguments() {

--- a/agent/command/attach_artifacts_test.go
+++ b/agent/command/attach_artifacts_test.go
@@ -34,9 +34,7 @@ func TestArtifactsSuite(t *testing.T) {
 }
 
 func (s *ArtifactsSuite) SetupSuite() {
-	var err error
-	s.tmpdir, err = ioutil.TempDir("", "evergreen.command.attach_artifacts.test")
-	s.Require().NoError(err)
+	s.tmpdir = s.T().TempDir()
 
 	path := filepath.Join(s.tmpdir, "example.json")
 	s.NoError(utility.WriteJSONFile(path,
@@ -47,12 +45,8 @@ func (s *ArtifactsSuite) SetupSuite() {
 			},
 		}))
 
-	_, err = os.Stat(path)
+	_, err := os.Stat(path)
 	s.Require().False(os.IsNotExist(err))
-}
-
-func (s *ArtifactsSuite) TearDownSuite() {
-	s.Require().NoError(os.RemoveAll(s.tmpdir))
 }
 
 func (s *ArtifactsSuite) SetupTest() {
@@ -143,10 +137,8 @@ func (s *ArtifactsSuite) TestCommandParsesFile() {
 }
 
 func (s *ArtifactsSuite) TestPrefixectoryEmptySubDir() {
-	dir, err := ioutil.TempDir("", "artifact_test")
-	defer os.RemoveAll(dir)
-	s.Require().NoError(err)
-	err = ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("[{}]"), 0644)
+	dir := s.T().TempDir()
+	err := ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("[{}]"), 0644)
 	s.Require().NoError(err)
 	s.Require().NoError(os.Mkdir(filepath.Join(dir, "subDir"), 0755))
 	err = ioutil.WriteFile(filepath.Join(dir, "subDir", "bar"), []byte("[{}]"), 0644)
@@ -158,10 +150,8 @@ func (s *ArtifactsSuite) TestPrefixectoryEmptySubDir() {
 }
 
 func (s *ArtifactsSuite) TestPrefixectoryWithSubDir() {
-	dir, err := ioutil.TempDir("", "artifact_test")
-	defer os.RemoveAll(dir)
-	s.Require().NoError(err)
-	err = ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("[{}]"), 0644)
+	dir := s.T().TempDir()
+	err := ioutil.WriteFile(filepath.Join(dir, "foo"), []byte("[{}]"), 0644)
 	s.Require().NoError(err)
 	s.Require().NoError(os.Mkdir(filepath.Join(dir, "subDir"), 0755))
 	err = ioutil.WriteFile(filepath.Join(dir, "subDir", "bar"), []byte("[{}]"), 0644)

--- a/agent/command/generate_test.go
+++ b/agent/command/generate_test.go
@@ -45,7 +45,7 @@ func (s *generateSuite) SetupTest() {
 	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
 	s.NoError(err)
 	s.g = &generateTask{}
-	s.tmpDirName, err = ioutil.TempDir("", "generate-suite-")
+	s.tmpDirName = s.T().TempDir()
 	s.conf.WorkDir = s.tmpDirName
 	s.Require().NoError(err)
 	s.json = `
@@ -73,7 +73,6 @@ func (s *generateSuite) SetupTest() {
 
 func (s *generateSuite) TearDownTest() {
 	s.cancel()
-	s.Require().NoError(os.RemoveAll(s.tmpDirName))
 }
 
 func (s *generateSuite) TestParseParamsWithNoFiles() {

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -97,9 +96,7 @@ func TestGitPush(t *testing.T) {
 			c.base.jasper = jpm
 			c.DryRun = true
 
-			var repoDir string
-			repoDir, err = ioutil.TempDir("", "test_repo")
-			require.NoError(t, err)
+			repoDir := t.TempDir()
 			require.NoError(t, ioutil.WriteFile(path.Join(repoDir, "test1.txt"), []byte("test1"), 0644))
 			require.NoError(t, ioutil.WriteFile(path.Join(repoDir, "test2.txt"), []byte("test2"), 0644))
 
@@ -136,8 +133,6 @@ func TestGitPush(t *testing.T) {
 			require.Len(t, filesChangedSlice, 2)
 			assert.Equal(t, "test1.txt", filesChangedSlice[0])
 			assert.Equal(t, "test3.txt", filesChangedSlice[1])
-
-			assert.NoError(t, os.RemoveAll(repoDir))
 		},
 		"PushPatchMock": func(*testing.T) {
 			manager := &mock.Manager{}

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -780,11 +779,7 @@ func (s *GitGetProjectSuite) TearDownSuite() {
 }
 
 func (s *GitGetProjectSuite) TestAllowsEmptyPatches() {
-	dir, err := ioutil.TempDir("", "evg-test")
-	s.Require().NoError(err)
-	defer func() {
-		s.NoError(os.RemoveAll(dir))
-	}()
+	dir := s.T().TempDir()
 
 	c := gitFetchProject{
 		Directory: dir,

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -74,8 +74,7 @@ func (s *createHostSuite) TestParamDefaults() {
 
 func (s *createHostSuite) TestParseFromFile() {
 	//file for testing parsing from a json file
-	tmpdir, err := ioutil.TempDir("", "evergreen.command.host_create.test")
-	s.Require().NoError(err)
+	tmpdir := s.T().TempDir()
 	ebsDevice := []map[string]interface{}{
 		map[string]interface{}{
 			"device_name": "myDevice",
@@ -91,7 +90,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	}
 	//parse from JSON file
 	s.NoError(utility.WriteJSONFile(path, fileContent))
-	_, err = os.Stat(path)
+	_, err := os.Stat(path)
 	s.Require().False(os.IsNotExist(err))
 	s.params = map[string]interface{}{
 		"file": path,
@@ -121,8 +120,6 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("task", s.cmd.CreateHost.Scope)
 	s.Equal("subnet-123456", s.cmd.CreateHost.Subnet)
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
-
-	s.Require().NoError(os.RemoveAll(tmpdir))
 
 	//test with both file and other params
 	s.params = map[string]interface{}{

--- a/agent/command/s3_pull_test.go
+++ b/agent/command/s3_pull_test.go
@@ -62,11 +62,7 @@ func TestS3PullExecute(t *testing.T) {
 			assert.NoError(t, tmpFile.Close())
 			require.NoError(t, err)
 
-			c.WorkingDir, err = ioutil.TempDir("", "pull_dir")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(c.WorkingDir))
-			}()
+			c.WorkingDir = t.TempDir()
 
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
 			pulledContent, err := ioutil.ReadFile(filepath.Join(c.WorkingDir, filepath.Base(tmpFile.Name())))
@@ -85,11 +81,7 @@ func TestS3PullExecute(t *testing.T) {
 			assert.NoError(t, tmpFile.Close())
 			require.NoError(t, err)
 
-			c.WorkingDir, err = ioutil.TempDir("", "pull_dir")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(c.WorkingDir))
-			}()
+			c.WorkingDir = t.TempDir()
 
 			c.ExcludeFilter = ".*"
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
@@ -104,12 +96,7 @@ func TestS3PullExecute(t *testing.T) {
 
 			require.NoError(t, ioutil.WriteFile(filepath.Join(taskDir, "foo"), []byte("bar"), 0777))
 
-			wd, err := ioutil.TempDir("", "s3-pull-output")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(wd))
-			}()
-			c.WorkingDir = wd
+			c.WorkingDir = t.TempDir()
 
 			c.ExcludeFilter = "${exclude_filter}"
 			excludeFilterExpansion := "expanded_exclude_filter"
@@ -170,11 +157,7 @@ func TestS3PullExecute(t *testing.T) {
 				Secret: conf.Task.Secret,
 			}, nil)
 			require.NoError(t, err)
-			tmpDir, err := ioutil.TempDir("", "s3-pull-bucket")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(tmpDir))
-			}()
+			tmpDir := t.TempDir()
 			c := &s3Pull{Task: "task", FromBuildVariant: "from_build_variant"}
 			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{
 				Path: tmpDir,

--- a/agent/command/s3_push_test.go
+++ b/agent/command/s3_push_test.go
@@ -44,11 +44,7 @@ func TestS3PushParseParams(t *testing.T) {
 func TestS3PushExecute(t *testing.T) {
 	for testName, testCase := range map[string]func(context.Context, *testing.T, *s3Push, *client.Mock, client.LoggerProducer, *internal.TaskConfig){
 		"PushesTaskDirectoryToS3": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
-			tmpDir, err := ioutil.TempDir("", "s3_push")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(tmpDir))
-			}()
+			tmpDir := t.TempDir()
 			workDir := filepath.Join(tmpDir, "work_dir")
 			require.NoError(t, os.MkdirAll(workDir, 0777))
 			tmpFile, err := ioutil.TempFile(workDir, "file")
@@ -75,11 +71,7 @@ func TestS3PushExecute(t *testing.T) {
 			assert.Equal(t, fileContent, pulledContent)
 		},
 		"IgnoresFilesExcludedByFilter": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
-			tmpDir, err := ioutil.TempDir("", "s3_push")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(tmpDir))
-			}()
+			tmpDir := t.TempDir()
 			workDir := filepath.Join(tmpDir, "work_dir")
 			require.NoError(t, os.MkdirAll(workDir, 0777))
 			tmpFile, err := ioutil.TempFile(workDir, "file")
@@ -106,12 +98,7 @@ func TestS3PushExecute(t *testing.T) {
 			assert.Empty(t, files)
 		},
 		"ExpandsParameters": func(ctx context.Context, t *testing.T, c *s3Push, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
-			tmpDir, err := ioutil.TempDir("", "s3_push")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(tmpDir))
-			}()
-			conf.WorkDir = tmpDir
+			conf.WorkDir = t.TempDir()
 
 			c.ExcludeFilter = "${exclude_filter}"
 			excludeFilterExpansion := "expanded_exclude_filter"
@@ -169,14 +156,9 @@ func TestS3PushExecute(t *testing.T) {
 				Secret: conf.Task.Secret,
 			}, nil)
 			require.NoError(t, err)
-			tmpDir, err := ioutil.TempDir("", "s3-push-bucket")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(tmpDir))
-			}()
 			c := &s3Push{}
 			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{
-				Path: tmpDir,
+				Path: t.TempDir(),
 			})
 			require.NoError(t, err)
 			testCase(ctx, t, c, comm, logger, conf)

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -364,8 +363,7 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 			defer cancel()
 			var err error
 
-			dir, err := ioutil.TempDir("", "s3put")
-			require.NoError(t, err)
+			dir := t.TempDir()
 			_, err = os.Create(filepath.Join(dir, "foo"))
 			require.NoError(t, err)
 			require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0755))

--- a/agent/command/util_test.go
+++ b/agent/command/util_test.go
@@ -13,20 +13,16 @@ import (
 
 func TestCreateEnclosingDirectory(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// create a temp directory and ensure that its cleaned up.
-	dirname, err := ioutil.TempDir("", "command-test")
-	require.NoError(err)
-	assert.True(dirExists(dirname))
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	// write data to a temp file and then ensure that the directory existing predicate is valid
 	fileName := filepath.Join(dirname, "foo")
 	assert.False(dirExists(fileName))
 	assert.NoError(ioutil.WriteFile(fileName, []byte("hello world"), 0744))
 	assert.False(dirExists(fileName))
-	_, err = os.Stat(fileName)
+	_, err := os.Stat(fileName)
 	assert.True(!os.IsNotExist(err))
 	assert.NoError(os.Remove(fileName))
 	_, err = os.Stat(fileName)
@@ -37,11 +33,6 @@ func TestCreateEnclosingDirectory(t *testing.T) {
 	fileName = filepath.Join(fileName, "bar")
 	assert.NoError(createEnclosingDirectoryIfNeeded(fileName))
 	assert.True(dirExists(filepath.Join(dirname, "foo")))
-
-	// ensure that directory existence check is correct
-	assert.True(dirExists(dirname))
-	assert.NoError(os.RemoveAll(dirname))
-	assert.False(dirExists(dirname))
 }
 
 func TestGetJoinedWithWorkDir(t *testing.T) {

--- a/agent/directory_test.go
+++ b/agent/directory_test.go
@@ -43,16 +43,12 @@ func TestDirectoryCleanup(t *testing.T) {
 	assert := assert.New(t)
 
 	// create a temp directory for the test
-	dir, err := ioutil.TempDir("", "dir-cleanup")
-	assert.NoError(err)
-	stat, err := os.Stat(dir)
-	assert.True(stat.IsDir())
-	assert.True(osExists(err))
+	dir := t.TempDir()
 
 	// create a file in that directory
 	fn := filepath.Join(dir, "foo")
 	assert.NoError(ioutil.WriteFile(fn, []byte("hello world!"), 0644))
-	stat, err = os.Stat(fn)
+	stat, err := os.Stat(fn)
 	assert.False(stat.IsDir())
 	assert.True(osExists(err))
 
@@ -89,6 +85,4 @@ func TestDirectoryCleanup(t *testing.T) {
 	assert.False(os.IsNotExist(err))
 	_, err = os.Stat(shouldNotDelete)
 	assert.False(os.IsNotExist(err))
-
-	assert.NoError(os.RemoveAll(dir))
 }

--- a/agent/internal/client/timeout_sender_test.go
+++ b/agent/internal/client/timeout_sender_test.go
@@ -69,9 +69,7 @@ func (s *logSenderSuite) SetupTest() {
 
 func (s *logSenderSuite) SetupSuite() {
 	s.restClient = NewHostCommunicator("foo", "hostID", "hostSecret").(*hostCommunicator)
-	tempDir, err := ioutil.TempDir("", "logSenderSuite")
-	s.Require().NoError(err)
-	s.tempDir = tempDir
+	s.tempDir = s.T().TempDir()
 	s.numMessages = 1000
 	s.maxSleep = 10 * time.Millisecond
 	rand.Seed(time.Now().UnixNano())
@@ -81,10 +79,6 @@ func (s *logSenderSuite) TearDownTest() {
 	for _, sender := range s.underlyingSenders {
 		s.Require().NoError(sender.Close())
 	}
-}
-
-func (s *logSenderSuite) TearDownSuite() {
-	s.Require().NoError(os.RemoveAll(s.tempDir))
 }
 
 func (s *logSenderSuite) randomSleep() {

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -32,10 +32,8 @@ func TestCommandFileLogging(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	tmpDirName, err := ioutil.TempDir("", "agent-logging-")
-	require.NoError(err)
+	tmpDirName := t.TempDir()
 	require.NoError(os.Mkdir(fmt.Sprintf("%s/tmp", tmpDirName), 0666))
-	defer os.RemoveAll(tmpDirName)
 
 	agt := &Agent{
 		opts: Options{
@@ -130,10 +128,7 @@ func TestCommandFileLogging(t *testing.T) {
 
 func TestStartLogging(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
-	tmpDirName, err := ioutil.TempDir("", "reset-logging-")
-	require.NoError(err)
-	defer os.RemoveAll(tmpDirName)
+	tmpDirName := t.TempDir()
 	agt := &Agent{
 		opts: Options{
 			HostID:           "host",
@@ -177,10 +172,7 @@ func TestStartLogging(t *testing.T) {
 
 func TestStartLoggingErrors(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
-	tmpDirName, err := ioutil.TempDir("", "logging-error-")
-	require.NoError(err)
-	defer os.RemoveAll(tmpDirName)
+	tmpDirName := t.TempDir()
 	agt := &Agent{
 		opts: Options{
 			HostID:           "host",

--- a/agent/util/archive_tar_test.go
+++ b/agent/util/archive_tar_test.go
@@ -31,11 +31,7 @@ func getDirectoryOfFile() string {
 func TestArchiveExtract(t *testing.T) {
 	Convey("After extracting a tarball", t, func() {
 		testDir := getDirectoryOfFile()
-		outputDir, err := ioutil.TempDir("", "artifacts_test")
-		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, os.RemoveAll(outputDir))
-		}()
+		outputDir := t.TempDir()
 
 		f, gz, tarReader, err := TarGzReader(filepath.Join(testDir, "testdata", "artifacts.tar.gz"))
 		require.NoError(t, err, "Couldn't open test tarball")
@@ -104,11 +100,7 @@ func TestArchiveRoundTrip(t *testing.T) {
 		So(gz.Close(), ShouldBeNil)
 		So(f.Close(), ShouldBeNil)
 
-		outputDir, err := ioutil.TempDir("", "artifacts_out")
-		require.NoError(t, err)
-		defer func() {
-			assert.NoError(t, os.RemoveAll(outputDir))
-		}()
+		outputDir := t.TempDir()
 		f2, gz2, tarReader, err := TarGzReader(outputFile.Name())
 		require.NoError(t, err, "Couldn't open test tarball")
 		err = extractTarArchive(context.Background(), tarReader, outputDir, []string{})

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -249,11 +249,7 @@ func TestGetSSHOptions(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			sshKeyDir, err := ioutil.TempDir("", "ssh_key_directory")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(sshKeyDir))
-			}()
+			sshKeyDir := t.TempDir()
 			testCase(t, &Host{
 				Id: "id",
 				Distro: distro.Distro{

--- a/operations/agent_monitor_test.go
+++ b/operations/agent_monitor_test.go
@@ -3,7 +3,6 @@ package operations
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -58,9 +57,7 @@ func TestAgentMonitorWithJasper(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, monitorTestTimeout)
 			defer tcancel()
 
-			tmpDir, err := ioutil.TempDir("", "monitor")
-			require.NoError(t, err)
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			m := &monitor{
 				clientPath: filepath.Join(tmpDir, "evergreen"),

--- a/operations/fetch_test.go
+++ b/operations/fetch_test.go
@@ -1,8 +1,6 @@
 package operations
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -60,12 +58,7 @@ func TestClone(t *testing.T) {
 }
 
 func runCloneTest(t *testing.T, opts cloneOptions, pass bool) {
-	tempDirName, err := ioutil.TempDir("", "testclone-")
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tempDirName))
-	}()
-	assert.NoError(t, err)
-	opts.rootDir = tempDirName
+	opts.rootDir = t.TempDir()
 	if !pass {
 		assert.Error(t, clone(opts))
 		return

--- a/operations/host_spawn_test.go
+++ b/operations/host_spawn_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -289,11 +288,7 @@ func TestHostRsync(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			localDir, err := ioutil.TempDir("", "local_dir")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(localDir))
-			}()
+			localDir := t.TempDir()
 
 			localFile, err := ioutil.TempFile(localDir, "local_file")
 			require.NoError(t, err)
@@ -302,11 +297,7 @@ func TestHostRsync(t *testing.T) {
 			require.Len(t, localFileContent, n)
 			require.NoError(t, localFile.Close())
 
-			remoteDir, err := ioutil.TempDir("", "remote_dir")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(remoteDir))
-			}()
+			remoteDir := t.TempDir()
 
 			remoteFile, err := ioutil.TempFile(remoteDir, "remote_file")
 			require.NoError(t, err)

--- a/operations/host_test.go
+++ b/operations/host_test.go
@@ -17,14 +17,12 @@ func TestHostSetupScript(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// With no setup script, noop
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err = runSetupScript(ctx, dir, false)
+	err := runSetupScript(ctx, dir, false)
 	assert.NoError(err)
 
 	// With a setup script, run the script

--- a/operations/metabuild/model/golang_test.go
+++ b/operations/metabuild/model/golang_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -729,11 +728,7 @@ func TestDiscoverPackages(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			rootPackage := util.ConsistentFilepath("github.com", "fake_user", "fake_repo")
-			gopath, err := ioutil.TempDir("", "gopath")
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, os.RemoveAll(gopath))
-			}()
+			gopath := t.TempDir()
 			rootPath := util.ConsistentFilepath(gopath, "src", rootPackage)
 			require.NoError(t, os.MkdirAll(rootPath, 0777))
 

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -119,12 +119,10 @@ func TestSetDefaultAlias(t *testing.T) {
 }
 
 func TestNewClientSettings(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "newclientsettings")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	globalTestConfigPath := filepath.Join(tmpdir, ".evergreen.test.yml")
-	err = ioutil.WriteFile(globalTestConfigPath,
+	err := ioutil.WriteFile(globalTestConfigPath,
 		[]byte(`api_server_host: https://some.evergreen.api
 ui_server_host: https://some.evergreen.ui
 api_key: not-a-valid-token
@@ -225,9 +223,7 @@ func TestLoadWorkingChangesFromFile(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "clientsettings")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	globalTestConfigPath := filepath.Join(tmpdir, ".evergreen.test.yml")
 
 	//Uncommitted changes : true

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -19,8 +18,7 @@ func TestPatchUtilTestSuite(t *testing.T) {
 }
 
 func (s *PatchUtilTestSuite) SetupSuite() {
-	dir, err := ioutil.TempDir("", "")
-	s.Require().NoError(err)
+	dir := s.T().TempDir()
 
 	s.tempDir = dir
 	s.testConfigFile = dir + ".evergreen.yml"
@@ -160,8 +158,4 @@ func (s *PatchUtilTestSuite) TestParseGitVersionString() {
 		s.NoError(err)
 		s.Equal(version, parsedVersion)
 	}
-}
-
-func (s *PatchUtilTestSuite) TearDownSuite() {
-	s.Require().NoError(os.RemoveAll(s.tempDir))
 }


### PR DESCRIPTION
[EVG-17574](https://jira.mongodb.org/browse/EVG-17574)

### Description 
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

### Testing 
Most of the tests that I modifed can be run locally without issues. Some tests required the `evg_settings.yml` which I don't have so I can't run them.