### PR TITLE
EVG-17627 Always return content-length header

### DIFF
--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -32,19 +32,21 @@ func (c *communicatorImpl) newRequest(method, path string, data interface{}) (*h
 	if err != nil {
 		return nil, errors.New("building request")
 	}
+
+	var out []byte
 	if data != nil {
 		if rc, ok := data.(io.ReadCloser); ok {
 			r.Body = rc
 		} else {
-			var out []byte
 			out, err = json.Marshal(data)
 			if err != nil {
 				return nil, err
 			}
-			r.Header.Add(evergreen.ContentLengthHeader, strconv.Itoa(len(out)))
 			r.Body = ioutil.NopCloser(bytes.NewReader(out))
 		}
 	}
+
+	r.Header.Add(evergreen.ContentLengthHeader, strconv.Itoa(len(out)))
 
 	if c.apiUser != "" {
 		r.Header.Add(evergreen.APIUserHeader, c.apiUser)


### PR DESCRIPTION
[EVG-17627](https://jira.mongodb.org/browse/EVG-17627)

### Description 
We should be returning a content-length header for all http responses. We will need this header to indicate download progress.

### Testing 
Existing tests 