### PR TITLE
EVG-17685 Redirect legacy task queue page to spruce

### DIFF
--- a/service/task_queue.go
+++ b/service/task_queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -56,6 +57,18 @@ type uiHostStatistics struct {
 	ActiveHosts       int `json:"active_hosts"`
 	ActiveStaticHosts int `json:"active_static_hosts"`
 	IdleStaticHosts   int `json:"idle_static_hosts"`
+}
+
+func (uis *UIServer) taskQueue(w http.ResponseWriter, r *http.Request) {
+	distro := gimlet.GetVars(r)["distro"]
+	taskId := gimlet.GetVars(r)["task_id"]
+	newUILink := ""
+	if len(uis.Settings.Ui.UIv2Url) > 0 {
+		newUILink = fmt.Sprintf("%s/task-queue/%s/%s", uis.Settings.Ui.UIv2Url, distro, taskId)
+	}
+
+	http.Redirect(w, r, newUILink, http.StatusTemporaryRedirect)
+	return
 }
 
 func (uis *UIServer) allTaskQueues(w http.ResponseWriter, r *http.Request) {

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -171,7 +171,7 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                     <tr ng-show="task.min_queue_pos != 0">
                       <td class="icon"><i class="fa fa-sort-numeric-asc"></i></td>
                       <td>
-                        Estimated Time to Start: [[task.wait_time | stringifyNanoseconds]] (<a href="/task_queue#/#[[task.id]]">[[task.min_queue_pos | ordinalNum]]</a>
+                        Estimated Time to Start: [[task.wait_time | stringifyNanoseconds]] (<a href="/task_queue/[[task.distro]]/[[task.id]]">[[task.min_queue_pos | ordinalNum]]</a>
                         in queue)
                       </td>
                     </tr>

--- a/service/ui.go
+++ b/service/ui.go
@@ -382,6 +382,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/build_variant/{project_id}/{variant}").Wrap(needsContext, viewTasks).Handler(uis.variantHistory).Get()
 
 	// Task queues
+	app.AddRoute("/task_queue/{distro}/{task_id}").Wrap(needsLogin, needsContext).Handler(uis.taskQueue).Get()
 	app.AddRoute("/task_queue/").Wrap(needsLogin, needsContext).Handler(uis.allTaskQueues).Get() // TODO: ¯\_(ツ)_/¯
 
 	// Patch pages


### PR DESCRIPTION
[EVG-17658](https://jira.mongodb.org/browse/EVG-17658)

### Description 
task queue was broken on legacy because it couldnt handle that many tasks 
so i am redirecting task queue to spruce now 

### Testing 
manually on staging 