### PR TITLE
EVG-17920 redirect commit queue links to spruce

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -1042,7 +1042,7 @@ func SendCommitQueueResult(p *patch.Patch, status message.GithubState, descripti
 		if err != nil {
 			return errors.Wrap(err, "unable to get settings")
 		}
-		url = fmt.Sprintf("%s/version/%s", settings.Ui.Url, p.Version)
+		url = fmt.Sprintf("%s/version/%s?redirect_spruce_users=true", settings.Ui.Url, p.Version)
 	}
 	msg := message.GithubStatus{
 		Owner:       projectRef.Owner,

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -213,9 +213,8 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		if err = handleGithubConflicts(mergedProjectRef, "Toggling GitHub features"); err != nil {
 			return nil, err
 		}
-		// At project creation we now insert a commit queue, however older projects still may not have one
-		// so we need to validate that this exists if the feature is being toggled on.
-		if mergedBeforeRef.CommitQueue.IsEnabled() && mergedProjectRef.CommitQueue.IsEnabled() {
+
+		if !mergedBeforeRef.CommitQueue.IsEnabled() && mergedProjectRef.CommitQueue.IsEnabled() {
 			if err = commitqueue.EnsureCommitQueueExistsForProject(mergedProjectRef.Id); err != nil {
 				return nil, err
 			}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -923,7 +923,7 @@ func SendCommitQueueGithubStatus(pr *github.PullRequest, state message.GithubSta
 	if versionID != "" {
 		uiConfig := evergreen.UIConfig{}
 		if err := uiConfig.Get(env); err == nil {
-			url = fmt.Sprintf("%s/version/%s", uiConfig.Url, versionID)
+			url = fmt.Sprintf("%s/version/%s?redirect_spruce_users=true", uiConfig.Url, versionID)
 		}
 	}
 

--- a/trigger/commit_queue.go
+++ b/trigger/commit_queue.go
@@ -88,7 +88,7 @@ func (t *commitQueueTriggers) makeData(sub *event.Subscription) (*commonTemplate
 	}
 	url := ""
 	if t.patch.Version != "" {
-		url = fmt.Sprintf("%s/version/%s", t.uiConfig.Url, t.patch.Version)
+		url = fmt.Sprintf("%s/version/%s?redirect_spruce_users=true", t.uiConfig.Url, t.patch.Version)
 	}
 	projectName := t.patch.Project
 	identifier, err := model.GetIdentifierForProject(t.patch.Project)


### PR DESCRIPTION
[EVG-17920](https://jira.mongodb.org/browse/EVG-17920)

### Description 
Redirect links to spruce and also fix a project settings bug.

### Testing 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/358 has a commit queue link that redirects to spruce.