### PR TITLE
EVG-18206: prevent potential deadlock in EC2 SNS test

### DIFF
--- a/mock/environment.go
+++ b/mock/environment.go
@@ -96,9 +96,17 @@ func (e *Environment) Configure(ctx context.Context) error {
 		ScopeCollection: evergreen.ScopeCollection,
 	})
 
+	catcher := grip.NewBasicCatcher()
+	catcher.Add(e.roleManager.RegisterPermissions(evergreen.ProjectPermissions))
+	catcher.Add(e.roleManager.RegisterPermissions(evergreen.DistroPermissions))
+	catcher.Add(e.roleManager.RegisterPermissions(evergreen.SuperuserPermissions))
+	if catcher.HasErrors() {
+		return errors.Wrap(catcher.Resolve(), "registering role manager permissions")
+	}
+
 	depot, err := BootstrapCredentialsCollection(ctx, e.MongoClient, e.EvergreenSettings.Database.Url, e.EvergreenSettings.Database.DB, e.EvergreenSettings.DomainName)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "bootstrapping host credentials collection")
 	}
 	e.Depot = depot
 
@@ -108,7 +116,7 @@ func (e *Environment) Configure(ctx context.Context) error {
 	// models.
 	um, err := gimlet.NewBasicUserManager(nil, nil)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "creating user manager")
 	}
 	e.userManager = um
 

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	serviceutil "github.com/evergreen-ci/evergreen/service/testutil"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -39,8 +39,10 @@ type HostsChangeStatusesSuite struct {
 func TestHostsChangeStatusesSuite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	s := &HostsChangeStatusesSuite{
-		env: testutil.NewEnvironment(ctx, t),
+		env: env,
 	}
 	suite.Run(t, s)
 }
@@ -205,8 +207,10 @@ type HostModifySuite struct {
 func TestHostModifySuite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	s := &HostModifySuite{
-		env: testutil.NewEnvironment(ctx, t),
+		env: env,
 	}
 	suite.Run(t, s)
 }
@@ -299,8 +303,10 @@ type HostSuite struct {
 func TestHostSuite(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	s := &HostSuite{
-		env: testutil.NewEnvironment(ctx, t),
+		env: env,
 	}
 	suite.Run(t, s)
 }
@@ -376,8 +382,10 @@ type hostTerminateHostHandlerSuite struct {
 func TestTerminateHostHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	s := &hostTerminateHostHandlerSuite{
-		env: testutil.NewEnvironment(ctx, t),
+		env: env,
 	}
 	suite.Run(t, s)
 }
@@ -515,7 +523,9 @@ func TestHostChangeRDPPasswordHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.env = testutil.NewEnvironment(ctx, t)
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	s.env = env
 
 	s.env.Settings().Keys["ssh_key_name"] = "ssh_key"
 
@@ -644,7 +654,9 @@ func TestHostExtendExpirationHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s := &hostExtendExpirationHandlerSuite{}
-	setupMockHostsConnector(t, testutil.NewEnvironment(ctx, t))
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	setupMockHostsConnector(t, env)
 	suite.Run(t, s)
 }
 
