### PR TITLE
EVG-16910: support manually rotating project pod secret

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -510,7 +510,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	// if owner/repo has changed and the project is attached to repo, update scope and repo accordingly
 	if h.newProjectRef.UseRepoSettings() && h.ownerRepoChanged() {
 		if err = h.newProjectRef.RemoveFromRepoScope(); err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "error removing project from old repo scope"))
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "removing project from old repo scope"))
 		}
 		if err = h.newProjectRef.AddToRepoScope(h.user); err != nil { // will re-add using the new owner/repo
 			return gimlet.MakeJSONInternalErrorResponder(err)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16910

### Description 
Expose an option for REST requests to manually rotate the project's pod secret value (or create if it doesn't exist). When the pod secret is rotated, pods that are already running will still authenticate just fine, but newly-created pods will use the new credentials.

### Testing
Updated unit test for the project modify route.
