### PR TITLE
fix(EVG-17606): assume role session name

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -100,7 +101,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 	}))
 
 	creds := stscreds.NewCredentials(session1, r.RoleARN, func(arp *stscreds.AssumeRoleProvider) {
-		arp.RoleSessionName = time.Now().String()
+		arp.RoleSessionName = strconv.Itoa(int(time.Now().Unix()))
 		if r.ExternalId != "" {
 			arp.ExternalID = utility.ToStringPtr(r.ExternalId)
 		}

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-08-09"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-08-23"
+	AgentVersion = "2022-08-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
The [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) API has the following pattern constraint:

```
[\w+=,.@-]*
```

`time.Now().String()` returns a string like the following:

```
2009-11-10 23:00:00 +0000 UTC m=+0.000000001
```

Which does not match the pattern constraint.

Using `time.Now().Unix()` matches the pattern constraint and should mitigate the `ValidationError` returned by the AWS API.

See [EVG-17606](https://jira.mongodb.org/browse/EVG-17606)
