### PR TITLE
EVG-18297: Fix volume migration job panic

### DIFF
--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -208,9 +208,13 @@ func (j *volumeMigrationJob) finishJob(ctx context.Context) {
 			})
 		}
 
-		if err := j.volume.SetMigrating(false); err != nil {
-			j.AddRetryableError(err)
-			return
+		if j.volume != nil {
+			err := j.volume.SetMigrating(false)
+			if err != nil {
+				j.AddRetryableError(err)
+				return
+			}
+
 		}
 
 	}


### PR DESCRIPTION
[EVG-18297](https://jira.mongodb.org/browse/EVG-18297)

### Description 
- Prevent panic when MigrateVolume job is invoked with a volume ID not found in the database. The job was still attempting to call `volume.SetMigrate(false)` to wrap up the job, so skip this if the volume doesn't exist.
- I am not sure how a user started a job on a volume that doesn't exist 😳 

### Testing 
- Add unit test