### PR TITLE
EVG-16900: clean up stale pod definitions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20220811175637-7f2d39fe31aa
+	github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788
 	github.com/evergreen-ci/gimlet v0.0.0-20220419172609-b882e01673e7
 	github.com/evergreen-ci/go-test2json v0.0.0-20180702150328-5b6cfd2e8cb0
 	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20220811175637-7f2d39fe31aa h1:7dshwaCsCOEyQP/Q2idQqcVt3QbofajHhZD5wQcwQ/A=
-github.com/evergreen-ci/cocoa v0.0.0-20220811175637-7f2d39fe31aa/go.mod h1:FC3CXscglVmGWfTFEjo9yi0RDEUXFijmeyKx6O8NTQ4=
+github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788 h1:rgb9st+6bsGagnXGh6MCSP0IWLfdArOB4YeDJUpz2tE=
+github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788/go.mod h1:FC3CXscglVmGWfTFEjo9yi0RDEUXFijmeyKx6O8NTQ4=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -55,6 +55,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 		PopulateVolumeExpirationJob(),
 		PopulateSSHKeyUpdates(j.env),
 		PopulateDuplicateTaskCheckJobs(),
+		PopulatePodDefinitionCleanupJobs(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/pod_definition_cleanup.go
+++ b/units/pod_definition_cleanup.go
@@ -1,0 +1,139 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/pod/definition"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const (
+	podDefinitionCleanupJobName = "pod-definition-cleanup"
+	podDefinitionTTL            = 30 * 24 * time.Hour
+)
+
+func init() {
+	registry.AddJobType(podDefinitionCleanupJobName, func() amboy.Job {
+		return makePodDefinitionCleanupJob()
+	})
+}
+
+type podDefinitionCleanupJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+
+	env       evergreen.Environment
+	settings  evergreen.Settings
+	ecsClient cocoa.ECSClient
+	podDefMgr cocoa.ECSPodDefinitionManager
+}
+
+func makePodDefinitionCleanupJob() *podDefinitionCleanupJob {
+	j := &podDefinitionCleanupJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    podDefinitionCleanupJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewPodDefinitionCleanupJob creates a job that cleans up pod definitions that
+// have not been used recently.
+func NewPodDefinitionCleanupJob(id string) amboy.Job {
+	j := makePodDefinitionCleanupJob()
+	j.SetID(fmt.Sprintf("%s.%s", podDefinitionCleanupJobName, id))
+	return j
+}
+
+func (j *podDefinitionCleanupJob) Run(ctx context.Context) {
+	defer func() {
+		j.MarkComplete()
+
+		if j.ecsClient != nil {
+			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
+		}
+	}()
+	if err := j.populate(); err != nil {
+		j.AddError(err)
+		return
+	}
+
+	podDefs, err := definition.FindByLastAccessedBefore(podDefinitionTTL, -1)
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+
+	for _, podDef := range podDefs {
+		if podDef.ExternalID == "" {
+			if err := podDef.Remove(); err != nil {
+				j.AddError(errors.Wrapf(err, "deleting pod definition '%s' which is missing an external ID", podDef.ID))
+				continue
+			}
+
+			grip.Info(message.Fields{
+				"message":        "cleaned up pod definition that has no corresponding external ID",
+				"pod_definition": podDef.ID,
+				"last_accessed":  podDef.LastAccessed,
+				"job":            j.ID(),
+			})
+			continue
+		}
+
+		if err := j.podDefMgr.DeletePodDefinition(ctx, podDef.ExternalID); err != nil {
+			j.AddError(errors.Wrapf(err, "deleting pod definition '%s'", podDef.ID))
+			continue
+		}
+
+		grip.Info(message.Fields{
+			"message":        "successfully cleaned up pod definition",
+			"pod_definition": podDef.ID,
+			"external_id":    podDef.ExternalID,
+			"last_accessed":  podDef.LastAccessed,
+			"job":            j.ID(),
+		})
+	}
+}
+
+func (j *podDefinitionCleanupJob) populate() error {
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	// Use the latest service flags instead of those cached in the environment.
+	settings := *j.env.Settings()
+	if err := settings.ServiceFlags.Get(j.env); err != nil {
+		return errors.Wrap(err, "getting service flags")
+	}
+	j.settings = settings
+
+	if j.ecsClient == nil {
+		client, err := cloud.MakeECSClient(&settings)
+		if err != nil {
+			return errors.Wrap(err, "initializing ECS client")
+		}
+		j.ecsClient = client
+	}
+
+	if j.podDefMgr == nil {
+		podDefMgr, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
+		if err != nil {
+			return errors.Wrap(err, "initializing ECS pod definition manager")
+		}
+		j.podDefMgr = podDefMgr
+	}
+
+	return nil
+}

--- a/units/pod_definition_cleanup_test.go
+++ b/units/pod_definition_cleanup_test.go
@@ -1,0 +1,168 @@
+package units
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsECS "github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/evergreen-ci/cocoa"
+	cocoaMock "github.com/evergreen-ci/cocoa/mock"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/db"
+	evgMock "github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/pod/definition"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPodDefinitionCleanupJob(t *testing.T) {
+	defer func() {
+		cocoaMock.ResetGlobalECSService()
+
+		assert.NoError(t, db.ClearCollections(definition.Collection))
+	}()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob){
+		"WithExistingPodDefinition": func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob) {
+			for tName, tCase := range map[string]func(pd definition.PodDefinition){
+				"CleansUpStaleUnusedPodDefinitions": func(pd definition.PodDefinition) {
+					pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
+					require.NoError(t, pd.Upsert())
+
+					j.Run(ctx)
+					require.NoError(t, j.Error())
+
+					describeOut, err := j.ecsClient.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
+						TaskDefinition: aws.String(pd.ExternalID),
+					})
+					assert.NoError(t, err, "cloud pod definition should still exist even after it's been cleaned up")
+					require.NotZero(t, describeOut.TaskDefinition)
+					assert.Equal(t, awsECS.TaskDefinitionStatusInactive, utility.FromStringPtr(describeOut.TaskDefinition.Status), "cloud pod definition should be inactive")
+
+					dbPodDef, err := definition.FindOneID(pd.ID)
+					assert.NoError(t, err)
+					assert.Zero(t, dbPodDef, "pod definition should have been cleaned up")
+				},
+				"NoopsWithoutAnyPodDefinitionsExceedingTTL": func(pd definition.PodDefinition) {
+					assert.InDelta(t, time.Now().Unix(), pd.LastAccessed.Unix(), 1)
+
+					j.Run(ctx)
+					require.NoError(t, j.Error())
+
+					describeOut, err := j.ecsClient.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
+						TaskDefinition: aws.String(pd.ExternalID),
+					})
+					assert.NoError(t, err, "cloud pod definition should still exist")
+					require.NotZero(t, describeOut.TaskDefinition)
+					assert.Equal(t, awsECS.TaskDefinitionStatusActive, utility.FromStringPtr(describeOut.TaskDefinition.Status), "cloud pod definition should still be active")
+
+					dbPodDef, err := definition.FindOneID(pd.ID)
+					assert.NoError(t, err)
+					assert.NotZero(t, dbPodDef, "pod definition should not have been cleaned up")
+				},
+				"ErrorsIfPodDefinitionCleanupErrors": func(pd definition.PodDefinition) {
+					mockPodDefMgr, ok := j.podDefMgr.(*cocoaMock.ECSPodDefinitionManager)
+					require.True(t, ok)
+					mockPodDefMgr.DeletePodDefinitionError = errors.New("fake error")
+
+					pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
+					require.NoError(t, pd.Upsert())
+
+					j.Run(ctx)
+					assert.Error(t, j.Error())
+
+					describeOut, err := j.ecsClient.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
+						TaskDefinition: aws.String(pd.ExternalID),
+					})
+					assert.NoError(t, err, "cloud pod definition should still exist")
+					require.NotZero(t, describeOut.TaskDefinition)
+					assert.Equal(t, awsECS.TaskDefinitionStatusActive, utility.FromStringPtr(describeOut.TaskDefinition.Status), "cloud pod definition should still be active")
+
+					dbPodDef, err := definition.FindOneID(pd.ID)
+					assert.NoError(t, err)
+					assert.NotZero(t, dbPodDef, "pod definition should not have been cleaned up")
+				},
+			} {
+				t.Run(tName, func(t *testing.T) {
+					cocoaMock.ResetGlobalECSService()
+					require.NoError(t, db.ClearCollections(definition.Collection))
+
+					containerDef := cocoa.NewECSContainerDefinition().
+						SetImage("image").
+						SetCommand([]string{"echo", "hello"})
+					podDefOpts := cocoa.NewECSPodDefinitionOptions().
+						AddContainerDefinitions(*containerDef).
+						SetCPU(128).
+						SetMemoryMB(128)
+
+					podDef, err := j.podDefMgr.CreatePodDefinition(ctx, *podDefOpts)
+					require.NoError(t, err)
+
+					describeOut, err := j.ecsClient.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
+						TaskDefinition: aws.String(podDef.ID),
+					})
+					require.NoError(t, err, "cloud pod definition should have been created")
+					require.NotZero(t, describeOut.TaskDefinition)
+					assert.Equal(t, podDef.ID, utility.FromStringPtr(describeOut.TaskDefinition.TaskDefinitionArn))
+
+					dbPodDef, err := definition.FindOneByExternalID(podDef.ID)
+					require.NoError(t, err)
+					require.NotZero(t, dbPodDef, "DB pod definition should have been created")
+
+					tCase(*dbPodDef)
+				})
+			}
+		},
+		"NoopsWithoutAnyPodDefinitions": func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob) {
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+		},
+		"CleansUpPodDefinitionMissingExternalID": func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob) {
+			pd := definition.PodDefinition{
+				ID:           "pod_definition",
+				LastAccessed: time.Now().Add(-1000 * 24 * time.Hour),
+			}
+			require.NoError(t, pd.Insert())
+
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+
+			dbPodDef, err := definition.FindOneID(pd.ID)
+			assert.NoError(t, err)
+			assert.Zero(t, dbPodDef)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cocoaMock.ResetGlobalECSService()
+
+			require.NoError(t, db.ClearCollections(definition.Collection))
+
+			env := &evgMock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+
+			j, ok := NewPodDefinitionCleanupJob(utility.RoundPartOfMinute(0).Format(TSFormat)).(*podDefinitionCleanupJob)
+			require.True(t, ok)
+
+			j.env = env
+			j.settings = *env.Settings()
+
+			j.ecsClient = &cocoaMock.ECSClient{}
+			defer func() {
+				assert.NoError(t, j.ecsClient.Close(ctx))
+			}()
+
+			pdm, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
+			require.NoError(t, err)
+			j.podDefMgr = cocoaMock.NewECSPodDefinitionManager(pdm)
+
+			tCase(ctx, t, j)
+		})
+	}
+}

