### PR TITLE
EVG-18231 Include author_email in patch created versions

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -453,8 +453,8 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	}
 
 	authorEmail := p.GitInfo.Email
-	if p.GithubPatchData.AuthorUID != 0 {
-		u, _ := user.FindByGithubUID(p.GithubPatchData.AuthorUID)
+	if p.Author != "" {
+		u, _ := user.FindOneById(p.Author)
 		if u != nil {
 			authorEmail = u.Email()
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -454,10 +454,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 
 	authorEmail := p.GitInfo.Email
 	if p.GithubPatchData.AuthorUID != 0 {
-		u, err := user.FindByGithubUID(p.GithubPatchData.AuthorUID)
-		grip.Error(message.WrapError(err, message.Fields{
-			"message": fmt.Sprintf("failed to fetch evergeen user with Github UID %d", p.GithubPatchData.AuthorUID),
-		}))
+		u, _ := user.FindByGithubUID(p.GithubPatchData.AuthorUID)
 		if u != nil {
 			authorEmail = u.Email()
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -452,9 +452,15 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		return nil, errors.Wrap(err, "fetching patch parameters")
 	}
 
-	authorEmail := p.GitInfo.Email
+	authorEmail := ""
+	if p.GitInfo != nil {
+		authorEmail = p.GitInfo.Email
+	}
 	if p.Author != "" {
-		u, _ := user.FindOneById(p.Author)
+		u, err := user.FindOneById(p.Author)
+		if err != nil {
+			return nil, errors.Wrap(err, "getting user")
+		}
 		if u != nil {
 			authorEmail = u.Email()
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -456,7 +456,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if p.GithubPatchData.AuthorUID != 0 {
 		u, err := user.FindByGithubUID(p.GithubPatchData.AuthorUID)
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": fmt.Sprintf("failed to fetch everg user with Github UID %d", p.GithubPatchData.AuthorUID),
+			"message": fmt.Sprintf("failed to fetch evergeen user with Github UID %d", p.GithubPatchData.AuthorUID),
 		}))
 		if u != nil {
 			authorEmail = u.Email()
@@ -481,7 +481,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		AuthorID:            p.Author,
 		Parameters:          params,
 		Activated:           utility.TruePtr(),
-		AuthorEmail:         p.GitInfo.Email,
+		AuthorEmail:         authorEmail,
 	}
 	intermediateProject.CreateTime = patchVersion.CreateTime
 


### PR DESCRIPTION
[EVG-18231](https://jira.mongodb.org/browse/EVG-18231)

### Description 
author_email was not previously included in versions that were created from a patch. This now includes the email from their git account by default if not it falls back to the email included in gitinfo. 

### Testing 
Example doc of a patch I created on staging
<img width="655" alt="image" src="https://user-images.githubusercontent.com/4605522/200647868-fc378af1-47b9-426d-beb0-289ed8e9f246.png">

