### PR TITLE
EVG-17457: check project ref for dispatchability during pod allocation

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -358,7 +358,7 @@ retryLoop:
 				}
 				filesList, err = b.Build()
 				if err != nil {
-					return errors.Wrapf(err, "processing local files include filter '%s'.",
+					return errors.Wrapf(err, "processing local files include filter '%s'",
 						strings.Join(s3pc.LocalFilesIncludeFilter, " "))
 				}
 				if len(filesList) == 0 {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-09-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-09-30"
+	AgentVersion = "2022-10-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -3,7 +3,6 @@ package model
 import (
 	"time"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -97,50 +96,26 @@ func (q *ContainerTaskQueue) filterByProjectRefSettings(tasks []task.Task) ([]ta
 			continue
 		}
 
-		if !ref.IsEnabled() {
-			// GitHub PR tasks are still allowed to run for disabled hidden
-			// projects.
-			if t.Requester == evergreen.GithubPRRequester && ref.IsHidden() {
-				grip.Debug(message.Fields{
-					"message": "queueing task because GitHub PRs are allowed to run tasks for projects that are both hidden and disabled",
-					"outcome": "not skipping",
-					"task":    t.Id,
-					"project": t.Project,
-					"context": "container task queue",
-				})
-			} else {
-				grip.Debug(message.Fields{
-					"message": "skipping task because project is disabled",
-					"outcome": "skipping",
-					"task":    t.Id,
-					"project": t.Project,
-					"context": "container task queue",
-				})
-				continue
-			}
-		}
-
-		if ref.IsDispatchingDisabled() {
+		canDispatch, reason := ProjectCanDispatchTask(&ref, &t)
+		if !canDispatch {
 			grip.Debug(message.Fields{
-				"message": "skipping task because dispatching is disabled for its project",
+				"message": "skipping allocation for undispatchable task",
 				"outcome": "skipping",
+				"reason":  reason,
 				"task":    t.Id,
 				"project": t.Project,
 				"context": "container task queue",
 			})
 			continue
 		}
-
-		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
-			grip.Debug(message.Fields{
-				"message": "skipping task because patch testing is disabled for its project",
-				"outcome": "skipping",
-				"task":    t.Id,
-				"project": t.Project,
-				"context": "container task queue",
-			})
-			continue
-		}
+		grip.DebugWhen(reason != "", message.Fields{
+			"message": "allowing allocation for task that can be dispatched",
+			"outcome": "not skipping",
+			"reason":  reason,
+			"task":    t.Id,
+			"project": t.Project,
+			"context": "container task queue",
+		})
 
 		readyForAllocation = append(readyForAllocation, t)
 	}

--- a/scheduler/task_finder.go
+++ b/scheduler/task_finder.go
@@ -65,58 +65,35 @@ func LegacyFindRunnableTasks(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() {
-			// PR tasks can still run for hidden projects
-			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
-				grip.Debug(message.Fields{
-					"runner":    RunnerName,
-					"message":   "project disabled but hidden",
-					"outcome":   "not skipping",
-					"task":      t.Id,
-					"requester": t.Requester,
-					"planner":   d.PlannerSettings.Version,
-					"project":   t.Project,
-				})
-			} else {
-				grip.Notice(message.Fields{
-					"runner":  RunnerName,
-					"message": "project disabled",
-					"outcome": "skipping",
-					"task":    t.Id,
-					"planner": d.PlannerSettings.Version,
-					"project": t.Project,
-				})
-				continue
-			}
-		}
-		if ref.IsDispatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "project dispatching disabled",
-				"outcome": "skipping",
-				"task":    t.Id,
-				"planner": d.PlannerSettings.Version,
-				"project": t.Project,
+		canDispatch, reason := model.ProjectCanDispatchTask(&ref, &t)
+		if !canDispatch {
+			grip.Debug(message.Fields{
+				"message":   "skipping task after checking project ref for dispatchability",
+				"reason":    reason,
+				"runner":    RunnerName,
+				"outcome":   "skipping",
+				"task":      t.Id,
+				"requester": t.Requester,
+				"planner":   d.PlannerSettings.Version,
+				"project":   t.Project,
 			})
 			continue
 		}
+		grip.DebugWhen(reason != "", message.Fields{
+			"message":   "scheduling task after checking project ref for dispatchability",
+			"reason":    reason,
+			"runner":    RunnerName,
+			"outcome":   "not skipping",
+			"task":      t.Id,
+			"requester": t.Requester,
+			"planner":   d.PlannerSettings.Version,
+			"project":   t.Project,
+		})
 
 		if len(d.ValidProjects) > 0 && !utility.StringSliceContains(d.ValidProjects, ref.Id) {
 			grip.Notice(message.Fields{
 				"runner":  RunnerName,
 				"message": "project is not valid for distro",
-				"outcome": "skipping",
-				"planner": d.PlannerSettings.Version,
-				"task":    t.Id,
-				"project": t.Project,
-			})
-			continue
-		}
-
-		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "patch testing disabled",
 				"outcome": "skipping",
 				"planner": d.PlannerSettings.Version,
 				"task":    t.Id,
@@ -203,58 +180,35 @@ func AlternateTaskFinder(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() {
-			// PR tasks can still run for hidden projects
-			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
-				grip.Debug(message.Fields{
-					"runner":    RunnerName,
-					"message":   "project disabled but hidden",
-					"outcome":   "not skipping",
-					"task":      t.Id,
-					"requester": t.Requester,
-					"planner":   d.PlannerSettings.Version,
-					"project":   t.Project,
-				})
-			} else {
-				grip.Notice(message.Fields{
-					"runner":  RunnerName,
-					"message": "project disabled",
-					"outcome": "skipping",
-					"task":    t.Id,
-					"planner": d.PlannerSettings.Version,
-					"project": t.Project,
-				})
-				continue
-			}
-		}
-		if ref.IsDispatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "project dispatching disabled",
-				"outcome": "skipping",
-				"task":    t.Id,
-				"planner": d.PlannerSettings.Version,
-				"project": t.Project,
+		canDispatch, reason := model.ProjectCanDispatchTask(&ref, &t)
+		if !canDispatch {
+			grip.Debug(message.Fields{
+				"message":   "skipping task after checking project ref for dispatchability",
+				"reason":    reason,
+				"runner":    RunnerName,
+				"outcome":   "skipping",
+				"task":      t.Id,
+				"requester": t.Requester,
+				"planner":   d.PlannerSettings.Version,
+				"project":   t.Project,
 			})
 			continue
 		}
+		grip.DebugWhen(reason != "", message.Fields{
+			"message":   "scheduling task after checking project ref for dispatchability",
+			"reason":    reason,
+			"runner":    RunnerName,
+			"outcome":   "not skipping",
+			"task":      t.Id,
+			"requester": t.Requester,
+			"planner":   d.PlannerSettings.Version,
+			"project":   t.Project,
+		})
 
 		if len(d.ValidProjects) > 0 && !utility.StringSliceContains(d.ValidProjects, ref.Id) {
 			grip.Notice(message.Fields{
 				"runner":  RunnerName,
 				"message": "project is not valid for distro",
-				"outcome": "skipping",
-				"planner": d.PlannerSettings.Version,
-				"task":    t.Id,
-				"project": t.Project,
-			})
-			continue
-		}
-
-		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "patch testing disabled",
 				"outcome": "skipping",
 				"planner": d.PlannerSettings.Version,
 				"task":    t.Id,
@@ -348,41 +302,30 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 			continue
 		}
 
-		if !ref.IsEnabled() {
-			// PR tasks can still run for hidden projects
-			if ref.IsHidden() && t.Requester == evergreen.GithubPRRequester {
-				grip.Debug(message.Fields{
-					"runner":    RunnerName,
-					"message":   "project disabled but hidden",
-					"outcome":   "not skipping",
-					"task":      t.Id,
-					"requester": t.Requester,
-					"planner":   d.PlannerSettings.Version,
-					"project":   t.Project,
-				})
-			} else {
-				grip.Notice(message.Fields{
-					"runner":  RunnerName,
-					"message": "project disabled",
-					"outcome": "skipping",
-					"task":    t.Id,
-					"planner": d.PlannerSettings.Version,
-					"project": t.Project,
-				})
-				continue
-			}
-		}
-		if ref.IsDispatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "project dispatching disabled",
-				"outcome": "skipping",
-				"task":    t.Id,
-				"planner": d.PlannerSettings.Version,
-				"project": t.Project,
+		canDispatch, reason := model.ProjectCanDispatchTask(&ref, &t)
+		if !canDispatch {
+			grip.Debug(message.Fields{
+				"message":   "skipping task after checking project ref for dispatchability",
+				"reason":    reason,
+				"runner":    RunnerName,
+				"outcome":   "skipping",
+				"task":      t.Id,
+				"requester": t.Requester,
+				"planner":   d.PlannerSettings.Version,
+				"project":   t.Project,
 			})
 			continue
 		}
+		grip.DebugWhen(reason != "", message.Fields{
+			"message":   "scheduling task after checking project ref for dispatchability",
+			"reason":    reason,
+			"runner":    RunnerName,
+			"outcome":   "not skipping",
+			"task":      t.Id,
+			"requester": t.Requester,
+			"planner":   d.PlannerSettings.Version,
+			"project":   t.Project,
+		})
 
 		if len(d.ValidProjects) > 0 && !utility.StringSliceContains(d.ValidProjects, ref.Id) {
 			grip.Notice(message.Fields{
@@ -390,17 +333,6 @@ func ParallelTaskFinder(d distro.Distro) ([]task.Task, error) {
 				"message": "project is not valid for distro",
 				"outcome": "skipping",
 				"planner": d.PlannerSettings.Version,
-				"task":    t.Id,
-				"project": t.Project,
-			})
-			continue
-		}
-
-		if t.IsPatchRequest() && ref.IsPatchingDisabled() {
-			grip.Notice(message.Fields{
-				"runner":  RunnerName,
-				"message": "patch testing disabled",
-				"outcome": "skipping",
 				"task":    t.Id,
 				"project": t.Project,
 			})

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -128,11 +128,8 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 
 	canDispatch, reason := model.ProjectCanDispatchTask(j.pRef, j.task)
 	if !canDispatch {
-		if reason == "" {
-			reason = "of unknown reason"
-		}
 		grip.Info(message.Fields{
-			"message": "refusing to allocate task because it is not dispatchable",
+			"message": "refusing to allocate task due to project ref settings",
 			"reason":  reason,
 			"task":    j.task.Id,
 			"project": j.pRef.Identifier,

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -133,6 +133,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		}
 		grip.Info(message.Fields{
 			"message": "refusing to allocate task because it is not dispatchable",
+			"reason":  reason,
 			"task":    j.task.Id,
 			"project": j.pRef.Identifier,
 			"job":     j.ID(),

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -77,12 +77,12 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 		}
 	}()
 
-	shouldAllocate, err := j.canAllocate()
+	canAllocate, err := j.systemCanAllocate()
 	if err != nil {
 		j.AddRetryableError(errors.Wrap(err, "checking allocation attempt against max parallel pod request limit"))
 		return
 	}
-	if !shouldAllocate {
+	if !canAllocate {
 		grip.Info(message.Fields{
 			"message":            "reached max parallel pod request limit, will re-attempt to allocate container to task later",
 			"task":               j.TaskID,
@@ -107,9 +107,36 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 			j.AddRetryableError(errors.Wrap(err, "marking unallocatable container task as system-failed"))
 		}
 
+		grip.Info(message.Fields{
+			"message": "refusing to allocate task because it has no more allocation attempts",
+			"task":    j.task.Id,
+			"project": j.pRef.Identifier,
+			"job":     j.ID(),
+		})
+
 		return
 	}
 	if !j.task.ShouldAllocateContainer() {
+		grip.Info(message.Fields{
+			"message": "refusing to allocate task because it is not in a valid state to be allocated",
+			"task":    j.task.Id,
+			"project": j.pRef.Identifier,
+			"job":     j.ID(),
+		})
+		return
+	}
+
+	canDispatch, reason := model.ProjectCanDispatchTask(j.pRef, j.task)
+	if !canDispatch {
+		if reason == "" {
+			reason = "of unknown reason"
+		}
+		grip.Info(message.Fields{
+			"message": "refusing to allocate task because it is not dispatchable",
+			"task":    j.task.Id,
+			"project": j.pRef.Identifier,
+			"job":     j.ID(),
+		})
 		return
 	}
 
@@ -149,7 +176,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	}
 }
 
-func (j *podAllocatorJob) canAllocate() (shouldAllocate bool, err error) {
+func (j *podAllocatorJob) systemCanAllocate() (canAllocate bool, err error) {
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
 		return false, errors.Wrap(err, "getting service flags")

--- a/units/pod_allocator_test.go
+++ b/units/pod_allocator_test.go
@@ -237,6 +237,20 @@ func TestPodAllocatorJob(t *testing.T) {
 			require.NotZero(t, dbTask)
 			assert.False(t, dbTask.ContainerAllocated)
 		},
+		"RunNoopsWhenProjectDoesNotAllowDispatching": func(ctx context.Context, t *testing.T, j *podAllocatorJob, v cocoa.Vault, tsk task.Task, pRef model.ProjectRef) {
+			pRef.Enabled = utility.FalsePtr()
+			require.NoError(t, pRef.Upsert())
+			require.NoError(t, tsk.Insert())
+
+			j.Run(ctx)
+
+			require.NoError(t, j.Error())
+
+			dbTask, err := task.FindOneId(tsk.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbTask)
+			assert.False(t, dbTask.ContainerAllocated)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17457

### Description 
Before allocating a pod, check whether a task will be allowed to dispatch based on project ref settings. If it's not allowed, don't allocate it.

* Add check for project ref against the task to ensure it can dispatch before allocating a pod.
* Reduce some copy-pasted identical project ref checks between host and container task schedulers.

### Testing 
Updated existing unit tests.