### PR TITLE
EVG-16884: set pod last communicated time

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -721,8 +721,8 @@ func (p *Pod) ClearRunningTask() error {
 	return nil
 }
 
-// SetAgentStartTime sets the time when the pod's agent started.
-func (p *Pod) SetAgentStartTime() error {
+// UpdateAgentStartTime updates the time when the pod's agent started to now.
+func (p *Pod) UpdateAgentStartTime() error {
 	ts := utility.BSONTime(time.Now())
 	if err := UpdateOne(ByID(p.ID), bson.M{
 		"$set": bson.M{
@@ -733,6 +733,23 @@ func (p *Pod) SetAgentStartTime() error {
 	}
 
 	p.TimeInfo.AgentStarted = ts
+
+	return nil
+}
+
+// UpdateLastCommunicated updates the last time that the pod and app server
+// successfully communicated to now, indicating that the pod is currently alive.
+func (p *Pod) UpdateLastCommunicated() error {
+	ts := utility.BSONTime(time.Now())
+	if err := UpdateOne(ByID(p.ID), bson.M{
+		"$set": bson.M{
+			bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoLastCommunicatedKey): ts,
+		},
+	}); err != nil {
+		return err
+	}
+
+	p.TimeInfo.LastCommunicated = ts
 
 	return nil
 }

--- a/rest/data/pod_test.go
+++ b/rest/data/pod_test.go
@@ -12,61 +12,118 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPodConnector(t *testing.T) {
-	for tName, tCase := range map[string]func(t *testing.T){
-		"CreatePodSucceeds": func(t *testing.T) {
-			p := model.APICreatePod{
-				Name:                utility.ToStringPtr("name"),
-				Memory:              utility.ToIntPtr(128),
-				CPU:                 utility.ToIntPtr(128),
-				Image:               utility.ToStringPtr("image"),
-				OS:                  model.APIPodOS(pod.OSWindows),
-				Arch:                model.APIPodArch(pod.ArchAMD64),
-				WindowsVersion:      model.APIPodWindowsVersion(pod.WindowsVersionServer2019),
-				WorkingDir:          utility.ToStringPtr("/working/dir"),
-				PodSecretExternalID: utility.ToStringPtr("pod_secret_external_id"),
-				PodSecretValue:      utility.ToStringPtr("pod_secret_value"),
-			}
-			res, err := CreatePod(p)
+func TestCreatePod(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(pod.Collection))
+	}()
+	require.NoError(t, db.ClearCollections(pod.Collection))
+
+	p := model.APICreatePod{
+		Name:                utility.ToStringPtr("name"),
+		Memory:              utility.ToIntPtr(128),
+		CPU:                 utility.ToIntPtr(128),
+		Image:               utility.ToStringPtr("image"),
+		OS:                  model.APIPodOS(pod.OSWindows),
+		Arch:                model.APIPodArch(pod.ArchAMD64),
+		WindowsVersion:      model.APIPodWindowsVersion(pod.WindowsVersionServer2019),
+		WorkingDir:          utility.ToStringPtr("/working/dir"),
+		PodSecretExternalID: utility.ToStringPtr("pod_secret_external_id"),
+		PodSecretValue:      utility.ToStringPtr("pod_secret_value"),
+	}
+	res, err := CreatePod(p)
+	require.NoError(t, err)
+	require.NotZero(t, res)
+
+	apiPod, err := FindAPIPodByID(res.ID)
+	require.NoError(t, err)
+	require.NotZero(t, apiPod)
+
+	assert.Equal(t, model.PodTypeAgent, apiPod.Type)
+	assert.Equal(t, model.PodStatusInitializing, apiPod.Status)
+	require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvVars)
+	assert.NotZero(t, apiPod.TaskContainerCreationOpts.EnvVars["POD_ID"])
+	require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvSecrets)
+	secret, ok := apiPod.TaskContainerCreationOpts.EnvSecrets[pod.PodSecretEnvVar]
+	require.True(t, ok)
+	assert.Equal(t, utility.FromStringPtr(p.PodSecretExternalID), utility.FromStringPtr(secret.ExternalID))
+	assert.Equal(t, utility.FromStringPtr(p.PodSecretValue), utility.FromStringPtr(secret.Value))
+}
+
+func TestFindAPIPodByID(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(pod.Collection))
+	}()
+	require.NoError(t, db.ClearCollections(pod.Collection))
+
+	t.Run("Succeeds", func(t *testing.T) {
+		p := pod.Pod{
+			ID:     "id",
+			Type:   pod.TypeAgent,
+			Status: pod.StatusInitializing,
+		}
+		require.NoError(t, p.Insert())
+
+		apiPod, err := FindAPIPodByID(p.ID)
+		require.NoError(t, err)
+		require.NotZero(t, apiPod)
+
+		assert.Equal(t, p.ID, utility.FromStringPtr(apiPod.ID))
+		assert.EqualValues(t, p.Type, apiPod.Type)
+		assert.EqualValues(t, p.Status, apiPod.Status)
+	})
+	t.Run("FailsWithNonexistentPod", func(t *testing.T) {
+		apiPod, err := FindAPIPodByID("nonexistent")
+		assert.Error(t, err)
+		assert.Zero(t, apiPod)
+	})
+}
+
+func TestCheckPodSecret(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, p pod.Pod, secret string){
+		"Succeeds": func(t *testing.T, p pod.Pod, secret string) {
+			assert.NoError(t, CheckPodSecret(p.ID, secret))
+
+			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
-			require.NotZero(t, res)
+			require.NotZero(t, dbPod)
+			assert.NotZero(t, dbPod.TimeInfo.LastCommunicated)
+		},
+		"FailsWithoutID": func(t *testing.T, p pod.Pod, secret string) {
+			assert.Error(t, CheckPodSecret("", secret))
 
-			apiPod, err := FindPodByID(res.ID)
+			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
-			require.NotZero(t, apiPod)
-
-			assert.Equal(t, model.PodTypeAgent, apiPod.Type)
-			assert.Equal(t, model.PodStatusInitializing, apiPod.Status)
-			require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvVars)
-			assert.NotZero(t, apiPod.TaskContainerCreationOpts.EnvVars["POD_ID"])
-			require.NotZero(t, apiPod.TaskContainerCreationOpts.EnvSecrets)
-			secret, ok := apiPod.TaskContainerCreationOpts.EnvSecrets[pod.PodSecretEnvVar]
-			require.True(t, ok)
-			assert.Equal(t, utility.FromStringPtr(p.PodSecretExternalID), utility.FromStringPtr(secret.ExternalID))
-			assert.Equal(t, utility.FromStringPtr(p.PodSecretValue), utility.FromStringPtr(secret.Value))
+			require.NotZero(t, dbPod)
+			assert.Zero(t, dbPod.TimeInfo.LastCommunicated)
 		},
