### PR TITLE
EVG-17667: use container task pod ID for notifications

### DIFF
--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -522,7 +522,7 @@ func TestEventExpiration(t *testing.T) {
 		{ResourceType: ResourceTypeAdmin, EventType: EventTypeValueChanged, Data: ""}:           false,
 		{ResourceType: ResourceTypeDistro, EventType: EventDistroAdded, Data: ""}:               false,
 		{ResourceType: ResourceTypeCommitQueue, EventType: CommitQueueConcludeTest, Data: ""}:   true,
-		{ResourceType: ResourceTypeTask, EventType: EventTaskFinished, Data: ""}:                true,
+		{ResourceType: ResourceTypeTask, EventType: EventHostTaskFinished, Data: ""}:            true,
 		{ResourceType: ResourceTypeHost, EventType: EventHostCreated, Data: ""}:                 true,
 	} {
 		assert.NoError(t, event.validateEvent())

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -49,7 +49,7 @@ const (
 	EventHostRunningTaskSet              = "HOST_RUNNING_TASK_SET"
 	EventHostRunningTaskCleared          = "HOST_RUNNING_TASK_CLEARED"
 	EventHostMonitorFlag                 = "HOST_MONITOR_FLAG"
-	EventTaskFinished                    = "HOST_TASK_FINISHED"
+	EventHostTaskFinished                = "HOST_TASK_FINISHED"
 	EventHostTerminatedExternally        = "HOST_TERMINATED_EXTERNALLY"
 	EventHostExpirationWarningSent       = "HOST_EXPIRATION_WARNING_SENT"
 	EventHostScriptExecuted              = "HOST_SCRIPT_EXECUTED"

--- a/model/event/host_event_finder.go
+++ b/model/event/host_event_finder.go
@@ -20,7 +20,7 @@ func (s *hostStatusDistro) UnmarshalBSON(in []byte) error { return mgobson.Unmar
 
 func getRecentStatusesForHost(hostId string, n int) (int, []string) {
 	or := ResourceTypeKeyIs(ResourceTypeHost)
-	or[TypeKey] = EventTaskFinished
+	or[TypeKey] = EventHostTaskFinished
 	or[ResourceIdKey] = hostId
 
 	pipeline := []bson.M{

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -24,6 +24,11 @@ const (
 	// EventPodAssignedTask represents an event where a pod is assigned a task
 	// to run.
 	EventPodAssignedTask PodEventType = "ASSIGNED_TASK"
+	// EventPodClearedTask represents an event where a pod's current running
+	// task is cleared.
+	EventPodClearedTask PodEventType = "CLEARED_TASK"
+	// EventPodFinishedTask represents an event where a pod's assigned task has
+	// finished running.
 	EventPodFinishedTask PodEventType = "CONTAINER_TASK_FINISHED"
 )
 
@@ -74,4 +79,10 @@ func LogPodStatusChanged(id, oldStatus, newStatus, reason string) {
 // task to run.
 func LogPodAssignedTask(id, taskID string, execution int) {
 	LogPodEvent(id, EventPodAssignedTask, podData{TaskID: taskID, TaskExecution: execution})
+}
+
+// LogPodRunningTaskCleared logs an event indicating that the pod's current
+// running task has been cleared, so it is no longer assigned to run the task.
+func LogPodRunningTaskCleared(id, taskID string, execution int) {
+	LogPodEvent(id, EventPodClearedTask, podData{TaskID: taskID, TaskExecution: execution})
 }

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -24,15 +24,19 @@ const (
 	// EventPodAssignedTask represents an event where a pod is assigned a task
 	// to run.
 	EventPodAssignedTask PodEventType = "ASSIGNED_TASK"
+	EventPodFinishedTask PodEventType = "CONTAINER_TASK_FINISHED"
 )
 
 // podData contains information relevant to a pod event.
 type podData struct {
-	OldStatus     string `bson:"old_status,omitempty" json:"old_status,omitempty"`
-	NewStatus     string `bson:"new_status,omitempty" json:"new_status,omitempty"`
-	Reason        string `bson:"reason,omitempty" json:"reason,omitempty"`
+	OldStatus string `bson:"old_status,omitempty" json:"old_status,omitempty"`
+	NewStatus string `bson:"new_status,omitempty" json:"new_status,omitempty"`
+	Reason    string `bson:"reason,omitempty" json:"reason,omitempty"`
+
+	// Fields related to pods running tasks
 	TaskID        string `bson:"task_id,omitempty" json:"task_id,omitempty"`
 	TaskExecution int    `bson:"task_execution,omitempty" json:"task_execution,omitempty"`
+	TaskStatus    string `bson:"task_status,omitempty" json:"task_status,omitempty"`
 }
 
 // LogPodEvent logs an event for a pod to the event log.

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -151,7 +151,7 @@ func LogTaskFinished(taskId string, execution int, status string) {
 // it was assigned to run on a host, it logs an additional host event indicating
 // that its assigned task has finished.
 func LogHostTaskFinished(taskId string, execution int, hostId, status string) {
-	logTaskEvent(taskId, TaskFinished, TaskEventData{Execution: execution, Status: status})
+	LogTaskFinished(taskId, execution, status)
 	if hostId != "" {
 		LogHostEvent(hostId, EventHostTaskFinished, HostEventData{Execution: strconv.Itoa(execution), TaskStatus: status, TaskId: taskId})
 	}
@@ -161,7 +161,7 @@ func LogHostTaskFinished(taskId string, execution int, hostId, status string) {
 // finished. If it was assigned to run on a pod, it logs an additional pod event
 // indicating that its assigned task has finished.
 func LogContainerTaskFinished(taskID string, execution int, podID, status string) {
-	logTaskEvent(taskID, TaskFinished, TaskEventData{Execution: execution, Status: status})
+	LogTaskFinished(taskID, execution, status)
 	if podID != "" {
 		LogPodEvent(podID, EventPodFinishedTask, podData{TaskExecution: execution, TaskStatus: status, TaskID: taskID})
 	}

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -142,10 +142,28 @@ func LogTaskStarted(taskId string, execution int) {
 	logTaskEvent(taskId, TaskStarted, TaskEventData{Execution: execution, Status: evergreen.TaskStarted})
 }
 
-func LogTaskFinished(taskId string, execution int, hostId, status string) {
+// LogTaskFinished logs an event indicating that the task has finished.
+func LogTaskFinished(taskId string, execution int, status string) {
+	logTaskEvent(taskId, TaskFinished, TaskEventData{Execution: execution, Status: status})
+}
+
+// LogHostTaskFinished logs an event for a host task being marked finished. If
+// it was assigned to run on a host, it logs an additional host event indicating
+// that its assigned task has finished.
+func LogHostTaskFinished(taskId string, execution int, hostId, status string) {
 	logTaskEvent(taskId, TaskFinished, TaskEventData{Execution: execution, Status: status})
 	if hostId != "" {
-		LogHostEvent(hostId, EventTaskFinished, HostEventData{Execution: strconv.Itoa(execution), TaskStatus: status, TaskId: taskId})
+		LogHostEvent(hostId, EventHostTaskFinished, HostEventData{Execution: strconv.Itoa(execution), TaskStatus: status, TaskId: taskId})
+	}
+}
+
+// LogContainerTaskFinished logs an event for a container task being marked
+// finished. If it was assigned to run on a pod, it logs an additional pod event
+// indicating that its assigned task has finished.
+func LogContainerTaskFinished(taskID string, execution int, podID, status string) {
+	logTaskEvent(taskID, TaskFinished, TaskEventData{Execution: execution, Status: status})
+	if podID != "" {
+		LogPodEvent(podID, EventPodFinishedTask, podData{TaskExecution: execution, TaskStatus: status, TaskID: taskID})
 	}
 }
 

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -35,7 +35,7 @@ func TestLoggingTaskEvents(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 			LogTaskStarted(taskId, 1)
 			time.Sleep(1 * time.Millisecond)
-			LogTaskFinished(taskId, 1, hostId, evergreen.TaskSucceeded)
+			LogHostTaskFinished(taskId, 1, hostId, evergreen.TaskSucceeded)
 
 			eventsForTask, err := Find(TaskEventsInOrder(taskId))
 			So(err, ShouldEqual, nil)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -32,7 +32,8 @@ import (
 )
 
 type Host struct {
-	Id              string        `bson:"_id" json:"id"`
+	Id string `bson:"_id" json:"id"`
+	// Host is the DNS name of the host.
 	Host            string        `bson:"host_id" json:"host"`
 	User            string        `bson:"user" json:"user"`
 	Secret          string        `bson:"secret" json:"secret"`

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -751,6 +751,8 @@ func (p *Pod) ClearRunningTask() error {
 		return errors.Wrap(err, "clearing running task")
 	}
 
+	event.LogPodRunningTaskCleared(p.ID, p.TaskRuntimeInfo.RunningTaskID, p.TaskRuntimeInfo.RunningTaskExecution)
+
 	p.TaskRuntimeInfo.RunningTaskID = ""
 	p.TaskRuntimeInfo.RunningTaskExecution = 0
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1453,6 +1453,8 @@ func (t *Task) MarkSystemFailed(description string) error {
 		t.Details.TimedOut = true
 	}
 
+	// kim: TODO: replace with two methods event.LogHostTaskFinished and
+	// event.LogContainerTaskFinished depending on host vs. container.
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed)
 	grip.Info(message.Fields{
 		"message":     "marking task system failed",
@@ -2052,6 +2054,7 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.ActivatedTime = now
 		t.Secret = newSecret
 		t.HostId = ""
+		// kim: TODO: reset pod ID.
 		t.Status = evergreen.TaskUndispatched
 		t.DispatchTime = utility.ZeroTime
 		t.StartTime = utility.ZeroTime
@@ -2515,6 +2518,7 @@ func (t *Task) String() (taskStruct string) {
 	taskStruct += fmt.Sprintf("Id: %v\n", t.Id)
 	taskStruct += fmt.Sprintf("Status: %v\n", t.Status)
 	taskStruct += fmt.Sprintf("Host: %v\n", t.HostId)
+	// kim: TODO: add line for pod ID.
 	taskStruct += fmt.Sprintf("ScheduledTime: %v\n", t.ScheduledTime)
 	taskStruct += fmt.Sprintf("ContainerAllocatedTime: %v\n", t.ContainerAllocatedTime)
 	taskStruct += fmt.Sprintf("DispatchTime: %v\n", t.DispatchTime)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -531,6 +531,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	}
 
 	status := t.GetDisplayStatus()
+	// kim: TODO: replace with host/container relevant log.
 	event.LogTaskFinished(t.Id, t.Execution, t.HostId, status)
 	grip.Info(message.Fields{
 		"message":   "marking task finished",
@@ -538,7 +539,8 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		"execution": t.Execution,
 		"status":    status,
 		"operation": "MarkEnd",
-		"host_id":   t.HostId,
+		// kim: TODO: set host ID/pod ID and execution platform.
+		"host_id": t.HostId,
 	})
 
 	if t.IsPartOfDisplay() {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1572,6 +1572,7 @@ func TestTryResetTask(t *testing.T) {
 					Status:                      evergreen.TaskSucceeded,
 					Version:                     b.Version,
 					ExecutionPlatform:           task.ExecutionPlatformContainer,
+					PodID:                       "pod_id",
 					ContainerAllocationAttempts: 2,
 				}
 				So(containerTask.Insert(), ShouldBeNil)
@@ -1586,6 +1587,7 @@ func TestTryResetTask(t *testing.T) {
 					So(dbTask.FinishTime, ShouldResemble, utility.ZeroTime)
 					So(dbTask.Activated, ShouldBeTrue)
 					So(dbTask.ContainerAllocationAttempts, ShouldEqual, 0)
+					So(dbTask.PodID, ShouldBeZeroValue)
 					oldTask, err := task.FindOneOldByIdAndExecution(dbTask.Id, 1)
 					So(err, ShouldBeNil)
 					So(oldTask, ShouldNotBeNil)
@@ -1593,6 +1595,7 @@ func TestTryResetTask(t *testing.T) {
 					So(oldTask.Details, ShouldResemble, *detail)
 					So(oldTask.FinishTime, ShouldNotResemble, utility.ZeroTime)
 					So(oldTask.ContainerAllocationAttempts, ShouldEqual, 2)
+					So(oldTask.PodID, ShouldEqual, containerTask.PodID)
 				})
 			})
 		})

--- a/service/pod.go
+++ b/service/pod.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/model/pod"
+	"github.com/evergreen-ci/gimlet"
+)
+
+func (uis *UIServer) podPage(w http.ResponseWriter, r *http.Request) {
+	id := gimlet.GetVars(r)["pod_id"]
+
+	p, err := pod.FindOneByID(id)
+	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if p == nil {
+		http.Error(w, "pod not found", http.StatusNotFound)
+		return
+	}
+
+	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/pod/%s", uis.Settings.Ui.UIv2Url, id)) {
+		return
+	}
+
+	http.Error(w, "user is not opted in to automatic redirects to Spruce and pod page is not supported in legacy UI", http.StatusNotImplemented)
+}

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -95,6 +95,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// kim: TODO: set container-specific info
 	destTask := &RestTask{}
 	destTask.Id = srcTask.Id
 	destTask.CreateTime = srcTask.CreateTime

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -95,7 +95,6 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// kim: TODO: set container-specific info
 	destTask := &RestTask{}
 	destTask.Id = srcTask.Id
 	destTask.CreateTime = srcTask.CreateTime

--- a/service/task.go
+++ b/service/task.go
@@ -309,6 +309,8 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var taskHost *host.Host
+	// kim: TODO: see what the host ID is used for here, then set pod ID if
+	// needed.
 	if projCtx.Task.HostId != "" {
 		uiTask.HostDNS = projCtx.Task.HostId
 		uiTask.HostId = projCtx.Task.HostId

--- a/service/task.go
+++ b/service/task.go
@@ -309,8 +309,6 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var taskHost *host.Host
-	// kim: TODO: see what the host ID is used for here, then set pod ID if
-	// needed.
 	if projCtx.Task.HostId != "" {
 		uiTask.HostDNS = projCtx.Task.HostId
 		uiTask.HostId = projCtx.Task.HostId

--- a/service/ui.go
+++ b/service/ui.go
@@ -365,6 +365,9 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/distros/{distro_id}").Wrap(needsContext, editDistroSettings).Handler(uis.modifyDistro).Post()
 	app.AddRoute("/distros/{distro_id}").Wrap(needsContext, removeDistroSettings).Handler(uis.removeDistro).Delete()
 
+	// TODO (EVG-17986): route should require pod-specific permissions.
+	app.AddRoute("/pod/{pod_id}").Wrap(needsLogin).Handler(uis.podPage).Get()
+
 	// Event Logs
 	app.AddRoute("/event_log/{resource_type}/{resource_id:[\\w_\\-\\:\\.\\@]+}").Wrap(needsLogin, needsContext, &route.EventLogPermissionsMiddleware{}).Handler(uis.fullEventLogs).Get()
 

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -487,7 +487,10 @@ func versionLink(i versionLinkInput) string {
 	return url
 }
 
-func hostLink(uiBase string, hostID string) string {
+func hostLink(uiBase, hostID string) string {
 	return fmt.Sprintf("%s/host/%s?redirect_spruce_users=true", uiBase, hostID)
+}
 
+func podLink(uiBase, podID string) string {
+	return fmt.Sprintf("%s/pod/%s?redirect_spruce_users=true", uiBase, podID)
 }

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/notification"
+	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -76,9 +77,8 @@ func newAlertRecord(subID string, t *task.Task, alertType string) *alertrecord.A
 		TaskName:            t.DisplayName,
 		Variant:             t.BuildVariant,
 		TaskId:              t.Id,
-		// kim: TODO: set pod ID instead of host ID.
-		HostId:    t.HostId,
-		AlertTime: time.Now(),
+		HostId:              t.HostId,
+		AlertTime:           time.Now(),
 	}
 }
 
@@ -91,12 +91,12 @@ func taskFinishedTwoOrMoreDaysAgo(taskID string, sub *event.Subscription) (bool,
 	query := db.Query(task.ById(taskID)).WithFields(task.FinishTimeKey)
 	t, err := task.FindOne(query)
 	if err != nil {
-		return false, errors.Wrapf(err, "error finding task '%s'", taskID)
+		return false, errors.Wrapf(err, "finding task '%s'", taskID)
 	}
 	if t == nil {
 		t, err = task.FindOneOldWithFields(task.ById(taskID), task.FinishTimeKey)
 		if err != nil {
-			return false, errors.Wrapf(err, "error finding old task '%s'", taskID)
+			return false, errors.Wrapf(err, "finding old task '%s'", taskID)
 		}
 		if t == nil {
 			return false, errors.Errorf("task %s not found", taskID)
@@ -161,12 +161,12 @@ func (t *taskTriggers) Fetch(e *event.EventLogEntry) error {
 
 	var err error
 	if err = t.uiConfig.Get(evergreen.GetEnvironment()); err != nil {
-		return errors.Wrap(err, "Failed to fetch ui config")
+		return errors.Wrap(err, "fetching UI config")
 	}
 
 	t.task, err = task.FindOneIdOldOrNew(e.ResourceId, t.data.Execution)
 	if err != nil {
-		return errors.Wrap(err, "failed to fetch task")
+		return errors.Wrap(err, "fetching task")
 	}
 	if t.task == nil {
 		return errors.New("couldn't find task")
@@ -174,12 +174,12 @@ func (t *taskTriggers) Fetch(e *event.EventLogEntry) error {
 
 	_, err = t.task.GetDisplayTask()
 	if err != nil {
-		return errors.Wrap(err, "error getting display task")
+		return errors.Wrap(err, "getting display task")
 	}
 
 	author, err := model.GetVersionAuthorID(t.task.Version)
 	if err != nil {
-		return errors.Wrap(err, "failed to get task owner")
+		return errors.Wrap(err, "getting task owner")
 	}
 	t.owner = author
 
@@ -275,37 +275,44 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 		data.PastTenseStatus = pastTenseOverride
 	}
 
+	attachmentFields := []*message.SlackAttachmentField{
+		{
+			Title: "Build",
+			Value: fmt.Sprintf("<%s|%s>", buildLink(t.uiConfig.Url, t.task.BuildId, hasPatch), t.task.BuildVariant),
+		},
+		{
+			Title: "Version",
+			Value: fmt.Sprintf("<%s|%s>", versionLink(
+				versionLinkInput{
+					uiBase:    t.uiConfig.Url,
+					versionID: t.task.Version,
+					hasPatch:  hasPatch,
+					isChild:   false,
+				},
+			), t.task.Version),
+		},
+		{
+			Title: "Duration",
+			Value: t.task.TimeTaken.String(),
+		},
+	}
+	if t.task.HostId != "" {
+		attachmentFields = append(attachmentFields, &message.SlackAttachmentField{
+			Title: "Host",
+			Value: fmt.Sprintf("<%s|%s>", hostLink(t.uiConfig.Url, t.task.HostId), t.task.HostId),
+		})
+	} else if t.task.PodID != "" {
+		attachmentFields = append(attachmentFields, &message.SlackAttachmentField{
+			Title: "Pod",
+			Value: fmt.Sprintf("<%s|%s>", podLink(t.uiConfig.Url, t.task.PodID), t.task.PodID),
+		})
+	}
 	data.slack = []message.SlackAttachment{
 		{
 			Title:     displayName,
 			TitleLink: data.URL,
 			Color:     slackColor,
-			Fields: []*message.SlackAttachmentField{
-				{
-					Title: "Build",
-					Value: fmt.Sprintf("<%s|%s>", buildLink(t.uiConfig.Url, t.task.BuildId, hasPatch), t.task.BuildVariant),
-				},
-				{
-					Title: "Version",
-					Value: fmt.Sprintf("<%s|%s>", versionLink(
-						versionLinkInput{
-							uiBase:    t.uiConfig.Url,
-							versionID: t.task.Version,
-							hasPatch:  hasPatch,
-							isChild:   false,
-						},
-					), t.task.Version),
-				},
-				{
-					Title: "Duration",
-					Value: t.task.TimeTaken.String(),
-				},
-				{
-					Title: "Host",
-					// kim: TODO: substitute pod link if needed.
-					Value: fmt.Sprintf("<%s|%s>", hostLink(t.uiConfig.Url, t.task.HostId), t.task.HostId),
-				},
-			},
+			Fields:    attachmentFields,
 		},
 	}
 
@@ -322,24 +329,24 @@ func (t *taskTriggers) generate(sub *event.Subscription, pastTenseOverride, test
 		var err error
 		payload, err = t.makeJIRATaskPayload(sub.ID, issueSub.Project, testNames)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create jira payload for task")
+			return nil, errors.Wrap(err, "creating Jira payload for task")
 		}
 
 	} else {
 		data, err := t.makeData(sub, pastTenseOverride, testNames)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to collect task data")
+			return nil, errors.Wrap(err, "collecting task data")
 		}
 		data.emailContent = emailTaskContentTemplate
 
 		payload, err = makeCommonPayload(sub, t.Attributes(), data)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to build notification")
+			return nil, errors.Wrap(err, "building notification")
 		}
 	}
 	n, err := notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create a notification")
+		return nil, errors.Wrap(err, "creating notification")
 	}
 	n.SetTaskMetadata(t.task.Id, t.task.Execution)
 
@@ -388,7 +395,7 @@ func GetRecordByTriggerType(subID, triggerType string, t *task.Task) (*alertreco
 		rec, err = alertrecord.FindByFirstRegressionInVersion(subID, t.Version)
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch alertrecord (%s)", triggerType))
+		return nil, errors.Wrapf(err, "fetching alertrecord (%s)", triggerType)
 	}
 	return rec, nil
 }
@@ -535,7 +542,7 @@ func (t *taskTriggers) taskRegression(sub *event.Subscription) (*notification.No
 	if err != nil {
 		return nil, err
 	}
-	return n, errors.Wrap(alert.Insert(), "failed to process regression trigger")
+	return n, errors.Wrap(alert.Insert(), "processing regression trigger")
 }
 
 func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord.AlertRecord, error) {
@@ -557,12 +564,12 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 		evergreen.TaskCompletedStatuses, t.BuildVariant, t.DisplayName, t.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
 	previousTask, err := task.FindOne(query)
 	if err != nil {
-		return false, nil, errors.Wrap(err, "error fetching previous task")
+		return false, nil, errors.Wrap(err, "fetching previous task")
 	}
 
 	shouldSend, err := shouldSendTaskRegression(sub, t, previousTask)
 	if err != nil {
-		return false, nil, errors.Wrap(err, "failed to determine if we should send notification")
+		return false, nil, errors.Wrap(err, "determining if we should send notification")
 	}
 	if !shouldSend {
 		return false, nil, nil
@@ -691,7 +698,7 @@ func (t *taskTriggers) taskRuntimeChange(sub *event.Subscription) (*notification
 
 	lastGreen, err := t.task.PreviousCompletedTask(t.task.Project, []string{evergreen.TaskSucceeded})
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving last green task")
+		return nil, errors.Wrap(err, "retrieving last green task")
 	}
 	if lastGreen == nil {
 		return nil, nil
@@ -739,7 +746,7 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 
 	alertForTask, err := alertrecord.FindByTaskRegressionByTaskTest(sub.ID, test.GetDisplayTestName(), currentTask.DisplayName, currentTask.BuildVariant, currentTask.Project, currentTask.Id)
 	if err != nil {
-		return false, errors.Wrap(err, "can't find alerts for task test")
+		return false, errors.Wrap(err, "finding alerts for task test")
 	}
 	// we've already alerted for this task
 	if alertForTask != nil {
@@ -761,7 +768,7 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 		// try to find a stepback alert
 		alertForStepback, err := alertrecord.FindByTaskRegressionTestAndOrderNumber(sub.ID, test.GetDisplayTestName(), currentTask.DisplayName, currentTask.BuildVariant, currentTask.Project, previousTask.RevisionOrderNumber)
 		if err != nil {
-			return false, errors.Wrap(err, "can't get alert for stepback")
+			return false, errors.Wrap(err, "getting alert for stepback")
 		}
 		// never alerted for this regression before
 		if alertForStepback == nil {
@@ -770,14 +777,14 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 	} else {
 		mostRecentAlert, err := alertrecord.FindByLastTaskRegressionByTest(sub.ID, test.GetDisplayTestName(), currentTask.DisplayName, currentTask.BuildVariant, currentTask.Project)
 		if err != nil {
-			return false, errors.Wrap(err, "can't get most recent alert")
+			return false, errors.Wrap(err, "getting most recent alert")
 		}
 		if mostRecentAlert == nil {
 			return true, nil
 		}
 		isOld, err := taskFinishedTwoOrMoreDaysAgo(mostRecentAlert.TaskId, sub)
 		if err != nil {
-			return false, errors.Wrap(err, "failed to fetch last alert age")
+			return false, errors.Wrap(err, "fetching last alert age")
 		}
 		// resend the alert for this regression if it's past the threshold
 		if isOld {
@@ -813,7 +820,7 @@ func (t *taskTriggers) taskRegressionByTest(sub *event.Subscription) (*notificat
 		evergreen.TaskCompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
 	previousCompleteTask, err := task.FindOne(query)
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching previous task")
+		return nil, errors.Wrap(err, "fetching previous task")
 	}
 	if previousCompleteTask != nil {
 		if err = previousCompleteTask.PopulateTestResults(); err != nil {
@@ -897,32 +904,39 @@ func (j *taskTriggers) makeJIRATaskPayload(subID, project, testNames string) (*m
 func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.Task) (*message.JiraIssue, error) {
 	buildDoc, err := build.FindOne(build.ById(t.BuildId))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch build while building jira task payload")
+		return nil, errors.Wrap(err, "fetching build while building Jira task payload")
 	}
 	if buildDoc == nil {
-		return nil, errors.New("could not find build while building jira task payload")
+		return nil, errors.New("could not find build while building Jira task payload")
 	}
 
 	var hostDoc *host.Host
-	// kim: TODO: use pod ID here if needed.
-	if len(t.HostId) != 0 {
+	if t.HostId != "" {
 		hostDoc, err = host.FindOneId(t.HostId)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to fetch host while building jira task payload")
+			return nil, errors.Wrap(err, "fetching host while building Jira task payload")
+		}
+	}
+
+	var podDoc *pod.Pod
+	if t.PodID != "" {
+		podDoc, err = pod.FindOneByID(t.PodID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding pod '%s'", t.PodID)
 		}
 	}
 
 	versionDoc, err := model.VersionFindOneId(t.Version)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch version while building jira task payload")
+		return nil, errors.Wrap(err, "fetching version while building Jira task payload")
 	}
 	if versionDoc == nil {
-		return nil, errors.New("could not find version while building jira task payload")
+		return nil, errors.New("could not find version while building Jira task payload")
 	}
 
 	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version, true)
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching project ref while building jira task payload")
+		return nil, errors.Wrap(err, "fetching project ref while building Jira task payload")
 	}
 	if projectRef == nil {
 		return nil, errors.Errorf("project ref '%s' not found", t.Project)
@@ -937,6 +951,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 		Project:         projectRef,
 		Build:           buildDoc,
 		Host:            hostDoc,
+		Pod:             podDoc,
 		TaskDisplayName: t.DisplayName,
 	}
 	if t.IsPartOfDisplay() {
@@ -953,7 +968,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 	}
 
 	if err = builder.mappings.Get(evergreen.GetEnvironment()); err != nil {
-		return nil, errors.Wrap(err, "failed to fetch jira custom field mappings while building jira task payload")
+		return nil, errors.Wrap(err, "fetching Jira custom field mappings while building Jira task payload")
 	}
 
 	return builder.build()
@@ -1017,7 +1032,7 @@ func (t *taskTriggers) buildBreak(sub *event.Subscription) (*notification.Notifi
 		evergreen.TaskCompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
 	previousTask, err := task.FindOne(query)
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching previous task")
+		return nil, errors.Wrap(err, "fetching previous task")
 	}
 	if previousTask != nil && previousTask.Status == evergreen.TaskFailed {
 		return nil, nil

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -76,8 +76,9 @@ func newAlertRecord(subID string, t *task.Task, alertType string) *alertrecord.A
 		TaskName:            t.DisplayName,
 		Variant:             t.BuildVariant,
 		TaskId:              t.Id,
-		HostId:              t.HostId,
-		AlertTime:           time.Now(),
+		// kim: TODO: set pod ID instead of host ID.
+		HostId:    t.HostId,
+		AlertTime: time.Now(),
 	}
 }
 
@@ -301,6 +302,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 				},
 				{
 					Title: "Host",
+					// kim: TODO: substitute pod link if needed.
 					Value: fmt.Sprintf("<%s|%s>", hostLink(t.uiConfig.Url, t.task.HostId), t.task.HostId),
 				},
 			},
@@ -902,6 +904,7 @@ func JIRATaskPayload(subID, project, uiUrl, eventID, testNames string, t *task.T
 	}
 
 	var hostDoc *host.Host
+	// kim: TODO: use pod ID here if needed.
 	if len(t.HostId) != 0 {
 		hostDoc, err = host.FindOneId(t.HostId)
 		if err != nil {

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -21,7 +23,7 @@ import (
 // DescriptionTemplateString defines the content of the alert ticket.
 const descriptionTemplateString = `
 h2. [{{.Task.DisplayName}} failed on {{.Build.DisplayName}}|{{taskurl .}}]
-Host: {{host .}}
+{{if isHostTask .}}Host: {{host .}}{{end}}{{if isContainerTask .}}Pod: {{pod .}}{{end}}
 Project: [{{.Project.DisplayName}}|{{.UIRoot}}/waterfall/{{.Project.Id}}?redirect_spruce_users=true]
 Commit: [diff|https://github.com/{{.Project.Owner}}/{{.Project.Repo}}/commit/{{.Version.Revision}}]: {{.Version.Message}} | {{.Task.CreateTime | formatAsTimestamp}}
 Evergreen Subscription: {{.SubscriptionID}}; Evergreen Event: {{.EventID}}
@@ -41,6 +43,9 @@ var descriptionTemplate = template.Must(template.New("Desc").Funcs(template.Func
 	"taskurl":           getTaskURL,
 	"formatAsTimestamp": formatAsTimestamp,
 	"host":              getHostMetadata,
+	"isHostTask":        getIsHostTask,
+	"pod":               getPodMetadata,
+	"isContainerTask":   getIsContainerTask,
 	"taskLogURLs":       getTaskLogURLs,
 }).Parse(descriptionTemplateString))
 
@@ -54,6 +59,32 @@ func getHostMetadata(data *jiraTemplateData) string {
 	}
 
 	return fmt.Sprintf("[%s|%s/host/%s?redirect_spruce_users=true]", data.Host.Host, data.UIRoot, url.PathEscape(data.Host.Id))
+}
+
+func getPodMetadata(data *jiraTemplateData) string {
+	if data.Pod == nil {
+		return "N/A"
+	}
+
+	return fmt.Sprintf("[%s|%s/pod/%s?redirect_spruce_users=true]", data.Pod.ID, data.UIRoot, url.PathEscape(data.Pod.ID))
+}
+
+// getIsContainerTask returns a non-empty string if it is a container task and
+// returns an empty string if it's not a container task.
+func getIsContainerTask(data *jiraTemplateData) string {
+	if data.Task.IsContainerTask() {
+		return strconv.FormatBool(true)
+	}
+	return ""
+}
+
+// getIsHostTask returns a non-empty string it is a host task and returns an
+// empty string if it's not a host task.
+func getIsHostTask(data *jiraTemplateData) string {
+	if data.Task.IsHostTask() {
+		return strconv.FormatBool(true)
+	}
+	return ""
 }
 
 func getTaskURL(data *jiraTemplateData) (string, error) {
@@ -153,6 +184,7 @@ type jiraTemplateData struct {
 	Task               *task.Task
 	Build              *build.Build
 	Host               *host.Host
+	Pod                *pod.Pod
 	Project            *model.ProjectRef
 	Version            *model.Version
 	FailedTests        []task.TestResult
@@ -362,9 +394,11 @@ func (j *jiraBuilder) getDescription() (string, error) {
 
 	buf := &bytes.Buffer{}
 	j.data.Tests = tests
+
 	if err := descriptionTemplate.Execute(buf, &j.data); err != nil {
 		return "", err
 	}
+
 	// Jira description length maximum
 	if buf.Len() > jiraMaxDescLength {
 		buf.Truncate(jiraMaxDescLength)

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -121,6 +121,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 		"id":        j.ID(),
 		"task":      j.task.Id,
 	}
+	// kim: TODO: set pod ID
 	if j.task.HostId != "" {
 		msg["host_id"] = j.task.HostId
 	}
@@ -141,6 +142,7 @@ func (j *taskExecutionTimeoutJob) Run(ctx context.Context) {
 // heartbeat timeout.
 func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error {
 	if j.task.IsContainerTask() {
+		// kim: TODO: enqueue pod health check job.
 		return errors.Wrapf(model.ResetStaleTask(j.task), "resetting stale task '%s'", j.task.Id)
 	}
 

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
@@ -33,8 +32,6 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, model.VersionCollection, model.ProjectRefCollection, host.Collection, event.LegacyEventLogCollection))
 		mp.Reset()
-
-		cocoaMock.ResetGlobalECSService()
 	}()
 
 	checkTaskRestarted := func(t *testing.T, taskID string, oldExecution int, description string) {
@@ -254,7 +251,6 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 
 			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, model.VersionCollection, model.ProjectRefCollection, host.Collection, event.LegacyEventLogCollection))
 			mp.Reset()
-			cocoaMock.ResetGlobalECSService()
 
 			const taskID = "task_id"
 			h := host.Host{

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
@@ -14,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -31,6 +33,8 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, model.VersionCollection, model.ProjectRefCollection, host.Collection, event.LegacyEventLogCollection))
 		mp.Reset()
+
+		cocoaMock.ResetGlobalECSService()
 	}()
 
 	checkTaskRestarted := func(t *testing.T, taskID string, oldExecution int, description string) {
@@ -131,6 +135,38 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 
 			checkTaskRestarted(t, j.task.Id, 0, evergreen.TaskDescriptionHeartbeat)
 		},
+		"RestartsStaleContainerTaskAndChecksForUnhealthyPod": func(ctx context.Context, t *testing.T, j *taskExecutionTimeoutJob, v model.Version) {
+			p := pod.Pod{
+				ID:     "pod_id",
+				Status: pod.StatusRunning,
+				TaskRuntimeInfo: pod.TaskRuntimeInfo{
+					RunningTaskID:        j.task.Id,
+					RunningTaskExecution: j.task.Execution,
+				},
+			}
+			j.task.ExecutionPlatform = task.ExecutionPlatformContainer
+			j.task.HostId = ""
+			j.task.ContainerAllocated = true
+			j.task.PodID = p.ID
+
+			require.NoError(t, v.Insert())
+			require.NoError(t, p.Insert())
+			require.NoError(t, j.task.Insert())
+
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			var foundHealthCheckJob bool
+			for info := range j.env.RemoteQueue().JobInfo(ctx) {
+				if info.Type.Name == podHealthCheckJobName {
+					foundHealthCheckJob = true
+					break
+				}
+			}
+			assert.True(t, foundHealthCheckJob, "should have enqueued a pod health check job")
+
+			checkTaskRestarted(t, j.task.Id, 0, evergreen.TaskDescriptionHeartbeat)
+		},
 		"RestartsParentDisplayTaskForStaleHostExecutionTask": func(ctx context.Context, t *testing.T, j *taskExecutionTimeoutJob, v model.Version) {
 			const displayTaskID = "display_task"
 			et0 := task.Task{
@@ -218,6 +254,7 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 
 			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, model.VersionCollection, model.ProjectRefCollection, host.Collection, event.LegacyEventLogCollection))
 			mp.Reset()
+			cocoaMock.ResetGlobalECSService()
 
 			const taskID = "task_id"
 			h := host.Host{


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17667

### Description 
This is a mishmash of different usages of the task's pod ID after it's been dispatched, which is pretty similar to usages of the task's `HostId` when it's a host task:

* Use pod ID for container tasks in notifications. Instead of giving a link to the host ID, container task notifications should have a link to the pod ID.
* Log events for task completion and task being cleared from a pod.
* Check pod health when a task hits the stale execution timeout.

### Testing
Added unit tests.

For the UI route, we only want to support it in Spruce, so I tested it in local Evergreen to ensure that it returns 501 if auto-redirection to Spruce is disabled by the user. Spruce itself has no UI for pods so far, but I verified that it did redirect to the expected Spruce URL when auto-redirection to Spruce was enabled.