### PR TITLE
EVG-18206: remove dependence on dropping databases in REST route tests

### DIFF
--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -8,12 +8,11 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/mongodb/amboy"
 	"github.com/pkg/errors"
 )
 
 // GenerateTasks parses JSON files for `generate.tasks` and creates the new builds and tasks.
-func GenerateTasks(taskID string, jsonBytes []json.RawMessage, group amboy.QueueGroup) error {
+func GenerateTasks(taskID string, jsonBytes []json.RawMessage) error {
 	t, err := task.FindOneId(taskID)
 	if err != nil {
 		return errors.Wrapf(err, "finding task '%s'", taskID)
@@ -39,7 +38,7 @@ func GenerateTasks(taskID string, jsonBytes []json.RawMessage, group amboy.Queue
 }
 
 // GeneratePoll checks to see if a `generate.tasks` job has finished.
-func GeneratePoll(ctx context.Context, taskID string, group amboy.QueueGroup) (bool, string, error) {
+func GeneratePoll(ctx context.Context, taskID string) (bool, string, error) {
 	t, err := task.FindOneId(taskID)
 	if err != nil {
 		return false, "", errors.Wrapf(err, "finding task '%s'", taskID)

--- a/rest/data/generate_test.go
+++ b/rest/data/generate_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,13 +13,9 @@ import (
 func TestGeneratePoll(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.ClearCollections(task.Collection))
-	require.NotNil(t, env)
-	q := env.RemoteQueueGroup()
-	require.NotNil(t, q)
 
-	finished, generateErrs, err := GeneratePoll(ctx, "task-0", q)
+	finished, generateErrs, err := GeneratePoll(ctx, "task-0")
 	assert.False(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.Error(t, err)
@@ -32,7 +27,7 @@ func TestGeneratePoll(t *testing.T) {
 		GeneratedTasks: false,
 	}).Insert())
 
-	finished, generateErrs, err = GeneratePoll(ctx, "task-1", q)
+	finished, generateErrs, err = GeneratePoll(ctx, "task-1")
 	assert.False(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.NoError(t, err)
@@ -44,7 +39,7 @@ func TestGeneratePoll(t *testing.T) {
 		GeneratedTasks: true,
 	}).Insert())
 
-	finished, generateErrs, err = GeneratePoll(ctx, "task-2", q)
+	finished, generateErrs, err = GeneratePoll(ctx, "task-2")
 	assert.True(t, finished)
 	assert.Empty(t, generateErrs)
 	assert.NoError(t, err)
@@ -57,7 +52,7 @@ func TestGeneratePoll(t *testing.T) {
 		GenerateTasksError: "this is an error",
 	}).Insert())
 
-	finished, generateErrs, err = GeneratePoll(context.Background(), "task-3", q)
+	finished, generateErrs, err = GeneratePoll(ctx, "task-3")
 	assert.True(t, finished)
 	assert.Equal(t, "this is an error", generateErrs)
 	assert.NoError(t, err)

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -21,7 +22,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v34/github"
 	"github.com/mongodb/amboy"
-	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -49,11 +49,12 @@ func (s *GithubWebhookRouteSuite) SetupSuite() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.canceler = cancel
 
-	s.env = testutil.NewEnvironment(ctx, s.T())
+	env := &mock.Environment{}
+	s.Require().NoError(env.Configure(ctx))
+	s.env = env
 	s.NotNil(s.env.Settings())
 	s.NotNil(s.env.Settings().Api)
 	s.NotEmpty(s.env.Settings().Api.GithubWebhookSecret)
-	s.Require().NoError(db.DropDatabases(s.env.Settings().Amboy.DB))
 
 	s.conf = testutil.TestConfig()
 	s.NotNil(s.conf)
@@ -64,18 +65,16 @@ func (s *GithubWebhookRouteSuite) TearDownSuite() {
 }
 
 func (s *GithubWebhookRouteSuite) SetupTest() {
-	grip.Critical(s.conf.Api)
-
 	s.NoError(db.Clear(model.ProjectRefCollection))
 	s.NoError(db.Clear(commitqueue.Collection))
 
-	s.queue = evergreen.GetEnvironment().LocalQueue()
+	s.queue = s.env.LocalQueue()
 	s.mockSc = &data.MockGitHubConnector{
 		MockGitHubConnectorImpl: data.MockGitHubConnectorImpl{},
 	}
 
-	s.rm = makeGithubHooksRoute(s.sc, s.queue, []byte(s.conf.Api.GithubWebhookSecret), evergreen.GetEnvironment().Settings())
-	s.mockRm = makeGithubHooksRoute(s.mockSc, s.queue, []byte(s.conf.Api.GithubWebhookSecret), evergreen.GetEnvironment().Settings())
+	s.rm = makeGithubHooksRoute(s.sc, s.queue, []byte(s.conf.Api.GithubWebhookSecret), s.env.Settings())
+	s.mockRm = makeGithubHooksRoute(s.mockSc, s.queue, []byte(s.conf.Api.GithubWebhookSecret), s.env.Settings())
 
 	s.Require().NoError(commitqueue.InsertQueue(&commitqueue.CommitQueue{ProjectID: "mci"}))
 

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -537,9 +537,9 @@ func TestHostNextTask(t *testing.T) {
 			defer cancel()
 
 			colls := []string{model.ProjectRefCollection, host.Collection, task.Collection, model.TaskQueuesCollection, build.Collection, evergreen.ConfigCollection}
-			require.NoError(t, db.DropCollections(colls...))
+			require.NoError(t, db.ClearCollections(colls...))
 			defer func() {
-				assert.NoError(t, db.DropCollections(colls...))
+				assert.NoError(t, db.ClearCollections(colls...))
 			}()
 			require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey))
 
@@ -778,9 +778,9 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			defer cancel()
 
 			colls := []string{host.Collection, task.Collection, model.TaskQueuesCollection, build.Collection, model.ParserProjectCollection, model.ProjectRefCollection, model.VersionCollection, alertrecord.Collection, event.EventCollection}
-			require.NoError(t, db.DropCollections(colls...))
+			require.NoError(t, db.ClearCollections(colls...))
 			defer func() {
-				assert.NoError(t, db.DropCollections(colls...))
+				assert.NoError(t, db.ClearCollections(colls...))
 			}()
 
 			env := &mock.Environment{}
@@ -864,9 +864,9 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionLegacy(t *testing.T
 		}
 
 		colls := []string{distro.Collection, host.Collection, task.Collection, model.TaskQueuesCollection, model.ProjectRefCollection}
-		require.NoError(t, db.DropCollections(colls...))
+		require.NoError(t, db.ClearCollections(colls...))
 		defer func() {
-			assert.NoError(t, db.DropCollections(colls...))
+			assert.NoError(t, db.ClearCollections(colls...))
 		}()
 		require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey))
 		distroID := "testDistro"
@@ -1213,9 +1213,9 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			Version: evergreen.DispatcherVersionRevisedWithDependencies,
 		}
 		colls := []string{distro.Collection, host.Collection, task.Collection, model.TaskQueuesCollection, model.ProjectRefCollection}
