### PR TITLE
EVG-17510 Allow emptying Github PR aliases when PR testing is enabled

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -54,6 +54,11 @@ const (
 // "linux"; and to run all tasks beginning with the string "compile" to run on all
 // variants beginning with the string "ubuntu1604".
 
+// For regular patch aliases, the Alias field is required to be a custom string defined by the user.
+// For all other special alias types (commit queue, github PR, etc) the Alias field must match its associated
+// constant in globals.go, i.e. evergreen.GithubPRAlias. For aliases defined within a project's config YAML
+// the Alias field for non-patch aliases is not-required since it will be inferred and assigned at runtime.
+
 // Git tags use a special alias "__git_tag" and create a new version for the matching
 // variants/tasks, assuming the tag matches the defined git_tag regex.
 // In this way, users can define different behavior for different kind of tags.

--- a/model/project_configs_test.go
+++ b/model/project_configs_test.go
@@ -32,9 +32,9 @@ build_baron_settings:
   ticket_create_project: BF
   ticket_search_projects: ["BF"]
 
-commit_queue_aliases:
-  - project_id: evg
-    variant: ubuntu1604
+github_pr_aliases:
+  - variant: "^ubuntu1604$"
+    task: ".*"
 
 `
 	pc, err = CreateProjectConfig([]byte(projYml), "")

--- a/service/project.go
+++ b/service/project.go
@@ -461,7 +461,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if GitHub aliases are set"))
 				return
 			}
-			if !aliasesDefined {
+			if !aliasesDefined && !responseRef.VersionControlEnabled {
 				uis.LoggedError(w, r, http.StatusBadRequest, errors.New("cannot enable PR testing without patch definitions"))
 				return
 			}

--- a/service/project.go
+++ b/service/project.go
@@ -484,7 +484,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if GitHub check aliases are set"))
 				return
 			}
-			if !aliasesDefined {
+			if !aliasesDefined && !responseRef.VersionControlEnabled {
 				uis.LoggedError(w, r, http.StatusBadRequest, errors.New("cannot enable Github checks without definitions"))
 				return
 			}
@@ -496,7 +496,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if GitHub aliases are set"))
 				return
 			}
-			if !aliasesDefined {
+			if !aliasesDefined && !responseRef.VersionControlEnabled {
 				uis.LoggedError(w, r, http.StatusBadRequest, errors.New("cannot enable git tag versions without version definitions"))
 				return
 			}
@@ -527,7 +527,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 				uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "can't check if commit queue aliases are set"))
 				return
 			}
-			if !exists {
+			if !exists && !responseRef.VersionControlEnabled {
 				uis.LoggedError(w, r, http.StatusBadRequest, errors.New("cannot enable commit queue without patch definitions"))
 				return
 			}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -480,7 +480,7 @@ func validateProjectConfigPlugins(pc *model.ProjectConfig) ValidationErrors {
 	}
 	// skip validation if no build baron configuration exists
 	if pc.BuildBaronSettings == nil {
-		return nil
+		return ValidationErrors{}
 	}
 	err := model.ValidateBbProject(pc.Project, *pc.BuildBaronSettings, webhook)
 	if err != nil {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -466,6 +466,9 @@ func validateProjectConfigPlugins(pc *model.ProjectConfig) ValidationErrors {
 	if annotationSettings != nil {
 		webhook = &annotationSettings.FileTicketWebhook
 	}
+	if pc.BuildBaronSettings == nil {
+		return errs
+	}
 	err := model.ValidateBbProject(pc.Project, *pc.BuildBaronSettings, webhook)
 	if err != nil {
 		errs = append(errs,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -480,7 +480,7 @@ func validateProjectConfigPlugins(pc *model.ProjectConfig) ValidationErrors {
 	}
 	// skip validation if no build baron configuration exists
 	if pc.BuildBaronSettings == nil {
-		return errs
+		return nil
 	}
 	err := model.ValidateBbProject(pc.Project, *pc.BuildBaronSettings, webhook)
 	if err != nil {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -478,6 +478,7 @@ func validateProjectConfigPlugins(pc *model.ProjectConfig) ValidationErrors {
 	if annotationSettings != nil {
 		webhook = &annotationSettings.FileTicketWebhook
 	}
+	// skip validation if no build baron configuration exists
 	if pc.BuildBaronSettings == nil {
 		return errs
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -421,6 +421,18 @@ func validateProjectConfigPeriodicBuilds(pc *model.ProjectConfig) ValidationErro
 
 func validateProjectConfigAliases(pc *model.ProjectConfig) ValidationErrors {
 	errs := []string{}
+	for i := range pc.GitTagAliases {
+		pc.GitTagAliases[i].Alias = evergreen.GitTagAlias
+	}
+	for i := range pc.GitHubChecksAliases {
+		pc.GitHubChecksAliases[i].Alias = evergreen.GithubChecksAlias
+	}
+	for i := range pc.CommitQueueAliases {
+		pc.CommitQueueAliases[i].Alias = evergreen.CommitQueueAlias
+	}
+	for i := range pc.GitHubPRAliases {
+		pc.GitHubPRAliases[i].Alias = evergreen.GithubPRAlias
+	}
 	errs = append(errs, model.ValidateProjectAliases(pc.GitHubPRAliases, "GitHub PR Aliases")...)
 	errs = append(errs, model.ValidateProjectAliases(pc.GitHubChecksAliases, "Github Checks Aliases")...)
 	errs = append(errs, model.ValidateProjectAliases(pc.CommitQueueAliases, "Commit Queue Aliases")...)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"math"
 	"testing"
 
@@ -1069,10 +1068,6 @@ func TestValidatePeriodicBuilds(t *testing.T) {
 
 func TestValidatePlugins(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
-	evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(model.ProjectRefCollection),
 		"Error clearing collection")
 	projectRef := &model.ProjectRef{
@@ -1211,7 +1206,6 @@ func TestValidateProjectAliases(t *testing.T) {
 						{
 							ID:        mgobson.NewObjectId(),
 							ProjectID: "project-1",
-							Alias:     evergreen.CommitQueueAlias,
 							Variant:   "v1",
 							Task:      "^test",
 						},
@@ -1220,7 +1214,6 @@ func TestValidateProjectAliases(t *testing.T) {
 						{
 							ID:        mgobson.NewObjectId(),
 							ProjectID: "project-1",
-							Alias:     evergreen.GithubChecksAlias,
 							Variant:   "v1",
 							Task:      "^test",
 						},
@@ -1229,14 +1222,12 @@ func TestValidateProjectAliases(t *testing.T) {
 						{
 							ID:        mgobson.NewObjectId(),
 							ProjectID: "project-1",
-							Alias:     evergreen.GitTagAlias,
 							Variant:   "v1",
 							Task:      "^test",
 						},
 						{
 							ID:        mgobson.NewObjectId(),
 							ProjectID: "project-1",
-							Alias:     evergreen.GitTagAlias,
 							Variant:   "v1",
 							Task:      "^test",
 							GitTag:    "[0-9]++",
@@ -1244,7 +1235,6 @@ func TestValidateProjectAliases(t *testing.T) {
 						{
 							ID:         mgobson.NewObjectId(),
 							ProjectID:  "project-1",
-							Alias:      evergreen.GitTagAlias,
 							Variant:    "v1",
 							Task:       "^test",
 							RemotePath: "remote/path",

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"math"
 	"testing"
 
@@ -1068,6 +1069,10 @@ func TestValidatePeriodicBuilds(t *testing.T) {
 
 func TestValidatePlugins(t *testing.T) {
 	assert := assert.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	evergreen.SetEnvironment(env)
 	require.NoError(t, db.Clear(model.ProjectRefCollection),
 		"Error clearing collection")
 	projectRef := &model.ProjectRef{
@@ -1077,6 +1082,7 @@ func TestValidatePlugins(t *testing.T) {
 	assert.Nil(projectRef.Insert())
 	Convey("When validating a project", t, func() {
 		Convey("ensure bad plugin configs throw an error", func() {
+			So(validateProjectConfigPlugins(&model.ProjectConfig{}), ShouldResemble, ValidationErrors{})
 			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},


### PR DESCRIPTION
[EVG-17510](https://jira.mongodb.org/browse/EVG-17510)

### Description 
The modify project route returns an error when PR testing is enabled and the PR patch definition list is empty.  Since PR patch definitions can now be defined in YAML, this change ignores that error if "version control" is enabled on the project page.

Also fixed a few things in project validation including a missing nil check for build baron plugins and automatically infer alias names to YAML defined aliases so that things like `alias: github_pr` aren't necessary to write in YAML.
### Testing 
Updated existing unit tests. 

Enabled version control on the sandbox project in staging and emptied the PR patch definitions, and replaced them with YAML definitions. Staged a few PRs using this YAML to confirm it was working.

[Example configuration](https://github.com/evergreen-ci/commit-queue-sandbox/blob/df8f7fc3529a11809802164f1d3716023a2ef6a9/evergreen.yml#L205), and [subsequent created patch](https://spruce-staging.corp.mongodb.com/version/6306afc497b1d31c2bb47ccc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).