### PR TITLE
EVG-17561 Remove ShouldExit field from GeneratePollResponse

### DIFF
--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -468,8 +468,7 @@ func (c *Mock) GenerateTasks(ctx context.Context, td TaskData, jsonBytes []json.
 
 func (c *Mock) GenerateTasksPoll(ctx context.Context, td TaskData) (*apimodels.GeneratePollResponse, error) {
 	resp := &apimodels.GeneratePollResponse{
-		Finished:   true,
-		ShouldExit: false,
+		Finished: true,
 	}
 	if c.GenerateTasksShouldFail {
 		resp.Error = "error polling generate tasks!"

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -312,9 +312,8 @@ func (ch *CreateHost) Expand(exp *util.Expansions) error {
 }
 
 type GeneratePollResponse struct {
-	Finished   bool   `json:"finished"`
-	ShouldExit bool   `json:"should_exit"`
-	Error      string `json:"error"`
+	Finished bool   `json:"finished"`
+	Error    string `json:"error"`
 }
 
 // DistroView represents the view of data that the agent uses from the distro

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-09-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-10-05"
+	AgentVersion = "2022-10-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -3,6 +3,8 @@ package route
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
@@ -11,7 +13,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 func makeGenerateTasksHandler(q amboy.QueueGroup) gimlet.RouteHandler {


### PR DESCRIPTION
[EVG-17561](https://jira.mongodb.org/browse/EVG-17561)

### Description 
Now that agents have had sufficient time to roll over, this should be safe to remove.