### PR TITLE
EVG-16860: Set task doc as failed due to abort immediately upon aborting

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -111,6 +111,9 @@ const (
 	// TaskDescriptionContainerUnallocatable indicates that the reason a
 	// container task failed is because it cannot be allocated a container.
 	TaskDescriptionContainerUnallocatable = "container task cannot be allocated"
+	// TaskDescriptionAborted indicates that the reason a task failed is specifically
+	// because it was manually aborted.
+	TaskDescriptionAborted = "aborted"
 
 	// Task Statuses that are currently used only by the UI, and in tests
 	// (these may be used in old tasks as actual task statuses rather than just

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -686,13 +686,6 @@ func ByExecutionTasks(ids []string) bson.M {
 	}
 }
 
-func bySubsetAborted(ids []string) bson.M {
-	return bson.M{
-		IdKey:      bson.M{"$in": ids},
-		AbortedKey: true,
-	}
-}
-
 // ByExecutionPlatform returns the query to find tasks matching the given
 // execution platform. If the empty string is given, the task is assumed to be
 // the default of ExecutionPlatformHost.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1633,8 +1633,6 @@ func AbortTasksForBuild(buildId string, taskIds []string, caller string) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: AbortInfo{User: caller},
-				StatusKey:    evergreen.TaskFailed,
-				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -1652,8 +1650,6 @@ func AbortAndMarkResetTasksForVersion(versionId string, taskIds []string, caller
 			AbortedKey:           true,
 			AbortInfoKey:         AbortInfo{User: caller},
 			ResetWhenFinishedKey: true,
-			StatusKey:            evergreen.TaskFailed,
-			DetailsKey:           getAbortedFailureDetails(),
 		}},
 	)
 	return err
@@ -1740,11 +1736,4 @@ func (t *Task) SetStepbackDepth(stepbackDepth int) error {
 				StepbackDepthKey: stepbackDepth,
 			},
 		})
-}
-
-func getAbortedFailureDetails() apimodels.TaskEndDetail {
-	return apimodels.TaskEndDetail{
-		Status:      evergreen.TaskFailed,
-		Description: evergreen.TaskDescriptionAborted,
-	}
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1640,6 +1640,8 @@ func AbortTasksForBuild(buildId string, taskIds []string, caller string) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: AbortInfo{User: caller},
+				StatusKey:    evergreen.TaskFailed,
+				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -1657,6 +1659,8 @@ func AbortAndMarkResetTasksForVersion(versionId string, taskIds []string, caller
 			AbortedKey:           true,
 			AbortInfoKey:         AbortInfo{User: caller},
 			ResetWhenFinishedKey: true,
+			StatusKey:            evergreen.TaskFailed,
+			DetailsKey:           getAbortedFailureDetails(),
 		}},
 	)
 	return err
@@ -1743,4 +1747,11 @@ func (t *Task) SetStepbackDepth(stepbackDepth int) error {
 				StepbackDepthKey: stepbackDepth,
 			},
 		})
