### PR TITLE
EVG-16501: clean up error and log messages in the agent package

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -569,10 +569,7 @@ func (a *Agent) runTaskTimeoutCommands(ctx context.Context, tc *taskContext) {
 	if taskGroup.Timeout != nil {
 		err := a.runCommands(ctx, tc, taskGroup.Timeout.List(), runCommandsOptions{})
 		tc.logger.Execution().Error(errors.Wrap(err, "running timeout commands"))
-		tc.logger.Task().InfoWhen(err == nil, message.Fields{
-			"message":    "finished running timeout commands",
-			"total_time": time.Since(start).String(),
-		})
+		tc.logger.Task().Infof("Finished running timeout commands in %s.", time.Since(start))
 	}
 }
 
@@ -705,10 +702,7 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 				return err
 			}
 		}
-		tc.logger.Task().InfoWhen(err == nil, message.Fields{
-			"message":    "Finished running post-task commands.",
-			"total_time": time.Since(start).String(),
-		})
+		tc.logger.Task().Infof("Finished running post-task commands in %s.", time.Since(start))
 	}
 	return nil
 }
@@ -776,10 +770,7 @@ func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *api
 		}))
 		return
 	}
-	tc.logger.Task().Info(message.Fields{
-		"message":    "finished running task sync",
-		"total_time": time.Since(start).String(),
-	})
+	tc.logger.Task().Infof("Finished running task sync in %s.", time.Since(start))
 }
 
 func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool) {

--- a/agent/agent_command_test.go
+++ b/agent/agent_command_test.go
@@ -87,7 +87,7 @@ func (s *CommandSuite) TestShellExec() {
 		if msg.Message == "Task completed - SUCCESS." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec'") {
+		if strings.HasPrefix(msg.Message, "Finished command 'shell.exec'") {
 			foundShellLogMessage = true
 		}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -251,7 +251,7 @@ func (s *AgentSuite) TestCancelRunCommands() {
 	cmds := []model.PluginCommandConf{cmd}
 	err := s.a.runCommands(ctx, s.tc, cmds, runCommandsOptions{})
 	s.Error(err)
-	s.Equal("runCommands canceled", err.Error())
+	s.Equal("canceled while running commands", err.Error())
 }
 
 func (s *AgentSuite) TestPre() {
@@ -282,8 +282,8 @@ pre:
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running pre-task commands.", msgs[1].Message)
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[3].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running pre-task commands")
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[3].Message)
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running pre-task commands.")
 }
 
 func (s *AgentSuite) TestPreFailsTask() {
@@ -372,8 +372,8 @@ post:
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running post-task commands.", msgs[1].Message)
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[2].Message)
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
 }
 
 func (s *AgentSuite) TestPostContinuesOnError() {
@@ -407,12 +407,12 @@ post:
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running post-task commands.", msgs[1].Message)
-	s.Equal("Running command 'shell.exec' (step 1 of 2)", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
+	s.Equal("Running command 'shell.exec' (step 1 of 2).", msgs[2].Message)
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
 	found := map[string]bool{
-		"Running post-task commands.":                false,
-		"Running command 'shell.exec' (step 1 of 2)": false,
-		"Running command 'shell.exec' (step 2 of 2)": false,
+		"Running post-task commands.":                 false,
+		"Running command 'shell.exec' (step 1 of 2).": false,
+		"Running command 'shell.exec' (step 2 of 2).": false,
 	}
 	for _, msg := range msgs {
 		for f := range found {
@@ -707,7 +707,7 @@ task_groups:
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running pre-task commands.", msgs[1].Message)
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[3].Message)
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[3].Message)
 	s.Equal("Finished running pre-task commands.", msgs[len(msgs)-1].Message)
 }
 
@@ -779,7 +779,7 @@ task_groups:
 	s.Error(s.a.runPreTaskCommands(ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
-	s.Contains(msgs[len(msgs)-1].Message, "error running task setup group")
+	s.Contains(msgs[len(msgs)-1].Message, "running task setup group")
 }
 
 func (s *AgentSuite) TestGroupPostGroupCommandsFail() {
@@ -849,7 +849,7 @@ task_groups:
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running pre-task commands.", msgs[1].Message)
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[3].Message)
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[3].Message)
 	s.Equal("Finished running pre-task commands.", msgs[len(msgs)-1].Message)
 }
 
