### PR TITLE
EVG-17358 Return display tasks in get build by id route

### DIFF
--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -55,7 +56,7 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	var tasks []task.Task
 	if len(taskIDs) > 0 {
-		tasks, err = task.Find(task.ByIds(taskIDs))
+		tasks, err = task.FindAll(db.Query(task.ByIds(taskIDs)))
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding tasks in build '%s'", b.buildId))
 		}

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -59,9 +59,6 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding tasks in build '%s'", b.buildId))
 		}
-		if len(tasks) == 0 {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("no tasks found in build '%s'", b.buildId))
-		}
 	}
 
 	buildModel := &model.APIBuild{}

--- a/rest/route/build_test.go
+++ b/rest/route/build_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
@@ -30,15 +31,34 @@ func TestBuildSuite(t *testing.T) {
 }
 
 func (s *BuildByIdSuite) SetupSuite() {
-	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, build.Collection))
+	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, build.Collection, task.Collection))
 	projRef := serviceModel.ProjectRef{Repo: "project", Id: "branch"}
 	s.NoError(projRef.Insert())
-	builds := []build.Build{
-		{Id: "build1", Project: "branch"},
-		{Id: "build2", Project: "notbranch"},
+	tasks := []task.Task{
+		{Id: "task1", BuildId: "build1", DisplayOnly: true},
+		{Id: "task2", BuildId: "build2"},
 	}
-	for _, item := range builds {
-		s.Require().NoError(item.Insert())
+	for _, task := range tasks {
+		s.Require().NoError(task.Insert())
+	}
+	builds := []build.Build{
+		{
+			Id:      "build1",
+			Project: "branch",
+			Tasks: []build.TaskCache{
+				{Id: "task1"},
+			},
+		},
+		{
+			Id:      "build2",
+			Project: "notbranch",
+			Tasks: []build.TaskCache{
+				{Id: "task2"},
+			},
+		},
+	}
+	for _, build := range builds {
+		s.Require().NoError(build.Insert())
 	}
 }
 
@@ -46,7 +66,7 @@ func (s *BuildByIdSuite) SetupTest() {
 	s.rm = makeGetBuildByID()
 }
 
-func (s *BuildByIdSuite) TestFindByIdProjFound() {
+func (s *BuildByIdSuite) TestFindBuildById() {
 	s.rm.(*buildGetHandler).buildId = "build1"
 	resp := s.rm.Run(context.TODO())
 	s.Equal(resp.Status(), http.StatusOK)
@@ -56,9 +76,21 @@ func (s *BuildByIdSuite) TestFindByIdProjFound() {
 	s.True(ok)
 	s.Equal(utility.ToStringPtr("build1"), b.Id)
 	s.Equal(utility.ToStringPtr("branch"), b.ProjectId)
+	s.Equal("task1", b.TaskCache[0].Id)
+
+	s.rm.(*buildGetHandler).buildId = "build2"
+	resp = s.rm.Run(context.TODO())
+	s.Equal(resp.Status(), http.StatusOK)
+	s.NotNil(resp.Data())
+
+	b, ok = (resp.Data()).(*model.APIBuild)
+	s.True(ok)
+	s.Equal(utility.ToStringPtr("build2"), b.Id)
+	s.Equal(utility.ToStringPtr("notbranch"), b.ProjectId)
+	s.Equal("task2", b.TaskCache[0].Id)
 }
 
-func (s *BuildByIdSuite) TestFindByIdFail() {
+func (s *BuildByIdSuite) TestFindBuildByIdFail() {
 	s.rm.(*buildGetHandler).buildId = "build3"
 	resp := s.rm.Run(context.TODO())
 	s.NotEqual(resp.Status(), http.StatusOK)

--- a/rest/route/build_test.go
+++ b/rest/route/build_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -35,8 +36,8 @@ func (s *BuildByIdSuite) SetupSuite() {
 	projRef := serviceModel.ProjectRef{Repo: "project", Id: "branch"}
 	s.NoError(projRef.Insert())
 	tasks := []task.Task{
-		{Id: "task1", BuildId: "build1", DisplayOnly: true},
-		{Id: "task2", BuildId: "build2"},
+		{Id: "task1", Status: evergreen.TaskFailed, BuildId: "build1", DisplayOnly: true},
+		{Id: "task2", Status: evergreen.TaskSucceeded, BuildId: "build2"},
 	}
 	for _, task := range tasks {
 		s.Require().NoError(task.Insert())
@@ -77,6 +78,7 @@ func (s *BuildByIdSuite) TestFindBuildById() {
 	s.Equal(utility.ToStringPtr("build1"), b.Id)
 	s.Equal(utility.ToStringPtr("branch"), b.ProjectId)
 	s.Equal("task1", b.TaskCache[0].Id)
+	s.Equal(evergreen.TaskFailed, b.TaskCache[0].Status)
 
 	s.rm.(*buildGetHandler).buildId = "build2"
 	resp = s.rm.Run(context.TODO())
@@ -88,6 +90,7 @@ func (s *BuildByIdSuite) TestFindBuildById() {
 	s.Equal(utility.ToStringPtr("build2"), b.Id)
 	s.Equal(utility.ToStringPtr("notbranch"), b.ProjectId)
 	s.Equal("task2", b.TaskCache[0].Id)
+	s.Equal(evergreen.TaskSucceeded, b.TaskCache[0].Status)
 }
 
 func (s *BuildByIdSuite) TestFindBuildByIdFail() {


### PR DESCRIPTION
[EVG-17358](https://jira.mongodb.org/browse/EVG-17358)

### Description 
The build route was erroring out because it only had 1 display task. 
The task.Find method automatically filters out display tasks.
We now use findall which will return display only tasks as well but still gets rid of the extra check

### Testing 
unit