### PR TITLE
EVG-18140: decommission task host when SNS notifies of stop/termination

### DIFF
--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -253,8 +253,15 @@ func (sns *ec2SNS) handleInstanceTerminated(ctx context.Context, instanceID stri
 		return nil
 	}
 
+	// The host is going to imminently stop work anyways. Decommissioning
+	// ensures that even if the external state check does not terminate the
+	// host, the host is eventually picked up for termination.
+	if err := h.SetDecommissioned(evergreen.User, false, "SNS notification indicates host is terminated"); err != nil {
+		return errors.Wrap(err, "decommissioning host")
+	}
+
 	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, units.NewHostMonitorExternalStateJob(sns.env, h, sns.payload.MessageId)); err != nil {
-		return err
+		return errors.Wrap(err, "enqueueing host external state check job")
 	}
 
 	return nil
@@ -286,8 +293,15 @@ func (sns *ec2SNS) handleInstanceStopped(ctx context.Context, instanceID string)
 		return nil
 	}
 
+	// The host is going to imminently stop work anyways. Decommissioning
+	// ensures that even if the external state check does not terminate the
+	// host, the host is eventually picked up for termination.
+	if err := h.SetDecommissioned(evergreen.User, false, "SNS notification indicates host is stopped"); err != nil {
+		return errors.Wrap(err, "decommissioning host")
+	}
+
 	if err := amboy.EnqueueUniqueJob(ctx, sns.queue, units.NewHostMonitorExternalStateJob(sns.env, h, sns.payload.MessageId)); err != nil {
-		return err
+		return errors.Wrap(err, "enqueueing host external state check job")
 	}
 
 	return nil

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -112,17 +112,23 @@ func TestHandleEC2SNSNotification(t *testing.T) {
 func TestEC2SNSNotificationHandlers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	defer func() {
+		assert.NoError(t, db.Clear(host.Collection))
+	}()
 	assert.NoError(t, db.Clear(host.Collection))
+
 	agentHost := host.Host{
 		Id:        "agent_host",
 		StartTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 		StartedBy: evergreen.User,
 		Provider:  evergreen.ProviderNameMock,
+		Status:    evergreen.HostRunning,
 	}
 	spawnHost := host.Host{
 		Id:        "spawn_host",
 		StartedBy: "user",
 		UserHost:  true,
+		Status:    evergreen.HostRunning,
 	}
 	messageID := "m0"
 	rh := ec2SNS{}
@@ -130,17 +136,28 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 	assert.NoError(t, agentHost.Insert())
 	assert.NoError(t, spawnHost.Insert())
 
+	checkStatus := func(t *testing.T, hostID, status string) {
+		dbHost, err := host.FindOneId(hostID)
+		require.NoError(t, err)
+		require.NotZero(t, dbHost)
+		assert.Equal(t, status, dbHost.Status)
+	}
+
 	for name, test := range map[string]func(*testing.T){
 		"InstanceTerminatedInitiatesInstanceStatusCheck": func(t *testing.T) {
 			require.NoError(t, rh.handleInstanceTerminated(ctx, agentHost.Id))
+			checkStatus(t, agentHost.Id, evergreen.HostDecommissioned)
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
 		},
 		"InstanceStoppedWithAgentHostInitiatesInstanceStatusCheck": func(t *testing.T) {
 			require.NoError(t, rh.handleInstanceStopped(ctx, agentHost.Id))
+			checkStatus(t, agentHost.Id, evergreen.HostDecommissioned)
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
 		},
 		"InstanceStoppedWithSpawnHostNoops": func(t *testing.T) {
+			originalStatus := spawnHost.Status
 			require.NoError(t, rh.handleInstanceStopped(ctx, spawnHost.Id))
+			checkStatus(t, spawnHost.Id, originalStatus)
 			assert.Zero(t, rh.queue.Stats(ctx).Total)
 		},
 	} {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18140

### Description 
Preserve the warning that SNS gave us (before acking it) by decommissioning the host.

### Testing 
Updated existing unit tests.
