### PR TITLE
EVG-17644: fix log format for dispatch race

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -639,7 +639,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 					"task_distro_id":       nextTask.DistroId,
 					"task_id":              nextTask.Id,
 					"host_id":              currentHost.Id,
-					"dispatch_race":        err,
+					"dispatch_race":        err.Error(),
 					"task_group":           nextTask.TaskGroup,
 					"task_build_variant":   nextTask.BuildVariant,
 					"task_version":         nextTask.Version,
@@ -650,7 +650,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 				if err := undoHostTaskDispatchWithFlag(ctx, env, currentHost, nextTask, shouldUseTransaction); err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
 						"message":              "problem undoing task group task dispatch after dispatch race",
-						"dispatch_race":        err,
+						"dispatch_race":        err.Error(),
 						"task_distro_id":       nextTask.DistroId,
 						"task_id":              nextTask.Id,
 						"host_id":              currentHost.Id,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17644

### Description
Fix the log format for the dispatch race reason. `message.Fields` does not show the error message when  the field value is an `error` object because Splunk can't JSONify it, so use the error message string.

### Testing
N/A