### PR TITLE
EVG-17124 display correct patch description for backports

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-11-08"
+	ClientVersion = "2022-11-10"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-11-10"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -445,7 +445,7 @@ func backport() cli.Command {
 				return errors.Wrap(err, "uploading backport patch")
 			}
 
-			if err = patchParams.displayPatch(backportPatch, uiV2, true); err != nil {
+			if err = patchParams.displayPatch(backportPatch, uiV2, false); err != nil {
 				return errors.Wrap(err, "getting result display")
 			}
 


### PR DESCRIPTION
[EVG-17124 ](https://jira.mongodb.org/browse/EVG-17124 )

### Description 
Shouldn't use the commit queue patch description, since it sends users to the commit queue page, which is confusing since backports don't go there to begin with.
