### PR TITLE
EVG-6938 Avoid a collection scan by eliminating an empty build variants list  

### DIFF
--- a/model/task_history.go
+++ b/model/task_history.go
@@ -1059,9 +1059,6 @@ func TaskHistoryPickaxe(params PickaxeParams) ([]task.Task, error) {
 		return nil, errors.Wrap(err, "finding build variants")
 	}
 	query := bson.M{
-		task.BuildVariantKey: bson.M{
-			"$in": buildVariants,
-		},
 		task.DisplayNameKey: params.TaskName,
 		task.RevisionOrderNumberKey: bson.M{
 			"$gte": params.OldestOrder,
@@ -1069,10 +1066,13 @@ func TaskHistoryPickaxe(params PickaxeParams) ([]task.Task, error) {
 		},
 		task.ProjectKey: params.Project.Identifier,
 	}
-	// If there are build variants in the filter, use them instead
 	if len(params.BuildVariants) > 0 {
 		query[task.BuildVariantKey] = bson.M{
 			"$in": params.BuildVariants,
+		}
+	} else if len(buildVariants) > 0 {
+		query[task.BuildVariantKey] = bson.M{
+			"$in": buildVariants,
 		}
 	}
 	projection := []string{


### PR DESCRIPTION
[EVG-6938](https://jira.mongodb.org/browse/EVG-6938)

### Description 
Only include build variants in the query if the list is not empty. 

