### PR TITLE
EVG-17627 Return content-length headers for taskLogRaw

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -638,16 +639,28 @@ func (uis *UIServer) taskLogRaw(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	buffer := new(bytes.Buffer)
+
 	if raw {
 		if logReader != nil {
 			gimlet.WriteText(w, logReader)
 		} else {
+			w.Header().Add(evergreen.ContentLengthHeader, strconv.Itoa(buffer.Len()))
 			uis.renderText.Stream(w, http.StatusOK, data, "base", "task_log_raw.html")
 		}
 		return
 	}
 
 	go apimodels.ReadBuildloggerToChan(r.Context(), projCtx.Task.Id, logReader, data.Buildlogger)
+
+	_, err = buffer.ReadFrom(logReader)
+	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error reading log data"))
+		return
+	}
+
+	w.Header().Add(evergreen.ContentLengthHeader, strconv.Itoa(buffer.Len()))
+
 	uis.render.Stream(w, http.StatusOK, data, "base", "task_log.html")
 }
 


### PR DESCRIPTION
[EVG-17627](https://jira.mongodb.org/browse/EVG-17627)

### Description 
We should be returning a content-length header for all http responses. We will need this header to indicate download progress.

### Testing 
Tested through Postman 