### PR TITLE
EVG-17203 remove unused unstarted task status

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -46,11 +46,6 @@ const (
 	// in the database and is used in the UI.
 	TaskInactive = "inactive"
 
-	// TaskUnstarted is assigned to a display task after cleaning up one of
-	// its execution tasks. This indicates that the display task is
-	// pending a rerun
-	TaskUnstarted = "unstarted"
-
 	// TaskUndispatched indicates either:
 	//  1. a task is not scheduled to run (when Task.Activated == false)
 	//  2. a task is scheduled to run (when Task.Activated == true)
@@ -317,7 +312,6 @@ var TaskStatuses = []string{
 	TaskWillRun,
 	TaskUnscheduled,
 	TaskUndispatched,
-	TaskUnstarted,
 	TaskDispatched,
 }
 
@@ -345,7 +339,6 @@ var TaskFailureStatuses = append([]string{TaskFailed}, TaskNonGenericFailureStat
 
 var TaskUnstartedStatuses = []string{
 	TaskInactive,
-	TaskUnstarted,
 	TaskUndispatched,
 }
 
@@ -765,7 +758,6 @@ var (
 	// TaskUncompletedStatuses are all statuses that do not represent a finished state.
 	TaskUncompletedStatuses = []string{
 		TaskStarted,
-		TaskUnstarted,
 		TaskUndispatched,
 		TaskDispatched,
 		TaskConflict,

--- a/globals.go
+++ b/globals.go
@@ -37,9 +37,6 @@ const (
 
 	HostExternalUserName = "external"
 
-	HostStatusSuccess = "success"
-	HostStatusFailed  = "failed"
-
 	// Task Statuses used in the database models
 
 	// TaskInactive is not assigned to any new tasks, but can be found

--- a/model/task/results.go
+++ b/model/task/results.go
@@ -18,8 +18,6 @@ func (t *Task) ResultStatus() string {
 	if t.Status == evergreen.TaskUndispatched {
 		if !t.Activated {
 			status = evergreen.TaskInactive
-		} else {
-			status = evergreen.TaskUnstarted
 		}
 	} else if t.Status == evergreen.TaskFailed {
 		if t.Details.Type == evergreen.CommandTypeSystem {
@@ -72,7 +70,7 @@ func GetResultCounts(tasks []Task) *ResultCounts {
 		switch t.ResultStatus() {
 		case evergreen.TaskInactive:
 			out.Inactive++
-		case evergreen.TaskUnstarted:
+		case evergreen.TaskUnscheduled:
 			out.Unstarted++
 		case evergreen.TaskStarted:
 			out.Started++

--- a/model/task/results.go
+++ b/model/task/results.go
@@ -70,7 +70,7 @@ func GetResultCounts(tasks []Task) *ResultCounts {
 		switch t.ResultStatus() {
 		case evergreen.TaskInactive:
 			out.Inactive++
-		case evergreen.TaskUnscheduled:
+		case evergreen.TaskUndispatched:
 			out.Unstarted++
 		case evergreen.TaskStarted:
 			out.Started++

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -208,22 +208,22 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 		{
 			Id:      "t211",
 			Version: v2.Id,
-			Status:  evergreen.TaskUnstarted,
+			Status:  evergreen.TaskUnscheduled,
 		},
 		{
 			Id:      "t212",
 			Version: v2.Id,
-			Status:  evergreen.TaskUnstarted,
+			Status:  evergreen.TaskUnscheduled,
 		},
 		{
 			Id:      "t221",
 			Version: v2.Id,
-			Status:  evergreen.TaskUnstarted,
+			Status:  evergreen.TaskUnscheduled,
 		},
 		{
 			Id:      "t222",
 			Version: v2.Id,
-			Status:  evergreen.TaskUnstarted,
+			Status:  evergreen.TaskUnscheduled,
 		},
 	}
 	for _, t := range tasks {

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -211,7 +211,7 @@ func (s *StatusSuite) TaskTaskType() {
 	s.h.minutes = 0
 	s.h.verbose = true
 
-	s.h.taskType = evergreen.TaskUnstarted
+	s.h.taskType = evergreen.TaskUnscheduled
 	resp := s.h.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -482,7 +482,7 @@ func makeRandomTasks() []task.Task {
 	tasks := []task.Task{}
 	statuses := []string{
 		evergreen.TaskStarted,
-		evergreen.TaskUnstarted,
+		evergreen.TaskUnscheduled,
 		evergreen.TaskUndispatched,
 		evergreen.TaskDispatched,
 		evergreen.TaskFailed,


### PR DESCRIPTION
[EVG-17203](https://jira.mongodb.org/browse/EVG-17203)

### Description 
Remove unstarted task status; we've previously verified that this isn't really used for anything except the recent_tasks rollup, for which unscheduled will work just as well (not changing that output from "unstarted" to "unscheduled" though since that would be a breaking change and it's not super necessary).

