### PR TITLE
EVG-17698: consistently check execution number for tasks assigned to pods

### DIFF
--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -23,7 +23,7 @@ var (
 	FamilyKey                    = bsonutil.MustHaveTag(Pod{}, "Family")
 	TimeInfoKey                  = bsonutil.MustHaveTag(Pod{}, "TimeInfo")
 	ResourcesKey                 = bsonutil.MustHaveTag(Pod{}, "Resources")
-	RunningTaskKey               = bsonutil.MustHaveTag(Pod{}, "RunningTask")
+	TaskRuntimeInfoKey           = bsonutil.MustHaveTag(Pod{}, "TaskRuntimeInfo")
 
 	TaskContainerCreationOptsImageKey    = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "Image")
 	TaskContainerCreationOptsMemoryMBKey = bsonutil.MustHaveTag(TaskContainerCreationOptions{}, "MemoryMB")
@@ -42,6 +42,9 @@ var (
 	ResourceInfoDefinitionIDKey = bsonutil.MustHaveTag(ResourceInfo{}, "DefinitionID")
 	ResourceInfoClusterKey      = bsonutil.MustHaveTag(ResourceInfo{}, "Cluster")
 	ResourceInfoContainersKey   = bsonutil.MustHaveTag(ResourceInfo{}, "Containers")
+
+	TaskRuntimeInfoRunningTaskIDKey        = bsonutil.MustHaveTag(TaskRuntimeInfo{}, "RunningTaskID")
+	TaskRuntimeInfoRunningTaskExecutionKey = bsonutil.MustHaveTag(TaskRuntimeInfo{}, "RunningTaskExecution")
 
 	ContainerResourceInfoExternalIDKey = bsonutil.MustHaveTag(ContainerResourceInfo{}, "ExternalID")
 	ContainerResourceInfoNameKey       = bsonutil.MustHaveTag(ContainerResourceInfo{}, "Name")

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -172,7 +172,7 @@ func TestAssignNextTask(t *testing.T) {
 		dbPod, err := pod.FindOneByID(p.ID)
 		require.NoError(t, err)
 		require.NotZero(t, dbPod)
-		assert.Equal(t, tsk.Id, dbPod.RunningTask)
+		assert.Equal(t, tsk.Id, dbPod.TaskRuntimeInfo.RunningTaskID)
 		assert.Equal(t, pod.StatusDecommissioned, dbPod.Status)
 
 		taskEvents, err := event.FindAllByResourceID(dbTask.Id)
@@ -408,7 +408,7 @@ func TestAssignNextTask(t *testing.T) {
 			checkDispatcherTasks(t, params.dispatcher, []string{params.task.Id})
 		},
 		"FailsWithPodAlreadyAssignedTask": func(ctx context.Context, t *testing.T, params testCaseParams) {
-			params.pod.RunningTask = "running-task"
+			params.pod.TaskRuntimeInfo.RunningTaskID = "running-task"
 			require.NoError(t, params.pod.Insert())
 			require.NoError(t, params.task.Insert())
 			require.NoError(t, params.ref.Insert())

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1553,6 +1553,13 @@ func ClearAndResetStrandedContainerTask(p *pod.Pod) error {
 		return errors.Wrapf(err, "resetting stranded task '%s'", t.Id)
 	}
 
+	grip.Info(message.Fields{
+		"message":            "successfully fixed stranded container task",
+		"task":               t.Id,
+		"execution":          t.Execution,
+		"execution_platform": t.ExecutionPlatform,
+	})
+
 	return nil
 }
 
@@ -1582,6 +1589,13 @@ func ClearAndResetStrandedHostTask(h *host.Host) error {
 		return errors.Wrapf(err, "resetting stranded task '%s'", t.Id)
 	}
 
+	grip.Info(message.Fields{
+		"message":            "successfully fixed stranded host task",
+		"task":               t.Id,
+		"execution":          t.Execution,
+		"execution_platform": t.ExecutionPlatform,
+	})
+
 	return nil
 }
 
@@ -1594,6 +1608,13 @@ func ResetStaleTask(t *task.Task) error {
 	if err := resetSystemFailedTask(t, evergreen.TaskDescriptionHeartbeat); err != nil {
 		return errors.Wrap(err, "resetting task")
 	}
+
+	grip.Info(message.Fields{
+		"message":            "successfully fixed stale heartbeat task",
+		"task":               t.Id,
+		"execution":          t.Execution,
+		"execution_platform": t.ExecutionPlatform,
+	})
 
 	return nil
 }

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1540,12 +1540,8 @@ func ClearAndResetStrandedContainerTask(p *pod.Pod) error {
 	}
 
 	if t.Archived {
-		// This should never log because a task should only be archived once
-		// it's in a finished state. It would be extra complexity to try putting
-		// an already-archived task execution in a finished state, so no-op in
-		// this case.
-		grip.WarningWhen(!t.IsFinished(), message.Fields{
-			"message":   "stranded container task has already been archived but is not in a finished state, refusing to fix it",
+		grip.Warning(message.Fields{
+			"message":   "stranded container task has already been archived, refusing to fix it",
 			"task":      t.Id,
 			"execution": t.Execution,
 			"status":    t.Status,

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3901,7 +3901,6 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			require.NotZero(t, dbTask)
 			assert.Equal(t, status, dbTask.Status)
 		},
-		// kim; TODO: add test for non-latest task fixing.
 		"FailsWithConflictingDBAndInMemoryRunningTasks": func(t *testing.T, p pod.Pod, tsk task.Task) {
 			const runningTask = "some_other_task"
 			p.TaskRuntimeInfo.RunningTaskID = runningTask

--- a/rest/model/pod_test.go
+++ b/rest/model/pod_test.go
@@ -82,6 +82,7 @@ func TestAPIPod(t *testing.T) {
 				},
 				WorkingDir: "working_dir",
 			},
+			Family: "family",
 			TimeInfo: pod.TimeInfo{
 				Initializing:     time.Now(),
 				Starting:         time.Now(),
@@ -99,6 +100,11 @@ func TestAPIPod(t *testing.T) {
 					},
 				},
 			},
+			TaskRuntimeInfo: pod.TaskRuntimeInfo{
+				RunningTaskID:        "task_id",
+				RunningTaskExecution: 3,
+			},
+			AgentVersion: "2020-01-01",
 		}
 	}
 
@@ -131,6 +137,7 @@ func TestAPIPod(t *testing.T) {
 				},
 				WorkingDir: utility.ToStringPtr("working_dir"),
 			},
+			Family: utility.ToStringPtr("family"),
 			TimeInfo: APIPodTimeInfo{
 				Initializing:     utility.ToTimePtr(time.Now()),
 				Starting:         utility.ToTimePtr(time.Now()),
@@ -148,6 +155,11 @@ func TestAPIPod(t *testing.T) {
 					},
 				},
 			},
