### PR TITLE
EVG-16983 Update stranded restarts to account for ResetFailedWhenFinished

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1583,6 +1583,10 @@ func resetStrandedTask(t *task.Task) error {
 				return errors.Wrap(err, "finding execution tasks")
 			}
 
+			if len(execTasks) == 0 {
+				return errors.Wrap(err, "no execution tasks found")
+			}
+
 			for _, execTask := range execTasks {
 				if err != nil { // Keeping existing error check logic?
 					return errors.Wrap(err, "finding execution task")

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1574,11 +1574,8 @@ func resetStrandedTask(t *task.Task) error {
 			if err != nil {
 				return errors.Wrap(err, "finding execution tasks")
 			}
-			if len(execTasks) == 0 {
-				return errors.Wrap(err, "no execution tasks found")
-			}
 			for _, execTask := range execTasks {
-				if evergreen.IsFinishedTaskStatus(execTask.Status) {
+				if !evergreen.IsFinishedTaskStatus(execTask.Status) {
 					if err := MarkEnd(&execTask, evergreen.MonitorPackage, time.Now(), &t.Details, false); err != nil {
 						return errors.Wrap(err, "marking execution task as ended")
 					}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1570,16 +1570,24 @@ func resetStrandedTask(t *task.Task) error {
 		// If the task has already exceeded the unschedulable threshold, we
 		// don't want to restart it, so just mark it as finished.
 		if t.DisplayOnly {
-			for _, etID := range t.ExecutionTasks {
-				var execTask *task.Task
-				execTask, err := task.FindOneId(etID)
-				if err != nil {
+			var execTasks []task.Task
+			var err error
+
+			if t.ResetFailedWhenFinished && !t.ResetWhenFinished {
+				execTasks, err = task.Find(task.FailedTasksByIds(t.ExecutionTasks))
+			} else {
+				execTasks, err = task.FindAll(db.Query(task.ByIds(t.ExecutionTasks)))
+			}
+
+			if err != nil {
+				return errors.Wrap(err, "finding execution tasks")
+			}
+
+			for _, execTask := range execTasks {
+				if err != nil { // Keeping existing error check logic?
 					return errors.Wrap(err, "finding execution task")
 				}
-				if execTask == nil {
-					return errors.New("execution task not found")
-				}
-				if err := MarkEnd(execTask, evergreen.MonitorPackage, time.Now(), &t.Details, false); err != nil {
+				if err := MarkEnd(&execTask, evergreen.MonitorPackage, time.Now(), &t.Details, false); err != nil {
 					return errors.Wrap(err, "marking execution task as ended")
 				}
 			}
@@ -1587,7 +1595,7 @@ func resetStrandedTask(t *task.Task) error {
 		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &t.Details, false))
 	}
 
-	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, false, &t.Details), "resetting task")
+	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, t.ResetFailedWhenFinished && !t.ResetWhenFinished, &t.Details), "resetting task")
 }
 
 // ResetTaskOrDisplayTask is a wrapper for TryResetTask that handles execution and display tasks that are restarted

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3668,7 +3668,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			dbDisplayTask, err := task.FindOneId(dt.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbDisplayTask)
-			assert.True(t, dbDisplayTask.ResetWhenFinished, "display task should reset when other exec task finishes running")
+			assert.True(t, dbDisplayTask.ResetFailedWhenFinished, "display task should reset failed when other exec task finishes running")
 
 			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
 			assert.NoError(t, err)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3367,6 +3367,73 @@ func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
 	assert.Equal("system", runningTask.Details.Type)
 }
 
+func TestClearAndResetStrandedHostTaskFailedOnly(t *testing.T) {
+	require.NoError(t, db.ClearCollections(host.Collection, task.Collection, task.OldCollection, build.Collection, VersionCollection))
+
+	dispTask := &task.Task{
+		Id:                      "dt",
+		Status:                  evergreen.TaskStarted,
+		Version:                 "version",
+		Activated:               true,
+		ActivatedTime:           time.Now(),
+		BuildId:                 "b",
+		ExecutionTasks:          []string{"et1", "et2"},
+		ResetFailedWhenFinished: true,
+		DisplayOnly:             true,
+	}
+
+	execTask1 := &task.Task{
+		Id:            "et1",
+		Status:        evergreen.TaskStarted,
+		Version:       "version",
+		Activated:     true,
+		ActivatedTime: time.Now(),
+		BuildId:       "b",
+	}
+
+	execTask2 := &task.Task{
+		Id:            "et2",
+		Status:        evergreen.TaskSucceeded,
+		Version:       "version",
+		Activated:     true,
+		ActivatedTime: time.Now(),
+		BuildId:       "b",
+	}
+	assert.NoError(t, dispTask.Insert())
+	assert.NoError(t, execTask1.Insert())
+	assert.NoError(t, execTask2.Insert())
+
+	h := &host.Host{
+		Id:          "h1",
+		RunningTask: "et1",
+	}
+	assert.NoError(t, h.Insert())
+
+	b := build.Build{
+		Id:      "b",
+		Version: "version",
+	}
+	assert.NoError(t, b.Insert())
+	v := Version{
+		Id: "version",
+	}
+	assert.NoError(t, v.Insert())
+
+	assert.NoError(t, ClearAndResetStrandedHostTask(h))
+	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)
+	assert.Equal(t, 1, restartedDisplayTask.Execution)
+	restartedExecutionTask, err := task.FindOne(db.Query(task.ById("et1")))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, restartedExecutionTask.Execution)
+	assert.Equal(t, evergreen.TaskUndispatched, restartedExecutionTask.Status)
+	nonRestartedExecutionTask, err := task.FindOne(db.Query(task.ById("et2")))
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.TaskSucceeded, nonRestartedExecutionTask.Status)
+	assert.Equal(t, 0, nonRestartedExecutionTask.Execution)
+}
+
 func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.LegacyEventLogCollection))


### PR DESCRIPTION
[EVG-16983](https://jira.mongodb.org/browse/EVG-16983)

### Description 
Adds checks to test if a display task has ResetFailedWhenFinished set to true (overriden by RestartWhenFinished)

### Testing 
Existing unit tests and TBA testing
