### PR TITLE
EVG-17550: check number of pods allocated before allocating more

### DIFF
--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -125,17 +125,26 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		return
 	}
 
-	if _, err := dispatcher.Allocate(ctx, j.env, j.task, intentPod); err != nil {
+	pd, err := dispatcher.Allocate(ctx, j.env, j.task, intentPod)
+	if err != nil {
 		j.AddRetryableError(errors.Wrap(err, "allocating pod for task dispatch"))
 		return
 	}
 
-	grip.Info(message.Fields{
-		"message":                    "successfully allocated pod for container task",
-		"task":                       j.task.Id,
-		"pod":                        intentPod.ID,
-		"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
-	})
+	if utility.StringSliceContains(pd.PodIDs, intentPod.ID) {
+		grip.Info(message.Fields{
+			"message":                    "successfully allocated pod for container task",
+			"task":                       j.task.Id,
+			"pod":                        intentPod.ID,
+			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
+		})
+	} else {
+		grip.Info(message.Fields{
+			"message":                    "container task already has a pod allocated to run it",
+			"task":                       j.task.Id,
+			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
+		})
+	}
 }
 
 func (j *podAllocatorJob) canAllocate() (shouldAllocate bool, err error) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17550

### Description 
This is the follow-up PR to #5878 to ensure that we do not wastefully allocate more pods when tasks are deallocated. If the task does not need another pod allocated to it, the task is just re-marked as allocated without giving it another pod.

### Testing 
Updated pod allocator unit tests.