### PR TITLE
EVG-16902: clean up stranded container secrets

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -378,13 +378,22 @@ func GetFilteredResourceIDs(ctx context.Context, c cocoa.TagClient, resources []
 
 	var allIDs []string
 	remaining := limit
-	for ids, nextToken, err := getResourcesPage(ctx, c, resourceFilters, tagFilters, nil, limit); ; ids, nextToken, err = getResourcesPage(ctx, c, resourceFilters, tagFilters, nextToken, remaining) {
+	var nextToken *string
+	for {
+		var (
+			ids []string
+			err error
+		)
+		ids, nextToken, err = getResourcesPage(ctx, c, resourceFilters, tagFilters, nextToken, limit)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting resources matching filters")
 		}
 		allIDs = append(allIDs, ids...)
 		remaining = remaining - len(ids)
 		if remaining <= 0 {
+			break
+		}
+		if len(ids) == 0 {
 			break
 		}
 		if nextToken == nil {

--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -357,8 +357,10 @@ func exportPodEnvVars(smConf evergreen.SecretsManagerConfig, opts pod.TaskContai
 	return allEnvVars
 }
 
-// GetFilteredResourceIDs gets at most n resources that match the given resource
-// and tag filters. If n is not a positive integer, the results are not limited.
+// GetFilteredResourceIDs gets resources that match the given resource and tag
+// filters. If the limit is positive, it will return at most that many results.
+// If the limit is zero, this will return no results. If the limit is negative,
+// the results are unlimited
 func GetFilteredResourceIDs(ctx context.Context, c cocoa.TagClient, resources []string, tags map[string][]string, limit int) ([]string, error) {
 	if limit == 0 {
 		return []string{}, nil

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788
+	github.com/evergreen-ci/cocoa v0.0.0-20220822162052-df9129525b02
 	github.com/evergreen-ci/gimlet v0.0.0-20220419172609-b882e01673e7
 	github.com/evergreen-ci/go-test2json v0.0.0-20180702150328-5b6cfd2e8cb0
 	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788 h1:rgb9st+6bsGagnXGh6MCSP0IWLfdArOB4YeDJUpz2tE=
-github.com/evergreen-ci/cocoa v0.0.0-20220818151246-03ca85964788/go.mod h1:FC3CXscglVmGWfTFEjo9yi0RDEUXFijmeyKx6O8NTQ4=
+github.com/evergreen-ci/cocoa v0.0.0-20220822162052-df9129525b02 h1:hV8rJWMAY1oiR1m2rKaY8PFTCfgwEpIQqYCTKlrSwX8=
+github.com/evergreen-ci/cocoa v0.0.0-20220822162052-df9129525b02/go.mod h1:FC3CXscglVmGWfTFEjo9yi0RDEUXFijmeyKx6O8NTQ4=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -214,7 +214,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
 				taskID: cocoaMock.ECSTask{
-					ARN:        utility.ToStringPtr(taskID),
+					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
 					Status:     utility.ToStringPtr(status),
@@ -265,7 +265,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			)
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
 				taskID: cocoaMock.ECSTask{
-					ARN:        utility.ToStringPtr(taskID),
+					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
 					Status:     utility.ToStringPtr(status),
@@ -319,7 +319,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
 				taskID: cocoaMock.ECSTask{
-					ARN:        utility.ToStringPtr(taskID),
+					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
 					Status:     utility.ToStringPtr(status),
@@ -370,7 +370,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
 				taskID: cocoaMock.ECSTask{
-					ARN:        utility.ToStringPtr(taskID),
+					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
 					Status:     utility.ToStringPtr(status),
@@ -456,7 +456,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			cocoaMock.GlobalECSService.Clusters[clusterID] = cocoaMock.ECSCluster{
 				taskARN: cocoaMock.ECSTask{
-					ARN:               utility.ToStringPtr(taskARN),
+					ARN:               taskARN,
 					ContainerInstance: utility.ToStringPtr(containerInstanceID),
 					Cluster:           utility.ToStringPtr(clusterID),
 					Created:           utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -72,7 +72,7 @@ func (j *containerSecretCleanupJob) Run(ctx context.Context) {
 
 	secretIDs, err := cloud.GetFilteredResourceIDs(ctx, j.tagClient, []string{cloud.SecretsManagerResourceFilter}, map[string][]string{
 		cloud.PodCacheTag: {strconv.FormatBool(false)},
-	}, j.env.Settings().PodLifecycle.MaxPodDefinitionCleanupRate)
+	}, j.env.Settings().PodLifecycle.MaxSecretCleanupRate)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "getting stranded Secrets Manager secrets"))
 		return

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -74,7 +74,7 @@ func (j *containerSecretCleanupJob) Run(ctx context.Context) {
 		cloud.PodCacheTag: {strconv.FormatBool(false)},
 	}, j.env.Settings().PodLifecycle.MaxPodDefinitionCleanupRate)
 	if err != nil {
-		j.AddError(errors.Wrap(err, "getting untracked Secrets Manager secrets"))
+		j.AddError(errors.Wrap(err, "getting stranded Secrets Manager secrets"))
 		return
 	}
 

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -29,7 +29,6 @@ type containerSecretCleanupJob struct {
 	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
 
 	env       evergreen.Environment
-	settings  evergreen.Settings
 	smClient  cocoa.SecretsManagerClient
 	vault     cocoa.Vault
 	tagClient cocoa.TagClient

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -1,0 +1,120 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/evergreen-ci/cocoa"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+const (
+	containerSecretCleanupJobName = "container-secret-cleanup"
+)
+
+func init() {
+	registry.AddJobType(containerSecretCleanupJobName, func() amboy.Job {
+		return makeContainerSecretCleanupJob()
+	})
+}
+
+type containerSecretCleanupJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+
+	env       evergreen.Environment
+	settings  evergreen.Settings
+	smClient  cocoa.SecretsManagerClient
+	vault     cocoa.Vault
+	tagClient cocoa.TagClient
+}
+
+func makeContainerSecretCleanupJob() *containerSecretCleanupJob {
+	j := &containerSecretCleanupJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    containerSecretCleanupJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewContainerSecretCleanupJob creates a job that cleans up stranded container
+// secrets that are not tracked by Evergreen.
+func NewContainerSecretCleanupJob(id string) amboy.Job {
+	j := makeContainerSecretCleanupJob()
+	j.SetID(fmt.Sprintf("%s.%s", containerSecretCleanupJobName, id))
+	return j
+}
+
+func (j *containerSecretCleanupJob) Run(ctx context.Context) {
+	defer func() {
+		j.MarkComplete()
+
+		if j.smClient != nil {
+			j.AddError(errors.Wrap(j.smClient.Close(ctx), "closing Secrets Manager client"))
+		}
+		if j.tagClient != nil {
+			j.AddError(errors.Wrap(j.tagClient.Close(ctx), "closing tag client"))
+		}
+	}()
+	if err := j.populate(); err != nil {
+		j.AddError(err)
+		return
+	}
+
+	secretIDs, err := cloud.GetFilteredResourceIDs(ctx, j.tagClient, []string{cloud.SecretsManagerResourceFilter}, map[string][]string{
+		cloud.PodCacheTag: {strconv.FormatBool(false)},
+	}, j.env.Settings().PodLifecycle.MaxPodDefinitionCleanupRate)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "getting untracked Secrets Manager secrets"))
+		return
+	}
+
+	catcher := grip.NewBasicCatcher()
+	for _, secretID := range secretIDs {
+		catcher.Wrapf(j.vault.DeleteSecret(ctx, secretID), "secret '%s'", secretID)
+	}
+
+	j.AddError(errors.Wrap(catcher.Resolve(), "deleting secrets"))
+}
+
+func (j *containerSecretCleanupJob) populate() error {
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	if j.smClient == nil {
+		client, err := cloud.MakeSecretsManagerClient(j.env.Settings())
+		if err != nil {
+			return errors.Wrap(err, "initializing Secrets Manager client")
+		}
+		j.smClient = client
+	}
+
+	if j.vault == nil {
+		vault, err := cloud.MakeSecretsManagerVault(j.smClient)
+		if err != nil {
+			return errors.Wrap(err, "initializing Secrets Manager vault")
+		}
+		j.vault = vault
+	}
+
+	if j.tagClient == nil {
+		client, err := cloud.MakeTagClient(j.env.Settings())
+		if err != nil {
+			return errors.Wrap(err, "initializing tag client")
+		}
+		j.tagClient = client
+	}
+
+	return nil
+}

--- a/units/container_secret_cleanup_test.go
+++ b/units/container_secret_cleanup_test.go
@@ -1,0 +1,131 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	cocoaMock "github.com/evergreen-ci/cocoa/mock"
+	"github.com/evergreen-ci/cocoa/secret"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerSecretCleanupJob(t *testing.T) {
+	defer cocoaMock.ResetGlobalSecretCache()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *containerSecretCleanupJob){
+		"DeletesStrandedSecretsWithMatchingTag": func(ctx context.Context, t *testing.T, j *containerSecretCleanupJob) {
+			var secretIDs []string
+			for i := 0; i < 5; i++ {
+				createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+					Name:         aws.String(fmt.Sprintf("secret_name%d", i)),
+					SecretString: aws.String("secret_string"),
+					Tags: []*secretsmanager.Tag{{
+						Key:   aws.String(cloud.PodCacheTag),
+						Value: aws.String(strconv.FormatBool(false)),
+					}},
+				})
+				require.NoError(t, err)
+				secretIDs = append(secretIDs, utility.FromStringPtr(createOut.ARN))
+			}
+
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+
+			for _, secretID := range secretIDs {
+				val, err := j.vault.GetValue(ctx, secretID)
+				assert.Error(t, err, "secret should have been deleted")
+				assert.Zero(t, val)
+			}
+		},
+		"DeletesLimitedNumberOfStrandedSecrets": func(ctx context.Context, t *testing.T, j *containerSecretCleanupJob) {
+			mockEnv, ok := j.env.(*mock.Environment)
+			require.True(t, ok)
+			const cleanupLimit = 2
+			mockEnv.EvergreenSettings.PodLifecycle.MaxPodDefinitionCleanupRate = cleanupLimit
+
+			var secretIDs []string
+			for i := 0; i < 5; i++ {
+				createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+					Name:         aws.String(fmt.Sprintf("secret_name%d", i)),
+					SecretString: aws.String("secret_string"),
+					Tags: []*secretsmanager.Tag{{
+						Key:   aws.String(cloud.PodCacheTag),
+						Value: aws.String(strconv.FormatBool(false)),
+					}},
+				})
+				require.NoError(t, err)
+				secretIDs = append(secretIDs, utility.FromStringPtr(createOut.ARN))
+			}
+
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+
+			var numDeleted int
+			for _, secretID := range secretIDs {
+				if _, err := j.vault.GetValue(ctx, secretID); err != nil {
+					numDeleted++
+				}
+			}
+			assert.Equal(t, cleanupLimit, numDeleted)
+		},
+		"NoopsWithNoSecrets": func(ctx context.Context, t *testing.T, j *containerSecretCleanupJob) {
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+		},
+		"NoopsWithNoSecretsMatchingTag": func(ctx context.Context, t *testing.T, j *containerSecretCleanupJob) {
+			createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+				Name:         aws.String("secret_name"),
+				SecretString: aws.String("secret_string"),
+				Tags:         []*secretsmanager.Tag{{Key: aws.String("cherry"), Value: aws.String("tomato")}},
+			})
+			require.NoError(t, err)
+
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+
+			val, err := j.vault.GetValue(ctx, utility.FromStringPtr(createOut.ARN))
+			assert.NoError(t, err, "secret should still exist")
+			assert.NotZero(t, val)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			cocoaMock.ResetGlobalSecretCache()
+
+			j, ok := NewContainerSecretCleanupJob(utility.RoundPartOfHour(0).Format(TSFormat)).(*containerSecretCleanupJob)
+			require.True(t, ok)
+			j.tagClient = &cocoaMock.TagClient{}
+			defer func() {
+				assert.NoError(t, j.tagClient.Close(ctx))
+			}()
+			j.smClient = &cocoaMock.SecretsManagerClient{}
+			defer func() {
+				assert.NoError(t, j.smClient.Close(ctx))
+			}()
+			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().
+				SetClient(j.smClient).
+				SetCache(&cloud.NoopSecretCache{}).
+				SetCacheTag(cloud.PodCacheTag))
+			require.NoError(t, err)
+			j.vault = cocoaMock.NewVault(v)
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+
+			env.EvergreenSettings.PodLifecycle.MaxPodDefinitionCleanupRate = 1000
+			j.env = env
+
+			tCase(ctx, t, j)
+		})
+	}
+}