@@ -884,9 +884,9 @@ task_groups:
 	s.NoError(s.a.runPostTaskCommands(ctx, s.tc))
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-2].Message, "Finished 'shell.exec'")
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[2].Message)
+	s.Contains(msgs[len(msgs)-2].Message, "Finished 'shell.exec'.")
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
 }
 
 func (s *AgentSuite) TestGroupPostGroupCommands() {
@@ -922,7 +922,7 @@ task_groups:
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Require().True(len(msgs) >= 2)
 	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[1].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished 'shell.exec'")
+	s.Contains(msgs[len(msgs)-1].Message, "Finished 'shell.exec'.")
 }
 
 func (s *AgentSuite) TestGroupTimeoutCommands() {
@@ -960,8 +960,8 @@ task_groups:
 	s.a.runTaskTimeoutCommands(ctx, s.tc)
 	_ = s.tc.logger.Close()
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
-	s.Equal("Running command 'shell.exec' (step 1 of 1)", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-2].Message, "Finished 'shell.exec'")
+	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[2].Message)
+	s.Contains(msgs[len(msgs)-2].Message, "Finished 'shell.exec'.")
 }
 
 func (s *AgentSuite) TestTimeoutDoesNotWaitForChildProcs() {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -373,7 +373,7 @@ post:
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running post-task commands.", msgs[1].Message)
 	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
 }
 
 func (s *AgentSuite) TestPostContinuesOnError() {
@@ -408,7 +408,7 @@ post:
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running post-task commands.", msgs[1].Message)
 	s.Equal("Running command 'shell.exec' (step 1 of 2).", msgs[2].Message)
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
 	found := map[string]bool{
 		"Running post-task commands.":                 false,
 		"Running command 'shell.exec' (step 1 of 2).": false,
@@ -466,7 +466,7 @@ func (s *AgentSuite) TestAbort() {
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
 	shouldFind := map[string]bool{
 		"initial task setup":                  false,
-		"Running post-task commands":          false,
+		"Running post-task commands.":         false,
 		"Sending final task status: 'failed'": false,
 	}
 	s.Require().NoError(s.tc.logger.Close())
@@ -886,7 +886,7 @@ task_groups:
 	msgs := s.mockCommunicator.GetMockMessages()["task_id"]
 	s.Equal("Running command 'shell.exec' (step 1 of 1).", msgs[2].Message)
 	s.Contains(msgs[len(msgs)-2].Message, "Finished command 'shell.exec'")
-	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands.")
+	s.Contains(msgs[len(msgs)-1].Message, "Finished running post-task commands")
 }
 
 func (s *AgentSuite) TestGroupPostGroupCommands() {

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -93,13 +93,13 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit exec timeout (1s)") {
+		if strings.HasPrefix(msg.Message, "Hit exec timeout (1s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}
@@ -161,13 +161,13 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit exec timeout (1s)") {
+		if strings.HasPrefix(msg.Message, "Hit exec timeout (1s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}
@@ -228,13 +228,13 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 1s)") {
+		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 1s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}
@@ -295,13 +295,13 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 1s)") {
+		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 1s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}
@@ -362,13 +362,13 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 2s)") {
+		if strings.HasPrefix(msg.Message, "Hit idle timeout (no message on stdout for more than 2s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}
@@ -429,13 +429,13 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 		if msg.Message == "Task completed - FAILURE." {
 			foundSuccessLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Hit exec timeout (2s)") {
+		if strings.HasPrefix(msg.Message, "Hit exec timeout (2s).") {
 			foundTimeoutMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Running task-timeout commands") {
+		if strings.HasPrefix(msg.Message, "Running task-timeout commands.") {
 			foundShellLogMessage = true
 		}
-		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\"") {
+		if strings.HasPrefix(msg.Message, "Finished 'shell.exec' in \"timeout\".") {
 			foundShellLogMessage = true
 		}
 	}

--- a/agent/background.go
+++ b/agent/background.go
@@ -27,14 +27,14 @@ func (a *Agent) startHeartbeat(ctx context.Context, cancel context.CancelFunc, t
 		case <-ticker.C:
 			signalBeat, err = a.doHeartbeat(ctx, tc)
 			if signalBeat == evergreen.TaskConflict {
-				tc.logger.Task().Error("Encountered task conflict while checking heartbeat, aborting task")
+				tc.logger.Task().Error("Encountered task conflict while checking heartbeat, aborting task.")
 				if err != nil {
 					tc.logger.Task().Error(err.Error())
 				}
 				cancel()
 			}
 			if signalBeat == evergreen.TaskFailed {
-				tc.logger.Task().Error("Heartbeat received signal to abort task")
+				tc.logger.Task().Error("Heartbeat received signal to abort task.")
 				heartbeat <- signalBeat
 				return
 			}
@@ -45,7 +45,7 @@ func (a *Agent) startHeartbeat(ctx context.Context, cancel context.CancelFunc, t
 			}
 			if failures == maxHeartbeats {
 				// Presumably this won't work, but we should try to notify the user anyway
-				tc.logger.Task().Error("Hit max heartbeats, aborting task")
+				tc.logger.Task().Error("Hit max heartbeat attempts, aborting task.")
 				heartbeat <- evergreen.TaskFailed
 				return
 			}
@@ -72,14 +72,14 @@ func (a *Agent) startIdleTimeoutWatch(ctx context.Context, tc *taskContext, canc
 	for {
 		select {
 		case <-ctx.Done():
-			grip.Info("Idle timeout watch canceled")
+			grip.Info("Idle timeout watcher canceled.")
 			return
 		case <-ticker.C:
 			timeout := tc.getCurrentTimeout()
 			timeSinceLastMessage := time.Since(a.comm.LastMessageAt())
 
 			if timeSinceLastMessage > timeout {
-				tc.logger.Execution().Errorf("Hit idle timeout (no message on stdout for more than %s)", timeout)
+				tc.logger.Execution().Errorf("Hit idle timeout (no message on stdout for more than %s).", timeout)
 				tc.reachTimeOut(idleTimeout, timeout)
 				return
 			}
@@ -96,14 +96,14 @@ func (a *Agent) startMaxExecTimeoutWatch(ctx context.Context, tc *taskContext, c
 	for {
 		select {
 		case <-ctx.Done():
-			grip.Info("Exec timeout watch canceled")
+			grip.Info("Exec timeout watcher canceled.")
 			return
 		case <-ticker.C:
 			timeout := tc.getExecTimeout()
 			timeSinceTickerStarted := time.Since(timeTickerStarted)
 
 			if timeSinceTickerStarted > timeout {
-				tc.logger.Execution().Errorf("Hit exec timeout (%s)", timeout)
+				tc.logger.Execution().Errorf("Hit exec timeout (%s).", timeout)
 				tc.reachTimeOut(execTimeout, timeout)
 				return
 			}
@@ -129,7 +129,7 @@ func (a *Agent) startEarlyTerminationWatcher(ctx context.Context, tc *taskContex
 	for {
 		select {
 		case <-ctx.Done():
-			grip.Info("Early termination watcher canceled")
+			grip.Info("Early termination watcher canceled.")
 			return
 		case <-ticker.C:
 			if check() {

--- a/agent/command.go
+++ b/agent/command.go
@@ -80,16 +80,16 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 		fullCommandName := getCommandName(commandInfo, cmd)
 
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {
-			tc.logger.Task().Infof("Skipping command '%s' on variant %s (step %d of %d).",
+			tc.logger.Task().Infof("Skipping command %s on variant %s (step %d of %d).",
 				fullCommandName, tc.taskConfig.BuildVariant.Name, index, total)
 			continue
 		}
 
 		if len(cmds) == 1 {
-			tc.logger.Task().Infof("Running command '%s' (step %d of %d).", fullCommandName, index, total)
+			tc.logger.Task().Infof("Running command %s (step %d of %d).", fullCommandName, index, total)
 		} else {
 			// for functions with more than one command
-			tc.logger.Task().Infof("Running command '%s' (step %d.%d of %d).", fullCommandName, index, idx+1, total)
+			tc.logger.Task().Infof("Running command %s (step %d.%d of %d).", fullCommandName, index, idx+1, total)
 		}
 		for key, val := range commandInfo.Vars {
 			var newVal string
@@ -140,7 +140,7 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			}
 			return errors.Wrap(ctx.Err(), "agent stopped early")
 		}
-		tc.logger.Task().Infof("Finished command '%s' in %s.", fullCommandName, time.Since(start).String())
+		tc.logger.Task().Infof("Finished command %s in %s.", fullCommandName, time.Since(start).String())
 		if (options.isTaskCommands || options.failPreAndPost) && a.endTaskResp != nil && !a.endTaskResp.ShouldContinue {
 			// only error if we're running a command that should fail, and we don't want to continue to run other tasks
 			return errors.Errorf("task status has been set to '%s'; triggering end task", a.endTaskResp.Status)
@@ -178,7 +178,7 @@ func getCommandName(commandInfo model.PluginCommandConf, cmd command.Command) st
 	if commandInfo.Function != "" {
 		commandName = fmt.Sprintf(`'%s' in "%s"`, commandName, commandInfo.Function)
 	} else if commandInfo.DisplayName != "" {
-		commandName = fmt.Sprintf(`("%s") %s`, commandInfo.DisplayName, commandName)
+		commandName = fmt.Sprintf(`("%s") '%s'`, commandInfo.DisplayName, commandName)
 	} else {
 		commandName = fmt.Sprintf("'%s'", commandName)
 	}

--- a/agent/command.go
+++ b/agent/command.go
@@ -28,14 +28,12 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 	defer func() { err = recovery.HandlePanicWithError(recover(), err, "run commands") }()
 
 	for i, commandInfo := range commands {
-		if ctx.Err() != nil {
-			grip.Error("runCommands canceled")
-			return errors.New("runCommands canceled")
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "canceled while running commands")
 		}
 		cmds, err = command.Render(commandInfo, tc.taskConfig.Project)
 		if err != nil {
-			tc.logger.Task().Error(errors.Wrapf(err, "Error parsing plugin command '%s'", commandInfo.Command))
-			return err
+			return errors.Wrapf(err, "rendering command '%s'", commandInfo.Command)
 		}
 		if err = a.runCommandSet(ctx, tc, commandInfo, cmds, options, i+1, len(commands)); err != nil {
 			return errors.WithStack(err)
@@ -56,17 +54,16 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 	} else {
 		logger, err = a.makeLoggerProducer(ctx, tc, commandInfo.Loggers, getFunctionName(commandInfo))
 		if err != nil {
-			return errors.Wrap(err, "making logger")
+			return errors.Wrap(err, "making command logger")
 		}
 		defer func() {
-			grip.Error(logger.Close())
+			grip.Error(errors.Wrap(logger.Close(), "closing command logger"))
 		}()
 	}
 
 	for idx, cmd := range cmds {
-		if ctx.Err() != nil {
-			grip.Error("runCommands canceled")
-			return errors.New("runCommands canceled")
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "canceled while running command list")
 		}
 		if cmd.DisplayName() == "" {
 			grip.Critical(message.Fields{
@@ -83,16 +80,16 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 		fullCommandName := getCommandName(commandInfo, cmd)
 
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {
-			tc.logger.Task().Infof("Skipping command %s on variant %s (step %d of %d)",
+			tc.logger.Task().Infof("Skipping command '%s' on variant %s (step %d of %d).",
 				fullCommandName, tc.taskConfig.BuildVariant.Name, index, total)
 			continue
 		}
 
 		if len(cmds) == 1 {
-			tc.logger.Task().Infof("Running command %s (step %d of %d)", fullCommandName, index, total)
+			tc.logger.Task().Infof("Running command '%s' (step %d of %d).", fullCommandName, index, total)
 		} else {
 			// for functions with more than one command
-			tc.logger.Task().Infof("Running command %v (step %d.%d of %d)", fullCommandName, index, idx+1, total)
+			tc.logger.Task().Infof("Running command '%s' (step %d.%d of %d).", fullCommandName, index, idx+1, total)
 		}
 		for key, val := range commandInfo.Vars {
 			var newVal string
@@ -121,14 +118,14 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			defer func() {
 				// this channel will get read from twice even though we only send once, hence why it's buffered
 				cmdChan <- recovery.HandlePanicWithError(recover(), nil,
-					fmt.Sprintf("running command '%s'", cmd.Name()))
+					fmt.Sprintf("running command '%s'", fullCommandName))
 			}()
 			cmdChan <- cmd.Execute(ctx, a.comm, logger, tc.taskConfig)
 		}()
 		select {
 		case err = <-cmdChan:
 			if err != nil {
-				tc.logger.Task().Errorf("Command failed: %v", err)
+				tc.logger.Task().Errorf("Command '%s' failed: %s.", fullCommandName, err)
 				if options.isTaskCommands || options.failPreAndPost ||
 					(cmd.Name() == "git.get_project" && tc.taskModel.Requester == evergreen.MergeTestRequester) {
 					// any git.get_project in the commit queue should fail
@@ -137,18 +134,16 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			}
 		case <-ctx.Done():
 			if ctx.Err() == context.DeadlineExceeded {
-				tc.logger.Task().Errorf("Command stopped early, idle timeout duration of %d seconds has been reached: %s", int(tc.timeout.idleTimeoutDuration.Seconds()), ctx.Err())
+				tc.logger.Task().Errorf("Command '%s' stopped early because idle timeout duration of %d seconds has been reached.", fullCommandName, int(tc.timeout.idleTimeoutDuration.Seconds()))
 			} else {
-				tc.logger.Task().Errorf("Command stopped early: %s", ctx.Err())
+				tc.logger.Task().Errorf("Command '%s' stopped early: %s.", fullCommandName, ctx.Err())
 			}
 			return errors.Wrap(ctx.Err(), "agent stopped early")
 		}
-		tc.logger.Task().Infof("Finished %s in %s", fullCommandName, time.Since(start).String())
+		tc.logger.Task().Infof("Finished command '%s' in %s.", fullCommandName, time.Since(start).String())
 		if (options.isTaskCommands || options.failPreAndPost) && a.endTaskResp != nil && !a.endTaskResp.ShouldContinue {
 			// only error if we're running a command that should fail, and we don't want to continue to run other tasks
-			msg := fmt.Sprintf("task status has been set to '%s'; triggering end task", a.endTaskResp.Status)
-			tc.logger.Task().Debug(msg)
-			return errors.New(msg)
+			return errors.Errorf("task status has been set to '%s'; triggering end task", a.endTaskResp.Status)
 		}
 	}
 	return nil
@@ -161,13 +156,11 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	task := conf.Project.FindProjectTask(conf.Task.DisplayName)
 
 	if task == nil {
-		tc.logger.Execution().Errorf("Can't find task '%s'", conf.Task.DisplayName)
-		return errors.New("unable to find task")
+		return errors.Errorf("unable to find task '%s' in project '%s'", conf.Task.DisplayName, conf.Task.Project)
 	}
 
-	if ctx.Err() != nil {
-		grip.Error("task canceled")
-		return errors.New("task canceled")
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, "canceled while running task commands")
 	}
 	tc.logger.Execution().Info("Running task commands.")
 	start := time.Now()
@@ -175,8 +168,7 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	err := a.runCommands(ctx, tc, task.Commands, opts)
 	tc.logger.Execution().Infof("Finished running task commands in %s.", time.Since(start).String())
 	if err != nil {
-		tc.logger.Execution().Errorf("Task failed: %v", err)
-		return errors.New("task failed")
+		return err
 	}
 	return nil
 }

--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -28,7 +28,7 @@ func autoExtractFactory() Command   { return &autoExtract{} }
 func (e *autoExtract) Name() string { return "archive.auto_extract" }
 func (e *autoExtract) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, e); err != nil {
-		return errors.Wrapf(err, "error parsing '%s' params", e.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if len(e.ExcludeFiles) != 0 {
@@ -46,7 +46,7 @@ func (e *autoExtract) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(e, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// if the target is a relative path, join it to the working dir
@@ -64,11 +64,11 @@ func (e *autoExtract) Execute(ctx context.Context,
 
 	unzipper := archiver.MatchingFormat(e.ArchivePath)
 	if unzipper == nil {
-		return errors.Errorf("could not detect archive format for '%s'", e.ArchivePath)
+		return errors.Errorf("could not detect archive format for archive '%s'", e.ArchivePath)
 	}
 
 	if err := unzipper.Open(e.ArchivePath, e.TargetDirectory); err != nil {
-		return errors.Wrapf(err, "problem extracting archive '%s'", e.ArchivePath)
+		return errors.Wrapf(err, "extracting archive '%s'", e.ArchivePath)
 	}
 
 	return nil

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,7 +106,7 @@ func (c *tarballCreate) Execute(ctx context.Context,
 			if c.Attempt < maxRetries {
 				if strings.Contains(err.Error(), retryError) {
 					c.Attempt += 1
-					logger.Execution().Infof("retrying targz pack command due to error: %s", err.Error())
+					logger.Execution().Infof("Retrying command '%s' due to error: %s.", c.Name(), err.Error())
 					return c.Execute(ctx, client, logger, conf)
 				}
 
@@ -115,13 +116,13 @@ func (c *tarballCreate) Execute(ctx context.Context,
 		if filesArchived == 0 {
 			deleteErr := os.Remove(c.Target)
 			if deleteErr != nil {
-				logger.Execution().Infof("problem deleting empty archive: %s", deleteErr.Error())
+				logger.Execution().Infof("Problem deleting empty archive: %s.", deleteErr.Error())
 			}
 		}
 		return nil
 	case <-ctx.Done():
 		logger.Execution().Info(message.Fields{
-			"message": "received signal to terminate execution of targz pack command",
+			"message": fmt.Sprintf("received signal to terminate execution of command '%s'", c.Name()),
 			"task_id": conf.Task.Id,
 		})
 		return nil

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -50,7 +50,7 @@ func (c *tarballCreate) Name() string { return "archive.targz_pack" }
 // ParseParams reads in the given parameters for the command.
 func (c *tarballCreate) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error parsing '%v' params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if c.Target == "" {
@@ -58,7 +58,7 @@ func (c *tarballCreate) ParseParams(params map[string]interface{}) error {
 	}
 
 	if c.SourceDir == "" {
-		return errors.New("source_dir cannot be blank")
+		return errors.New("source directory cannot be blank")
 	}
 
 	if len(c.Include) == 0 {
@@ -73,7 +73,7 @@ func (c *tarballCreate) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// if the source dir is a relative path, join it to the working dir
@@ -134,7 +134,7 @@ func (c *tarballCreate) Execute(ctx context.Context,
 func (c *tarballCreate) makeArchive(ctx context.Context, logger grip.Journaler) (int, error) {
 	f, gz, tarWriter, err := agentutil.TarGzWriter(c.Target)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error opening target archive file %s", c.Target)
+		return -1, errors.Wrapf(err, "opening target archive file '%s'", c.Target)
 	}
 	defer func() {
 		logger.Error(tarWriter.Close())

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -10,7 +10,6 @@ import (
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -69,8 +68,7 @@ func (e *tarballExtract) Execute(ctx context.Context,
 	}
 
 	defer func() {
-		logger.Task().Notice(message.WrapError(archive.Close(),
-			message.NewFormatted("problem closing file '%s'", e.ArchivePath)))
+		logger.Task().Notice(errors.Wrapf(archive.Close(), "closing file '%s'", e.ArchivePath))
 	}()
 
 	if err := agentutil.ExtractTarball(ctx, archive, e.TargetDirectory, e.ExcludeFiles); err != nil {

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -29,7 +29,7 @@ func tarballExtractFactory() Command   { return &tarballExtract{} }
 func (e *tarballExtract) Name() string { return "archive.targz_extract" }
 func (e *tarballExtract) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, e); err != nil {
-		return errors.Wrapf(err, "error parsing '%s' params", e.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if e.ArchivePath == "" {
@@ -43,7 +43,7 @@ func (e *tarballExtract) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(e, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	if e.TargetDirectory == "" {
@@ -65,16 +65,16 @@ func (e *tarballExtract) Execute(ctx context.Context,
 
 	archive, err := os.Open(e.ArchivePath)
 	if err != nil {
-		return errors.Wrapf(err, "problem reading file '%s'", e.ArchivePath)
+		return errors.Wrapf(err, "reading file '%s'", e.ArchivePath)
 	}
 
 	defer func() {
 		logger.Task().Notice(message.WrapError(archive.Close(),
-			message.NewFormatted("problem closing '%s'", e.ArchivePath)))
+			message.NewFormatted("problem closing file '%s'", e.ArchivePath)))
 	}()
 
 	if err := agentutil.ExtractTarball(ctx, archive, e.TargetDirectory, e.ExcludeFiles); err != nil {
-		return errors.Wrapf(err, "problem extracting '%s'", e.ArchivePath)
+		return errors.Wrapf(err, "extracting file '%s'", e.ArchivePath)
 	}
 
 	return nil

--- a/agent/command/archive_zip_create.go
+++ b/agent/command/archive_zip_create.go
@@ -37,7 +37,7 @@ func (c *zipArchiveCreate) Name() string { return "archive.zip_pack" }
 
 func (c *zipArchiveCreate) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error parsing '%v' params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if c.Target == "" {
@@ -45,7 +45,7 @@ func (c *zipArchiveCreate) ParseParams(params map[string]interface{}) error {
 	}
 
 	if c.SourceDir == "" {
-		return errors.New("source_dir cannot be blank")
+		return errors.New("source directory cannot be blank")
 	}
 
 	if len(c.Include) == 0 {
@@ -59,7 +59,7 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// if the source dir is a relative path, join it to the working dir
@@ -74,7 +74,7 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 
 	files, err := agentutil.FindContentsToArchive(ctx, c.SourceDir, c.Include, c.ExcludeFiles)
 	if err != nil {
-		return errors.Wrap(err, "problem finding files to archive")
+		return errors.Wrap(err, "finding files to archive")
 	}
 
 	filenames := make([]string, len(files))
@@ -83,7 +83,7 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 	}
 
 	if err := archiver.Zip.Make(c.Target, filenames); err != nil {
-		return errors.Wrapf(err, "problem constructing zip archive '%s'", c.Target)
+		return errors.Wrapf(err, "constructing zip archive '%s'", c.Target)
 	}
 
 	logger.Task().Info(message.Fields{

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -28,7 +28,7 @@ func zipExtractFactory() Command   { return &zipExtract{} }
 func (e *zipExtract) Name() string { return "archive.zip_extract" }
 func (e *zipExtract) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, e); err != nil {
-		return errors.Wrapf(err, "error parsing '%s' params", e.Name())
+		return errors.Wrapf(err, "decoding mapstructure params")
 	}
 
 	if len(e.ExcludeFiles) != 0 {
@@ -46,7 +46,7 @@ func (e *zipExtract) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(e, conf.Expansions); err != nil {
-		return errors.Wrap(err, "error expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// if the target is a relative path, join it to the working dir
@@ -63,7 +63,7 @@ func (e *zipExtract) Execute(ctx context.Context,
 	}
 
 	if err := archiver.Zip.Open(e.ArchivePath, e.TargetDirectory); err != nil {
-		return errors.Wrapf(err, "problem extracting archive '%s'", e.ArchivePath)
+		return errors.Wrapf(err, "extracting archive '%s' to directory '%s'", e.ArchivePath, e.TargetDirectory)
 	}
 
 	return nil

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -48,7 +48,7 @@ func (r *ec2AssumeRole) Name() string { return "ec2.assume_role" }
 
 func (r *ec2AssumeRole) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, r); err != nil {
-		return errors.Wrapf(err, "error parsing '%s' params", r.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	return r.validate()
@@ -72,7 +72,7 @@ func (r *ec2AssumeRole) validate() error {
 func (r *ec2AssumeRole) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if err := util.ExpandValues(r, conf.Expansions); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "applying expansions")
 	}
 	// Re-validate the command here, in case an expansion is not defined.
 	if err := r.validate(); err != nil {
@@ -88,7 +88,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 
 	// Error if key or secret are blank
 	if key == "" || secret == "" {
-		return errors.New("AWS ID and Secret could not be retrieved")
+		return errors.New("AWS key and secret must not be empty")
 	}
 
 	defaultCreds := credentials.NewStaticCredentialsFromCreds(credentials.Value{

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -36,12 +36,11 @@ func (c *attachArtifacts) Name() string { return evergreen.AttachArtifactsComman
 
 func (c *attachArtifacts) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding '%s' params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if len(c.Files) == 0 {
-		return errors.Errorf("error validating params: must specify at least one "+
-			"file pattern to parse: '%+v'", params)
+		return errors.Errorf("must specify at least one file pattern to parse")
 	}
 	return nil
 }
@@ -52,9 +51,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 	var err error
 
 	if err = util.ExpandValues(c, conf.Expansions); err != nil {
-		err = errors.Wrap(err, "error expanding params")
-		logger.Task().Error(err)
-		return err
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	workDir := getJoinedWithWorkDir(conf, c.Prefix)
@@ -64,7 +61,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		Include:    include,
 	}
 	if c.Files, err = b.Build(); err != nil {
-		err = errors.Wrap(err, "problem building wildcard paths")
+		err = errors.Wrap(err, "building wildcard paths")
 		logger.Task().Error(err)
 		return err
 	}
@@ -101,7 +98,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		files = append(files, segment...)
 	}
 	if catcher.HasErrors() {
-		err = errors.Wrap(catcher.Resolve(), "encountered errors reading artifact json files")
+		err = errors.Wrap(catcher.Resolve(), "reading artifact JSON files")
 		logger.Task().Error(err)
 		return err
 	}
@@ -135,14 +132,14 @@ func readArtifactsFile(wd, fn string) ([]*artifact.File, error) {
 
 	file, err := os.Open(fn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "problem opening file '%s'", fn)
+		return nil, errors.Wrapf(err, "opening file '%s'", fn)
 	}
 	defer file.Close()
 
 	out := []*artifact.File{}
 
 	if err = utility.ReadJSON(file, &out); err != nil {
-		return nil, errors.Wrapf(err, "problem reading JSON from file '%s'", fn)
+		return nil, errors.Wrapf(err, "reading JSON from file '%s'", fn)
 	}
 
 	return out, nil

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -61,15 +61,13 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		Include:    include,
 	}
 	if c.Files, err = b.Build(); err != nil {
-		err = errors.Wrap(err, "building wildcard paths")
-		logger.Task().Error(err)
-		return err
+		return errors.Wrap(err, "building wildcard paths")
 	}
 
 	if len(c.Files) == 0 {
 		err = errors.New("expanded file specification had no items")
-		logger.Task().Error(err)
 		if c.Optional {
+			logger.Task().Error(err)
 			return nil
 		}
 		return err
@@ -98,17 +96,15 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		files = append(files, segment...)
 	}
 	if catcher.HasErrors() {
-		err = errors.Wrap(catcher.Resolve(), "reading artifact JSON files")
-		logger.Task().Error(err)
-		return err
+		return errors.Wrap(catcher.Resolve(), "reading artifact JSON files")
 	}
 
 	if missedSegments > 0 {
-		logger.Task().Noticef("encountered %d empty file definitions", missedSegments)
+		logger.Task().Noticef("Encountered %d empty file definitions.", missedSegments)
 	}
 
 	if len(files) == 0 {
-		logger.Task().Warning("no artifacts defined")
+		logger.Task().Warning("No artifacts defined.")
 		return nil
 	}
 
@@ -117,7 +113,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "attach artifacts failed")
 	}
 
-	logger.Task().Infof("'%s' attached %d resources to task", c.Name(), len(files))
+	logger.Task().Infof("'%s' attached %d resources to task.", c.Name(), len(files))
 	return nil
 }
 

--- a/agent/command/command_test.go
+++ b/agent/command/command_test.go
@@ -13,7 +13,7 @@ import (
 func setupTestPatchData(apiData *modelutil.TestModelData, patchPath string, t *testing.T) error {
 	if patchPath != "" {
 		modulePatchContent, err := ioutil.ReadFile(patchPath)
-		require.NoError(t, err, "should have read test module patch file")
+		require.NoError(t, err)
 
 		patch := &patch.Patch{
 			Status:  evergreen.PatchCreated,
@@ -27,7 +27,7 @@ func setupTestPatchData(apiData *modelutil.TestModelData, patchPath string, t *t
 			},
 		}
 
-		require.NoError(t, patch.Insert(), "should have inserted patch")
+		require.NoError(t, patch.Insert())
 
 	}
 

--- a/agent/command/command_test.go
+++ b/agent/command/command_test.go
@@ -13,7 +13,7 @@ import (
 func setupTestPatchData(apiData *modelutil.TestModelData, patchPath string, t *testing.T) error {
 	if patchPath != "" {
 		modulePatchContent, err := ioutil.ReadFile(patchPath)
-		require.NoError(t, err, "failed to read test module patch file")
+		require.NoError(t, err, "should have read test module patch file")
 
 		patch := &patch.Patch{
 			Status:  evergreen.PatchCreated,
@@ -27,7 +27,7 @@ func setupTestPatchData(apiData *modelutil.TestModelData, patchPath string, t *t
 			},
 		}
 
-		require.NoError(t, patch.Insert(), "failed to insert patch")
+		require.NoError(t, patch.Insert(), "should have inserted patch")
 
 	}
 

--- a/agent/command/downstream_expansions_set.go
+++ b/agent/command/downstream_expansions_set.go
@@ -34,7 +34,7 @@ func (c *setDownstream) Name() string { return "downstream_expansions.set" }
 func (c *setDownstream) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing '%v' params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if c.YamlFile == "" {
@@ -68,7 +68,7 @@ func (c *setDownstream) Execute(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	logger.Task().Infof("Saving downstream parameters to patch with keys from file: %s", c.YamlFile)
+	logger.Task().Infof("Saving downstream parameters to patch with keys from file '%s'", c.YamlFile)
 
 	if len(c.downstreamParams) == 0 {
 		return nil

--- a/agent/command/downstream_expansions_set.go
+++ b/agent/command/downstream_expansions_set.go
@@ -68,7 +68,7 @@ func (c *setDownstream) Execute(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	logger.Task().Infof("Saving downstream parameters to patch with keys from file '%s'", c.YamlFile)
+	logger.Task().Infof("Saving downstream parameters to patch with keys from file '%s'.", c.YamlFile)
 
 	if len(c.downstreamParams) == 0 {
 		return nil

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -236,9 +236,9 @@ func (c *subprocessExec) getProc(ctx context.Context, taskID string, logger clie
 			agentutil.TrackProcess(taskID, pid, logger.System())
 
 			if c.Background {
-				logger.Execution().Debugf("running command in the background [pid=%d]", pid)
+				logger.Execution().Debugf("Running process in the background with pid %d.", pid)
 			} else {
-				logger.Execution().Infof("started process with pid %d", pid)
+				logger.Execution().Infof("Started process with pid %d.", pid)
 			}
 
 			return proc, nil
@@ -276,8 +276,7 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 	var err error
 
 	if err = c.doExpansions(conf.Expansions); err != nil {
-		logger.Execution().Error("expanding command values")
-		return errors.WithStack(err)
+		return errors.Wrap(err, "expanding command parameters")
 	}
 
 	logger.Execution().WarningWhen(
@@ -289,13 +288,12 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 		})
 	c.WorkingDir, err = conf.GetWorkingDirectory(c.WorkingDir)
 	if err != nil {
-		logger.Execution().Warning(err.Error())
-		return errors.WithStack(err)
+		return errors.Wrap(err, "getting working directory")
 	}
 
 	taskTmpDir, err := conf.GetWorkingDirectory("tmp")
 	if err != nil {
-		logger.Execution().Notice(err.Error())
+		logger.Execution().Notice(errors.Wrap(err, "getting temporary directory"))
 	}
 
 	var exp util.Expansions
@@ -327,12 +325,12 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 
 	err = errors.WithStack(c.runCommand(ctx, conf.Task.Id, c.getProc(ctx, conf.Task.Id, logger), logger))
 
-	if ctx.Err() != nil {
-		logger.System().Debug("dumping running processes")
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		logger.System().Debugf("Canceled command '%s', dumping running processes.", c.Name())
 		logger.System().Debug(message.CollectAllProcesses())
 		logger.Execution().Notice(err)
 
-		return errors.Errorf("%s aborted", c.Name())
+		return errors.Wrapf(ctxErr, "canceled while running command '%s'", c.Name())
 	}
 
 	return err
@@ -340,7 +338,7 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 
 func (c *subprocessExec) runCommand(ctx context.Context, taskID string, cmd *jasper.Command, logger client.LoggerProducer) error {
 	if c.Silent {
-		logger.Execution().Info("executing command in silent mode")
+		logger.Execution().Info("Executing command in silent mode.")
 	}
 
 	err := cmd.Run(ctx)
@@ -358,6 +356,7 @@ func (c *subprocessExec) runCommand(ctx context.Context, taskID string, cmd *jas
 			"silent":     c.Silent,
 			"continue":   c.ContinueOnError,
 		}))
+		logger.Execution().Noticef("Script errored, but continue on error is set - continuing task execution. Error: %s.", err)
 		return nil
 	}
 

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -249,7 +250,7 @@ func (s *execCmdSuite) TestCommandIntegrationFailureExpansion() {
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	if s.Error(err) {
-		s.Contains(err.Error(), "problem expanding")
+		s.Contains(err.Error(), "expanding")
 	}
 }
 
@@ -276,7 +277,7 @@ func (s *execCmdSuite) TestExecuteErrorsIfCommandAborts() {
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	if s.Error(err) {
-		s.Contains(err.Error(), "aborted")
+		s.True(utility.IsContextError(errors.Cause(err)))
 	}
 }
 

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -93,7 +93,7 @@ func TestExpansionWriter(t *testing.T) {
 			"password": true,
 		},
 	}
-	f, err := ioutil.TempFile("", "TestExpansionWriter")
+	f, err := ioutil.TempFile("", t.Name())
 	require.NoError(err)
 	defer os.Remove(f.Name())
 

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -62,8 +62,8 @@ func (c *update) ParseParams(params map[string]interface{}) error {
 
 func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
 	for _, update := range c.Updates {
-		if ctx.Err() != nil {
-			return errors.New("operation aborted")
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "operation aborted")
 		}
 
 		if update.Concat == "" {
@@ -113,7 +113,7 @@ func (c *update) Execute(ctx context.Context,
 			return errors.Errorf("file '%s' does not exist", filename)
 		}
 
-		logger.Task().Infof("Updating expansions with keys from file '%s'", filename)
+		logger.Task().Infof("Updating expansions with keys from file '%s'.", filename)
 		err := conf.Expansions.UpdateFromYaml(filename)
 		if err != nil {
 			return errors.WithStack(err)

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -48,13 +48,12 @@ func (c *update) Name() string         { return "expansions.update" }
 func (c *update) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
-	for _, item := range c.Updates {
+	for i, item := range c.Updates {
 		if item.Key == "" {
-			return errors.Errorf("error parsing '%v' params: key must not be "+
-				"a blank string", c.Name())
+			return errors.Errorf("expansion key at index %d must not be a blank string", i)
 		}
 	}
 
@@ -114,7 +113,7 @@ func (c *update) Execute(ctx context.Context,
 			return errors.Errorf("file '%s' does not exist", filename)
 		}
 
-		logger.Task().Infof("Updating expansions with keys from file: %s", filename)
+		logger.Task().Infof("Updating expansions with keys from file '%s'", filename)
 		err := conf.Expansions.UpdateFromYaml(filename)
 		if err != nil {
 			return errors.WithStack(err)

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -35,7 +35,7 @@ func (c *expansionsWriter) Name() string { return "expansions.write" }
 func (c *expansionsWriter) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
-		return errors.Wrap(err, "couldn't decode params")
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	return nil
@@ -57,12 +57,12 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	}
 	out, err := yaml.Marshal(expansions)
 	if err != nil {
-		return errors.Wrap(err, "error marshaling expansions")
+		return errors.Wrap(err, "marshalling expansions")
 	}
 	fn := getJoinedWithWorkDir(conf, c.File)
 	if err := ioutil.WriteFile(fn, out, 0600); err != nil {
-		return errors.Wrapf(err, "error writing expansions to file (%s)", fn)
+		return errors.Wrapf(err, "writing expansions to file '%s'", fn)
 	}
-	logger.Task().Infof("expansions written to file (%s)", fn)
+	logger.Task().Infof("expansions written to file '%s'", fn)
 	return nil
 }

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -63,6 +63,6 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	if err := ioutil.WriteFile(fn, out, 0600); err != nil {
 		return errors.Wrapf(err, "writing expansions to file '%s'", fn)
 	}
-	logger.Task().Infof("expansions written to file '%s'", fn)
+	logger.Task().Infof("Expansions written to file '%s'.", fn)
 	return nil
 }

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -58,18 +58,18 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 
 	if len(c.Files) == 0 {
 		if c.Optional {
-			logger.Task().Info("no files found and optional is true, skipping generate.tasks")
+			logger.Task().Infof("No files found and optional is true, skipping command '%s'.", c.Name())
 			return nil
 		}
-		return errors.New("no files found for generate.tasks")
+		return errors.Errorf("no files found for command '%s'", c.Name())
 	}
 
 	catcher := grip.NewBasicCatcher()
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 	var jsonBytes [][]byte
 	for _, fn := range c.Files {
-		if ctx.Err() != nil {
-			catcher.Add(ctx.Err())
+		if err := ctx.Err(); err != nil {
+			catcher.Wrapf(ctx.Err(), "cancelled while processing file '%s'", fn)
 			break
 		}
 		var data []byte

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -33,10 +33,10 @@ func (c *generateTask) Name() string { return "generate.tasks" }
 
 func (c *generateTask) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "Error decoding %s params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 	if len(c.Files) == 0 {
-		return errors.Errorf("Must provide at least 1 file to '%s'", c.Name())
+		return errors.Errorf("must provide at least 1 file containing task generation definitions")
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func (c *generateTask) ParseParams(params map[string]interface{}) error {
 func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	var err error
 	if err = util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "expanding params")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	include := utility.NewGitIgnoreFileMatcher(conf.WorkDir, c.Files...)
@@ -137,18 +137,18 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 func generateTaskForFile(fn string, conf *internal.TaskConfig) ([]byte, error) {
 	fileLoc := getJoinedWithWorkDir(conf, fn)
 	if _, err := os.Stat(fileLoc); os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "File '%s' does not exist", fn)
+		return nil, errors.Wrapf(err, "getting information for file '%s'", fn)
 	}
 	jsonFile, err := os.Open(fileLoc)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Couldn't open file '%s'", fn)
+		return nil, errors.Wrapf(err, "opening file '%s'", fn)
 	}
 	defer jsonFile.Close()
 
 	var data []byte
 	data, err = ioutil.ReadAll(jsonFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Problem reading from file '%s'", fn)
+		return nil, errors.Wrapf(err, "reading from file '%s'", fn)
 	}
 
 	return data, nil
@@ -162,8 +162,7 @@ func makeJsonOfAllFiles(jsonBytes [][]byte) ([]json.RawMessage, error) {
 	for _, j := range jsonBytes {
 		jsonRaw := json.RawMessage{}
 		if err := json.Unmarshal(j, &jsonRaw); err != nil {
-
-			catcher.Add(errors.Wrap(err, "error unmarshaling JSON for generate.tasks"))
+			catcher.Wrap(err, "unmarshalling JSON from file")
 			continue
 		}
 		post = append(post, jsonRaw)

--- a/agent/command/generate_test.go
+++ b/agent/command/generate_test.go
@@ -105,7 +105,7 @@ func (s *generateSuite) TestExecuteFailsWithGeneratePollError() {
 
 	c := &generateTask{Files: []string{tmpFileBase}}
 	s.comm.GenerateTasksShouldFail = true
-	s.Contains(c.Execute(s.ctx, s.comm, s.logger, s.conf).Error(), "error polling generate tasks!")
+	s.Contains(c.Execute(s.ctx, s.comm, s.logger, s.conf).Error(), "polling generate tasks")
 }
 
 func (s *generateSuite) TestExecuteSuccess() {

--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -79,7 +79,7 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		status = evergreen.PatchSucceeded
 	}
 	if status != evergreen.PatchSucceeded {
-		logger.Task().Warning("at least 1 task failed, will not merge pull request")
+		logger.Task().Warning("At least 1 task failed, will not merge pull request.")
 		return nil
 	}
 	// only successful patches should get past here. Failed patches will just send the failed

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -94,14 +94,14 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(modulePatch.PatchSet.Summary) == 0 {
-			logger.Execution().Infof("Skipping empty patch for module '%s' on patch ID '%s'", modulePatch.ModuleName, p.Id.Hex())
+			logger.Execution().Infof("Skipping empty patch for module '%s' on patch '%s'.", modulePatch.ModuleName, p.Id.Hex())
 			continue
 		}
 
 		var module *model.Module
 		module, err = conf.Project.GetModuleByName(modulePatch.ModuleName)
 		if err != nil {
-			logger.Execution().Errorf("Module '%s' not found", modulePatch.ModuleName)
+			logger.Execution().Errorf("Module '%s' not found.", modulePatch.ModuleName)
 			continue
 		}
 		moduleBase := filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
@@ -114,7 +114,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 			return errors.Wrapf(err, "checking out branch '%s'", module.Branch)
 		}
 
-		logger.Execution().Infof("Pushing patch for module '%s'", module.Name)
+		logger.Execution().Infof("Pushing patch for module '%s'.", module.Name)
 		params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))
 		params.branch = module.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {
@@ -129,11 +129,11 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(mainPatch.PatchSet.Summary) == 0 {
-			logger.Execution().Infof("Skipping empty main patch on patch ID '%s'", p.Id.Hex())
+			logger.Execution().Infof("Skipping empty main patch on patch '%s'.", p.Id.Hex())
 			continue
 		}
 
-		logger.Execution().Info("Pushing patch")
+		logger.Execution().Info("Pushing patch.")
 		params.directory = filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))
 		params.branch = conf.ProjectRef.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// gitMerge is a command that commits tracked changes and pushes the resulting commit to a remote repository
+// gitPush is a command that commits tracked changes and pushes the resulting commit to a remote repository
 type gitPush struct {
 	// The root directory (locally) that the code is checked out into.
 	// Must be a valid non-blank directory name.
@@ -36,12 +36,11 @@ func (c *gitPush) Name() string { return "git.push" }
 func (c *gitPush) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if c.Directory == "" {
-		return errors.Errorf("error parsing '%s' params: value for directory "+
-			"must not be blank", c.Name())
+		return errors.Errorf("directory must not be blank")
 	}
 
 	return nil
@@ -51,7 +50,7 @@ func (c *gitPush) ParseParams(params map[string]interface{}) error {
 func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	var err error
 	defer func() {
-		pErr := recovery.HandlePanicWithError(recover(), nil, "unexpected error in git.push")
+		pErr := recovery.HandlePanicWithError(recover(), nil, fmt.Sprintf("unexpected error in '%s'", c.Name()))
 		status := evergreen.MergeTestSucceeded
 		if err != nil || pErr != nil {
 			status = evergreen.MergeTestFailed
@@ -62,13 +61,13 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		logger.Task().Error(comm.ConcludeMerge(ctx, conf.Task.Version, status, td))
 	}()
 	if err = util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "can't apply expansions")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	var p *patch.Patch
 	p, err = comm.GetTaskPatch(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, "")
 	if err != nil {
-		return errors.Wrap(err, "Failed to get patch")
+		return errors.Wrap(err, "getting task patch")
 	}
 
 	checkoutCommand := fmt.Sprintf("git checkout %s", conf.ProjectRef.Branch)
@@ -77,14 +76,14 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))).Append(checkoutCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 	if err = cmd.Run(ctx); err != nil {
-		return errors.Wrapf(err, "can't checkout '%s' branch", conf.ProjectRef.Branch)
+		return errors.Wrapf(err, "checking out branch '%s'", conf.ProjectRef.Branch)
 	}
 
 	// get commit information
 	var projectToken string
 	_, projectToken, err = getProjectMethodAndToken(c.Token, conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion), conf.GetCloneMethod())
 	if err != nil {
-		return errors.Wrap(err, "failed to get token")
+		return errors.Wrap(err, "getting token")
 	}
 	params := pushParams{token: projectToken}
 
@@ -102,7 +101,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		var module *model.Module
 		module, err = conf.Project.GetModuleByName(modulePatch.ModuleName)
 		if err != nil {
-			logger.Execution().Errorf("No module found for %s", modulePatch.ModuleName)
+			logger.Execution().Errorf("Module '%s' not found", modulePatch.ModuleName)
 			continue
 		}
 		moduleBase := filepath.Join(expandModulePrefix(conf, module.Name, module.Prefix, logger), module.Name)
@@ -112,14 +111,14 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))).Append(checkoutCommand).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 		if err = cmd.Run(ctx); err != nil {
-			return errors.Wrapf(err, "can't checkout '%s' branch", module.Branch)
+			return errors.Wrapf(err, "checking out branch '%s'", module.Branch)
 		}
 
-		logger.Execution().Infof("Pushing patch for module %s", module.Name)
+		logger.Execution().Infof("Pushing patch for module '%s'", module.Name)
 		params.directory = filepath.ToSlash(filepath.Join(conf.WorkDir, c.Directory, moduleBase))
 		params.branch = module.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {
-			return errors.Wrap(err, "can't push module patch")
+			return errors.Wrap(err, "pushing module patch")
 		}
 	}
 
@@ -130,7 +129,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		if len(mainPatch.PatchSet.Summary) == 0 {
-			logger.Execution().Infof("Skipping empty main patch on patch id '%s'", p.Id.Hex())
+			logger.Execution().Infof("Skipping empty main patch on patch ID '%s'", p.Id.Hex())
 			continue
 		}
 
@@ -138,7 +137,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		params.directory = filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))
 		params.branch = conf.ProjectRef.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {
-			return errors.Wrap(err, "can't push patch")
+			return errors.Wrap(err, "pushing patch")
 		}
 	}
 
@@ -171,7 +170,7 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 		logger.Execution().Error(errorOutput)
 	}
 	if err != nil {
-		return errors.Wrap(err, "can't push to remote")
+		return errors.Wrap(err, "pushing to remote")
 	}
 
 	return nil

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -733,7 +733,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 	ref := strings.Trim(out.String(), "\n")
 	s.Equal(correctHash, ref) // this revision is defined in the patch, returned by GetTaskPatch
 	s.NoError(logger.Close())
-	toCheck := `Using revision/ref 'b27779f856b211ffaf97cbc124b7082a20ea8bc0' for module 'sample' (reason: specified in set-module)`
+	toCheck := `Using revision/ref 'b27779f856b211ffaf97cbc124b7082a20ea8bc0' for module 'sample' (reason: specified in set-module).`
 	foundMsg := false
 	for _, task := range comm.GetMockMessages() {
 		for _, msg := range task {
@@ -777,7 +777,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 	ref := strings.Trim(out.String(), "\n")
 	s.Equal(correctHash, ref)
 	s.NoError(logger.Close())
-	toCheck := `Using revision/ref '3585388b1591dfca47ac26a5b9a564ec8f138a5e' for module 'sample' (reason: from manifest)`
+	toCheck := `Using revision/ref '3585388b1591dfca47ac26a5b9a564ec8f138a5e' for module 'sample' (reason: from manifest).`
 	foundMsg := false
 	for _, task := range comm.GetMockMessages() {
 		for _, msg := range task {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -71,7 +71,7 @@ func TestGitGetProjectSuite(t *testing.T) {
 	env := testutil.NewEnvironment(ctx, t)
 	settings := env.Settings()
 
-	testutil.ConfigureIntegrationTest(t, settings, "TestGitGetProjectSuite")
+	testutil.ConfigureIntegrationTest(t, settings, t.Name())
 	s.settings = settings
 	suite.Run(t, s)
 }
@@ -999,7 +999,7 @@ func TestManifestLoad(t *testing.T) {
 	env := testutil.NewEnvironment(ctx, t)
 	testConfig := env.Settings()
 
-	testutil.ConfigureIntegrationTest(t, testConfig, "TestManifestFetch")
+	testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 
 	// Skipping: this test runs the manifest command and then
 	// checks that the database records were properly changed, and
@@ -1022,7 +1022,7 @@ func TestManifestLoad(t *testing.T) {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
 					pluginCmds, err := Render(command, taskConfig.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 
@@ -1050,7 +1050,7 @@ func TestManifestLoad(t *testing.T) {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
 					pluginCmds, err := Render(command, taskConfig.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 					err = pluginCmds[0].Execute(ctx, comm, logger, taskConfig)

--- a/agent/command/host_create.go
+++ b/agent/command/host_create.go
@@ -38,7 +38,7 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 		fileName := fmt.Sprintf("%v", params["file"])
 		c.File = fileName
 		if len(params) > 1 {
-			return errors.New("no params should be defined when using a file to parse params")
+			return errors.New("when using a file to parse params, no additional params other than file name should be defined")
 		}
 		return nil
 	}
@@ -48,17 +48,16 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 		Result:           c.CreateHost,
 	})
 	if err != nil {
-		return errors.Wrap(err, "problem constructing mapstructure decoder")
+		return errors.Wrap(err, "constructing mapstructure decoder")
 	}
-	return errors.Wrapf(decoder.Decode(params), "error parsing '%s' params", c.Name())
+	return errors.Wrap(decoder.Decode(params), "decoding mapstructure params")
 }
 
 func (c *createHost) parseParamsFromFile(fn string, conf *internal.TaskConfig) error {
 	if !filepath.IsAbs(fn) {
 		fn = getJoinedWithWorkDir(conf, fn)
 	}
-	return errors.Wrapf(utility.ReadYAMLFile(fn, &c.CreateHost),
-		"error reading from file '%s'", fn)
+	return errors.Wrapf(utility.ReadYAMLFile(fn, &c.CreateHost), "reading YAML from file '%s'", fn)
 }
 
 func (c *createHost) expandAndValidate(conf *internal.TaskConfig) error {
@@ -75,7 +74,7 @@ func (c *createHost) expandAndValidate(conf *internal.TaskConfig) error {
 	}
 
 	if err := c.CreateHost.Validate(); err != nil {
-		return errors.Wrap(err, "command is invalid")
+		return errors.Wrap(err, "invalid command options")
 	}
 	return nil
 }
@@ -101,10 +100,10 @@ func (c *createHost) Execute(ctx context.Context, comm client.Communicator,
 	c.logAMI(ctx, comm, logger, taskData)
 	ids, err := comm.CreateHost(ctx, taskData, *c.CreateHost)
 	if err != nil {
-		return errors.Wrap(err, "error creating host")
+		return errors.Wrap(err, "creating host")
 	} else if c.CreateHost.CloudProvider == apimodels.ProviderDocker {
 		if err = c.getLogsFromNewDockerHost(ctx, logger, comm, ids, startTime, conf); err != nil {
-			return errors.Wrap(err, "problem getting logs from created host")
+			return errors.Wrap(err, "getting logs from created host")
 		}
 	}
 
@@ -143,7 +142,7 @@ func (c *createHost) getLogsFromNewDockerHost(ctx context.Context, logger client
 	ids []string, startTime time.Time, conf *internal.TaskConfig) error {
 	var err error
 	if len(ids) == 0 {
-		return errors.New("Programmer error: no intent host ID received")
+		return errors.New("programmer error: no intent host ID received")
 	}
 
 	info, err := c.initializeLogBatchInfo(ids[0], conf, startTime)
@@ -154,14 +153,14 @@ func (c *createHost) getLogsFromNewDockerHost(ctx context.Context, logger client
 	if !c.CreateHost.Background {
 		defer info.outFile.Close()
 		defer info.errFile.Close()
-		return errors.Wrapf(c.waitForLogs(ctx, comm, logger, info), "error waiting for logs")
+		return errors.Wrapf(c.waitForLogs(ctx, comm, logger, info), "waiting for logs")
 	}
 
 	go func() {
 		defer info.outFile.Close()
 		defer info.errFile.Close()
 		if err = c.waitForLogs(ctx, comm, logger, info); err != nil {
-			logger.Task().Errorf("error waiting for logs in background: %v", err)
+			logger.Task().Error(errors.Wrap(err, "waiting for logs in the background"))
 		}
 	}()
 
@@ -190,15 +189,15 @@ func (c *createHost) initializeLogBatchInfo(id string, conf *internal.TaskConfig
 	var err error
 	info.outFile, err = os.OpenFile(c.CreateHost.StdoutFile, permissions, 0644)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating file %s", c.CreateHost.StdoutFile)
+		return nil, errors.Wrapf(err, "creating file '%s'", c.CreateHost.StdoutFile)
 	}
 	info.errFile, err = os.OpenFile(c.CreateHost.StderrFile, permissions, 0644)
 	if err != nil {
 		// the outfile already exists, so close it
 		if fileErr := info.outFile.Close(); fileErr != nil {
-			return nil, errors.Wrapf(fileErr, "error removing stdout file after failed stderr file creation")
+			return nil, errors.Wrapf(fileErr, "removing stdout file after failed stderr file creation")
 		}
-		return nil, errors.Wrapf(err, "error creating file %s", c.CreateHost.StderrFile)
+		return nil, errors.Wrapf(err, "creating file '%s'", c.CreateHost.StderrFile)
 	}
 	return info, nil
 }
@@ -216,7 +215,7 @@ func (c *createHost) waitForLogs(ctx context.Context, comm client.Communicator, 
 	for {
 		select {
 		case <-ctx.Done():
-			logger.Task().Infof("context cancelled waiting for host %s to exit", info.hostID)
+			logger.Task().Infof("context cancelled waiting for host '%s' to exit", info.hostID)
 			return nil
 		case <-pollTicker.C:
 			info.batchEnd = time.Now()
@@ -234,7 +233,7 @@ func (c *createHost) waitForLogs(ctx context.Context, comm client.Communicator, 
 				info.batchStart = info.batchEnd.Add(time.Nanosecond) // to prevent repeat logs
 
 				if !status.IsRunning { // container exited
-					logger.Task().Infof("Logs retrieved for container _id %s in %d seconds",
+					logger.Task().Infof("Logs retrieved for container ID '%s' in %d seconds",
 						info.hostID, int(time.Since(info.batchStart).Seconds()))
 					return nil
 				}
@@ -248,11 +247,11 @@ func (c *createHost) waitForLogs(ctx context.Context, comm client.Communicator, 
 func (info *logBatchInfo) getAndWriteLogBatch(ctx context.Context, comm client.Communicator, logger client.LoggerProducer) {
 	outLogs, err := comm.GetDockerLogs(ctx, info.hostID, info.batchStart, info.batchEnd, false)
 	if err != nil {
-		logger.Task().Errorf("error retrieving docker out logs: %s", err.Error())
+		logger.Task().Error(errors.Wrap(err, "error retrieving Docker output logs"))
 	}
 	errLogs, err := comm.GetDockerLogs(ctx, info.hostID, info.batchStart, info.batchEnd, true)
 	if err != nil {
-		logger.Task().Errorf("error retrieving docker error logs: %s", err.Error())
+		logger.Task().Error(errors.Wrap(err, "error retrieving Docker error logs"))
 	}
 	if _, err = info.outFile.Write(outLogs); err != nil {
 		logger.Task().Errorf("error writing stdout to file: %s", outLogs)
@@ -265,12 +264,12 @@ func (info *logBatchInfo) getAndWriteLogBatch(ctx context.Context, comm client.C
 func (c *createHost) populateUserdata() error {
 	file, err := os.Open(c.CreateHost.UserdataFile)
 	if err != nil {
-		return errors.Wrap(err, "error opening UserData file")
+		return errors.Wrap(err, "opening user data file")
 	}
 	defer file.Close()
 	fileData, err := ioutil.ReadAll(file)
 	if err != nil {
-		return errors.Wrap(err, "error reading UserData file")
+		return errors.Wrap(err, "reading user data file")
 	}
 	c.CreateHost.UserdataCommand = string(fileData)
 

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -128,7 +128,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	}
 
 	err = s.cmd.ParseParams(s.params)
-	s.Contains(err.Error(), "no params should be defined when using a file to parse params")
+	s.Contains(err.Error(), "when using a file to parse params, no additional params other than file name should be defined")
 
 }
 
@@ -136,15 +136,15 @@ func (s *createHostSuite) TestParamValidation() {
 	// having no ami or distro is an error
 	s.params["distro"] = ""
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "must set exactly one of ami or distro")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "must set exactly one of AMI or distro")
 
 	// verify errors if missing required info for ami
 	s.params["ami"] = "ami"
 	s.NoError(s.cmd.ParseParams(s.params))
 	err := s.cmd.expandAndValidate(s.conf)
-	s.Contains(err.Error(), "instance_type must be set if ami is set")
-	s.Contains(err.Error(), "must specify security_group_ids if ami is set")
-	s.Contains(err.Error(), "instance_type must be set if ami is set")
+	s.Contains(err.Error(), "must specify security group IDs if AMI is set")
+	s.Contains(err.Error(), "subnet ID must be set if AMI is set")
+	s.Contains(err.Error(), "instance type must be set if AMI is set")
 
 	// valid AMI info
 	s.params["instance_type"] = "instance"
@@ -156,7 +156,7 @@ func (s *createHostSuite) TestParamValidation() {
 	// having a key id but nothing else is an error
 	s.params["aws_access_key_id"] = "keyid"
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "aws_access_key_id, aws_secret_access_key, key_name must all be set or unset")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "AWS access key ID, AWS secret access key, and key name must all be set or unset")
 	s.params["aws_secret_access_key"] = "secret"
 	s.params["key_name"] = "key"
 	s.NoError(s.cmd.ParseParams(s.params))
@@ -165,13 +165,13 @@ func (s *createHostSuite) TestParamValidation() {
 	// verify errors for things controlled by the agent
 	s.params["num_hosts"] = "11"
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "num_hosts must be between 1 and 10")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "num hosts must be between 1 and 10")
 	s.params["scope"] = "idk"
 	s.NoError(s.cmd.ParseParams(s.params))
 	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "scope must be build or task")
 	s.params["timeout_teardown_secs"] = 55
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "timeout_teardown_secs must be between 60 and 604800")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "timeout teardown seconds must be between 60 and 604800")
 
 	// Validate num_hosts can be an int
 	s.params["timeout_teardown_secs"] = 60
@@ -189,8 +189,8 @@ func (s *createHostSuite) TestParamValidation() {
 	settings.Providers.Docker.DefaultDistro = "my-default-distro"
 	s.NoError(evergreen.UpdateConfig(settings))
 
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "docker image must be set")
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "num_hosts cannot be greater than 1")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "Docker image must be set")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "num hosts cannot be greater than 1")
 	s.params["image"] = "my-image"
 	s.params["command"] = "echo hi"
 	s.params["num_hosts"] = 1

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -140,6 +140,9 @@ func (s *createHostSuite) TestParamValidation() {
 
 	// verify errors if missing required info for ami
 	s.params["ami"] = "ami"
+	delete(s.params, "security_group_ids")
+	delete(s.params, "subnet_id")
+	delete(s.params, "instance_type")
 	s.NoError(s.cmd.ParseParams(s.params))
 	err := s.cmd.expandAndValidate(s.conf)
 	s.Contains(err.Error(), "must specify security group IDs if AMI is set")
@@ -171,7 +174,7 @@ func (s *createHostSuite) TestParamValidation() {
 	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "scope must be build or task")
 	s.params["timeout_teardown_secs"] = 55
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "timeout teardown seconds must be between 60 and 604800")
+	s.Contains(s.cmd.expandAndValidate(s.conf).Error(), "timeout teardown (seconds) must be between 60 and 604800")
 
 	// Validate num_hosts can be an int
 	s.params["timeout_teardown_secs"] = 60

--- a/agent/command/host_list.go
+++ b/agent/command/host_list.go
@@ -91,7 +91,7 @@ func (c *listHosts) Execute(ctx context.Context, comm client.Communicator, logge
 	if c.NumHosts != "" {
 		numHosts, err = strconv.Atoi(c.NumHosts)
 		if err != nil {
-			return errors.Wrapf(err, "cannot convert '%s' to int", c.NumHosts)
+			return errors.Wrapf(err, "converting num hosts '%s' to int", c.NumHosts)
 		}
 	}
 

--- a/agent/command/initial_setup.go
+++ b/agent/command/initial_setup.go
@@ -10,6 +10,9 @@ import (
 	"github.com/mongodb/jasper"
 )
 
+// initialSetup is an internal command used as a placeholder when the agent is
+// setting up in preparation to run a task's commands. This is not meant to be
+// invoked by end users.
 type initialSetup struct{}
 
 func initialSetupFactory() Command                                    { return &initialSetup{} }

--- a/agent/command/initial_setup.go
+++ b/agent/command/initial_setup.go
@@ -29,6 +29,6 @@ func (*initialSetup) SetJasperManager(_ jasper.Manager)               {}
 func (*initialSetup) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
-	logger.Task().Info("performing initial task setup")
+	logger.Task().Info("Performing initial task setup.")
 	return nil
 }

--- a/agent/command/keyval_test.go
+++ b/agent/command/keyval_test.go
@@ -21,8 +21,8 @@ func TestIncKey(t *testing.T) {
 
 	Convey("With keyval plugin installed", t, func() {
 		err := db.Clear(model.KeyValCollection)
-		require.NoError(t, err, "Couldn't clear test collection: %s", model.KeyValCollection)
-		require.NoError(t, err, "Couldn't register keyval plugin")
+		require.NoError(t, err)
+		require.NoError(t, err)
 
 		testConfig := testutil.TestConfig()
 		configPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "plugin_keyval.yml")
@@ -30,7 +30,7 @@ func TestIncKey(t *testing.T) {
 		comm := client.NewMock("http://localhost.com")
 
 		modelData, err := modelutil.SetupAPITestData(testConfig, "testinc", "rhel55", configPath, modelutil.NoPatch)
-		require.NoError(t, err, "couldn't create test task")
+		require.NoError(t, err)
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
 		require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestIncKey(t *testing.T) {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
 					pluginCmds, err := Render(command, &model.Project{})
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 					for _, cmd := range pluginCmds {

--- a/agent/command/macsign.go
+++ b/agent/command/macsign.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// A plugin command to sign and notarize macOS artifacts.
+// macSign is a command to sign and notarize macOS artifacts.
 type macSign struct {
 	// KeyId and Secret are the credentials for
 	// authenticating into the macOS signing and notarization service.
@@ -26,37 +26,37 @@ type macSign struct {
 	ServiceUrl string `mapstructure:"service_url" plugin:"expand"`
 
 	// ClientBinary is the path to the macOS signing and notarization service client.
-	// If empty default location(/usr/local/bin/macnotary) will be used.
+	// If empty, the default location (/usr/local/bin/macnotary) will be used.
 	ClientBinary string `mapstructure:"client_binary" plugin:"expand"`
 
-	// LocalZipFile is the local filepath to the zip file the user
-	// wishes to sign. It should contains the list of artifacts that need to be signed.
+	// LocalZipFile is the local filepath to the zip file the user wishes to
+	// sign. It should contain the artifacts that need to be signed.
 	LocalZipFile string `mapstructure:"local_zip_file" plugin:"expand"`
 
 	// OutputZipFile is the local filepath to the zip file the service outputs
 	// It will contain the list of artifacts that are signed by the server.
 	OutputZipFile string `mapstructure:"output_zip_file" plugin:"expand"`
 
-	// ArtifactType is a type of artifact(s) that need to be signed.
+	// ArtifactType is the type of artifact(s) that need to be signed.
 	// Currently supported list: app, binary.
 	ArtifactType string `mapstructure:"artifact_type" plugin:"expand"`
 
-	// EntitlementsFilePath is the local filepath to the entitlements file that the users
+	// EntitlementsFilePath is the local filepath to the entitlements file that the user
 	// wishes to execute the signing process with. This is optional.
 	EntitlementsFilePath string `mapstructure:"entitlements_file" plugin:"expand"`
 
-	// Verify determines if the signature(or notarization) should be verified.
-	// Verification is only supported on MacOS. It is optional, default value if false.
+	// Verify determines if the signature (or notarization) should be verified.
+	// Verification is only supported on macOS. It is optional, default value if false.
 	Verify bool `mapstructure:"verify"`
 
 	// Notarize determines if the file should also be notarized after signing.
 	Notarize bool `mapstructure:"notarize"`
 
-	// BundleId is the bundle id of the artifact used during notarization.
+	// BundleId is the bundle ID of the artifact used during notarization.
 	// This is mandatory if notarization is requested.
 	BundleId string `mapstructure:"bundle_id"  plugin:"expand"`
 
-	// BuildVariants stores a list of MCI build variants to run the command for.
+	// BuildVariants stores a list of build variants to run the command for.
 	// If the list is empty, it runs for all build variants.
 	BuildVariants []string `mapstructure:"build_variants"`
 
@@ -209,23 +209,23 @@ func (macSign *macSign) Execute(ctx context.Context,
 	stdout, err := cmd.CombinedOutput()
 	output := string(stdout)
 
+	if len(output) != 0 {
+		logger.Task().Info(output)
+	}
+
 	if err != nil {
 
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {
-			logger.Task().Error(output)
 			return errors.Wrapf(err, "unexpected error on OS '%s' arch '%s'", runtime.GOOS, runtime.GOARCH)
 		}
 
 		if exitErr.ExitCode() != 0 {
-			logger.Task().Error(output)
 			return errors.Errorf("non-zero exit code %d", exitErr.ExitCode())
 		}
 	}
 
-	logger.Task().Info(output)
-
-	logger.Task().Infof("Artifact - file '%s' signed (and/or notarized) and new file created: '%s'", macSign.LocalZipFile, macSign.OutputZipFile)
+	logger.Task().Infof("Artifact - file '%s' signed (and/or notarized) and new file created: '%s'.", macSign.LocalZipFile, macSign.OutputZipFile)
 
 	return nil
 }

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -16,12 +16,12 @@ import (
 
 type perfSend struct {
 	// AWSKey and AWSSecret are the user's credentials for authenticating
-	// interactions with s3. These are required if any of the tests have
+	// interactions with S3. These are required if any of the tests have
 	// artifacts.
 	AWSKey    string `mapstructure:"aws_key" plugin:"expand"`
 	AWSSecret string `mapstructure:"aws_secret" plugin:"expand"`
 
-	// Region is the s3 region where the global bucket is located. It
+	// Region is the S3 region where the global bucket is located. It
 	// defaults to "us-east-1".
 	Region string `mapstructure:"region" plugin:"expand"`
 
@@ -29,11 +29,11 @@ type perfSend struct {
 	// without a bucket specified.
 	Bucket string `mapstructure:"bucket" plugin:"expand"`
 
-	// Prefix specifies the global prefix to use within the s3 bucket for
+	// Prefix specifies the global prefix to use within the S3 bucket for
 	// any artifacts without a prefix specified.
 	Prefix string `mapstructure:"prefix" plugin:"expand"`
 
-	// File is the file containing either the json or yaml representation
+	// File is the file containing either the JSON or YAML representation
 	// of the performance report tests.
 	File string `mapstructure:"file" plugin:"expand"`
 
@@ -49,7 +49,7 @@ func (c *perfSend) ParseParams(params map[string]interface{}) error {
 	}
 
 	if c.File == "" {
-		return errors.New("'file' param must not be blank")
+		return errors.New("file must not be blank")
 	}
 
 	return nil
@@ -64,7 +64,7 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 	filename := getJoinedWithWorkDir(conf, c.File)
 	report, err := poplar.LoadTests(filename)
 	if err != nil {
-		return errors.Wrapf(err, "reading tests from '%s'", filename)
+		return errors.Wrapf(err, "reading tests from file '%s'", filename)
 	}
 	c.addEvgData(report, conf)
 

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -45,7 +45,7 @@ func (*perfSend) Name() string { return "perf.send" }
 
 func (c *perfSend) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding '%v' params", c.Name())
+		return errors.Wrap(err, "decoding params")
 	}
 
 	if c.File == "" {
@@ -57,7 +57,7 @@ func (c *perfSend) ParseParams(params map[string]interface{}) error {
 
 func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
-		return err
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// Read the file and add the Evergreen info.

--- a/agent/command/results_go_test2json.go
+++ b/agent/command/results_go_test2json.go
@@ -71,14 +71,14 @@ func (c *goTest2JSONCommand) executeOneFile(ctx context.Context, file string,
 	}
 
 	if len(results.Tests) == 0 {
-		logger.Task().Warning("parsed no events from test file")
+		logger.Task().Warning("Parsed no tests from test file.")
 		if len(results.Log) == 0 {
-			logger.Task().Warning("test log is empty")
+			logger.Task().Warning("Test log is empty.")
 			return nil
 		}
 	}
 
-	logger.Task().Info("posting test logs...")
+	logger.Task().Info("Posting test logs...")
 	_, suiteName := filepath.Split(file)
 	log := model.TestLog{
 		Name:          suiteName,
@@ -89,7 +89,7 @@ func (c *goTest2JSONCommand) executeOneFile(ctx context.Context, file string,
 	if err := sendTestLog(ctx, comm, conf, &log); err != nil {
 		return errors.Wrap(err, "sending test log")
 	}
-	logger.Task().Info("successfully posted test logs")
+	logger.Task().Info("Successfully posted test logs.")
 
 	if len(results.Tests) == 0 {
 		return nil

--- a/agent/command/results_go_test2json.go
+++ b/agent/command/results_go_test2json.go
@@ -29,12 +29,11 @@ func (c *goTest2JSONCommand) Name() string { return "gotest.parse_json" }
 
 func (c *goTest2JSONCommand) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding '%s' params", c.Name())
+		return errors.Wrapf(err, "decoding mapstructure params")
 	}
 
 	if len(c.Files) == 0 {
-		return errors.Errorf("error validating params: must specify at least one "+
-			"file pattern to parse: '%+v'", params)
+		return errors.Errorf("must specify at least one file pattern to parse")
 	}
 	return nil
 }
@@ -43,7 +42,7 @@ func (c *goTest2JSONCommand) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := util.ExpandValues(c, conf.Expansions); err != nil {
-		return errors.Wrap(err, "failed to expand files")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// All file patterns should be relative to the task's working directory.
@@ -68,8 +67,7 @@ func (c *goTest2JSONCommand) executeOneFile(ctx context.Context, file string,
 	logger.Task().Infof("parsing test file '%s'...", file)
 	results, err := c.loadJSONFile(file, logger, conf)
 	if err != nil {
-		logger.Task().Errorf("error parsing test file: %v", err)
-		return errors.Wrapf(err, "parsing test file: %v", err)
+		return errors.Wrapf(err, "parsing JSON test file")
 	}
 
 	if len(results.Tests) == 0 {
@@ -89,7 +87,6 @@ func (c *goTest2JSONCommand) executeOneFile(ctx context.Context, file string,
 		Lines:         results.Log,
 	}
 	if err := sendTestLog(ctx, comm, conf, &log); err != nil {
-		logger.Task().Errorf("error posting test log: %v", err)
 		return errors.Wrap(err, "sending test log")
 	}
 	logger.Task().Info("successfully posted test logs")
@@ -124,14 +121,12 @@ func (c *goTest2JSONCommand) loadJSONFile(file string, logger client.LoggerProdu
 
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		logger.Task().Errorf("Failed to open '%s'", filePath)
-		return nil, errors.Wrapf(err, "failed to open: %s", filePath)
+		return nil, errors.Wrapf(err, "reading file '%s'", filePath)
 	}
 
 	results, err := test2json.ProcessBytes(data)
 	if err != nil {
-		logger.Task().Errorf("Failed to process '%s': %+v", filePath, err)
-		return nil, errors.Wrapf(err, "failed to process '%s'", filePath)
+		return nil, errors.Wrapf(err, "processing file '%s'", filePath)
 	}
 
 	return results, nil

--- a/agent/command/results_go_test2json_test.go
+++ b/agent/command/results_go_test2json_test.go
@@ -73,7 +73,7 @@ func (s *test2JSONSuite) TestNoFiles() {
 	}
 	err = s.c.ParseParams(s.args)
 	s.Require().Error(err)
-	s.Contains(err, "must specify at least one file pattern to parse")
+	s.Contains(err.Error(), "must specify at least one file pattern to parse")
 
 	err = s.c.ParseParams(nil)
 	s.Require().Error(err)

--- a/agent/command/results_go_test2json_test.go
+++ b/agent/command/results_go_test2json_test.go
@@ -63,15 +63,21 @@ func (s *test2JSONSuite) SetupTest() {
 func (s *test2JSONSuite) TestNoFiles() {
 	s.c.Files = []string{}
 	s.args = map[string]interface{}{}
-	s.EqualError(s.c.ParseParams(s.args), "error validating params: must specify at least one file pattern to parse: 'map[]'")
+	err := s.c.ParseParams(s.args)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "must specify at least one file pattern to parse")
 
 	s.c.Files = []string{}
 	s.args = map[string]interface{}{
 		"files": []string{},
 	}
-	s.EqualError(s.c.ParseParams(s.args), "error validating params: must specify at least one file pattern to parse: 'map[files:[]]'")
+	err = s.c.ParseParams(s.args)
+	s.Require().Error(err)
+	s.Contains(err, "must specify at least one file pattern to parse")
 
-	s.EqualError(s.c.ParseParams(nil), "error validating params: must specify at least one file pattern to parse: 'map[]'")
+	err = s.c.ParseParams(nil)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "must specify at least one file pattern to parse")
 }
 
 func (s *test2JSONSuite) TestParseArgs() {

--- a/agent/command/results_gotest.go
+++ b/agent/command/results_gotest.go
@@ -157,8 +157,8 @@ func parseTestOutputFiles(ctx context.Context, logger client.LoggerProducer,
 
 	// now, open all the files, and parse the test results
 	for _, outputFile := range outputFiles {
-		if ctx.Err() != nil {
-			return nil, nil, errors.New("command was stopped")
+		if err := ctx.Err(); err != nil {
+			return nil, nil, errors.Wrap(err, "canceled while processing test output files")
 		}
 
 		_, suiteName := filepath.Split(outputFile)

--- a/agent/command/results_gotest_parser.go
+++ b/agent/command/results_gotest_parser.go
@@ -117,7 +117,7 @@ func (vp *goTestParser) Parse(testOutput io.Reader) error {
 	vp.tests = map[string][]*goTestResult{}
 	for testScanner.Scan() {
 		if err := testScanner.Err(); err != nil {
-			return errors.Wrap(err, "error reading test output")
+			return errors.Wrap(err, "reading test output")
 		}
 		// logs are appended at the start of the loop, allowing
 		// len(vp.logs) to represent the current line number [1...]
@@ -153,7 +153,7 @@ func (vp *goTestParser) handleLine(line string) error {
 func (vp *goTestParser) handleEnd(line string, rgx *regexp.Regexp) error {
 	name, status, duration, err := endInfoFromLogLine(line, rgx)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing end line '%s'", line)
+		return errors.Wrapf(err, "parsing end line '%s'", line)
 	}
 	tAry, ok := vp.tests[name]
 	if !ok || tAry == nil {
@@ -174,7 +174,7 @@ func (vp *goTestParser) handleEnd(line string, rgx *regexp.Regexp) error {
 func (vp *goTestParser) handleStart(line string, rgx *regexp.Regexp, defaultFail bool) error {
 	name, err := startInfoFromLogLine(line, rgx)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing start line '%s'", line)
+		return errors.Wrapf(err, "parsing start line '%s'", line)
 	}
 	t := vp.newTestResult(name)
 
@@ -201,7 +201,7 @@ func (vp *goTestParser) handleStart(line string, rgx *regexp.Regexp, defaultFail
 func (vp *goTestParser) handleFailedBuild(line string) error {
 	path, err := pathNameFromLogLine(line)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing start line '%s'", line)
+		return errors.Wrapf(err, "parsing start line '%s'", line)
 	}
 	return errors.Errorf("go test failed for path '%s'", path)
 }
@@ -223,8 +223,7 @@ func startInfoFromLogLine(line string, rgx *regexp.Regexp) (string, error) {
 	if len(matches) < 2 {
 		// futureproofing -- this can't happen as long as we
 		// check Match() before calling startInfoFromLogLine
-		return "", errors.Errorf(
-			"unable to match start line regular expression on line: %s", line)
+		return "", errors.Errorf("unable to match start line regular expression on line '%s'", line)
 	}
 	return matches[1], nil
 }
@@ -237,8 +236,7 @@ func endInfoFromLogLine(line string, rgx *regexp.Regexp) (string, string, time.D
 	if len(matches) < 4 {
 		// this block should never be reached if we call endRegex.Match()
 		// before entering this function
-		return "", "", 0, errors.Errorf(
-			"unable to match end line regular expression on line: %s", line)
+		return "", "", 0, errors.Errorf("unable to match end line regular expression on line '%s'", line)
 	}
 	status := matches[1]
 	name := matches[2]
@@ -247,7 +245,7 @@ func endInfoFromLogLine(line string, rgx *regexp.Regexp) (string, string, time.D
 		var err error
 		duration, err = time.ParseDuration(strings.Replace(matches[3], " ", "", -1))
 		if err != nil {
-			return "", "", 0, errors.Wrap(err, "error parsing test runtime")
+			return "", "", 0, errors.Wrap(err, "parsing test runtime duration")
 		}
 	}
 	return name, status, duration, nil
@@ -257,7 +255,7 @@ func endInfoFromLogLine(line string, rgx *regexp.Regexp) (string, string, time.D
 func pathNameFromLogLine(line string) (string, error) {
 	matches := goTestFailedStatusRegex.FindStringSubmatch(line)
 	if len(matches) < 2 {
-		return "", errors.Errorf("unable to match build line to regular expression on line: %s", line)
+		return "", errors.Errorf("unable to match build line to regular expression on line '%s'", line)
 	}
 	return matches[1], nil
 }

--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func reset(t *testing.T) {
-	require.NoError(t, db.ClearCollections(task.Collection, model.TestLogCollection), "error clearing test collections")
+	require.NoError(t, db.ClearCollections(task.Collection, model.TestLogCollection))
 }
 
 func TestGotestPluginOnFailingTests(t *testing.T) {
@@ -35,7 +35,7 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 
 		configPath := filepath.Join(currentDirectory, "testdata", "gotest", "bad.yml")
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
+		require.NoError(t, err)
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
 		require.NoError(t, err)
 		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
@@ -43,14 +43,14 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 
 		Convey("all commands in test project should execute successfully", func() {
 			curWD, err := os.Getwd()
-			require.NoError(t, err, "Couldn't get working directory: %s", curWD)
+			require.NoError(t, err)
 			conf.WorkDir = curWD
 
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
 					pluginCmds, err := Render(command, conf.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
@@ -94,7 +94,7 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 		configPath := filepath.Join(currentDirectory, "testdata", "bad.yml")
 
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
+		require.NoError(t, err)
 
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
 		require.NoError(t, err)
@@ -105,14 +105,14 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 
 		Convey("all commands in test project should execute successfully", func() {
 			curWD, err := os.Getwd()
-			require.NoError(t, err, "Couldn't get working directory: %s", curWD)
+			require.NoError(t, err)
 			conf.WorkDir = curWD
 
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
 					pluginCmds, err := Render(command, conf.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 

--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -88,10 +88,10 @@ func (c *attachResults) Execute(ctx context.Context,
 }
 
 func (c *attachResults) sendTestLogs(ctx context.Context, conf *internal.TaskConfig, logger client.LoggerProducer, comm client.Communicator, results *task.LocalTestResults) error {
-	logger.Execution().Info("posting test logs...")
+	logger.Execution().Info("Posting test logs...")
 	for i, res := range results.Results {
-		if ctx.Err() != nil {
-			return errors.Errorf("operation canceled")
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "operation canceled")
 		}
 
 		if res.LogRaw != "" {

--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -33,11 +33,11 @@ func (c *attachResults) Name() string { return evergreen.AttachResultsCommandNam
 // to satisfy the 'Command' interface
 func (c *attachResults) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding '%v' params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	if c.FileLoc == "" {
-		return errors.New("file_location cannot be blank")
+		return errors.New("file location cannot be blank")
 	}
 
 	return nil
@@ -48,7 +48,7 @@ func (c *attachResults) expandAttachResultsParams(taskConfig *internal.TaskConfi
 
 	c.FileLoc, err = taskConfig.Expansions.ExpandString(c.FileLoc)
 	if err != nil {
-		return errors.Wrap(err, "error expanding file_location")
+		return errors.Wrap(err, "expanding file location")
 	}
 
 	return nil
@@ -60,7 +60,7 @@ func (c *attachResults) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	if err := c.expandAttachResultsParams(conf); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	reportFileLoc := c.FileLoc
@@ -71,13 +71,13 @@ func (c *attachResults) Execute(ctx context.Context,
 	// attempt to open the file
 	reportFile, err := os.Open(reportFileLoc)
 	if err != nil {
-		return errors.Wrapf(err, "couldn't open report file '%s'", reportFileLoc)
+		return errors.Wrapf(err, "opening report file '%s'", reportFileLoc)
 	}
 	defer reportFile.Close()
 
 	results := &task.LocalTestResults{}
 	if err = utility.ReadJSON(reportFile, results); err != nil {
-		return errors.Wrapf(err, "couldn't read report file '%s'", reportFileLoc)
+		return errors.Wrapf(err, "reading report file '%s'", reportFileLoc)
 	}
 
 	if err := c.sendTestLogs(ctx, conf, logger, comm, results); err != nil {
@@ -109,7 +109,7 @@ func (c *attachResults) sendTestLogs(ctx context.Context, conf *internal.TaskCon
 			if err := sendTestLog(ctx, comm, conf, testLogs); err != nil {
 				// Continue on error to let other logs be
 				// posted.
-				logger.Execution().Errorf("error posting test logs: %+v", err)
+				logger.Execution().Error(errors.Wrap(err, "sending test logs"))
 			} else {
 				results.Results[i].LogTestName = testLogs.Name
 			}

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -20,8 +20,7 @@ import (
 )
 
 func resetTasks(t *testing.T) {
-	require.NoError(t, db.ClearCollections(task.Collection, model.TestLogCollection),
-		"error clearing test collections")
+	require.NoError(t, db.ClearCollections(task.Collection, model.TestLogCollection))
 }
 
 func TestAttachResults(t *testing.T) {
@@ -40,7 +39,7 @@ func TestAttachResults(t *testing.T) {
 		resultsLoc := filepath.Join(cwd, "testdata", "attach", "plugin_attach_results.json")
 
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configFile, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
+		require.NoError(t, err)
 		So(err, ShouldBeNil)
 
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
@@ -55,24 +54,24 @@ func TestAttachResults(t *testing.T) {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
 					pluginCmds, err := Render(command, conf.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
 					So(err, ShouldBeNil)
 					testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
-					require.NoError(t, err, "Couldn't find task")
+					require.NoError(t, err)
 					So(testTask, ShouldNotBeNil)
 					// ensure test results are exactly as expected
 					// attempt to open the file
 					reportFile, err := os.Open(resultsLoc)
-					require.NoError(t, err, "Couldn't open report file: '%v'", err)
+					require.NoError(t, err)
 					results := &task.LocalTestResults{}
 					err = utility.ReadJSON(reportFile, results)
-					require.NoError(t, err, "Couldn't read report file: '%v'", err)
+					require.NoError(t, err)
 					testResults := *results
 					So(testTask.LocalTestResults, ShouldResemble, testResults.Results)
-					require.NoError(t, err, "Couldn't clean up test temp dir")
+					require.NoError(t, err)
 				}
 			}
 		})
@@ -92,7 +91,7 @@ func TestAttachRawResults(t *testing.T) {
 		resultsLoc := filepath.Join(cwd, "testdata", "attach", "plugin_attach_results_raw.json")
 
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configFile, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
+		require.NoError(t, err)
 
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
 		require.NoError(t, err)
@@ -106,7 +105,7 @@ func TestAttachRawResults(t *testing.T) {
 				for _, command := range projTask.Commands {
 
 					pluginCmds, err := Render(command, conf.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 					// create a plugin communicator
@@ -116,16 +115,16 @@ func TestAttachRawResults(t *testing.T) {
 					Convey("when retrieving task", func() {
 						// fetch the task
 						testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
-						require.NoError(t, err, "Couldn't find task")
+						require.NoError(t, err)
 						So(testTask, ShouldNotBeNil)
 
 						Convey("test results should match and raw log should be in appropriate collection", func() {
 
 							reportFile, err := os.Open(resultsLoc)
-							require.NoError(t, err, "Couldn't open report file: '%v'", err)
+							require.NoError(t, err)
 							results := &task.LocalTestResults{}
 							err = utility.ReadJSON(reportFile, results)
-							require.NoError(t, err, "Couldn't read report file: '%v'", err)
+							require.NoError(t, err)
 
 							testResults := *results
 							So(len(testResults.Results), ShouldEqual, 3)

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -26,7 +26,7 @@ func sendTestResults(ctx context.Context, comm client.Communicator, logger clien
 		return errors.New("cannot send nil results")
 	}
 
-	logger.Task().Info("attaching test results...")
+	logger.Task().Info("Attaching test results...")
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 
 	// TODO (PM-2940): Stop sending Mongo project test results to the
@@ -40,7 +40,7 @@ func sendTestResults(ctx context.Context, comm client.Communicator, logger clien
 	if err := sendTestResultsToCedar(ctx, conf, td, comm, results); err != nil {
 		return errors.Wrap(err, "sending test results to Cedar")
 	}
-	logger.Task().Info("successfully attached results")
+	logger.Task().Info("Successfully attached results.")
 
 	return nil
 }
@@ -53,11 +53,11 @@ func sendTestLog(ctx context.Context, comm client.Communicator, conf *internal.T
 // sendTestLogsAndResults sends the test logs and test results to backend
 // logging results services.
 func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, logs []model.TestLog, results [][]task.TestResult) error {
-	logger.Task().Info("posting test logs...")
+	logger.Task().Info("Posting test logs...")
 	allResults := task.LocalTestResults{}
 	for idx, log := range logs {
-		if ctx.Err() != nil {
-			return errors.New("operation canceled")
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "canceled while sending test logs")
 		}
 
 		if err := sendTestLog(ctx, comm, conf, &log); err != nil {
@@ -69,7 +69,7 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 		// the full list of results.
 		allResults.Results = append(allResults.Results, results[idx]...)
 	}
-	logger.Task().Info("finshed posting test logs")
+	logger.Task().Info("Finished posting test logs.")
 
 	return sendTestResults(ctx, comm, logger, conf, &allResults)
 }

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -33,13 +33,11 @@ func sendTestResults(ctx context.Context, comm client.Communicator, logger clien
 	// database once they can support Presto test results.
 	if model.IsServerResmokeProject(conf.ProjectRef.Identifier) {
 		if err := comm.SendTestResults(ctx, td, results); err != nil {
-			logger.Task().Errorf("error posting parsed results to Evergreen: %+v", err)
-			return errors.Wrap(err, "sending test results to Evergreen")
+			return errors.Wrap(err, "sending parsed test results to Evergreen")
 		}
 	}
 
 	if err := sendTestResultsToCedar(ctx, conf, td, comm, results); err != nil {
-		logger.Task().Errorf("error posting parsed results to Cedar: %+v", err)
 		return errors.Wrap(err, "sending test results to Cedar")
 	}
 	logger.Task().Info("successfully attached results")
@@ -64,7 +62,7 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 
 		if err := sendTestLog(ctx, comm, conf, &log); err != nil {
 			// Continue on error to let the other logs be posted.
-			logger.Task().Errorf("error posting test log: %+v", err)
+			logger.Task().Error(errors.Wrap(err, "sending test log"))
 		}
 
 		// Add all of the test results that correspond to that log to
@@ -116,7 +114,7 @@ func sendTestResultsToCedar(ctx context.Context, conf *internal.TaskConfig, td c
 func sendTestLogToCedar(ctx context.Context, t *task.Task, comm client.Communicator, log *model.TestLog) error {
 	conn, err := comm.GetCedarGRPCConn(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "getting the Cedar gRPC connection for test %s", log.Name)
+		return errors.Wrapf(err, "getting the Cedar gRPC connection for test '%s'", log.Name)
 	}
 
 	timberOpts := &buildlogger.LoggerOptions{
@@ -134,12 +132,12 @@ func sendTestLogToCedar(ctx context.Context, t *task.Task, comm client.Communica
 	levelInfo := send.LevelInfo{Default: level.Info, Threshold: level.Debug}
 	sender, err := buildlogger.NewLoggerWithContext(ctx, log.Name, levelInfo, timberOpts)
 	if err != nil {
-		return errors.Wrapf(err, "creating buildlogger logger for test result %s", log.Name)
+		return errors.Wrapf(err, "creating buildlogger logger for test result '%s'", log.Name)
 	}
 
 	sender.Send(message.ConvertToComposer(level.Info, strings.Join(log.Lines, "\n")))
 	if err = sender.Close(); err != nil {
-		return errors.Wrapf(err, "closing buildlogger logger for test result %s", log.Name)
+		return errors.Wrapf(err, "closing buildlogger logger for test result '%s'", log.Name)
 	}
 
 	return nil

--- a/agent/command/results_xunit_parser.go
+++ b/agent/command/results_xunit_parser.go
@@ -73,17 +73,17 @@ func parseXMLResults(reader io.Reader) ([]testSuite, error) {
 	results := testSuites{}
 	fileData, err := ioutil.ReadAll(reader)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to read results file")
+		return nil, errors.Wrap(err, "reading results file")
 	}
 	// need to try to unmarshal into 2 different structs since the JUnit XML schema
 	// allows for <testsuite> or <testsuites> to be the root
 	// https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
 	if err = xml.Unmarshal(fileData, &results); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "unmarshalling XML test suite")
 	}
 	if len(results.Suites) == 0 {
 		if err = xml.Unmarshal(fileData, &results.Suites); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unmarshalling XML test suites")
 		}
 	}
 	return results.Suites, nil

--- a/agent/command/results_xunit_parser_test.go
+++ b/agent/command/results_xunit_parser_test.go
@@ -20,7 +20,7 @@ func TestXMLParsing(t *testing.T) {
 	Convey("With some test xml files", t, func() {
 		Convey("with a basic test junit file", func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "junit_1.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -68,7 +68,7 @@ func TestXMLParsing(t *testing.T) {
 
 		Convey(`with a "real" pymongo xunit file`, func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "junit_3.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -95,7 +95,7 @@ func TestXMLParsing(t *testing.T) {
 		})
 		Convey(`with a "real" java driver xunit file`, func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "junit_4.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -117,7 +117,7 @@ func TestXMLParsing(t *testing.T) {
 
 		Convey("with a result file produced by a mocha junit reporter", func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "mocha.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -140,7 +140,7 @@ func TestXMLParsing(t *testing.T) {
 
 		Convey("with a result file with errors", func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "results.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -162,7 +162,7 @@ func TestXMLParsing(t *testing.T) {
 
 		Convey("with a result file with test suite errors", func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "junit_5.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -181,7 +181,7 @@ func TestXMLParsing(t *testing.T) {
 
 		Convey("with nested suites", func() {
 			file, err := os.Open(filepath.Join(cwd, "testdata", "xunit", "junit_6.xml"))
-			require.NoError(t, err, "Error reading file")
+			require.NoError(t, err)
 			defer file.Close()
 
 			Convey("the file should parse without error", func() {
@@ -208,7 +208,7 @@ func TestXMLParsing(t *testing.T) {
 func TestXMLToModelConversion(t *testing.T) {
 	Convey("With a parsed XML file and a task", t, func() {
 		file, err := os.Open(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "xunit", "junit_3.xml"))
-		require.NoError(t, err, "Error reading file")
+		require.NoError(t, err)
 		defer file.Close()
 		res, err := parseXMLResults(file)
 		So(err, ShouldBeNil)

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -37,7 +37,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 
 	SkipConvey("With attachResults plugin installed into plugin registry", t, func() {
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
-		require.NoError(t, err, "failed to setup test data")
+		require.NoError(t, err)
 
 		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
 		require.NoError(t, err)
@@ -50,14 +50,14 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
 					pluginCmds, err := Render(command, conf.Project)
-					require.NoError(t, err, "Couldn't get plugin command: %s", command.Command)
+					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
 
 					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
 					So(err, ShouldBeNil)
 					testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
-					require.NoError(t, err, "Couldn't find task")
+					require.NoError(t, err)
 					So(testTask, ShouldNotBeNil)
 				}
 			}

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -58,12 +58,12 @@ func (c *s3get) Name() string { return "s3.get" }
 // s3get-specific implementation of ParseParams.
 func (c *s3get) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {
-		return errors.Wrapf(err, "error decoding %v params", c.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	// make sure the command params are valid
 	if err := c.validateParams(); err != nil {
-		return errors.Wrapf(err, "error validating %v params", c.Name())
+		return errors.Wrap(err, "validating params")
 	}
 
 	return nil
@@ -73,13 +73,13 @@ func (c *s3get) ParseParams(params map[string]interface{}) error {
 // local_file and extract_to is specified.
 func (c *s3get) validateParams() error {
 	if c.AwsKey == "" {
-		return errors.New("aws_key cannot be blank")
+		return errors.New("AWS key cannot be blank")
 	}
 	if c.AwsSecret == "" {
-		return errors.New("aws_secret cannot be blank")
+		return errors.New("AWS secret cannot be blank")
 	}
 	if c.RemoteFile == "" {
-		return errors.New("remote_file cannot be blank")
+		return errors.New("remote file cannot be blank")
 	}
 
 	if c.Region == "" {
@@ -88,17 +88,17 @@ func (c *s3get) validateParams() error {
 
 	// make sure the bucket is valid
 	if err := validateS3BucketName(c.Bucket); err != nil {
-		return errors.Wrapf(err, "%v is an invalid bucket name", c.Bucket)
+		return errors.Wrapf(err, "validating bucket name '%s'", c.Bucket)
 	}
 
 	// make sure local file and extract-to dir aren't both specified
 	if c.LocalFile != "" && c.ExtractTo != "" {
-		return errors.New("cannot specify both local_file and extract_to directory")
+		return errors.New("cannot specify both local file path and directory to extract to")
 	}
 
 	// make sure one is specified
 	if c.LocalFile == "" && c.ExtractTo == "" {
-		return errors.New("must specify either local_file or extract_to")
+		return errors.New("must specify either local file path or directory to extract to")
 	}
 
 	return nil
@@ -127,12 +127,12 @@ func (c *s3get) Execute(ctx context.Context,
 
 	// expand necessary params
 	if err := c.expandParams(conf); err != nil {
-		return err
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	// validate the params
 	if err := c.validateParams(); err != nil {
-		return errors.Wrap(err, "expanded params are not valid")
+		return errors.Wrap(err, "validating expanded params")
 	}
 
 	// create pail bucket
@@ -141,15 +141,15 @@ func (c *s3get) Execute(ctx context.Context,
 	defer utility.PutHTTPClient(httpClient)
 	err := c.createPailBucket(httpClient)
 	if err != nil {
-		return errors.Wrap(err, "problem connecting to s3")
+		return errors.Wrap(err, "creating S3 bucket")
 	}
 
 	if err := c.bucket.Check(ctx); err != nil {
-		return errors.Wrap(err, "invalid pail bucket")
+		return errors.Wrap(err, "checking bucket")
 	}
 
 	if !c.shouldRunForVariant(conf.BuildVariant.Name) {
-		logger.Task().Infof("Skipping S3 get of remote file %v for variant %v",
+		logger.Task().Infof("Skipping S3 get of remote file '%s' for variant '%s'",
 			c.RemoteFile, conf.BuildVariant.Name)
 		return nil
 	}
@@ -162,7 +162,7 @@ func (c *s3get) Execute(ctx context.Context,
 		}
 
 		if err := createEnclosingDirectoryIfNeeded(c.LocalFile); err != nil {
-			return errors.Wrap(err, "unable to create local_file directory")
+			return errors.Wrapf(err, "creating parent directories for local file '%s'", c.LocalFile)
 		}
 	}
 
@@ -172,7 +172,7 @@ func (c *s3get) Execute(ctx context.Context,
 		}
 
 		if err := createEnclosingDirectoryIfNeeded(c.ExtractTo); err != nil {
-			return errors.Wrap(err, "unable to create extract_to directory")
+			return errors.Wrapf(err, "creating enclosing directories for directory '%s'", c.ExtractTo)
 		}
 	}
 
@@ -185,7 +185,7 @@ func (c *s3get) Execute(ctx context.Context,
 	case err := <-errChan:
 		return errors.WithStack(err)
 	case <-ctx.Done():
-		logger.Execution().Info("Received signal to terminate execution of S3 Get Command")
+		logger.Execution().Infof("Received signal to terminate execution of command '%s'", c.Name())
 		return nil
 	}
 
@@ -198,25 +198,25 @@ func (c *s3get) getWithRetry(ctx context.Context, logger client.LoggerProducer) 
 	defer timer.Stop()
 
 	for i := 1; i <= maxS3OpAttempts; i++ {
-		logger.Task().Infof("fetching %s from s3 bucket %s (attempt %d of %d)",
+		logger.Task().Infof("fetching '%s' from S3 bucket '%s' (attempt %d of %d)",
 			c.RemoteFile, c.Bucket, i, maxS3OpAttempts)
 
 		select {
 		case <-ctx.Done():
-			return errors.New("s3 get operation aborted")
+			return errors.Errorf("command '%s' aborted", c.Name())
 		case <-timer.C:
 			err := errors.WithStack(c.get(ctx))
 			if err == nil {
 				return nil
 			}
 
-			logger.Execution().Errorf("problem getting %s from s3 bucket, retrying. [%v]",
+			logger.Execution().Errorf("problem getting remote file '%s' from S3 bucket, retrying. [%s]",
 				c.RemoteFile, err)
 			timer.Reset(backoffCounter.Duration())
 		}
 	}
 
-	return errors.Errorf("S3 get failed after %d attempts", maxS3OpAttempts)
+	return errors.Errorf("command '%s' failed after %d attempts", c.Name(), maxS3OpAttempts)
 }
 
 // Fetch the specified resource from s3.
@@ -226,22 +226,22 @@ func (c *s3get) get(ctx context.Context) error {
 		// remove the file, if it exists
 		if utility.FileExists(c.LocalFile) {
 			if err := os.RemoveAll(c.LocalFile); err != nil {
-				return errors.Wrapf(err, "error clearing local file %v", c.LocalFile)
+				return errors.Wrapf(err, "removing local file '%s'", c.LocalFile)
 			}
 		}
 
 		// download to local file
 		return errors.Wrapf(c.bucket.Download(ctx, c.RemoteFile, c.LocalFile),
-			"error downloading %s to %s", c.RemoteFile, c.LocalFile)
+			"downloading remote file '%s' to local file '%s'", c.RemoteFile, c.LocalFile)
 
 	}
 
 	reader, err := c.bucket.Reader(ctx, c.RemoteFile)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrapf(err, "getting reader for remote file '%s'", c.RemoteFile)
 	}
 	if err := agentutil.ExtractTarball(ctx, reader, c.ExtractTo, []string{}); err != nil {
-		return errors.Wrapf(err, "problem extracting %s from archive", c.RemoteFile)
+		return errors.Wrapf(err, "extracting file '%s' from archive to destination '%s'", c.RemoteFile, c.ExtractTo)
 	}
 
 	return nil

--- a/agent/command/s3_pull.go
+++ b/agent/command/s3_pull.go
@@ -124,7 +124,7 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	// Verify that the contents exist before pulling, otherwise pull may no-op.
 
 	logger.Execution().WarningWhen(filepath.IsAbs(c.WorkingDir) && !strings.HasPrefix(c.WorkingDir, conf.WorkDir),
-		fmt.Sprintf("the working directory ('%s') is an absolute path, which isn't supported except when prefixed by '%s'",
+		fmt.Sprintf("The working directory ('%s') is an absolute path, which isn't supported except when prefixed by '%s'.",
 			c.WorkingDir, conf.WorkDir))
 
 	if err := createEnclosingDirectoryIfNeeded(c.WorkingDir); err != nil {
@@ -137,8 +137,9 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 
 	pullMsg := fmt.Sprintf("Pulling task directory files from S3 from task '%s' on build variant '%s'", c.Task, c.FromBuildVariant)
 	if c.ExcludeFilter != "" {
-		pullMsg += ", excluding files matching filter " + c.ExcludeFilter
+		pullMsg = fmt.Sprintf("%s, excluding files matching filter '%s'", pullMsg, c.ExcludeFilter)
 	}
+	pullMsg += "."
 	logger.Task().Infof(pullMsg)
 	if err = c.bucket.Pull(ctx, pail.SyncOptions{
 		Local:   wd,
@@ -147,6 +148,8 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	}); err != nil {
 		return errors.Wrap(err, "pulling task data from S3")
 	}
+
+	logger.Task().Info("Successfully pulled task directory files.")
 
 	return nil
 }

--- a/agent/command/s3_push.go
+++ b/agent/command/s3_push.go
@@ -25,27 +25,27 @@ func (*s3Push) Name() string {
 }
 
 func (c *s3Push) ParseParams(params map[string]interface{}) error {
-	return errors.Wrapf(c.s3Base.ParseParams(params), "error decoding %s params", c.Name())
+	return errors.Wrapf(c.s3Base.ParseParams(params), "parsing common S3 parameters")
 }
 
 func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if err := c.expandParams(conf); err != nil {
-		return errors.Wrap(err, "error applying expansions to parameters")
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	httpClient := utility.GetDefaultHTTPRetryableClient()
 	defer utility.PutHTTPClient(httpClient)
 
 	if err := c.createBucket(httpClient, conf); err != nil {
-		return errors.Wrap(err, "could not set up S3 task bucket")
+		return errors.Wrap(err, "creating S3 task bucket")
 	}
 
 	wd, err := conf.GetWorkingDirectory("")
 	if err != nil {
-		return errors.Wrap(err, "could not get working directory")
+		return errors.Wrap(err, "getting working directory")
 	}
 
-	pushMsg := fmt.Sprintf("Pushing task directory files from %s into S3", wd)
+	pushMsg := fmt.Sprintf("Pushing task directory files from directory '%s' into S3", wd)
 	if c.ExcludeFilter != "" {
 		pushMsg += ", excluding files matching filter " + c.ExcludeFilter
 	}
@@ -57,7 +57,7 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		Remote:  s3Path,
 		Exclude: c.ExcludeFilter,
 	}); err != nil {
-		return errors.Wrap(err, "error pushing task data to S3")
+		return errors.Wrap(err, "pushing task data to S3")
 	}
 
 	logger.Task().Infof("Successfully pushed task directory files")

--- a/agent/command/s3_push.go
+++ b/agent/command/s3_push.go
@@ -47,8 +47,9 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 
 	pushMsg := fmt.Sprintf("Pushing task directory files from directory '%s' into S3", wd)
 	if c.ExcludeFilter != "" {
-		pushMsg += ", excluding files matching filter " + c.ExcludeFilter
+		pushMsg = fmt.Sprintf("%s, excluding files matching filter '%s'", pushMsg, c.ExcludeFilter)
 	}
+	pushMsg += "."
 	logger.Task().Infof(pushMsg)
 
 	s3Path := conf.Task.S3Path(conf.Task.BuildVariant, conf.Task.DisplayName)
@@ -60,7 +61,7 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		return errors.Wrap(err, "pushing task data to S3")
 	}
 
-	logger.Task().Infof("Successfully pushed task directory files")
+	logger.Task().Info("Successfully pushed task directory files.")
 
 	return nil
 }

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -122,11 +122,11 @@ func (s3pc *s3put) ParseParams(params map[string]interface{}) error {
 		Result:           s3pc,
 	})
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "initializing mapstructure decoder")
 	}
 
 	if err := decoder.Decode(params); err != nil {
-		return errors.Wrapf(err, "error decoding %s params", s3pc.Name())
+		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
 	return s3pc.validate()
@@ -137,35 +137,35 @@ func (s3pc *s3put) validate() error {
 
 	// make sure the command params are valid
 	if s3pc.AwsKey == "" {
-		catcher.Add(errors.New("aws_key cannot be blank"))
+		catcher.New("AWS key cannot be blank")
 	}
 	if s3pc.AwsSecret == "" {
-		catcher.Add(errors.New("aws_secret cannot be blank"))
+		catcher.New("AWS secret cannot be blank")
 	}
 	if s3pc.LocalFile == "" && !s3pc.isMulti() {
-		catcher.Add(errors.New("local_file and local_files_include_filter cannot both be blank"))
+		catcher.New("local file and local files include filter cannot both be blank")
 	}
 	if s3pc.LocalFile != "" && s3pc.isMulti() {
-		catcher.Add(errors.New("local_file and local_files_include_filter cannot both be specified"))
+		catcher.New("local file and local files include filter cannot both be specified")
 	}
 	if s3pc.skipMissing && s3pc.isMulti() {
-		catcher.Add(errors.New("cannot use optional upload with local_files_include_filter"))
+		catcher.New("cannot use optional upload with local files include filter")
 	}
 	if s3pc.RemoteFile == "" {
-		catcher.Add(errors.New("remote_file cannot be blank"))
+		catcher.New("remote file cannot be blank")
 	}
 	if s3pc.ContentType == "" {
-		catcher.Add(errors.New("content_type cannot be blank"))
+		catcher.New("content type cannot be blank")
 	}
 	if s3pc.isMulti() && filepath.IsAbs(s3pc.LocalFile) {
-		catcher.Add(errors.New("cannot use absolute path with local_files_include_filter"))
+		catcher.New("cannot use absolute path with local files include filter")
 	}
 	if s3pc.Visibility == artifact.Signed && (s3pc.Permissions == s3.BucketCannedACLPublicRead || s3pc.Permissions == s3.BucketCannedACLPublicReadWrite) {
 		catcher.New("visibility: signed should not be combined with permissions: public-read or permissions: public-read-write")
 	}
 
 	if !utility.StringSliceContains(artifact.ValidVisibilities, s3pc.Visibility) {
-		catcher.Add(errors.Errorf("invalid visibility setting: %v", s3pc.Visibility))
+		catcher.Errorf("invalid visibility setting '%s'", s3pc.Visibility)
 	}
 
 	if s3pc.Region == "" {
@@ -174,12 +174,12 @@ func (s3pc *s3put) validate() error {
 
 	// make sure the bucket is valid
 	if err := validateS3BucketName(s3pc.Bucket); err != nil {
-		catcher.Add(errors.Wrapf(err, "%v is an invalid bucket name", s3pc.Bucket))
+		catcher.Wrapf(err, "invalid bucket name '%s'", s3pc.Bucket)
 	}
 
 	// make sure the s3 permissions are valid
 	if !validS3Permissions(s3pc.Permissions) {
-		catcher.Add(errors.Errorf("permissions '%v' are not valid", s3pc.Permissions))
+		catcher.Errorf("invalid permissions '%s'", s3pc.Permissions)
 	}
 
 	return catcher.Resolve()
@@ -190,7 +190,7 @@ func (s3pc *s3put) validate() error {
 func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	var err error
 	if err = util.ExpandValues(s3pc, conf.Expansions); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "applying expansions")
 	}
 
 	s3pc.workDir = conf.WorkDir
@@ -202,7 +202,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	if s3pc.Optional != "" {
 		s3pc.skipMissing, err = strconv.ParseBool(s3pc.Optional)
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.Wrap(err, "parsing optional parameter as a boolean")
 		}
 	}
 
@@ -210,7 +210,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	if s3pc.SkipExisting != "" {
 		s3pc.skipExistingBool, err = strconv.ParseBool(s3pc.SkipExisting)
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.Wrap(err, "parsing skip existing parameter as a boolean")
 		}
 	}
 
@@ -218,7 +218,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	if s3pc.PatchOnly != "" {
 		s3pc.isPatchOnly, err = strconv.ParseBool(s3pc.PatchOnly)
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.Wrap(err, "parsing patch only parameter as a boolean")
 		}
 	}
 
@@ -226,7 +226,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	if s3pc.Patchable != "" {
 		s3pc.isPatchable, err = strconv.ParseBool(s3pc.Patchable)
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.Wrap(err, "parsing patchable parameter as a boolean")
 		}
 	}
 
@@ -260,14 +260,14 @@ func (s3pc *s3put) Execute(ctx context.Context,
 	}
 	// re-validate command here, in case an expansion is not defined
 	if err := s3pc.validate(); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "validating expanded parameters")
 	}
 	if conf.Task.IsPatchRequest() && !s3pc.isPatchable {
-		logger.Task().Info("Skipping s3 put because the command is not patchable")
+		logger.Task().Infof("Skipping command '%s' because it is not patchable and this task is part of a patch", s3pc.Name())
 		return nil
 	}
 	if !conf.Task.IsPatchRequest() && s3pc.isPatchOnly {
-		logger.Task().Info("Skipping s3 put because the command is patch only")
+		logger.Task().Infof("Skipping command '%s' because the command is patch only and this task is not part of a patch", s3pc.Name())
 		return nil
 	}
 
@@ -276,32 +276,32 @@ func (s3pc *s3put) Execute(ctx context.Context,
 	httpClient.Timeout = s3HTTPClientTimeout
 	defer utility.PutHTTPClient(httpClient)
 	if err := s3pc.createPailBucket(httpClient); err != nil {
-		return errors.Wrap(err, "problem connecting to s3")
+		return errors.Wrap(err, "connecting to S3")
 	}
 
 	if err := s3pc.bucket.Check(ctx); err != nil {
-		return errors.Wrap(err, "invalid bucket")
+		return errors.Wrap(err, "checking bucket")
 	}
 
 	s3pc.taskdata = client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 
 	if !s3pc.shouldRunForVariant(conf.BuildVariant.Name) {
-		logger.Task().Infof("Skipping S3 put of local file %v for variant %v",
+		logger.Task().Infof("Skipping S3 put of local file '%s' for variant '%s'",
 			s3pc.LocalFile, conf.BuildVariant.Name)
 		return nil
 	}
 
 	if s3pc.isPrivate(s3pc.Visibility) {
-		logger.Task().Infof("Putting private files into s3")
+		logger.Task().Infof("Putting private files into S3")
 
 	} else {
 		if s3pc.isMulti() {
-			logger.Task().Infof("Putting files matching filter %v into path %v in s3 bucket %v",
+			logger.Task().Infof("Putting files matching filter '%s' into path '%s' in S3 bucket '%s'",
 				s3pc.LocalFilesIncludeFilter, s3pc.RemoteFile, s3pc.Bucket)
 		} else if s3pc.isPublic() {
-			logger.Task().Infof("Putting %s into %s/%s (%s)", s3pc.LocalFile, s3pc.Bucket, s3pc.RemoteFile, agentutil.S3DefaultURL(s3pc.Bucket, s3pc.RemoteFile))
+			logger.Task().Infof("Putting local file '%s' into path '%s/%s' (%s)", s3pc.LocalFile, s3pc.Bucket, s3pc.RemoteFile, agentutil.S3DefaultURL(s3pc.Bucket, s3pc.RemoteFile))
 		} else {
-			logger.Task().Infof("Putting %s into %s/%s", s3pc.LocalFile, s3pc.Bucket, s3pc.RemoteFile)
+			logger.Task().Infof("Putting local file '%s' into '%s/%s'", s3pc.LocalFile, s3pc.Bucket, s3pc.RemoteFile)
 		}
 	}
 
@@ -336,16 +336,16 @@ func (s3pc *s3put) putWithRetry(ctx context.Context, comm client.Communicator, l
 retryLoop:
 	for i := 1; i <= maxS3OpAttempts; i++ {
 		if s3pc.isPrivate(s3pc.Visibility) {
-			logger.Task().Infof("performing s3 put of a hidden file")
+			logger.Task().Infof("performing S3 put of a hidden file")
 		} else {
-			logger.Task().Infof("performing s3 put to %s of %s [%d of %d]",
-				s3pc.Bucket, s3pc.RemoteFile,
+			logger.Task().Infof("performing S3 put to file '%s' in bucket '%s' [%d of %d]",
+				s3pc.RemoteFile, s3pc.Bucket,
 				i, maxS3OpAttempts)
 		}
 
 		select {
 		case <-ctx.Done():
-			return errors.New("s3 put operation canceled")
+			return errors.Errorf("command '%s' canceled", s3pc.Name())
 		case <-timer.C:
 			filesList = []string{s3pc.LocalFile}
 
@@ -358,11 +358,11 @@ retryLoop:
 				}
 				filesList, err = b.Build()
 				if err != nil {
-					return errors.Wrapf(err, "error processing filter %s",
+					return errors.Wrapf(err, "processing local files include filter '%s'",
 						strings.Join(s3pc.LocalFilesIncludeFilter, " "))
 				}
 				if len(filesList) == 0 {
-					logger.Task().Infof("s3.put: file filter '%s' matched no files", strings.Join(s3pc.LocalFilesIncludeFilter, " "))
+					logger.Task().Infof("file filter '%s' matched no files", strings.Join(s3pc.LocalFilesIncludeFilter, " "))
 					return nil
 				}
 			}
@@ -373,7 +373,7 @@ retryLoop:
 		uploadLoop:
 			for _, fpath := range filesList {
 				if ctx.Err() != nil {
-					return errors.New("s3 put operation canceled")
+					return errors.Errorf("command '%s' canceled", s3pc.Name())
 				}
 
 				remoteName := s3pc.RemoteFile
@@ -387,7 +387,7 @@ retryLoop:
 				if s3pc.skipExistingBool {
 					exists, err := s3pc.remoteFileExists(remoteName)
 					if err != nil {
-						return errors.Wrapf(err, "error checking if file '%s' exists", remoteName)
+						return errors.Wrapf(err, "checking if file '%s' exists", remoteName)
 					}
 					if exists {
 						logger.Task().Infof("noop: not uploading file '%s' because remote file '%s' already exists. Continuing to upload other files.", fpath, remoteName)
@@ -415,7 +415,7 @@ retryLoop:
 					}
 
 					// in all other cases, log an error and retry after an interval.
-					logger.Task().Error(errors.WithMessage(err, "problem putting s3 file"))
+					logger.Task().Error(errors.WithMessage(err, "putting S3 file"))
 					timer.Reset(backoffCounter.Duration())
 					continue retryLoop
 				}
@@ -428,7 +428,7 @@ retryLoop:
 	}
 
 	if len(uploadedFiles) == 0 && s3pc.skipMissing {
-		logger.Task().Info("s3 put uploaded no files")
+		logger.Task().Info("S3 put uploaded no files")
 		return nil
 	}
 
@@ -437,7 +437,7 @@ retryLoop:
 		return err
 	}
 
-	logger.Task().WarningWhen(strings.Contains(s3pc.Bucket, "."), "bucket names containing dots that are created after Sept. 30, 2020 are not guaranteed to have valid attached URLs")
+	logger.Task().WarningWhen(strings.Contains(s3pc.Bucket, "."), "Bucket names containing dots that are created after Sept. 30, 2020 are not guaranteed to have valid attached URLs.")
 
 	if len(uploadedFiles) != len(filesList) && !s3pc.skipMissing {
 		logger.Task().Infof("attempted to upload %d files, %d successfully uploaded", len(filesList), len(uploadedFiles))
@@ -487,7 +487,7 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 
 	err := comm.AttachFiles(ctx, s3pc.taskdata, files)
 	if err != nil {
-		return errors.Wrap(err, "Attach files failed")
+		return errors.Wrap(err, "attaching files")
 	}
 
 	return nil
@@ -531,15 +531,10 @@ func (s3pc *s3put) remoteFileExists(remoteName string) (bool, error) {
 	}
 	_, err := pail.GetHeadObject(requestParams)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case notFoundError:
-				return false, nil
-			default:
-				return false, errors.Wrapf(err, "error getting head object for: %s", remoteName)
-			}
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == notFoundError {
+			return false, nil
 		} else {
-			return false, errors.Wrapf(err, "error reading error while getting head object '%s'", remoteName)
+			return false, errors.Wrapf(err, " getting head object for remote file '%s'", remoteName)
 		}
 	}
 	return true, nil

--- a/agent/command/scripting_test.go
+++ b/agent/command/scripting_test.go
@@ -23,7 +23,7 @@ func TestScripting(t *testing.T) {
 			cmd := &scriptingExec{Harness: "lisp"}
 			err := cmd.ParseParams(map[string]interface{}{"args": true})
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "error decoding")
+			assert.Contains(t, err.Error(), "decoding")
 		})
 		t.Run("NoArgsErrors", func(t *testing.T) {
 			cmd := &scriptingExec{Harness: "lisp"}

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -176,8 +178,7 @@ func (s *shellExecuteCommandSuite) TestCancellingContextShouldCancelCommand() {
 
 	err := cmd.Execute(ctx, s.comm, s.logger, s.conf)
 	s.Require().NotNil(err)
-	s.Contains(err.Error(), "shell command interrupted")
-	s.NotContains(err.Error(), "error while stopping process")
+	s.True(utility.IsContextError(errors.Cause(err)))
 }
 
 func (s *shellExecuteCommandSuite) TestEnvIsSetAndDefaulted() {

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// kim: TODO: continue here
+
 type shellExecuteCommandSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -19,8 +19,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// kim: TODO: continue here
-
 type shellExecuteCommandSuite struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -103,29 +101,29 @@ func (s *shellExecuteCommandSuite) TestTerribleQuotingIsHandledProperly() {
 		`echo "'"; exit 0`,
 		`echo \'; exit 0`,
 		`process_kill_list="(^cl\.exe$|bsondump|java|lein|lldb|mongo|python|_test$|_test\.exe$)"
-        process_exclude_list="(main|tuned|evergreen|go|godoc|gocode|make)"
+		process_exclude_list="(main|tuned|evergreen|go|godoc|gocode|make)"
 
-        if [ "Windows_NT" = "$OS" ]; then
-          processes=$(tasklist /fo:csv | awk -F'","' '{x=$1; gsub("\"","",x); print $2, x}' | grep -iE "$process_kill_list" | grep -ivE "$process_exclude_list")
-          kill_process () { pid=$(echo $1 | cut -f1 -d ' '); echo "Killing process $1"; taskkill /pid "$pid" /f; }
-        else
-          pgrep -f --list-full ".*" 2>&1 | grep -qE "(illegal|invalid|unrecognized) option"
-          if [ $? -ne 0 ]; then
-            pgrep_list=$(pgrep -f --list-full "$process_kill_list")
-          else
-            pgrep_list=$(pgrep -f -l "$process_kill_list")
-          fi
+		if [ "Windows_NT" = "$OS" ]; then
+			processes=$(tasklist /fo:csv | awk -F'","' '{x=$1; gsub("\"","",x); print $2, x}' | grep -iE "$process_kill_list" | grep -ivE "$process_exclude_list")
+			kill_process () { pid=$(echo $1 | cut -f1 -d ' '); echo "Killing process $1"; taskkill /pid "$pid" /f; }
+		else
+			pgrep -f --list-full ".*" 2>&1 | grep -qE "(illegal|invalid|unrecognized) option"
+			if [ $? -ne 0 ]; then
+				pgrep_list=$(pgrep -f --list-full "$process_kill_list")
+			else
+				pgrep_list=$(pgrep -f -l "$process_kill_list")
+			fi
 
-          processes=$(echo "$pgrep_list" | grep -ivE "$process_exclude_list" | sed -e '/^ *[0-9]/!d; s/^ *//; s/[[:cntrl:]]//g;')
-          kill_process () { pid=$(echo $1 | cut -f1 -d ' '); echo "Killing process $1"; kill -9 $pid; }
-        fi
-        IFS=$(printf "\n\r")
-        for process in $processes
-        do
-          kill_process "$process"
-        done
+			processes=$(echo "$pgrep_list" | grep -ivE "$process_exclude_list" | sed -e '/^ *[0-9]/!d; s/^ *//; s/[[:cntrl:]]//g;')
+			kill_process () { pid=$(echo $1 | cut -f1 -d ' '); echo "Killing process $1"; kill -9 $pid; }
+		fi
+		IFS=$(printf "\n\r")
+		for process in $processes
+		do
+			kill_process "$process"
+		done
 
-        exit 0
+		exit 0
 `,
 	} {
 		cmd := &shellExec{
@@ -242,5 +240,4 @@ func (s *shellExecuteCommandSuite) TestFailingShellCommandErrors() {
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	s.Require().NotNil(err)
 	s.Contains(err.Error(), "shell script encountered problem: exit code 1")
-	s.NotContains(err.Error(), "error waiting on process")
 }

--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -48,7 +48,7 @@ func (c *timeout) Execute(ctx context.Context,
 		// If destructuring as ints fails, or neither timeout is set, destructure as strings.
 		t := &timeoutStr{}
 		if errStr := mapstructure.Decode(c.params, t); errStr != nil {
-			return errors.New("could not decode params as either string or int")
+			return errors.Wrap(err, "decoding mapstructure params")
 		}
 		if err := util.ExpandValues(t, conf.Expansions); err != nil {
 			return errors.Wrap(err, "applying expansions")
@@ -56,7 +56,7 @@ func (c *timeout) Execute(ctx context.Context,
 		timeout, errTimeout := strconv.Atoi(t.TimeoutSecs)
 		exec, errExec := strconv.Atoi(t.ExecTimeoutSecs)
 		if errTimeout != nil && errExec != nil {
-			return errors.Errorf("could not convert strings to int, %s, %s", t.TimeoutSecs, t.ExecTimeoutSecs)
+			return errors.Errorf("could not convert idle timeout '%s' and exec timeout '%s' to integers", t.TimeoutSecs, t.ExecTimeoutSecs)
 		}
 		c.TimeoutSecs = timeout
 		c.ExecTimeoutSecs = exec
@@ -64,11 +64,11 @@ func (c *timeout) Execute(ctx context.Context,
 
 	if c.TimeoutSecs != 0 {
 		conf.SetIdleTimeout(c.TimeoutSecs)
-		logger.Execution().Infof("Set idle timeout to %d seconds", c.TimeoutSecs)
+		logger.Execution().Infof("Set idle timeout to %d seconds.", c.TimeoutSecs)
 	}
 	if c.ExecTimeoutSecs != 0 {
 		conf.SetExecTimeout(c.ExecTimeoutSecs)
-		logger.Execution().Infof("Set exec timeout to %d seconds", c.ExecTimeoutSecs)
+		logger.Execution().Infof("Set exec timeout to %d seconds.", c.ExecTimeoutSecs)
 	}
 	return nil
 

--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -51,7 +51,7 @@ func (c *timeout) Execute(ctx context.Context,
 			return errors.New("could not decode params as either string or int")
 		}
 		if err := util.ExpandValues(t, conf.Expansions); err != nil {
-			return errors.Wrap(err, "error expanding expansion values")
+			return errors.Wrap(err, "applying expansions")
 		}
 		timeout, errTimeout := strconv.Atoi(t.TimeoutSecs)
 		exec, errExec := strconv.Atoi(t.ExecTimeoutSecs)

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -15,7 +15,7 @@ func dirExists(path string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, errors.Wrap(err, "problem running stat on path")
+		return false, errors.Wrap(err, "running stat on path")
 	}
 
 	if !stat.IsDir() {
@@ -37,7 +37,7 @@ func createEnclosingDirectoryIfNeeded(path string) error {
 	}
 
 	if err := os.MkdirAll(localDir, 0755); err != nil {
-		return errors.Wrapf(err, "problem creating directory %s", localDir)
+		return errors.Wrapf(err, "creating directory '%s'", localDir)
 	}
 
 	return nil
@@ -46,9 +46,9 @@ func createEnclosingDirectoryIfNeeded(path string) error {
 func expandModulePrefix(conf *internal.TaskConfig, module, prefix string, logger client.LoggerProducer) string {
 	modulePrefix, err := conf.Expansions.ExpandString(prefix)
 	if err != nil {
+		logger.Task().Error(errors.Wrapf(err, "expanding module prefix '%s'", modulePrefix))
 		modulePrefix = prefix
-		logger.Task().Errorf("module prefix '%s' can't be expanded: %s", prefix, err.Error())
-		logger.Task().Warning("will attempt to check out into the module prefix verbatim")
+		logger.Task().Warningf("Will attempt to check out into the module prefix '%s' verbatim.", prefix)
 	}
 	if conf.ModulePaths == nil {
 		conf.ModulePaths = map[string]string{}

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -67,7 +67,7 @@ func (a *Agent) removeTaskDirectory(tc *taskContext) {
 	err = a.removeAll(abs)
 	grip.Critical(errors.Wrapf(err, "removing task directory '%s'", tc.taskDirectory))
 	grip.InfoWhen(err == nil, message.Fields{
-		"message":   "Successfully deleted directory for completed task",
+		"message":   "Successfully deleted directory for completed task.",
 		"directory": tc.taskDirectory,
 	})
 }

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -24,22 +24,23 @@ func (a *Agent) createTaskDirectory(tc *taskContext) (string, error) {
 	_, err := h.Write([]byte(
 		fmt.Sprintf("%s_%d_%d", tc.taskConfig.Task.Id, tc.taskConfig.Task.Execution, os.Getpid())))
 	if err != nil {
-		tc.logger.Execution().Errorf("Error creating task directory name: %v", err)
+		tc.logger.Execution().Error(errors.Wrap(err, "creating task directory name"))
 		return "", err
 	}
 
 	dirName := hex.EncodeToString(h.Sum(nil))
 	newDir := filepath.Join(a.opts.WorkingDirectory, dirName)
 
-	tc.logger.Execution().Infof("Making new folder for task execution: %v", newDir)
+	tc.logger.Execution().Infof("Making new folder '%s' for task execution.", newDir)
 
 	if err = os.MkdirAll(newDir, 0777); err != nil {
-		tc.logger.Execution().Errorf("Error creating task directory: %v", err)
+		tc.logger.Execution().Error(errors.Wrapf(err, "creating task directory '%s'", newDir))
 		return "", err
 	}
 
-	if err = os.MkdirAll(filepath.Join(newDir, "tmp"), 0777); err != nil {
-		tc.logger.Execution().Warning(message.WrapError(err, "problem creating task temporary, continuing"))
+	tmpDir := filepath.Join(newDir, "tmp")
+	if err = os.MkdirAll(tmpDir, 0777); err != nil {
+		tc.logger.Execution().Warning(errors.Wrapf(err, "creating task temporary directory '%s'", tmpDir))
 	}
 
 	return newDir, nil
@@ -51,20 +52,20 @@ func (a *Agent) createTaskDirectory(tc *taskContext) (string, error) {
 // exits.
 func (a *Agent) removeTaskDirectory(tc *taskContext) {
 	if tc.taskDirectory == "" {
-		grip.Info("Task directory is not set, not removing")
+		grip.Info("Task directory is not set, not removing.")
 		return
 	}
-	grip.Infof("Deleting directory for completed task: %s", tc.taskDirectory)
+	grip.Infof("Deleting task directory '%s' for completed task.", tc.taskDirectory)
 
 	// Removing long relative paths hangs on Windows https://github.com/golang/go/issues/36375,
 	// so we have to convert to an absolute path before removing.
 	abs, err := filepath.Abs(tc.taskDirectory)
 	if err != nil {
-		grip.Critical(errors.Wrap(err, "Problem getting absolute directory for task directory"))
+		grip.Critical(errors.Wrapf(err, "getting absolute path for task directory '%s'", tc.taskDirectory))
 		return
 	}
 	err = a.removeAll(abs)
-	grip.Critical(errors.Wrapf(err, "Error removing working directory for the task: %s", tc.taskDirectory))
+	grip.Critical(errors.Wrapf(err, "removing task directory '%s'", tc.taskDirectory))
 	grip.InfoWhen(err == nil, message.Fields{
 		"message":   "Successfully deleted directory for completed task",
 		"directory": tc.taskDirectory,
@@ -73,13 +74,13 @@ func (a *Agent) removeTaskDirectory(tc *taskContext) {
 
 // removeAll is the same as os.RemoveAll, but recursively changes permissions for subdirectories and contents before removing
 func (a *Agent) removeAll(dir string) error {
-	grip.Error(filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+	grip.Error(errors.Wrapf(filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
-		grip.Error(os.Chmod(path, 0777))
+		grip.Error(errors.Wrapf(os.Chmod(path, 0777), "changing permission before removal for path '%s'", path))
 		return nil
-	}))
+	}), "recursively walking through path to change permissions"))
 	return os.RemoveAll(dir)
 }
 
@@ -118,18 +119,18 @@ func tryCleanupDirectory(dir string) {
 
 	// Don't run in a development environment
 	if _, err = os.Stat(filepath.Join(dir, ".git")); !os.IsNotExist(err) {
-		grip.Notice("refusing to clean a directory that contains '.git'")
+		grip.Notice("Refusing to clean a directory that contains '.git'.")
 		return
 	}
 
 	usr, err := user.Current()
 	if err != nil {
-		grip.Warning(err)
+		grip.Warning(errors.Wrap(err, "getting current user"))
 		return
 	}
 
 	if strings.HasPrefix(dir, usr.HomeDir) || strings.Contains(dir, "cygwin") {
-		grip.Notice("not cleaning up directory, because it is in the home directory.")
+		grip.Notice("Not cleaning up directory, because it is in the home directory.")
 		return
 	}
 
@@ -159,10 +160,10 @@ func tryCleanupDirectory(dir string) {
 		return
 	}
 
-	grip.Infof("attempting to clean up directory '%s'", dir)
+	grip.Infof("Attempting to clean up directory '%s'.", dir)
 	for _, p := range paths {
 		if err = os.RemoveAll(p); err != nil {
-			grip.Notice(err)
+			grip.Notice(errors.Wrapf(err, "removing path '%s'", p))
 		}
 	}
 }

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -1,2 +1,3 @@
-// Package agent runs tasks on build hosts.
+// Package agent runs tasks on differents runtime environments, such as hosts
+// and containers.
 package agent

--- a/agent/global.go
+++ b/agent/global.go
@@ -18,10 +18,10 @@ const (
 	// timeout_secs can be specified only on a command.
 	defaultIdleTimeout = 2 * time.Hour
 
-	// defaultExecTimeoutSecs specifies in seconds the maximum time a task
-	// is allowed to run for, even if it is not idle. This default is used
-	// if exec_timeout_secs is not specified in the project file.
-	// exec_timeout_secs can be specified only at the project and task level.
+	// DefaultExecTimeout specifies the maximum time a task is allowed to run
+	// for, even if it is not idle. This default is used if exec_timeout_secs is
+	// not specified in the project file. exec_timeout_secs can be specified
+	// only at the project and task level.
 	DefaultExecTimeout = 6 * time.Hour
 
 	// defaultHeartbeatInterval is the interval after which agent sends a

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -585,7 +585,7 @@ func (c *baseCommunicator) SendTaskResults(ctx context.Context, taskData TaskDat
 	info.setTaskPathSuffix("results")
 	resp, err := c.retryRequest(ctx, info, r)
 	if err != nil {
-		return utility.RespErrorf(resp, errors.Wrapf(err, "adding %d results").Error())
+		return utility.RespErrorf(resp, errors.Wrapf(err, "adding %d results", len(r.Results)).Error())
 	}
 	defer resp.Body.Close()
 	return nil

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -88,14 +88,12 @@ type SharedCommunicator interface {
 	// SendLogMessages sends a group of log messages to the API Server
 	SendLogMessages(context.Context, TaskData, []apimodels.LogMessage) error
 
-	// The following operations use the legacy API server and are
-	// used by task commands.
+	// The following operations are used by task commands.
 	SendTestResults(context.Context, TaskData, *task.LocalTestResults) error
 	SendTestLog(context.Context, TaskData, *model.TestLog) (string, error)
 	GetTaskPatch(context.Context, TaskData, string) (*patchmodel.Patch, error)
 	GetPatchFile(context.Context, TaskData, string) (string, error)
 
-	// The following operations are used by
 	NewPush(context.Context, TaskData, *apimodels.S3CopyRequest) (*model.PushLog, error)
 	UpdatePushStatus(context.Context, TaskData, *model.PushLog) error
 	AttachFiles(context.Context, TaskData, []*artifact.File) error

--- a/agent/internal/client/logger_producer.go
+++ b/agent/internal/client/logger_producer.go
@@ -63,7 +63,7 @@ func (l *logHarness) Close() error {
 		catcher.Add(s.Close())
 	}
 
-	return errors.Wrap(catcher.Resolve(), "problem closing log harness")
+	return errors.Wrap(catcher.Resolve(), "closing log harness")
 }
 
 func (l *logHarness) Closed() bool {
@@ -126,7 +126,7 @@ func (l *singleChannelLogHarness) Close() error {
 
 	catcher.Add(l.logger.GetSender().Close())
 
-	return errors.Wrap(catcher.Resolve(), "problem closing log harness")
+	return errors.Wrap(catcher.Resolve(), "closing log harness")
 }
 
 func (l *singleChannelLogHarness) Closed() bool {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -200,7 +200,7 @@ func (c *Mock) Heartbeat(ctx context.Context, td TaskData) (string, error) {
 		return evergreen.TaskFailed, nil
 	}
 	if c.HeartbeatShouldConflict {
-		return evergreen.TaskConflict, errors.Errorf("Unauthorized - wrong secret")
+		return evergreen.TaskConflict, errors.Errorf("unauthorized - wrong secret")
 	}
 	if c.HeartbeatShouldSometimesErr {
 		if c.HeartbeatShouldErr {
@@ -423,7 +423,7 @@ func (c *Mock) NewPush(ctx context.Context, td TaskData, req *apimodels.S3CopyRe
 	return nil, nil
 }
 
-func (c *Mock) UpdatePushStatus(ctx context.Context, td TaskData, pushlog *serviceModel.PushLog) error {
+func (c *Mock) UpdatePushStatus(ctx context.Context, td TaskData, pushLog *serviceModel.PushLog) error {
 	return nil
 }
 

--- a/agent/internal/client/pod_methods.go
+++ b/agent/internal/client/pod_methods.go
@@ -12,26 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *podCommunicator) GetAgentSetupData(ctx context.Context) (*apimodels.AgentSetupData, error) {
-	info := requestInfo{
-		method: http.MethodGet,
-		path:   "agent/setup",
-	}
-
-	resp, err := c.retryRequest(ctx, info, nil)
-	if err != nil {
-		return nil, utility.RespErrorf(resp, "getting agent setup data: %s", err.Error())
-	}
-
-	var data apimodels.AgentSetupData
-	if err := utility.ReadJSON(resp.Body, data); err != nil {
-		return nil, errors.Wrap(err, "reading agent setup data from response")
-	}
-
-	return &data, nil
-}
-
-// EndTask marks the task as finished with the given status
+// EndTask marks the task as finished with the given status.
 func (c *podCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEndDetail, taskData TaskData) (*apimodels.EndTaskResponse, error) {
 	info := requestInfo{
 		method:   http.MethodPost,
@@ -40,7 +21,7 @@ func (c *podCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEnd
 	}
 	resp, err := c.retryRequest(ctx, info, detail)
 	if err != nil {
-		return nil, utility.RespErrorf(resp, "ending task '%s': %s", taskData.ID, err.Error())
+		return nil, utility.RespErrorf(resp, errors.Wrap(err, "ending task").Error())
 	}
 	var taskEndResp apimodels.EndTaskResponse
 	if err = utility.ReadJSON(resp.Body, &taskEndResp); err != nil {
@@ -54,7 +35,8 @@ func (c *podCommunicator) EndTask(ctx context.Context, detail *apimodels.TaskEnd
 	return &taskEndResp, nil
 }
 
-// GetNextTask returns a next task response by getting the next task for a given host.
+// GetNextTask returns information about the next task to run, or other
+// miscellaneous actions to take in between tasks.
 func (c *podCommunicator) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDetails) (*apimodels.NextTaskResponse, error) {
 	info := requestInfo{
 		method: http.MethodGet,
@@ -62,12 +44,12 @@ func (c *podCommunicator) GetNextTask(ctx context.Context, details *apimodels.Ge
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
-		return nil, utility.RespErrorf(resp, "getting next task: %s", err.Error())
+		return nil, utility.RespErrorf(resp, errors.Wrap(err, "getting next task").Error())
 	}
 
 	var nextTask apimodels.NextTaskResponse
 	if err := utility.ReadJSON(resp.Body, &nextTask); err != nil {
-		return nil, errors.Wrap(err, "reading next task from response")
+		return nil, errors.Wrap(err, "reading next task reply from response")
 	}
 
 	return &nextTask, nil

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -67,17 +67,17 @@ func (t *TaskConfig) GetExecTimeout() int {
 func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t *task.Task, r *model.ProjectRef, patchDoc *patch.Patch, e util.Expansions) (*TaskConfig, error) {
 	// do a check on if the project is empty
 	if p == nil {
-		return nil, errors.Errorf("project for task with project_id %v is empty", t.Project)
+		return nil, errors.Errorf("project '%s' is nil", t.Project)
 	}
 
 	// check on if the project ref is empty
 	if r == nil {
-		return nil, errors.Errorf("Project ref with identifier: %v was empty", p.Identifier)
+		return nil, errors.Errorf("project ref '%s' is nil", p.Identifier)
 	}
 
 	bv := p.FindBuildVariant(t.BuildVariant)
 	if bv == nil {
-		return nil, errors.Errorf("couldn't find buildvariant: '%v'", t.BuildVariant)
+		return nil, errors.Errorf("cannot find build variant '%s' for task in project '%s'", t.BuildVariant, t.Project)
 	}
 
 	taskConfig := &TaskConfig{
@@ -108,11 +108,11 @@ func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
 	}
 
 	if stat, err := os.Stat(dir); os.IsNotExist(err) {
-		return "", errors.Errorf("directory %s does not exist", dir)
+		return "", errors.Errorf("path '%s' does not exist", dir)
 	} else if err != nil || stat == nil {
-		return "", errors.Wrapf(err, "error retrieving file info for %s", dir)
+		return "", errors.Wrapf(err, "retrieving file info for path '%s'", dir)
 	} else if !stat.IsDir() {
-		return "", errors.Errorf("path %s is not a directory", dir)
+		return "", errors.Errorf("path '%s' is not a directory", dir)
 	}
 
 	return dir, nil
@@ -127,10 +127,10 @@ func (c *TaskConfig) GetCloneMethod() string {
 
 func (tc *TaskConfig) GetTaskGroup(taskGroup string) (*model.TaskGroup, error) {
 	if tc == nil {
-		return nil, errors.New("unable to get task group: TaskConfig is nil")
+		return nil, errors.New("unable to get task group because task config is nil")
 	}
 	if tc.Task == nil {
-		return nil, errors.New("unable to get task group: task is nil")
+		return nil, errors.New("unable to get task group because task is nil")
 	}
 	if tc.Task.Version == "" {
 		return nil, errors.New("task has no version")
@@ -152,7 +152,7 @@ func (tc *TaskConfig) GetTaskGroup(taskGroup string) (*model.TaskGroup, error) {
 	} else {
 		tg = tc.Project.FindTaskGroup(taskGroup)
 		if tg == nil {
-			return nil, errors.Errorf("couldn't find task group %s", tc.Task.TaskGroup)
+			return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", tc.Task.TaskGroup, tc.Project.Identifier)
 		}
 	}
 	if tg.Timeout == nil {

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -42,7 +42,7 @@ func TestTaskConfigGetWorkingDirectory(t *testing.T) {
 }
 
 func TestTaskConfigGetTaskGroup(t *testing.T) {
-	require.NoError(t, db.ClearCollections(model.VersionCollection), "failed to clear collections")
+	require.NoError(t, db.ClearCollections(model.VersionCollection))
 	tgName := "example_task_group"
 	projYml := `
 timeout:

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -13,11 +13,11 @@ import (
 func MakeTaskConfigFromModelData(settings *evergreen.Settings, data *testutil.TestModelData) (*internal.TaskConfig, error) {
 	oauthToken, err := settings.GetGithubOauthToken()
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting oauth token")
+		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 	exp, err := model.PopulateExpansions(data.Task, data.Host, oauthToken)
 	if err != nil {
-		return nil, errors.Wrap(err, "error populating expansions")
+		return nil, errors.Wrap(err, "populating expansions")
 	}
 	var dv *apimodels.DistroView
 	if data.Host != nil {
@@ -27,7 +27,7 @@ func MakeTaskConfigFromModelData(settings *evergreen.Settings, data *testutil.Te
 	}
 	config, err := internal.NewTaskConfig(data.Host.Distro.WorkDir, dv, data.Project, data.Task, data.ProjectRef, nil, exp)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not make task config from test model data")
+		return nil, errors.Wrap(err, "making task config from test model data")
 	}
 	return config, nil
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -172,11 +172,11 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, fileName string) client.LogOpts {
 	splunkServer, err := tc.expansions.ExpandString(in.SplunkServer)
 	if err != nil {
-		grip.Error(errors.Wrap(err, "error expanding splunk server"))
+		grip.Error(errors.Wrap(err, "expanding Splunk server"))
 	}
 	splunkToken, err := tc.expansions.ExpandString(in.SplunkToken)
 	if err != nil {
-		grip.Error(errors.Wrap(err, "error expanding splunk token"))
+		grip.Error(errors.Wrap(err, "expanding Splunk token"))
 	}
 	if in.LogDirectory != "" {
 		grip.Error(errors.Wrap(os.MkdirAll(in.LogDirectory, os.ModeDir|os.ModePerm), "error making log directory"))

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/jasper"
+	"github.com/pkg/errors"
 )
 
 // StatsCollector samples machine statistics and logs them
@@ -40,7 +41,7 @@ func (sc *StatsCollector) expandCommands(exp *util.Expansions) {
 	for _, cmd := range sc.Cmds {
 		expanded, err := exp.ExpandString(cmd)
 		if err != nil {
-			sc.logger.System().Warningf("Couldn't expand '%s': %v", cmd, err)
+			sc.logger.System().Warning(errors.Wrapf(err, "expanding stats command '%s'", cmd))
 			continue
 		}
 		expandedCmds = append(expandedCmds, expanded)
@@ -50,7 +51,7 @@ func (sc *StatsCollector) expandCommands(exp *util.Expansions) {
 
 func (sc *StatsCollector) logStats(ctx context.Context, exp *util.Expansions) {
 	if sc.Interval < 0 {
-		panic(fmt.Sprintf("Illegal interval: %v", sc.Interval))
+		panic(fmt.Sprintf("Illegal stats collection interval: %s", sc.Interval))
 	}
 	if sc.Interval == 0 {
 		sc.Interval = 60 * time.Second

--- a/agent/status_test.go
+++ b/agent/status_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -54,8 +53,6 @@ func (s *StatusSuite) TestBasicAssumptions() {
 }
 
 func (s *StatusSuite) TestPopulateSystemInfo() {
-	grip.Alert(strings.Join(s.resp.SystemInfo.Errors, ";\n"))
-	grip.Info(s.resp.SystemInfo)
 	s.NotNil(s.resp.SystemInfo)
 }
 
@@ -140,7 +137,7 @@ func (s *StatusSuite) TestAgentFailsToStartTwice() {
 	case err = <-second:
 	}
 	s.Error(err)
-	s.Contains(err.Error(), "another agent is running on 2287")
+	s.Contains(err.Error(), "another process is running on localhost port 2287")
 
 	cancel()
 	err = <-first

--- a/agent/system_metrics_test.go
+++ b/agent/system_metrics_test.go
@@ -38,7 +38,7 @@ func (m *mockMetricCollector) format() systemmetrics.DataFormat {
 
 func (m *mockMetricCollector) collect(context.Context) ([]byte, error) {
 	if m.collectErr {
-		return nil, errors.New("Error collecting metrics")
+		return nil, errors.New("error collecting metrics")
 	} else {
 		m.count += 1
 		return []byte(fmt.Sprintf("%s-%d", m.name(), m.count)), nil

--- a/agent/util/archive_tar.go
+++ b/agent/util/archive_tar.go
@@ -66,7 +66,7 @@ FileLoop:
 		//strip any leading slash from the tarball header path
 		intarball = strings.TrimLeft(intarball, "/")
 
-		logger.Infoln("Adding to tarball:", intarball)
+		logger.Infof("Adding file to tarball: '%s'.", intarball)
 		if _, hasKey := processed[intarball]; hasKey {
 			continue
 		} else {
@@ -92,22 +92,25 @@ FileLoop:
 		numFilesArchived++
 		err := tarWriter.WriteHeader(hdr)
 		if err != nil {
-			return numFilesArchived, errors.Wrapf(err, "writing header for tarball '%s'", intarball)
+			return numFilesArchived, errors.Wrapf(err, "writing tarball header for file '%s'", intarball)
 		}
 
 		in, err := os.Open(file.Path)
 		if err != nil {
 			return numFilesArchived, errors.Wrapf(err, "opening file '%s'", file.Path)
 		}
-		logger.Debug(errors.Wrapf(in.Close(), "closing file '%s'", file.Path))
 		amountWrote, err := io.Copy(tarWriter, in)
 		if err != nil {
+			logger.Debug(errors.Wrapf(in.Close(), "closing file '%s'", file.Path))
 			return numFilesArchived, errors.Wrapf(err, "copying file '%s' into tarball", file.Path)
 		}
 
 		if amountWrote != hdr.Size {
+			logger.Debug(errors.Wrapf(in.Close(), "closing file '%s'", file.Path))
 			return numFilesArchived, errors.Errorf("tarball header size is %d but actually wrote %d", hdr.Size, amountWrote)
 		}
+
+		logger.Debug(errors.Wrapf(in.Close(), "closing file '%s'", file.Path))
 		logger.Warning(errors.Wrap(tarWriter.Flush(), "flushing tar writer"))
 	}
 

--- a/agent/util/archive_tar_test.go
+++ b/agent/util/archive_tar_test.go
@@ -34,7 +34,7 @@ func TestArchiveExtract(t *testing.T) {
 		outputDir := t.TempDir()
 
 		f, gz, tarReader, err := TarGzReader(filepath.Join(testDir, "testdata", "artifacts.tar.gz"))
-		require.NoError(t, err, "Couldn't open test tarball")
+		require.NoError(t, err)
 		defer f.Close()
 		defer gz.Close()
 
@@ -65,7 +65,7 @@ func TestMakeArchive(t *testing.T) {
 		require.NoError(t, outputFile.Close())
 
 		f, gz, tarWriter, err := TarGzWriter(outputFile.Name())
-		require.NoError(t, err, "Couldn't open test tarball")
+		require.NoError(t, err)
 		defer f.Close()
 		defer gz.Close()
 		defer tarWriter.Close()
@@ -89,7 +89,7 @@ func TestArchiveRoundTrip(t *testing.T) {
 		}()
 
 		f, gz, tarWriter, err := TarGzWriter(outputFile.Name())
-		require.NoError(t, err, "Couldn't open test tarball")
+		require.NoError(t, err)
 		includes := []string{"dir1/**"}
 		excludes := []string{"*.pdb"}
 		var found int
@@ -102,7 +102,7 @@ func TestArchiveRoundTrip(t *testing.T) {
 
 		outputDir := t.TempDir()
 		f2, gz2, tarReader, err := TarGzReader(outputFile.Name())
-		require.NoError(t, err, "Couldn't open test tarball")
+		require.NoError(t, err)
 		err = extractTarArchive(context.Background(), tarReader, outputDir, []string{})
 		defer f2.Close()
 		defer gz2.Close()

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/evergreen-ci/utility"
@@ -24,7 +23,7 @@ func SpotHostWillTerminateSoon() bool {
 	defer utility.PutHTTPClient(c)
 	resp, err := c.Get(url)
 	if err != nil {
-		grip.Info(errors.Wrap(err, "problem getting termination endpoint"))
+		grip.Info(errors.Wrap(err, "getting spot host termination time"))
 		return false
 	}
 	defer resp.Body.Close()
@@ -58,10 +57,4 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 	}
 
 	return string(instanceID), nil
-
-}
-
-func ExitAgent() {
-	grip.Info("Spot instance terminating, so agent is exiting")
-	os.Exit(1)
 }

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || linux
 // +build darwin linux
 
 package util
@@ -31,25 +32,25 @@ func TrackProcess(key string, pid int, logger grip.Journaler) {}
 func KillSpawnedProcs(ctx context.Context, key, workingDir string, logger grip.Journaler) error {
 	pidsToKill, err := getPIDsToKill(ctx, key, workingDir, logger)
 	if err != nil {
-		return errors.Wrap(err, "problem getting list of PIDs to kill")
+		return errors.Wrap(err, "getting list of PIDs to kill")
 	}
 
 	for _, pid := range pidsToKill {
 		p := os.Process{Pid: pid}
 		err := p.Kill()
 		if err != nil {
-			logger.Errorf("Cleanup got error killing pid '%d': %v", pid, err)
+			logger.Errorf("Cleanup got error killing process with PID %d: %s.", pid, err)
 		} else {
-			logger.Infof("Cleanup killed pid '%d'", pid)
+			logger.Infof("Cleanup killed process with PID %d.", pid)
 		}
 	}
 
 	pidsStillRunning, err := waitForExit(ctx, pidsToKill)
 	if err != nil {
-		logger.Infof("Problem waiting for processes to exit: %s", err)
+		logger.Infof("Problem waiting for processes to exit: %s.", err)
 	}
 	for _, pid := range pidsStillRunning {
-		logger.Infof("Failed to clean up process '%d'", pid)
+		logger.Infof("Failed to clean up process with PID %d.", pid)
 	}
 
 	return nil
@@ -135,7 +136,7 @@ func waitForExit(ctx context.Context, pidsToWait []int) ([]int, error) {
 				}
 			}
 			if len(unkilledPids) > 0 {
-				return true, errors.Errorf("'%d' of '%d' processes are still running", len(unkilledPids), len(pidsToWait))
+				return true, errors.Errorf("%d of %d processes are still running", len(unkilledPids), len(pidsToWait))
 			}
 
 			return false, nil

--- a/agent/util/subtree_windows.go
+++ b/agent/util/subtree_windows.go
@@ -98,7 +98,7 @@ func (r *processRegistry) getJob(taskId string) (*Job, error) {
 		var err error
 		j, err = NewJob(taskId)
 		if err != nil {
-			return nil, errors.Wrapf(err, "problem creating job object for %s", taskId)
+			return nil, errors.Wrapf(err, "creating job object for task '%s'", taskId)
 		}
 
 		r.jobs[taskId] = j
@@ -120,7 +120,7 @@ func (r *processRegistry) removeJob(taskId string) error {
 
 	var err error
 	defer func() {
-		err = errors.Wrapf(job.Close(), "problem closing job for task %s", taskId)
+		err = errors.Wrapf(job.Close(), "closing job object for task '%s'", taskId)
 	}()
 
 	delete(r.jobs, taskId)
@@ -141,14 +141,14 @@ func (r *processRegistry) removeJob(taskId string) error {
 func TrackProcess(taskId string, pid int, logger grip.Journaler) {
 	job, err := processMapping.getJob(taskId)
 	if err != nil {
-		logger.Errorf("failed creating job object: %v", err)
+		logger.Errorf("Failed to get job object: %s", err)
 		return
 	}
 
-	logger.Infof("tracking process with pid %d", pid)
+	logger.Infof("Tracking process with PID %d.", pid)
 
 	if err = job.AssignProcess(uint(pid)); err != nil {
-		logger.Errorf("failed assigning process %d to job object: %v", pid, err)
+		logger.Errorf("Failed assigning process with PID %d to job object: %s.", pid, err)
 		return
 	}
 }
@@ -163,12 +163,11 @@ func KillSpawnedProcs(ctx context.Context, key, workingDir string, logger grip.J
 	}
 
 	if err := job.Terminate(0); err != nil {
-		logger.Errorf("terminating job object [%s] failed: %v", key, err)
-		return errors.WithStack(err)
+		logger.Errorf("Failed to terminate job object '%s': %s.", key, err)
+		return errors.Wrapf(err, "terminating job object '%s'", key)
 	}
 
-	return errors.Wrap(processMapping.removeJob(key),
-		"problem removing job object from internal evergreen tracking mechanism")
+	return errors.Wrapf(processMapping.removeJob(key), "removing job object '%s' from internal Evergreen tracking mechanism", key)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -183,7 +183,7 @@ func (ch *CreateHost) ValidateDocker() error {
 	catcher.Add(ch.validateAgentOptions())
 
 	if ch.Image == "" {
-		catcher.New("docker image must be set")
+		catcher.New("Docker image must be set")
 	}
 	if ch.Distro == "" {
 		settings, err := evergreen.GetConfig()
@@ -197,7 +197,7 @@ func (ch *CreateHost) ValidateDocker() error {
 	if ch.ContainerWaitTimeoutSecs <= 0 {
 		ch.ContainerWaitTimeoutSecs = DefaultContainerWaitTimeoutSecs
 	} else if ch.ContainerWaitTimeoutSecs >= 3600 || ch.ContainerWaitTimeoutSecs <= 10 {
-		catcher.New("container_wait_timeout_secs must be between 10 and 3600 seconds")
+		catcher.New("container wait timeout (seconds) must be between 10 and 3600 seconds")
 	}
 
 	if ch.PollFrequency <= 0 {
@@ -223,23 +223,23 @@ func (ch *CreateHost) ValidateEC2() error {
 	}
 
 	if (ch.AMI != "" && ch.Distro != "") || (ch.AMI == "" && ch.Distro == "") {
-		catcher.New("must set exactly one of ami or distro")
+		catcher.New("must set exactly one of AMI or distro")
 	}
 	if ch.AMI != "" {
 		if ch.InstanceType == "" {
-			catcher.New("instance_type must be set if ami is set")
+			catcher.New("instance type must be set if AMI is set")
 		}
 		if len(ch.SecurityGroups) == 0 {
-			catcher.New("must specify security_group_ids if ami is set")
+			catcher.New("must specify security group IDs if AMI is set")
 		}
 		if ch.Subnet == "" {
-			catcher.New("subnet_id must be set if ami is set")
+			catcher.New("subnet ID must be set if AMI is set")
 		}
 	}
 
 	if !(ch.AWSKeyID == "" && ch.AWSSecret == "" && ch.KeyName == "") &&
 		!(ch.AWSKeyID != "" && ch.AWSSecret != "" && ch.KeyName != "") {
-		catcher.New("aws_access_key_id, aws_secret_access_key, key_name must all be set or unset")
+		catcher.New("AWS access key ID, AWS secret access key, and key name must all be set or unset")
 	}
 
 	return catcher.Resolve()
@@ -263,13 +263,13 @@ func (ch *CreateHost) validateAgentOptions() error {
 		ch.SetupTimeoutSecs = DefaultSetupTimeoutSecs
 	}
 	if ch.SetupTimeoutSecs < 60 || ch.SetupTimeoutSecs > 3600 {
-		catcher.New("timeout_setup_secs must be between 60 and 3600")
+		catcher.New("timeout setup (seconds) must be between 60 and 3600")
 	}
 	if ch.TeardownTimeoutSecs == 0 {
 		ch.TeardownTimeoutSecs = DefaultTeardownTimeoutSecs
 	}
 	if ch.TeardownTimeoutSecs < 60 || ch.TeardownTimeoutSecs > 604800 {
-		catcher.New("timeout_teardown_secs must be between 60 and 604800")
+		catcher.New("timeout teardown (seconds) must be between 60 and 604800")
 	}
 	return catcher.Resolve()
 }
@@ -279,14 +279,14 @@ func (ch *CreateHost) setNumHosts() error {
 		ch.NumHosts = "1"
 	}
 	if ch.CloudProvider == ProviderDocker && ch.NumHosts != "1" {
-		return errors.Errorf("num_hosts cannot be greater than 1 for cloud provider %s", ProviderDocker)
+		return errors.Errorf("num hosts cannot be greater than 1 for cloud provider '%s'", ProviderDocker)
 	} else {
 		numHosts, err := strconv.Atoi(ch.NumHosts)
 		if err != nil {
-			return errors.Errorf("problem parsing '%s' as an int", ch.NumHosts)
+			return errors.Wrapf(err, "parsing num hosts specification '%s' as an int", ch.NumHosts)
 		}
 		if numHosts > 10 || numHosts < 0 {
-			return errors.New("num_hosts must be between 1 and 10")
+			return errors.New("num hosts must be between 1 and 10")
 		} else if numHosts == 0 {
 			ch.NumHosts = "1"
 		}
@@ -304,7 +304,7 @@ func (ch *CreateHost) Validate() error {
 		return ch.ValidateDocker()
 	}
 
-	return errors.Errorf("Cloud provider must be either '%s' or '%s'", ProviderEC2, ProviderDocker)
+	return errors.Errorf("cloud provider must be either '%s' or '%s'", ProviderEC2, ProviderDocker)
 }
 
 func (ch *CreateHost) Expand(exp *util.Expansions) error {

--- a/apimodels/task_log.go
+++ b/apimodels/task_log.go
@@ -120,7 +120,7 @@ func GetBuildloggerLogs(ctx context.Context, opts GetBuildloggerLogsOptions) (io
 	}
 	logReader, err := buildlogger.Get(ctx, getOpts)
 
-	return logReader, errors.Wrapf(err, "failed to get logs for '%s' from buildlogger, using evergreen logger", opts.TaskID)
+	return logReader, errors.Wrapf(err, "getting logs for '%s' from Buildlogger, using Evergreen logger", opts.TaskID)
 }
 
 // ReadBuildloggerToChan parses Cedar buildlogger log lines by message and

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-09-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-09-28"
+	AgentVersion = "2022-09-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -228,11 +228,11 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 		Result:           createHost,
 	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "constructing mapstructure decoder")
 	}
 	err = decoder.Decode(cmd.Params)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "parsing params")
 	}
 	return createHost, nil
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16501

### Description 
The agent has a mix of inconsistent logging and error messages due to how old this code is and how many times it's been modified. I applied these rules to try making the logging story better:

* Usual rules for `errors.Wrap` and `errors.Wrapf`.
* For task/execution/system logs, I tried making those that are unambiguously supposed to be sentences have proper grammar (capitalization, punctuation, whatever).
* For task/execution/system logs that involve logging `error` types directly (e.g. `logger.Task().Error(err)`), they're still a bit weird because they aren't very conducive to logging sentences with grammar/capitalization/punctuation. In addition, the loggers don't have a way of conditionally logging error messages in a full-sentence way without adding lots and lots of `if err != nil` checks. A future improvement might be to have a way to auto-prefix `error` types with `Error:` in the logs or something else to make it obvious that it's an error message, but I didn't feel inclined to do it for this PR.
* Remove a lot of duplicate logs in places where it already returns an error and then logs that error. I verified as best as I can that the removed logs are really duplicates and will still log to the task/execution/system logs eventually.
* Fix a couple minor doc comments.

### Testing 
Updated existing tests and ran a task in staging to make sure the output generally looked okay.

There's some risk that a user somewhere is relying on exact strings being logged in the task logs, but I'm really hoping that's not the case.