### PR TITLE
EVG-16671 continue stepback for system failures

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -898,7 +898,7 @@ func removeNextMergeTaskDependency(cq commitqueue.CommitQueue, currentIssue stri
 }
 
 func evalStepback(t *task.Task, caller, status string, deactivatePrevious bool) error {
-	if status == evergreen.TaskFailed && !t.Aborted {
+	if evergreen.IsFailedTaskStatus(status) && !t.Aborted {
 		var shouldStepBack bool
 		shouldStepBack, err := getStepback(t.Id)
 		if err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -898,7 +898,9 @@ func removeNextMergeTaskDependency(cq commitqueue.CommitQueue, currentIssue stri
 }
 
 func evalStepback(t *task.Task, caller, status string, deactivatePrevious bool) error {
-	if evergreen.IsFailedTaskStatus(status) && !t.Aborted {
+	// Stepback if the task failed regularly _or_ if we are currently stepping back and we encountered any failure.
+	if (status == evergreen.TaskFailed && !t.Aborted) ||
+		(evergreen.IsFailedTaskStatus(status) && t.ActivatedBy == evergreen.StepbackTaskActivator) {
 		var shouldStepBack bool
 		shouldStepBack, err := getStepback(t.Id)
 		if err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4969,7 +4969,8 @@ tasks:
 		BuildVariant: "bv",
 	}
 	assert.NoError(b5.Insert())
-	assert.NoError(evalStepback(&generated, "", evergreen.TaskFailed, false))
+	// Ensure system failure and classic stepback works.
+	assert.NoError(evalStepback(&generated, "", evergreen.TaskSystemFailed, false))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.True(checkTask.Activated)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4902,7 +4902,7 @@ tasks:
 	require.NoError(t, err)
 	assert.True(checkTask.Activated)
 
-	// generated task should step back its generator
+	// Generated task should step back its generator.
 	prevComplete = task.Task{
 		Id:                  "g1",
 		BuildId:             "b1",
@@ -4969,7 +4969,14 @@ tasks:
 		BuildVariant: "bv",
 	}
 	assert.NoError(b5.Insert())
-	// Ensure system failure and classic stepback works.
+	// Ensure system failure doesn't cause a stepback unless we're already stepping back.
+	assert.NoError(evalStepback(&generated, "", evergreen.TaskSystemFailed, false))
+	checkTask, err = task.FindOneId(stepbackTask.Id)
+	assert.NoError(err)
+	assert.False(checkTask.Activated)
+
+	// System failure steps back since activated by stepback (and steps back generator).
+	generated.ActivatedBy = evergreen.StepbackTaskActivator
 	assert.NoError(evalStepback(&generated, "", evergreen.TaskSystemFailed, false))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)


### PR DESCRIPTION
[EVG-16671 ](https://jira.mongodb.org/browse/EVG-16671 )

### Description 
Continue stepping back on system failures, _if_ we were already stepping back (otherwise we're going to be starting a bunch of new step backs, in which case it'd probably be better to just not do this at all). 

### Description 
Added to existing test.