### PR TITLE
EVG-17572: decommission pods once they have been assigned a task

### DIFF
--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -182,8 +182,18 @@ func TestAssignNextTask(t *testing.T) {
 
 		podEvents, err := event.FindAllByResourceID(p.ID)
 		require.NoError(t, err)
-		require.Len(t, podEvents, 1)
-		assert.Equal(t, string(event.EventPodAssignedTask), podEvents[0].EventType)
+		var foundPodAssignedTask bool
+		var foundPodUpdatedStatus bool
+		for _, podEvent := range podEvents {
+			switch podEvent.EventType {
+			case string(event.EventPodAssignedTask):
+				foundPodAssignedTask = true
+			case string(event.EventPodStatusChange):
+				foundPodUpdatedStatus = true
+			}
+		}
+		assert.True(t, foundPodAssignedTask)
+		assert.True(t, foundPodUpdatedStatus)
 	}
 
 	checkTaskUnallocated := func(t *testing.T, tsk task.Task) {

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -173,6 +173,7 @@ func TestAssignNextTask(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, dbPod)
 		assert.Equal(t, tsk.Id, dbPod.RunningTask)
+		assert.Equal(t, pod.StatusDecommissioned, dbPod.Status)
 
 		taskEvents, err := event.FindAllByResourceID(dbTask.Id)
 		require.NoError(t, err)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -673,6 +673,10 @@ func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, tas
 	update := bson.M{
 		"$set": bson.M{
 			RunningTaskKey: taskID,
+			// Decommissioning ensures that the pod cannot run another task.
+			// TODO (PM-2618): adjust this to handle cases such as
+			// single-container task groups, where the pod may be reused.
+			StatusKey: StatusDecommissioned,
 		},
 	}
 

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
@@ -689,6 +690,9 @@ func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, tas
 	}
 
 	p.RunningTask = taskID
+	p.Status = StatusDecommissioned
+
+	event.LogPodStatusChanged(p.ID, string(StatusRunning), string(StatusDecommissioned), "pod has been assigned a task and will not be reused")
 
 	return nil
 }

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -543,6 +543,7 @@ func TestSetRunningTask(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
 			assert.Equal(t, taskID, dbPod.RunningTask)
+			assert.Equal(t, StatusDecommissioned, dbPod.Status)
 		},
 		"NoopsWithPodAlreadyRunningSameTask": func(ctx context.Context, t *testing.T, env *mock.Environment, p Pod) {
 			const taskID = "task"

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -263,7 +263,7 @@ func TestPodAgentNextTask(t *testing.T) {
 			stats := env.RemoteQueue().Stats(ctx)
 			assert.Equal(t, 1, stats.Total)
 		},
-		"RunUpdatesStartingPodToRunning": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
+		"RunUpdatesStartingPodToDecommissionedAfterTaskDispatch": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
 			p := getPod()
 			p.TimeInfo.Initializing = time.Now()
 			require.NoError(t, p.Insert())
@@ -284,7 +284,8 @@ func TestPodAgentNextTask(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
 			assert.NotZero(t, dbPod.TimeInfo.AgentStarted)
-			assert.Equal(t, pod.StatusRunning, dbPod.Status)
+			assert.Equal(t, pod.StatusDecommissioned, dbPod.Status)
+			assert.Equal(t, tsk.Id, dbPod.RunningTask)
 		},
 		"RunReturnsRunningTaskIfItExists": func(ctx context.Context, t *testing.T, rh *podAgentNextTask, env evergreen.Environment) {
 			tsk := getTask()


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17572

### Description 
Add an extra safety check to ensure that we do not try running more tasks on a pod once it's been assigned a task. This is only meant as a temporary measure and will probably need more complex logic once task groups are supported to decide when a pod can no longer be reused.

### Testing
Added unit tests.