### PR TITLE
EVG-18222: add one host creation attempt for initial try

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -72,7 +72,7 @@ func NewHostCreateJob(env evergreen.Environment, h host.Host, id string, current
 		maxAttempts = maxPollAttempts
 	} else {
 		wait = 10 * time.Second
-		maxAttempts = j.host.SpawnOptions.Retries
+		maxAttempts = j.host.SpawnOptions.Retries + 1
 	}
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18222

### Description 
There's an option exposed in host.create to specify the number of times that a host.create host is allowed to retry. All I did was make it so that the number of retries they specify means number of times to try again after an initial failure, rather than total number of attempts, which seems more intuitive based on the option name.

### Testing 
Didn't seem that applicable since host creation retries are a minor thing.
