### PR TITLE
EVG-16886 Split raw test logs by line breaks

### DIFF
--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
@@ -102,7 +103,7 @@ func (c *attachResults) sendTestLogs(ctx context.Context, conf *internal.TaskCon
 				Name:          utility.RandomString(),
 				Task:          conf.Task.Id,
 				TaskExecution: conf.Task.Execution,
-				Lines:         []string{res.LogRaw},
+				Lines:         strings.Split(res.LogRaw, "\n"),
 			}
 
 			if err := sendTestLog(ctx, comm, conf, testLogs); err != nil {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-08-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-08-23"
+	AgentVersion = "2022-08-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-16886](https://jira.mongodb.org/browse/EVG-16886)

### Description 
Currently multi-line log files are uploaded on a single line in the attach.results command.  This causes the HTML log page to highlight the entire document as the "first line". Change has been made to split these logs accordingly.
### Testing 
Deployed to staging and ran attach.results on the sandbox project with two sample raw logs, one delimited by `\n` line breaks and one delimited by `\r\n` line breaks and checked that both html log pages were divided by line appropriately.