### PR TITLE
EVG-18111: remove generate tasks scope feature flag

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -729,7 +729,7 @@ func PopulateGenerateTasksJobs(env evergreen.Environment) amboy.QueueOperation {
 				catcher.Wrapf(err, "getting generate tasks queue '%s' for version '%s'", queueName, t.Version)
 				continue
 			}
-			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewGenerateTasksJob(t.Version, t.Id, ts, true)), "enqueueing generate tasks job for task '%s'", t.Id)
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewGenerateTasksJob(t.Version, t.Id, ts)), "enqueueing generate tasks job for task '%s'", t.Id)
 		}
 
 		return catcher.Resolve()

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -48,17 +48,15 @@ func makeGenerateTaskJob() *generateTasksJob {
 
 // NewGenerateTasksJob returns a job that dynamically updates the project
 // configuration based on the given task's generate.tasks configuration.
-func NewGenerateTasksJob(versionID, taskID string, ts string, useScopes bool) amboy.Job {
+func NewGenerateTasksJob(versionID, taskID string, ts string) amboy.Job {
 	j := makeGenerateTaskJob()
 	j.TaskID = taskID
 
 	j.SetID(fmt.Sprintf("%s-%s-%s", generateTasksJobName, taskID, ts))
-	if useScopes {
-		versionScope := fmt.Sprintf("%s.%s", generateTasksJobName, versionID)
-		taskScope := fmt.Sprintf("%s.%s", generateTasksJobName, taskID)
-		j.SetScopes([]string{versionScope, taskScope})
-		j.SetEnqueueScopes(taskScope)
-	}
+	versionScope := fmt.Sprintf("%s.%s", generateTasksJobName, versionID)
+	taskScope := fmt.Sprintf("%s.%s", generateTasksJobName, taskID)
+	j.SetScopes([]string{versionScope, taskScope})
+	j.SetEnqueueScopes(taskScope)
 	return j
 }
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -213,7 +213,7 @@ func TestGenerateTasks(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1", false)
+	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks := []task.Task{}
@@ -378,7 +378,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1", false)
+	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 
@@ -408,7 +408,7 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	}
 	require.NoError(t, sampleTask.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1", false)
+	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
 	j.Run(context.Background())
 	assert.Error(t, j.Error())
 	dbTask, err := task.FindOneId(sampleTask.Id)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18111

### Description 
Remove the flag on using a scope for the generate tasks job. There was originally a feature flag on it, but it's been removed and the job always uses scopes now, so the lingering boolean is unnecessary.

### Testing 
Existing tests pass.