### PR TITLE
EVG-16907: handle creating project secrets for new projects without an ID

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -356,6 +356,10 @@ func DeleteContainerSecrets(ctx context.Context, v cocoa.Vault, pRef *model.Proj
 // getCopiedContainerSecrets gets a copy of an existing set of container
 // secrets. It returns the new secrets to create.
 func getCopiedContainerSecrets(ctx context.Context, settings *evergreen.Settings, v cocoa.Vault, projectID string, toCopy []model.ContainerSecret) ([]model.ContainerSecret, error) {
+	if projectID == "" {
+		return nil, errors.New("cannot copy container secrets without a project ID")
+	}
+
 	var copied []model.ContainerSecret
 	catcher := grip.NewBasicCatcher()
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16907

### Description
This is a small bugfix to ensure that newly-created projects that don't have an ID have their new pod ID populated correctly. Originally, the container secrets were copied before inserting it into the DB, but [for new projects that don't explicitly set an ID, the ID is not set until `Add` populates it](https://github.com/evergreen-ci/evergreen/blob/04dae53af29c217ae84b6dbd8d13620c893c977d/model/project_ref.go#L459-L461). I moved it so that the container secrets are set after the project is inserted so the project ID is set.

### Testing 
Existing tests should be sufficient.
