### PR TITLE
EVG-17379 return early if the distro is disabled

### DIFF
--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -125,6 +125,14 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		return
 	}
 
+	if distro.Disabled {
+		return
+	}
+
+	////////////////////////
+	// host-allocation phase
+	////////////////////////
+
 	existingHosts, err := host.AllActiveHosts(j.DistroID)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "finding active hosts"))
@@ -137,10 +145,6 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		j.AddError(errors.Wrapf(err, "getting distro queue info for distro '%s'", j.DistroID))
 		return
 	}
-
-	////////////////////////
-	// host-allocation phase
-	////////////////////////
 
 	hostAllocationBegins := time.Now()
 


### PR DESCRIPTION
[EVG-17379](https://jira.mongodb.org/browse/EVG-17379)

### Description 
If a distro is disabled we shouldn't run the host allocator for it. I think it makes sense to run the beginning half of the job, though, since we still want to clean up stale initializing hosts (like if it was just disabled) etc.
This PR will have it continue to run the job for every non-container pool distro but we'll exit early if the distro is disabled.
