### PR TITLE
EVG-17519: add flag to print current agent version

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-08-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-08-16"
+	AgentVersion = "2022-08-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17519

### Description 
Add a new flag so we can check the agent revision of a particular binary. This is helpful when diagnosing host provisioning issues because it can be hard to tell what particular version the agent is running on.

### Testing 
This seemed like a minor change, so I only checked that it worked locally using `evergreen agent --version`.