### PR TITLE
EVG-17644: use transaction to dispatch host tasks

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1352,27 +1352,15 @@ func (h *Host) ClearRunningAndSetLastTask(t *task.Task) error {
 
 // ClearRunningTask unsets the running task on the host.
 func (h *Host) ClearRunningTask() error {
-	err := UpdateOne(
-		bson.M{
-			IdKey: h.Id,
-		},
-		bson.M{
-			"$unset": bson.M{
-				RunningTaskKey:             1,
-				RunningTaskExecutionKey:    1,
-				RunningTaskGroupKey:        1,
-				RunningTaskGroupOrderKey:   1,
-				RunningTaskBuildVariantKey: 1,
-				RunningTaskVersionKey:      1,
-				RunningTaskProjectKey:      1,
-			},
-		})
-
-	if err != nil {
+	hadRunningTask := h.RunningTask != ""
+	doUpdate := func(update bson.M) error {
+		return UpdateOne(bson.M{IdKey: h.Id}, update)
+	}
+	if err := h.clearRunningTaskWithFunc(doUpdate); err != nil {
 		return err
 	}
 
-	if h.RunningTask != "" {
+	if hadRunningTask {
 		event.LogHostRunningTaskCleared(h.Id, h.RunningTask, h.RunningTaskExecution)
 		grip.Info(message.Fields{
 			"message":  "cleared host running task",
@@ -1381,6 +1369,38 @@ func (h *Host) ClearRunningTask() error {
 			"distro":   h.Distro.Id,
 			"task_id":  h.RunningTask,
 		})
+	}
+
+	return nil
+}
+
+func (h *Host) ClearRunningTaskWithContext(ctx context.Context, env evergreen.Environment) error {
+	doUpdate := func(update bson.M) error {
+		_, err := env.DB().Collection(Collection).UpdateByID(ctx, h.Id, update)
+		return err
+	}
+	return h.clearRunningTaskWithFunc(doUpdate)
+}
+
+func (h *Host) clearRunningTaskWithFunc(doUpdate func(update bson.M) error) error {
+	if h.RunningTask == "" {
+		// kim: TODO: ensure that this is a sufficient condition to skip the update.
+		return nil
+	}
+
+	update := bson.M{
+		"$unset": bson.M{
+			RunningTaskKey:             1,
+			RunningTaskExecutionKey:    1,
+			RunningTaskGroupKey:        1,
+			RunningTaskGroupOrderKey:   1,
+			RunningTaskBuildVariantKey: 1,
+			RunningTaskVersionKey:      1,
+			RunningTaskProjectKey:      1,
+		},
+	}
+	if err := doUpdate(update); err != nil {
+		return err
 	}
 
 	h.RunningTask = ""

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1384,7 +1384,6 @@ func (h *Host) ClearRunningTaskWithContext(ctx context.Context, env evergreen.En
 
 func (h *Host) clearRunningTaskWithFunc(doUpdate func(update bson.M) error) error {
 	if h.RunningTask == "" {
-		// kim: TODO: ensure that this is a sufficient condition to skip the update.
 		return nil
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1350,7 +1350,8 @@ func (h *Host) ClearRunningAndSetLastTask(t *task.Task) error {
 	return nil
 }
 
-// ClearRunningTask unsets the running task on the host.
+// ClearRunningTask unsets the running task on the host and logs an event
+// indicating it is no longer running the task.
 func (h *Host) ClearRunningTask() error {
 	hadRunningTask := h.RunningTask != ""
 	doUpdate := func(update bson.M) error {
@@ -1374,6 +1375,8 @@ func (h *Host) ClearRunningTask() error {
 	return nil
 }
 
+// ClearRunningTaskWithContext unsets the running task on the log. It does not
+// log an event for clearing the task.
 func (h *Host) ClearRunningTaskWithContext(ctx context.Context, env evergreen.Environment) error {
 	doUpdate := func(update bson.M) error {
 		_, err := env.DB().Collection(Collection).UpdateByID(ctx, h.Id, update)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1105,6 +1105,9 @@ func (t *Task) markAsHostDispatchedWithFunc(doUpdate func(update bson.M) error, 
 	t.AgentVersion = agentRevision
 	t.LastHeartbeat = dispatchTime
 	t.DistroId = distroID
+	t.Aborted = false
+	t.AbortInfo = AbortInfo{}
+	t.Details = apimodels.TaskEndDetail{}
 
 	return nil
 }
@@ -1163,6 +1166,9 @@ func (t *Task) markAsHostUndispatchedWithFunc(doUpdate func(update bson.M) error
 	t.LastHeartbeat = utility.ZeroTime
 	t.HostId = ""
 	t.AgentVersion = ""
+	t.Aborted = false
+	t.AbortInfo = AbortInfo{}
+	t.Details = apimodels.TaskEndDetail{}
 
 	return nil
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1109,32 +1109,39 @@ func (t *Task) markAsHostDispatchedWithFunc(doUpdate func(update bson.M) error, 
 	return nil
 }
 
-// MarkAsHostUndispatched marks that the host task is undispatched. If the task
-// is already dispatched to a host, it unsets the host ID field on the task. It
-// returns an error if any of the database updates fail.
-func (t *Task) MarkAsHostUndispatched() error {
-	// then, update the task document
-	t.Status = evergreen.TaskUndispatched
+// MarkAsHostUndispatchedWithContext marks that the host task is undispatched.
+// If the task is already dispatched to a host, it aborts the dispatch by
+// undoing the dispatch updates. This is the inverse operation of
+// MarkAsHostDispatchedWithContext.
+// kim: TODO: test
+func (t *Task) MarkAsHostUndispatchedWithContext(ctx context.Context, env evergreen.Environment) error {
+	update := bson.M{
+		"$set": bson.M{
+			StatusKey:        evergreen.TaskUndispatched,
+			DispatchTimeKey:  utility.ZeroTime,
+			LastHeartbeatKey: utility.ZeroTime,
+		},
+		"$unset": bson.M{
+			HostIdKey:       "",
+			AgentVersionKey: "",
+			AbortedKey:      "",
+			AbortInfoKey:    "",
+			DetailsKey:      "",
+		},
+	}
+	// kim: TODO: consider adding more checks like for current task status and
+	// task host ID association.
+	if _, err := env.DB().Collection(Collection).UpdateByID(ctx, t.Id, update); err != nil {
+		return err
+	}
 
-	return UpdateOne(
-		bson.M{
-			IdKey: t.Id,
-		},
-		bson.M{
-			"$set": bson.M{
-				StatusKey: evergreen.TaskUndispatched,
-			},
-			"$unset": bson.M{
-				DispatchTimeKey:  utility.ZeroTime,
-				LastHeartbeatKey: utility.ZeroTime,
-				DistroIdKey:      "",
-				HostIdKey:        "",
-				AbortedKey:       "",
-				AbortInfoKey:     "",
-				DetailsKey:       "",
-			},
-		},
-	)
+	t.Status = evergreen.TaskUndispatched
+	t.DispatchTime = utility.ZeroTime
+	t.LastHeartbeat = utility.ZeroTime
+	t.HostId = ""
+	t.AgentVersion = ""
+
+	return nil
 }
 
 // maxContainerAllocationAttempts is the maximum number of times a container

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1320,22 +1320,6 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 	return nil
 }
 
-// MarkHostTaskUndispatched marks a task as no longer dispatched to a host. If
-// it's part of a display task, update the display task as necessary.
-func MarkHostTaskUndispatched(t *task.Task) error {
-	if err := t.MarkAsHostUndispatched(); err != nil {
-		return errors.WithStack(err)
-	}
-
-	event.LogHostTaskUndispatched(t.Id, t.Execution, t.HostId)
-
-	if t.IsPartOfDisplay() {
-		return UpdateDisplayTaskForTask(t)
-	}
-
-	return nil
-}
-
 // MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
 // part of a display task, update the display task as necessary.
 func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1320,6 +1320,20 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 	return nil
 }
 
+// MarkHostTaskUndispatched marks a task as no longer dispatched to a host. If
+// it's part of a display task, update the display task as necessary.
+func MarkHostTaskUndispatched(t *task.Task) error {
+	if err := t.MarkAsHostUndispatched(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if t.IsPartOfDisplay() {
+		return UpdateDisplayTaskForTask(t)
+	}
+
+	return nil
+}
+
 // MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
 // part of a display task, update the display task as necessary.
 func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2254,43 +2254,6 @@ func TestMarkStart(t *testing.T) {
 	})
 }
 
-func TestMarkUndispatched(t *testing.T) {
-	Convey("With a task, build and version", t, func() {
-		require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection))
-		displayName := "testName"
-		b := &build.Build{
-			Id:      "buildtest",
-			Status:  evergreen.BuildStarted,
-			Version: "abc",
-		}
-		v := &Version{
-			Id:     b.Version,
-			Status: evergreen.VersionStarted,
-			Config: "identifier: sample",
-		}
-		testTask := &task.Task{
-			Id:          "testTask",
-			DisplayName: displayName,
-			Activated:   true,
-			BuildId:     b.Id,
-			Project:     "sample",
-			Status:      evergreen.TaskStarted,
-			Version:     b.Version,
-		}
-
-		So(b.Insert(), ShouldBeNil)
-		So(testTask.Insert(), ShouldBeNil)
-		So(v.Insert(), ShouldBeNil)
-		Convey("when calling MarkStart, the task, version and build should be updated", func() {
-			var err error
-			So(MarkHostTaskUndispatched(testTask), ShouldBeNil)
-			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
-			So(err, ShouldBeNil)
-			So(testTask.Status, ShouldEqual, evergreen.TaskUndispatched)
-		})
-	})
-}
-
 func TestMarkDispatched(t *testing.T) {
 	Convey("With a task, build and version", t, func() {
 		require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection))

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -69,12 +69,29 @@ func TestHostNextTask(t *testing.T) {
 		StartTime: utility.ZeroTime,
 		BuildId:   buildID,
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	originalServiceFlags, err := evergreen.GetServiceFlags()
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, originalServiceFlags.Set())
+	}()
+	newServiceFlags := *originalServiceFlags
+	newServiceFlags.DispatchTransactionDisabled = false
+	require.NoError(t, newServiceFlags.Set())
+
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *hostAgentNextTask){
 		"ShouldSucceedAndSetAgentStartTime": func(ctx context.Context, t *testing.T, rh *hostAgentNextTask) {
 			resp := rh.Run(ctx)
 			assert.NotNil(t, resp)
 			assert.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := resp.Data().(apimodels.NextTaskResponse)
+			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+			require.True(t, ok, resp.Data())
 			assert.NotNil(t, taskResp)
 			assert.Equal(t, taskResp.TaskId, "task1")
 			nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
@@ -88,13 +105,16 @@ func TestHostNextTask(t *testing.T) {
 			sampleHost, err := host.FindOneId("h1")
 			require.NoError(t, err)
 			require.NoError(t, sampleHost.SetAgentRevision("out-of-date-string"))
+			defer func() {
+				assert.NoError(t, sampleHost.SetAgentRevision(evergreen.AgentVersion)) // reset
+			}()
 			rh.host = sampleHost
 			rh.details = &apimodels.GetNextTaskDetails{TaskGroup: "task_group"}
 			resp := rh.Run(ctx)
-			taskResp := resp.Data().(apimodels.NextTaskResponse)
+			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+			require.True(t, ok, resp.Data())
 			assert.Equal(t, resp.Status(), http.StatusOK)
 			assert.False(t, taskResp.ShouldExit)
-			require.NoError(t, sampleHost.SetAgentRevision(evergreen.AgentVersion)) // reset
 		},
 		"NonLegacyHostThatNeedsReprovision": func(ctx context.Context, t *testing.T, rh *hostAgentNextTask) {
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, handler hostAgentNextTask){
@@ -107,7 +127,8 @@ func TestHostNextTask(t *testing.T) {
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.True(t, taskResp.ShouldExit)
 					dbHost, err := host.FindOneId(h.Id)
 					require.NoError(t, err)
@@ -128,7 +149,8 @@ func TestHostNextTask(t *testing.T) {
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
 					dbHost, err := host.FindOneId(h.Id)
 					require.NoError(t, err)
@@ -158,7 +180,9 @@ func TestHostNextTask(t *testing.T) {
 						NeedsReprovision: host.ReprovisionToNew,
 					}
 					require.NoError(t, h.Insert())
-					handler := hostAgentNextTask{}
+					handler := hostAgentNextTask{
+						env: env,
+					}
 					testCase(ctx, t, handler)
 				})
 			}
@@ -179,7 +203,8 @@ func TestHostNextTask(t *testing.T) {
 
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
 					assert.Empty(t, taskResp.TaskId)
 
@@ -207,7 +232,8 @@ func TestHostNextTask(t *testing.T) {
 
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.True(t, taskResp.ShouldExit)
 					assert.True(t, taskResp.ShouldExit)
 					assert.Empty(t, taskResp.TaskId)
@@ -236,7 +262,8 @@ func TestHostNextTask(t *testing.T) {
 
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.True(t, taskResp.ShouldExit)
 					assert.Empty(t, taskResp.TaskId)
 
@@ -295,7 +322,8 @@ func TestHostNextTask(t *testing.T) {
 				resp := rh.Run(ctx)
 				assert.NotNil(t, resp)
 				assert.Equal(t, resp.Status(), http.StatusOK)
-				taskResp := resp.Data().(apimodels.NextTaskResponse)
+				taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+				require.True(t, ok, resp.Data())
 				assert.True(t, taskResp.ShouldExit)
 				assert.Empty(t, taskResp.TaskId)
 				dbHost, err := host.FindOneId(nonLegacyHost.Id)
@@ -312,7 +340,8 @@ func TestHostNextTask(t *testing.T) {
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					rh.host = nonLegacyHost
 					resp := rh.Run(ctx)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
 					dbHost, err := host.FindOneId(nonLegacyHost.Id)
 					require.NoError(t, err)
@@ -330,7 +359,8 @@ func TestHostNextTask(t *testing.T) {
 					// next task action
 					rh.host = dbHost
 					resp := rh.Run(ctx)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.NotEmpty(t, taskResp.TaskId)
 					assert.Equal(t, taskResp.Build, buildID)
 				},
@@ -341,7 +371,8 @@ func TestHostNextTask(t *testing.T) {
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					resp := rh.Run(ctx)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
 				},
 				"OutdatedAgentRevisionInNextTaskDetails": func(ctx context.Context, t *testing.T, handler hostAgentNextTask) {
@@ -351,7 +382,8 @@ func TestHostNextTask(t *testing.T) {
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: "out-of-date"}
 					resp := rh.Run(ctx)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.True(t, taskResp.ShouldExit)
 				},
 			} {
@@ -391,7 +423,8 @@ func TestHostNextTask(t *testing.T) {
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.Equal(t, taskResp.TaskId, "existingTask")
 					nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
 					require.NoError(t, err)
@@ -421,7 +454,8 @@ func TestHostNextTask(t *testing.T) {
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusOK)
-					taskResp := resp.Data().(apimodels.NextTaskResponse)
+					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+					require.True(t, ok, resp.Data())
 					assert.Equal(t, taskResp.TaskId, t1.Id)
 					nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
 					require.NoError(t, err)
@@ -473,16 +507,23 @@ func TestHostNextTask(t *testing.T) {
 						Activated: true,
 					}
 					require.NoError(t, existingTask.Insert())
-					handler := hostAgentNextTask{}
+					handler := hostAgentNextTask{
+						env: env,
+					}
 					testCase(ctx, t, handler)
 				})
 			}
 		},
 		"WithDegradedModeSet": func(ctx context.Context, t *testing.T, rh *hostAgentNextTask) {
-			serviceFlags := evergreen.ServiceFlags{
-				TaskDispatchDisabled: true,
-			}
-			require.NoError(t, evergreen.SetServiceFlags(serviceFlags))
+			originalServiceFlags, err := evergreen.GetServiceFlags()
+			require.NoError(t, err)
+			defer func() {
+				// Reset to original service flags.
+				assert.NoError(t, originalServiceFlags.Set())
+			}()
+			newServiceFlags := *originalServiceFlags
+			newServiceFlags.TaskDispatchDisabled = true
+			require.NoError(t, newServiceFlags.Set())
 			resp := rh.Run(ctx)
 			assert.NotNil(t, resp)
 			assert.Equal(t, resp.Status(), http.StatusOK)
@@ -490,8 +531,6 @@ func TestHostNextTask(t *testing.T) {
 			assert.NotNil(t, taskResp)
 			assert.Equal(t, taskResp.TaskId, "")
 			assert.False(t, taskResp.ShouldExit)
-			serviceFlags.TaskDispatchDisabled = false // unset degraded mode
-			require.NoError(t, evergreen.SetServiceFlags(serviceFlags))
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -504,7 +543,6 @@ func TestHostNextTask(t *testing.T) {
 				assert.NoError(t, db.DropCollections(colls...))
 			}()
 			require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey))
-			require.NoError(t, evergreen.SetServiceFlags(evergreen.ServiceFlags{}))
 
 			tq := &model.TaskQueue{
 				Distro: distroID,
@@ -542,7 +580,7 @@ func TestHostNextTask(t *testing.T) {
 			require.NoError(t, sampleHost.Insert())
 			require.NoError(t, tq.Save())
 
-			r, ok := makeHostAgentNextTask(evergreen.GetEnvironment(), nil, nil).(*hostAgentNextTask)
+			r, ok := makeHostAgentNextTask(env, nil, nil).(*hostAgentNextTask)
 			require.True(t, ok)
 
 			r.host = &sampleHost
@@ -818,6 +856,9 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
 	Convey("with a task queue and a host", t, func() {
 		settings := distro.DispatcherSettings{
 			Version: evergreen.DispatcherVersionLegacy,
@@ -888,7 +929,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 		details := &apimodels.GetNextTaskDetails{}
 
 		Convey("a host should get the task at the top of the queue", func() {
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(shouldTeardown, ShouldBeFalse)
@@ -907,7 +948,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 			pref.Enabled = utility.FalsePtr()
 			So(pref.Upsert(), ShouldBeNil)
 
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
@@ -920,7 +961,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 			pref.DispatchingDisabled = utility.TruePtr()
 			So(pref.Upsert(), ShouldBeNil)
 
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
@@ -935,7 +976,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 			So(currentTq.Length(), ShouldEqual, 2)
 
 			details.TaskGroup = "my-task-group"
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchAliasService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchAliasService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldBeNil)
 			So(shouldTeardown, ShouldBeTrue)
@@ -956,7 +997,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				Status: evergreen.TaskStarted,
 			}
 			So(undispatchedTask.Insert(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t.Id, ShouldEqual, "task2")
@@ -968,7 +1009,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 		Convey("an empty task queue should return a nil task", func() {
 			taskQueue.Queue = []model.TaskQueueItem{}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t, ShouldBeNil)
@@ -976,7 +1017,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 		Convey("a tasks queue with a task that does not exist should continue", func() {
 			taskQueue.Queue = []model.TaskQueueItem{{Id: "notatask"}}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t, ShouldBeNil)
@@ -1022,7 +1063,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 			}
 			So(taskQueue.Save(), ShouldBeNil)
 			Convey("the task that is in the other host should not be assigned to another host", func() {
-				t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &h2, details)
+				t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &h2, true, details)
 				So(err, ShouldBeNil)
 				So(shouldTeardown, ShouldBeFalse)
 				So(t, ShouldNotBeNil)
@@ -1032,7 +1073,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				So(h.RunningTask, ShouldEqual, t2.Id)
 			})
 			Convey("a host with a running task should return an error", func() {
-				_, _, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &anotherHost, details)
+				_, _, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &anotherHost, true, details)
 				So(err, ShouldNotBeNil)
 			})
 		})
@@ -1084,7 +1125,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				{Id: task4.Id},
 			}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, _, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, details)
+			t, _, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			// task 3 should not be dispatched, because it's already running on max
@@ -1148,7 +1189,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 				{Id: task4.Id},
 			}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, _, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, details)
+			t, _, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			// task 3 should not be dispatched, because it has a later task group
@@ -1164,6 +1205,9 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 
 	Convey("with a task queue and a host", t, func() {
 		settings := distro.DispatcherSettings{
@@ -1235,7 +1279,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 
 		details := &apimodels.GetNextTaskDetails{}
 		Convey("a host should get the task at the top of the queue", func() {
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t, ShouldNotBeNil)
@@ -1255,7 +1299,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			So(currentTq.Length(), ShouldEqual, 2)
 
 			details.TaskGroup = "my-task-group"
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldBeNil)
 			So(shouldTeardown, ShouldBeTrue)
@@ -1279,7 +1323,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				StartTime: utility.ZeroTime,
 			}
 			So(undispatchedTask.Insert(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t.Id, ShouldEqual, "task2")
@@ -1291,7 +1335,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 		Convey("an empty task queue should return a nil task", func() {
 			taskQueue.Queue = []model.TaskQueueItem{}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t, ShouldBeNil)
@@ -1303,7 +1347,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			}
 			taskQueue.Queue = []model.TaskQueueItem{item}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, true, details)
 			So(err, ShouldBeNil)
 			So(shouldTeardown, ShouldBeFalse)
 			So(t, ShouldBeNil)
@@ -1351,7 +1395,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			}
 			So(taskQueue.Save(), ShouldBeNil)
 			Convey("the task that is in the other host should not be assigned to another host", func() {
-				t, shouldTeardown, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &h2, details)
+				t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &h2, true, details)
 				So(err, ShouldBeNil)
 				So(shouldTeardown, ShouldBeFalse)
 				So(t, ShouldNotBeNil)
@@ -1361,7 +1405,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				So(h.RunningTask, ShouldEqual, t2.Id)
 			})
 			Convey("a host with a running task should return an error", func() {
-				_, _, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &anotherHost, details)
+				_, _, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &anotherHost, true, details)
 				So(err, ShouldNotBeNil)
 			})
 		})
@@ -1413,7 +1457,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				{Id: task4.Id},
 			}
 			So(taskQueue.Save(), ShouldBeNil)
-			t, _, err := assignNextAvailableTask(ctx, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, details)
+			t, _, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &host2, true, details)
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			// task 3 should not be dispatched, because it's already running on max

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -505,15 +505,19 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
-	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
-	}
+	// The order of operations here for clearing the task from the pod and
+	// marking the task finished is critical and must be done in this particular
+	// order. See the host end task route for more detailed explanation.
 
 	// Clear the running task on the pod now that the task has finished.
 	if err = p.ClearRunningTask(); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "clearing running task '%s' for pod '%s'", t.Id, p.ID))
