### PR TITLE
EVG-17305  Add debug logging for patch finished but status is still "started" in DB

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1119,7 +1119,7 @@ func updateVersionGithubStatus(v *Version, builds []build.Build) error {
 
 // Update the status of the version based on its constituent builds
 func updateVersionStatus(v *Version) (string, error) {
-	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+	grip.DebugWhen(v.Author == "didier.nadeau", message.Fields{
 		"message": "updateVersionStatus",
 		"ticket":  "EVG-17305",
 		"version": v.Id,
@@ -1137,7 +1137,7 @@ func updateVersionStatus(v *Version) (string, error) {
 
 	versionStatus := getVersionStatus(builds)
 
-	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+	grip.DebugWhen(v.Author == "didier.nadeau", message.Fields{
 		"message":        "updateVersionStatus getVersionStatus",
 		"ticket":         "EVG-17305",
 		"version":        v.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -484,6 +484,7 @@ func doStepback(t *task.Task) error {
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status
 func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
 	deactivatePrevious bool) error {
+
 	const slowThreshold = time.Second
 
 	detailsCopy := *detail
@@ -528,6 +529,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	}
 	startPhaseAt := time.Now()
 	err = t.MarkEnd(finishTime, &detailsCopy)
+
 	grip.NoticeWhen(time.Since(startPhaseAt) > slowThreshold, message.Fields{
 		"message":       "slow operation",
 		"function":      "MarkEnd",
@@ -602,10 +604,15 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 			err = evalStepback(t, caller, status, deactivatePrevious)
 		}
 		if err != nil {
-			return err
+			return errors.Wrap(err, "evaluating stepback")
 		}
 	}
 
+	grip.DebugWhen(t.ActivatedBy == "chaya.malik", message.Fields{
+		"message": "calling UpdateBuildAndVersionStatusForTask in MarkEnd",
+		"ticket":  "EVG-17305",
+		"task":    t.Id,
+	})
 	if err := UpdateBuildAndVersionStatusForTask(t); err != nil {
 		return errors.Wrap(err, "updating build/version status")
 	}
@@ -1112,6 +1119,11 @@ func updateVersionGithubStatus(v *Version, builds []build.Build) error {
 
 // Update the status of the version based on its constituent builds
 func updateVersionStatus(v *Version) (string, error) {
+	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+		"message": "updateVersionStatus",
+		"ticket":  "EVG-17305",
+		"version": v.Id,
+	})
 	builds, err := build.Find(build.ByVersion(v.Id).WithFields(build.ActivatedKey, build.StatusKey,
 		build.IsGithubCheckKey, build.GithubCheckStatusKey, build.AbortedKey))
 	if err != nil {
@@ -1124,6 +1136,16 @@ func updateVersionStatus(v *Version) (string, error) {
 	}
 
 	versionStatus := getVersionStatus(builds)
+
+	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+		"message":        "updateVersionStatus getVersionStatus",
+		"ticket":         "EVG-17305",
+		"version":        v.Id,
+		"author":         v.Author,
+		"new_status":     versionStatus,
+		"current_status": v.Status,
+	})
+
 	if versionStatus == v.Status {
 		return versionStatus, nil
 	}
@@ -1198,6 +1220,13 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	}
 	// If no build has changed status, then we can assume the version and patch statuses have also stayed the same.
 	if !buildStatusChanged {
+
+		grip.DebugWhen(t.ActivatedBy == "chaya.malik", message.Fields{
+			"message": "!buildStatusChanged in UpdateBuildAndVersionStatusForTask",
+			"ticket":  "EVG-17305",
+			"task":    t.Id,
+			"build":   taskBuild.Id,
+		})
 		return nil
 	}
 
@@ -1208,6 +1237,7 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	if taskVersion == nil {
 		return errors.Errorf("no version '%s' found for task '%s'", t.Version, t.Id)
 	}
+
 	newVersionStatus, err := updateVersionStatus(taskVersion)
 	if err != nil {
 		return errors.Wrapf(err, "updating version '%s' status", taskVersion.Id)

--- a/model/version.go
+++ b/model/version.go
@@ -230,7 +230,7 @@ func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
 func (v *Version) MarkFinished(status string, finishTime time.Time) error {
 	v.Status = status
 	v.FinishTime = finishTime
-	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+	grip.DebugWhen(v.Author == "didier.nadeau", message.Fields{
 		"message":     "Version MarkFinished",
 		"ticket":      "EVG-17305",
 		"version":     v.Id,

--- a/model/version.go
+++ b/model/version.go
@@ -14,6 +14,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -228,6 +230,12 @@ func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
 func (v *Version) MarkFinished(status string, finishTime time.Time) error {
 	v.Status = status
 	v.FinishTime = finishTime
+	grip.DebugWhen(v.Author == "chaya.malik", message.Fields{
+		"message":     "Version MarkFinished",
+		"ticket":      "EVG-17305",
+		"version":     v.Id,
+		"statusInput": status,
+	})
 	return VersionUpdateOne(
 		bson.M{VersionIdKey: v.Id},
 		bson.M{"$set": bson.M{


### PR DESCRIPTION
[EVG-17305](https://jira.mongodb.org/browse/EVG-17305)

### Description 
I plan to restart some tasks in some of [these patches ](https://spruce.mongodb.com/user/didier.nadeau/patches?commitQueue=true) and try to see if these logs shed some light. I tried to restart some tasks already and the version remains in "running". 

