### PR TITLE
EVG-15148 rename distro alias queue to secondary queue

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1234,12 +1234,12 @@ func createOneTask(id string, creationInfo TaskCreationInfo, buildVarTask BuildV
 		}
 		t.ContainerOpts = *opts
 	} else {
-		distroID, distroAliases, err := getDistrosFromRunOn(id, buildVarTask, creationInfo.BuildVariant)
+		distroID, secondaryDistros, err := getDistrosFromRunOn(id, buildVarTask, creationInfo.BuildVariant)
 		if err != nil {
 			return nil, err
 		}
 		t.DistroId = distroID
-		t.DistroAliases = distroAliases
+		t.SecondaryDistros = secondaryDistros
 	}
 
 	if isStepback {
@@ -1266,19 +1266,19 @@ func createOneTask(id string, creationInfo TaskCreationInfo, buildVarTask BuildV
 
 func getDistrosFromRunOn(id string, buildVarTask BuildVariantTaskUnit, buildVariant *BuildVariant) (string, []string, error) {
 	if len(buildVarTask.RunOn) > 0 {
-		distroAliases := []string{}
+		secondaryDistros := []string{}
 		distroID := buildVarTask.RunOn[0]
 		if len(buildVarTask.RunOn) > 1 {
-			distroAliases = buildVarTask.RunOn[1:]
+			secondaryDistros = buildVarTask.RunOn[1:]
 		}
-		return distroID, distroAliases, nil
+		return distroID, secondaryDistros, nil
 	} else if len(buildVariant.RunOn) > 0 {
-		distroAliases := []string{}
+		secondaryDistros := []string{}
 		distroID := buildVariant.RunOn[0]
 		if len(buildVariant.RunOn) > 1 {
-			distroAliases = buildVariant.RunOn[1:]
+			secondaryDistros = buildVariant.RunOn[1:]
 		}
-		return distroID, distroAliases, nil
+		return distroID, secondaryDistros, nil
 	}
 	return "", nil, errors.Errorf("task '%s' is not runnable as there is no distro specified", id)
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -56,7 +56,7 @@ var (
 	DeactivatedForDependencyKey    = bsonutil.MustHaveTag(Task{}, "DeactivatedForDependency")
 	BuildIdKey                     = bsonutil.MustHaveTag(Task{}, "BuildId")
 	DistroIdKey                    = bsonutil.MustHaveTag(Task{}, "DistroId")
-	DistroAliasesKey               = bsonutil.MustHaveTag(Task{}, "DistroAliases")
+	SecondaryDistrosKey            = bsonutil.MustHaveTag(Task{}, "SecondaryDistros")
 	BuildVariantKey                = bsonutil.MustHaveTag(Task{}, "BuildVariant")
 	DependsOnKey                   = bsonutil.MustHaveTag(Task{}, "DependsOn")
 	OverrideDependenciesKey        = bsonutil.MustHaveTag(Task{}, "OverrideDependencies")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -130,9 +130,8 @@ type Task struct {
 
 	// SecondaryDistros refer to the optional secondary distros that can be
 	// associated with a task. This is used for running tasks in case there are
-	// idle hosts in a distro with an empty primary queue. Despite the variable
-	// name, this is a distinct concept from actual distro aliases (i.e.
-	// alternative distro names).
+	// idle hosts in a distro with an empty primary queue. This is a distinct concept
+	// from distro aliases (i.e. alternative distro names).
 	// Tags refer to outdated naming; maintained for compatibility.
 	SecondaryDistros []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -128,13 +128,13 @@ type Task struct {
 	NumDependents           int              `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
 	OverrideDependencies    bool             `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
 
-	// DistroAliases refer to the optional secondary distros that can be
+	// SecondaryDistros refer to the optional secondary distros that can be
 	// associated with a task. This is used for running tasks in case there are
 	// idle hosts in a distro with an empty primary queue. Despite the variable
 	// name, this is a distinct concept from actual distro aliases (i.e.
 	// alternative distro names).
-	// TODO (EVG-15148): rename this to represent secondary distros.
-	DistroAliases []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
+	// Tags refer to outdated naming; maintained for compatibility.
+	SecondaryDistros []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
 
 	// Human-readable name
 	DisplayName string `bson:"display_name" json:"display_name"`
@@ -3018,7 +3018,7 @@ func addApplicableDistroFilter(id string, fieldName string, query bson.M) error 
 func FindHostSchedulableForAlias(id string) ([]Task, error) {
 	q := schedulableHostTasksQuery()
 
-	if err := addApplicableDistroFilter(id, DistroAliasesKey, q); err != nil {
+	if err := addApplicableDistroFilter(id, SecondaryDistrosKey, q); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -386,7 +386,7 @@ func ClearTaskQueue(distroId string) error {
 
 	catcher := grip.NewBasicCatcher()
 
-	// task queue should always exist, so proceed with clearing
+	// Task queue should always exist, so proceed with clearing
 	distroQueueInfo, err := GetDistroQueueInfo(distroId)
 	if err != nil {
 		catcher.Wrap(err, "getting task queue info")
@@ -397,24 +397,24 @@ func ClearTaskQueue(distroId string) error {
 		catcher.Wrap(err, "clearing task queue")
 	}
 
-	// make sure task alias queue actually exists before modifying
-	aliasQuery := bson.M{
+	// Make sure task secondary queue actually exists before modifying
+	secondaryQueueQuery := bson.M{
 		taskQueueDistroKey: distroId,
 	}
-	aliasCount, err := db.Count(TaskSecondaryQueuesCollection, aliasQuery)
+	aliasCount, err := db.Count(TaskSecondaryQueuesCollection, secondaryQueueQuery)
 	if err != nil {
-		catcher.Wrap(err, "counting task alias queues matching distro")
+		catcher.Wrap(err, "counting secondary queues matching distro")
 	}
-	// want to at least try to clear even in the case of an error
+	// Want to at least try to clear even in the case of an error
 	if aliasCount == 0 && err == nil {
 		grip.Info(message.Fields{
-			"message": "alias task queue not found, skipping",
+			"message": "secondary task queue not found, skipping",
 			"distro":  distroId,
 		})
 		return catcher.Resolve()
 	}
 	distroQueueInfo, err = GetDistroSecondaryQueueInfo(distroId)
-	catcher.Wrap(err, "getting task alias queue info")
+	catcher.Wrap(err, "getting task secondary queue info")
 	distroQueueInfo = clearQueueInfo(distroQueueInfo)
 
 	err = clearTaskQueueCollection(distroId, distroQueueInfo)

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -105,7 +105,7 @@ func (s *taskDispatchService) ensureQueue(distroID string) (CachedDispatcher, er
 
 	var taskQueue TaskQueue
 	if s.useAliases {
-		taskQueue, err = FindDistroAliasTaskQueue(distroID)
+		taskQueue, err = FindDistroSecondaryTaskQueue(distroID)
 	} else {
 		taskQueue, err = FindDistroTaskQueue(distroID)
 	}

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -603,7 +603,7 @@ func TestDistroDeleteSuite(t *testing.T) {
 }
 
 func (s *DistroDeleteByIDSuite) SetupTest() {
-	s.NoError(db.ClearCollections(distro.Collection, model.TaskAliasQueuesCollection, model.TaskQueuesCollection))
+	s.NoError(db.ClearCollections(distro.Collection, model.TaskSecondaryQueuesCollection, model.TaskQueuesCollection))
 	distros := []*distro.Distro{
 		{
 			Id: "distro1",
@@ -709,16 +709,16 @@ func (s *DistroPatchByIDSuite) SetupTest() {
 				"ConnectTimeout=10"},
 			SpawnAllowed: false,
 			Expansions: []distro.Expansion{
-				distro.Expansion{
+				{
 					Key:   "decompress",
 					Value: "tar zxvf"},
-				distro.Expansion{
+				{
 					Key:   "ps",
 					Value: "ps aux"},
-				distro.Expansion{
+				{
 					Key:   "kill_pid",
 					Value: "kill -- -$(ps opgid= %v)"},
-				distro.Expansion{
+				{
 					Key:   "scons_prune_ratio",
 					Value: "0.8"},
 			},

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -210,12 +210,12 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	if nextTask == nil && !shouldRunTeardown {
 		// if we couldn't find a task in the task queue,
 		// check the alias queue...
-		aliasQueue, err := model.LoadDistroAliasTaskQueue(h.host.Distro.Id)
+		secondaryQueue, err := model.LoadDistroSecondaryTaskQueue(h.host.Distro.Id)
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
-		if aliasQueue != nil {
-			nextTask, shouldRunTeardown, err = assignNextAvailableTask(ctx, h.env, aliasQueue, h.taskAliasDispatcher, h.host, h.details)
+		if secondaryQueue != nil {
+			nextTask, shouldRunTeardown, err = assignNextAvailableTask(ctx, h.env, secondaryQueue, h.taskAliasDispatcher, h.host, h.details)
 			if err != nil {
 				return gimlet.MakeJSONErrorResponder(err)
 			}

--- a/scheduler/distro_alias_test.go
+++ b/scheduler/distro_alias_test.go
@@ -20,23 +20,23 @@ func init() {
 func TestDistroAliases(t *testing.T) {
 	tasks := []task.Task{
 		{
-			Id:            "other",
-			DistroId:      "one",
-			Priority:      200,
-			Version:       "foo",
-			DistroAliases: []string{"two"},
+			Id:               "other",
+			DistroId:         "one",
+			Priority:         200,
+			Version:          "foo",
+			SecondaryDistros: []string{"two"},
 		},
 		{
-			Id:            "one",
-			DistroId:      "one",
-			Priority:      2000,
-			Version:       "foo",
-			DistroAliases: []string{"two"},
+			Id:               "one",
+			DistroId:         "one",
+			Priority:         2000,
+			Version:          "foo",
+			SecondaryDistros: []string{"two"},
 		},
 	}
 
 	require.NoError(t, db.Clear(model.TaskQueuesCollection))
-	require.NoError(t, db.Clear(model.TaskAliasQueuesCollection))
+	require.NoError(t, db.Clear(model.TaskSecondaryQueuesCollection))
 
 	require.NoError(t, db.Clear(model.VersionCollection))
 	require.NoError(t, (&model.Version{Id: "foo"}).Insert())
@@ -60,7 +60,7 @@ func TestDistroAliases(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskAliasQueuesCollection, bson.M{})
+			ct, err = db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
@@ -78,14 +78,14 @@ func TestDistroAliases(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskAliasQueuesCollection, bson.M{})
+			ct, err = db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
 	})
 
 	require.NoError(t, db.Clear(model.TaskQueuesCollection))
-	require.NoError(t, db.Clear(model.TaskAliasQueuesCollection))
+	require.NoError(t, db.Clear(model.TaskSecondaryQueuesCollection))
 
 	t.Run("DistroAlias", func(t *testing.T) {
 		distroTwo := &distro.Distro{
@@ -93,7 +93,7 @@ func TestDistroAliases(t *testing.T) {
 		}
 
 		t.Run("Tunable", func(t *testing.T) {
-			require.NoError(t, db.Clear(model.TaskAliasQueuesCollection))
+			require.NoError(t, db.Clear(model.TaskSecondaryQueuesCollection))
 
 			distroTwo.PlannerSettings.Version = evergreen.PlannerVersionTunable
 			output, err := PrioritizeTasks(distroTwo, tasks, TaskPlannerOptions{ID: "tunable-0", IsSecondaryQueue: true})
@@ -102,7 +102,7 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskAliasQueuesCollection, bson.M{})
+			ct, err := db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
@@ -112,7 +112,7 @@ func TestDistroAliases(t *testing.T) {
 
 		})
 		t.Run("UseLegacy", func(t *testing.T) {
-			require.NoError(t, db.Clear(model.TaskAliasQueuesCollection))
+			require.NoError(t, db.Clear(model.TaskSecondaryQueuesCollection))
 
 			distroTwo.PlannerSettings.Version = evergreen.PlannerVersionLegacy
 			output, err := PrioritizeTasks(distroTwo, tasks, TaskPlannerOptions{ID: "legacy-0", IsSecondaryQueue: true})
@@ -121,7 +121,7 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskAliasQueuesCollection, bson.M{})
+			ct, err := db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -44,7 +44,7 @@ func runTunablePlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOpti
 
 	plan := PrepareTasksForPlanning(d, tasks).Export()
 	info := GetDistroQueueInfo(d.Id, plan, d.GetTargetTime(), opts)
-	info.AliasQueue = opts.IsSecondaryQueue
+	info.SecondaryQueue = opts.IsSecondaryQueue
 	info.PlanCreatedAt = opts.StartedAt
 
 	if err = PersistTaskQueue(d.Id, plan, info); err != nil {
@@ -108,7 +108,7 @@ func (s *distroScheduler) scheduleDistro(distroID string, runnableTasks []task.T
 	}
 
 	distroQueueInfo := GetDistroQueueInfo(distroID, prioritizedTasks, maxThreshold, s.opts)
-	distroQueueInfo.AliasQueue = isSecondaryQueue
+	distroQueueInfo.SecondaryQueue = isSecondaryQueue
 	distroQueueInfo.PlanCreatedAt = s.startedAt
 
 	// persist the queue of tasks and its associated distroQueueInfo
@@ -124,7 +124,7 @@ func (s *distroScheduler) scheduleDistro(distroID string, runnableTasks []task.T
 func GetDistroQueueInfo(distroID string, tasks []task.Task, maxDurationThreshold time.Duration, opts TaskPlannerOptions) model.DistroQueueInfo {
 	var distroExpectedDuration, distroDurationOverThreshold time.Duration
 	var distroCountDurationOverThreshold, distroCountWaitOverThreshold int
-	var isAliasQueue bool
+	var isSecondaryQueue bool
 	taskGroupInfosMap := make(map[string]*model.TaskGroupInfo)
 	depCache := make(map[string]task.Task, len(tasks))
 	for _, t := range tasks {
@@ -141,7 +141,7 @@ func GetDistroQueueInfo(distroID string, tasks []task.Task, maxDurationThreshold
 		duration := task.FetchExpectedDuration().Average
 
 		if task.DistroId != distroID {
-			isAliasQueue = true
+			isSecondaryQueue = true
 		}
 
 		var exists bool
@@ -211,7 +211,7 @@ func GetDistroQueueInfo(distroID string, tasks []task.Task, maxDurationThreshold
 		DurationOverThreshold:      distroDurationOverThreshold,
 		CountWaitOverThreshold:     distroCountWaitOverThreshold,
 		TaskGroupInfos:             taskGroupInfos,
-		AliasQueue:                 isAliasQueue,
+		SecondaryQueue:             isSecondaryQueue,
 	}
 
 	return distroQueueInfo

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -58,20 +58,18 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "getting task queue for distro '%s'", j.DistroId))
 	}
-	aliasQueue, err := model.FindDistroAliasTaskQueue(j.DistroId)
+	secondaryQueue, err := model.FindDistroSecondaryTaskQueue(j.DistroId)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "getting alias task queue for distro '%s'", j.DistroId))
 	}
 	taskIds := []string{}
-	lenQueue := len(queue.Queue)
 	for _, item := range queue.Queue {
 		if !item.IsDispatched && len(item.Dependencies) > 0 {
 			taskIds = append(taskIds, item.Id)
 		}
 	}
 
-	lenAliasQueue := len(aliasQueue.Queue)
-	for _, item := range aliasQueue.Queue {
+	for _, item := range secondaryQueue.Queue {
 		if !item.IsDispatched && len(item.Dependencies) > 0 {
 			taskIds = append(taskIds, item.Id)
 		}
@@ -80,8 +78,8 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	if len(taskIds) == 0 {
 		grip.Debug(message.Fields{
 			"message":         "no task IDs found for distro",
-			"len_queue":       lenQueue,
-			"len_alias_queue": lenAliasQueue,
+			"len_queue":       len(queue.Queue),
+			"len_alias_queue": len(secondaryQueue.Queue),
 			"distro":          j.DistroId,
 			"job":             j.ID(),
 			"source":          checkBlockedTasks,

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -77,12 +77,12 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 
 	if len(taskIds) == 0 {
 		grip.Debug(message.Fields{
-			"message":         "no task IDs found for distro",
-			"len_queue":       len(queue.Queue),
-			"len_alias_queue": len(secondaryQueue.Queue),
-			"distro":          j.DistroId,
-			"job":             j.ID(),
-			"source":          checkBlockedTasks,
+			"message":             "no task IDs found for distro",
+			"len_queue":           len(queue.Queue),
+			"len_secondary_queue": len(secondaryQueue.Queue),
+			"distro":              j.DistroId,
+			"job":                 j.ID(),
+			"source":              checkBlockedTasks,
 		})
 		return
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -516,7 +516,7 @@ func PopulateAliasSchedulerJobs(env evergreen.Environment) amboy.QueueOperation 
 		}
 		catcher := grip.NewBasicCatcher()
 
-		lastPlanned, err := model.FindTaskAliasQueueLastGenerationTimes()
+		lastPlanned, err := model.FindTaskSecondaryQueueLastGenerationTimes()
 		catcher.Add(err)
 
 		// find all active distros


### PR DESCRIPTION
[EVG-15148](https://jira.mongodb.org/browse/EVG-15148 )

### Description 
Longer rational included in ticket; TLDR s that "alias" is already used to give distros multiple names so shouldn't be used for "secondary queue" as well.

Didn't change bson tags to avoid migrations.
