### PR TITLE
EVG-17556 check webhooks at more places

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -337,7 +337,7 @@ func (r *mutationResolver) AttachProjectToNewRepo(ctx context.Context, project M
 	pRef.Owner = project.NewOwner
 	pRef.Repo = project.NewRepo
 
-	if err = pRef.AttachToNewRepo(usr); err != nil {
+	if err = pRef.AttachToNewRepo(ctx, usr); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating owner/repo: %s", err.Error()))
 	}
 
@@ -375,7 +375,7 @@ func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.
 	}
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 
-	if err := data.CreateProject(dbProjectRef, u); err != nil {
+	if err := data.CreateProject(ctx, dbProjectRef, u); err != nil {
 		apiErr, ok := err.(gimlet.ErrorResponse)
 		if ok {
 			if apiErr.StatusCode == http.StatusBadRequest {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -309,7 +309,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, u.Insert())
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
-	assert.NoError(t, pRef.AttachToNewRepo(u))
+	assert.NoError(t, pRef.AttachToNewRepo(context.Background(), u))
 
 	pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 	assert.NoError(t, err)
@@ -340,7 +340,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, pRef.Insert())
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
-	assert.NoError(t, pRef.AttachToNewRepo(u))
+	assert.NoError(t, pRef.AttachToNewRepo(context.Background(), u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
 
@@ -2085,11 +2085,11 @@ func TestMergeWithProjectConfig(t *testing.T) {
 				},
 			},
 			ContainerSizes: map[string]ContainerResources{
-				"small": ContainerResources{
+				"small": {
 					MemoryMB: 200,
 					CPU:      1,
 				},
-				"large": ContainerResources{
+				"large": {
 					MemoryMB: 400,
 					CPU:      2,
 				},
@@ -2125,7 +2125,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.Equal(t, 2, projectRef.ContainerSizes["large"].CPU)
 
 	projectRef.ContainerSizes = map[string]ContainerResources{
-		"xlarge": ContainerResources{
+		"xlarge": {
 			MemoryMB: 800,
 			CPU:      4,
 		},

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -49,7 +49,7 @@ func FindProjectById(id string, includeRepo bool, includeProjectConfig bool) (*m
 }
 
 // CreateProject inserts the given model.ProjectRef.
-func CreateProject(projectRef *model.ProjectRef, u *user.DBUser) error {
+func CreateProject(ctx context.Context, projectRef *model.ProjectRef, u *user.DBUser) error {
 	config, err := evergreen.GetConfig()
 	if err != nil {
 		return gimlet.ErrorResponse{
@@ -101,6 +101,16 @@ func CreateProject(projectRef *model.ProjectRef, u *user.DBUser) error {
 		"project_identifier": projectRef.Identifier,
 		"user":               u.DisplayName(),
 	}))
+	_, err = model.EnableWebhooks(ctx, projectRef)
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":            "error enabling webhooks",
+			"project_id":         projectRef.Id,
+			"project_identifier": projectRef.Identifier,
+			"owner":              projectRef.Owner,
+			"repo":               projectRef.Repo,
+		}))
+	}
 	return nil
 }
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -139,6 +139,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err != nil {
 				return nil, errors.Wrapf(err, "enabling webhooks for project '%s'", projectId)
 			}
+			modified = true
 		} else if mergedProjectRef.IsEnabled() && !mergedBeforeRef.IsEnabled() {
 			if err = handleGithubConflicts(mergedBeforeRef, "Enabling project"); err != nil {
 				return nil, err

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -52,7 +52,7 @@ func CopyProject(ctx context.Context, opts CopyProjectOpts) (*restModel.APIProje
 	disableStartingSettings(projectToCopy)
 
 	u := gimlet.GetUser(ctx).(*user.DBUser)
-	if err := CreateProject(projectToCopy, u); err != nil {
+	if err := CreateProject(ctx, projectToCopy, u); err != nil {
 		return nil, err
 	}
 	apiProjectRef := &restModel.APIProjectRef{}
@@ -134,12 +134,11 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err = handleGithubConflicts(mergedBeforeRef, "Changing owner/repo"); err != nil {
 				return nil, err
 			}
-			// check if webhook is enabled if the owner/repo has changed
+			// Check if webhook is enabled if the owner/repo has changed
 			_, err = model.EnableWebhooks(ctx, mergedProjectRef)
 			if err != nil {
 				return nil, errors.Wrapf(err, "enabling webhooks for project '%s'", projectId)
 			}
-			modified = true
 		} else if mergedProjectRef.IsEnabled() && !mergedBeforeRef.IsEnabled() {
 			if err = handleGithubConflicts(mergedBeforeRef, "Enabling project"); err != nil {
 				return nil, err

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -606,7 +606,7 @@ func (h *projectIDPutHandler) Parse(ctx context.Context, r *http.Request) error 
 	return nil
 }
 
-// creates a new resource based on the Request-URI and JSON payload and returns a http.StatusCreated (201)
+// Run creates a new resource based on the Request-URI and JSON payload and returns a http.StatusCreated (201)
 func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 	p, err := data.FindProjectById(h.projectName, false, false)
 	if err != nil && err.(gimlet.ErrorResponse).StatusCode != http.StatusNotFound {
@@ -629,7 +629,7 @@ func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 
-	if err = data.CreateProject(&dbProjectRef, u); err != nil {
+	if err = data.CreateProject(ctx, &dbProjectRef, u); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating project '%s'", h.projectName))
 	}
 
@@ -989,7 +989,7 @@ func (p *GetProjectAliasResultsHandler) Parse(ctx context.Context, r *http.Reque
 	if p.alias == "" {
 		return errors.New("alias parameter must be specified")
 	}
-	p.includeDependencies = (params.Get("include_deps") == "true")
+	p.includeDependencies = params.Get("include_deps") == "true"
 
 	return nil
 }

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -285,7 +285,7 @@ Evergreen Projects
       </div>
       <div class="h3">Repotracker Settings</div>
       <div class="project-error" ng-hide="github_webhooks_enabled">
-        Webhooks must be enabled to run the repotracker. Webhooks are enabled after saving with a valid repository and branch.
+        Webhooks must be enabled to run the repotracker. Webhooks are enabled after saving with a valid owner and repo.
       </div>
       <div class="form-group" ng-show="github_webhooks_enabled">
         <div class="col-lg-5 col-header">
@@ -423,7 +423,7 @@ Evergreen Projects
             GitHub webhooks are enabled.
           </div>
           <div class="project-error" ng-hide="github_webhooks_enabled">
-            <div>GitHub Pull Request testing and the commit queue are disabled because webhooks are not enabled. Webhooks are enabled after saving with a repository and branch.</div>
+            <div>GitHub Pull Request testing and the commit queue are disabled because webhooks are not enabled. Webhooks are enabled after saving with a owner and repo.</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
[EVG-17556](https://jira.mongodb.org/browse/EVG-17556)

### Description 
Check webhooks during project creation and when owner/repo changes.
Created https://github.com/evergreen-ci/spruce/pull/1407 to fix spruce text.

### Testing 
Tested with a local project and verified that we attempted to setup webhooks with a new project.
