### PR TITLE
EVG-16981 Update query resolver to account for skipped execution levels

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -499,7 +499,7 @@ func (r *queryResolver) MyVolumes(ctx context.Context) ([]*restModel.APIVolume, 
 }
 
 func (r *queryResolver) Task(ctx context.Context, taskID string, execution *int) (*restModel.APITask, error) {
-	dbTask, err := task.FindOneIdWithHighestExecutionWithDisplayStatus(taskID, *execution)
+	dbTask, err := task.FindOneIdWithHighestExecutionWithDisplayStatus(taskID, execution)
 	isCached := dbTask.Execution != *execution
 	from_execution := execution
 	if err != nil {
@@ -563,7 +563,7 @@ func (r *queryResolver) TaskFiles(ctx context.Context, taskID string, execution 
 		FileCount:    0,
 		GroupedFiles: []*GroupedFiles{},
 	}
-	t, err := task.FindByIdWithHighestExecution(taskID, *execution)
+	t, err := task.FindByIdWithHighestExecution(taskID, execution)
 	if t == nil {
 		return &emptyTaskFiles, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id %s", taskID))
 	}
@@ -601,7 +601,7 @@ func (r *queryResolver) TaskFiles(ctx context.Context, taskID string, execution 
 }
 
 func (r *queryResolver) TaskLogs(ctx context.Context, taskID string, execution *int) (*TaskLogs, error) {
-	t, err := task.FindByIdWithHighestExecution(taskID, *execution)
+	t, err := task.FindByIdWithHighestExecution(taskID, execution)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding task by id %s: %s", taskID, err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -512,7 +512,7 @@ func (r *queryResolver) Task(ctx context.Context, taskID string, execution *int)
 	}
 	// If the executions don't match, the dbTask is a previous task (this task was cached)
 	if execution != nil && dbTask.Execution != *execution {
-		apiTask.FromExecution = execution
+		apiTask.CachedFromExecution = execution
 	}
 	return apiTask, err
 }
@@ -537,7 +537,7 @@ func (r *queryResolver) TaskAllExecutions(ctx context.Context, taskID string) ([
 			previousTask := allTasks[i-1]
 			if previousTask != nil {
 				apiTask := *previousTask
-				apiTask.FromExecution = &apiTask.Execution
+				apiTask.CachedFromExecution = &apiTask.Execution
 				apiTask.Execution = i
 				allTasks = append(allTasks, &apiTask)
 				continue

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1233,6 +1233,9 @@ func FindByIdExecution(id string, execution *int) (*Task, error) {
 // FindByIdWithHighestExecution returns a single task with the given ID and execution.
 // If the execution doesn't exist, it finds the closest execution below.
 func FindByIdWithHighestExecution(id string, execution *int) (*Task, error) {
+	if execution == nil {
+		return FindOneId(id)
+	}
 	var task *Task
 	var err error
 	for i := *execution; i >= 0; i-- {
@@ -1288,9 +1291,13 @@ func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, e
 	return FindOneOldByIdAndExecutionWithDisplayStatus(id, execution)
 }
 
-// FindByIdWithHighestExecution returns a single task with the given ID and execution.
-// If the execution doesn't exist, it finds the closest execution below.
+// FindByIdWithHighestExecution returns a single task with the given ID and execution,
+// with display statuses added. If the execution doesn't exist, it finds the closest
+// execution below.
 func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
+	if execution == nil {
+		return FindOneIdAndExecutionWithDisplayStatus(id, nil)
+	}
 	var task *Task
 	var err error
 	for i := *execution; i >= 0; i-- {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1230,6 +1230,20 @@ func FindByIdExecution(id string, execution *int) (*Task, error) {
 	return FindOneIdAndExecution(id, *execution)
 }
 
+// FindByIdWithHighestExecution returns a single task with the given ID and execution.
+// If the execution doesn't exist, it finds the closest execution below.
+func FindByIdWithHighestExecution(id string, execution int) (*Task, error) {
+	var task *Task
+	var err error
+	for i := execution; i >= 0; i-- {
+		task, err = FindByIdExecution(id, &execution)
+		if err == nil && task != nil {
+			break
+		}
+	}
+	return task, errors.Wrap(err, "finding task with highest execution")
+}
+
 // FindOneIdAndExecution returns a single task with the given ID and execution.
 func FindOneIdAndExecution(id string, execution int) (*Task, error) {
 	task := &Task{}
@@ -1272,6 +1286,20 @@ func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, e
 	}
 
 	return FindOneOldByIdAndExecutionWithDisplayStatus(id, execution)
+}
+
+// FindByIdWithHighestExecution returns a single task with the given ID and execution.
+// If the execution doesn't exist, it finds the closest execution below.
+func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution int) (*Task, error) {
+	var task *Task
+	var err error
+	for i := execution; i >= 0; i-- {
+		task, err = FindOneIdAndExecutionWithDisplayStatus(id, &execution)
+		if err == nil && task != nil {
+			break
+		}
+	}
+	return task, errors.Wrap(err, "finding task with highest execution")
 }
 
 // FindOneOldByIdAndExecutionWithDisplayStatus returns a single task with the

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1232,11 +1232,11 @@ func FindByIdExecution(id string, execution *int) (*Task, error) {
 
 // FindByIdWithHighestExecution returns a single task with the given ID and execution.
 // If the execution doesn't exist, it finds the closest execution below.
-func FindByIdWithHighestExecution(id string, execution int) (*Task, error) {
+func FindByIdWithHighestExecution(id string, execution *int) (*Task, error) {
 	var task *Task
 	var err error
-	for i := execution; i >= 0; i-- {
-		task, err = FindByIdExecution(id, &execution)
+	for i := *execution; i >= 0; i-- {
+		task, err = FindByIdExecution(id, execution)
 		if err == nil && task != nil {
 			break
 		}
@@ -1290,11 +1290,11 @@ func FindOneIdAndExecutionWithDisplayStatus(id string, execution *int) (*Task, e
 
 // FindByIdWithHighestExecution returns a single task with the given ID and execution.
 // If the execution doesn't exist, it finds the closest execution below.
-func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution int) (*Task, error) {
+func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution *int) (*Task, error) {
 	var task *Task
 	var err error
-	for i := execution; i >= 0; i-- {
-		task, err = FindOneIdAndExecutionWithDisplayStatus(id, &execution)
+	for i := *execution; i >= 0; i-- {
+		task, err = FindOneIdAndExecutionWithDisplayStatus(id, execution)
 		if err == nil && task != nil {
 			break
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1239,7 +1239,7 @@ func FindByIdWithHighestExecution(id string, execution *int) (*Task, error) {
 	var task *Task
 	var err error
 	for i := *execution; i >= 0; i-- {
-		task, err = FindByIdExecution(id, execution)
+		task, err = FindByIdExecution(id, &i)
 		if err == nil && task != nil {
 			break
 		}
@@ -1301,7 +1301,7 @@ func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution *int) (
 	var task *Task
 	var err error
 	for i := *execution; i >= 0; i-- {
-		task, err = FindOneIdAndExecutionWithDisplayStatus(id, execution)
+		task, err = FindOneIdAndExecutionWithDisplayStatus(id, &i)
 		if err == nil && task != nil {
 			break
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1244,7 +1244,7 @@ func FindByIdWithHighestExecution(id string, execution *int) (*Task, error) {
 			break
 		}
 	}
-	return task, errors.Wrap(err, "finding task with highest execution")
+	return task, errors.Wrapf(err, "finding task '%s' with highest execution", id)
 }
 
 // FindOneIdAndExecution returns a single task with the given ID and execution.
@@ -1306,7 +1306,7 @@ func FindOneIdWithHighestExecutionWithDisplayStatus(id string, execution *int) (
 			break
 		}
 	}
-	return task, errors.Wrap(err, "finding task with highest execution")
+	return task, errors.Wrapf(err, "finding task '%s' with highest execution", id)
 }
 
 // FindOneOldByIdAndExecutionWithDisplayStatus returns a single task with the

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -76,6 +76,11 @@ type APITask struct {
 	AMI                     *string             `json:"ami"`
 	MustHaveResults         bool                `json:"must_have_test_results"`
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
+
+	// These fields are only for cached tasks (tasks displaying info from a previous task)
+	IsCachedResult bool `json:"is_cached"`
+	FromExecution  int  `json:"from_execution"`
+
 	// These fields are used by graphql gen, but do not need to be exposed
 	// via Evergreen's user-facing API.
 	OverrideDependencies bool `json:"-"`

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -78,7 +78,7 @@ type APITask struct {
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
 
 	// These fields are only for cached tasks (tasks displaying info from a previous task)
-	FromExecution *int `json:"from_execution,omitempty"`
+	CachedFromExecution *int `json:"from_execution,omitempty"`
 
 	// These fields are used by graphql gen, but do not need to be exposed
 	// via Evergreen's user-facing API.

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -78,7 +78,7 @@ type APITask struct {
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
 
 	// These fields are only for cached tasks (tasks displaying info from a previous task)
-	FromExecution *int `json:"from_execution"`
+	FromExecution *int `json:"from_execution,omitempty"`
 
 	// These fields are used by graphql gen, but do not need to be exposed
 	// via Evergreen's user-facing API.

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -78,8 +78,7 @@ type APITask struct {
 	BaseTask                APIBaseTaskInfo     `json:"base_task"`
 
 	// These fields are only for cached tasks (tasks displaying info from a previous task)
-	IsCachedResult bool `json:"is_cached"`
-	FromExecution  int  `json:"from_execution"`
+	FromExecution *int `json:"from_execution"`
 
 	// These fields are used by graphql gen, but do not need to be exposed
 	// via Evergreen's user-facing API.


### PR DESCRIPTION
[EVG-16981](https://jira.mongodb.org/browse/EVG-16981)

### Description 
Exposes two new fields for api tasks that hold the information if the task information was pulled from a previous task, as well as the execution of that task that the information was pulled from. Adds a couple db methods to pull tasks from previous executions, and updates the query resolver to use them. The query resolver also sets the fields if the task was taken from a previous one. This is so spruce can include these fields in its graphql request and then display information like (cached from x execution).

### Testing 
Deployed to spruce and tested on patch https://spruce-staging.corp.mongodb.com/version/62fbf4bf9dbe32458bd4dff7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

This patch has the following history / state:
display_task
- always_fail
- validate_commit_message (always succeeds)

It was restarted like:
- Only failed
- Restart all
- Restart all

Leaving the complete state as such:
display_task execution on the fourth (execution = 3)
- always_fail
  - execution 0: failed
  - execution 1: failed
  - execution 2: failed
  - execution 3: failed
- validate_commit_message
  - execution 0: success
  - execution 1: N/A (cache from execution 0)
  - execution 2: success
  - execution 3: success

Viewing validate_commit_message without this PR will show a broken execution dropdown, and you can manually adjust the execution number at the end of the link and you can successfully view 0, 2, and 3. You cannot view the non-existent 1.

With this PR, you can view execution = 1 (the 2nd execution) and it will display the same information as execution = 0 (the 1st execution). As well as a proper dropdown that has access to all tasks (the frontend also recieves if it was cached here too)

It also returns the IsCachedResult and FromExecution inside the APITask as well, but the frontend doesn't read those values.

Viewing dropdown
Viewing execution = 0 (1st execution)
Viewing execution = 1 (2nd execution)

With PR:
<img width="390" alt="Screen Shot 2022-08-18 at 9 29 45 AM" src="https://user-images.githubusercontent.com/64446617/185407259-2c2a52a0-e950-4854-aebb-28462f37d0bf.png">
<img width="396" alt="Screen Shot 2022-08-18 at 9 20 55 AM" src="https://user-images.githubusercontent.com/64446617/185407312-82b1ac1d-4833-4881-9f71-673912a3364f.png">
<img width="424" alt="Screen Shot 2022-08-18 at 9 29 34 AM" src="https://user-images.githubusercontent.com/64446617/185407332-d59b0c6b-02f4-4abb-9c20-4f0218c6cded.png">

Without PR:
<img width="507" alt="Screen Shot 2022-08-18 at 9 37 21 AM" src="https://user-images.githubusercontent.com/64446617/185408785-aa5d22d8-c94d-4fc5-b6d2-4308e3506e6d.png">
<img width="548" alt="Screen Shot 2022-08-18 at 9 37 14 AM" src="https://user-images.githubusercontent.com/64446617/185408883-0d6c23f1-d690-43b6-9ea2-fbb4018598c3.png">
<img width="569" alt="Screen Shot 2022-08-18 at 9 36 57 AM" src="https://user-images.githubusercontent.com/64446617/185408897-21a82d8d-62fc-4dcf-9360-f0cdc2653010.png">