-		"FindPodByIDSucceeds": func(t *testing.T) {
-			p := pod.Pod{
-				ID:     "id",
-				Type:   pod.TypeAgent,
-				Status: pod.StatusInitializing,
-			}
-			require.NoError(t, p.Insert())
+		"FailsWithoutSecret": func(t *testing.T, p pod.Pod, secret string) {
+			assert.Error(t, CheckPodSecret(p.ID, ""))
 
-			apiPod, err := FindPodByID(p.ID)
+			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
-			require.NotZero(t, apiPod)
+			require.NotZero(t, dbPod)
+			assert.Zero(t, dbPod.TimeInfo.LastCommunicated)
+		},
+		"FailsWithBadID": func(t *testing.T, p pod.Pod, secret string) {
+			assert.Error(t, CheckPodSecret("bad_id", secret))
 
-			assert.Equal(t, p.ID, utility.FromStringPtr(apiPod.ID))
-			assert.EqualValues(t, p.Type, apiPod.Type)
-			assert.EqualValues(t, p.Status, apiPod.Status)
+			dbPod, err := pod.FindOneByID(p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Zero(t, dbPod.TimeInfo.LastCommunicated)
 		},
-		"FindPodByIDReturnsNilWithNonexistentPod": func(t *testing.T) {
-			apiPod, err := FindPodByID("nonexistent")
-			assert.NoError(t, err)
-			assert.Zero(t, apiPod)
+		"FailsWithBadSecret": func(t *testing.T, p pod.Pod, secret string) {
+			assert.Error(t, CheckPodSecret(p.ID, "bad_secret"))
+
+			dbPod, err := pod.FindOneByID(p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbPod)
+			assert.Zero(t, dbPod.TimeInfo.LastCommunicated)
 		},
-		"CheckPodSecret": func(t *testing.T) {
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(pod.Collection, event.LegacyEventLogCollection))
+
 			secretVal := "secret_value"
 			p := pod.Pod{
 				ID:   "id",
@@ -82,29 +139,7 @@ func TestPodConnector(t *testing.T) {
 			}
 			require.NoError(t, p.Insert())
 
-			t.Run("Succeeds", func(t *testing.T) {
-				assert.NoError(t, CheckPodSecret(p.ID, secretVal))
-			})
-			t.Run("FailsWithoutID", func(t *testing.T) {
-				assert.Error(t, CheckPodSecret("", secretVal))
-			})
-			t.Run("FailsWithoutSecret", func(t *testing.T) {
-				assert.Error(t, CheckPodSecret(p.ID, ""))
-			})
-			t.Run("FailsWithBadID", func(t *testing.T) {
-				assert.Error(t, CheckPodSecret("bad_id", secretVal))
-			})
-			t.Run("FailsWithBadSecret", func(t *testing.T) {
-				assert.Error(t, CheckPodSecret(p.ID, "bad_secret"))
-			})
-		},
-	} {
-		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(pod.Collection, event.LegacyEventLogCollection))
-			defer func() {
-				assert.NoError(t, db.ClearCollections(pod.Collection, event.LegacyEventLogCollection))
-			}()
-			tCase(t)
+			tCase(t, p, secretVal)
 		})
 	}
 }

