### PR TITLE
EVG-17562: decommission pods that have no tasks to dispatch

### DIFF
--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -30,6 +30,7 @@ const (
 type podData struct {
 	OldStatus     string `bson:"old_status,omitempty" json:"old_status,omitempty"`
 	NewStatus     string `bson:"new_status,omitempty" json:"new_status,omitempty"`
+	Reason        string `bson:"reason,omitempty" json:"reason,omitempty"`
 	TaskID        string `bson:"task_id,omitempty" json:"task_id,omitempty"`
 	TaskExecution int    `bson:"task_execution,omitempty" json:"task_execution,omitempty"`
 }
@@ -57,10 +58,11 @@ func LogPodEvent(id string, kind PodEventType, data podData) {
 
 // LogPodStatusChanged logs an event indicating that the pod's status has been
 // updated.
-func LogPodStatusChanged(id, oldStatus, newStatus string) {
+func LogPodStatusChanged(id, oldStatus, newStatus, reason string) {
 	LogPodEvent(id, EventPodStatusChange, podData{
 		OldStatus: oldStatus,
 		NewStatus: newStatus,
+		Reason:    reason,
 	})
 }
 

--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -14,7 +14,8 @@ func TestPodEvents(t *testing.T) {
 			id := "pod_id"
 			oldStatus := "initializing"
 			newStatus := "starting"
-			LogPodStatusChanged(id, oldStatus, newStatus)
+			reason := "some reason"
+			LogPodStatusChanged(id, oldStatus, newStatus, reason)
 
 			events, err := Find(MostRecentPodEvents(id, 10))
 			require.NoError(t, err)
@@ -26,6 +27,7 @@ func TestPodEvents(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, oldStatus, data.OldStatus)
 			assert.Equal(t, newStatus, data.NewStatus)
+			assert.Equal(t, reason, data.Reason)
 		},
 		"LogPodAssignedTask": func(t *testing.T) {
 			podID := "pod_id"

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -158,7 +158,7 @@ func FindIntentByFamily(family string) ([]Pod, error) {
 // information about the status update. If the current status is identical to
 // the updated one, this will no-op. If the current status does not match the
 // stored status, this will error.
-func UpdateOneStatus(id string, current, updated Status, ts time.Time) error {
+func UpdateOneStatus(id string, current, updated Status, ts time.Time, reason string) error {
 	if current == updated {
 		return nil
 	}
@@ -180,7 +180,7 @@ func UpdateOneStatus(id string, current, updated Status, ts time.Time) error {
 		return err
 	}
 
-	event.LogPodStatusChanged(id, string(current), string(updated))
+	event.LogPodStatusChanged(id, string(current), string(updated), reason)
 
 	return nil
 }

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -350,7 +350,7 @@ func TestUpdateOneStatus(t *testing.T) {
 			p.Status = StatusInitializing
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(p.Status))
+			require.NoError(t, p.UpdateStatus(p.Status, ""))
 			assert.Equal(t, StatusInitializing, p.Status)
 
 			dbPod, err := FindOneByID(p.ID)
@@ -363,7 +363,7 @@ func TestUpdateOneStatus(t *testing.T) {
 			require.NoError(t, p.Insert())
 
 			updated := StatusInitializing
-			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now()))
+			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now(), ""))
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -375,7 +375,7 @@ func TestUpdateOneStatus(t *testing.T) {
 			require.NoError(t, p.Insert())
 
 			updated := StatusStarting
-			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now()))
+			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now(), ""))
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -386,13 +386,13 @@ func TestUpdateOneStatus(t *testing.T) {
 		"FailsWithMismatchedCurrentStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			assert.Error(t, UpdateOneStatus(p.ID, StatusInitializing, StatusTerminated, time.Now()))
+			assert.Error(t, UpdateOneStatus(p.ID, StatusInitializing, StatusTerminated, time.Now(), ""))
 		},
 		"SucceedsWithTerminatedStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
 			updated := StatusTerminated
