### PR TITLE
EVG-18139: gracefully handle nonexistent hosts when checking statuses

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -113,8 +113,11 @@ type ContainerManager interface {
 
 // BatchManager is an interface for cloud providers that support batch operations.
 type BatchManager interface {
-	// GetInstanceStatuses gets the status of a slice of instances.
-	GetInstanceStatuses(context.Context, []host.Host) ([]CloudStatus, error)
+	// GetInstanceStatuses gets the statuses of a slice of instances. It returns
+	// a map of the instance IDs to their current status. If some of the
+	// instance statuses cannot be retrieved, implementations are allowed to
+	// either error or return StatusNonExistent.
+	GetInstanceStatuses(context.Context, []host.Host) (map[string]CloudStatus, error)
 }
 
 // ManagerOpts is a struct containing the fields needed to get a new cloud manager

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -116,7 +116,9 @@ type BatchManager interface {
 	// GetInstanceStatuses gets the statuses of a slice of instances. It returns
 	// a map of the instance IDs to their current status. If some of the
 	// instance statuses cannot be retrieved, implementations are allowed to
-	// either error or return StatusNonExistent.
+	// either return an error or return StatusNonExistent for those hosts.
+	// If there is no error, implementations should return the same number of
+	// results in the map as there are hosts.
 	GetInstanceStatuses(context.Context, []host.Host) (map[string]CloudStatus, error)
 }
 

--- a/cloud/cloud_status.go
+++ b/cloud/cloud_status.go
@@ -52,7 +52,11 @@ func (stat CloudStatus) String() string {
 		return "stopped"
 	case StatusTerminated:
 		return "terminated"
-	default:
+	case StatusNonExistent:
+		return "nonexistent"
+	case StatusUnknown:
 		return "unknown"
+	default:
+		return "invalid"
 	}
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -937,7 +937,7 @@ func addPublicKey(ctx context.Context, h *host.Host, key string) error {
 }
 
 // GetInstanceStatuses returns the current status of a slice of EC2 instances.
-func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) ([]CloudStatus, error) {
+func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) (map[string]CloudStatus, error) {
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
@@ -970,20 +970,24 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		if err != nil {
 			return nil, errors.Wrap(err, "describing spot instances")
 		}
-		if len(spotOut.SpotInstanceRequests) != len(spotHosts) {
-			return nil, errors.New("programmer error: length of spot instance requests != length of spot host IDs")
-		}
 		spotInstanceRequestsMap := map[string]*ec2.SpotInstanceRequest{}
 		for i := range spotOut.SpotInstanceRequests {
 			spotInstanceRequestsMap[*spotOut.SpotInstanceRequests[i].SpotInstanceRequestId] = spotOut.SpotInstanceRequests[i]
 		}
 		for i := range spotHosts {
-			if spotInstanceRequestsMap[spotHosts[i].Id].InstanceId == nil || *spotInstanceRequestsMap[spotHosts[i].Id].InstanceId == "" {
-				hostToStatusMap[spotHosts[i].Id] = cloudStatusFromSpotStatus(*spotInstanceRequestsMap[spotHosts[i].Id].State)
+			spotHostID := spotHosts[i].Id
+			spotRequest, ok := spotInstanceRequestsMap[spotHostID]
+			if !ok {
+				hostToStatusMap[spotHostID] = StatusNonExistent
 				continue
 			}
-			hostsToCheck = append(hostsToCheck, spotInstanceRequestsMap[spotHosts[i].Id].InstanceId)
-			instanceIdToHostMap[*spotInstanceRequestsMap[spotHosts[i].Id].InstanceId] = spotHosts[i]
+			instanceID := utility.FromStringPtr(spotRequest.InstanceId)
+			if instanceID == "" {
+				hostToStatusMap[spotHostID] = cloudStatusFromSpotStatus(*spotRequest.State)
+				continue
+			}
+			hostsToCheck = append(hostsToCheck, &instanceID)
+			instanceIdToHostMap[instanceID] = spotHosts[i]
 		}
 	}
 
@@ -1005,18 +1009,8 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		for i := range hostsToCheck {
 			instance, ok := reservationsMap[*hostsToCheck[i]]
 			if !ok {
-				// Terminate an unknown host in the db
-				for _, h := range hosts {
-					if h.Id == *hostsToCheck[i] {
-						grip.Error(message.WrapError(h.Terminate(evergreen.User, "host is missing from DescribeInstances response"), message.Fields{
-							"message":       "can't mark instance as terminated",
-							"host_id":       h.Id,
-							"host_provider": h.Distro.Provider,
-							"distro":        h.Distro.Id,
-						}))
-					}
-				}
-				return nil, errors.Errorf("host '%s' not included in DescribeInstances response", *hostsToCheck[i])
+				hostToStatusMap[*hostsToCheck[i]] = StatusNonExistent
+				continue
 			}
 			status := ec2StatusToEvergreenStatus(*instance.State.Name)
 			if status == StatusRunning {
@@ -1029,12 +1023,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		}
 	}
 
-	// Populate cloud statuses
-	statuses := []CloudStatus{}
-	for _, h := range hosts {
-		statuses = append(statuses, hostToStatusMap[h.Id])
-	}
-	return statuses, nil
+	return hostToStatusMap, nil
 }
 
 // GetInstanceStatus returns the current status of an EC2 instance.

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -981,7 +981,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 				hostToStatusMap[spotHostID] = StatusNonExistent
 				continue
 			}
