### PR TITLE
EVG-17927: Do not clear default logger from project ref and set the global correctly on all project_ref routes

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -234,6 +234,12 @@ func (as *APIServer) GetProjectRef(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if p.DefaultLogger == "" {
+		// If the default logger is not set at the project level, use
+		// the global default logger.
+		p.DefaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger
+	}
+
 	gimlet.WriteJSON(w, p)
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -277,7 +277,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		PatchAliases           []model.ProjectAlias           `json:"patch_aliases,omitempty"`
 		GitTagAliases          []model.ProjectAlias           `json:"git_tag_aliases,omitempty"`
 		DeleteAliases          []string                       `json:"delete_aliases"`
-		DefaultLogger          string                         `json:"default_logger"`
 		PrivateVars            map[string]bool                `json:"private_vars"`
 		AdminOnlyVars          map[string]bool                `json:"admin_only_vars"`
 		Enabled                bool                           `json:"enabled"`
@@ -570,7 +569,6 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 	projectRef.BatchTime = responseRef.BatchTime
 	projectRef.Branch = responseRef.Branch
 	projectRef.Enabled = &responseRef.Enabled
-	projectRef.DefaultLogger = responseRef.DefaultLogger
 	projectRef.Private = &responseRef.Private
 	projectRef.Restricted = &responseRef.Restricted
 	projectRef.Owner = responseRef.Owner


### PR DESCRIPTION
https://jira.mongodb.org/browse/EVG-17927

### Description 
This just ensures that the project ref does not get unset from the project page UI and the global default is set when appropriate on all project_ref routes used by the agent.

### Testing 
I tested in staging that the field is not unset when saving the project page and that if the logger is unset in the project ref, the global default logger is set properly.
