### PR TITLE
EVG-17558 fix create project directive

### DIFF
--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -37,7 +37,7 @@ func setupPermissions(t *testing.T) {
 		ID:          "superuser",
 		Name:        "superuser",
 		Scope:       "superuser_scope",
-		Permissions: map[string]int{"admin_settings": 10, "project_create": 10, "distro_create": 10, "modify_roles": 10},
+		Permissions: map[string]int{"project_create": 10, "distro_create": 10, "modify_roles": 10},
 	}
 	err = roleManager.UpdateRole(superUserRole)
 	require.NoError(t, err)

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -32,8 +32,8 @@ func New(apiURL string) Config {
 		opts := gimlet.PermissionOpts{
 			Resource:      evergreen.SuperUserPermissionsID,
 			ResourceType:  evergreen.SuperUserResourceType,
-			Permission:    evergreen.PermissionAdminSettings,
-			RequiredLevel: evergreen.AdminSettingsEdit.Value,
+			Permission:    evergreen.PermissionProjectCreate,
+			RequiredLevel: evergreen.ProjectCreate.Value,
 		}
 		if user.HasPermission(opts) {
 			return next(ctx)


### PR DESCRIPTION
[EVG-17558](https://jira.mongodb.org/browse/EVG-17558)

### Description 
Probably my fault this wasn't caught before; there's a special permission for project creation we should test instead of what we test here.

### Testing 
Removed the older permission that was being checked from the test to verify that the actual permission needed is enough.