--- a/units/container_secret_cleanup_test.go
+++ b/units/container_secret_cleanup_test.go
@@ -49,7 +49,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 			mockEnv, ok := j.env.(*mock.Environment)
 			require.True(t, ok)
 			const cleanupLimit = 2
-			mockEnv.EvergreenSettings.PodLifecycle.MaxPodDefinitionCleanupRate = cleanupLimit
+			mockEnv.EvergreenSettings.PodLifecycle.MaxSecretCleanupRate = cleanupLimit
 
 			var secretIDs []string
 			for i := 0; i < 5; i++ {
@@ -122,7 +122,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
 
-			env.EvergreenSettings.PodLifecycle.MaxPodDefinitionCleanupRate = 1000
+			env.EvergreenSettings.PodLifecycle.MaxSecretCleanupRate = 1000
 			j.env = env
 
 			tCase(ctx, t, j)

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -205,14 +205,14 @@ func (j *podAllocatorJob) populate() error {
 		j.pRef = pRef
 	}
 
-	if j.vault == nil {
-		if j.smClient == nil {
-			client, err := cloud.MakeSecretsManagerClient(&settings)
-			if err != nil {
-				return errors.Wrap(err, "initializing Secrets Manager client")
-			}
-			j.smClient = client
+	if j.smClient == nil {
+		client, err := cloud.MakeSecretsManagerClient(&settings)
+		if err != nil {
+			return errors.Wrap(err, "initializing Secrets Manager client")
 		}
+		j.smClient = client
+	}
+	if j.vault == nil {
 		vault, err := cloud.MakeSecretsManagerVault(j.smClient)
 		if err != nil {
 			return errors.Wrap(err, "initializing Secrets Manager vault")

--- a/units/pod_allocator_test.go
+++ b/units/pod_allocator_test.go
@@ -284,6 +284,7 @@ func TestPodAllocatorJob(t *testing.T) {
 			allocatorJob := j.(*podAllocatorJob)
 			allocatorJob.env = env
 
+			allocatorJob.smClient = smClient
 			allocatorJob.vault = mv
 
 			tCase(tctx, t, allocatorJob, mv, tsk, pRef)

--- a/units/pod_definition_cleanup_test.go
+++ b/units/pod_definition_cleanup_test.go
@@ -68,6 +68,9 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 					mockPodDefMgr, ok := j.podDefMgr.(*cocoaMock.ECSPodDefinitionManager)
 					require.True(t, ok)
 					mockPodDefMgr.DeletePodDefinitionError = errors.New("fake error")
+					defer func() {
+						mockPodDefMgr.DeletePodDefinitionError = nil
+					}()
 
 					pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
 					require.NoError(t, pd.Upsert())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16902

### Description 
* Add a job to clean up container secrets that were created but never stored in Evergreen's DB.
* Fix a flaky pod definition cleanup test.

### Testing
Added unit tests. I also spot checked that running the job cleaned up stranded secrets in Secrets Manager.