### PR TITLE
EVG-17608 remove ticket from debug logic

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -484,7 +484,6 @@ func UpsertAliasesForProject(aliases []ProjectAlias, projectId string) error {
 		catcher.Add(aliases[i].Upsert())
 	}
 	grip.Debug(message.WrapError(catcher.Resolve(), message.Fields{
-		"ticket":     "EVG-17608",
 		"message":    "problem getting aliases",
 		"project_id": projectId,
 	}))


### PR DESCRIPTION
[EVG-17608](https://jira.mongodb.org/browse/EVG-17608)

### Description 
The original problem hasn't recurred in a few weeks (but also isn't likely to come up often since it requires copying a project) so I'd like to keep this logging but remove the ticket number, since I think the logging itself will still be helpful in this case.