### PR TITLE
EVG-17388: ensure pods cannot exceed max global CPU/memory

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -135,6 +135,12 @@ func (c *AWSPodConfig) Validate() error {
 
 // ECSConfig represents configuration for AWS ECS.
 type ECSConfig struct {
+	// MaxCPU is the maximum allowed CPU units (1024 CPU units = 1 vCPU) that a
+	// single pod can use.
+	MaxCPU int `bson:"max_cpu" json:"max_cpu" yaml:"max_cpu"`
+	// MaxMemoryMB is the maximum allowed memory (in MB) that a single pod can
+	// use.
+	MaxMemoryMB int `bson:"max_memory_mb" json:"max_memory_mb" yaml:"max_memory_mb"`
 	// TaskDefinitionPrefix is the prefix for the task definition families.
 	TaskDefinitionPrefix string `bson:"task_definition_prefix" json:"task_definition_prefix" yaml:"task_definition_prefix"`
 	// TaskRole is the IAM role that ECS tasks can assume to make AWS requests.

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -290,6 +290,28 @@ func TestNewTaskIntentPod(t *testing.T) {
 		assert.Error(t, err)
 		assert.Zero(t, p)
 	})
+	t.Run("FailsWithCPUExceedingGlobalMaxCPU", func(t *testing.T) {
+		opts := makeValidOpts()
+		ecsConf := evergreen.ECSConfig{
+			MaxCPU:      1024,
+			MaxMemoryMB: 2048,
+		}
+		opts.CPU = ecsConf.MaxCPU + 1
+		p, err := NewTaskIntentPod(ecsConf, opts)
+		assert.Error(t, err)
+		assert.Zero(t, p)
+	})
+	t.Run("FailsWithCPUExceedingGlobalMaxMemoryMB", func(t *testing.T) {
+		opts := makeValidOpts()
+		ecsConf := evergreen.ECSConfig{
+			MaxCPU:      1024,
+			MaxMemoryMB: 2048,
+		}
+		opts.MemoryMB = ecsConf.MaxMemoryMB + 1
+		p, err := NewTaskIntentPod(ecsConf, opts)
+		assert.Error(t, err)
+		assert.Zero(t, p)
+	})
 }
 
 func TestUpdateStatus(t *testing.T) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2613,16 +2613,16 @@ func GetMessageForPatch(patchID string) (string, error) {
 // ValidateContainers inspects the list of containers defined in the project YAML and checks that each
 // are properly configured, and that their definitions can coexist with what is defined for container sizes
 // on the project admin page.
-func ValidateContainers(pRef *ProjectRef, containers []Container) error {
+func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, containers []Container) error {
 	catcher := grip.NewSimpleCatcher()
 	for _, container := range containers {
 		catcher.Add(container.System.Validate())
 		if container.Resources != nil {
-			catcher.Add(container.Resources.Validate())
+			catcher.Add(container.Resources.Validate(ecsConf))
 		}
 		size, ok := pRef.ContainerSizes[container.Size]
 		if ok {
-			catcher.Add(size.Validate())
+			catcher.Add(size.Validate(ecsConf))
 		}
 		catcher.ErrorfWhen(container.Size != "" && !ok, "size '%s' is not defined anywhere", container.Size)
 		if container.Credential != "" {
@@ -2661,10 +2661,14 @@ func (c ContainerSystem) Validate() error {
 }
 
 // Validate that essential ContainerResources fields are properly defined.
-func (c ContainerResources) Validate() error {
+func (c ContainerResources) Validate(ecsConf evergreen.ECSConfig) error {
 	catcher := grip.NewSimpleCatcher()
 	catcher.NewWhen(c.CPU <= 0, "container resource CPU must be a positive integer")
 	catcher.NewWhen(c.MemoryMB <= 0, "container resource memory MB must be a positive integer")
+
+	catcher.ErrorfWhen(ecsConf.MaxCPU > 0 && c.CPU > ecsConf.MaxCPU, "CPU cannot exceed maximum global limit of %d CPU units", ecsConf.MaxCPU)
+	catcher.ErrorfWhen(ecsConf.MaxMemoryMB > 0 && c.MemoryMB > ecsConf.MaxMemoryMB, "memory cannot exceed maximum global limit of %d MB", ecsConf.MaxMemoryMB)
+
 	return catcher.Resolve()
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1689,6 +1689,8 @@ func (a *APIAWSPodConfig) ToService() (*evergreen.AWSPodConfig, error) {
 
 // APIECSConfig represents configuration options for AWS ECS.
 type APIECSConfig struct {
+	MaxCPU               *int                     `json:"max_cpu"`
+	MaxMemoryMB          *int                     `json:"max_memory_mb"`
 	TaskDefinitionPrefix *string                  `json:"task_definition_prefix"`
 	TaskRole             *string                  `json:"task_role"`
 	ExecutionRole        *string                  `json:"execution_role"`
@@ -1698,6 +1700,8 @@ type APIECSConfig struct {
 }
 
 func (a *APIECSConfig) BuildFromService(conf evergreen.ECSConfig) {
+	a.MaxCPU = utility.ToIntPtr(conf.MaxCPU)
+	a.MaxMemoryMB = utility.ToIntPtr(conf.MaxMemoryMB)
 	a.TaskDefinitionPrefix = utility.ToStringPtr(conf.TaskDefinitionPrefix)
 	a.TaskRole = utility.ToStringPtr(conf.TaskRole)
 	a.ExecutionRole = utility.ToStringPtr(conf.ExecutionRole)
@@ -1739,6 +1743,8 @@ func (a *APIECSConfig) ToService() (*evergreen.ECSConfig, error) {
 	}
 
 	return &evergreen.ECSConfig{
+		MaxCPU:               utility.FromIntPtr(a.MaxCPU),
+		MaxMemoryMB:          utility.FromIntPtr(a.MaxMemoryMB),
 		TaskDefinitionPrefix: utility.FromStringPtr(a.TaskDefinitionPrefix),
 		TaskRole:             utility.FromStringPtr(a.TaskRole),
 		ExecutionRole:        utility.FromStringPtr(a.ExecutionRole),

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -172,6 +172,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.TaskSyncRead.Bucket, utility.FromStringPtr(apiSettings.Providers.AWS.TaskSync.Bucket))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.Role, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Role))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.Region, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.Region))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.MaxCPU, utility.FromIntPtr(apiSettings.Providers.AWS.Pod.ECS.MaxCPU))
+	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.MaxMemoryMB, utility.FromIntPtr(apiSettings.Providers.AWS.Pod.ECS.MaxMemoryMB))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.TaskDefinitionPrefix))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.TaskRole, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.TaskRole))
 	assert.EqualValues(testSettings.Providers.AWS.Pod.ECS.AWSVPC.Subnets, apiSettings.Providers.AWS.Pod.ECS.AWSVPC.Subnets)

