### PR TITLE
EVG-18064 Add help text for re-inviting the slack bot

### DIFF
--- a/public/static/partials/subscription_list.html
+++ b/public/static/partials/subscription_list.html
@@ -14,6 +14,10 @@
             <button class="pull-right plus-button btn btn-primary" type="button" ng-click="addSubscription()">
                 <i class="fa fa-plus"></i>
             </button>
+            <div class="muted small">
+                The evergreen bot needs to be re-invited to private slack channels for notifications to go through. You can do so by
+                running 'invite @evergreen-bot' in the channel.
+            </div>
         </h4>
         <div ng-show="subscriptions.length === 0">
             No event subscriptions. Click the plus to add some.

--- a/public/static/partials/subscription_list.html
+++ b/public/static/partials/subscription_list.html
@@ -14,8 +14,9 @@
             <button class="pull-right plus-button btn btn-primary" type="button" ng-click="addSubscription()">
                 <i class="fa fa-plus"></i>
             </button>
+            <!-- this help text will be updated in EVG-17477 -->
             <div class="muted small">
-                The evergreen bot needs to be re-invited to private slack channels for notifications to go through. You can do so by
+                The Evergreen bot needs to be re-invited to private Slack channels for notifications to go through. You can do so by
                 running 'invite @evergreen-bot' in the channel.
             </div>
         </h4>


### PR DESCRIPTION
[EVG-18064](https://jira.mongodb.org/browse/EVG-18064)

### Description
This adds help text to the notifications page to help users debug why they are not receiving notifications. 

### Screenshots
<img width="742" alt="image" src="https://user-images.githubusercontent.com/13104717/195930019-ed4707de-12a1-4362-adf9-02cadc0f015a.png">

### Testing
Tested on staging 

### Spruce PR 
[1466](https://github.com/evergreen-ci/spruce/pull/1466)