-			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now()))
+			require.NoError(t, UpdateOneStatus(p.ID, p.Status, updated, time.Now(), ""))
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -404,7 +404,7 @@ func TestUpdateOneStatus(t *testing.T) {
 		"FailsWithNonexistentPod": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			assert.Error(t, UpdateOneStatus("nonexistent", StatusStarting, StatusRunning, time.Now()))
+			assert.Error(t, UpdateOneStatus("nonexistent", StatusStarting, StatusRunning, time.Now(), ""))
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -612,9 +612,9 @@ func (p *Pod) Remove() error {
 }
 
 // UpdateStatus updates the pod status.
-func (p *Pod) UpdateStatus(s Status) error {
+func (p *Pod) UpdateStatus(s Status, reason string) error {
 	ts := utility.BSONTime(time.Now())
-	if err := UpdateOneStatus(p.ID, p.Status, s, ts); err != nil {
+	if err := UpdateOneStatus(p.ID, p.Status, s, ts, reason); err != nil {
 		return errors.Wrap(err, "updating status")
 	}
 

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -330,7 +330,7 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithInitializingStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(StatusInitializing))
+			require.NoError(t, p.UpdateStatus(StatusInitializing, ""))
 			assert.Equal(t, StatusInitializing, p.Status)
 
 			checkStatusAndTimeInfo(t, p)
@@ -339,7 +339,7 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithStartingStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(StatusStarting))
+			require.NoError(t, p.UpdateStatus(StatusStarting, ""))
 			assert.Equal(t, StatusStarting, p.Status)
 
 			checkStatusAndTimeInfo(t, p)
@@ -348,7 +348,7 @@ func TestUpdateStatus(t *testing.T) {
 		"SucceedsWithTerminatedStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(StatusTerminated))
+			require.NoError(t, p.UpdateStatus(StatusTerminated, ""))
 			assert.Equal(t, StatusTerminated, p.Status)
 
 			checkStatus(t, p)
@@ -357,11 +357,11 @@ func TestUpdateStatus(t *testing.T) {
 		"NoopsWithIdenticalStatus": func(t *testing.T, p Pod) {
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, p.UpdateStatus(p.Status))
+			require.NoError(t, p.UpdateStatus(p.Status, ""))
 			checkStatus(t, p)
 		},
 		"FailsWithNonexistentPod": func(t *testing.T, p Pod) {
-			assert.Error(t, p.UpdateStatus(StatusTerminated))
+			assert.Error(t, p.UpdateStatus(StatusTerminated, ""))
 
 			dbPod, err := FindOneByID(p.ID)
 			assert.NoError(t, err)
@@ -374,7 +374,7 @@ func TestUpdateStatus(t *testing.T) {
 				"$set": bson.M{StatusKey: StatusInitializing},
 			}))
 
-			assert.Error(t, p.UpdateStatus(StatusTerminated))
+			assert.Error(t, p.UpdateStatus(StatusTerminated, ""))
 
 			dbPod, err := FindOneByID(p.ID)
 			require.NoError(t, err)

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -240,7 +240,7 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	h.setAgentFirstContactTime(p)
 
 	if p.Status == pod.StatusTerminated || p.Status == pod.StatusDecommissioned {
-		if err = h.enqueuePodTerminationJob(ctx, "pod is no longer running"); err != nil {
+		if err = h.prepareForPodTermination(ctx, p, "pod is no longer running"); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
 		return gimlet.NewJSONResponse(&apimodels.NextTaskResponse{})
@@ -289,7 +289,7 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 	if nextTask == nil {
-		if err = h.enqueuePodTerminationJob(ctx, "reached end of pod lifecycle"); err != nil {
+		if err = h.prepareForPodTermination(ctx, p, "dispatch queue has no more tasks to run"); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
 		return gimlet.NewJSONResponse(&apimodels.NextTaskResponse{})
@@ -304,8 +304,17 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	})
 }
 
-// enqueuePodTerminationJob will enqueue the job to terminate a pod with a detailed reason for doing so.
-func (h *podAgentNextTask) enqueuePodTerminationJob(ctx context.Context, reason string) error {
+// prepareForPodTermination will mark the pod as preparing to terminate if it is
+// not already attempting to terminate and enqueue the job to terminate it with
+// a detailed reason for doing so.
+func (h *podAgentNextTask) prepareForPodTermination(ctx context.Context, p *pod.Pod, reason string) error {
+	if p.Status != pod.StatusDecommissioned && p.Status != pod.StatusTerminated {
+		// kim: TODO: test
+		if err := p.UpdateStatus(pod.StatusDecommissioned, reason); err != nil {
+			return errors.Wrap(err, "updating pod status to decommissioned")
+		}
+	}
+
 	j := units.NewPodTerminationJob(h.podID, reason, utility.RoundPartOfMinute(0))
 	if err := amboy.EnqueueUniqueJob(ctx, h.env.RemoteQueue(), j); err != nil {
 		return errors.Wrap(err, "enqueueing job to terminate pod")
@@ -320,7 +329,7 @@ func (h *podAgentNextTask) transitionStartingToRunning(p *pod.Pod) error {
 		return nil
 	}
 
-	return p.UpdateStatus(pod.StatusRunning)
+	return p.UpdateStatus(pod.StatusRunning, "agent requested next task to run, indicating that it is now running")
 }
 
 func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -309,7 +309,6 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 // a detailed reason for doing so.
 func (h *podAgentNextTask) prepareForPodTermination(ctx context.Context, p *pod.Pod, reason string) error {
 	if p.Status != pod.StatusDecommissioned && p.Status != pod.StatusTerminated {
-		// kim: TODO: test
 		if err := p.UpdateStatus(pod.StatusDecommissioned, reason); err != nil {
 			return errors.Wrap(err, "updating pod status to decommissioned")
 		}

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -490,7 +490,7 @@ func (sns *ecsSNS) handleStoppedPod(ctx context.Context, p *pod.Pod, reason stri
 		return nil
 	}
 
-	if err := p.UpdateStatus(pod.StatusDecommissioned); err != nil {
+	if err := p.UpdateStatus(pod.StatusDecommissioned, reason); err != nil {
 		return err
 	}
 

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -80,7 +80,7 @@ func (j *podCreationJob) Run(ctx context.Context) {
 		}
 
 		if j.pod != nil && j.pod.Status == pod.StatusInitializing && (j.RetryInfo().GetRemainingAttempts() == 0 || !j.RetryInfo().ShouldRetry()) {
-			j.AddError(errors.Wrap(j.pod.UpdateStatus(pod.StatusDecommissioned), "updating pod status to decommissioned after pod failed to start"))
+			j.AddError(errors.Wrap(j.pod.UpdateStatus(pod.StatusDecommissioned, "pod failed to start and will not retry"), "updating pod status to decommissioned after pod failed to start"))
 
 			terminationJob := NewPodTerminationJob(j.PodID, fmt.Sprintf("pod creation job hit max attempts %d", j.RetryInfo().MaxAttempts), time.Now())
 			if err := amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminationJob); err != nil {
@@ -137,7 +137,7 @@ func (j *podCreationJob) Run(ctx context.Context) {
 			j.AddError(errors.Wrap(err, "updating pod resources"))
 		}
 
-		if err := j.pod.UpdateStatus(pod.StatusStarting); err != nil {
+		if err := j.pod.UpdateStatus(pod.StatusStarting, "pod successfully started"); err != nil {
 			j.AddError(errors.Wrap(err, "marking pod as starting"))
 		}
 

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -85,7 +85,7 @@ func TestPodCreationJob(t *testing.T) {
 		},
 		"FailsWithStartingStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
-			require.NoError(t, j.pod.UpdateStatus(pod.StatusStarting))
+			require.NoError(t, j.pod.UpdateStatus(pod.StatusStarting, ""))
 			assert.Equal(t, pod.StatusStarting, j.pod.Status)
 
 			j.Run(ctx)
@@ -101,7 +101,7 @@ func TestPodCreationJob(t *testing.T) {
 		},
 		"FailsWithRunningStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
-			require.NoError(t, j.pod.UpdateStatus(pod.StatusRunning))
+			require.NoError(t, j.pod.UpdateStatus(pod.StatusRunning, ""))
 			assert.Equal(t, pod.StatusRunning, j.pod.Status)
 
 			j.Run(ctx)
@@ -117,7 +117,7 @@ func TestPodCreationJob(t *testing.T) {
 		},
 		"FailsWithTerminatedStatus": func(ctx context.Context, t *testing.T, j *podCreationJob) {
 			require.NoError(t, j.pod.Insert())
-			require.NoError(t, j.pod.UpdateStatus(pod.StatusTerminated))
+			require.NoError(t, j.pod.UpdateStatus(pod.StatusTerminated, ""))
 
 			j.Run(ctx)
 			require.Error(t, j.Error())

--- a/units/pod_definition_creation.go
+++ b/units/pod_definition_creation.go
@@ -175,7 +175,7 @@ func (j *podDefinitionCreationJob) decommissionDependentIntentPods() error {
 	catcher := grip.NewBasicCatcher()
 	var podIDs []string
 	for _, p := range podsToDecommission {
-		catcher.Wrapf(p.UpdateStatus(pod.StatusDecommissioned), "pod '%s'", p.ID)
+		catcher.Wrapf(p.UpdateStatus(pod.StatusDecommissioned, "pod definition could not be created"), "pod '%s'", p.ID)
 		podIDs = append(podIDs, p.ID)
 	}
 

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -122,7 +122,7 @@ func (j *podTerminationJob) Run(ctx context.Context) {
 		})
 	}
 
-	if err := j.pod.UpdateStatus(pod.StatusTerminated); err != nil {
+	if err := j.pod.UpdateStatus(pod.StatusTerminated, j.Reason); err != nil {
 		j.AddError(errors.Wrap(err, "marking pod as terminated"))
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17562

### Description 
* Decommission pods that have no tasks to dispatch. This is just small extra safety in case enqueueing the pod termination job fails to ensure that the pod will refuse to dispatch tasks until it's terminated.
* Allow pod status to be updated with optional reason indicating why the status got updated. The reason makes it more traceable in the event logs why the system took particular actions on the pod.

### Testing 
Updated unit tests.