### PR TITLE
EVG-12490: Adjust commit queue position to be one-indexed on patch page

### DIFF
--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -59,10 +59,14 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, obj *restModel.
 	if *obj.Alias == evergreen.CommitQueueAlias {
 		cq, err := commitqueue.FindOneId(*obj.ProjectId)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting commit queue position for patch %s: %s", *obj.Id, err.Error()))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting commit queue position for patch '%s': %s", *obj.Id, err.Error()))
 		}
 		if cq != nil {
 			position := cq.FindItem(*obj.Id)
+			// Adjust to be one-indexed if found on commit queue.
+			if position >= 0 {
+				position += 1
+			}
 			commitQueuePosition = &position
 		}
 	}

--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -134,7 +134,7 @@
       "result": {
         "data": {
           "patch": {
-            "commitQueuePosition": 0
+            "commitQueuePosition": 1
           }
         }
       }


### PR DESCRIPTION
[EVG-12490](https://jira.mongodb.org/browse/EVG-12490)

### Description 
On the commit-queue page ([example](https://spruce.mongodb.com/commit-queue/mongodb-mongo-master)), the list of patches is 1-indexed. However on the patches page, the commit queue position is 0-indexed. If a patch has a commit queue position of 0, that means it's actually the first patch on the commit queue.

To be consistent with the commit queue list, I adjusted the commit queue position to be 1-indexed in `patch_resolver.go`. This is also consistent with how we report task queue positions, which are 1-indexed.

### Note
This is only a UI facing change. Internally we rely on the 0-indexed commit queue in a few different places so I did not make any changes around that.

I'm not sure if this means that I should also update the commit queue position for the patch route once [EVG-17314](https://jira.mongodb.org/browse/EVG-17314) is complete. It could be confusing to see different commit queue positions between the UI and the API. 

### Testing 
- On staging Sandbox
- Adjusted GraphQL test
