### PR TITLE
EVG-17330 script from stdin

### DIFF
--- a/units/host_execute.go
+++ b/units/host_execute.go
@@ -89,10 +89,11 @@ func (j *hostExecuteJob) Run(ctx context.Context) {
 				args = append(args, fmt.Sprintf("--user=%s", j.SudoUser))
 			}
 		}
-		args = append(args, j.host.Distro.ShellBinary(), "-l", "-c", j.Script)
+		args = append(args, j.host.Distro.ShellBinary(), "-s")
 		var output []string
 		output, err := j.host.RunJasperProcess(ctx, j.env, &options.Create{
-			Args: args,
+			Args:               args,
+			StandardInputBytes: []byte(j.Script),
 		})
 		if err != nil {
 			event.LogHostScriptExecuteFailed(j.host.Id, err)


### PR DESCRIPTION
[EVG-17330](https://jira.mongodb.org/browse/EVG-17330)

### Description 
If a user-provided provisioning script is greater than a certain length it won't run on spawn hosts of Windows userdata distros.
idk if there's a specific reason we avoided this until now, but this PR gets around the issue by passing the script to the shell through stdin. This is consistent with [how the script is executed through ssh for non-userdata distros](https://github.com/ybrill/evergreen/blob/d4eab8faf353d473bfec8478c3572ab85450d039/model/host/hostutil.go#L234).

### Testing 
With these changes deployed to staging [the example problem script from the ticket](https://github.com/visemet/mongo/blob/5af9ad0e1ec467b9848636ff426a8fe9d8c49d63/buildscripts/setup_spawnhost_coredump) ran on a Windows spawn host.
