### PR TITLE
EVG-17275 check parser project collection if patched parser project is empty

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -188,7 +188,11 @@ func hasEnqueuePatchPermission(u *user.DBUser, existingPatch *restModel.APIPatch
 
 // getPatchProjectVariantsAndTasksForUI gets the variants and tasks for a project for a patch id
 func getPatchProjectVariantsAndTasksForUI(ctx context.Context, apiPatch *restModel.APIPatch) (*PatchProject, error) {
-	patchProjectVariantsAndTasks, err := model.GetVariantsAndTasksFromProject(ctx, *apiPatch.PatchedParserProject, *apiPatch.ProjectId)
+	p, err := apiPatch.ToService()
+	if err != nil {
+		return nil, errors.Wrap(err, "building patch")
+	}
+	patchProjectVariantsAndTasks, err := model.GetVariantsAndTasksFromPatchProject(ctx, &p)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting project variants and tasks for patch %s: %s", *apiPatch.Id, err.Error()))
 	}
@@ -268,8 +272,8 @@ func getAPITaskFromTask(ctx context.Context, url string, task task.Task) (*restM
 
 // Takes a version id and some filter criteria and returns the matching associated tasks grouped together by their build variant.
 func generateBuildVariants(versionId string, buildVariantOpts BuildVariantOptions) ([]*GroupedBuildVariant, error) {
-	var variantDisplayName map[string]string = map[string]string{}
-	var tasksByVariant map[string][]*restModel.APITask = map[string][]*restModel.APITask{}
+	var variantDisplayName = map[string]string{}
+	var tasksByVariant = map[string][]*restModel.APITask{}
 	defaultSort := []task.TasksSortOrder{
 		{Key: task.DisplayNameKey, Order: 1},
 	}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -23,18 +23,18 @@ var (
 	taskBatchTime          = 30
 	sampleGeneratedProject = GeneratedProject{
 		Tasks: []parserTask{
-			parserTask{
+			{
 				Name: "new_task",
 				Commands: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "shell.exec",
 					},
 				},
 			},
-			parserTask{
+			{
 				Name: "another_task",
 				Commands: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "shell.exec",
 					},
 				},
@@ -47,11 +47,11 @@ var (
 			},
 		},
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Name:  "new_buildvariant",
 				RunOn: []string{"arch"},
 			},
-			parserBV{
+			{
 				Name: "a_variant",
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
@@ -60,13 +60,13 @@ var (
 					},
 				},
 				DisplayTasks: []displayTask{
-					displayTask{
+					{
 						Name:           "my_display_task_old_variant",
 						ExecutionTasks: []string{"say-bye"},
 					},
 				},
 			},
-			parserBV{
+			{
 				Name:      "another_variant",
 				BatchTime: &bvBatchTime,
 				Tasks: parserBVTaskUnits{
@@ -80,7 +80,7 @@ var (
 				},
 				RunOn: []string{"arch"},
 				DisplayTasks: []displayTask{
-					displayTask{
+					{
 						Name:           "my_display_task_new_variant",
 						ExecutionTasks: []string{"another_task"},
 					},
@@ -88,12 +88,12 @@ var (
 			},
 		},
 		Functions: map[string]*YAMLCommandSet{
-			"new_function": &YAMLCommandSet{
+			"new_function": {
 				MultiCommand: []PluginCommandConf{},
 			},
 		},
 		TaskGroups: []parserTaskGroup{
-			parserTaskGroup{
+			{
 				Name:     "example_task_group",
 				MaxHosts: 1,
 				Tasks: []string{
@@ -105,10 +105,10 @@ var (
 
 	smallGeneratedProject = GeneratedProject{
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Name: "my_build_variant",
 				DisplayTasks: []displayTask{
-					displayTask{
+					{
 						Name:           "my_display_task",
 						ExecutionTasks: []string{"my_display_task_gen"},
 					},
@@ -119,7 +119,7 @@ var (
 
 	sampleGeneratedProjectAddToBVOnly = GeneratedProject{
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Name: "a_variant",
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
@@ -440,28 +440,28 @@ func (s *GenerateSuite) TestValidateNoRedefine() {
 	g := GeneratedProject{}
 	s.NoError(g.validateNoRedefine(projectMaps{}))
 
-	g.BuildVariants = []parserBV{parserBV{Name: "buildvariant_name", DisplayName: "I am a buildvariant"}}
-	g.Tasks = []parserTask{parserTask{Name: "task_name"}}
+	g.BuildVariants = []parserBV{{Name: "buildvariant_name", DisplayName: "I am a buildvariant"}}
+	g.Tasks = []parserTask{{Name: "task_name"}}
 	g.Functions = map[string]*YAMLCommandSet{"function_name": nil}
 	s.NoError(g.validateNoRedefine(projectMaps{}))
 
 	cachedProject := projectMaps{
 		buildVariants: map[string]struct{}{
-			"buildvariant_name": struct{}{},
+			"buildvariant_name": {},
 		},
 	}
 	s.Error(g.validateNoRedefine(cachedProject))
 
 	cachedProject = projectMaps{
 		tasks: map[string]*ProjectTask{
-			"task_name": &ProjectTask{},
+			"task_name": {},
 		},
 	}
 	s.Error(g.validateNoRedefine(cachedProject))
 
 	cachedProject = projectMaps{
 		functions: map[string]*YAMLCommandSet{
-			"function_name": &YAMLCommandSet{},
+			"function_name": {},
 		},
 	}
 	s.Error(g.validateNoRedefine(cachedProject))
@@ -475,9 +475,9 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 	cachedProject = projectMaps{}
 	g = GeneratedProject{
 		Tasks: []parserTask{
-			parserTask{
+			{
 				Commands: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "generate.tasks",
 					},
 				},
@@ -489,9 +489,9 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 	cachedProject = projectMaps{}
 	g = GeneratedProject{
 		Functions: map[string]*YAMLCommandSet{
-			"a_function": &YAMLCommandSet{
+			"a_function": {
 				MultiCommand: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "generate.tasks",
 					},
 				},
@@ -502,9 +502,9 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 
 	cachedProject = projectMaps{
 		tasks: map[string]*ProjectTask{
-			"task_name": &ProjectTask{
+			"task_name": {
 				Commands: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "generate.tasks",
 					},
 				},
@@ -513,9 +513,9 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 	}
 	g = GeneratedProject{
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Tasks: []parserBVTaskUnit{
-					parserBVTaskUnit{
+					{
 						Name: "task_name",
 					},
 				},
@@ -526,18 +526,18 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 
 	cachedProject = projectMaps{
 		tasks: map[string]*ProjectTask{
-			"task_name": &ProjectTask{
+			"task_name": {
 				Commands: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Function: "generate_function",
 					},
 				},
 			},
 		},
 		functions: map[string]*YAMLCommandSet{
-			"generate_function": &YAMLCommandSet{
+			"generate_function": {
 				MultiCommand: []PluginCommandConf{
-					PluginCommandConf{
+					{
 						Command: "generate.tasks",
 					},
 				},
@@ -546,9 +546,9 @@ func (s *GenerateSuite) TestValidateNoRecursiveGenerateTasks() {
 	}
 	g = GeneratedProject{
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Tasks: []parserBVTaskUnit{
-					parserBVTaskUnit{
+					{
 						Name: "task_name",
 					},
 				},
@@ -678,7 +678,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g := sampleGeneratedProject
 	g.Task = genTask
 
-	p, pp, err := FindAndTranslateProjectForVersion(v, "proj")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "proj")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)
@@ -766,7 +766,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert())
 	// Setup parser project to be partially generated.
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
 	s.NoError(err)
 
 	g := partiallyGeneratedProject
@@ -851,7 +851,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.Task = &tasksThatExist[0]
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -937,7 +937,7 @@ buildvariants:
 			},
 		},
 		BuildVariants: []parserBV{
-			parserBV{
+			{
 				Name: "a_new_variant",
 				Tasks: parserBVTaskUnits{
 					parserBVTaskUnit{
@@ -949,7 +949,7 @@ buildvariants:
 		},
 	}
 
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -1001,7 +1001,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.Task = &taskThatExists
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/yaml.v2"
 )
@@ -116,8 +117,8 @@ type PatchUpdate struct {
 // Returns an http status code and error.
 func ConfigurePatch(ctx context.Context, p *patch.Patch, version *Version, proj *ProjectRef, patchUpdateReq PatchUpdate) (int, error) {
 	var err error
-	project := &Project{}
-	if _, err := LoadProjectInto(ctx, []byte(p.PatchedParserProject), nil, p.Project, project); err != nil {
+	project, _, err := FindAndTranslateProjectForPatch(ctx, p)
+	if err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "unmarshalling project config")
 	}
 
@@ -207,15 +208,15 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 		return nil, nil, errors.Errorf("patch '%s' already finalized", p.Version)
 	}
 
-	project := &Project{}
 	projectRef, opts, err := getLoadProjectOptsForPatch(p, githubOauthToken)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "fetching project options for patch")
 	}
 	// if the patched config exists, use that as the project file bytes.
 	if p.PatchedParserProject != "" {
-		if _, err := LoadProjectInto(ctx, []byte(p.PatchedParserProject), opts, p.Project, project); err != nil {
-			return nil, nil, errors.WithStack(err)
+		project, _, err := FindAndTranslateProjectForPatch(ctx, p)
+		if err != nil {
+			return nil, nil, err
 		}
 		patchConfig := &PatchConfig{
 			PatchedParserProject: p.PatchedParserProject,
@@ -259,6 +260,7 @@ func GetPatchedProject(ctx context.Context, p *patch.Patch, githubOauthToken str
 			return nil, nil, errors.Wrap(err, "patching remote configuration file")
 		}
 	}
+	project := &Project{}
 	pp, err := LoadProjectInto(ctx, projectFileBytes, opts, p.Project, project)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
@@ -921,9 +923,14 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 		return nil, errors.WithStack(err)
 	}
 
-	project := &Project{}
-	if _, err = LoadProjectInto(ctx, []byte(existingPatch.PatchedParserProject), nil, existingPatch.Project, project); err != nil {
-		return nil, errors.Wrap(err, "loading project")
+	project, pp, err := FindAndTranslateProjectForPatch(ctx, existingPatch)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading existing project")
+	}
+
+	projBytes, err := bson.Marshal(pp)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling project bytes to bson")
 	}
 
 	patchDoc := &patch.Patch{
@@ -933,7 +940,8 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 		Githash:              existingPatch.Githash,
 		Status:               evergreen.PatchCreated,
 		Alias:                evergreen.CommitQueueAlias,
-		PatchedParserProject: existingPatch.PatchedParserProject,
+		PatchedParserProject: string(projBytes),
+		PatchedProjectConfig: existingPatch.PatchedProjectConfig,
 		CreateTime:           time.Now(),
 		MergedFrom:           existingPatch.Id.Hex(),
 	}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -107,7 +107,7 @@ func FindAliasesForProjectFromDb(projectID string) ([]ProjectAlias, error) {
 // on the project ref and aliases defined in the project YAML.  Aliases defined on the project ref will take precedence over the
 // project YAML in the case that both are defined.
 func GetAliasesMergedWithProjectConfig(projectID string, dbAliases []ProjectAlias) ([]ProjectAlias, error) {
-	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
+	projectConfig, err := FindLastKnownGoodProjectConfig(projectID)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project config")
 	}
@@ -207,9 +207,9 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bo
 	return out, len(out) > 0, nil
 }
 
-// findMatchingAliasForProjectConfig finds any aliases matching the alias input in the project config.
-func findMatchingAliasForProjectConfig(projectID, alias string) ([]ProjectAlias, error) {
-	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, "")
+// getMatchingAliasForVersion finds any aliases matching the alias input in the project config.
+func getMatchingAliasForVersion(versionID, alias string) ([]ProjectAlias, error) {
+	projectConfig, err := FindProjectConfigById(versionID)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project config")
 	}
@@ -262,7 +262,7 @@ func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, er
 	if len(aliases) > 0 || shouldExit {
 		return aliases, nil
 	}
-	return findMatchingAliasForProjectConfig(projectID, alias)
+	return getMatchingAliasForVersion(projectID, alias)
 }
 
 // patchAliasKey is used internally to group patch aliases together.

--- a/model/project_configs_db.go
+++ b/model/project_configs_db.go
@@ -57,14 +57,3 @@ func FindProjectConfigById(id string) (*ProjectConfig, error) {
 	}
 	return project, err
 }
-
-// ProjectConfigUpsertOne updates one project config
-func ProjectConfigUpsertOne(query interface{}, update interface{}) error {
-	_, err := db.Upsert(
-		ProjectConfigCollection,
-		query,
-		update,
-	)
-
-	return err
-}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -528,7 +528,7 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 // MergeWithProjectConfig looks up the project config with the given project ref id and modifies
 // the project ref scanning for any properties that can be set on both project ref and project parser.
 // Any values that are set at the project config level will be set on the project ref IF they are not set on
-// the project ref.
+// the project ref. If the version isn't specified, we get the latest config.
 func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 	projectConfig, err := FindProjectConfigForProjectOrVersion(p.Id, version)
 	if err != nil {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -168,7 +168,7 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if v == nil {
 		return nil, nil, errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading project")
 	}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -374,6 +374,7 @@ func (apiPatch *APIPatch) ToService() (patch.Patch, error) {
 	}
 
 	res.GithubPatchData = apiPatch.GithubPatchData.ToService()
+	res.PatchedParserProject = utility.FromStringPtr(apiPatch.PatchedParserProject)
 	return res, catcher.Resolve()
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1223,7 +1223,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", task.Version))
 	}
 
-	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "loading project from version"))
 	}

--- a/service/patch.go
+++ b/service/patch.go
@@ -47,7 +47,7 @@ func (uis *UIServer) patchPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Unmarshall project and get project variants and tasks
-	variantsAndTasksFromProject, err := model.GetVariantsAndTasksFromProject(r.Context(), projCtx.Patch.PatchedParserProject, projCtx.Patch.Project)
+	variantsAndTasksFromProject, err := model.GetVariantsAndTasksFromPatchProject(r.Context(), projCtx.Patch)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -67,6 +67,7 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 	if projCtx.Patch.PatchedParserProject != "" {
 		_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
 		grip.Warning(errors.Wrap(err, "writing patched parser project"))
+		return
 	}
 	pp, err := model.ParserProjectFindOneById(projCtx.Patch.Version)
 	if pp != nil {

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -4,10 +4,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 type RestPatch struct {
@@ -62,6 +64,17 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
-	grip.Warning(err)
+	if projCtx.Patch.PatchedParserProject != "" {
+		_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
+		grip.Warning(errors.Wrap(err, "writing patched parser project"))
+	}
+	pp, err := model.ParserProjectFindOneById(projCtx.Patch.Version)
+	if pp != nil {
+		var projBytes []byte
+		projBytes, err = bson.Marshal(pp)
+		if err == nil {
+			_, err = w.Write(projBytes)
+		}
+	}
+	grip.Warning(errors.Wrap(err, "writing parser project"))
 }

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -81,7 +81,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, parserProject, err := model.FindAndTranslateProjectForVersion(v, t.Project)
+	project, parserProject, err := model.FindAndTranslateProjectForVersion(v.Id, t.Project)
 	if err != nil {
 		return errors.Wrapf(err, "loading project for version '%s'", t.Version)
 	}

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -199,10 +199,10 @@ func TestGenerateTasks(t *testing.T) {
 		Status:                evergreen.TaskStarted,
 	}
 	sampleDistros := []distro.Distro{
-		distro.Distro{
+		{
 			Id: "ubuntu1604-test",
 		},
-		distro.Distro{
+		{
 			Id: "archlinux-test",
 		},
 	}
@@ -240,7 +240,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p, _, err := model.FindAndTranslateProjectForVersion(v, "mci")
+	p, _, err := model.FindAndTranslateProjectForVersion(v.Id, "mci")
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
@@ -251,7 +251,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p, _, err = model.FindAndTranslateProjectForVersion(v, "mci")
+	p, _, err = model.FindAndTranslateProjectForVersion(v.Id, "mci")
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 6)
@@ -361,7 +361,7 @@ buildvariants:
 		Requester:             evergreen.RepotrackerVersionRequester,
 	}
 	sampleDistros := []distro.Distro{
-		distro.Distro{
+		{
 			Id: "ubuntu1604-test",
 		},
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -234,6 +234,41 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithNoTasksAndVariants() {
 	s.Equal("patch has no build variants or tasks", err.Error())
 }
 
+func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithBadAlias() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resp, err := http.Get(s.diffURL)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	s.Require().NoError(err)
+
+	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
+		User:         s.user,
+		Project:      s.project,
+		BaseGitHash:  s.hash,
+		PatchContent: string(body),
+		Description:  s.desc,
+		Finalize:     true,
+		Alias:        "typo",
+	})
+	s.NoError(err)
+	s.Require().NotNil(intent)
+	s.NoError(intent.Insert())
+
+	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
+	s.Require().NoError(err)
+
+	j := NewPatchIntentProcessor(mgobson.NewObjectId(), intent).(*patchIntentProcessor)
+	j.env = s.env
+
+	patchDoc := intent.NewPatch()
+	err = j.finishPatch(ctx, patchDoc, githubOauthToken)
+	s.Require().Error(err)
+	s.Equal("alias 'typo' could not be found on project 'mci'", err.Error())
+}
+
 func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVariants() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
[EVG-17275](https://jira.mongodb.org/browse/EVG-17275)

### Description 
Exact same as the original except added a missing return in the second commit 🤦‍♀️ 

### Testing 
Tested by running set-module on a scheduled patch.
Before:
egss set-module -m evergreen -i 6375292c9dbe32575c2026e3 
load project error(s): unmarshalling parser project from YAML: invalid configuration file: yaml: control characters are not allowed

After:
Success

