### PR TITLE
EVG-18123: Temporarily disable GQL introspection 

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -18,6 +18,13 @@ import (
 // Handler returns a gimlet http handler func used as the gql route handler
 func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(New(apiURL)))
+
+	// Temporarily disable GQL introspection (EVG-18123)
+	srv.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+		graphql.GetOperationContext(ctx).DisableIntrospection = true
+		return next(ctx)
+	})
+
 	// Apollo tracing support https://github.com/apollographql/apollo-tracing
 	srv.Use(apollotracing.Tracer{})
 


### PR DESCRIPTION
[EVG-18123](https://jira.mongodb.org/browse/EVG-18123)

### Description 
Temporarily disable the GQL playground (evergreen.mongodb.com/graphql) to reduce splunk reporting during investigation.
Relevant api doc: https://github.com/99designs/gqlgen/blob/master/docs/content/reference/introspection.md#disabling-introspection-based-on-authentication