+}
+
+func getAbortedFailureDetails() apimodels.TaskEndDetail {
+	return apimodels.TaskEndDetail{
+		Status:      evergreen.TaskFailed,
+		Description: evergreen.TaskDescriptionAborted,
+	}
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1567,6 +1567,10 @@ func SetManyAborted(taskIds []string, reason AbortInfo) error {
 
 // SetAborted sets the abort field of task to aborted
 func (t *Task) SetAborted(reason AbortInfo) error {
+	taskEndDetails := apimodels.TaskEndDetail{
+		Status:      evergreen.TaskFailed,
+		Description: evergreen.TaskDescriptionAborted,
+	}
 	t.Aborted = true
 	return UpdateOne(
 		bson.M{
@@ -1576,6 +1580,8 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: reason,
+				StatusKey:    evergreen.TaskFailed,
+				DetailsKey:   taskEndDetails,
 			},
 		},
 	)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1560,6 +1560,8 @@ func SetManyAborted(taskIds []string, reason AbortInfo) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: reason,
+				StatusKey:    evergreen.TaskFailed,
+				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -1567,10 +1569,6 @@ func SetManyAborted(taskIds []string, reason AbortInfo) error {
 
 // SetAborted sets the abort field of task to aborted
 func (t *Task) SetAborted(reason AbortInfo) error {
-	taskEndDetails := apimodels.TaskEndDetail{
-		Status:      evergreen.TaskFailed,
-		Description: evergreen.TaskDescriptionAborted,
-	}
 	t.Aborted = true
 	return UpdateOne(
 		bson.M{
@@ -1581,7 +1579,7 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 				AbortedKey:   true,
 				AbortInfoKey: reason,
 				StatusKey:    evergreen.TaskFailed,
-				DetailsKey:   taskEndDetails,
+				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -2542,6 +2540,8 @@ func AbortBuild(buildId string, reason AbortInfo) error {
 		bson.M{"$set": bson.M{
 			AbortedKey:   true,
 			AbortInfoKey: reason,
+			StatusKey:    evergreen.TaskFailed,
+			DetailsKey:   getAbortedFailureDetails(),
 		}},
 	)
 	if err != nil {
@@ -2578,6 +2578,8 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 		bson.M{"$set": bson.M{
 			AbortedKey:   true,
 			AbortInfoKey: reason,
+			StatusKey:    evergreen.TaskFailed,
+			DetailsKey:   getAbortedFailureDetails(),
 		}},
 	)
 	if err != nil {
@@ -2947,19 +2949,6 @@ func (t *Task) SetResetFailedWhenFinished() error {
 			},
 		},
 	)
-}
-
-// SetAbortedTasksResetWhenFinished sets all matching aborted tasks as ResetWhenFinished.
-func SetAbortedTasksResetWhenFinished(taskIds []string) error {
-	_, err := UpdateAll(
-		bySubsetAborted(taskIds),
-		bson.M{
-			"$set": bson.M{
-				ResetWhenFinishedKey: true,
-			},
-		},
-	)
-	return err
 }
 
 // MergeTestResultsBulk takes a slice of task structs and returns the slice with

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1560,8 +1560,6 @@ func SetManyAborted(taskIds []string, reason AbortInfo) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: reason,
-				StatusKey:    evergreen.TaskFailed,
-				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -1578,8 +1576,6 @@ func (t *Task) SetAborted(reason AbortInfo) error {
 			"$set": bson.M{
 				AbortedKey:   true,
 				AbortInfoKey: reason,
-				StatusKey:    evergreen.TaskFailed,
-				DetailsKey:   getAbortedFailureDetails(),
 			},
 		},
 	)
@@ -2540,8 +2536,6 @@ func AbortBuild(buildId string, reason AbortInfo) error {
 		bson.M{"$set": bson.M{
 			AbortedKey:   true,
 			AbortInfoKey: reason,
-			StatusKey:    evergreen.TaskFailed,
-			DetailsKey:   getAbortedFailureDetails(),
 		}},
 	)
 	if err != nil {
@@ -2578,8 +2572,6 @@ func AbortVersion(versionId string, reason AbortInfo) error {
 		bson.M{"$set": bson.M{
 			AbortedKey:   true,
 			AbortInfoKey: reason,
-			StatusKey:    evergreen.TaskFailed,
-			DetailsKey:   getAbortedFailureDetails(),
 		}},
 	)
 	if err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1643,13 +1643,11 @@ func ClearAndResetStrandedHostTask(h *host.Host) error {
 	return nil
 }
 
-// ResetStaleTask fixes a task that has either exceeded the heartbeat timeout
-// or has been marked as aborted but was never ended by the agent.
-// The current task execution is marked as finished and, if the task is not
-// aborted, a new execution is created to restart the task.
-// If the task is aborted, the task is marked as failed alongside necessary
-// logic that would typically be run by the agent.
-func ResetStaleTask(t *task.Task) error {
+// FixStaleTask fixes a task that has exceeded the heartbeat timeout.
+// The current task execution is marked as finished and, if the task was not
+// aborted, the task is reset. If the task was aborted, we do not reset the task
+// and it is just marked as failed alongside other necessary updates to finish the task.
+func FixStaleTask(t *task.Task) error {
 	CheckAndBlockSingleHostTaskGroup(t, t.Status)
 
 	failureDesc := evergreen.TaskDescriptionHeartbeat

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1663,10 +1663,11 @@ func ResetStaleTask(t *task.Task) error {
 	}
 
 	grip.Info(message.Fields{
-		"message":            fmt.Sprintf("successfully fixed stale %s task", failureDesc),
+		"message":            "successfully fixed stale task",
 		"task":               t.Id,
 		"execution":          t.Execution,
 		"execution_platform": t.ExecutionPlatform,
+		"description":        failureDesc,
 	})
 
 	return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1645,8 +1645,8 @@ func ClearAndResetStrandedHostTask(h *host.Host) error {
 
 // ResetStaleTask fixes a task that has either exceeded the heartbeat timeout
 // or has been marked as aborted but was never ended by the agent.
-// The current task execution is marked as finished and, if possible, a new
-// execution is created to restart the task.
+// The current task execution is marked as finished and, if the task is not
+// aborted, a new execution is created to restart the task.
 func ResetStaleTask(t *task.Task) error {
 	CheckAndBlockSingleHostTaskGroup(t, t.Status)
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4107,6 +4107,7 @@ func TestResetStaleTask(t *testing.T) {
 			require.Zero(t, dbArchivedTask, "should not have archived the aborted task")
 
 			dbTask, err := task.FindOneId(tsk.Id)
+			require.NoError(t, err)
 			assert.Equal(t, evergreen.TaskFailed, dbTask.Status)
 			assert.Equal(t, evergreen.CommandTypeSystem, dbTask.Details.Type)
 			assert.Equal(t, evergreen.TaskDescriptionAborted, dbTask.Details.Description)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1870,9 +1870,6 @@ func TestAbortTask(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(testTask.Activated, ShouldEqual, false)
 			So(testTask.Aborted, ShouldEqual, true)
-			So(testTask.Status, ShouldEqual, evergreen.TaskFailed)
-			So(testTask.Details.Description, ShouldEqual, evergreen.TaskDescriptionAborted)
-			So(testTask.Details.Status, ShouldEqual, evergreen.TaskFailed)
 		})
 		Convey("a task that is finished should error when aborting", func() {
 			So(AbortTask(finishedTask.Id, userName), ShouldNotBeNil)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4068,7 +4068,7 @@ func TestResetStaleTask(t *testing.T) {
 		"SuccessfullyRestartsStaleTask": func(t *testing.T, tsk task.Task) {
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ResetStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(&tsk))
 
 			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
 			require.NoError(t, err)
@@ -4100,7 +4100,7 @@ func TestResetStaleTask(t *testing.T) {
 		"SuccessfullySystemFailsAbortedTask": func(t *testing.T, tsk task.Task) {
 			tsk.Aborted = true
 			require.NoError(t, tsk.Insert())
-			require.NoError(t, ResetStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(&tsk))
 
 			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
 			require.NoError(t, err)
@@ -4133,7 +4133,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.DisplayTaskId = utility.ToStringPtr(dt.Id)
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ResetStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(&tsk))
 
 			dbDisplayTask, err := task.FindOneId(dt.Id)
 			require.NoError(t, err)
@@ -4163,7 +4163,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.ActivatedTime = time.Now().Add(-10 * task.UnschedulableThreshold)
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ResetStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(&tsk))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4195,7 +4195,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.Execution = execNum
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ResetStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(&tsk))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1226,9 +1226,6 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
-	if t.Aborted {
-		h.details = t.Details
-	}
 	currentHost, err := host.FindOneId(h.hostID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting host"))
@@ -1311,7 +1308,14 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
-	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
+	details := &h.details
+	if t.Aborted {
+		details = &apimodels.TaskEndDetail{
+			Status:      evergreen.TaskFailed,
+			Description: evergreen.TaskDescriptionAborted,
+		}
+	}
+	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, details, deactivatePrevious)
 	if err != nil {
 		err = errors.Wrapf(err, "calling mark finish on task '%s'", t.Id)
 		return gimlet.MakeJSONInternalErrorResponder(err)

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1226,6 +1226,9 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
+	if t.Aborted {
+		h.details = t.Details
+	}
 	currentHost, err := host.FindOneId(h.hostID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting host"))

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -64,18 +64,20 @@ func (s *TaskAbortSuite) TestAbort() {
 	s.NoError(err)
 	s.Equal("user1", tasks[0].ActivatedBy)
 	s.Equal("", tasks[1].ActivatedBy)
-	s.Equal("user1", tasks[0].AbortInfo.User)
-	s.Equal("", tasks[1].AbortInfo.User)
 	t, ok := res.Data().(*model.APITask)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr("task1"), t.Id)
 
 	res = rm.Run(ctx)
-	s.Equal(http.StatusInternalServerError, res.Status())
+	s.Equal(http.StatusOK, res.Status())
 	s.NotNil(res)
-	errResp, ok := res.Data().(gimlet.ErrorResponse)
+	tasks, err = task.Find(task.ByIds([]string{"task1", "task2"}))
+	s.NoError(err)
+	s.Equal("user1", tasks[0].AbortInfo.User)
+	s.Equal("", tasks[1].AbortInfo.User)
+	t, ok = (res.Data()).(*model.APITask)
 	s.True(ok)
-	s.Equal(errResp.Message, "task 'task1' currently has status 'failed' - cannot abort task in this status")
+	s.Equal(utility.ToStringPtr("task1"), t.Id)
 }
 
 func TestFetchArtifacts(t *testing.T) {

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -64,20 +64,18 @@ func (s *TaskAbortSuite) TestAbort() {
 	s.NoError(err)
 	s.Equal("user1", tasks[0].ActivatedBy)
 	s.Equal("", tasks[1].ActivatedBy)
+	s.Equal("user1", tasks[0].AbortInfo.User)
+	s.Equal("", tasks[1].AbortInfo.User)
 	t, ok := res.Data().(*model.APITask)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr("task1"), t.Id)
 
 	res = rm.Run(ctx)
-	s.Equal(http.StatusOK, res.Status())
+	s.Equal(http.StatusInternalServerError, res.Status())
 	s.NotNil(res)
-	tasks, err = task.Find(task.ByIds([]string{"task1", "task2"}))
-	s.NoError(err)
-	s.Equal("user1", tasks[0].AbortInfo.User)
-	s.Equal("", tasks[1].AbortInfo.User)
-	t, ok = (res.Data()).(*model.APITask)
+	errResp, ok := res.Data().(gimlet.ErrorResponse)
 	s.True(ok)
-	s.Equal(utility.ToStringPtr("task1"), t.Id)
+	s.Equal(errResp.Message, "task 'task1' currently has status 'failed' - cannot abort task in this status")
 }
 
 func TestFetchArtifacts(t *testing.T) {

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -151,7 +151,7 @@ func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error
 			}
 		}
 
-		return errors.Wrapf(model.ResetStaleTask(j.task), "resetting stale task '%s'", j.task.Id)
+		return errors.Wrapf(model.FixStaleTask(j.task), "resetting stale task '%s'", j.task.Id)
 	}
 
 	host, err := host.FindOne(host.ById(j.task.HostId))
@@ -193,7 +193,7 @@ func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error
 		}
 	}
 
-	if err := model.ResetStaleTask(j.task); err != nil {
+	if err := model.FixStaleTask(j.task); err != nil {
 		return errors.Wrapf(err, "resetting stale task '%s'", j.task.Id)
 	}
 


### PR DESCRIPTION
[EVG-16860](https://jira.mongodb.org/browse/EVG-16860)

### Description 
This is a follow up to this [previous PR](https://github.com/evergreen-ci/evergreen/pull/5996).  There are some instances in the code when resetting a version / build where the version/build's running tasks are marked as aborted and the finished tasks are reset.  With the previous PR's changes to set the failed status at the same time as setting the aborted field, an issue arose where Evergreen now thought that these tasks are in a state where we can reset them - which is not the case. This is because when we reset these tasks their secrets get reset, which prevents the agent from performing its normal function of calling `"/end"` on a task once it sees it has been aborted - which is essential task ending logic.

As it stands aborted tasks that have been stranded by their hosts will eventually get cleaned up by an existing job, although the job will incorrectly mark the task as failed due to "heartbeat". This change adds the same new aborted failure description as before, as well as a check in the `cleanupTimedOutTask` function to check if the task was marked as aborted or not and if so, fail it with the appropriate aborted description instead.
### Testing 
Added unit tests.