### PR TITLE
EVG-18050 add iops to io1 volumes

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -232,6 +232,8 @@ const (
 	SpotStatusFailed   = "failed"
 
 	EC2ErrorSpotRequestNotFound = "InvalidSpotInstanceRequestID.NotFound"
+
+	defaultIops = 3000
 )
 
 const (
@@ -242,7 +244,7 @@ const (
 
 const (
 	VolumeTypeStandard = "standard"
-	VolumeTypeIo2      = "io1"
+	VolumeTypeIo1      = "io1"
 	VolumeTypeGp3      = "gp3"
 	VolumeTypeGp2      = "gp2"
 	VolumeTypeSc1      = "sc1"
@@ -252,7 +254,7 @@ const (
 var (
 	ValidVolumeTypes = []string{
 		VolumeTypeStandard,
-		VolumeTypeIo2,
+		VolumeTypeIo1,
 		VolumeTypeGp3,
 		VolumeTypeGp2,
 		VolumeTypeSc1,
@@ -1479,15 +1481,19 @@ func (m *ec2Manager) CreateVolume(ctx context.Context, volume *host.Volume) (*ho
 		{Key: aws.String(evergreen.TagOwner), Value: aws.String(volume.CreatedBy)},
 		{Key: aws.String(evergreen.TagExpireOn), Value: aws.String(expireInDays(evergreen.SpawnHostExpireDays))},
 	}
-
-	resp, err := m.client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+	input := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String(volume.AvailabilityZone),
 		VolumeType:       aws.String(volume.Type),
 		Size:             aws.Int64(int64(volume.Size)),
 		TagSpecifications: []*ec2.TagSpecification{
 			{ResourceType: aws.String(ec2.ResourceTypeVolume), Tags: volumeTags},
 		},
-	})
+	}
+	// Iops is required for io1.
+	if volume.Type == VolumeTypeIo1 {
+		input.Iops = aws.Int64(int64(defaultIops))
+	}
+	resp, err := m.client.CreateVolume(ctx, input)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "creating volume in client")


### PR DESCRIPTION
[EVG-18050](https://jira.mongodb.org/browse/EVG-18050)

### Description 
Iops is required for io1 so adding that; using 3000 because this is the default (if changing types, according to AWS) and I don't think anyone is going to want/need more than that.

### Testing 
Tested that creating io1 works now on staging.