--- a/rest/route/pod.go
+++ b/rest/route/pod.go
@@ -2,7 +2,6 @@ package route
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
@@ -104,15 +103,9 @@ func (h *podGetHandler) Parse(ctx context.Context, r *http.Request) error {
 
 // Run finds and returns the REST pod.
 func (h *podGetHandler) Run(ctx context.Context) gimlet.Responder {
-	p, err := data.FindPodByID(h.podID)
+	p, err := data.FindAPIPodByID(h.podID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding pod '%s'", h.podID))
-	}
-	if p == nil {
-		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("pod '%s' not found", h.podID),
-		})
 	}
 
 	return gimlet.NewJSONResponse(p)

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -228,7 +228,7 @@ func (h *podAgentNextTask) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (h *podAgentNextTask) Run(ctx context.Context) gimlet.Responder {
-	p, err := data.FindPod(h.podID)
+	p, err := data.FindPodByID(h.podID)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -338,7 +338,7 @@ func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {
 		return
 	}
 
-	if err := p.SetAgentStartTime(); err != nil {
+	if err := p.UpdateAgentStartTime(); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "could not update pod's agent first contact time",
 			"pod":     p.ID,
@@ -419,7 +419,7 @@ func (h *podAgentEndTask) Parse(ctx context.Context, r *http.Request) error {
 // It then marks the task as finished. If the task is aborted, this will no-op.
 func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	finishTime := time.Now()
-	p, err := data.FindPod(h.podID)
+	p, err := data.FindPodByID(h.podID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -137,6 +137,12 @@ func (j *podCreationJob) Run(ctx context.Context) {
 			j.AddError(errors.Wrap(err, "updating pod resources"))
 		}
 
+		// Bump the last communication time to ensure that the pod has a
+		// sufficient grace period to start up.
+		if err := j.pod.UpdateLastCommunicated(); err != nil {
+			j.AddError(errors.Wrap(err, "updating pod last communication time"))
+		}
+
 		if err := j.pod.UpdateStatus(pod.StatusStarting, "pod successfully started"); err != nil {
 			j.AddError(errors.Wrap(err, "marking pod as starting"))
 		}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16884

### Description 
This is pre-work for detecting when a pod is potentially unhealthy. This design is much the same as how hosts work in terms of showing liveliness. There will be a follow-up PR to actually find and handle those unhealthy pods.

* Update pod last communicated time when first starting the pod and whenever it successfully auths.
* Move around some existing tests in the pod data connector.

### Testing 
Added unit tests.