### PR TITLE
EVG-17968 suppress messages from CLI when relevant

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-11-08"
+	ClientVersion = "2022-11-10"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-11-10"

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/20210107192922/yaml.v3"
 )
 
 func Admin() cli.Command {
@@ -103,7 +103,7 @@ func adminSetBanner() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -134,7 +134,7 @@ func doViewSettings() cli.ActionFunc {
 		if err != nil {
 			return errors.Wrap(err, "loading configuration")
 		}
-		client, err := conf.setupRestCommunicator(ctx)
+		client, err := conf.setupRestCommunicator(ctx, false)
 		if err != nil {
 			return errors.Wrap(err, "setting up REST communicator")
 		}
@@ -186,7 +186,7 @@ func updateSettings() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -236,7 +236,7 @@ func listEvents() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -276,7 +276,7 @@ func revert() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -406,7 +406,7 @@ func updateRoleCmd() cli.Command {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -494,7 +494,7 @@ func adminDistroExecute() cli.Command {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -536,7 +536,7 @@ func getServiceUsers() cli.Command {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -590,7 +590,7 @@ func updateServiceUser() cli.Command {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -625,7 +625,7 @@ func deleteServiceUser() cli.Command {
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -236,7 +236,7 @@ func listEvents() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx, true)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -36,7 +36,7 @@ func fetchAllProjectConfigs() cli.Command {
 				return err
 			}
 
-			client, err := settings.setupRestCommunicator(ctx)
+			client, err := settings.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/20210107192922/yaml.v3"
 )
 
 var testConfig = testutil.TestConfig()
@@ -156,7 +156,7 @@ func TestCLIFetchSource(t *testing.T) {
 
 		client, err := NewClientSettings(testSetup.settingsFilePath)
 		So(err, ShouldBeNil)
-		comm, err := client.setupRestCommunicator(ctx)
+		comm, err := client.setupRestCommunicator(ctx, true)
 		require.NoError(t, err)
 		defer comm.Close()
 		ac, rc, err := client.getLegacyClients()

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -69,7 +69,7 @@ func listQueue() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -109,7 +109,7 @@ func deleteItem() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -186,7 +186,7 @@ func mergeCommand() cli.Command {
 				return errors.Wrap(err, "setting up legacy Evergreen client")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -228,7 +228,7 @@ func setModuleCommand() cli.Command {
 				return errors.Wrap(err, "setting up legacy Evergreen client")
 			}
 			ctx := context.Background()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -272,7 +272,7 @@ func enqueuePatch() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -403,7 +403,7 @@ func backport() cli.Command {
 				return errors.Wrap(err, "setting up legacy Evergreen client")
 			}
 			showCQMessageForProject(ac, patchParams.Project)
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/20210107192922/yaml.v3"
 )
 
 type CommitQueueSuite struct {
@@ -70,7 +70,7 @@ func (s *CommitQueueSuite) SetupSuite() {
 	s.Require().NoError(settingsFile.Close())
 	s.conf, err = NewClientSettings(settingsFile.Name())
 	s.Require().NoError(err)
-	s.client, err = s.conf.setupRestCommunicator(s.ctx)
+	s.client, err = s.conf.setupRestCommunicator(s.ctx, true)
 	s.Require().NoError(err)
 }
 

--- a/operations/create_version.go
+++ b/operations/create_version.go
@@ -35,7 +35,7 @@ func CreateVersion() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 			ctx := context.Background()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/manifest"
@@ -104,7 +104,7 @@ func Fetch() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -19,7 +19,7 @@ import (
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/shlex"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
@@ -102,7 +102,7 @@ func hostCreate() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -253,7 +253,7 @@ func hostModify() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -389,7 +389,7 @@ func hostConfigure() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, !quiet)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -500,7 +500,7 @@ func hostStop() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -549,7 +549,7 @@ func hostStart() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -622,7 +622,7 @@ Examples:
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -694,7 +694,7 @@ func hostAttach() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -744,7 +744,7 @@ func hostDetach() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -822,7 +822,7 @@ func hostModifyVolume() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -856,7 +856,7 @@ func hostListVolume() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -945,7 +945,7 @@ func hostCreateVolume() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -997,7 +997,7 @@ func hostDeleteVolume() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -1059,7 +1059,7 @@ func hostList() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, !showJSON)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -1148,7 +1148,7 @@ func hostTerminate() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -1247,7 +1247,7 @@ func hostRunCommand() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -1577,7 +1577,7 @@ func hostFindBy() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.getRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "getting REST communicator")
 			}
@@ -1642,7 +1642,7 @@ func getUserAndHostname(ctx context.Context, hostID, confPath string) (user, hos
 	if err != nil {
 		return "", "", errors.Wrap(err, "loading configuration")
 	}
-	client, err := conf.setupRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, true)
 	if err != nil {
 		return "", "", errors.Wrap(err, "setting up REST communicator")
 	}

--- a/operations/http_test.go
+++ b/operations/http_test.go
@@ -38,7 +38,7 @@ func (s *CliHttpTestSuite) TestV2Client() {
 
 	settings, err := NewClientSettings(testFileName)
 	s.Require().NoError(err)
-	client, err := settings.setupRestCommunicator(ctx)
+	client, err := settings.setupRestCommunicator(ctx, true)
 	s.Require().NoError(err)
 	defer client.Close()
 	if s.NoError(err) {

--- a/operations/keys.go
+++ b/operations/keys.go
@@ -66,7 +66,7 @@ func keysAdd() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -108,7 +108,7 @@ func keysList() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -159,7 +159,7 @@ func keysDelete() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/last_green.go
+++ b/operations/last_green.go
@@ -36,7 +36,7 @@ func LastGreen() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/list.go
+++ b/operations/list.go
@@ -102,7 +102,7 @@ func listProjects(ctx context.Context, confPath string) error {
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	client, err := conf.setupRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -145,7 +145,7 @@ func listVariants(ctx context.Context, confPath, project, filename string) error
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	client, err := conf.setupRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -199,7 +199,7 @@ func listTasks(ctx context.Context, confPath, project, filename string) error {
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	client, err := conf.setupRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -240,7 +240,7 @@ func listParameters(ctx context.Context, confPath, project, filename string) err
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	comm, err := conf.setupRestCommunicator(ctx)
+	comm, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -281,7 +281,7 @@ func listTriggerAliases(ctx context.Context, confPath, project string) error {
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	comm, err := conf.setupRestCommunicator(ctx)
+	comm, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -308,7 +308,7 @@ func listPatchAliases(ctx context.Context, confPath, project string) error {
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	comm, err := conf.setupRestCommunicator(ctx)
+	comm, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}
@@ -338,7 +338,7 @@ func listDistros(ctx context.Context, confPath string, onlyUserSpawnable bool) e
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
 	}
-	client, err := conf.setupRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "setting up REST communicator")
 	}

--- a/operations/notification.go
+++ b/operations/notification.go
@@ -56,7 +56,7 @@ func notificationSlack() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -122,7 +122,7 @@ func notificationEmail() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -160,7 +160,7 @@ func Patch() cli.Command {
 				}
 			}
 
-			comm, err := conf.setupRestCommunicator(ctx)
+			comm, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -266,7 +266,7 @@ func PatchFile() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			comm, err := conf.setupRestCommunicator(ctx)
+			comm, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/patch_cancel.go
+++ b/operations/patch_cancel.go
@@ -26,7 +26,7 @@ func PatchCancel() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/patch_finalize.go
+++ b/operations/patch_finalize.go
@@ -26,7 +26,7 @@ func PatchFinalize() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/patch_list.go
+++ b/operations/patch_list.go
@@ -49,7 +49,7 @@ func PatchList() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, !outputJSON)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -54,7 +54,7 @@ func PatchSetModule() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -197,7 +197,7 @@ func PatchRemoveModule() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/pull.go
+++ b/operations/pull.go
@@ -47,7 +47,7 @@ func Pull() cli.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/scheduler.go
+++ b/operations/scheduler.go
@@ -46,7 +46,7 @@ func compareTasks() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 			ctx := context.Background()
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/subscriptions.go
+++ b/operations/subscriptions.go
@@ -33,7 +33,7 @@ func subscriptionsList() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			comm, err := conf.setupRestCommunicator(ctx)
+			comm, err := conf.setupRestCommunicator(ctx, false)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}

--- a/operations/update.go
+++ b/operations/update.go
@@ -83,7 +83,7 @@ func Update() cli.Command {
 // Otherwise, it will simply be downloaded and a suggested 'mv' command will be printed so the user can replace the binary at their discretion.
 // Toggling forceUpdate will download a new CLI even if the current CLI does not have an out-of-date CLI version string.
 func checkAndUpdateVersion(conf *ClientSettings, ctx context.Context, doInstall bool, forceUpdate bool, silent bool) error {
-	client, err := conf.getRestCommunicator(ctx)
+	client, err := conf.setupRestCommunicator(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "getting REST communicator")
 	}

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -59,7 +59,7 @@ func Validate() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			client, err := conf.setupRestCommunicator(ctx)
+			client, err := conf.setupRestCommunicator(ctx, !quiet)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}


### PR DESCRIPTION
[EVG-17968](https://jira.mongodb.org/browse/EVG-17968)

### Description 
Removed getSetupCommunicator since it's not immediately obvious when to use get vs setup (since a lot of CLI setup ends up being copy paste, having a boolean makes it more likely that engineers will consider its value). 

### Testing 
Ensured client still works, and used list-patches to audit the JSON flag (with it, we don't print banner).