### PR TITLE
EVG-17335 validate commit queue aliases

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2663,6 +2663,22 @@ func (h *Host) MarkShouldExpire(expireOnValue string) error {
 	)
 }
 
+// UnsetHomeVolume disassociates a home volume from a (stopped) host.
+// This is for internal use, and should only be used on hosts that
+// will be terminated imminently; otherwise, the host will fail to boot.
+func (h *Host) UnsetHomeVolume() error {
+	err := UpdateOne(
+		bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{HomeVolumeIDKey: ""}},
+	)
+	if err != nil {
+		return err
+	}
+
+	h.HomeVolumeID = ""
+	return nil
+}
+
 func (h *Host) SetHomeVolumeID(volumeID string) error {
 	h.HomeVolumeID = volumeID
 	return UpdateOne(bson.M{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4516,6 +4516,38 @@ func TestAddVolumeToHost(t *testing.T) {
 	}, foundHost.Volumes)
 }
 
+func TestUnsetHomeVolume(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+	h := &Host{
+		Id:           "host-1",
+		HomeVolumeID: "volume-1",
+		Volumes: []VolumeAttachment{
+			{
+				VolumeID:   "volume-1",
+				DeviceName: "device-1",
+			},
+		},
+	}
+	assert.NoError(t, h.Insert())
+	assert.NoError(t, h.UnsetHomeVolume())
+	assert.Equal(t, "", h.HomeVolumeID)
+	assert.Equal(t, []VolumeAttachment{
+		{
+			VolumeID:   "volume-1",
+			DeviceName: "device-1",
+		},
+	}, h.Volumes)
+	foundHost, err := FindOneId("host-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "", foundHost.HomeVolumeID)
+	assert.Equal(t, []VolumeAttachment{
+		{
+			VolumeID:   "volume-1",
+			DeviceName: "device-1",
+		},
+	}, foundHost.Volumes)
+}
+
 func TestRemoveVolumeFromHost(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
 	h := &Host{

--- a/model/project.go
+++ b/model/project.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-gitignore"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/20210107192922/yaml.v3"
 )
 
 const (
@@ -43,39 +43,34 @@ type GetProjectTasksOpts struct {
 }
 
 type Project struct {
-	Enabled             bool                       `yaml:"enabled,omitempty" bson:"enabled"`
-	Stepback            bool                       `yaml:"stepback,omitempty" bson:"stepback"`
-	PreErrorFailsTask   bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
-	PostErrorFailsTask  bool                       `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
-	OomTracker          bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker"`
-	BatchTime           int                        `yaml:"batchtime,omitempty" bson:"batch_time"`
-	Owner               string                     `yaml:"owner,omitempty" bson:"owner_name"`
-	Repo                string                     `yaml:"repo,omitempty" bson:"repo_name"`
-	RemotePath          string                     `yaml:"remote_path,omitempty" bson:"remote_path"`
-	Branch              string                     `yaml:"branch,omitempty" bson:"branch_name"`
-	Identifier          string                     `yaml:"identifier,omitempty" bson:"identifier"`
-	DisplayName         string                     `yaml:"display_name,omitempty" bson:"display_name"`
-	CommandType         string                     `yaml:"command_type,omitempty" bson:"command_type"`
-	Ignore              []string                   `yaml:"ignore,omitempty" bson:"ignore"`
-	Parameters          []ParameterInfo            `yaml:"parameters,omitempty" bson:"parameters,omitempty"`
-	Pre                 *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre"`
-	Post                *YAMLCommandSet            `yaml:"post,omitempty" bson:"post"`
-	Timeout             *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout"`
-	EarlyTermination    *YAMLCommandSet            `yaml:"early_termination,omitempty" bson:"early_termination,omitempty"`
-	CallbackTimeout     int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs"`
-	Modules             ModuleList                 `yaml:"modules,omitempty" bson:"modules"`
-	Containers          []Container                `yaml:"containers,omitempty" bson:"containers"`
-	BuildVariants       BuildVariants              `yaml:"buildvariants,omitempty" bson:"build_variants"`
-	Functions           map[string]*YAMLCommandSet `yaml:"functions,omitempty" bson:"functions"`
-	TaskGroups          []TaskGroup                `yaml:"task_groups,omitempty" bson:"task_groups"`
-	Tasks               []ProjectTask              `yaml:"tasks,omitempty" bson:"tasks"`
-	ExecTimeoutSecs     int                        `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
-	Loggers             *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
-	CommitQueueAliases  []ProjectAlias             `yaml:"commit_queue_aliases,omitempty" bson:"commit_queue_aliases,omitempty"`
-	GitHubPRAliases     []ProjectAlias             `yaml:"github_pr_aliases,omitempty" bson:"github_pr_aliases,omitempty"`
-	GitTagAliases       []ProjectAlias             `yaml:"git_tag_aliases,omitempty" bson:"git_tag_aliases,omitempty"`
-	GitHubChecksAliases []ProjectAlias             `yaml:"github_checks_aliases,omitempty" bson:"github_checks_aliases,omitempty"`
-	PatchAliases        []ProjectAlias             `yaml:"patch_aliases,omitempty" bson:"patch_aliases,omitempty"`
+	Enabled            bool                       `yaml:"enabled,omitempty" bson:"enabled"`
+	Stepback           bool                       `yaml:"stepback,omitempty" bson:"stepback"`
+	PreErrorFailsTask  bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
+	PostErrorFailsTask bool                       `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
+	OomTracker         bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker"`
+	BatchTime          int                        `yaml:"batchtime,omitempty" bson:"batch_time"`
+	Owner              string                     `yaml:"owner,omitempty" bson:"owner_name"`
+	Repo               string                     `yaml:"repo,omitempty" bson:"repo_name"`
+	RemotePath         string                     `yaml:"remote_path,omitempty" bson:"remote_path"`
+	Branch             string                     `yaml:"branch,omitempty" bson:"branch_name"`
+	Identifier         string                     `yaml:"identifier,omitempty" bson:"identifier"`
+	DisplayName        string                     `yaml:"display_name,omitempty" bson:"display_name"`
+	CommandType        string                     `yaml:"command_type,omitempty" bson:"command_type"`
+	Ignore             []string                   `yaml:"ignore,omitempty" bson:"ignore"`
+	Parameters         []ParameterInfo            `yaml:"parameters,omitempty" bson:"parameters,omitempty"`
+	Pre                *YAMLCommandSet            `yaml:"pre,omitempty" bson:"pre"`
+	Post               *YAMLCommandSet            `yaml:"post,omitempty" bson:"post"`
+	Timeout            *YAMLCommandSet            `yaml:"timeout,omitempty" bson:"timeout"`
+	EarlyTermination   *YAMLCommandSet            `yaml:"early_termination,omitempty" bson:"early_termination,omitempty"`
+	CallbackTimeout    int                        `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs"`
+	Modules            ModuleList                 `yaml:"modules,omitempty" bson:"modules"`
+	Containers         []Container                `yaml:"containers,omitempty" bson:"containers"`
+	BuildVariants      BuildVariants              `yaml:"buildvariants,omitempty" bson:"build_variants"`
+	Functions          map[string]*YAMLCommandSet `yaml:"functions,omitempty" bson:"functions"`
+	TaskGroups         []TaskGroup                `yaml:"task_groups,omitempty" bson:"task_groups"`
+	Tasks              []ProjectTask              `yaml:"tasks,omitempty" bson:"tasks"`
+	ExecTimeoutSecs    int                        `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
+	Loggers            *LoggerConfig              `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 
 	// Flag that indicates a project as requiring user authentication
 	Private bool `yaml:"private,omitempty" bson:"private"`
@@ -1770,7 +1765,7 @@ func (p *Project) IsGenerateTask(taskName string) bool {
 }
 
 func (p *Project) findAliasesForPatch(alias string, patchDoc *patch.Patch) ([]ProjectAlias, error) {
-	vars, shouldExit, err := FindAliasInProjectOrRepoFromDb(p.Identifier, alias)
+	vars, shouldExit, err := findAliasInProjectOrRepoFromDb(p.Identifier, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting alias from project")
 	}
@@ -1857,29 +1852,29 @@ func (p *Project) BuildProjectTVPairsWithAlias(vars []ProjectAlias) ([]TVPair, [
 	displayTaskPairs := []TVPair{}
 	for _, v := range vars {
 		var variantRegex *regexp.Regexp
-		variantRegex, err := regexp.Compile(v.Variant)
+		variantRegex, err := v.getVariantRegex()
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "compiling regex '%s'", v.Variant)
+			return nil, nil, err
 		}
 
 		var taskRegex *regexp.Regexp
-		taskRegex, err = regexp.Compile(v.Task)
+		taskRegex, err = v.getTaskRegex()
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "compiling regex '%s'", v.Task)
+			return nil, nil, err
 		}
 
 		for _, variant := range p.BuildVariants {
-			if isValidRegexOrTag(variant.Name, v.Variant, variant.Tags, v.VariantTags, variantRegex) {
-				for _, task := range p.Tasks {
-					if task.Patchable != nil && !(*task.Patchable) {
+			if isValidRegexOrTag(variant.Name, variant.Tags, v.VariantTags, variantRegex) {
+				for _, t := range p.Tasks {
+					if t.Patchable != nil && !(*t.Patchable) {
 						continue
 					}
-					if !isValidRegexOrTag(task.Name, v.Task, task.Tags, v.TaskTags, taskRegex) {
+					if !isValidRegexOrTag(t.Name, t.Tags, v.TaskTags, taskRegex) {
 						continue
 					}
 
-					if p.FindTaskForVariant(task.Name, variant.Name) != nil {
-						pairs = append(pairs, TVPair{variant.Name, task.Name})
+					if p.FindTaskForVariant(t.Name, variant.Name) != nil {
+						pairs = append(pairs, TVPair{variant.Name, t.Name})
 					}
 				}
 

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -74,7 +74,16 @@ type ProjectAlias struct {
 	VariantTags []string         `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
 	Task        string           `bson:"task,omitempty" json:"task" yaml:"task"`
 	TaskTags    []string         `bson:"tags,omitempty" json:"tags" yaml:"task_tags"`
+
+	// Source is not stored; indicates where the alias is stored for the project.
+	Source string `bson:"-" json:"-" yaml:"-"`
 }
+
+const (
+	AliasSourceProject = "project"
+	AliasSourceConfig  = "config"
+	AliasSourceRepo    = "repo"
+)
 
 type ProjectAliases []ProjectAlias
 
@@ -91,15 +100,23 @@ func FindAliasesForProjectFromDb(projectID string) ([]ProjectAlias, error) {
 	return out, nil
 }
 
-// MergeAliasesWithProjectConfig returns a merged list of project aliases that includes the merged result of aliases defined
+// GetAliasesMergedWithProjectConfig returns a merged list of project aliases that includes the merged result of aliases defined
 // on the project ref and aliases defined in the project YAML.  Aliases defined on the project ref will take precedence over the
 // project YAML in the case that both are defined.
-func MergeAliasesWithProjectConfig(projectID string, dbAliases []ProjectAlias) ([]ProjectAlias, error) {
-	dbAliasMap := aliasesToMap(dbAliases)
+func GetAliasesMergedWithProjectConfig(projectID string, dbAliases []ProjectAlias) ([]ProjectAlias, error) {
 	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project config")
 	}
+	return mergeProjectConfigAndAliases(projectConfig, dbAliases), nil
+}
+
+func mergeProjectConfigAndAliases(projectConfig *ProjectConfig, dbAliases []ProjectAlias) []ProjectAlias {
+	if projectConfig == nil {
+		return dbAliases
+	}
+	dbAliasMap := aliasesToMap(dbAliases)
+
 	patchAliases := []ProjectAlias{}
 	for alias, aliases := range dbAliasMap {
 		if IsPatchAlias(alias) {
@@ -129,7 +146,7 @@ func MergeAliasesWithProjectConfig(projectID string, dbAliases []ProjectAlias) (
 	mergedAliases = append(mergedAliases, dbAliasMap[evergreen.GitTagAlias]...)
 	mergedAliases = append(mergedAliases, dbAliasMap[evergreen.GithubPRAlias]...)
 	mergedAliases = append(mergedAliases, patchAliases...)
-	return mergedAliases, nil
+	return mergedAliases
 }
 
 // FindAliasesForRepo fetches all aliases for a given project
@@ -201,7 +218,8 @@ func findMatchingAliasForProjectConfig(projectID, alias string) ([]ProjectAlias,
 }
 
 func findAliasFromProjectConfig(projectConfig *ProjectConfig, alias string) ([]ProjectAlias, error) {
-	projectConfigAliases := aliasesToMap(getFullProjectConfigAliases(projectConfig))
+	projectConfig.SetInternalAliases()
+	projectConfigAliases := aliasesToMap(projectConfig.AllAliases())
 	return projectConfigAliases[alias], nil
 }
 
@@ -220,34 +238,18 @@ func aliasesToMap(aliases []ProjectAlias) map[string][]ProjectAlias {
 	return output
 }
 
-func getFullProjectConfigAliases(projectConfig *ProjectConfig) []ProjectAlias {
-	var projectConfigAliases []ProjectAlias
-	if projectConfig != nil {
-		for _, commitQueueAlias := range projectConfig.CommitQueueAliases {
-			commitQueueAlias.Alias = evergreen.CommitQueueAlias
-			projectConfigAliases = append(projectConfigAliases, commitQueueAlias)
-		}
-		for _, gitTagAlias := range projectConfig.GitTagAliases {
-			gitTagAlias.Alias = evergreen.GitTagAlias
-			projectConfigAliases = append(projectConfigAliases, gitTagAlias)
-		}
-		for _, githubPrAlias := range projectConfig.GitHubPRAliases {
-			githubPrAlias.Alias = evergreen.GithubPRAlias
-			projectConfigAliases = append(projectConfigAliases, githubPrAlias)
-		}
-		for _, gitHubCheckAlias := range projectConfig.GitHubChecksAliases {
-			gitHubCheckAlias.Alias = evergreen.GithubChecksAlias
-			projectConfigAliases = append(projectConfigAliases, gitHubCheckAlias)
-		}
-		projectConfigAliases = append(projectConfigAliases, projectConfig.PatchAliases...)
+func aliasesFromMap(input map[string]ProjectAliases) []ProjectAlias {
+	output := []ProjectAlias{}
+	for _, aliases := range input {
+		output = append(output, aliases...)
 	}
-	return projectConfigAliases
+	return output
 }
 
 // FindAliasInProjectRepoOrConfig finds all aliases with a given name for a project.
 // If the project has no aliases, the repo is checked for aliases.
 func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, error) {
-	aliases, shouldExit, err := FindAliasInProjectOrRepoFromDb(projectID, alias)
+	aliases, shouldExit, err := findAliasInProjectOrRepoFromDb(projectID, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
 	}
@@ -260,26 +262,97 @@ func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, er
 	return findMatchingAliasForProjectConfig(projectID, alias)
 }
 
-// FindAliasInProjectRepoOrPatchedConfig finds all aliases with a given name for a project.
+// patchAliasKey is used internally to group patch aliases together.
+const patchAliasKey = "patch_alias"
+
+// FindMergedAliasesFromProjectRepoOrProjectConfig returns all aliases tht would be used by this project ref configuration,
+// by merging together repo and config aliases, if defined by the project.
+// Sets source equal to where the alias was defined.
+func FindMergedAliasesFromProjectRepoOrProjectConfig(projectRef *ProjectRef, projectConfig *ProjectConfig) ([]ProjectAlias, error) {
+	if projectRef == nil {
+		return nil, nil
+	}
+	projectAliases, err := FindAliasesForProjectFromDb(projectRef.Id)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding project aliases")
+	}
+	aliasesToReturn := map[string]ProjectAliases{}
+	for _, alias := range projectAliases {
+		aliasName := alias.Alias
+		if IsPatchAlias(aliasName) {
+			aliasName = patchAliasKey
+		}
+		alias.Source = AliasSourceProject
+		aliasesToReturn[aliasName] = append(aliasesToReturn[aliasName], alias)
+	}
+	// If all aliases are covered in the project, so there's no reason to look at other sources
+	uncoveredAliases := uncoveredAliasTypes(aliasesToReturn)
+	if len(uncoveredAliases) > 0 && projectRef.UseRepoSettings() {
+		// Get repo aliases and merge with project aliases
+		repoAliases, err := FindAliasesForRepo(projectRef.RepoRefId)
+		if err != nil {
+			return nil, errors.Wrap(err, "finding repo aliases")
+		}
+		for _, alias := range repoAliases {
+			aliasName := alias.Alias
+			if IsPatchAlias(aliasName) {
+				aliasName = patchAliasKey
+			}
+			if !utility.StringSliceContains(uncoveredAliases, aliasName) { // Only add alias if there aren't project aliases
+				continue
+			}
+			alias.Source = AliasSourceRepo
+			aliasesToReturn[aliasName] = append(aliasesToReturn[aliasName], alias)
+		}
+		// If all aliases covered in project/repo, then no reason to look at config
+		uncoveredAliases = uncoveredAliasTypes(aliasesToReturn)
+	}
+	res := aliasesFromMap(aliasesToReturn)
+	if len(uncoveredAliases) > 0 && projectRef.IsVersionControlEnabled() {
+		mergedAliases := mergeProjectConfigAndAliases(projectConfig, res)
+		// If we've added any new aliases, ensure they're given the config source
+		if len(mergedAliases) > len(res) {
+			for i, a := range mergedAliases {
+				if a.Source == "" {
+					mergedAliases[i].Source = AliasSourceConfig
+				}
+			}
+		}
+		return mergedAliases, nil
+	}
+	return res, nil
+}
+
+// uncoveredAliasTypes returns a list of alias types that aren't populated keys in the given map.
+func uncoveredAliasTypes(aliases map[string]ProjectAliases) []string {
+	res := []string{}
+	aliasesToCheck := append(evergreen.InternalAliases, patchAliasKey)
+	for _, name := range aliasesToCheck {
+		if len(aliases[name]) == 0 {
+			res = append(res, name)
+		}
+	}
+	return res
+}
+
+// FindAliasInProjectRepoOrProjectConfig finds all aliases with a given name for a project.
 // If the project has no aliases, the patched config string is checked for the alias as well.
-func FindAliasInProjectRepoOrPatchedConfig(projectID, alias, patchedConfig string) ([]ProjectAlias, error) {
-	aliases, shouldExit, err := FindAliasInProjectOrRepoFromDb(projectID, alias)
+func FindAliasInProjectRepoOrProjectConfig(projectID, alias string, projectConfig *ProjectConfig) ([]ProjectAlias, error) {
+	aliases, shouldExit, err := findAliasInProjectOrRepoFromDb(projectID, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
 	}
-	if len(aliases) > 0 || shouldExit || patchedConfig == "" {
+	if len(aliases) > 0 || shouldExit || projectConfig == nil {
 		return aliases, nil
 	}
-	projectConfig, err := CreateProjectConfig([]byte(patchedConfig), "")
-	if err != nil {
-		return nil, errors.Wrap(err, "creating project config from patch")
-	}
+
 	return findAliasFromProjectConfig(projectConfig, alias)
 }
 
-// FindAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
+// findAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
 // If the project has no aliases, the repo is checked for aliases.
-func FindAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, bool, error) {
+// Returns true if we should continue to look for repos from a different source.
+func findAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, bool, error) {
 	aliases, shouldExit, err := findMatchingAliasForProjectRef(projectID, alias)
 	if err != nil {
 		return aliases, false, errors.Wrapf(err, "finding aliases for project ref '%s'", projectID)
@@ -442,11 +515,11 @@ func (a ProjectAliases) HasMatchingGitTag(tag string) (bool, error) {
 func aliasesMatchingGitTag(a ProjectAliases, tag string) (ProjectAliases, error) {
 	res := []ProjectAlias{}
 	for _, alias := range a {
-		gitTagRegex, err := regexp.Compile(alias.GitTag)
+		gitTagRegex, err := alias.getGitTagRegex()
 		if err != nil {
-			return nil, errors.Wrapf(err, "compiling git tag regex '%s'", alias.GitTag)
+			return nil, err
 		}
-		if isValidRegexOrTag(tag, alias.GitTag, nil, nil, gitTagRegex) {
+		if isValidRegexOrTag(tag, nil, nil, gitTagRegex) {
 			res = append(res, alias)
 		}
 	}
@@ -456,47 +529,96 @@ func aliasesMatchingGitTag(a ProjectAliases, tag string) (ProjectAliases, error)
 func (a ProjectAliases) AliasesMatchingVariant(variant string, variantTags []string) (ProjectAliases, error) {
 	res := []ProjectAlias{}
 	for _, alias := range a {
-		variantRegex, err := regexp.Compile(alias.Variant)
+		hasMatch, err := alias.HasMatchingVariant(variant, variantTags)
 		if err != nil {
-			return nil, errors.Wrapf(err, "compiling variant regex '%s'", alias.Variant)
+			return nil, err
 		}
-		if isValidRegexOrTag(variant, alias.Variant, variantTags, alias.VariantTags, variantRegex) {
+		if hasMatch {
 			res = append(res, alias)
 		}
 	}
 	return res, nil
 }
 
+func (a ProjectAlias) HasMatchingVariant(variant string, variantTags []string) (bool, error) {
+	variantRegex, err := a.getVariantRegex()
+	if err != nil {
+		return false, err
+	}
+	return isValidRegexOrTag(variant, variantTags, a.VariantTags, variantRegex), nil
+}
+
+func (a *ProjectAlias) getVariantRegex() (*regexp.Regexp, error) {
+	if a.Variant == "" {
+		return nil, nil
+	}
+	variantRegex, err := regexp.Compile(a.Variant)
+	if err != nil {
+		return nil, errors.Wrapf(err, "compiling variant regex '%s'", a.Variant)
+	}
+	return variantRegex, nil
+}
+
+func (a *ProjectAlias) getTaskRegex() (*regexp.Regexp, error) {
+	if a.Task == "" {
+		return nil, nil
+	}
+	taskRegex, err := regexp.Compile(a.Task)
+	if err != nil {
+		return nil, errors.Wrapf(err, "compiling task regex '%s'", a.Variant)
+	}
+	return taskRegex, nil
+}
+
+func (a *ProjectAlias) getGitTagRegex() (*regexp.Regexp, error) {
+	if a.GitTag == "" {
+		return nil, nil
+	}
+	gitTagRegex, err := regexp.Compile(a.GitTag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "compiling git tag regex '%s'", a.GitTag)
+	}
+	return gitTagRegex, nil
+}
+
 // HasMatchingTask assumes that the aliases given already match the preferred variant.
 func (a ProjectAliases) HasMatchingTask(taskName string, taskTags []string) (bool, error) {
 	for _, alias := range a {
-		taskRegex, err := regexp.Compile(alias.Task)
+		hasMatch, err := alias.HasMatchingTask(taskName, taskTags)
 		if err != nil {
-			return false, errors.Wrapf(err, "compiling task regex '%s'", alias.Task)
+			return false, err
 		}
-		if isValidRegexOrTag(taskName, alias.Task, taskTags, alias.TaskTags, taskRegex) {
+		if hasMatch {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func isValidRegexOrTag(curItem, aliasRegex string, curTags, aliasTags []string, regexp *regexp.Regexp) bool {
-	isValidRegex := aliasRegex != "" && regexp.MatchString(curItem)
-	isValidTag := false
+func (a ProjectAlias) HasMatchingTask(taskName string, taskTags []string) (bool, error) {
+	taskRegex, err := a.getTaskRegex()
+	if err != nil {
+		return false, err
+	}
+
+	return isValidRegexOrTag(taskName, taskTags, a.TaskTags, taskRegex), nil
+}
+
+// isValidRegexOrTag returns true if the item/tag matches the alias tag/regex.
+func isValidRegexOrTag(curItem string, curTags, aliasTags []string, aliasRegex *regexp.Regexp) bool {
+	if aliasRegex != nil && aliasRegex.MatchString(curItem) {
+		return true
+	}
 	for _, tag := range aliasTags {
 		if utility.StringSliceContains(curTags, tag) {
-			isValidTag = true
-			break
+			return true
 		}
 		// a negated tag
 		if len(tag) > 0 && tag[0] == '!' && !utility.StringSliceContains(curTags, tag[1:]) {
-			isValidTag = true
-			break
+			return true
 		}
 	}
-
-	return isValidRegex || isValidTag
+	return false
 }
 
 func ValidateProjectAliases(aliases []ProjectAlias, aliasType string) []string {
@@ -527,10 +649,10 @@ func validateAliasPatchDefinition(pd ProjectAlias, aliasType string, lineNum int
 		errs = append(errs, fmt.Sprintf("%s: must specify exactly one of task regex or task tags on line #%d", aliasType, lineNum))
 	}
 
-	if _, err := regexp.Compile(pd.Variant); err != nil {
+	if _, err := pd.getVariantRegex(); err != nil {
 		errs = append(errs, fmt.Sprintf("%s: variant regex #%d is invalid", aliasType, lineNum))
 	}
-	if _, err := regexp.Compile(pd.Task); err != nil {
+	if _, err := pd.getTaskRegex(); err != nil {
 		errs = append(errs, fmt.Sprintf("%s: task regex #%d is invalid", aliasType, lineNum))
 	}
 	return errs
@@ -541,7 +663,7 @@ func validateGitTagAlias(pd ProjectAlias, aliasType string, lineNum int) []strin
 	if strings.TrimSpace(pd.GitTag) == "" {
 		errs = append(errs, fmt.Sprintf("%s: must define valid git tag regex on line #%d", aliasType, lineNum))
 	}
-	if _, err := regexp.Compile(pd.GitTag); err != nil {
+	if _, err := pd.getGitTagRegex(); err != nil {
 		errs = append(errs, fmt.Sprintf("%s: git tag regex #%d is invalid", aliasType, lineNum))
 	}
 	// if path is defined then no patch definition can be given

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -211,11 +213,12 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.Len(found, 2)
 }
 
-func (s *ProjectAliasSuite) TestMergeAliasesWithProjectConfig() {
+func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 	s.Require().NoError(db.ClearCollections(ProjectAliasCollection, ProjectConfigCollection, ProjectRefCollection))
 	pRef := ProjectRef{
-		Id:        "project-1",
-		RepoRefId: "r1",
+		Id:                    "project-1",
+		RepoRefId:             "r1",
+		VersionControlEnabled: utility.TruePtr(),
 	}
 	s.NoError(pRef.Upsert())
 	a1 := ProjectAlias{
@@ -245,14 +248,12 @@ func (s *ProjectAliasSuite) TestMergeAliasesWithProjectConfig() {
 		ProjectConfigFields: ProjectConfigFields{
 			PatchAliases: []ProjectAlias{
 				{
-					ID:        mgobson.NewObjectId(),
-					ProjectID: "project-1",
-					Alias:     "alias-2",
+					ID:    mgobson.NewObjectId(),
+					Alias: "alias-2",
 				},
 				{
-					ID:        mgobson.NewObjectId(),
-					ProjectID: "project-1",
-					Alias:     "alias-1",
+					ID:    mgobson.NewObjectId(),
+					Alias: "alias-1",
 				},
 			},
 			CommitQueueAliases: []ProjectAlias{
@@ -286,7 +287,9 @@ func (s *ProjectAliasSuite) TestMergeAliasesWithProjectConfig() {
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-2")
+	// Even with version control enabled, we ignore the config aliases
+	// since the project also has patch aliases enabled.
+	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-1")
 	s.NoError(err)
 	s.Len(projectAliases, 0)
 
@@ -297,22 +300,132 @@ func (s *ProjectAliasSuite) TestMergeAliasesWithProjectConfig() {
 	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "nonexistent")
 	s.NoError(err)
 	s.Len(projectAliases, 0)
-}
 
-func (s *ProjectAliasSuite) TestFindAliasInProjectOrPatchedConfig() {
-	projYml := `
-patch_aliases:
-  - alias: "test"
-    variant: "^ubuntu1604$"
-    task: "^test.*$"
-    remote_path: ""
-    description: "Test Description"
-`
-	projectAliases, err := FindAliasInProjectRepoOrPatchedConfig("", "test", projYml)
+	s.NoError(RemoveProjectAlias(patchAlias.ID.Hex()))
+	// Version control patch aliases can now be found
+	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-1")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
-	s.Equal("^ubuntu1604$", projectAliases[0].Variant)
-	s.Equal("Test Description", projectAliases[0].Description)
+	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-2")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+
+}
+
+func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
+	pRef := ProjectRef{
+		Id:                    "p1",
+		RepoRefId:             "r1",
+		VersionControlEnabled: utility.TruePtr(),
+	}
+	cqAliases := []ProjectAlias{
+		{
+			Alias:       evergreen.CommitQueueAlias,
+			Description: "first",
+		},
+		{
+			Alias:       evergreen.CommitQueueAlias,
+			Description: "second",
+		},
+	}
+	gitTagAliases := []ProjectAlias{
+		{
+			Alias:       evergreen.GitTagAlias,
+			Description: "first",
+		},
+		{
+			Alias:       evergreen.GitTagAlias,
+			Description: "second",
+		},
+	}
+	patchAliases := []ProjectAlias{
+		{
+			Alias: "something rad",
+		},
+		{
+			Alias: "something dastardly",
+		},
+	}
+	projectConfig := ProjectConfig{ProjectConfigFields: ProjectConfigFields{
+		PatchAliases: []ProjectAlias{
+			{
+				Alias: "something cool",
+			},
+		},
+		CommitQueueAliases: []ProjectAlias{
+			{
+				Alias: "something useless",
+			},
+		},
+	}}
+
+	for testName, testCase := range map[string]func(t *testing.T){
+		"nothing enabled": func(t *testing.T) {
+			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
+			tempRef := ProjectRef{ // This ref has nothing else enabled so merging should only return project aliases
+				Id: pRef.Id,
+			}
+			res, err := FindMergedAliasesFromProjectRepoOrProjectConfig(&tempRef, &projectConfig)
+			assert.NoError(t, err)
+			require.Len(t, res, 2)
+			assert.Equal(t, res[0].ProjectID, pRef.Id)
+			assert.Equal(t, res[1].ProjectID, pRef.Id)
+		},
+		"all enabled": func(t *testing.T) {
+			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
+			res, err := FindMergedAliasesFromProjectRepoOrProjectConfig(&pRef, &projectConfig)
+			assert.NoError(t, err)
+			// Uses aliases from project, repo, and config
+			require.Len(t, res, 5)
+			cqCount := 0
+			// There should only be two commit queue aliases, and they should all be from the project
+			for _, a := range res {
+				if a.Alias == evergreen.CommitQueueAlias {
+					cqCount++
+					assert.Equal(t, a.ProjectID, pRef.Id)
+					assert.Equal(t, a.Source, AliasSourceProject)
+				} else if a.Alias == evergreen.GitTagAlias {
+					assert.Equal(t, a.ProjectID, pRef.RepoRefId)
+					assert.Equal(t, a.Source, AliasSourceRepo)
+				} else {
+					assert.Equal(t, a.Source, AliasSourceConfig)
+				}
+			}
+			assert.Equal(t, cqCount, 2)
+		},
+		"project and repo only used": func(t *testing.T) {
+			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(patchAliases, pRef.RepoRefId))
+			res, err := FindMergedAliasesFromProjectRepoOrProjectConfig(&pRef, &projectConfig)
+			assert.NoError(t, err)
+			// Ignores config aliases because they're already used
+			require.Len(t, res, 4)
+			cqCount := 0
+			patchCount := 0
+			for _, a := range res {
+				if a.Alias == evergreen.CommitQueueAlias {
+					cqCount++
+					assert.Equal(t, a.ProjectID, pRef.Id)
+					assert.Equal(t, a.Source, AliasSourceProject)
+				} else {
+					patchCount++
+					assert.Equal(t, a.ProjectID, pRef.RepoRefId)
+					assert.Equal(t, a.Source, AliasSourceRepo)
+				}
+			}
+			assert.Equal(t, cqCount, 2)
+			assert.Equal(t, patchCount, 2)
+		},
+	} {
+		assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection,
+			ProjectConfigCollection, ProjectAliasCollection))
+
+		t.Run(testName, testCase)
+	}
 }
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {

--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -65,6 +65,29 @@ func (pc *ProjectConfig) isEmpty() bool {
 	return true
 }
 
+func (pc *ProjectConfig) SetInternalAliases() {
+	for i := range pc.GitTagAliases {
+		pc.GitTagAliases[i].Alias = evergreen.GitTagAlias
+	}
+	for i := range pc.GitHubChecksAliases {
+		pc.GitHubChecksAliases[i].Alias = evergreen.GithubChecksAlias
+	}
+	for i := range pc.CommitQueueAliases {
+		pc.CommitQueueAliases[i].Alias = evergreen.CommitQueueAlias
+	}
+	for i := range pc.GitHubPRAliases {
+		pc.GitHubPRAliases[i].Alias = evergreen.GithubPRAlias
+	}
+}
+
+func (pc *ProjectConfig) AllAliases() ProjectAliases {
+	pc.SetInternalAliases()
+	res := append(pc.PatchAliases, pc.GitTagAliases...)
+	res = append(res, pc.GitHubPRAliases...)
+	res = append(res, pc.CommitQueueAliases...)
+	return append(res, pc.GitHubChecksAliases...)
+}
+
 // CreateProjectConfig marshals the supplied YAML into our
 // intermediate configs representation.
 func CreateProjectConfig(yml []byte, identifier string) (*ProjectConfig, error) {

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -26,6 +26,7 @@ func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIPr
 			aliasModels = append(aliasModels, a)
 		}
 	}
+	// TODO EVG-17952: modify to correctly merge aliases based on type
 	if projectId != "" {
 		aliases, err = model.FindAliasesForProjectFromDb(projectId)
 		if err != nil {
@@ -39,7 +40,7 @@ func FindProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIPr
 		}
 	}
 	if projectId != "" && includeProjectConfig {
-		aliases, err = model.MergeAliasesWithProjectConfig(projectId, aliases)
+		aliases, err = model.GetAliasesMergedWithProjectConfig(projectId, aliases)
 		if err != nil {
 			return nil, err
 		}

--- a/service/api.go
+++ b/service/api.go
@@ -657,8 +657,9 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	}
 
 	errs := validator.ValidationErrors{}
+	var projectRef *model.ProjectRef
 	if input.ProjectID != "" {
-		projectRef, err := model.FindMergedProjectRef(input.ProjectID, "", false)
+		projectRef, err = model.FindMergedProjectRef(input.ProjectID, "", false)
 		if err != nil {
 			validationErr = validator.ValidationError{
 				Message: "error finding project; validation will proceed without checking project settings",
@@ -692,6 +693,16 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 		errs = errs.AtLevel(validator.Error)
 	} else {
 		errs = append(errs, validator.CheckProjectWarnings(project)...)
+		// Check project aliases
+		aliases, err := model.FindMergedAliasesFromProjectRepoOrProjectConfig(projectRef, projectConfig)
+		if err != nil {
+			errs = append(errs, validator.ValidationError{
+				Message: "problem finding aliases; validation will proceed without checking alias coverage",
+				Level:   validator.Warning,
+			})
+		} else {
+			errs = append(errs, validator.CheckAliasWarnings(project, aliases)...)
+		}
 	}
 
 	if len(errs) > 0 {

--- a/service/project.go
+++ b/service/project.go
@@ -371,7 +371,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	origGithubWebhookEnabled := (hook != nil)
+	origGithubWebhookEnabled := hook != nil
 	if hook == nil {
 		hook, err = model.SetupNewGithubHook(ctx, uis.Settings, responseRef.Owner, responseRef.Repo)
 		if err == nil || strings.Contains(err.Error(), "Hook already exists on this repository") {
@@ -967,7 +967,7 @@ func verifyAliasExists(alias, projectId string, newAliasDefinitions []model.Proj
 		return true, nil
 	}
 
-	existingAliasDefinitions, _, err := model.FindAliasInProjectOrRepoFromDb(projectId, alias)
+	existingAliasDefinitions, err := model.FindAliasInProjectRepoOrProjectConfig(projectId, alias, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "error checking for existing aliases")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -898,7 +898,15 @@ func (j *patchIntentProcessor) verifyValidAlias(projectId string, patchDoc *patc
 	if alias == "" {
 		return nil
 	}
-	aliases, err := model.FindAliasInProjectRepoOrPatchedConfig(projectId, alias, patchDoc.PatchedProjectConfig)
+	var projectConfig *model.ProjectConfig
+	if patchDoc.PatchedProjectConfig != "" {
+		var err error
+		projectConfig, err = model.CreateProjectConfig([]byte(patchDoc.PatchedProjectConfig), "")
+		if err != nil {
+			return errors.Wrap(err, "creating project config")
+		}
+	}
+	aliases, err := model.FindAliasInProjectRepoOrProjectConfig(projectId, alias, projectConfig)
 	if err != nil {
 		return errors.Wrapf(err, "retrieving aliases for project '%s'", projectId)
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -135,7 +136,6 @@ var projectErrorValidators = []projectValidator{
 	validateHostCreates,
 	validateDuplicateBVTasks,
 	validateGenerateTasks,
-	validateAliases,
 }
 
 // Functions used to validate the syntax of project configs representing properties found on the project page.
@@ -227,6 +227,10 @@ func CheckProjectWarnings(project *model.Project) ValidationErrors {
 			projectWarningValidator(project)...)
 	}
 	return validationErrs
+}
+
+func CheckAliasWarnings(project *model.Project, aliases model.ProjectAliases) ValidationErrors {
+	return validateAliasCoverage(project, aliases)
 }
 
 // verify that the project configuration syntax is valid
@@ -421,18 +425,7 @@ func validateProjectConfigPeriodicBuilds(pc *model.ProjectConfig) ValidationErro
 
 func validateProjectConfigAliases(pc *model.ProjectConfig) ValidationErrors {
 	errs := []string{}
-	for i := range pc.GitTagAliases {
-		pc.GitTagAliases[i].Alias = evergreen.GitTagAlias
-	}
-	for i := range pc.GitHubChecksAliases {
-		pc.GitHubChecksAliases[i].Alias = evergreen.GithubChecksAlias
-	}
-	for i := range pc.CommitQueueAliases {
-		pc.CommitQueueAliases[i].Alias = evergreen.CommitQueueAlias
-	}
-	for i := range pc.GitHubPRAliases {
-		pc.GitHubPRAliases[i].Alias = evergreen.GithubPRAlias
-	}
+	pc.SetInternalAliases()
 	errs = append(errs, model.ValidateProjectAliases(pc.GitHubPRAliases, "GitHub PR Aliases")...)
 	errs = append(errs, model.ValidateProjectAliases(pc.GitHubChecksAliases, "Github Checks Aliases")...)
 	errs = append(errs, model.ValidateProjectAliases(pc.CommitQueueAliases, "Commit Queue Aliases")...)
@@ -447,6 +440,132 @@ func validateProjectConfigAliases(pc *model.ProjectConfig) ValidationErrors {
 		})
 	}
 	return validationErrs
+}
+
+// validateAliasCoverage validates that all commit queue aliases defined match some variants/tasks.
+func validateAliasCoverage(p *model.Project, aliases model.ProjectAliases) ValidationErrors {
+	aliasMap := map[string]model.ProjectAlias{}
+	for _, a := range aliases {
+		aliasMap[a.ID.Hex()] = a
+	}
+	aliasNeedsVariant, aliasNeedsTask, err := getAliasCoverage(p, aliasMap)
+	if err != nil {
+		return ValidationErrors{
+			{
+				Message: "error checking alias coverage, continuing without validation",
+				Level:   Warning,
+			},
+		}
+	}
+	return constructAliasWarnings(aliasMap, aliasNeedsVariant, aliasNeedsTask)
+}
+
+// constructAliasWarnings returns validation errors given a map of aliases, and whether they need variants/tasks to match.
+func constructAliasWarnings(aliasMap map[string]model.ProjectAlias, aliasNeedsVariant, aliasNeedsTask map[string]bool) ValidationErrors {
+	res := ValidationErrors{}
+	errs := []string{}
+	for aliasID, a := range aliasMap {
+		needsVariant := aliasNeedsVariant[aliasID]
+		needsTask := aliasNeedsTask[aliasID]
+		if !needsVariant && !needsTask {
+			continue
+		}
+
+		msgComponents := []string{}
+		switch a.Alias {
+		case evergreen.CommitQueueAlias:
+			msgComponents = append(msgComponents, "Commit queue alias")
+		case evergreen.GithubPRAlias:
+			msgComponents = append(msgComponents, "Github PR alias")
+		case evergreen.GitTagAlias:
+			msgComponents = append(msgComponents, "Git tag alias")
+		case evergreen.GithubChecksAlias:
+			msgComponents = append(msgComponents, "Github check alias")
+		default:
+			msgComponents = append(msgComponents, "Patch alias")
+		}
+		if len(a.VariantTags) > 0 {
+			msgComponents = append(msgComponents, fmt.Sprintf("matching variant tags '%v'", a.VariantTags))
+		} else {
+			msgComponents = append(msgComponents, fmt.Sprintf("matching variant regexp '%s'", a.Variant))
+		}
+		if needsVariant {
+			msgComponents = append(msgComponents, "has no matching variants")
+		} else {
+			// This is only relevant information if the alias matches the variant but not the task.
+			if len(a.TaskTags) > 0 {
+				msgComponents = append(msgComponents, fmt.Sprintf("and matching task tags '%v'", a.TaskTags))
+			} else {
+				msgComponents = append(msgComponents, fmt.Sprintf("and matching task regexp '%s'", a.Task))
+			}
+			msgComponents = append(msgComponents, "has no matching tasks")
+		}
+		errs = append(errs, strings.Join(msgComponents, " "))
+	}
+	sort.Strings(errs)
+	for _, err := range errs {
+		res = append(res, ValidationError{
+			Message: err,
+			Level:   Warning,
+		})
+	}
+
+	return res
+}
+
+// getAliasCoverage returns a map of aliases that don't match variants and a map of aliases that don't match tasks.
+func getAliasCoverage(p *model.Project, aliasMap map[string]model.ProjectAlias) (map[string]bool, map[string]bool, error) {
+	type taskInfo struct {
+		name string
+		tags []string
+	}
+	aliasNeedsVariant := map[string]bool{}
+	aliasNeedsTask := map[string]bool{}
+	bvtCache := map[string]taskInfo{}
+	for a := range aliasMap {
+		aliasNeedsVariant[a] = true
+		aliasNeedsTask[a] = true
+	}
+	for _, bv := range p.BuildVariants {
+		for aliasID, alias := range aliasMap {
+			if !aliasNeedsVariant[aliasID] && !aliasNeedsTask[aliasID] { // Have already found both variants and tasks.
+				continue
+			}
+			// If we still need a task to match the variant, still check if the alias matches, so we know if checking tasks is needed.
+			matchesThisVariant, err := alias.HasMatchingVariant(bv.Name, bv.Tags)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !matchesThisVariant { // If the variant doesn't match, then there's no reason to keep checking tasks.
+				continue
+			}
+			aliasNeedsVariant[aliasID] = false
+			// Loop through all tasks to verify if there is task coverage.
+			for _, t := range bv.Tasks {
+				var name string
+				var tags []string
+				if info, ok := bvtCache[t.Name]; ok {
+					name = info.name
+					tags = info.tags
+				} else {
+					name, tags, _ = p.GetTaskNameAndTags(t)
+					// Even if we can't find the name/tags, still store it, so we don't try again.
+					bvtCache[t.Name] = taskInfo{name: name, tags: tags}
+				}
+				if name != "" {
+					matchesThisTask, err := alias.HasMatchingTask(name, tags)
+					if err != nil {
+						return nil, nil, err
+					}
+					if matchesThisTask {
+						aliasNeedsTask[aliasID] = false
+						break
+					}
+				}
+			}
+		}
+	}
+	return aliasNeedsVariant, aliasNeedsTask, nil
 }
 
 func validateProjectConfigContainers(pc *model.ProjectConfig) ValidationErrors {
@@ -492,24 +611,6 @@ func validateProjectConfigPlugins(pc *model.ProjectConfig) ValidationErrors {
 		)
 	}
 	return errs
-}
-
-func validateAliases(p *model.Project) ValidationErrors {
-	errs := []string{}
-	errs = append(errs, model.ValidateProjectAliases(p.GitHubPRAliases, "GitHub PR Aliases")...)
-	errs = append(errs, model.ValidateProjectAliases(p.GitHubChecksAliases, "Github Checks Aliases")...)
-	errs = append(errs, model.ValidateProjectAliases(p.CommitQueueAliases, "Commit Queue Aliases")...)
-	errs = append(errs, model.ValidateProjectAliases(p.PatchAliases, "Patch Aliases")...)
-	errs = append(errs, model.ValidateProjectAliases(p.GitTagAliases, "Git Tag Aliases")...)
-
-	validationErrs := ValidationErrors{}
-	for _, errorMsg := range errs {
-		validationErrs = append(validationErrs, ValidationError{
-			Message: errorMsg,
-			Level:   Error,
-		})
-	}
-	return validationErrs
 }
 
 // Ensures that the project has at least one buildvariant and also that all the

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1161,6 +1161,185 @@ func TestValidatePlugins(t *testing.T) {
 	})
 }
 
+func TestValidateAliasCoverage(t *testing.T) {
+	for testName, testCase := range map[string]func(*testing.T, *model.Project){
+		"matchesNothing": func(t *testing.T, p *model.Project) {
+			alias1 := model.ProjectAlias{
+				ID:          mgobson.NewObjectId(),
+				Alias:       evergreen.CommitQueueAlias,
+				VariantTags: []string{"notTheVariantTag"},
+				TaskTags:    []string{"taskTag"},
+			}
+			alias2 := model.ProjectAlias{
+				ID:      mgobson.NewObjectId(),
+				Alias:   evergreen.CommitQueueAlias,
+				Variant: "nonsense",
+				Task:    ".*",
+			}
+			aliasMap := map[string]model.ProjectAlias{
+				"alias1": alias1,
+				"alias2": alias2,
+			}
+			needsVariants, needsTasks, err := getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 2)
+			assert.Len(t, needsTasks, 2)
+			for _, matches := range needsVariants {
+				assert.True(t, matches)
+			}
+			// Doesn't matter that the tasks match since the variants don't match
+			for _, matches := range needsTasks {
+				assert.True(t, matches)
+			}
+			errs := validateAliasCoverage(p, model.ProjectAliases{alias1, alias2})
+			require.Len(t, errs, 2)
+			assert.Contains(t, errs[0].Message, "Commit queue alias")
+			assert.Contains(t, errs[0].Message, "has no matching variants")
+			assert.Contains(t, errs[1].Message, "Commit queue alias")
+			assert.Contains(t, errs[1].Message, "has no matching variants")
+			assert.NotContains(t, errs[0].Message, "tasks")
+			assert.NotContains(t, errs[1].Message, "tasks")
+			assert.Equal(t, errs[0].Level, Warning)
+			assert.Equal(t, errs[1].Level, Warning)
+		},
+		"matchesAll": func(t *testing.T, p *model.Project) {
+			alias1 := model.ProjectAlias{
+				ID:          mgobson.NewObjectId(),
+				Alias:       evergreen.CommitQueueAlias,
+				VariantTags: []string{"variantTag"},
+				TaskTags:    []string{"taskTag"},
+			}
+			alias2 := model.ProjectAlias{
+				ID:      mgobson.NewObjectId(),
+				Alias:   evergreen.CommitQueueAlias,
+				Variant: "bvWith.*",
+				Task:    ".*",
+			}
+			aliasMap := map[string]model.ProjectAlias{
+				"alias1": alias1,
+				"alias2": alias2,
+			}
+			needsVariants, needsTasks, err := getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 2)
+			assert.Len(t, needsTasks, 2)
+			for _, matches := range needsVariants {
+				assert.False(t, matches)
+			}
+			for _, matches := range needsTasks {
+				assert.False(t, matches)
+			}
+			errs := validateAliasCoverage(p, model.ProjectAliases{alias1, alias2})
+			assert.Len(t, errs, 0)
+		},
+		"matchesVariantTag": func(t *testing.T, p *model.Project) {
+			alias1 := model.ProjectAlias{
+				ID:          mgobson.NewObjectId(),
+				Alias:       evergreen.CommitQueueAlias,
+				VariantTags: []string{"variantTag"},
+			}
+			alias2 := model.ProjectAlias{
+				ID:      mgobson.NewObjectId(),
+				Alias:   evergreen.CommitQueueAlias,
+				Variant: "badRegex",
+			}
+			aliasMap := map[string]model.ProjectAlias{
+				"alias1": alias1,
+				"alias2": alias2,
+			}
+			needsVariants, needsTasks, err := getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 2)
+			assert.Len(t, needsTasks, 2)
+			assert.False(t, needsVariants["alias1"])
+			assert.True(t, needsVariants["alias2"])
+			for _, matches := range needsTasks {
+				assert.True(t, matches)
+			}
+
+			errs := validateAliasCoverage(p, model.ProjectAliases{alias1, alias2})
+			require.Len(t, errs, 2)
+			assert.Contains(t, errs[0].Message, "Commit queue alias")
+			assert.Contains(t, errs[0].Message, "has no matching variants")
+			assert.NotContains(t, errs[0].Message, "matching task regexp")
+			assert.Contains(t, errs[1].Message, "Commit queue alias")
+			assert.Contains(t, errs[1].Message, "has no matching tasks")
+			assert.Contains(t, errs[1].Message, "variant tags")
+			assert.Contains(t, errs[1].Message, "matching task regexp")
+			assert.Equal(t, errs[0].Level, Warning)
+			assert.Equal(t, errs[1].Level, Warning)
+		},
+		"negatedTag": func(t *testing.T, p *model.Project) {
+			negatedAlias := model.ProjectAlias{
+				ID:          mgobson.NewObjectId(),
+				Alias:       evergreen.CommitQueueAlias,
+				VariantTags: []string{"!variantTag"},
+				TaskTags:    []string{"!newTaskTag"},
+			}
+			aliasMap := map[string]model.ProjectAlias{
+				"negatedAlias": negatedAlias,
+			}
+			needsVariants, needsTasks, err := getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 1)
+			assert.Len(t, needsTasks, 1)
+			assert.False(t, needsVariants["negatedAlias"]) // Matches the second build variant
+			assert.False(t, needsTasks["negatedAlias"])
+
+			p.BuildVariants[1].Tags = []string{"variantTag"}
+			needsVariants, needsTasks, err = getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 1)
+			assert.Len(t, needsTasks, 1)
+			assert.True(t, needsVariants["negatedAlias"]) // Doesn't match either build variant
+			assert.True(t, needsTasks["negatedAlias"])    // Because the variants don't match
+
+			p.BuildVariants[1].Tags = nil
+			p.Tasks[1].Tags = []string{"newTaskTag"}
+			needsVariants, needsTasks, err = getAliasCoverage(p, aliasMap)
+			assert.NoError(t, err)
+			assert.Len(t, needsVariants, 1)
+			assert.Len(t, needsTasks, 1)
+			assert.False(t, needsVariants["negatedAlias"]) // Matches the second build variant again
+			assert.True(t, needsTasks["negatedAlias"])     // Second build variant task doesn't match
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			p := &model.Project{
+				BuildVariants: model.BuildVariants{
+					{
+						Name: "bvWithTag",
+						Tags: []string{"variantTag"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{
+								Name: "taskWithTag",
+							},
+						},
+					},
+					{
+						Name: "bvWithoutTag",
+						Tasks: []model.BuildVariantTaskUnit{
+							{
+								Name: "taskWithoutTag",
+							},
+						},
+					},
+				},
+				Tasks: []model.ProjectTask{
+					{
+						Name: "taskWithTag",
+						Tags: []string{"taskTag"},
+					},
+					{
+						Name: "taskWithoutTag",
+					},
+				},
+			}
+			testCase(t, p)
+		})
+	}
+}
+
 func TestValidateProjectAliases(t *testing.T) {
 	Convey("When validating a project", t, func() {
 		Convey("ensure misconfigured aliases throw an error", func() {
@@ -3951,13 +4130,13 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				TaskGroups: []model.TaskGroup{
-					model.TaskGroup{
+					{
 						Name:  "task1-and-task2",
 						Tasks: []string{"task1", "task2"},
 					},
 				},
 				BuildVariants: []model.BuildVariant{
-					model.BuildVariant{
+					{
 						Name: "ubuntu",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "task1-and-task2", IsGroup: true},
@@ -3983,13 +4162,13 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				TaskGroups: []model.TaskGroup{
-					model.TaskGroup{
+					{
 						Name:  "task1-and-task2",
 						Tasks: []string{"task1", "task2"},
 					},
 				},
 				BuildVariants: []model.BuildVariant{
-					model.BuildVariant{
+					{
 						Name: "ubuntu",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "task2"},
@@ -4015,13 +4194,13 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				TaskGroups: []model.TaskGroup{
-					model.TaskGroup{
+					{
 						Name:  "task1-and-task2",
 						Tasks: []string{"task1", "task2"},
 					},
 				},
 				BuildVariants: []model.BuildVariant{
-					model.BuildVariant{
+					{
 						Name: "ubuntu",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "task3"},
@@ -4046,13 +4225,13 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				TaskGroups: []model.TaskGroup{
-					model.TaskGroup{
+					{
 						Name:  "task1-and-task2",
 						Tasks: []string{"task1", "task2"},
 					},
 				},
 				BuildVariants: []model.BuildVariant{
-					model.BuildVariant{
+					{
 						Name: "ubuntu",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "task3"},
@@ -4078,7 +4257,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				TaskGroups: []model.TaskGroup{
-					model.TaskGroup{
+					{
 						Name:  "task1-and-task2",
 						Tasks: []string{"task1", "task2"},
 					},
@@ -4088,7 +4267,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 					},
 				},
 				BuildVariants: []model.BuildVariant{
-					model.BuildVariant{
+					{
 						Name: "ubuntu",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "task1-and-task2", IsGroup: true},
@@ -4269,13 +4448,13 @@ func TestBVsWithTasksThatCallCommand(t *testing.T) {
 			"TaskFunctionExpandsCommands": {
 				project: model.Project{
 					Functions: map[string]*model.YAMLCommandSet{
-						"pull_func": &model.YAMLCommandSet{
+						"pull_func": {
 							SingleCommand: &model.PluginCommandConf{
 								Command:     evergreen.S3PullCommandName,
 								DisplayName: "pull_dir",
 							},
 						},
-						"test_func": &model.YAMLCommandSet{
+						"test_func": {
 							MultiCommand: []model.PluginCommandConf{
 								{
 									Command:     evergreen.S3PullCommandName,
@@ -4803,7 +4982,7 @@ func TestBVsWithTasksThatCallCommand(t *testing.T) {
 
 	t.Run("MissingDefintiion", func(t *testing.T) {
 		for testName, project := range map[string]model.Project{
-			"ForTaskReferencedInBV": model.Project{
+			"ForTaskReferencedInBV": {
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "ubuntu",
@@ -4816,7 +4995,7 @@ func TestBVsWithTasksThatCallCommand(t *testing.T) {
 					},
 				},
 			},
-			"ForTaskGroupReferencedInBV": model.Project{
+			"ForTaskGroupReferencedInBV": {
 				BuildVariants: []model.BuildVariant{
 					{
 						Name: "ubuntu",
@@ -4829,7 +5008,7 @@ func TestBVsWithTasksThatCallCommand(t *testing.T) {
 					},
 				},
 			},
-			"ForTaskReferencedInTaskGroupInBV": model.Project{
+			"ForTaskReferencedInTaskGroupInBV": {
 				TaskGroups: []model.TaskGroup{
 					{
 						Name:  "test_group",


### PR DESCRIPTION
[EVG-17335](https://jira.mongodb.org/browse/EVG-17335)

### Description 
User made a case that commit queue aliases are important enough that they should be validated if they don't match anything. Wrote a change to do this, and it included some refactors.

Open question @hadjri : I think it would be cool to validate all aliases but its tricky thinking of how that would work, in terms of joining all the aliases together. Should we just validate all aliases since it's only warnings anyway? But then we'd probably need to show the source (maybe that's okay though).
### Testing 
Added unit test and tested locally:
```
commit-queue-sandbox [new-branch] $ ../evergreen/clients/darwin_amd64/evergreen -c ~/.evergreen-local.yml validate -p spruce evergreen.yml 
WARNING: Commit queue alias matching variant regexp 'nothing' has no matching variants
WARNING: Commit queue alias matching variant regexp 'ubuntu1604' and matching task tags '[something specific]' has no matching tasks
```