+			TaskRuntimeInfo: APITaskRuntimeInfo{
+				RunningTaskID:        utility.ToStringPtr("task_id"),
+				RunningTaskExecution: utility.ToIntPtr(3),
+			},
+			AgentVersion: utility.ToStringPtr("2020-01-01"),
 		}
 	}
 	t.Run("ToService", func(t *testing.T) {
@@ -158,6 +170,7 @@ func TestAPIPod(t *testing.T) {
 			assert.Equal(t, utility.FromStringPtr(apiPod.ID), dbPod.ID)
 			assert.Equal(t, pod.TypeAgent, dbPod.Type)
 			assert.Equal(t, pod.StatusRunning, dbPod.Status)
+			assert.Equal(t, utility.FromStringPtr(apiPod.Family), dbPod.Family)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image), dbPod.TaskContainerCreationOpts.Image)
 			assert.Equal(t, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.RepoCredsExternalID), dbPod.TaskContainerCreationOpts.RepoCredsExternalID)
 			assert.Equal(t, utility.FromIntPtr(apiPod.TaskContainerCreationOpts.MemoryMB), dbPod.TaskContainerCreationOpts.MemoryMB)
@@ -189,6 +202,9 @@ func TestAPIPod(t *testing.T) {
 				assert.Empty(t, left, "actual is missing container secret IDs: %s", left)
 				assert.Empty(t, right, "actual has extra unexpected container secret IDs: %s", right)
 			}
