### PR TITLE
EVG-17963: remove auto-upgrade CLI check from 'evergreen evaluate'

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,10 +33,10 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-09-21"
+	ClientVersion = "2022-09-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-09-14"
+	AgentVersion = "2022-09-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -29,7 +29,7 @@ func Evaluate() cli.Command {
 				Name:  variantsFlagName,
 				Usage: "only show variant definitions",
 			}),
-		Before: mergeBeforeFuncs(autoUpdateCLI, requirePathFlag),
+		Before: mergeBeforeFuncs(requirePathFlag),
 		Action: func(c *cli.Context) error {
 			path := c.String(pathFlagName)
 			showTasks := c.Bool(taskFlagName)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17963

### Description
Some people use the Evergreen CLI in CI testing to do automated stuff. `evergreen evaluate` doesn't require the `~/.evergreen.yml` file to exist to evaluate the YAML, so it should be fine to remove the auto-upgrading functionality temporarily. We can evaluate re-adding it and possibly improving the way it logs to interfere with scripting in a follow-up.

I bumped both the CLI and agent versions because this command is being used for CI tests, so we have to force the agents to roll over to the latest version.

### Testing 
N/A