### PR TITLE
EVG-17450 Agent-side v2 upgrades

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -156,7 +156,6 @@ func (c *baseCommunicator) GetProjectRef(ctx context.Context, taskData TaskData)
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("project_ref")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -174,9 +173,8 @@ func (c *baseCommunicator) GetProjectRef(ctx context.Context, taskData TaskData)
 // DisableHost signals to the app server that the host should be disabled.
 func (c *baseCommunicator) DisableHost(ctx context.Context, hostID string, details apimodels.DisableInfo) error {
 	info := requestInfo{
-		method:  http.MethodPost,
-		version: apiVersion2,
-		path:    fmt.Sprintf("hosts/%s/disable", hostID),
+		method: http.MethodPost,
+		path:   fmt.Sprintf("hosts/%s/disable", hostID),
 	}
 	resp, err := c.retryRequest(ctx, info, &details)
 	if err != nil {
@@ -193,7 +191,6 @@ func (c *baseCommunicator) GetTask(ctx context.Context, taskData TaskData) (*tas
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -215,7 +212,6 @@ func (c *baseCommunicator) GetDisplayTaskInfoFromExecution(ctx context.Context, 
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("tasks/%s/display_task", td.ID),
 		taskData: &td,
-		version:  apiVersion2,
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
@@ -236,7 +232,6 @@ func (c *baseCommunicator) GetDistroView(ctx context.Context, taskData TaskData)
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("distro_view")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -257,7 +252,6 @@ func (c *baseCommunicator) GetDistroAMI(ctx context.Context, distro, region stri
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("distros/%s/ami", distro)
 	if region != "" {
@@ -279,7 +273,6 @@ func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("parser_project")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -298,7 +291,6 @@ func (c *baseCommunicator) GetExpansions(ctx context.Context, taskData TaskData)
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("expansions")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -320,7 +312,6 @@ func (c *baseCommunicator) Heartbeat(ctx context.Context, taskData TaskData) (st
 	defer cancel()
 	info := requestInfo{
 		method:   http.MethodPost,
-		version:  apiVersion1,
 		taskData: &taskData,
 	}
 	info.setTaskPathSuffix("heartbeat")
@@ -355,7 +346,6 @@ func (c *baseCommunicator) FetchExpansionVars(ctx context.Context, taskData Task
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("fetch_vars")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -549,7 +539,6 @@ func (c *baseCommunicator) SendLogMessages(ctx context.Context, taskData TaskDat
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("log")
 	var cancel context.CancelFunc
@@ -600,7 +589,6 @@ func (c *baseCommunicator) SendTaskResults(ctx context.Context, taskData TaskDat
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("results")
 	resp, err := c.retryRequest(ctx, info, r)
@@ -620,7 +608,6 @@ func (c *baseCommunicator) GetTaskPatch(ctx context.Context, taskData TaskData, 
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	suffix := "git/patch"
 	if patchId != "" {
@@ -643,9 +630,8 @@ func (c *baseCommunicator) GetTaskPatch(ctx context.Context, taskData TaskData, 
 // GetCedarConfig returns the Cedar service configuration.
 func (c *baseCommunicator) GetCedarConfig(ctx context.Context) (*apimodels.CedarConfig, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    "agent/cedar_config",
+		method: http.MethodGet,
+		path:   "agent/cedar_config",
 	}
 
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -664,9 +650,8 @@ func (c *baseCommunicator) GetCedarConfig(ctx context.Context) (*apimodels.Cedar
 // GetDataPipesConfig returns the Data-Pipes service configuration.
 func (c *baseCommunicator) GetDataPipesConfig(ctx context.Context) (*apimodels.DataPipesConfig, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    "agent/data_pipes_config",
+		method: http.MethodGet,
+		path:   "agent/data_pipes_config",
 	}
 
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -688,7 +673,6 @@ func (c *baseCommunicator) GetPatchFile(ctx context.Context, taskData TaskData, 
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("git/patchfile/" + patchFileID)
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -716,7 +700,6 @@ func (c *baseCommunicator) SendTestLog(ctx context.Context, taskData TaskData, l
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("test_logs")
 	resp, err := c.retryRequest(ctx, info, log)
@@ -746,7 +729,6 @@ func (c *baseCommunicator) SendTestResults(ctx context.Context, taskData TaskDat
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("results")
 	resp, err := c.retryRequest(ctx, info, results)
@@ -763,7 +745,6 @@ func (c *baseCommunicator) SetHasCedarResults(ctx context.Context, taskData Task
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("tasks/%s/set_has_cedar_results", taskData.ID)
 	resp, err := c.retryRequest(ctx, info, &apimodels.CedarTestResultsTaskInfo{Failed: failed})
@@ -779,7 +760,6 @@ func (c *baseCommunicator) NewPush(ctx context.Context, taskData TaskData, req *
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 
 	info.setTaskPathSuffix("new_push")
@@ -801,7 +781,6 @@ func (c *baseCommunicator) UpdatePushStatus(ctx context.Context, taskData TaskDa
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 
 	info.setTaskPathSuffix("update_push_status")
@@ -827,7 +806,6 @@ func (c *baseCommunicator) AttachFiles(ctx context.Context, taskData TaskData, t
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("files")
 	resp, err := c.retryRequest(ctx, info, taskFiles)
@@ -843,7 +821,6 @@ func (c *baseCommunicator) SetDownstreamParams(ctx context.Context, downstreamPa
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 
 	info.setTaskPathSuffix("downstreamParams")
@@ -860,7 +837,6 @@ func (c *baseCommunicator) GetManifest(ctx context.Context, taskData TaskData) (
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("manifest/load")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -881,7 +857,6 @@ func (c *baseCommunicator) KeyValInc(ctx context.Context, taskData TaskData, kv 
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("keyval/inc")
 	resp, err := c.retryRequest(ctx, info, kv.Key)
@@ -901,7 +876,6 @@ func (c *baseCommunicator) PostJSONData(ctx context.Context, taskData TaskData, 
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix(fmt.Sprintf("json/data/%s", path))
 	resp, err := c.retryRequest(ctx, info, data)
@@ -921,7 +895,6 @@ func (c *baseCommunicator) GetJSONData(ctx context.Context, taskData TaskData, t
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix(strings.Join(pathParts, "/"))
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -949,7 +922,6 @@ func (c *baseCommunicator) GetJSONHistory(ctx context.Context, taskData TaskData
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix(path)
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -971,7 +943,6 @@ func (c *baseCommunicator) GenerateTasks(ctx context.Context, td TaskData, jsonB
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &td,
-		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("tasks/%s/generate", td.ID)
 	resp, err := c.retryRequest(ctx, info, jsonBytes)
@@ -986,7 +957,6 @@ func (c *baseCommunicator) GenerateTasksPoll(ctx context.Context, td TaskData) (
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &td,
-		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("tasks/%s/generate", td.ID)
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -1006,7 +976,6 @@ func (c *baseCommunicator) CreateHost(ctx context.Context, td TaskData, options 
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &td,
-		version:  apiVersion2,
 	}
 	info.path = fmt.Sprintf("hosts/%s/create", td.ID)
 	resp, err := c.retryRequest(ctx, info, options)
@@ -1026,7 +995,6 @@ func (c *baseCommunicator) ListHosts(ctx context.Context, td TaskData) (restmode
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &td,
-		version:  apiVersion2,
 		path:     fmt.Sprintf("hosts/%s/list", td.ID),
 	}
 
@@ -1045,9 +1013,8 @@ func (c *baseCommunicator) ListHosts(ctx context.Context, td TaskData) (restmode
 
 func (c *baseCommunicator) GetDistroByName(ctx context.Context, id string) (*restmodel.APIDistro, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    fmt.Sprintf("distros/%s", id),
+		method: http.MethodGet,
+		path:   fmt.Sprintf("distros/%s", id),
 	}
 
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -1077,7 +1044,6 @@ func (c *baseCommunicator) StartTask(ctx context.Context, taskData TaskData) err
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	info.setTaskPathSuffix("start")
 	resp, err := c.retryRequest(ctx, info, taskStartRequest)
@@ -1096,9 +1062,8 @@ func (c *baseCommunicator) StartTask(ctx context.Context, taskData TaskData) err
 // GetDockerStatus returns status of the container for the given host
 func (c *baseCommunicator) GetDockerStatus(ctx context.Context, hostID string) (*cloud.ContainerStatus, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		path:    fmt.Sprintf("hosts/%s/status", hostID),
-		version: apiVersion2,
+		method: http.MethodGet,
+		path:   fmt.Sprintf("hosts/%s/status", hostID),
 	}
 	resp, err := c.request(ctx, info, nil)
 	if err != nil {
@@ -1133,9 +1098,8 @@ func (c *baseCommunicator) GetDockerLogs(ctx context.Context, hostID string, sta
 	}
 
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    path,
+		method: http.MethodGet,
+		path:   path,
 	}
 	resp, err := c.request(ctx, info, "")
 	if err != nil {
@@ -1159,7 +1123,6 @@ func (c *baseCommunicator) ConcludeMerge(ctx context.Context, patchId, status st
 	info := requestInfo{
 		method:   http.MethodPost,
 		path:     fmt.Sprintf("commit_queue/%s/conclude_merge", patchId),
-		version:  apiVersion2,
 		taskData: &td,
 	}
 	body := struct {
@@ -1184,7 +1147,6 @@ func (c *baseCommunicator) GetAdditionalPatches(ctx context.Context, patchId str
 	info := requestInfo{
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("commit_queue/%s/additional", patchId),
-		version:  apiVersion2,
 		taskData: &td,
 	}
 	resp, err := c.request(ctx, info, nil)

--- a/agent/internal/client/host_client.go
+++ b/agent/internal/client/host_client.go
@@ -20,6 +20,9 @@ const (
 // for an agent running on a host.
 type hostCommunicator struct {
 	baseCommunicator
+
+	hostID     string
+	hostSecret string
 }
 
 // NewHostCommunicator returns a Communicator capable of making HTTP REST
@@ -32,6 +35,8 @@ func NewHostCommunicator(serverURL, hostID, hostSecret string) Communicator {
 			evergreen.HostHeader:       hostID,
 			evergreen.HostSecretHeader: hostSecret,
 		}),
+		hostID:     hostID,
+		hostSecret: hostSecret,
 	}
 
 	c.resetClient()

--- a/agent/internal/client/host_methods.go
+++ b/agent/internal/client/host_methods.go
@@ -15,9 +15,8 @@ import (
 func (c *hostCommunicator) GetAgentSetupData(ctx context.Context) (*apimodels.AgentSetupData, error) {
 	out := &apimodels.AgentSetupData{}
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion1,
-		path:    "agent/setup",
+		method: http.MethodGet,
+		path:   "agent/setup",
 	}
 
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -44,9 +43,8 @@ func (c *hostCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEn
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion1,
+		path:     fmt.Sprintf("hosts/%s/task/%s/end", c.hostID, taskData.ID),
 	}
-	info.setTaskPathSuffix("end")
 	resp, err := c.retryRequest(ctx, info, detail)
 	if err != nil {
 		return nil, utility.RespErrorf(resp, "failed to end task %s: %s", taskData.ID, err.Error())
@@ -68,10 +66,9 @@ func (c *hostCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEn
 func (c *hostCommunicator) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDetails) (*apimodels.NextTaskResponse, error) {
 	nextTask := &apimodels.NextTaskResponse{}
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion1,
+		method: http.MethodGet,
 	}
-	info.path = "agent/next_task"
+	info.path = fmt.Sprintf("hosts/%s/agent/next_task", c.hostID)
 	resp, err := c.retryRequest(ctx, info, details)
 	if err != nil {
 		err = utility.RespErrorf(resp, "failed to get next task: %s", err.Error())

--- a/agent/internal/client/pod_methods.go
+++ b/agent/internal/client/pod_methods.go
@@ -14,9 +14,8 @@ import (
 
 func (c *podCommunicator) GetAgentSetupData(ctx context.Context) (*apimodels.AgentSetupData, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    fmt.Sprintf("pods/%s/agent/setup", c.podID),
+		method: http.MethodGet,
+		path:   "agent/setup",
 	}
 
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -37,7 +36,6 @@ func (c *podCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEnd
 	info := requestInfo{
 		method:   http.MethodPost,
 		taskData: &taskData,
-		version:  apiVersion2,
 		path:     fmt.Sprintf("pods/%s/task/%s/end", c.podID, taskData.ID),
 	}
 	resp, err := c.retryRequest(ctx, info, detail)
@@ -59,9 +57,8 @@ func (c *podCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEnd
 // GetNextTask returns a next task response by getting the next task for a given host.
 func (c *podCommunicator) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDetails) (*apimodels.NextTaskResponse, error) {
 	info := requestInfo{
-		method:  http.MethodGet,
-		version: apiVersion2,
-		path:    fmt.Sprintf("pods/%s/agent/next_task", c.podID),
+		method: http.MethodGet,
+		path:   fmt.Sprintf("pods/%s/agent/next_task", c.podID),
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {

--- a/agent/internal/client/request.go
+++ b/agent/internal/client/request.go
@@ -22,22 +22,13 @@ import (
 type requestInfo struct {
 	method   string
 	path     string
-	version  apiVersion
 	taskData *TaskData
 }
 
-// Version is an "enum" for the different API versions
-type apiVersion string
-
-const (
-	apiVersion1 apiVersion = "/api/2"
-	apiVersion2 apiVersion = evergreen.APIRoutePrefixV2
-)
-
 var HTTPConflictError = errors.New(evergreen.TaskConflict)
 
-func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret, version string, data interface{}) (*http.Request, error) {
-	url := c.getPath(path, version)
+func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret string, data interface{}) (*http.Request, error) {
+	url := c.getPath(path, evergreen.APIRoutePrefixV2)
 	r, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, errors.New("Error building request")
@@ -83,7 +74,7 @@ func (c *baseCommunicator) createRequest(info requestInfo, data interface{}) (*h
 		taskID = info.taskData.ID
 		secret = info.taskData.Secret
 	}
-	r, err := c.newRequest(info.method, info.path, taskID, secret, string(info.version), data)
+	r, err := c.newRequest(info.method, info.path, taskID, secret, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating request")
 	}
@@ -185,10 +176,6 @@ func (r *requestInfo) validateRequestInfo() error {
 	case http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
 	default:
 		return errors.New("invalid HTTP method")
-	}
-
-	if r.version != apiVersion1 && r.version != apiVersion2 {
-		return errors.New("invalid API version")
 	}
 
 	return nil

--- a/agent/internal/client/request_test.go
+++ b/agent/internal/client/request_test.go
@@ -31,7 +31,7 @@ func (s *RequestTestSuite) SetupTest() {
 }
 
 func (s *RequestTestSuite) TestNewRequest() {
-	r, err := s.evergreenREST.newRequest("method", "path", "task1", "taskSecret", string(apiVersion1), nil)
+	r, err := s.evergreenREST.newRequest("method", "path", "task1", "taskSecret", nil)
 	s.NoError(err)
 	s.Equal("task1", r.Header.Get(evergreen.TaskHeader))
 	s.Equal("taskSecret", r.Header.Get(evergreen.TaskSecretHeader))
@@ -41,12 +41,8 @@ func (s *RequestTestSuite) TestNewRequest() {
 }
 
 func (s *RequestTestSuite) TestGetPathReturnsCorrectPath() {
-	// V1 path
-	path := s.evergreenREST.getPath("foo", string(apiVersion1))
-	s.Equal("url/api/2/foo", path)
-
 	// V2 path
-	path = s.evergreenREST.getPath("foo", string(apiVersion2))
+	path := s.evergreenREST.getPath("foo", evergreen.APIRoutePrefixV2)
 	s.Equal("url/rest/v2/foo", path)
 }
 
@@ -57,7 +53,6 @@ func (s *RequestTestSuite) TestValidateRequestInfo() {
 	}
 	info := requestInfo{
 		taskData: &taskData,
-		version:  apiVersion1,
 	}
 	err := info.validateRequestInfo()
 	s.Error(err)

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-08-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-08-10"
+	AgentVersion = "2022-08-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-17450](https://jira.mongodb.org/browse/EVG-17450)

### Description 
Following the merge of[ server-side](https://github.com/evergreen-ci/evergreen/pull/5860) changes to the agent routes in an effort to reduce the chance of agent errors during deployment, this PR represents the agent-side changes that were a part of [EVG-16989](https://github.com/evergreen-ci/evergreen/pull/5811/files).
### Testing 
Ran tasks and versions in staging.