### PR TITLE
EVG-18217: Allow migration of volumes with previously terminated hosts

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2770,9 +2770,9 @@ func FindHostWithVolume(volumeID string) (*Host, error) {
 	return FindOne(q)
 }
 
-// FindHostWithVolume finds the host associated with the
+// FindUpHostWithHomeVolume finds the up host associated with the
 // specified home volume ID.
-func FindHostWithHomeVolume(homeVolumeID string) (*Host, error) {
+func FindUpHostWithHomeVolume(homeVolumeID string) (*Host, error) {
 	q := db.Query(
 		bson.M{
 			StatusKey:       bson.M{"$in": evergreen.UpHostStatus},
@@ -2780,6 +2780,19 @@ func FindHostWithHomeVolume(homeVolumeID string) (*Host, error) {
 			HomeVolumeIDKey: homeVolumeID,
 		},
 	)
+	return FindOne(q)
+}
+
+// FindLatestTerminatedHostWithHomeVolume finds the most recently terminated host
+// associated with the specified home volume ID.
+func FindLatestTerminatedHostWithHomeVolume(homeVolumeID string) (*Host, error) {
+	q := db.Query(
+		bson.M{
+			StatusKey:       evergreen.HostTerminated,
+			UserHostKey:     true,
+			HomeVolumeIDKey: homeVolumeID,
+		},
+	).Sort([]string{TerminationTimeKey})
 	return FindOne(q)
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2783,12 +2783,13 @@ func FindUpHostWithHomeVolume(homeVolumeID string) (*Host, error) {
 	return FindOne(q)
 }
 
-// FindLatestTerminatedHostWithHomeVolume finds the most recently terminated host
+// FindLatestTerminatedHostWithHomeVolume finds the user's most recently terminated host
 // associated with the specified home volume ID.
-func FindLatestTerminatedHostWithHomeVolume(homeVolumeID string) (*Host, error) {
+func FindLatestTerminatedHostWithHomeVolume(homeVolumeID string, startedBy string) (*Host, error) {
 	q := db.Query(
 		bson.M{
 			StatusKey:       evergreen.HostTerminated,
+			StartedByKey:    startedBy,
 			UserHostKey:     true,
 			HomeVolumeIDKey: homeVolumeID,
 		},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2792,7 +2792,7 @@ func FindLatestTerminatedHostWithHomeVolume(homeVolumeID string) (*Host, error) 
 			UserHostKey:     true,
 			HomeVolumeIDKey: homeVolumeID,
 		},
-	).Sort([]string{TerminationTimeKey})
+	).Sort([]string{"-" + TerminationTimeKey})
 	return FindOne(q)
 }
 

--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -99,7 +99,7 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 		return
 	}
 
-	if j.initialHost.HomeVolumeID != "" {
+	if j.volume.Host != "" {
 		if err := mgr.DetachVolume(ctx, j.initialHost, j.VolumeID); err != nil {
 			j.AddError(errors.Wrapf(err, "detaching volume '%s'", j.VolumeID))
 			return
@@ -121,11 +121,12 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 			j.AddError(errors.Errorf("volume '%s' not found", j.VolumeID))
 			return
 		}
+		fmt.Println("UPDATING VOLUME")
 		j.volume = volume
 	}
 
 	// Avoid recreating new host on retry
-	newHost, err := host.FindHostWithHomeVolume(j.VolumeID)
+	newHost, err := host.FindUpHostWithHomeVolume(j.VolumeID)
 	if err != nil {
 		j.AddRetryableError(errors.Wrapf(err, "finding host with volume '%s'", j.VolumeID))
 		return
@@ -137,10 +138,14 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 		}
 	}
 
-	// Set initial host to have expiration in 24 hours
-	if err := j.initialHost.SetExpirationTime(time.Now().Add(evergreen.DefaultSpawnHostExpiration)); err != nil {
-		j.AddError(errors.Wrapf(err, "setting expiration for host '%s'", j.InitialHostID))
-		return
+	// If not terminated, set initial host to have expiration in 24 hours
+	if j.initialHost.Status == evergreen.HostStopped {
+		err := j.initialHost.SetExpirationTime(time.Now().Add(evergreen.DefaultSpawnHostExpiration))
+		if err != nil {
+			j.AddError(errors.Wrapf(err, "setting expiration for host '%s'", j.InitialHostID))
+			return
+		}
+
 	}
 }
 
@@ -164,7 +169,7 @@ func (j *volumeMigrationJob) stopInitialHost(ctx context.Context) {
 // startNewHost attempts to start a new host with the volume attached.
 func (j *volumeMigrationJob) startNewHost(ctx context.Context) {
 	// Ensure volume has been detached
-	if j.volume.Host == j.InitialHostID {
+	if j.volume.Host != "" {
 		j.AddRetryableError(errors.New("volume still attached to host"))
 		return
 	}
@@ -190,7 +195,7 @@ func (j *volumeMigrationJob) startNewHost(ctx context.Context) {
 // finishJob marks the job as completed and attempts some additional cleanup if this is the job's final attempt.
 func (j *volumeMigrationJob) finishJob(ctx context.Context) {
 	if !j.RetryInfo().ShouldRetry() || j.RetryInfo().GetRemainingAttempts() == 0 {
-		volumeHost, err := host.FindHostWithHomeVolume(j.VolumeID)
+		volumeHost, err := host.FindUpHostWithHomeVolume(j.VolumeID)
 		if err != nil {
 			j.AddRetryableError(errors.Wrapf(err, "finding host with volume '%s'", j.VolumeID))
 			return
@@ -231,7 +236,20 @@ func (j *volumeMigrationJob) populateIfUnset() error {
 	}
 
 	if j.InitialHostID == "" {
-		j.InitialHostID = j.volume.Host
+		// If volume was attached to terminated host, query this host by its home volume field.
+		if j.volume.Host == "" {
+			initialHost, err := host.FindLatestTerminatedHostWithHomeVolume(j.VolumeID)
+			if err != nil {
+				return errors.Wrapf(err, "getting host attached to volume '%s'", j.VolumeID)
+			}
+			if initialHost == nil {
+				return errors.Errorf("host attached to volume '%s' not found", j.VolumeID)
+			}
+			j.InitialHostID = initialHost.Id
+		} else {
+
+			j.InitialHostID = j.volume.Host
+		}
 	}
 
 	if j.initialHost == nil {

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -235,6 +235,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 			h := &host.Host{
 				Id:           "h0",
 				UserHost:     true,
+				StartedBy:    evergreen.User,
 				Status:       evergreen.HostRunning,
 				Provider:     evergreen.ProviderNameMock,
 				Distro:       *d,
@@ -265,7 +266,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 				Host:             h.Id,
 				HomeVolume:       true,
 				AvailabilityZone: evergreen.DefaultEBSAvailabilityZone,
-				CreatedBy:        "test-user",
+				CreatedBy:        evergreen.User,
 				Type:             "standard",
 				Size:             32,
 				Expiration:       time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),


### PR DESCRIPTION
[EVG-18217](https://jira.mongodb.org/browse/EVG-18217)

### Description 
- Fixes a bug where home volumes that were attached to a workstation that was terminated would fail to migrate because the initial host could not be found.
  - At present, these volumes can still be attached to a new workstation by adding them during the spawn host stage. However, migration should be supported too as it is in some ways a more obvious workflow.

### Testing 
- Tested on staging
- Add unit test for this case