### PR TITLE
EVG-17338 Remove error when starting task is not found

### DIFF
--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -85,8 +86,13 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 				break
 			}
 		}
-		// TODO: EVG-17897 remove the debug statement
-		grip.DebugWhen(!found, fmt.Sprintf("starting task '%s' not found", opts.StartingTaskId))
+		grip.DebugWhen(!found, message.Fields{
+			"message":       "starting task not found",
+			"ticket":        "EVG-17338",
+			"starting_task": opts.StartingTaskId,
+			"project":       projectId,
+			"commit":        opts.CommitHash,
+		})
 	}
 	return res, nil
 }

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -50,7 +50,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    errors.Wrapf(err, "project '%s' not found").Error(),
+			Message:    errors.Wrapf(err, "project '%s' not found", projectId).Error(),
 		}
 	}
 
@@ -85,6 +85,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 				break
 			}
 		}
+		// TODO: EVG-17897 remove the debug statement
 		grip.DebugWhen(!found, fmt.Sprintf("starting task '%s' not found", opts.StartingTaskId))
 	}
 	return res, nil

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -49,7 +49,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    err.Error(),
+			Message:    errors.Wrapf(err, "project '%s' not found").Error(),
 		}
 	}
 
@@ -87,7 +87,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 		if !found {
 			return []task.Task{}, gimlet.ErrorResponse{
 				StatusCode: http.StatusNotFound,
-				Message:    fmt.Sprintf("task '%s' not found", opts.StartingTaskId),
+				Message:    fmt.Sprintf("starting task '%s' not found", opts.StartingTaskId),
 			}
 		}
 	}

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -87,11 +87,9 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 			}
 		}
 		grip.DebugWhen(!found, message.Fields{
-			"message":       "starting task not found",
-			"ticket":        "EVG-17338",
-			"starting_task": opts.StartingTaskId,
-			"project":       projectId,
-			"commit":        opts.CommitHash,
+			"message": "starting task not found",
+			"ticket":  "EVG-17338",
+			"opts":    opts,
 		})
 	}
 	return res, nil

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -8,6 +8,7 @@ import (
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
@@ -84,12 +85,7 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 				break
 			}
 		}
-		if !found {
-			return []task.Task{}, gimlet.ErrorResponse{
-				StatusCode: http.StatusNotFound,
-				Message:    fmt.Sprintf("starting task '%s' not found", opts.StartingTaskId),
-			}
-		}
+		grip.DebugWhen(!found, fmt.Sprintf("starting task '%s' not found", opts.StartingTaskId))
 	}
 	return res, nil
 }

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -392,26 +392,6 @@ func (s *TaskConnectorFetchByProjectAndCommitSuite) TestFindFromMiddle() {
 
 }
 
-func (s *TaskConnectorFetchByProjectAndCommitSuite) TestFindFromMiddleFail() {
-	opts := task.GetTasksByProjectAndCommitOptions{
-		Project:        "project_0",
-		CommitHash:     "commit_0",
-		StartingTaskId: "fake_task",
-		Status:         "",
-		TaskName:       "",
-		VariantName:    "",
-		Limit:          0,
-	}
-	foundTests, err := FindTasksByProjectAndCommit(opts)
-	s.Error(err)
-	s.Equal(0, len(foundTests))
-
-	s.IsType(gimlet.ErrorResponse{}, err)
-	apiErr, ok := err.(gimlet.ErrorResponse)
-	s.True(ok)
-	s.Equal(http.StatusNotFound, apiErr.StatusCode)
-}
-
 func (s *TaskConnectorFetchByProjectAndCommitSuite) TestFindWithLimit() {
 	commitId := "commit_0"
 	projectId := "project_0"


### PR DESCRIPTION
[EVG-17338](https://jira.mongodb.org/browse/EVG-17338)

### Description 
We currently error when the start_at task is not found for the projects/{project_id}/revisions/{hash}/tasks route 
I'm not super sure why we error at this point but I think we can log something at this point instead of returning a 404 and investigate if it keeps coming up 
(I was also not able to recreate this bug myself)

### Testing 
