### PR TITLE
EVG-18084 reference correct PR number for module merges

### DIFF
--- a/model/commit_queue.go
+++ b/model/commit_queue.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -10,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func GetModulesFromPR(ctx context.Context, githubToken string, prNum int, modules []commitqueue.Module, projectConfig *Project) ([]*github.PullRequest, []patch.ModulePatch, error) {
+func GetModulesFromPR(ctx context.Context, githubToken string, modules []commitqueue.Module, projectConfig *Project) ([]*github.PullRequest, []patch.ModulePatch, error) {
 	var modulePRs []*github.PullRequest
 	var modulePatches []patch.ModulePatch
 	for _, mod := range modules {
@@ -23,6 +24,10 @@ func GetModulesFromPR(ctx context.Context, githubToken string, prNum int, module
 			return nil, nil, errors.Wrapf(err, "malformed URL for module '%s'", mod.Module)
 		}
 
+		prNum, err := strconv.Atoi(mod.Issue)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "malformed PR number for module '%s'", mod.Module)
+		}
 		pr, err := thirdparty.GetMergeablePullRequest(ctx, prNum, githubToken, owner, repo)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "PR not valid for merge")

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -108,7 +108,7 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	for _, module := range modules {
 		serviceModules = append(serviceModules, *restModel.APIModuleToService(module))
 	}
-	modulePRs, modulePatches, err := model.GetModulesFromPR(ctx, githubToken, prNum, serviceModules, projectConfig)
+	modulePRs, modulePatches, err := model.GetModulesFromPR(ctx, githubToken, serviceModules, projectConfig)
 	if err != nil {
 		return "", err
 	}

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -402,7 +402,7 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	}
 
 	j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStatePending, "preparing to test merge", v.Id))
-	modulePRs, _, err := model.GetModulesFromPR(ctx, githubToken, patchDoc.GithubPatchData.PRNumber, nextItem.Modules, projectConfig)
+	modulePRs, _, err := model.GetModulesFromPR(ctx, githubToken, nextItem.Modules, projectConfig)
 	if err != nil {
 		j.logError(err, "can't get modules", nextItem)
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't get modules", ""))


### PR DESCRIPTION
[EVG-18084](https://jira.mongodb.org/browse/EVG-18084)

### Description 
In testing this to verify we get the right PR number, I also confirmed that this feature doesn't do what we say it does. It looks to me like this is meant to merge all modules https://github.com/evergreen-ci/evergreen/wiki/Commit-Queue but i don't see anywhere where we handle merges in the existing code for this: https://github.com/evergreen-ci/evergreen/blob/4487dbd483f9e1a593a82b079941cb573736cc2e/agent/command/git_merge_pr.go#L98 I'm also not convinced we correctly test with the module changes. 

I think it's worth breaking that investigation into two new tickets (or one), and I can update the documentation with the tickets to indicate that the feature won't work until then. 

### Testing 
All of the above can be seen here: https://spruce-staging.corp.mongodb.com/version/636ac01997b1d3600de92ae8/changes?duration=DESC