-		require.NoError(t, db.DropCollections(colls...))
+		require.NoError(t, db.ClearCollections(colls...))
 		defer func() {
-			assert.NoError(t, db.DropCollections(colls...))
+			assert.NoError(t, db.ClearCollections(colls...))
 		}()
 		require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey))
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -15,7 +15,6 @@ const defaultLimit = 100
 
 type HandlerOpts struct {
 	APIQueue            amboy.Queue
-	QueueGroup          amboy.QueueGroup
 	TaskDispatcher      model.TaskQueueItemDispatcher
 	TaskAliasDispatcher model.TaskQueueItemDispatcher
 	URL                 string
@@ -233,8 +232,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/created_ticket").Version(2).Put().Wrap(requireUser, editAnnotations).RouteHandler(makeCreatedTicketByTask())
 	app.AddRoute("/tasks/{task_id}/abort").Version(2).Post().Wrap(requireUser, editTasks).RouteHandler(makeTaskAbortHandler())
 	app.AddRoute("/tasks/{task_id}/display_task").Version(2).Get().Wrap(requireTask).RouteHandler(makeGetDisplayTaskHandler())
-	app.AddRoute("/tasks/{task_id}/generate").Version(2).Post().Wrap(requireTask).RouteHandler(makeGenerateTasksHandler(opts.QueueGroup))
-	app.AddRoute("/tasks/{task_id}/generate").Version(2).Get().Wrap(requireTask).RouteHandler(makeGenerateTasksPollHandler(opts.QueueGroup))
+	app.AddRoute("/tasks/{task_id}/generate").Version(2).Post().Wrap(requireTask).RouteHandler(makeGenerateTasksHandler())
+	app.AddRoute("/tasks/{task_id}/generate").Version(2).Get().Wrap(requireTask).RouteHandler(makeGenerateTasksPollHandler())
 	app.AddRoute("/tasks/{task_id}/manifest").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetManifestHandler())
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, requireUser, editTasks).RouteHandler(makeTaskRestartHandler())
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(sc))

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -9,28 +9,22 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
-func makeGenerateTasksHandler(q amboy.QueueGroup) gimlet.RouteHandler {
-	return &generateHandler{
-		queue: q,
-	}
+func makeGenerateTasksHandler() gimlet.RouteHandler {
+	return &generateHandler{}
 }
 
 type generateHandler struct {
 	files  []json.RawMessage
 	taskID string
-	queue  amboy.QueueGroup
 }
 
 func (h *generateHandler) Factory() gimlet.RouteHandler {
-	return &generateHandler{
-		queue: h.queue,
-	}
+	return &generateHandler{}
 }
 
 func (h *generateHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -50,28 +44,23 @@ func parseJson(r *http.Request) ([]json.RawMessage, error) {
 }
 
 func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
-	if err := data.GenerateTasks(h.taskID, h.files, h.queue); err != nil {
+	if err := data.GenerateTasks(h.taskID, h.files); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "generating tasks for task '%s'", h.taskID))
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
 }
 
