### PR TITLE
EVG-17550: unset container allocation when task finishes

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1883,19 +1883,24 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 	t.Status = detail.Status
 	t.FinishTime = finishTime
 	t.Details = *detail
+	t.ContainerAllocated = false
 	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				FinishTimeKey:       finishTime,
-				StatusKey:           detail.Status,
-				TimeTakenKey:        t.TimeTaken,
-				DetailsKey:          detail,
-				StartTimeKey:        t.StartTime,
-				LogsKey:             detail.Logs,
-				HasLegacyResultsKey: t.HasLegacyResults,
+				FinishTimeKey:         finishTime,
+				StatusKey:             detail.Status,
+				TimeTakenKey:          t.TimeTaken,
+				DetailsKey:            detail,
+				StartTimeKey:          t.StartTime,
+				LogsKey:               detail.Logs,
+				HasLegacyResultsKey:   t.HasLegacyResults,
+				ContainerAllocatedKey: false,
+			},
+			"$unset": bson.M{
+				ContainerAllocatedTimeKey: 1,
 			},
 		})
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1057,6 +1057,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 		Id: "p1",
 	}
 	assert.NoError(t, projRef.Insert())
+
 	Convey("With a successful task one failed test should result in a task failure", t, func() {
 		displayName := "testName"
 
@@ -3749,13 +3750,16 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			}
 			require.NoError(t, v.Insert())
 			tsk := task.Task{
-				Id:            "task_id",
-				Execution:     1,
-				Status:        evergreen.TaskStarted,
-				Activated:     true,
-				ActivatedTime: time.Now(),
-				BuildId:       b.Id,
-				Version:       v.Id,
+				Id:                     "task_id",
+				Execution:              1,
+				ExecutionPlatform:      task.ExecutionPlatformContainer,
+				ContainerAllocated:     true,
+				ContainerAllocatedTime: time.Now(),
+				Status:                 evergreen.TaskStarted,
+				Activated:              true,
+				ActivatedTime:          time.Now(),
+				BuildId:                b.Id,
+				Version:                v.Id,
 			}
 			p := pod.Pod{
 				ID:          "pod_id",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17550

### Description 
I'm splitting up this ticket so there will be a follow-up PR to re-assess the task's container allocation state during pod allocation to avoid unnecessarily giving a task more pods to run it. For now, just resetting the container allocation state when the task finishes should be good enough to allow tasks to restart in the normal way, barring edge cases like tasks whose agents abruptly stop (which is supposed to be handled in [EVG-16883](https://jira.mongodb.org/browse/EVG-16883) and [EVG-16884](https://jira.mongodb.org/browse/EVG-16884)).

### Testing 
Added unit tests.