### PR TITLE
EVG-17123 Allow variable lookup in expansion secondary value

### DIFF
--- a/util/expansion.go
+++ b/util/expansion.go
@@ -90,10 +90,10 @@ func (exp *Expansions) ExpandString(toExpand string) (string, error) {
 				malformedFound = true
 			}
 
-			// parse into the name and default value
-			var defaultVal string
+			// parse into the name and secondary value
+			var secondaryValue string
 			if idx := strings.Index(match, "|"); idx != -1 {
-				defaultVal = match[idx+1:]
+				secondaryValue = match[idx+1:]
 				match = match[0:idx]
 			}
 
@@ -102,7 +102,15 @@ func (exp *Expansions) ExpandString(toExpand string) (string, error) {
 				return []byte(exp.Get(match))
 			}
 
-			return []byte(defaultVal)
+			// look for an expansion in the secondary value
+			if strings.HasPrefix(secondaryValue, "*") {
+				// trim off *
+				secondaryValue = secondaryValue[1:]
+				return []byte(exp.Get(secondaryValue))
+			}
+
+			// return the raw value if no expansion is found for either value
+			return []byte(secondaryValue)
 		}))
 
 	if malformedFound || strings.Contains(expanded, "${") {

--- a/util/expansion_test.go
+++ b/util/expansion_test.go
@@ -136,9 +136,8 @@ func TestExpandString(t *testing.T) {
 				Convey("any variables with default values provided should be"+
 					" replaced with their default value", func() {
 
-					toExpand := "hello ${key1|blah}${key3|blech}hello " +
-						"${key4|}hello"
-					expanded := "hello val1blechhello hello"
+					toExpand := "hello ${key1|blah} ${key3|blech} hello ${key4|}hello ${key5|*key1}"
+					expanded := "hello val1 blech hello hello val1"
 
 					exp, err := expansions.ExpandString(toExpand)
 					So(err, ShouldBeNil)
@@ -149,9 +148,8 @@ func TestExpandString(t *testing.T) {
 				Convey("any variables without default values provided should"+
 					" be replaced with the empty string", func() {
 
-					toExpand := "hello ${key1|blah}${key3}hello ${key4} " +
-						"${key5|blech}hello"
-					expanded := "hello val1hello  blechhello"
+					toExpand := "hello ${key1|blah} ${key3}hello ${key4} ${key5|blech} hello ${key6|*key3}"
+					expanded := "hello val1 hello  blech hello "
 
 					exp, err := expansions.ExpandString(toExpand)
 					So(err, ShouldBeNil)


### PR DESCRIPTION
[EVG-17123](https://jira.mongodb.org/browse/EVG-17123)

### Description 
To improve the maintainability of config files, the secondary value that can be specified in an expansion (i.e. `${val1|val2}`) is no longer a hard coded string but can itself act as a backup variable lookup.  To distinguish between what should be a hardcoded string vs a variable lookup secondary value, I'm proposing that users should specify that the secondary value should be looked up by prepending a `*` to it. Example: `${val1|*val2}`
### Testing 
Updated unit tests, and checked in staging that the secondary value in `ExpandString` has its value looked up properly if it is prepended with `*`