### PR TITLE
EVG-17582: fix flaky Windows tests

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3,6 +3,9 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -72,7 +75,8 @@ func (s *AgentSuite) SetupTest() {
 	factory, ok := command.GetCommandFactory("setup.initial")
 	s.True(ok)
 	s.tc.setCurrentCommand(factory())
-	s.tmpDirName = s.T().TempDir()
+	s.tmpDirName, err = ioutil.TempDir("", filepath.Base(s.T().Name()))
+	s.Require().NoError(err)
 	s.tc.taskDirectory = s.tmpDirName
 	sender, err := s.a.GetSender(ctx, evergreen.LocalLoggingOverride)
 	s.Require().NoError(err)
@@ -81,6 +85,7 @@ func (s *AgentSuite) SetupTest() {
 
 func (s *AgentSuite) TearDownTest() {
 	s.canceler()
+	s.Require().NoError(os.RemoveAll(s.tmpDirName))
 }
 
 func (s *AgentSuite) TestNextTaskResponseShouldExit() {

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -387,7 +387,10 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 				Permissions:                   s3.BucketCannedACLPublicRead,
 				RemoteFile:                    "remote",
 			}
-			opts := pail.LocalOptions{}
+			require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0755))
+			opts := pail.LocalOptions{
+				Path: filepath.Join(dir, "destination"),
+			}
 			s.bucket, err = pail.NewLocalBucket(opts)
 			require.NoError(t, err)
 			comm := client.NewMock("http://localhost.com")

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -388,7 +388,7 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 				RemoteFile:                    "remote",
 			}
 			opts := pail.LocalOptions{}
-			s.bucket, err = pail.NewLocalTemporaryBucket(opts)
+			s.bucket, err = pail.NewLocalBucket(opts)
 			require.NoError(t, err)
 			comm := client.NewMock("http://localhost.com")
 			conf := &internal.TaskConfig{

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -364,11 +364,13 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 			var err error
 
 			dir := t.TempDir()
-			_, err = os.Create(filepath.Join(dir, "foo"))
+			f, err := os.Create(filepath.Join(dir, "foo"))
 			require.NoError(t, err)
+			require.NoError(t, f.Close())
 			require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0755))
-			_, err = os.Create(filepath.Join(dir, "subDir", "bar"))
+			f, err = os.Create(filepath.Join(dir, "subDir", "bar"))
 			require.NoError(t, err)
+			require.NoError(t, f.Close())
 
 			var localFilesIncludeFilterPrefix string
 			if prefix == "emptyPrefix" {

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -103,10 +103,8 @@ func TestCommandFileLogging(t *testing.T) {
 	// verify log contents
 	f, err := os.Open(fmt.Sprintf("%s/%s/%s/task.log", tmpDirName, taskLogDirectory, "shell.exec"))
 	require.NoError(err)
-	defer func() {
-		assert.NoError(f.Close())
-	}()
 	bytes, err := ioutil.ReadAll(f)
+	assert.NoError(f.Close())
 	require.NoError(err)
 	assert.Contains(string(bytes), "hello world")
 
@@ -121,6 +119,7 @@ func TestCommandFileLogging(t *testing.T) {
 	f, err = os.Open(fmt.Sprintf("%s/logs/%s/%d/%s/task.log", tmpDirName, tc.taskConfig.Task.Id, tc.taskConfig.Task.Execution, "shell.exec"))
 	require.NoError(err)
 	bytes, err = ioutil.ReadAll(f)
+	assert.NoError(f.Close())
 	require.NoError(err)
 	assert.Contains(string(bytes), "hello world")
 

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -103,6 +103,9 @@ func TestCommandFileLogging(t *testing.T) {
 	// verify log contents
 	f, err := os.Open(fmt.Sprintf("%s/%s/%s/task.log", tmpDirName, taskLogDirectory, "shell.exec"))
 	require.NoError(err)
+	defer func() {
+		assert.NoError(f.Close())
+	}()
 	bytes, err := ioutil.ReadAll(f)
 	require.NoError(err)
 	assert.Contains(string(bytes), "hello world")


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17582

### Description 
In Windows, deleting a directory will fail if there's a process that's actively using it or there's an unclosed file handle (which is a resource leak). I had to tweak the tests where this was relevant.

* One failing agent test is checking the expected behavior of the agent that if a command times out, the agent should continue on without waiting for the command to finish. Since the command exits asynchronously, there will be a race between the asynchronous command exiting and the main testing thread attempting to clean up that command's directory when the command may not be exited yet. I just reverted this to its previous temporary directory usage since there's no easy way to wait until the command finishes. As to why removing the directory succeeds if it's in the teardown block, I don't know, but it's probably due to something internal to the testify suite implementation.
* Another failing agent test was failing to close a file handle.
* The S3 test was failing because it wasn't closing file handles.

### Testing 
Re-ran unit tests.