### PR TITLE
EVG-18131: exclude hosts running tasks from self-throttle

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -268,8 +268,8 @@ func CountAllRunningDynamicHosts() (int, error) {
 	return num, errors.Wrap(err, "counting running dynamic hosts")
 }
 
-// CountIdleStartedTaskHosts returns the count of task hosts that are not
-// currently running a task.
+// CountIdleStartedTaskHosts returns the count of task hosts that are starting
+// and not currently running a task.
 func CountIdleStartedTaskHosts() (int, error) {
 	num, err := Count(db.Query(idleStartedTaskHostsQuery("")))
 	return num, errors.Wrap(err, "counting starting hosts")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -230,10 +230,11 @@ func runningHostsQuery(distroID string) bson.M {
 	return query
 }
 
-func startedTaskHostsQuery(distroID string) bson.M {
+func idleStartedTaskHostsQuery(distroID string) bson.M {
 	query := bson.M{
-		StatusKey:    bson.M{"$in": evergreen.StartedHostStatus},
-		StartedByKey: evergreen.User,
+		StatusKey:      bson.M{"$in": evergreen.StartedHostStatus},
+		StartedByKey:   evergreen.User,
+		RunningTaskKey: bson.M{"$exists": false},
 	}
 	if distroID != "" {
 		query[bsonutil.GetDottedKeyName(DistroKey, distro.IdKey)] = distroID
@@ -267,14 +268,11 @@ func CountAllRunningDynamicHosts() (int, error) {
 	return num, errors.Wrap(err, "counting running dynamic hosts")
 }
 
-func CountStartedTaskHosts() (int, error) {
-	num, err := Count(db.Query(startedTaskHostsQuery("")))
+// CountIdleStartedTaskHosts returns the count of task hosts that are not
+// currently running a task.
+func CountIdleStartedTaskHosts() (int, error) {
+	num, err := Count(db.Query(idleStartedTaskHostsQuery("")))
 	return num, errors.Wrap(err, "counting starting hosts")
-}
-
-func CountStartedTaskHostsForDistro(distroID string) (int, error) {
-	num, err := Count(db.Query(startedTaskHostsQuery(distroID)))
-	return num, errors.Wrap(err, "counting started task hosts")
 }
 
 // IdleHostsWithDistroID, given a distroID, returns a slice of all idle hosts in that distro

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -231,7 +231,7 @@ func (j *createHostJob) selfThrottle() bool {
 		err                error
 	)
 
-	numProv, err = host.CountStartedTaskHosts()
+	numProv, err = host.CountIdleStartedTaskHosts()
 	if err != nil {
 		j.AddError(errors.Wrap(err, "counting pending host pool size"))
 		return true


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18131

### Description 
Hosts that are already running a task should be excluded from the self-throttle count of provisioning hosts. If they're already running a task, they're already provisioned.

### Testing 
There's no unit tests for this query or for the self-throttling behavior, so I didn't think it was worth improving this test coverage issue here for such a tiny change.