-			instanceID := utility.FromStringPtr(spotRequest.InstanceId)
+			instanceID := aws.StringValue(spotRequest.InstanceId)
 			if instanceID == "" {
 				hostToStatusMap[spotHostID] = cloudStatusFromSpotStatus(*spotRequest.State)
 				continue
@@ -1211,7 +1211,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 
 	if len(out.StoppingInstances) == 1 {
 		instance := out.StoppingInstances[0]
-		status := ec2StatusToEvergreenStatus(utility.FromStringPtr(instance.CurrentState.Name))
+		status := ec2StatusToEvergreenStatus(aws.StringValue(instance.CurrentState.Name))
 		switch status {
 		case StatusStopping:
 			grip.Error(message.WrapError(h.SetStopping(user), message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -174,7 +174,6 @@ func (m *ec2FleetManager) ModifyHost(context.Context, *host.Host, host.HostModif
 	return errors.New("can't modify instances for EC2 fleet provider")
 }
 
-// kim; TODO: add test for instance not found.
 func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) (map[string]CloudStatus, error) {
 	instanceIDs := make([]*string, 0, len(hosts))
 	for _, h := range hosts {

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -32,6 +32,7 @@ func TestFleet(t *testing.T) {
 
 			statuses, err := m.GetInstanceStatuses(context.Background(), hosts)
 			assert.NoError(t, err)
+			assert.Len(t, statuses, len(hosts), "should return same number of statuses as there are hosts")
 			for _, status := range statuses {
 				assert.Equal(t, StatusRunning, status)
 			}

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -455,11 +455,11 @@ func (mockMgr *mockManager) GetVolumeAttachment(ctx context.Context, volumeID st
 	return nil, nil
 }
 
-func (mockMgr *mockManager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) ([]CloudStatus, error) {
+func (mockMgr *mockManager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) (map[string]CloudStatus, error) {
 	if len(hosts) != 1 {
 		return nil, errors.New("expecting 1 hosts")
 	}
-	return []CloudStatus{StatusRunning}, nil
+	return map[string]CloudStatus{hosts[0].Id: StatusRunning}, nil
 }
 
 func (m *mockManager) CheckInstanceType(ctx context.Context, instanceType string) error {

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -101,14 +101,7 @@ clientsLoop:
 			statusesCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 			defer cancel()
 
-			startAt := time.Now()
 			statuses, err := batch.GetInstanceStatuses(statusesCtx, hosts)
-			grip.Debug(message.Fields{
-				"message":       "finished getting instance statuses",
-				"num_hosts":     len(hosts),
-				"provider":      clientOpts.Provider,
-				"duration_secs": time.Since(startAt).Seconds(),
-			})
 			if err != nil {
 				if strings.Contains(err.Error(), cloud.EC2ErrorNotFound) {
 					j.AddError(j.terminateUnknownHosts(ctx, err.Error()))
@@ -117,38 +110,29 @@ clientsLoop:
 				j.AddError(errors.Wrap(err, "getting host statuses for providers"))
 				continue clientsLoop
 			}
-			if len(statuses) != len(hosts) {
-				j.AddError(errors.Errorf("programmer error: length of statuses != length of hosts"))
-				continue clientsLoop
-			}
+
 			for i := range hosts {
-				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, hosts[i], statuses[i]), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
+				hostID := hosts[i].Id
+				status, ok := statuses[hostID]
+				if !ok {
+					grip.Error(message.WrapError(err, message.Fields{
+						"message": "could not get any cloud instance status for host",
+						"host_id": hostID,
+					}))
+					continue
+				}
+				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, hosts[i], status), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
 			}
-			continue clientsLoop
+
+			continue
 		}
+
 		for _, h := range hosts {
 			statusCtx, cancel := context.WithTimeout(ctx, time.Minute)
-			startAt := time.Now()
 			cloudStatus, err := m.GetInstanceStatus(statusCtx, &h)
 			cancel()
-			grip.Debug(message.Fields{
-				"message":       "finished getting instance status",
-				"host_id":       h.Id,
-				"provider":      clientOpts.Provider,
-				"duration_secs": time.Since(startAt).Seconds(),
-			})
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "checking instance status of host '%s'", h.Id))
-				continue clientsLoop
-			}
-			if cloudStatus == cloud.StatusNonExistent {
-				// Terminate unknown host in the DB.
-				grip.Error(message.WrapError(h.Terminate(evergreen.User, "host does not exist"), message.Fields{
-					"message":       "can't mark instance as terminated",
-					"host_id":       h.Id,
-					"host_provider": h.Distro.Provider,
-					"distro":        h.Distro.Id,
-				}))
 				continue clientsLoop
 			}
 			j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, h, cloudStatus), "setting status for host '%s' based on its cloud instance's status", h.Id))
@@ -156,6 +140,8 @@ clientsLoop:
 	}
 }
 
