### PR TITLE
EVG-17291: add CLI option to validate against upgraded YAML version

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-10-19"
+	ClientVersion = "2022-10-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-10-19"

--- a/go.mod
+++ b/go.mod
@@ -71,4 +71,5 @@ require (
 	github.com/trinodb/trino-go-client v0.300.0
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
 	gopkg.in/20210107192922/yaml.v3 v3.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/model/generate.go
+++ b/model/generate.go
@@ -578,7 +578,7 @@ func appendTasks(pairs TaskVariantPairs, bv parserBV, p *Project) TaskVariantPai
 func (g *GeneratedProject) addGeneratedProjectToConfig(intermediateProject *ParserProject, config string, cachedProject projectMaps) (*ParserProject, error) {
 	var err error
 	if intermediateProject == nil {
-		intermediateProject, err = createIntermediateProject([]byte(config), false)
+		intermediateProject, err = createIntermediateProject([]byte(config), false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating intermediate project")
 		}

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,7 +41,7 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, err := createIntermediateProject([]byte(axes), true)
+			p, err := createIntermediateProject([]byte(axes), true, false)
 			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
@@ -77,7 +77,7 @@ buildvariants:
     - blue
     - green
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
@@ -108,7 +108,7 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -566,8 +566,6 @@ func GetProjectFromBSON(data []byte) (*Project, error) {
 // and sets the project's identifier field to identifier. Tags are evaluated. Returns the intermediate step.
 // If reading from a version config, LoadProjectForVersion should be used to persist the resulting parser project.
 // opts is used to look up files on github if the main parser project has an Include.
-// kim: TODO: find usages and ensure CheckUpgradedYAML is only set for
-// project validation route.
 func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, identifier string, project *Project) (*ParserProject, error) {
 	unmarshalStrict := false
 	checkUpgradedYAML := false

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -91,7 +91,7 @@ func FindParametersForVersion(v *Version) ([]patch.Parameter, error) {
 		if v.Config == "" {
 			return nil, errors.New("version has no config")
 		}
-		pp, err = createIntermediateProject([]byte(v.Config), false)
+		pp, err = createIntermediateProject([]byte(v.Config), false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing legacy config")
 		}
@@ -110,7 +110,7 @@ func FindExpansionsForVariant(v *Version, variant string) (util.Expansions, erro
 		if v.Config == "" {
 			return nil, errors.New("version has no config")
 		}
-		pp, err = createIntermediateProject([]byte(v.Config), false)
+		pp, err = createIntermediateProject([]byte(v.Config), false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "parsing legacy config")
 		}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -59,7 +59,7 @@ tasks:
     status: "failed"
     patch_optional: true
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "compile")
@@ -76,7 +76,7 @@ tasks:
 - name: task1
   depends_on: task0
 `
-			p, err := createIntermediateProject([]byte(single), false)
+			p, err := createIntermediateProject([]byte(single), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "task0")
@@ -88,7 +88,7 @@ tasks:
 - name: "compile"
   depends_on: ""
 `
-				p, err := createIntermediateProject([]byte(nameless), false)
+				p, err := createIntermediateProject([]byte(nameless), false, false)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -100,7 +100,7 @@ tasks:
   - name: "task1"
   - status: "failed" #this has no task attached
 `
-				p, err := createIntermediateProject([]byte(nameless), false)
+				p, err := createIntermediateProject([]byte(nameless), false, false)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -109,7 +109,7 @@ tasks:
 tasks:
 - name: "compile"
 `
-				p, err := createIntermediateProject([]byte(nameless), false)
+				p, err := createIntermediateProject([]byte(nameless), false, false)
 				So(p, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 			})
@@ -138,7 +138,7 @@ buildvariants:
     stepback: false
     priority: 77
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -163,7 +163,7 @@ buildvariants:
   - name: "t2"
     depends_on: "t3"
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -181,7 +181,7 @@ buildvariants:
   tasks:
     name: "t1"
 `
-			p, err := createIntermediateProject([]byte(simple), false)
+			p, err := createIntermediateProject([]byte(simple), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
@@ -205,7 +205,7 @@ buildvariants:
   run_on: "distro1"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(single), false)
+			p, err := createIntermediateProject([]byte(single), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.Ignore), ShouldEqual, 1)
@@ -226,7 +226,7 @@ buildvariants:
   - name: "t1"
     run_on: "test"
 `
-			p, err := createIntermediateProject([]byte(single), false)
+			p, err := createIntermediateProject([]byte(single), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.BuildVariants[0].Tasks[0].RunOn[0], ShouldEqual, "test")
@@ -241,7 +241,7 @@ buildvariants:
     run_on: "test"
     distros: "asdasdasd"
 `
-			p, err := createIntermediateProject([]byte(single), false)
+			p, err := createIntermediateProject([]byte(single), false, false)
 			So(p, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
@@ -253,7 +253,7 @@ buildvariants:
   - name: "t1"
     commit_queue_merge: true
 `
-			p, err := createIntermediateProject([]byte(single), false)
+			p, err := createIntermediateProject([]byte(single), false, false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -277,7 +277,7 @@ buildvariants:
   - name: "t1"
     activate: true
 `
-	p, err := createIntermediateProject([]byte(yml), false)
+	p, err := createIntermediateProject([]byte(yml), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	bv := p.BuildVariants[0]
@@ -569,7 +569,7 @@ tasks:
 - name: execTask3
 - name: execTask4
 `
-	p, err := createIntermediateProject([]byte(yml), false)
+	p, err := createIntermediateProject([]byte(yml), false, false)
 
 	// check that display tasks in bv1 parsed correctly
 	assert.NoError(err)
@@ -598,7 +598,7 @@ parameters:
 - key: buggy
   value: driver
 `
-	p, err := createIntermediateProject([]byte(yml), false)
+	p, err := createIntermediateProject([]byte(yml), false, false)
 	assert.NoError(t, err)
 	require.Len(t, p.Parameters, 2)
 	assert.Equal(t, "iter_count", p.Parameters[0].Key)
@@ -951,7 +951,7 @@ tasks:
 - name: execTask4
   tags: [ "even" ]
 `
-	pp, err := createIntermediateProject([]byte(tagYml), false)
+	pp, err := createIntermediateProject([]byte(tagYml), false, false)
 	assert.NotNil(pp)
 	assert.NoError(err)
 	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
@@ -1622,7 +1622,7 @@ func TestParserProjectRoundtrip(t *testing.T) {
 	yml, err := ioutil.ReadFile(filepath)
 	assert.NoError(t, err)
 
-	original, err := createIntermediateProject(yml, false)
+	original, err := createIntermediateProject(yml, false, false)
 	assert.NoError(t, err)
 
 	// to and from yaml
@@ -1711,7 +1711,7 @@ buildvariants:
 }
 
 func checkProjectPersists(t *testing.T, yml []byte) {
-	pp, err := createIntermediateProject(yml, false)
+	pp, err := createIntermediateProject(yml, false, false)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("old-project-identifier")
@@ -1730,7 +1730,7 @@ func checkProjectPersists(t *testing.T, yml []byte) {
 	assert.True(t, bytes.Equal(newYaml, yamlToCompare))
 
 	// ensure that updating with the re-parsed project doesn't error
-	pp, err = createIntermediateProject(newYaml, false)
+	pp, err = createIntermediateProject(newYaml, false, false)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("new-project-identifier")
@@ -2395,10 +2395,10 @@ ignore:
   - ".github/*"
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false)
+	p1, err := createIntermediateProject([]byte(mainYaml), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(smallYaml), false)
+	p2, err := createIntermediateProject([]byte(smallYaml), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -2444,13 +2444,13 @@ buildvariants:
       - name: task3
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false)
+	p1, err := createIntermediateProject([]byte(mainYaml), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(succeed), false)
+	p2, err := createIntermediateProject([]byte(succeed), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
-	p3, err := createIntermediateProject([]byte(fail), false)
+	p3, err := createIntermediateProject([]byte(fail), false, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p3)
 	err = p1.mergeMultipleParserProjects(p2)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1256,7 +1256,7 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, err := createIntermediateProject([]byte(projYml), false)
+	intermediate, err := createIntermediateProject([]byte(projYml), false, false)
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -16,6 +16,7 @@ const (
 	patchIDFlagName           = "patch"
 	moduleFlagName            = "module"
 	localModulesFlagName      = "local_modules"
+	checkUpgradedYAMLFlagName = "check_upgraded_yaml"
 	skipConfirmFlagName       = "skip_confirm"
 	yesFlagName               = "yes"
 	variantsFlagName          = "variants"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -16,7 +16,7 @@ const (
 	patchIDFlagName           = "patch"
 	moduleFlagName            = "module"
 	localModulesFlagName      = "local_modules"
-	checkUpgradedYAMLFlagName = "check_upgraded_yaml"
+	useUpgradedYAMLFlagName   = "use_upgraded_yaml"
 	skipConfirmFlagName       = "skip_confirm"
 	yesFlagName               = "yes"
 	variantsFlagName          = "variants"

--- a/operations/http.go
+++ b/operations/http.go
@@ -147,13 +147,13 @@ func (ac *legacyClient) modifyExisting(patchId, action string) error {
 }
 
 // ValidateLocalConfig validates the local project config with the server
-func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong, checkUpgradedYAML bool, projectID string) (validator.ValidationErrors, error) {
+func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong, useUpgradedYAML bool, projectID string) (validator.ValidationErrors, error) {
 	input := validator.ValidationInput{
-		ProjectYaml:       data,
-		Quiet:             quiet,
-		IncludeLong:       includeLong,
-		ProjectID:         projectID,
-		CheckUpgradedYAML: checkUpgradedYAML,
+		ProjectYaml:     data,
+		Quiet:           quiet,
+		IncludeLong:     includeLong,
+		ProjectID:       projectID,
+		UseUpgradedYAML: useUpgradedYAML,
 	}
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)

--- a/operations/http.go
+++ b/operations/http.go
@@ -147,12 +147,13 @@ func (ac *legacyClient) modifyExisting(patchId, action string) error {
 }
 
 // ValidateLocalConfig validates the local project config with the server
-func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong bool, projectID string) (validator.ValidationErrors, error) {
+func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong, checkUpgradedYAML bool, projectID string) (validator.ValidationErrors, error) {
 	input := validator.ValidationInput{
-		ProjectYaml: data,
-		Quiet:       quiet,
-		IncludeLong: includeLong,
-		ProjectID:   projectID,
+		ProjectYaml:       data,
+		Quiet:             quiet,
+		IncludeLong:       includeLong,
+		ProjectID:         projectID,
+		CheckUpgradedYAML: checkUpgradedYAML,
 	}
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -18,8 +18,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// kim: TODO: verify that compass YAML succeeds by default but fails with
-// with --check_upgraded_yaml
 func Validate() cli.Command {
 	return cli.Command{
 		Name:  "validate",
@@ -142,8 +140,6 @@ func validateFile(path string, ac *legacyClient, quiet, includeLong, checkUpgrad
 	}
 
 	if pc != nil {
-		// kim: TODO: need to consider whether this matters when doing optional
-		// validation with YAML v3.0.1
 		projectConfigYaml, err := yaml.Marshal(pc.ProjectConfigFields)
 		if err != nil {
 			return errors.Wrapf(err, "marshalling project config into YAML")

--- a/service/api.go
+++ b/service/api.go
@@ -213,7 +213,8 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	var projectConfig *model.ProjectConfig
 	ctx := context.Background()
 	opts := &model.GetProjectOpts{
-		ReadFileFrom: model.ReadFromLocal,
+		ReadFileFrom:      model.ReadFromLocal,
+		CheckUpgradedYAML: input.CheckUpgradedYAML,
 	}
 	validationErr := validator.ValidationError{}
 	if _, err = model.LoadProjectInto(ctx, input.ProjectYaml, opts, "", project); err != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -213,8 +213,8 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	var projectConfig *model.ProjectConfig
 	ctx := context.Background()
 	opts := &model.GetProjectOpts{
-		ReadFileFrom:      model.ReadFromLocal,
-		CheckUpgradedYAML: input.CheckUpgradedYAML,
+		ReadFileFrom:    model.ReadFromLocal,
+		UseUpgradedYAML: input.UseUpgradedYAML,
 	}
 	validationErr := validator.ValidationError{}
 	if _, err = model.LoadProjectInto(ctx, input.ProjectYaml, opts, "", project); err != nil {

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	yaml "gopkg.in/20210107192922/yaml.v3"
 	yaml2 "gopkg.in/yaml.v2"
+	upgradedYAML "gopkg.in/yaml.v3"
 )
 
 const UnmarshalStrictError = "error unmarshalling yaml strict"
@@ -32,6 +33,36 @@ func UnmarshalYAMLStrictWithFallback(in []byte, out interface{}) error {
 	d.KnownFields(true)
 	if err := d.Decode(out); err != nil {
 		if err2 := yaml2.UnmarshalStrict(in, out); err2 != nil {
+			return errors.Wrap(err, UnmarshalStrictError)
+		}
+	}
+	return nil
+}
+
+// UnmarshalUpgradedYAMLWithFallback is identical to UnmarshalYAMLWithFallback but uses the upgraded YAML version
+// (v3.0.1) instead of the current YAML version.
+// This should only be used for user validation to see if their project's YAML hypothetically produces a valid config
+// should the YAML version be upgraded.
+func UnmarshalUpgradedYAMLWithFallback(in []byte, out interface{}) error {
+	if err := upgradedYAML.Unmarshal(in, out); err != nil {
+		// try the older version of yaml before erroring, in case it's just an outdated yaml
+		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UnmarshalUpgradedYAMLStrictWithFallback is identical to UnmarshalYAMLStrictWithFallback but uses the upgraded YAML
+// version (v3.0.1) instead of the current YAML version.
+// This should only be used for user validation to see if their project's YAML hypothetically produces a valid config
+// should the YAML version be upgraded.
+func UnmarshalUpgradedYAMLStrictWithFallback(in []byte, out interface{}) error {
+	d := upgradedYAML.NewDecoder(bytes.NewReader(in))
+	d.KnownFields(true)
+	if err := d.Decode(out); err != nil {
+		// try the older version of yaml before erroring, in case it's just an outdated yaml
+		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
 			return errors.Wrap(err, UnmarshalStrictError)
 		}
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -110,10 +110,11 @@ func (v ValidationErrors) HasError() bool {
 }
 
 type ValidationInput struct {
-	ProjectYaml []byte `json:"project_yaml" yaml:"project_yaml"`
-	Quiet       bool   `json:"quiet" yaml:"quiet"`
-	IncludeLong bool   `json:"include_long" yaml:"include_long"`
-	ProjectID   string `json:"project_id" yaml:"project_id"`
+	ProjectYaml       []byte `json:"project_yaml" yaml:"project_yaml"`
+	Quiet             bool   `json:"quiet" yaml:"quiet"`
+	IncludeLong       bool   `json:"include_long" yaml:"include_long"`
+	CheckUpgradedYAML bool   `json:"check_upgraded_yaml" yaml:"check_upgraded_yaml"`
+	ProjectID         string `json:"project_id" yaml:"project_id"`
 }
 
 // Functions used to validate the syntax of a project configuration file.

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -110,11 +110,11 @@ func (v ValidationErrors) HasError() bool {
 }
 
 type ValidationInput struct {
-	ProjectYaml       []byte `json:"project_yaml" yaml:"project_yaml"`
-	Quiet             bool   `json:"quiet" yaml:"quiet"`
-	IncludeLong       bool   `json:"include_long" yaml:"include_long"`
-	CheckUpgradedYAML bool   `json:"check_upgraded_yaml" yaml:"check_upgraded_yaml"`
-	ProjectID         string `json:"project_id" yaml:"project_id"`
+	ProjectYaml     []byte `json:"project_yaml" yaml:"project_yaml"`
+	Quiet           bool   `json:"quiet" yaml:"quiet"`
+	IncludeLong     bool   `json:"include_long" yaml:"include_long"`
+	UseUpgradedYAML bool   `json:"use_upgraded_yaml" yaml:"use_upgraded_yaml"`
+	ProjectID       string `json:"project_id" yaml:"project_id"`
 }
 
 // Functions used to validate the syntax of a project configuration file.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17291

### Description 
This is related to #6002 and adds a more user-friendly means to check if a project YAML will be invalidated by the upcoming YAML upgrade. Since we're not sure how many projects are affected by the change to how the YAML module treats nested maps (especially `params`) and I'm not sure people will know what to look for, I added a temporary flag to `evergreen validate` so users can conveniently check if their YAML is still valid using the upgraded YAML version. If their project YAML passes with `--use_upgraded_yaml`, their project config is still valid after the YAML upgrade; otherwise, they'll have to fix their YAML. We'll provide a grace period for them to fix the nested map merging dependency.

### Testing 
Tested `evergreen validate` against staging using [the project YAML with a known dependency on nested map merging](https://github.com/mongodb-js/compass/blob/d65d51613adab4a3e86cf062eac64d06ad9d861f/.evergreen.yml), with and without `--use_upgraded_yaml`. Without the upgraded YAML flag, it passes validation. With the upgraded YAML flag, it has errors.

I also tested against a YAML that I know doesn't have this nested map issue, and it passed validation both with and without the flag.