### PR TITLE
EVG-17655: add logging for container task dashboard

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -66,6 +66,7 @@ func (q *ContainerTaskQueue) populate() error {
 
 	grip.Info(message.Fields{
 		"message":    "generated container task queue",
+		"usage":      "container task health dashboard",
 		"candidates": len(candidates),
 		"queue":      len(readyForAllocation),
 		"duration":   time.Since(startAt),

--- a/model/host/stats.go
+++ b/model/host/stats.go
@@ -102,7 +102,7 @@ func GetProviderCounts() (ProviderStats, error) {
 
 ////////////////////////////////////////////////////////////////////////
 //
-// Pipeline impelementations
+// Pipeline implementations
 
 // statsByDistroPipeline returns a pipeline that will group all up hosts by distro
 // and return the count of hosts as well as how many are running tasks

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -562,3 +562,125 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStatsByStatus(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+	for tName, tCase := range map[string]func(t *testing.T){
+		"ReturnsEmptyForNoMatchingPods": func(t *testing.T) {
+			stats, err := GetStatsByStatus()
+			assert.NoError(t, err)
+			assert.Empty(t, stats)
+		},
+		"ReturnsStatisticsForMatchingStatusAndType": func(t *testing.T) {
+			for _, p := range []Pod{
+				{
+					ID:     "p0",
+					Status: StatusRunning,
+					Type:   TypeAgent,
+					TaskRuntimeInfo: TaskRuntimeInfo{
+						RunningTaskID:        "t0",
+						RunningTaskExecution: 5,
+					},
+				},
+				{
+					ID:     "p1",
+					Status: StatusTerminated,
+					Type:   TypeAgent,
+				},
+				{
+					ID:     "p2",
+					Status: StatusRunning,
+					Type:   TypeAgent,
+				},
+				{
+					ID:     "p3",
+					Status: StatusRunning,
+				},
+			} {
+				require.NoError(t, p.Insert())
+			}
+
+			stats, err := GetStatsByStatus(StatusRunning)
+			require.NoError(t, err)
+			require.Len(t, stats, 1)
+			assert.Equal(t, StatusRunning, stats[0].Status)
+			assert.Equal(t, 2, stats[0].Count)
+			assert.Equal(t, 1, stats[0].NumRunningTasks)
+		},
+		"ReturnsStatisticsForMultipleMatchingStatuses": func(t *testing.T) {
+			for _, p := range []Pod{
+				{
+					ID:     "p0",
+					Status: StatusRunning,
+					Type:   TypeAgent,
+					TaskRuntimeInfo: TaskRuntimeInfo{
+						RunningTaskID:        "t0",
+						RunningTaskExecution: 2,
+					},
+				},
+				{
+					ID:     "p1",
+					Status: StatusTerminated,
+					Type:   TypeAgent,
+				},
+				{
+					ID:     "p2",
+					Status: StatusInitializing,
+					Type:   TypeAgent,
+				},
+				{
+					ID:     "p3",
+					Status: StatusStarting,
+					Type:   TypeAgent,
+				},
+				{
+					ID:     "p4",
+					Status: StatusInitializing,
+				},
+				{
+					ID:     "p5",
+					Status: StatusDecommissioned,
+					Type:   TypeAgent,
+					TaskRuntimeInfo: TaskRuntimeInfo{
+						RunningTaskID:        "t1",
+						RunningTaskExecution: 0,
+					},
+				},
+				{
+					ID:     "p6",
+					Status: StatusRunning,
+					Type:   TypeAgent,
+				},
+			} {
+				require.NoError(t, p.Insert())
+			}
+
+			stats, err := GetStatsByStatus(StatusInitializing, StatusStarting, StatusRunning)
+			require.NoError(t, err)
+			require.Len(t, stats, 3)
+			for _, s := range stats {
+				switch s.Status {
+				case StatusInitializing:
+					assert.Equal(t, 1, s.Count)
+					assert.Zero(t, s.NumRunningTasks)
+				case StatusStarting:
+					assert.Equal(t, 1, s.Count)
+					assert.Zero(t, s.NumRunningTasks)
+				case StatusRunning:
+					assert.Equal(t, 2, s.Count)
+					assert.Equal(t, 1, s.NumRunningTasks)
+				default:
+					assert.Fail(t, "unexpected pod status '%s'", s.Status)
+				}
+			}
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection))
+
+			tCase(t)
+		})
+	}
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1456,6 +1456,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed)
 	grip.Info(message.Fields{
 		"message":     "marking task system failed",
+		"usage":       "container task health dashboard",
 		"task_id":     t.Id,
 		"execution":   t.Execution,
 		"status":      t.Status,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -533,12 +533,14 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	status := t.GetDisplayStatus()
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 	grip.Info(message.Fields{
-		"message":   "marking task finished",
-		"task_id":   t.Id,
-		"execution": t.Execution,
-		"status":    status,
-		"operation": "MarkEnd",
-		"host_id":   t.HostId,
+		"message":            "marking task finished",
+		"usage":              "container task health dashboard",
+		"task_id":            t.Id,
+		"execution":          t.Execution,
+		"status":             status,
+		"operation":          "MarkEnd",
+		"host_id":            t.HostId,
+		"execution_platform": t.ExecutionPlatform,
 	})
 
 	if t.IsPartOfDisplay() {

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -331,6 +331,7 @@ func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {
 
 	grip.Info(message.Fields{
 		"message":                   "pod initiated first contact with application server",
+		"usage":                     "container task health dashboard",
 		"pod":                       p.ID,
 		"secs_since_pod_allocation": time.Since(p.TimeInfo.Initializing).Seconds(),
 		"secs_since_pod_creation":   time.Since(p.TimeInfo.Starting).Seconds(),

--- a/units/crons.go
+++ b/units/crons.go
@@ -994,7 +994,7 @@ func PopulateBackgroundStatsJobs(env evergreen.Environment, part int) amboy.Queu
 		if flags.BackgroundStatsDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 				"message": "background stats collection disabled",
-				"impact":  "host, task, latency, amboy, and notification stats disabled",
+				"impact":  "host, pod, task, latency, amboy, and notification stats disabled",
 				"mode":    "degraded",
 			})
 			return nil
@@ -1005,6 +1005,7 @@ func PopulateBackgroundStatsJobs(env evergreen.Environment, part int) amboy.Queu
 
 		catcher.Wrap(queue.Put(ctx, NewRemoteAmboyStatsCollector(env, ts)), "enqueueing remote Amboy stats collector job")
 		catcher.Wrap(queue.Put(ctx, NewHostStatsCollector(ts)), "enqueueing host stats collector job")
+		catcher.Wrap(queue.Put(ctx, NewPodStatsCollector(ts)), "enqueueing pod stats collector job")
 		catcher.Wrap(queue.Put(ctx, NewTaskStatsCollector(ts)), "enqueueing task stats collector job")
 		catcher.Wrap(queue.Put(ctx, NewNotificationStatsCollector(ts)), "enqueueing notification stats collector job")
 		catcher.Wrap(queue.Put(ctx, NewQueueStatsCollector(ts)), "enqueueing task queue stats collector job")
@@ -1362,6 +1363,7 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		grip.InfoWhen(remaining <= 0 && ctq.Len() > 0, message.Fields{
 			"message":             "reached max parallel pod request limit, not allocating any more",
+			"usage":               "container task health dashboard",
 			"context":             "pod allocation",
 			"num_remaining_tasks": ctq.Len(),
 		})

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -134,6 +134,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	if utility.StringSliceContains(pd.PodIDs, intentPod.ID) {
 		grip.Info(message.Fields{
 			"message":                    "successfully allocated pod for container task",
+			"usage":                      "container task health dashboard",
 			"task":                       j.task.Id,
 			"pod":                        intentPod.ID,
 			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
@@ -141,6 +142,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	} else {
 		grip.Info(message.Fields{
 			"message":                    "container task already has a pod allocated to run it",
+			"usage":                      "container task health dashboard",
 			"task":                       j.task.Id,
 			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
 		})

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -234,6 +234,7 @@ func (j *podCreationJob) logTaskTimingStats() error {
 
 	msg := message.Fields{
 		"message":          "created pod to run container tasks",
+		"usage":            "container task health dashboard",
 		"pod":              j.pod.ID,
 		"dispatcher_group": disp.GroupID,
 	}

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -92,10 +92,10 @@ func (j *podTerminationJob) Run(ctx context.Context) {
 	switch j.pod.Status {
 	case pod.StatusInitializing:
 		grip.Info(message.Fields{
-			"message":                    "not deleting resources because pod has not initialized any yet",
-			"pod":                        j.PodID,
-			"termination_attempt_reason": j.Reason,
-			"job":                        j.ID(),
+			"message":            "not deleting resources because pod has not initialized any yet",
+			"pod":                j.PodID,
+			"termination_reason": j.Reason,
+			"job":                j.ID(),
 		})
 	case pod.StatusStarting, pod.StatusRunning, pod.StatusDecommissioned:
 		if j.ecsPod != nil {
@@ -106,19 +106,19 @@ func (j *podTerminationJob) Run(ctx context.Context) {
 		}
 	case pod.StatusTerminated:
 		grip.Info(message.Fields{
-			"message":                    "pod is already terminated",
-			"pod":                        j.PodID,
-			"termination_attempt_reason": j.Reason,
-			"job":                        j.ID(),
+			"message":            "pod is already terminated",
+			"pod":                j.PodID,
+			"termination_reason": j.Reason,
+			"job":                j.ID(),
 		})
 		return
 	default:
 		grip.Error(message.Fields{
-			"message":                    "could not terminate pod with unrecognized status",
-			"pod":                        j.PodID,
-			"status":                     j.pod.Status,
-			"termination_attempt_reason": j.Reason,
-			"job":                        j.ID(),
+			"message":            "could not terminate pod with unrecognized status",
+			"pod":                j.PodID,
+			"status":             j.pod.Status,
+			"termination_reason": j.Reason,
+			"job":                j.ID(),
 		})
 	}
 
@@ -127,10 +127,11 @@ func (j *podTerminationJob) Run(ctx context.Context) {
 	}
 
 	grip.Info(message.Fields{
-		"message":                    "successfully terminated pod",
-		"pod":                        j.PodID,
-		"termination_attempt_reason": j.Reason,
-		"job":                        j.ID(),
+		"message":            "successfully terminated pod",
+		"pod":                j.PodID,
+		"usage":              "container task health dashboard",
+		"termination_reason": j.Reason,
+		"job":                j.ID(),
 	})
 }
 

--- a/units/stats_pod.go
+++ b/units/stats_pod.go
@@ -1,0 +1,104 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const podStatsCollectorJobName = "pod-stats-collector"
+
+func init() {
+	registry.AddJobType(podStatsCollectorJobName, func() amboy.Job {
+		return makePodStatsCollector()
+	})
+}
+
+type podStatsCollector struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+}
+
+// NewPodStatsCollector logs statistics about current pod usage.
+func NewPodStatsCollector(id string) amboy.Job {
+	j := makePodStatsCollector()
+	j.SetID(fmt.Sprintf("%s.%s", podStatsCollectorJobName, id))
+	j.SetEnqueueScopes(podStatsCollectorJobName)
+
+	return j
+}
+
+func makePodStatsCollector() *podStatsCollector {
+	j := &podStatsCollector{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    podStatsCollectorJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+func (j *podStatsCollector) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+
+	if flags.BackgroundStatsDisabled {
+		grip.Debug(message.Fields{
+			"mode":     "degraded",
+			"impact":   "pod stats collection disabled",
+			"job":      j.ID(),
+			"job_type": j.Type().Name,
+		})
+		return
+	}
+
+	j.AddError(j.logStats())
+}
+
+func (j *podStatsCollector) logStats() error {
+	statuses := []pod.Status{
+		pod.StatusInitializing,
+		pod.StatusStarting,
+		pod.StatusRunning,
+		pod.StatusDecommissioned,
+	}
+	stats, err := pod.GetStatsByStatus(statuses...)
+	if err != nil {
+		return errors.Wrap(err, "getting statistics by pod status")
+	}
+
+	msg := message.Fields{
+		"message": "pod stats",
+		"usage":   "container task health dashboard",
+	}
+	// Ensure that the statuses of interest are always set, even if the query
+	// returns no statistics for that status.
+	for _, s := range statuses {
+		msg[fmt.Sprintf("num_%s", s)] = 0
+	}
+
+	var totalRunningTasks int
+	for _, s := range stats {
+		msg[fmt.Sprintf("num_%s", s.Status)] = s.Count
+		totalRunningTasks += s.NumRunningTasks
+	}
+	msg["num_running_tasks"] = totalRunningTasks
+
+	grip.Info(msg)
+
+	return nil
+}

--- a/units/stats_pod.go
+++ b/units/stats_pod.go
@@ -52,7 +52,7 @@ func (j *podStatsCollector) Run(ctx context.Context) {
 
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
-		j.AddError(err)
+		j.AddError(errors.Wrap(err, "getting service flags"))
 		return
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17655

### Description 
* Add metadata information for logs that are relevant to the [container task health dashboard](https://mongodb.splunkcloud.com/en-US/app/search/evergreen_container_task_health). I added a `usage` field as a signal that these logs are depended on to populate the dashboard.
* Add job to periodically collect stats on pods and container tasks. This has the equivalent purpose to the [host stats collector](https://github.com/evergreen-ci/evergreen/blob/c5abc064bc679a5063ab4cbe5ce14af5cad1287c/units/stats_host.go).

### Testing 
Added unit tests.