### PR TITLE
EVG-17480 Update Slack API calls 

### DIFF
--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -274,7 +274,7 @@ func FormatSlackTarget(target string) (string, error) {
 		user, err := user.FindBySlackUsername(trimmedTarget)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"message": "finding user by slack username",
+				"message": "could not find user by Slack username, falling back to default target instead of using the member ID",
 				"target":  target,
 			}))
 			return target, nil

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -176,10 +176,6 @@ func (n *Notification) Composer(env evergreen.Environment) (message.Composer, er
 			return nil, errors.New("slack payload is invalid")
 		}
 
-		grip.Info(message.Fields{
-			"message": "chayaMTesting model/notification/notification.go",
-			"target":  formattedTarget,
-		})
 		return message.NewSlackMessage(level.Notice, formattedTarget, payload.Body, payload.Attachments), nil
 
 	case event.GithubPullRequestSubscriberType:
@@ -272,7 +268,7 @@ func (n *Notification) SetTaskMetadata(ID string, execution int) {
 }
 
 func FormatSlackTarget(target string) (string, error) {
-	//check if it's a userID
+	//check if it's a userID (can potentially also be a user-group)
 	if strings.HasPrefix(target, "@") {
 		//use the memberId if it exists
 		trimmedTarget := strings.TrimPrefix(target, "@")

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -267,14 +267,17 @@ func (n *Notification) SetTaskMetadata(ID string, execution int) {
 	n.Metadata.TaskExecution = execution
 }
 
+// FormatSlackTarget uses the slackMemberId instead of the userName when possible.
 func FormatSlackTarget(target string) (string, error) {
-	//check if it's a userID (can potentially also be a user-group)
 	if strings.HasPrefix(target, "@") {
-		//use the memberId if it exists
 		trimmedTarget := strings.TrimPrefix(target, "@")
 		user, err := user.FindBySlackUsername(trimmedTarget)
 		if err != nil {
-			return "", errors.Wrapf(err, "finding user by slack username '%s'", target)
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "finding user by slack username",
+				"target":  target,
+			}))
+			return target, nil
 		}
 		if user != nil && user.Settings.SlackMemberId != "" {
 			return user.Settings.SlackMemberId, nil

--- a/rest/route/notification.go
+++ b/rest/route/notification.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
@@ -218,11 +217,6 @@ func (h *slackNotificationPostHandler) Run(ctx context.Context) gimlet.Responder
 
 	h.sender = s
 	h.sender.Send(h.composer)
-
-	grip.Info(message.Fields{
-		"message": "chayaMTesting rest/route/notifications.go",
-		"target":  formattedTarget,
-	})
 
 	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/rest/route/notification.go
+++ b/rest/route/notification.go
@@ -201,7 +201,6 @@ func (h *slackNotificationPostHandler) Run(ctx context.Context) gimlet.Responder
 	for _, a := range h.APISlack.Attachments {
 		attachments = append(attachments, a.ToService())
 	}
-	// this should be the memberId
 	target := utility.FromStringPtr(h.APISlack.Target)
 	formattedTarget, err := notification.FormatSlackTarget(target)
 	if err != nil {


### PR DESCRIPTION
[EVG-17480](https://jira.mongodb.org/browse/EVG-17480)

### Description 
When available, use the slackMemberId and not the userName. 

### Testing 
Tested on staging and the slack sandbox.