### PR TITLE
EVG-17946: fix auto update CLI context

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-09-16"
+	ClientVersion = "2022-09-21"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-09-14"

--- a/operations/before.go
+++ b/operations/before.go
@@ -102,7 +102,7 @@ var (
 	// Some functions that one would expect to return quickly have been omitted from having this as a 'before' function since downloading and installing
 	// takes time that would be cumbersome to the user (e.g. list functions, delete functions).
 	autoUpdateCLI = func(c *cli.Context) error {
-		confPath := c.String("conf")
+		confPath := c.Parent().String(confFlagName)
 		// we do not return an error in case of failure to find a valid config path because we do not want to block the underlying CLI operation.
 		if confPath == "" {
 			return nil

--- a/operations/before.go
+++ b/operations/before.go
@@ -121,8 +121,9 @@ var (
 		}
 
 		confPath := rootCtx.String(confFlagName)
-		// we do not return an error in case of failure to find a valid config path because we do not want to block the underlying CLI operation.
+		// we do not return an error in case of failure to find the config path flag because we do not want to block the underlying CLI operation.
 		if confPath == "" {
+			grip.Warning("Config path flag could not be read, skipping auto upgrade CLI check.")
 			return nil
 		}
 

--- a/operations/before.go
+++ b/operations/before.go
@@ -104,9 +104,10 @@ var (
 	autoUpdateCLI = func(c *cli.Context) error {
 		rootCtx := c
 		var i int
-		// Since we don't know at which sub-command context level this can be
-		// called at, we have to search for the parent context until we reach
-		// the root. Parent() should return either nil (no parent) or the exact
+		// Since this could be used at any sub-command context level, walk up
+		// the parent contexts until the root context containing the config flag
+		// is found.
+		// Parent() should return either nil (no parent) or the exact
 		// same context (the root context's parent is self-referential).
 		for parentCtx := rootCtx.Parent(); parentCtx != nil && parentCtx != rootCtx; parentCtx = rootCtx.Parent() {
 			if i > 10 {

--- a/operations/before.go
+++ b/operations/before.go
@@ -123,7 +123,7 @@ var (
 		confPath := rootCtx.String(confFlagName)
 		// we do not return an error in case of failure to find the config path flag because we do not want to block the underlying CLI operation.
 		if confPath == "" {
-			grip.Warning("Config path flag could not be read, skipping auto upgrade CLI check.")
+			grip.Warning("Config path flag had no config set, skipping auto upgrade CLI check.")
 			return nil
 		}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17946

### Description 
It seems like the auto upgrade CLI option for the user Evergreen YAMLs isn't working because it's checking the sub-command's CLI context flags (e.g. the flags immediately following `evergreen patch` or `evergreen commit-queue list`), but it should be checking the root CLI context flags (i.e. the flags immediately after `evergreen` but before any subcommand).

After this is deployed, we'll have to announce that any person using the `auto_upgrade_cli` option in their YAML with an `evergreen --version` older than 2022-09-21 (containing this fix) has to manually run `evergreen update` to get the correctly auto-updating CLI.

### Testing 
* Enabled `auto_upgrade_cli` in my YAML.
* Compiled the Evergreen CLI with an older CLI date date (2022-09-10) using what's currently in main, then ran `evergreen patch`. No auto update.
* Compiled the Evergreen CLI with an older CLI date (2022-09-10) and this change, then ran `evergreen patch`. Auto-update succeeded.