### PR TITLE
EVG-17638 Use new index for UnscheduleStaleUnderwaterHostTasks

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -27,6 +27,8 @@ var (
 		{Key: StatusKey, Value: 1},
 		{Key: ActivatedKey, Value: 1},
 		{Key: PriorityKey, Value: 1},
+		{Key: OverrideDependenciesKey, Value: 1},
+		{Key: bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey), Value: 1},
 	}
 )
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1331,9 +1331,8 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	return nil
 }
 
-// Removes host tasks older than the unscheduable threshold (e.g. one week) from
+// UnscheduleStaleUnderwaterHostTasks Removes host tasks older than the unscheduable threshold (e.g. one week) from
 // the scheduler queue.
-//
 // If you pass an empty string as an argument to this function, this operation
 // will select tasks from all distros.
 func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
@@ -1352,7 +1351,7 @@ func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
 		},
 	}
 
-	// Force the query to use 'distro_1_status_1_activated_1_priority_1'
+	// Force the query to use 'distro_1_status_1_activated_1_priority_1_override_dependencies_1_depends_on.unattainable_1'
 	// instead of defaulting to 'status_1_depends_on.status_1_depends_on.unattainable_1'.
 	info, err := UpdateAllWithHint(query, update, ActivatedTasksByDistroIndex)
 	if err != nil {


### PR DESCRIPTION
[EVG-17638](https://jira.mongodb.org/browse/EVG-17638)

### Description 
This query is currently slow because the current `distro_1_status_1_activated_1_priority_1` index doesn't have any sorting on the `depends_on.unattainable` key which causes us to return many index keys for some queries which we then have to filter down. Now that the `distro_1_status_1_activated_1_priority_1_override_dependencies_1_depends_on.unattainable_1` index has been created in prod we'll need to update our hint for this function to use the new index.
### Testing 
In Compass I constructed manually the aggregation used by this query and ran it with and without the new index, and noticed a significant reduction in returned index keys. (screenshots attached). 
