### PR TITLE
EVG-17217 use shared index for admin events

### DIFF
--- a/model/event/admin_event.go
+++ b/model/event/admin_event.go
@@ -165,7 +165,7 @@ func convertRaw(in rawAdminEventData) (*AdminEventData, error) {
 
 // RevertConfig reverts one config section to the before state of the specified GUID in the event log
 func RevertConfig(guid string, user string) error {
-	events, err := FindAdmin(ByGuid(guid))
+	events, err := FindAdmin(ByAdminGuid(guid))
 	if err != nil {
 		return errors.Wrap(err, "finding events")
 	}

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -205,10 +205,12 @@ func RecentAdminEvents(n int) db.Q {
 	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(n)
 }
 
-func ByGuid(guid string) db.Q {
-	return db.Query(bson.M{
-		bsonutil.GetDottedKeyName(DataKey, "guid"): guid,
-	})
+// ByAdminGuid returns a query for the admin events with the given guid.
+func ByAdminGuid(guid string) db.Q {
+	filter := ResourceTypeKeyIs(ResourceTypeAdmin)
+	filter[ResourceIdKey] = ""
+	filter[bsonutil.GetDottedKeyName(DataKey, "guid")] = guid
+	return db.Query(filter)
 }
 
 func AdminEventsBefore(before time.Time, n int) db.Q {


### PR DESCRIPTION
[EVG-17217](https://jira.mongodb.org/browse/EVG-17217)

### Description 
Modify the query to use the same index many of the other event queries use. This avoids us needing a special index for this one uncommon query.

### Testing 
I deployed these changes to staging and removed the guid index from the staging db. Reverting an event was still performant so it ostensibly used the shared index.