+// terminateUnknownHosts prepares hosts that do not have any status information
+// in their cloud provider to be terminated.
 func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr string) error {
 	pieces := strings.Split(awsErr, "'")
 	if len(pieces) != 3 {
@@ -165,6 +151,7 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 	grip.Warning(message.Fields{
 		"message": "host IDs not found in AWS, will terminate",
 		"hosts":   instanceIDs,
+		"job":     j.ID(),
 	})
 	catcher := grip.NewBasicCatcher()
 	for _, hostID := range instanceIDs {
@@ -176,6 +163,13 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 		if h == nil {
 			continue
 		}
+		// Decommission the host to prevent this job from checking it again.
+		grip.Error(message.WrapError(h.SetDecommissioned(evergreen.User, false, ""), message.Fields{
+			"message": "could not set nonexistent host to decommissioned in preparation for termination",
+			"host_id": h.Id,
+			"job":     j.ID(),
+		}))
+
 		terminationJob := NewHostTerminationJob(j.env, h, HostTerminationOptions{
 			TerminateIfBusy:   true,
 			TerminationReason: "instance ID not found",
@@ -191,18 +185,19 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 // Hosts found in an unrecoverable state are terminated.
 func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, cloudStatus cloud.CloudStatus) error {
 	switch cloudStatus {
-	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped, cloud.StatusStopping:
+	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped, cloud.StatusStopping, cloud.StatusNonExistent:
 		j.logHostStatusMessage(&h, cloudStatus)
 
 		event.LogHostTerminatedExternally(h.Id, h.Status)
 		grip.Info(message.Fields{
-			"message":   "host terminated externally",
-			"operation": "setCloudHostStatus",
-			"host_id":   h.Id,
-			"host_tag":  h.Tag,
-			"distro":    h.Distro.Id,
-			"provider":  h.Provider,
-			"status":    h.Status,
+			"message":      "host terminated externally",
+			"operation":    "setCloudHostStatus",
+			"host_id":      h.Id,
+			"host_tag":     h.Tag,
+			"distro":       h.Distro.Id,
+			"provider":     h.Provider,
+			"status":       h.Status,
+			"cloud_status": cloudStatus,
 		})
 
 		catcher := grip.NewBasicCatcher()
@@ -211,7 +206,7 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 		terminationJob := NewHostTerminationJob(j.env, &h, HostTerminationOptions{
 			TerminateIfBusy:          true,
 			TerminationReason:        "instance was found in stopped state",
-			SkipCloudHostTermination: cloudStatus == cloud.StatusTerminated,
+			SkipCloudHostTermination: cloudStatus == cloud.StatusTerminated || cloudStatus == cloud.StatusNonExistent,
 		})
 		catcher.Wrap(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminationJob), "enqueueing job to terminate host")
 

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -115,8 +115,8 @@ clientsLoop:
 				hostID := hosts[i].Id
 				status, ok := statuses[hostID]
 				if !ok {
-					grip.Error(message.WrapError(err, message.Fields{
-						"message": "could not get any cloud instance status for host, defaulting to nonexistent status",
+					grip.Alert(message.WrapError(err, message.Fields{
+						"message": "GetInstanceStatuses is violating interface requirements - host instance status was requested but none was returned, defaulting to nonexistent status",
 						"host_id": hostID,
 						"job":     j.ID(),
 					}))

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -116,10 +116,11 @@ clientsLoop:
 				status, ok := statuses[hostID]
 				if !ok {
 					grip.Error(message.WrapError(err, message.Fields{
-						"message": "could not get any cloud instance status for host",
+						"message": "could not get any cloud instance status for host, defaulting to nonexistent status",
 						"host_id": hostID,
+						"job":     j.ID(),
 					}))
-					continue
+					statuses[hostID] = cloud.StatusNonExistent
 				}
 				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, hosts[i], status), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
 			}

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -165,11 +165,7 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 			continue
 		}
 		// Decommission the host to prevent this job from checking it again.
-		grip.Error(message.WrapError(h.SetDecommissioned(evergreen.User, false, "cloud host has no status"), message.Fields{
-			"message": "could not set nonexistent host to decommissioned in preparation for termination",
-			"host_id": h.Id,
-			"job":     j.ID(),
-		}))
+		catcher.Wrap(h.SetDecommissioned(evergreen.User, false, "cloud host has no status"), "setting nonexistent host to decommissioned in preparation for termination")
 
 		terminationJob := NewHostTerminationJob(j.env, h, HostTerminationOptions{
 			TerminateIfBusy:   true,

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -164,7 +164,7 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 			continue
 		}
 		// Decommission the host to prevent this job from checking it again.
-		grip.Error(message.WrapError(h.SetDecommissioned(evergreen.User, false, ""), message.Fields{
+		grip.Error(message.WrapError(h.SetDecommissioned(evergreen.User, false, "cloud host has no status"), message.Fields{
 			"message": "could not set nonexistent host to decommissioned in preparation for termination",
 			"host_id": h.Id,
 			"job":     j.ID(),
@@ -201,8 +201,8 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 		})
 
 		catcher := grip.NewBasicCatcher()
-		catcher.Wrap(handleTerminatedHostSpawnedByTask(&h), "handling task host that was terminating before it was running")
-		catcher.Wrap(h.SetUnprovisioned(), "marking host as failed provisioning")
+		catcher.Wrap(handleTerminatedHostSpawnedByTask(&h), "handling host.create host that was terminating before it was running")
+		catcher.Wrap(h.SetDecommissioned(evergreen.User, false, fmt.Sprintf("host status is '%s'", cloudStatus.String())), "decommissioning host")
 		terminationJob := NewHostTerminationJob(j.env, &h, HostTerminationOptions{
 			TerminateIfBusy:          true,
 			TerminationReason:        "instance was found in stopped state",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18139

### Description
Looking through the logs, AWS did an unexpectedly new thing with `DescribeInstances` that we haven't seen before. In the past, when we requested at least 1 instance ID that AWS has no knowledge of, it would return an `InvalidInstanceID.NotFound` error (e.g. because the instance never existed or it was terminated a long time ago), which we handle already by terminating it. This time, it behaved in a different way - it had no status for some of the requested IDs (and those instances did not exist in AWS), but instead of producing the `InvalidInstanceID.NotFound` error, it simply returned no instance reservation for them (i.e. no status). I updated the logic to be more resilient to the possibility that either it will return `InvalidInstanceID.NotFound` or it simply will return no error and no status for that instance. The working assumption I'm making here is that if it doesn't have any status in AWS, it's safe to terminate (which appeared to be the case). That being said, I've never seen it return no error and give fewer statuses than there are hosts except in this one case.

* Change `GetInstanceStatuses` to set the host status as nonexistent the response is successful but the result is still missing that host.
* Refactor `GetInstanceStatuses` to return a map instead of a slice since it's a little weird to return statuses that depend on the order of the input slice.
* Handle nonexistent (i.e. those resulting in `InvalidInstanceID.NotFound` or those with no status) hosts the same as terminated ones for `set-cloud-hosts-ready`.
* Remove some old debug logs that are no longer used.

### Testing
Updated existing tests for EC2 providers and `set-cloud-hosts-ready` job.