### PR TITLE
EVG-17656: add TTL field for pod dispatchers

### DIFF
--- a/model/pod/definition/definition.go
+++ b/model/pod/definition/definition.go
@@ -73,7 +73,7 @@ func (pdc PodDefinitionCache) Put(_ context.Context, item cocoa.ECSPodDefinition
 			LastAccessedKey: time.Now(),
 		},
 		"$setOnInsert": bson.M{
-			IDKey: primitive.NewObjectID().String(),
+			IDKey: primitive.NewObjectID().Hex(),
 		},
 	}
 	if _, err := UpsertOne(idAndFamily, newPodDef); err != nil {

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -177,6 +177,8 @@ func TestAllocate(t *testing.T) {
 		assert.Equal(t, pd.PodIDs, dbDispatcher.PodIDs)
 		assert.Equal(t, pd.TaskIDs, dbDispatcher.TaskIDs)
 		assert.Equal(t, pd.ModificationCount, dbDispatcher.ModificationCount)
+		assert.False(t, utility.IsZeroTime(dbDispatcher.LastModified))
+		assert.Equal(t, pd.LastModified, dbDispatcher.LastModified)
 	}
 	checkEventLogged := func(t *testing.T, tsk *task.Task) {
 		dbEvents, err := event.FindAllByResourceID(tsk.Id)
@@ -228,6 +230,7 @@ func TestAllocate(t *testing.T) {
 			assert.Empty(t, right)
 			assert.Equal(t, pd.TaskIDs, updatedDispatcher.TaskIDs)
 			assert.True(t, updatedDispatcher.ModificationCount > pd.ModificationCount)
+			assert.False(t, utility.IsZeroTime(updatedDispatcher.LastModified))
 
 			checkAllocated(t, tsk, p, updatedDispatcher)
 		},
@@ -248,6 +251,7 @@ func TestAllocate(t *testing.T) {
 			assert.Equal(t, pd.PodIDs, updatedDispatcher.PodIDs)
 			assert.Equal(t, pd.TaskIDs, updatedDispatcher.TaskIDs)
 			assert.True(t, updatedDispatcher.ModificationCount > pd.ModificationCount)
+			assert.False(t, utility.IsZeroTime(updatedDispatcher.LastModified))
 
 			checkTaskAllocated(t, tsk)
 			checkDispatcherUpdated(t, tsk, updatedDispatcher)

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -52,6 +52,8 @@ func TestUpsertAtomically(t *testing.T) {
 			assert.Equal(t, pd.TaskIDs, dbDispatcher.TaskIDs)
 			assert.NotZero(t, pd.ModificationCount)
 			assert.Equal(t, pd.ModificationCount, dbDispatcher.ModificationCount)
+			assert.False(t, utility.IsZeroTime(dbDispatcher.LastModified))
+			assert.Equal(t, pd.LastModified, dbDispatcher.LastModified)
 		},
 		"FailsWithMatchingGroupIDButDifferentDispatcherID": func(t *testing.T, pd PodDispatcher) {
 			require.NoError(t, pd.Insert())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17656

### Description 
Pod dispatchers are only supposed to be used for the brief period of time that they're dispatching tasks and afterwards serve no purpose to keep around (even if they are used again after a long period of time to dispatch a task, they can simply be re-created). Therefore, we can apply a TTL to them once they haven't been used for a while.

* Add a field indicating the last time the pod dispatcher was updated. This will be the key for a TTL index for the collection.

### Testing 
Added unit tests.