### PR TITLE
EVG-17608 add some logging to alias copying

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -405,6 +406,11 @@ func UpsertAliasesForProject(aliases []ProjectAlias, projectId string) error {
 		}
 		catcher.Add(aliases[i].Upsert())
 	}
+	grip.Debug(message.WrapError(catcher.Resolve(), message.Fields{
+		"ticket":     "EVG-17608",
+		"message":    "problem getting aliases",
+		"project_id": projectId,
+	}))
 	return catcher.Resolve()
 }
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -43,7 +43,7 @@ func CopyProject(ctx context.Context, env evergreen.Environment, opts CopyProjec
 	}
 
 	oldId := projectToCopy.Id
-	// project ID will be validated or generated during CreateProject
+	// Project ID will be validated or generated during CreateProject
 	if opts.NewProjectId != "" {
 		projectToCopy.Id = opts.NewProjectId
 	} else {
@@ -64,7 +64,7 @@ func CopyProject(ctx context.Context, env evergreen.Environment, opts CopyProjec
 		return nil, errors.Wrap(err, "converting project to API model")
 	}
 
-	// copy variables, aliases, and subscriptions
+	// Copy variables, aliases, and subscriptions
 	catcher := grip.NewBasicCatcher()
 	if err := model.CopyProjectVars(oldId, projectToCopy.Id); err != nil {
 		catcher.Wrapf(err, "copying project vars from project '%s'", oldIdentifier)
@@ -75,9 +75,14 @@ func CopyProject(ctx context.Context, env evergreen.Environment, opts CopyProjec
 	if err := event.CopyProjectSubscriptions(oldId, projectToCopy.Id); err != nil {
 		catcher.Wrapf(err, "copying subscriptions from project '%s'", oldIdentifier)
 	}
-	// set the same admin roles from the old project on the newly copied project.
+	// Set the same admin roles from the old project on the newly copied project.
 	if err := model.UpdateAdminRoles(projectToCopy, projectToCopy.Admins, nil); err != nil {
 		catcher.Wrapf(err, "updating admins for project '%s'", opts.NewProjectIdentifier)
+	}
+
+	// We can pass in an empty before here since the project is new
+	if err := model.GetAndLogProjectModified(projectToCopy.Id, u.Id, false, &model.ProjectSettings{}); err != nil {
+		catcher.Wrapf(err, "logging project modified")
 	}
 	// Since the errors above are nonfatal and still permit copying the project, return both the new project and any errors that were encountered.
 	return apiProjectRef, catcher.Resolve()


### PR DESCRIPTION
[EVG-17608 ](https://jira.mongodb.org/browse/EVG-17608 )

### Description 
I've been unable to replicate this bug, and I haven't been able to reason over how we would've copied some but not all aliases, given that we use catchers everywhere. I've added some logging to try to make this a bit more traceable.

