### PR TITLE
EVG-17518: Don't clear owner or repo when defaulting project

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2243,24 +2243,11 @@ func TestValidateOwnerAndRepo(t *testing.T) {
 	err = project.ValidateOwnerAndRepo([]string{"evergreen-ci"})
 	assert.NoError(t, err)
 
-	// a project with now owner and repo that is attached to a repo with
-	// an owner and repo should not error
-	repoRef := RepoRef{ProjectRef{
-		Id:      "my_repo",
-		Enabled: utility.TruePtr(),
-		Owner:   "evergreen-ci",
-		Repo:    "test",
-	}}
-	assert.NoError(t, repoRef.Upsert())
-
-	projectWithRepo := ProjectRef{
-		Id:        "project-with-repo",
-		Enabled:   utility.TruePtr(),
-		RepoRefId: repoRef.Id,
+	// a disabled project should not error
+	disabledProject := ProjectRef{
+		Id:      "project",
+		Enabled: utility.FalsePtr(),
 	}
-	require.NoError(t, projectWithRepo.Insert())
-
-	err = projectWithRepo.ValidateOwnerAndRepo([]string{"evergreen-ci"})
+	err = disabledProject.ValidateOwnerAndRepo([]string{"evergreen-ci"})
 	assert.NoError(t, err)
-
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2199,25 +2199,28 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	assert.NotNil(t, projectRef)
 
 	update := &ProjectRef{
-		Id:    "iden_",
-		Owner: "invalid",
-		Repo:  "nonexistent",
+		Id:      "iden_",
+		Enabled: utility.TruePtr(),
+		Owner:   "invalid",
+		Repo:    "nonexistent",
 	}
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
 	assert.Error(err)
 
 	update = &ProjectRef{
-		Id:    "iden_",
-		Owner: "",
-		Repo:  "",
+		Id:      "iden_",
+		Enabled: utility.TruePtr(),
+		Owner:   "",
+		Repo:    "",
 	}
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
-	assert.NoError(err)
+	assert.Error(err)
 
 	update = &ProjectRef{
-		Id:    "iden_",
-		Owner: "evergreen-ci",
-		Repo:  "test",
+		Id:      "iden_",
+		Enabled: utility.TruePtr(),
+		Owner:   "evergreen-ci",
+		Repo:    "test",
 	}
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
 	assert.NoError(err)


### PR DESCRIPTION
[EVG-17518](https://jira.mongodb.org/browse/EVG-17518)

### Description 
- Because some queries depend on a project having an owner/repo, we shouldn't clear these fields when "Default to Repo" is clicked on the General settings page
- Allow owner/repo to be empty only if project is disabled

### Testing 
- Updated unit tests, tested on UI