### PR TITLE
EVG-17224 Terminate pod when task dispatching is disabled

### DIFF
--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -251,8 +251,10 @@ func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "retrieving admin settings"))
 	}
 	if flags.TaskDispatchDisabled {
-		// TODO: EVG-17224 Potentially terminate pod when task dispatching is disabled
 		grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), "task dispatch is disabled, returning no task")
+		if err = h.prepareForPodTermination(ctx, p, "task dispatching is disabled"); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
 		return gimlet.NewJSONResponse(&apimodels.NextTaskResponse{})
 	}
 


### PR DESCRIPTION
[EVG-17224](https://jira.mongodb.org/browse/EVG-17224)

### Description 
Change made to terminate a pod when task dispatching is disabled, since it is an unnecessary cost to keep pods alive that are not going to actually be running any tasks.
### Testing 
Added testing confirming that when dispatching is disabled that the pod termination job enqueues and terminates the pod successfully.