+	}
+
+	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
+	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
 	}
 
 	if t.Requester == evergreen.MergeTestRequester {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17644

### Description 
The motive behind the change here is to enforce a rule that **if the host is currently assigned a task to run, then that task must be in a dispatched/running state**. The logical order of operations to achieve this is:
#### Task dispatch
* Mark the task as dispatched _and_ set the host's running task atomically.

#### Task completion
* Clear the host's running task.
* Mark the task as finished.

Following this rule is crucial to being able to [this expensive query](https://github.com/evergreen-ci/evergreen/blob/e0ef15893b4ed9f51fca7a3a3623b34a8610d5ef/units/task_monitor_execution_timeout.go#L281-L290) by making the queried condition an impossible state.

To do so, this PR adds the transaction for host task dispatch, with a feature flag to fall back to the old logic if it causes performance or correctness problems in prod. There will be follow-on work in ticket ticket to 1. remove the expensive query once this change has time to bake and suss out any issues, and 2. remove the fallback logic.

* Conditionally enable using a transaction to dispatch a task vs. using the old logic to dispatch a task.
    * Since there is some logic to back out of a race in case the task group check fails, add a conditionally-enabled transaction to also undo dispatch.
* Re-order statements in end task to enforce the above rule around order of operations.
* Re-check if the task group max hosts is being respected when sending back a running task. This check is needed regardless of whether we use a transaction or not when we're sending an already-dispatched task back to the host.

### Testing 
* Updated existing unit tests.
* Tested in staging. The transaction itself took on average 10 ms to run in staging. It's a bit difficult to test its correctness and performance under a more realistic scenario since it will only be useful in cases where multiple hosts are racing to dispatch a task, but from the spot check, it seems to be correct and performant.