--- a/units/pod_definition_creation.go
+++ b/units/pod_definition_creation.go
@@ -35,10 +35,10 @@ type podDefinitionCreationJob struct {
 	ContainerOpts pod.TaskContainerCreationOptions `bson:"container_opts" json:"container_opts" yaml:"container_opts"`
 	Family        string                           `bson:"family" json:"family" yaml:"family"`
 
-	ecsClient        cocoa.ECSClient
-	ecsPodDefManager cocoa.ECSPodDefinitionManager
-	env              evergreen.Environment
-	settings         evergreen.Settings
+	ecsClient cocoa.ECSClient
+	podDefMgr cocoa.ECSPodDefinitionManager
+	env       evergreen.Environment
+	settings  evergreen.Settings
 }
 
 func makePodDefinitionCreationJob() *podDefinitionCreationJob {
@@ -120,7 +120,7 @@ func (j *podDefinitionCreationJob) Run(ctx context.Context) {
 		return
 	}
 
-	item, err := j.ecsPodDefManager.CreatePodDefinition(ctx, *podDefOpts)
+	item, err := j.podDefMgr.CreatePodDefinition(ctx, *podDefOpts)
 	if err != nil {
 		j.AddRetryableError(errors.Wrapf(err, "creating pod definition with family '%s'", j.Family))
 		return
@@ -154,12 +154,12 @@ func (j *podDefinitionCreationJob) populateIfUnset(ctx context.Context) error {
 		j.ecsClient = client
 	}
 
-	if j.ecsPodDefManager == nil {
+	if j.podDefMgr == nil {
 		podDefMgr, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
 		if err != nil {
-			return errors.Wrap(err, "initializing ECS pod creator")
+			return errors.Wrap(err, "initializing ECS pod definition manager")
 		}
-		j.ecsPodDefManager = podDefMgr
+		j.podDefMgr = podDefMgr
 	}
 
 	return nil

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -122,7 +122,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			require.NotZero(t, podDef, "pre-existing pod definition should still exist")
 			assert.Equal(t, j.Family, podDef.Family)
 
-			pdm, ok := j.ecsPodDefManager.(*cocoaMock.ECSPodDefinitionManager)
+			pdm, ok := j.podDefMgr.(*cocoaMock.ECSPodDefinitionManager)
 			require.True(t, ok)
 			assert.Zero(t, pdm.CreatePodDefinitionInput, "should not have created a pod definition")
 		},
@@ -134,7 +134,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, podDef, "should not have cached a pod definition")
 
-			pdm, ok := j.ecsPodDefManager.(*cocoaMock.ECSPodDefinitionManager)
+			pdm, ok := j.podDefMgr.(*cocoaMock.ECSPodDefinitionManager)
 			require.True(t, ok)
 			assert.Zero(t, pdm.CreatePodDefinitionInput, "should not have created a pod definition")
 
@@ -143,7 +143,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 		"DecommissionsDependentIntentPodsWithNoRetriesRemaining": func(ctx context.Context, t *testing.T, j *podDefinitionCreationJob, p *pod.Pod) {
 			require.NoError(t, p.Insert())
 
-			pdm, ok := j.ecsPodDefManager.(*cocoaMock.ECSPodDefinitionManager)
+			pdm, ok := j.podDefMgr.(*cocoaMock.ECSPodDefinitionManager)
 			require.True(t, ok)
 			pdm.CreatePodDefinitionError = errors.New("fail")
 
@@ -214,7 +214,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 
 			pdm, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
 			require.NoError(t, err)
-			j.ecsPodDefManager = cocoaMock.NewECSPodDefinitionManager(pdm)
+			j.podDefMgr = cocoaMock.NewECSPodDefinitionManager(pdm)
 
 			tCase(ctx, t, j, p)
 		})


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16900

### Description 
Create job to clean up stale unused pod definitions after they pass a TTL. I arbitrarily set it to 30 days, but we could change it if it's too low/high.

### Testing 
Added unit tests.