### PR TITLE
EVG-17693: Promote variables from project to repo

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -461,6 +461,15 @@ func (r *mutationResolver) ForceRepotrackerRun(ctx context.Context, projectID st
 	return true, nil
 }
 
+func (r *mutationResolver) PromoteVarsToRepo(ctx context.Context, projectID string, varNames []string) (bool, error) {
+	usr := mustHaveUser(ctx)
+	if err := data.PromoteVarsToRepo(projectID, varNames, usr.Username()); err != nil {
+		return false, InternalServerError.Send(ctx, fmt.Sprintf("promoting variables to repo for project '%s': %s", projectID, err.Error()))
+
+	}
+	return true, nil
+}
+
 func (r *mutationResolver) RemoveFavoriteProject(ctx context.Context, identifier string) (*restModel.APIProjectRef, error) {
 	p, err := model.FindBranchProjectRef(identifier)
 	if err != nil || p == nil {

--- a/graphql/schema/mutation.graphql
+++ b/graphql/schema/mutation.graphql
@@ -53,6 +53,7 @@ type Mutation {
   defaultSectionToRepo(projectId: String! @requireProjectAccess(access: EDIT), section: ProjectSettingsSection!): String
   detachProjectFromRepo(projectId: String! @requireProjectAccess(access: EDIT)): Project!
   forceRepotrackerRun(projectId: String! @requireProjectAccess(access: EDIT)): Boolean!
+  promoteVarsToRepo(projectId: String! @requireProjectAccess(access: EDIT), varNames: [String!]!): Boolean!
   removeFavoriteProject(identifier: String!): Project!
   saveProjectSettingsForSection(projectSettings: ProjectSettingsInput, section: ProjectSettingsSection!): ProjectSettings!
   saveRepoSettingsForSection(repoSettings: RepoSettingsInput, section: ProjectSettingsSection!): RepoSettings!

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -97,6 +97,9 @@ func disableStartingSettings(p *model.ProjectRef) {
 	p.CommitQueue.Enabled = utility.FalsePtr()
 }
 
+// PromoteVarsToRepo moves variables from an attached project to its repo.
+// Promoted vars are removed from the project as part of this operation.
+// Variables whose names already appear in the repo settings will be overwritten.
 func PromoteVarsToRepo(projectId string, varNames []string, userId string) error {
 	project, err := model.GetProjectSettingsById(projectId, false)
 	if err != nil {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -153,13 +153,13 @@ func PromoteVarsToRepo(projectId string, varNames []string, userId string) error
 		}
 	}
 
-	for key, _ := range projectVars.PrivateVars {
+	for key := range projectVars.PrivateVars {
 		if _, contains := apiProjectVars.Vars[key]; contains {
 			apiProjectVars.PrivateVars[key] = true
 		}
 	}
 
-	for key, _ := range projectVars.AdminOnlyVars {
+	for key := range projectVars.AdminOnlyVars {
 		if _, contains := apiProjectVars.Vars[key]; contains {
 			apiProjectVars.AdminOnlyVars[key] = true
 		}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -120,6 +120,10 @@ func PromoteVarsToRepo(projectId string, varNames []string, userId string) error
 	apiRepoVars := &restModel.APIProjectVars{}
 	apiRepoVars.BuildFromService(*repoVars)
 	for _, varName := range varNames {
+		// Ignore nonexistent variables
+		if _, contains := projectVars.Vars[varName]; !contains {
+			continue
+		}
 		// Variables promoted from projects will overwrite matching repo variables
 		apiRepoVars.Vars[varName] = projectVars.Vars[varName]
 		if _, contains := projectVars.PrivateVars[varName]; contains {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -564,138 +564,124 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 func TestPromoteVarsToRepo(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		"SuccessfullyPromotesAllVariables": func(t *testing.T, ref model.ProjectRef) {
-			projectId := "pId"
-			repoId := "rId"
-
 			varsToPromote := []string{"a", "b", "c"}
-			err := PromoteVarsToRepo(projectId, varsToPromote, "u")
+			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
-			projectVarsFromDb, err := model.FindOneProjectVars(projectId)
+			projectVarsFromDB, err := model.FindOneProjectVars(ref.Id)
 			assert.NoError(t, err)
-			assert.Len(t, projectVarsFromDb.Vars, 0)
-			assert.Len(t, projectVarsFromDb.PrivateVars, 0)
-			assert.Len(t, projectVarsFromDb.AdminOnlyVars, 0)
+			assert.Len(t, projectVarsFromDB.Vars, 0)
+			assert.Len(t, projectVarsFromDB.PrivateVars, 0)
+			assert.Len(t, projectVarsFromDB.AdminOnlyVars, 0)
 
-			repoVarsFromDb, err := model.FindOneProjectVars(repoId)
+			repoVarsFromDB, err := model.FindOneProjectVars(ref.RepoRefId)
 			assert.NoError(t, err)
-			assert.Len(t, repoVarsFromDb.Vars, 4)
-			assert.Len(t, repoVarsFromDb.PrivateVars, 2)
-			assert.Len(t, repoVarsFromDb.AdminOnlyVars, 1)
-			assert.Equal(t, repoVarsFromDb.Vars["a"], "1")
-			assert.Equal(t, repoVarsFromDb.Vars["b"], "2")
-			assert.Equal(t, repoVarsFromDb.Vars["c"], "3")
+			assert.Len(t, repoVarsFromDB.Vars, 4)
+			assert.Len(t, repoVarsFromDB.PrivateVars, 2)
+			assert.Len(t, repoVarsFromDB.AdminOnlyVars, 1)
+			assert.Equal(t, repoVarsFromDB.Vars["a"], "1")
+			assert.Equal(t, repoVarsFromDB.Vars["b"], "2")
+			assert.Equal(t, repoVarsFromDB.Vars["c"], "3")
 
-			projectEvents, err := model.MostRecentProjectEvents(projectId, 10)
+			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 1)
 
-			repoEvents, err := model.MostRecentProjectEvents(repoId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 1)
 		},
 		"SuccessfullyPromotesSomeVariables": func(t *testing.T, ref model.ProjectRef) {
-			projectId := "pId"
-			repoId := "rId"
-
 			varsToPromote := []string{"a", "b"}
-			err := PromoteVarsToRepo(projectId, varsToPromote, "u")
+			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
-			varsFromDb, err := model.FindOneProjectVars(projectId)
+			varsFromDB, err := model.FindOneProjectVars(ref.Id)
 			assert.NoError(t, err)
-			assert.Len(t, varsFromDb.Vars, 1)
-			assert.Equal(t, varsFromDb.Vars["c"], "3")
-			assert.Len(t, varsFromDb.PrivateVars, 0)
-			assert.Len(t, varsFromDb.AdminOnlyVars, 0)
+			assert.Len(t, varsFromDB.Vars, 1)
+			assert.Equal(t, varsFromDB.Vars["c"], "3")
+			assert.Len(t, varsFromDB.PrivateVars, 0)
+			assert.Len(t, varsFromDB.AdminOnlyVars, 0)
 
-			repoVarsFromDb, err := model.FindOneProjectVars(repoId)
+			repoVarsFromDB, err := model.FindOneProjectVars(ref.RepoRefId)
 			assert.NoError(t, err)
-			assert.Len(t, repoVarsFromDb.Vars, 3)
-			assert.Len(t, repoVarsFromDb.PrivateVars, 2)
-			assert.Len(t, repoVarsFromDb.AdminOnlyVars, 1)
-			assert.NotContains(t, repoVarsFromDb.Vars, "c")
-			assert.Equal(t, repoVarsFromDb.Vars["a"], "1")
-			assert.Equal(t, repoVarsFromDb.Vars["b"], "2")
+			assert.Len(t, repoVarsFromDB.Vars, 3)
+			assert.Len(t, repoVarsFromDB.PrivateVars, 2)
+			assert.Len(t, repoVarsFromDB.AdminOnlyVars, 1)
+			assert.NotContains(t, repoVarsFromDB.Vars, "c")
+			assert.Equal(t, repoVarsFromDB.Vars["a"], "1")
+			assert.Equal(t, repoVarsFromDB.Vars["b"], "2")
 
-			projectEvents, err := model.MostRecentProjectEvents(projectId, 10)
+			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 1)
 
-			repoEvents, err := model.MostRecentProjectEvents(repoId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 1)
 		},
 		"CorrectlyPromotesNoVariables": func(t *testing.T, ref model.ProjectRef) {
-			projectId := "pId"
-			repoId := "rId"
-
 			varsToPromote := []string{}
-			err := PromoteVarsToRepo(projectId, varsToPromote, "u")
+			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
-			varsFromDb, err := model.FindOneProjectVars(projectId)
+			varsFromDB, err := model.FindOneProjectVars(ref.Id)
 			assert.NoError(t, err)
-			assert.Len(t, varsFromDb.Vars, 3)
-			assert.Equal(t, varsFromDb.Vars["a"], "1")
-			assert.Equal(t, varsFromDb.Vars["b"], "2")
-			assert.Equal(t, varsFromDb.Vars["c"], "3")
-			assert.Len(t, varsFromDb.PrivateVars, 1)
-			assert.True(t, varsFromDb.PrivateVars["a"])
-			assert.Len(t, varsFromDb.AdminOnlyVars, 0)
+			assert.Len(t, varsFromDB.Vars, 3)
+			assert.Equal(t, varsFromDB.Vars["a"], "1")
+			assert.Equal(t, varsFromDB.Vars["b"], "2")
+			assert.Equal(t, varsFromDB.Vars["c"], "3")
+			assert.Len(t, varsFromDB.PrivateVars, 1)
+			assert.True(t, varsFromDB.PrivateVars["a"])
+			assert.Len(t, varsFromDB.AdminOnlyVars, 0)
 
-			repoVarsFromDb, err := model.FindOneProjectVars(repoId)
+			repoVarsFromDB, err := model.FindOneProjectVars(ref.RepoRefId)
 			assert.NoError(t, err)
-			assert.Len(t, repoVarsFromDb.Vars, 1)
-			assert.Len(t, repoVarsFromDb.PrivateVars, 1)
-			assert.True(t, repoVarsFromDb.PrivateVars["d"])
-			assert.True(t, repoVarsFromDb.AdminOnlyVars["d"])
+			assert.Len(t, repoVarsFromDB.Vars, 1)
+			assert.Len(t, repoVarsFromDB.PrivateVars, 1)
+			assert.True(t, repoVarsFromDB.PrivateVars["d"])
+			assert.True(t, repoVarsFromDB.AdminOnlyVars["d"])
 
-			projectEvents, err := model.MostRecentProjectEvents(projectId, 10)
+			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 0)
 
-			repoEvents, err := model.MostRecentProjectEvents(repoId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 0)
 		},
 		"FailsOnUnattachedRepo": func(t *testing.T, ref model.ProjectRef) {
-			projectId := "pUnattached"
-
 			varsToPromote := []string{"test"}
-			err := PromoteVarsToRepo(projectId, varsToPromote, "u")
+			err := PromoteVarsToRepo("pUnattached", varsToPromote, "u")
 			assert.Error(t, err)
 		},
 		"IgnoresNonexistentVars": func(t *testing.T, ref model.ProjectRef) {
-			projectId := "pId"
-			repoId := "rId"
-
 			varsToPromote := []string{"test"}
-			err := PromoteVarsToRepo(projectId, varsToPromote, "u")
+			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
-			varsFromDb, err := model.FindOneProjectVars(projectId)
+			varsFromDB, err := model.FindOneProjectVars(ref.Id)
 			assert.NoError(t, err)
-			assert.Len(t, varsFromDb.Vars, 3)
-			assert.Equal(t, varsFromDb.Vars["a"], "1")
-			assert.Equal(t, varsFromDb.Vars["b"], "2")
-			assert.Equal(t, varsFromDb.Vars["c"], "3")
-			assert.Len(t, varsFromDb.PrivateVars, 1)
-			assert.True(t, varsFromDb.PrivateVars["a"])
-			assert.Len(t, varsFromDb.AdminOnlyVars, 0)
+			assert.Len(t, varsFromDB.Vars, 3)
+			assert.Equal(t, varsFromDB.Vars["a"], "1")
+			assert.Equal(t, varsFromDB.Vars["b"], "2")
+			assert.Equal(t, varsFromDB.Vars["c"], "3")
+			assert.Len(t, varsFromDB.PrivateVars, 1)
+			assert.True(t, varsFromDB.PrivateVars["a"])
+			assert.Len(t, varsFromDB.AdminOnlyVars, 0)
 
-			repoVarsFromDb, err := model.FindOneProjectVars(repoId)
+			repoVarsFromDB, err := model.FindOneProjectVars(ref.RepoRefId)
 			assert.NoError(t, err)
-			assert.Len(t, repoVarsFromDb.Vars, 1)
-			assert.Len(t, repoVarsFromDb.PrivateVars, 1)
-			assert.True(t, repoVarsFromDb.PrivateVars["d"])
-			assert.True(t, repoVarsFromDb.AdminOnlyVars["d"])
+			assert.Len(t, repoVarsFromDB.Vars, 1)
+			assert.Len(t, repoVarsFromDB.PrivateVars, 1)
+			assert.True(t, repoVarsFromDB.PrivateVars["d"])
+			assert.True(t, repoVarsFromDB.AdminOnlyVars["d"])
 
-			projectEvents, err := model.MostRecentProjectEvents(projectId, 10)
+			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 0)
 
-			repoEvents, err := model.MostRecentProjectEvents(repoId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 0)
 		},

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -562,10 +562,6 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 }
 
 func TestPromoteVarsToRepo(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "u"})
-
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		"SuccessfullyPromotesAllVariables": func(t *testing.T, ref model.ProjectRef) {
 			projectId := "pId"


### PR DESCRIPTION
[EVG-17693](https://jira.mongodb.org/browse/EVG-17693)

### Description 
- Add function + resolver for promoting variables from a project to the repo to which it is attached. Variables are removed from projects as part of this operation. This solves the problem where users could not move secret variables (where the value is no longer known to them) to their repo settings.
  - Note that the ticket wasn't specific about whether or not variables should be removed from the project or simply copied to the repo. I opted for the former, but am open to the other approach too if it seems preferable!

### Testing 
- Add unit tests
- Test resolver via GraphQL playground