### PR TITLE
EVG-17497 Reset priority when activating task

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -156,6 +156,7 @@ const (
 	MaxTaskPriority = 100
 
 	DisabledTaskPriority = int64(-1)
+	DefaultPriority      = int64(0)
 
 	// if a patch has NumTasksForLargePatch number of tasks or greater, we log to splunk for investigation
 	NumTasksForLargePatch = 10000

--- a/globals.go
+++ b/globals.go
@@ -156,7 +156,6 @@ const (
 	MaxTaskPriority = 100
 
 	DisabledTaskPriority = int64(-1)
-	DefaultPriority      = int64(0)
 
 	// if a patch has NumTasksForLargePatch number of tasks or greater, we log to splunk for investigation
 	NumTasksForLargePatch = 10000

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2673,9 +2673,22 @@ func activateTasks(taskIDs []string, caller string, activationTime time.Time) er
 	if err != nil {
 		return errors.Wrap(err, "setting tasks to active")
 	}
-	err = enableDisabledTasks(taskIDs)
-	if err != nil {
+	if err = enableDisabledTasks(taskIDs); err != nil {
 		return errors.Wrap(err, "enabling disabled tasks")
 	}
 	return nil
+}
+
+func enableDisabledTasks(taskIDs []string) error {
+	_, err := UpdateAll(
+		bson.M{
+			IdKey:       bson.M{"$in": taskIDs},
+			PriorityKey: evergreen.DisabledTaskPriority,
+		},
+		bson.M{
+			"$unset": bson.M{
+				PriorityKey: 1,
+			},
+		})
+	return err
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2657,3 +2657,25 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 	)
 	return FindAll(query)
 }
+
+func activateTasks(taskIDs []string, caller string, activationTime time.Time) error {
+	_, err := UpdateAll(
+		bson.M{
+			IdKey: bson.M{"$in": taskIDs},
+		},
+		bson.M{
+			"$set": bson.M{
+				ActivatedKey:     true,
+				ActivatedByKey:   caller,
+				ActivatedTimeKey: activationTime,
+			},
+		})
+	if err != nil {
+		return errors.Wrap(err, "setting tasks to active")
+	}
+	err = enableDisabledTasks(taskIDs)
+	if err != nil {
+		return errors.Wrap(err, "enabling disabled tasks")
+	}
+	return nil
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1679,6 +1679,7 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 				ActivatedKey:     true,
 				ActivatedByKey:   caller,
 				ActivatedTimeKey: activationTime,
+				PriorityKey:      evergreen.DefaultPriority,
 			},
 		})
 	if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1673,10 +1673,6 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 	if err != nil {
 		return errors.Wrap(err, "activating tasks")
 	}
-	err = enableDisabledTasks(taskIDs)
-	if err != nil {
-		return errors.Wrap(err, "enabling disabled tasks")
-	}
 	logs := []event.EventLogEntry{}
 	for _, t := range tasks {
 		logs = append(logs, event.GetTaskActivatedEvent(t.Id, t.Execution, caller))
@@ -1700,26 +1696,8 @@ func enableDisabledTasks(taskIDs []string) error {
 			PriorityKey: evergreen.DisabledTaskPriority,
 		},
 		bson.M{
-			"$set": bson.M{
-				PriorityKey: evergreen.DefaultPriority,
-			},
-		})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func activateTasks(taskIDs []string, caller string, activationTime time.Time) error {
-	_, err := UpdateAll(
-		bson.M{
-			IdKey: bson.M{"$in": taskIDs},
-		},
-		bson.M{
-			"$set": bson.M{
-				ActivatedKey:     true,
-				ActivatedByKey:   caller,
-				ActivatedTimeKey: activationTime,
+			"$unset": bson.M{
+				PriorityKey: 1,
 			},
 		})
 	if err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1689,23 +1689,6 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 	return nil
 }
 
-func enableDisabledTasks(taskIDs []string) error {
-	_, err := UpdateAll(
-		bson.M{
-			IdKey:       bson.M{"$in": taskIDs},
-			PriorityKey: evergreen.DisabledTaskPriority,
-		},
-		bson.M{
-			"$unset": bson.M{
-				PriorityKey: 1,
-			},
-		})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // ActivateTasksByIdsWithDependencies activates the given tasks and their dependencies.
 func ActivateTasksByIdsWithDependencies(ids []string, caller string) error {
 	q := db.Query(bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2236,7 +2236,7 @@ func TestActivateTasks(t *testing.T) {
 	assert.Len(t, dbTasks, 5)
 
 	for _, task := range dbTasks {
-		assert.Equal(t, task.Priority, 0)
+		assert.Equal(t, task.Priority, int64(0))
 		if utility.StringSliceContains(updatedIDs, task.Id) {
 			assert.True(t, task.Activated)
 		} else {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2236,7 +2236,7 @@ func TestActivateTasks(t *testing.T) {
 	assert.Len(t, dbTasks, 5)
 
 	for _, task := range dbTasks {
-		assert.Equal(t, task.Priority, evergreen.DefaultPriority)
+		assert.Equal(t, task.Priority, 0)
 		if utility.StringSliceContains(updatedIDs, task.Id) {
 			assert.True(t, task.Activated)
 		} else {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2217,7 +2217,7 @@ func TestActivateTasks(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection, event.EventCollection))
 
 	tasks := []Task{
-		{Id: "t0"},
+		{Id: "t0", Priority: evergreen.DisabledTaskPriority},
 		{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false},
 		{Id: "t2", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t1"}}, Activated: false, DeactivatedForDependency: true},
 		{Id: "t3", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false, DeactivatedForDependency: true},
@@ -2236,6 +2236,7 @@ func TestActivateTasks(t *testing.T) {
 	assert.Len(t, dbTasks, 5)
 
 	for _, task := range dbTasks {
+		assert.Equal(t, task.Priority, evergreen.DefaultPriority)
 		if utility.StringSliceContains(updatedIDs, task.Id) {
 			assert.True(t, task.Activated)
 		} else {


### PR DESCRIPTION
[EVG-17497](https://jira.mongodb.org/browse/EVG-17497)

### Description 
Currently in both legacy and spruce UI, you can disable a task, and then subsequently manually hit "Schedule".  This sets the status of the task to "Will Run" as expected but the priority remains at -1 and the task will actually never get scheduled (screenshot attached).  Change has been made such that when we activate a task, if it is set as disabled, reset its priority to zero.  

### Testing 
Updated unit test and deployed to staging to confirm that manually scheduling a disabled task in the UI resets its priority and lets the task actually get scheduled.