### PR TITLE
EVG-16907: fix temporary nil interface check

### DIFF
--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -134,41 +134,26 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	// infrastructure is productionized and AWS admin settings are set.
 	smClient, err := cloud.MakeSecretsManagerClient(settings)
 	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "setting up Secrets Manager client to store newly-created project's container secrets").Error(),
-		}
+		return errors.Wrap(err, "setting up Secrets Manager client to store newly-created project's container secrets")
 	}
 	defer smClient.Close(ctx)
 
 	vault, err := cloud.MakeSecretsManagerVault(smClient)
 	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "setting up Secrets Manager vault to store newly-created project's container secrets").Error(),
-		}
+		return errors.Wrap(err, "setting up Secrets Manager vault to store newly-created project's container secrets")
 	}
 
 	pRef.ContainerSecrets, err = getCopiedContainerSecrets(ctx, settings, vault, pRef.Id, existingSecrets)
 	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "copying existing container secrets").Error(),
-		}
+		return errors.Wrapf(err, "copying existing container secrets")
 	}
 	if err := pRef.Update(); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "updating project ref's container secrets").Error(),
-		}
+		return errors.Wrapf(err, "updating project ref's container secrets")
 	}
 	// This updates the container secrets in the DB project ref only, not
 	// the in-memory copy.
 	if err := UpsertContainerSecrets(ctx, vault, pRef.ContainerSecrets); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "upserting container secrets").Error(),
-		}
+		return errors.Wrapf(err, "upserting container secrets")
 	}
 
 	return nil

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -456,6 +456,9 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
+	// TODO (PM-2950): remove this temporary conditional initialization for the
+	// vault once the AWS infrastructure is productionized and AWS admin
+	// settings are set.
 	if h.vault == nil && (len(h.apiNewProjectRef.DeleteContainerSecrets) != 0 || len(h.apiNewProjectRef.ContainerSecrets) != 0) {
 		smClient, err := cloud.MakeSecretsManagerClient(h.settings)
 		if err != nil {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16907

### Description 
I forgot about [the nil interface checking rule](https://mangatmodi.medium.com/go-check-nil-interface-the-right-way-d142776edef1), so checking for a non-nil Secrets Manager client is insufficient because an interface (`cocoa.SecretsManagerClient`) wrapping a nil pointer (`*BasicSecretsManagerClient`) is not nil. It seems like setting up container secrets _should_ happen (or else the project can't run container tasks), but we have to wait until Secrets Manager is available to production.

### Testing 
Not really testable, so I just did it by inspection.
