### PR TITLE
EVG-17640 data cleanup efficiency

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -1256,8 +1256,8 @@ func PopulateDataCleanupJobs(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		catcher := grip.NewBasicCatcher()
-		catcher.Wrap(queue.Put(ctx, NewTestResultsCleanupJob(utility.RoundPartOfMinute(2))), "enqueueing test results cleanup job")
-		catcher.Wrap(queue.Put(ctx, NewTestLogsCleanupJob(utility.RoundPartOfMinute(2))), "enqueueing test logs cleanup job")
+		catcher.Wrap(amboy.EnqueueUniqueJob(ctx, queue, NewTestResultsCleanupJob(utility.RoundPartOfMinute(2))), "enqueueing test results cleanup job")
+		catcher.Wrap(amboy.EnqueueUniqueJob(ctx, queue, NewTestLogsCleanupJob(utility.RoundPartOfMinute(2))), "enqueueing test logs cleanup job")
 
 		return catcher.Resolve()
 	}

--- a/units/data_cleanup_test_logs.go
+++ b/units/data_cleanup_test_logs.go
@@ -48,6 +48,8 @@ func NewTestLogsCleanupJob(ts time.Time) amboy.Job {
 	j := makeTestLogsCleanupJob()
 	j.SetID(fmt.Sprintf("%s.%s", testLogsCleanupJobName, ts.Format(TSFormat)))
 	j.UpdateTimeInfo(amboy.JobTimeInfo{MaxTime: time.Minute})
+	j.SetScopes([]string{testLogsCleanupJobName})
+	j.SetEnqueueAllScopes(true)
 	return j
 }
 

--- a/units/data_cleanup_test_logs.go
+++ b/units/data_cleanup_test_logs.go
@@ -91,7 +91,7 @@ deleteDocs:
 		case <-ctx.Done():
 			break deleteDocs
 		default:
-			if time.Since(startAt) >= 50*time.Second {
+			if time.Since(startAt) >= 45*time.Second {
 				break deleteDocs
 			}
 			opStart := time.Now()

--- a/units/data_cleanup_testresults.go
+++ b/units/data_cleanup_testresults.go
@@ -93,7 +93,7 @@ deleteDocs:
 		case <-ctx.Done():
 			break deleteDocs
 		default:
-			if time.Since(startAt) >= 50*time.Second {
+			if time.Since(startAt) >= 45*time.Second {
 				break deleteDocs
 			}
 			opStart := time.Now()

--- a/units/data_cleanup_testresults.go
+++ b/units/data_cleanup_testresults.go
@@ -50,6 +50,8 @@ func NewTestResultsCleanupJob(ts time.Time) amboy.Job {
 	j := makeTestResultsCleanupJob()
 	j.SetID(fmt.Sprintf("%s.%s", testResultsCleanupJobName, ts.Format(TSFormat)))
 	j.UpdateTimeInfo(amboy.JobTimeInfo{MaxTime: time.Minute})
+	j.SetScopes([]string{testResultsCleanupJobName})
+	j.SetEnqueueAllScopes(true)
 	return j
 }
 


### PR DESCRIPTION
[EVG-17640](https://jira.mongodb.org/browse/EVG-17640)

### Description 
As the TSE explained, the db is suffering from these cleanup jobs since the deletes are each racing for the same document and the losers have an expensive backoff algorithm. Looking over the timing in Splunk, it doesn't appear that there are multiple instances of the job running simultaneously. Rather, each job fires off 100k parallel deletes in a bulk write. Still, I added scopes to make sure there wouldn't be more than one job running at once.

I considered parallelizing the id reads with the deletions. When I tried it out locally it took roughly the same time either way (i.e. most of the time was for the deletions) so the additional complexity seemed unjustified.

We'll have to keep an eye on how this affects the deletion rate. The job is intended to run ~50s and gets enqueued once a minute. Right now it's not using the full time since we never get past the first or second batch. I think the reason is that we break [here](https://github.com/evergreen-ci/evergreen/blob/c5abc064bc679a5063ab4cbe5ce14af5cad1287c/units/data_cleanup_testresults.go#L105) when we haven't deleted the full number of documents and an unintended consequence is that if some of the deletes race with each other we will also break. This should be fixed now, so we will actually be deleting several batches. In staging it was usually 4 batches in 50s.

We'd been breaking after [50s](https://github.com/evergreen-ci/evergreen/blob/c5abc064bc679a5063ab4cbe5ce14af5cad1287c/units/data_cleanup_testresults.go#L94). I changed this to 45s since, at least in staging, each batch was ~12s. This way we'll only start on a batch if we have 15 seconds to go and we won't have to cancel db operations by cancelling the ctx.

### Testing 
I deployed to staging and we appear to be deleting documents apace because we're no longer breaking when the deletes race.

We'll see how things go in prod. If someone advocates for it we could add an admin setting for the batch size and/or number of batches since it's possible that speeding up deletes will put extra load on the db.