@@ -993,7 +1005,8 @@ func TestRemoveAdminHandler(t *testing.T) {
 	offboardedUser := "user0"
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	userManager := env.UserManager()
 
 	handler := offboardUserHandler{
@@ -1089,9 +1102,11 @@ func TestDisableHostHandler(t *testing.T) {
 	for _, hostToAdd := range hosts {
 		assert.NoError(t, hostToAdd.Insert())
 	}
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	dh := disableHost{
 		hostID: hostID,
-		env:    testutil.NewEnvironment(ctx, t),
+		env:    env,
 	}
 
 	responder := dh.Run(context.Background())
@@ -1104,7 +1119,8 @@ func TestDisableHostHandler(t *testing.T) {
 func TestHostProvisioningOptionsGetHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	env := testutil.NewEnvironment(ctx, t)
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	require.NoError(t, db.Clear(host.Collection))
 	defer func() {
 		assert.NoError(t, db.Clear(host.Collection))

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -143,28 +143,35 @@ func TestEC2SNSNotificationHandlers(t *testing.T) {
 		assert.Equal(t, status, dbHost.Status)
 	}
 
-	for name, test := range map[string]func(*testing.T){
-		"InstanceTerminatedInitiatesInstanceStatusCheck": func(t *testing.T) {
+	for name, test := range map[string]func(ctx context.Context, t *testing.T){
+		"InstanceTerminatedInitiatesInstanceStatusCheck": func(ctx context.Context, t *testing.T) {
 			require.NoError(t, rh.handleInstanceTerminated(ctx, agentHost.Id))
 			checkStatus(t, agentHost.Id, evergreen.HostDecommissioned)
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
 		},
-		"InstanceStoppedWithAgentHostInitiatesInstanceStatusCheck": func(t *testing.T) {
+		"InstanceStoppedWithAgentHostInitiatesInstanceStatusCheck": func(ctx context.Context, t *testing.T) {
 			require.NoError(t, rh.handleInstanceStopped(ctx, agentHost.Id))
 			checkStatus(t, agentHost.Id, evergreen.HostDecommissioned)
 			require.Equal(t, 1, rh.queue.Stats(ctx).Total)
 		},
-		"InstanceStoppedWithSpawnHostNoops": func(t *testing.T) {
+		"InstanceStoppedWithSpawnHostNoops": func(ctx context.Context, t *testing.T) {
 			originalStatus := spawnHost.Status
 			require.NoError(t, rh.handleInstanceStopped(ctx, spawnHost.Id))
 			checkStatus(t, spawnHost.Id, originalStatus)
 			assert.Zero(t, rh.queue.Stats(ctx).Total)
 		},
 	} {
-		rh.queue = queue.NewLocalLimitedSize(1, 1)
-		require.NoError(t, rh.queue.Start(ctx))
+		t.Run(name, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
+			defer tcancel()
 
-		t.Run(name, test)
+			queue, err := queue.NewLocalLimitedSizeSerializable(1, 1)
+			require.NoError(t, err)
+			rh.queue = queue
+			require.NoError(t, rh.queue.Start(ctx))
+
+			test(tctx, t)
+		})
 	}
 }
 

--- a/units/util.go
+++ b/units/util.go
@@ -51,7 +51,7 @@ func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment
 		return errors.Wrap(err, "disabling poisoned host")
 	}
 
-	if err = env.RemoteQueue().Put(ctx, NewDecoHostNotifyJob(env, h, nil, reason)); err != nil {
+	if err = amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewDecoHostNotifyJob(env, h, nil, reason)); err != nil {
 		return errors.Wrap(err, "enqueueing decohost notify job")
 	}
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18206

### Description 
Alright, apparently, I didn't re-run my previous PR (#6044) enough times because the test timed out for the same reason when committed to the waterfall... I suspect that the `TimestampMonitor` cleaning up dropped collections from the previous PR is a symptom and not the cause - the DB might only doing that because it's detected that it's idle (due to the test hanging for another reason).

My second best guess (which I verified by running it even more times) is that the test is flaky because `queue.NewLocalLimitedSize` has an undiagnosed deadlock somewhere in it, resulting in the call to `queue.Stats(ctx)` to hang until Go times out the test. I don't really see _how_ it could deadlock, but I don't totally trust that the implementation is bug-free either, so I changed it to another (more verified) implementation and put a timed context on the test so it doesn't block the other tests for 10 straight minutes.

* Swap out queue implementations for test and reduce chance of test deadlock.
* Fix a couple unrelated tests which were failing because they are relying on global Amboy remote queue DB state (i.e. `testutil.NewEnvironment` uses a DB-backed queue) and were making my re-runs of `test-rest-route` fail.

### Testing 
Ran `test-rest-route` in patches a bunch more times.