+			assert.Equal(t, utility.FromStringPtr(apiPod.TaskRuntimeInfo.RunningTaskID), dbPod.TaskRuntimeInfo.RunningTaskID)
+			assert.Equal(t, utility.FromIntPtr(apiPod.TaskRuntimeInfo.RunningTaskExecution), dbPod.TaskRuntimeInfo.RunningTaskExecution)
+			assert.Equal(t, utility.FromStringPtr(apiPod.AgentVersion), dbPod.AgentVersion)
 		})
 		t.Run("FailsWithInvalidPodType", func(t *testing.T) {
 			apiPod := validAPIPod()
@@ -221,6 +237,8 @@ func TestAPIPod(t *testing.T) {
 			var apiPod APIPod
 			require.NoError(t, apiPod.BuildFromService(&dbPod))
 			assert.Equal(t, dbPod.ID, utility.FromStringPtr(apiPod.ID))
+			assert.Equal(t, dbPod.Family, utility.FromStringPtr(apiPod.Family))
+			assert.Equal(t, dbPod.AgentVersion, utility.FromStringPtr(apiPod.AgentVersion))
 			assert.Equal(t, PodTypeAgent, apiPod.Type)
 			assert.Equal(t, PodStatusRunning, apiPod.Status)
 			assert.Equal(t, dbPod.TaskContainerCreationOpts.Image, utility.FromStringPtr(apiPod.TaskContainerCreationOpts.Image))
@@ -255,6 +273,8 @@ func TestAPIPod(t *testing.T) {
 				assert.Empty(t, left, "actual is missing container secret IDs: %s", left)
 				assert.Empty(t, right, "actual has extra unexpected container secret IDs: %s", right)
 			}
+			assert.Equal(t, dbPod.TaskRuntimeInfo.RunningTaskID, utility.FromStringPtr(apiPod.TaskRuntimeInfo.RunningTaskID))
+			assert.Equal(t, dbPod.TaskRuntimeInfo.RunningTaskExecution, utility.FromIntPtr(apiPod.TaskRuntimeInfo.RunningTaskExecution))
 		})
 		t.Run("FailsWithInvalidPodType", func(t *testing.T) {
 			dbPod := validDBPod()

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -223,12 +223,8 @@ func (j *podTerminationJob) fixStrandedRunningTask(ctx context.Context) error {
 		return nil
 	}
 	if t.Archived {
-		// This should never log because a task should only be archived once
-		// it's in a finished state. It would be extra complexity to try putting
-		// an already-archived task execution in a finished state, so no-op in
-		// this case.
-		grip.WarningWhen(!t.IsFinished(), message.Fields{
-			"message":   "stranded container task has already been archived but is not in a finished state, refusing to fix it",
+		grip.Warning(message.Fields{
+			"message":   "stranded container task has already been archived, refusing to fix it",
 			"task":      t.Id,
 			"execution": t.Execution,
 			"status":    t.Status,

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -158,7 +158,8 @@ func TestPodTerminationJob(t *testing.T) {
 				ContainerAllocated: true,
 			}
 			require.NoError(t, tsk.Insert())
-			j.pod.RunningTask = tsk.Id
+			j.pod.TaskRuntimeInfo.RunningTaskID = tsk.Id
+			j.pod.TaskRuntimeInfo.RunningTaskExecution = tsk.Execution
 			require.NoError(t, j.pod.Insert())
 
 			j.Run(ctx)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17698

### Description 
I made the task/pod lifecycle interaction a bit safer by ensuring that if the pod lifecycle tries to make a decision based on its currently running task, it also accounts for the execution number. Before, it would assume that the pod was definitely running the latest execution of a task, but there are some cases (such as restarting a task and aborting currently running tasks) where the pod might end up having an archived task execution assigned to it, in which case it should act based on its own task execution and not assume it's the latest. I'd like to avoid that entirely if possible by always acting on the exact task execution that the pod was assigned to run.

* Add new struct to hold information about current/previous tasks run by a pod (previous tasks are only relevant to task groups).
* Update REST API model for pods.
* Check both task ID and execution when looking for tasks assigned to pods.
* No-op in cases where the task execution running on the pod is already archived. Since this is an edge case, I added logging for cases where an archived task is still assigned to a pod for traceability.
* Remove a couple unneeded YAML tags on DB models.

Once this is merged, I'm going to drop the unique index on `running_task` in the DB. I don't think we need it anyways since assigning the next task is done in a transaction.

### Testing 
Updated existing unit tests for refactor and added a couple extra tests.