--- a/service/project.go
+++ b/service/project.go
@@ -617,7 +617,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	}
 	for size, containerResource := range containerSizes {
 		catcher.NewWhen(size == "", "container size name cannot be empty")
-		catcher.Wrapf(containerResource.Validate(), "invalid container size '%s'", size)
+		catcher.Wrapf(containerResource.Validate(evergreen.GetEnvironment().Settings().Providers.AWS.Pod.ECS), "invalid container size '%s'", size)
 	}
 
 	if catcher.HasErrors() {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1894,6 +1894,14 @@ Admin Settings
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>Pod ECS Max CPU Units Per Pod</label>
+										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_cpu">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<label>Pod ECS Max Memory (MB) Per Pod</label>
+										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_memory_mb">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.role">
 									</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -293,6 +293,8 @@ func MockConfig() *evergreen.Settings {
 					Role:   "role",
 					Region: "region",
 					ECS: evergreen.ECSConfig{
+						MaxCPU:               2048,
+						MaxMemoryMB:          4096,
 						TaskDefinitionPrefix: "ecs_prefix",
 						TaskRole:             "task_role",
 						ExecutionRole:        "execution_role",

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -342,7 +342,7 @@ func validateAllDependenciesSpec(project *model.Project) ValidationErrors {
 
 func validateContainers(project *model.Project, ref *model.ProjectRef, _ bool) ValidationErrors {
 	errs := ValidationErrors{}
-	err := model.ValidateContainers(ref, project.Containers)
+	err := model.ValidateContainers(evergreen.GetEnvironment().Settings().Providers.AWS.Pod.ECS, ref, project.Containers)
 	if err != nil {
 		errs = append(errs,
 			ValidationError{
@@ -459,7 +459,7 @@ func validateProjectConfigContainers(pc *model.ProjectConfig) ValidationErrors {
 			})
 		}
 
-		if err := containerResource.Validate(); err != nil {
+		if err := containerResource.Validate(evergreen.GetEnvironment().Settings().Providers.AWS.Pod.ECS); err != nil {
 			errs = append(errs,
 				ValidationError{
 					Message: errors.Wrap(err, "error validating container resources").Error(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17388

### Description 
* Add admin setting for max CPU and memory for ECS. This is to ensure that users can't specify a CPU/memory value that exceeds the amount available for the EC2 instance type.
* Check CPU and memory limit during validation.
* Check CPU and memory limit during pod creation. This is to ensure that the limit is enforced even if the limit changes after the task already exists (such as restarting a very old task that may exceed the current limits).

### Testing 
Added unit tests. I checked with local Evergreen that the admin settings work in an e2e way.
