### PR TITLE
EVG-17387: Fix project dropdown naming

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -162,7 +162,7 @@ func (q *ContainerTaskQueue) getProjectRefs(tasks []task.Task) (map[string]Proje
 		return map[string]ProjectRef{}, nil
 	}
 
-	projRefs, err := FindProjectRefsByIds(projRefIDs...)
+	projRefs, err := FindMergedProjectRefsByIds(projRefIDs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project refs for tasks")
 	}

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -251,7 +251,7 @@ func (pd *PodDispatcher) checkTaskIsDispatchable(ctx context.Context, env evergr
 		return false, nil
 	}
 
-	refs, err := model.FindProjectRefsByIds(t.Project)
+	refs, err := model.FindMergedProjectRefsByIds(t.Project)
 	if err != nil {
 		return false, errors.Wrapf(err, "finding project ref '%s' for task '%s'", t.Project, t.Id)
 	}

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -251,7 +251,7 @@ func (pd *PodDispatcher) checkTaskIsDispatchable(ctx context.Context, env evergr
 		return false, nil
 	}
 
-	refs, err := model.FindMergedProjectRefsByIds(t.Project)
+	refs, err := model.FindProjectRefsByIds(t.Project)
 	if err != nil {
 		return false, errors.Wrapf(err, "finding project ref '%s' for task '%s'", t.Project, t.Id)
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1241,32 +1241,32 @@ func addLoggerAndRepoSettingsToProjects(pRefs []ProjectRef) ([]ProjectRef, error
 
 // FindAllMergedProjectRefs returns all project refs in the db, with repo ref information merged
 func FindAllMergedProjectRefs() ([]ProjectRef, error) {
-	return FindMergedProjectRefsQ(bson.M{})
+	return findProjectRefsQ(bson.M{}, true)
 }
 
 func FindMergedProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	return FindMergedProjectRefsQ(bson.M{
+	return findProjectRefsQ(bson.M{
 		ProjectRefIdKey: bson.M{
 			"$in": ids,
 		},
-	})
+	}, true)
 }
 
 func FindProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	return FindProjectRefsQ(bson.M{
+	return findProjectRefsQ(bson.M{
 		ProjectRefIdKey: bson.M{
 			"$in": ids,
 		},
-	})
+	}, false)
 }
 
-func FindMergedProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
+func findProjectRefsQ(filter bson.M, merged bool) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	q := db.Query(filter)
 	err := db.FindAllQ(ProjectRefCollection, q, &projectRefs)
@@ -1274,17 +1274,9 @@ func FindMergedProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
 		return nil, err
 	}
 
-	return addLoggerAndRepoSettingsToProjects(projectRefs)
-}
-
-func FindProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
-	projectRefs := []ProjectRef{}
-	q := db.Query(filter)
-	err := db.FindAllQ(ProjectRefCollection, q, &projectRefs)
-	if err != nil {
-		return nil, err
+	if merged {
+		return addLoggerAndRepoSettingsToProjects(projectRefs)
 	}
-
 	return projectRefs, nil
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1241,7 +1241,18 @@ func addLoggerAndRepoSettingsToProjects(pRefs []ProjectRef) ([]ProjectRef, error
 
 // FindAllMergedProjectRefs returns all project refs in the db, with repo ref information merged
 func FindAllMergedProjectRefs() ([]ProjectRef, error) {
-	return FindProjectRefsQ(bson.M{})
+	return FindMergedProjectRefsQ(bson.M{})
+}
+
+func FindMergedProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	return FindMergedProjectRefsQ(bson.M{
+		ProjectRefIdKey: bson.M{
+			"$in": ids,
+		},
+	})
 }
 
 func FindProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
@@ -1255,7 +1266,7 @@ func FindProjectRefsByIds(ids ...string) ([]ProjectRef, error) {
 	})
 }
 
-func FindProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
+func FindMergedProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	q := db.Query(filter)
 	err := db.FindAllQ(ProjectRefCollection, q, &projectRefs)
@@ -1264,6 +1275,17 @@ func FindProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
 	}
 
 	return addLoggerAndRepoSettingsToProjects(projectRefs)
+}
+
+func FindProjectRefsQ(filter bson.M) ([]ProjectRef, error) {
+	projectRefs := []ProjectRef{}
+	q := db.Query(filter)
+	err := db.FindAllQ(ProjectRefCollection, q, &projectRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	return projectRefs, nil
 }
 
 func byOwnerAndRepo(owner, repoName string) bson.M {

--- a/service/project.go
+++ b/service/project.go
@@ -32,7 +32,7 @@ func (uis *UIServer) filterViewableProjects(u *user.DBUser) ([]model.ProjectRef,
 	if err != nil {
 		return nil, err
 	}
-	projects, err := model.FindProjectRefsByIds(projectIds...)
+	projects, err := model.FindMergedProjectRefsByIds(projectIds...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[EVG-17387](https://jira.mongodb.org/browse/EVG-17387)

### Description 
Attached projects in the project dropdown were displaying their repo's display name when they did not have one set (i.e. empty string in the db). This is because the function to fetch the projects (`FindProjectRefsByIds`) was merging the projects with their repos, resulting in the displayName field being overwritten. To fix:
- Rename `FindProjectRefsByIds` to `FindMergedProjectRefsByIds`
- Added a new `FindProjectRefsByIds` that does not merge the projects and repos
- Replace all existing uses of `FindProjectRefsByIds` with `FindMergedProjectRefsByIds` to maintain previous functionality

### Testing 
Front end now renders attached project names correctly. If a project lacks a display name, its identifier is used.