### PR TITLE
EVG-16771 remove redundant gimlet formatting

### DIFF
--- a/rest/route/admin_events.go
+++ b/rest/route/admin_events.go
@@ -85,11 +85,6 @@ func (h *adminEventsGet) Run(ctx context.Context) gimlet.Responder {
 	if catcher.HasErrors() {
 		return gimlet.MakeJSONInternalErrorResponder(catcher.Resolve())
 	}
-
-	if err = resp.SetStatus(http.StatusOK); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-
 	return resp
 }
 

--- a/rest/route/build_task.go
+++ b/rest/route/build_task.go
@@ -69,10 +69,6 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
-
 	lastIndex := len(tasks)
 	if len(tasks) > tbh.limit {
 		lastIndex = tbh.limit

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -619,10 +619,6 @@ func (h *distroGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
-
 	for _, d := range distros {
 		distroModel := &model.APIDistro{}
 		distroModel.BuildFromService(d)

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -69,10 +69,6 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 	user := MustHaveUser(ctx)
 
 	resp := gimlet.NewResponseBuilder()
-	if err := resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
-
 	for id, status := range h.HostToStatus {
 		foundHost, err := data.FindHostByIdWithOwner(id, user)
 		if err != nil {
@@ -204,10 +200,6 @@ func (hgh *hostGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(err)
-	}
-
 	lastIndex := len(hosts)
 	if len(hosts) > hgh.limit {
 		lastIndex = hgh.limit
@@ -488,9 +480,6 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
 	for _, h := range hosts {
 		apiHost := &model.APIHost{}
 		apiHost.BuildFromService(&h, nil)

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -199,10 +199,6 @@ func (p *patchesByUserHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
-
 	if len(patches) > p.limit {
 		err = resp.SetPages(&gimlet.ResponsePages{
 			Next: &gimlet.Page{
@@ -280,10 +276,6 @@ func (p *patchesByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	err = resp.SetFormat(gimlet.JSON)
-	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
 	if len(patches) > p.limit {
 		err = resp.SetPages(&gimlet.ResponsePages{
 			Next: &gimlet.Page{
@@ -306,11 +298,6 @@ func (p *patchesByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "adding response data for patch '%s'", utility.FromStringPtr(model.Id)))
 		}
 	}
-	err = resp.SetStatus(http.StatusOK)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "unable to set response status"))
-	}
-
 	return resp
 }
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -71,10 +71,6 @@ func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting JSON response format"))
-	}
-
 	lastIndex := len(projects)
 	if len(projects) > p.limit {
 		lastIndex = p.limit

--- a/rest/route/project_events.go
+++ b/rest/route/project_events.go
@@ -89,10 +89,5 @@ func (h *projectEventsGet) Run(ctx context.Context) gimlet.Responder {
 	if catcher.HasErrors() {
 		return gimlet.MakeJSONInternalErrorResponder(catcher.Resolve())
 	}
-
-	if err = resp.SetStatus(http.StatusOK); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-
 	return resp
 }

--- a/rest/route/reliability.go
+++ b/rest/route/reliability.go
@@ -251,10 +251,6 @@ func (trh *taskReliabilityHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
-	}
-
 	requestLimit := trh.filter.Limit
 	if len(taskReliabilityResult) == requestLimit {
 		last := taskReliabilityResult[len(taskReliabilityResult)-1]

--- a/rest/route/stats.go
+++ b/rest/route/stats.go
@@ -562,10 +562,6 @@ func (tsh *taskStatsHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting"))
-	}
-
 	requestLimit := tsh.filter.Limit - 1
 	lastIndex := len(taskStatsResult)
 	if len(taskStatsResult) > requestLimit {

--- a/rest/route/task_project.go
+++ b/rest/route/task_project.go
@@ -86,10 +86,6 @@ func (tph *tasksByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	resp := gimlet.NewResponseBuilder()
-	if err = resp.SetFormat(gimlet.JSON); err != nil {
-		return gimlet.MakeJSONErrorResponder(err)
-	}
-
 	lastIndex := len(tasks)
 	if len(tasks) > tph.limit {
 		lastIndex = tph.limit


### PR DESCRIPTION
[EVG-16771](https://jira.mongodb.org/browse/EVG-16771)

### Description 
Gimlet defaults to OK / json already so this is unnecessary. 
https://github.com/evergreen-ci/gimlet/blob/main/framework_response.go#L75