-func makeGenerateTasksPollHandler(q amboy.QueueGroup) gimlet.RouteHandler {
-	return &generatePollHandler{
-		queue: q,
-	}
+func makeGenerateTasksPollHandler() gimlet.RouteHandler {
+	return &generatePollHandler{}
 }
 
 type generatePollHandler struct {
 	taskID string
-	queue  amboy.QueueGroup
 }
 
 func (h *generatePollHandler) Factory() gimlet.RouteHandler {
-	return &generatePollHandler{
-		queue: h.queue,
-	}
+	return &generatePollHandler{}
 }
 
 func (h *generatePollHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -81,7 +70,7 @@ func (h *generatePollHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *generatePollHandler) Run(ctx context.Context) gimlet.Responder {
-	finished, jobErr, err := data.GeneratePoll(ctx, h.taskID, h.queue)
+	finished, jobErr, err := data.GeneratePoll(ctx, h.taskID)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error polling for generated tasks",

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,25 +65,18 @@ func TestGenerateExecute(t *testing.T) {
 func TestGeneratePollParse(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.ClearCollections(task.Collection, host.Collection))
 	r, err := http.NewRequest(http.MethodGet, "/task/1/generate", nil)
 	require.NoError(t, err)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "1"})
 
-	require.NoError(t, db.DropDatabases(env.Settings().Amboy.DB))
-	require.NotNil(t, env)
-	q := env.RemoteQueueGroup()
-	require.NotNil(t, q)
-
-	h := makeGenerateTasksPollHandler(q)
+	h := makeGenerateTasksPollHandler()
 	require.NoError(t, h.Parse(ctx, r))
 }
 
 func TestGeneratePollRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.ClearCollections(task.Collection))
 	tasks := []task.Task{
 		{
@@ -99,11 +91,7 @@ func TestGeneratePollRun(t *testing.T) {
 		require.NoError(t, task.Insert())
 	}
 
-	require.NotNil(t, env)
-	q := env.RemoteQueueGroup()
-	require.NotNil(t, q)
-
-	h := makeGenerateTasksPollHandler(q)
+	h := makeGenerateTasksPollHandler()
 
 	impl, ok := h.(*generatePollHandler)
 	require.True(t, ok)

--- a/service/service.go
+++ b/service/service.go
@@ -56,7 +56,6 @@ func GetRouter(as *APIServer, uis *UIServer) (http.Handler, error) {
 
 	opts := route.HandlerOpts{
 		APIQueue:            as.queue,
-		QueueGroup:          as.env.RemoteQueueGroup(),
 		URL:                 as.Settings.Ui.Url,
 		GithubSecret:        []byte(as.Settings.Api.GithubWebhookSecret),
 		TaskDispatcher:      as.taskDispatcher,
@@ -73,7 +72,6 @@ func GetRouter(as *APIServer, uis *UIServer) (http.Handler, error) {
 	apiRestV2.SetPrefix(evergreen.APIRoutePrefix + "/" + evergreen.RestRoutePrefix)
 	opts = route.HandlerOpts{
 		APIQueue:            as.queue,
-		QueueGroup:          as.env.RemoteQueueGroup(),
 		URL:                 as.Settings.Ui.Url,
 		GithubSecret:        []byte(as.Settings.Api.GithubWebhookSecret),
 		TaskDispatcher:      as.taskDispatcher,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18206

### Description 
As far as I can tell, the EC2 SNS test is being flaky for reasons unrelated to this particular test. From what I can see, the test DB is spending a ton of time trying to clean up some state as a result of dropping a bunch of collections/DBs in other unrelated tests in the REST route package, which is holding the lock on the DB and preventing any reads/writes to it. There are [logs in the test](https://evergreen.mongodb.com/task_log_raw/evergreen_ubuntu1604_test_rest_route_cddfabfb14478c7534a9f94dc140e1fda860412c_22_11_02_20_19_23/0?type=T#L7614) to back up this hypothesis since they're fixing collections that were dropped in other tests using `DropCollections`.

* Remove some unused parameters to reduce the need to drop the Amboy test DB in a few REST route tests.
* Replace dropping collections/DBs with just clearing the collections in REST route tests.

### Testing 
Existing tests pass. I ran a bunch of patches repeatedly to empirically verify that the TimestampMonitor is no longer doing this.