### PR TITLE
EVG-16837 Remove generate tasks retry logic

### DIFF
--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -44,7 +44,7 @@ func (c *generateTask) ParseParams(params map[string]interface{}) error {
 func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	var err error
 	if err = util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "expanding params")
 	}
 
 	include := utility.NewGitIgnoreFileMatcher(conf.WorkDir, c.Files...)
@@ -53,15 +53,15 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 		Include:    include,
 	}
 	if c.Files, err = b.Build(); err != nil {
-		return errors.Wrap(err, "problem building wildcard paths")
+		return errors.Wrap(err, "building wildcard paths")
 	}
 
 	if len(c.Files) == 0 {
 		if c.Optional {
-			logger.Task().Info("No files found and optional is true, skipping generate.tasks")
+			logger.Task().Info("no files found and optional is true, skipping generate.tasks")
 			return nil
 		}
-		return errors.New("No files found for generate.tasks")
+		return errors.New("no files found for generate.tasks")
 	}
 
 	catcher := grip.NewBasicCatcher()
@@ -87,14 +87,14 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 	var post []json.RawMessage
 	post, err = makeJsonOfAllFiles(jsonBytes)
 	if err != nil {
-		return errors.Wrap(err, "problem parsing JSON")
+		return errors.Wrap(err, "parsing JSON")
 	}
 	if err = comm.GenerateTasks(ctx, td, post); err != nil {
 		if strings.Contains(err.Error(), evergreen.TasksAlreadyGeneratedError) {
 			logger.Task().Info("Tasks have already been generated, nooping.")
 			return nil
 		}
-		return errors.Wrap(err, "Problem posting task data")
+		return errors.Wrap(err, "posting task data")
 	}
 
 	const (
@@ -135,7 +135,7 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 			MaxDelay:    pollRetryMaxDelay,
 		})
 	if err != nil {
-		return errors.WithMessage(err, "problem polling for generate tasks job")
+		return errors.WithMessage(err, "polling for generate tasks job")
 	}
 	return nil
 }

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -3,6 +3,10 @@ package command
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -11,9 +15,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"os"
-	"strings"
 )
 
 type generateTask struct {

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -116,13 +116,8 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 				generateErr = errors.New(generateStatus.Error)
 			}
 
-			if generateStatus.ShouldExit {
-				return false, generateErr
-			}
 			if generateErr != nil {
-				if !strings.Contains(generateErr.Error(), evergreen.SaveGenerateTasksError) {
-					logger.Task().Infof("Problem polling for generate tasks job", generateErr.Error())
-				}
+				logger.Task().Infof("Problem polling for generate tasks job", generateErr.Error())
 				return false, generateErr
 			}
 			if generateStatus.Finished {

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -117,7 +117,6 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 			}
 
 			if generateErr != nil {
-				logger.Task().Infof("Problem polling for generate tasks job", generateErr.Error())
 				return false, generateErr
 			}
 			if generateStatus.Finished {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -45,6 +45,7 @@ type Mock struct {
 	EndTaskResult               endTaskResult
 	ShellExecFilename           string
 	TimeoutFilename             string
+	GenerateTasksShouldFail     bool
 	HeartbeatShouldAbort        bool
 	HeartbeatShouldConflict     bool
 	HeartbeatShouldErr          bool
@@ -474,10 +475,14 @@ func (c *Mock) GenerateTasks(ctx context.Context, td TaskData, jsonBytes []json.
 }
 
 func (c *Mock) GenerateTasksPoll(ctx context.Context, td TaskData) (*apimodels.GeneratePollResponse, error) {
-	return &apimodels.GeneratePollResponse{
+	resp := &apimodels.GeneratePollResponse{
 		Finished:   true,
 		ShouldExit: false,
-	}, nil
+	}
+	if c.GenerateTasksShouldFail {
+		resp.Error = "error polling generate tasks!"
+	}
+	return resp, nil
 }
 
 func (c *Mock) CreateHost(ctx context.Context, td TaskData, options apimodels.CreateHost) ([]string, error) {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-08-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-08-10"
+	AgentVersion = "2022-08-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16837](https://jira.mongodb.org/browse/EVG-16837)

### Description 
Since the merging of [this PR](https://github.com/evergreen-ci/evergreen/pull/5507) the generate tasks job uses scopes and has been moved to a single queue within the queue group. Some of the retry logic within the agent was structured to retry on error in case of a race between jobs. Now, if an error is encountered in generate.tasks the command will fail without retry.  

I did not remove the entire retry block, and we are still checking for the successful completion of a spawned generate tasks job for the given task. 
### Testing 
Tested generate.tasks in staging successfully. Added new unit test and mock property to test a failure response from polling generate.tasks.