### PR TITLE
EVG-17928: Add ability to unset home volume

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2663,6 +2663,22 @@ func (h *Host) MarkShouldExpire(expireOnValue string) error {
 	)
 }
 
+// UnsetHomeVolume disassociates a home volume from a (stopped) host.
+// This is for internal use, and should only be used on hosts that
+// will be terminated imminently; otherwise, the host will fail to boot.
+func (h *Host) UnsetHomeVolume() error {
+	err := UpdateOne(
+		bson.M{IdKey: h.Id},
+		bson.M{"$unset": bson.M{HomeVolumeIDKey: true}},
+	)
+	if err != nil {
+		return err
+	}
+
+	h.HomeVolumeID = ""
+	return nil
+}
+
 func (h *Host) SetHomeVolumeID(volumeID string) error {
 	h.HomeVolumeID = volumeID
 	return UpdateOne(bson.M{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2669,7 +2669,7 @@ func (h *Host) MarkShouldExpire(expireOnValue string) error {
 func (h *Host) UnsetHomeVolume() error {
 	err := UpdateOne(
 		bson.M{IdKey: h.Id},
-		bson.M{"$unset": bson.M{HomeVolumeIDKey: true}},
+		bson.M{"$set": bson.M{HomeVolumeIDKey: ""}},
 	)
 	if err != nil {
 		return err

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4516,6 +4516,38 @@ func TestAddVolumeToHost(t *testing.T) {
 	}, foundHost.Volumes)
 }
 
+func TestUnsetHomeVolume(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+	h := &Host{
+		Id:           "host-1",
+		HomeVolumeID: "volume-1",
+		Volumes: []VolumeAttachment{
+			{
+				VolumeID:   "volume-1",
+				DeviceName: "device-1",
+			},
+		},
+	}
+	assert.NoError(t, h.Insert())
+	assert.NoError(t, h.UnsetHomeVolume())
+	assert.Equal(t, "", h.HomeVolumeID)
+	assert.Equal(t, []VolumeAttachment{
+		{
+			VolumeID:   "volume-1",
+			DeviceName: "device-1",
+		},
+	}, h.Volumes)
+	foundHost, err := FindOneId("host-1")
+	assert.NoError(t, err)
+	assert.Equal(t, "", foundHost.HomeVolumeID)
+	assert.Equal(t, []VolumeAttachment{
+		{
+			VolumeID:   "volume-1",
+			DeviceName: "device-1",
+		},
+	}, foundHost.Volumes)
+}
+
 func TestRemoveVolumeFromHost(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
 	h := &Host{


### PR DESCRIPTION
[EVG-17928](https://jira.mongodb.org/browse/EVG-17928)

### Description 
- Add ability to unset home volume on stopped host (for internal use only). This will facilitate the migration of volumes between hosts by allowing a volume to be detached without requiring termination of the host.

### Testing 
- Add unit test
- Spruce failure appears to be a flaky test