### PR TITLE
EVG-17504 have CLI prompts that don't default yes default no"

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-11-16"
+	ClientVersion = "2022-11-18"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-11-18"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -173,7 +173,8 @@ func mergeCommand() cli.Command {
 				force:        c.Bool(forceFlagName),
 				githubAuthor: c.String(githubAuthorFlag),
 			}
-			if params.force && !params.skipConfirm && !confirm("Forcing item to front of queue will be reported. Continue? (y/N)", false) {
+			if params.force && !params.skipConfirm && !confirm(
+				"Forcing item to front of queue will be reported. Continue?", false) {
 				return errors.New("Merge aborted.")
 			}
 			conf, err := NewClientSettings(c.Parent().Parent().String(confFlagName))
@@ -300,7 +301,7 @@ func enqueuePatch() cli.Command {
 				}
 			}
 			if multipleCommits && !skipConfirm &&
-				!confirm("Original patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
+				!confirm("Original patch has multiple commits (these will be tested together but merged separately). Continue?", false) {
 				return errors.New("enqueue aborted")
 			}
 
@@ -606,7 +607,7 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient, u
 		return errors.Wrap(err, "getting commit count")
 	}
 	if commitCount > 1 && !p.skipConfirm &&
-		!confirm("Commit queue patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
+		!confirm("Commit queue patch has multiple commits (these will be tested together but merged separately). Continue?", false) {
 		return errors.New("patch aborted")
 	}
 
@@ -678,7 +679,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 		return errors.New("no commits for module")
 	}
 	if commitCount > 1 && !p.skipConfirm &&
-		!confirm("Commit queue module patch has multiple commits (these will be tested together but merged separately). Continue? (y/N):", false) {
+		!confirm("Commit queue module patch has multiple commits (these will be tested together but merged separately). Continue?", false) {
 		return errors.New("module patch aborted")
 	}
 
@@ -714,7 +715,7 @@ func (p *moduleParams) addModule(ac *legacyClient, rc *legacyClient) error {
 	if !p.skipConfirm {
 		grip.InfoWhen(diffData.patchSummary != "", diffData.patchSummary)
 		grip.InfoWhen(diffData.log != "", diffData.log)
-		if !confirm("This is a summary of the patch to be submitted. Continue? (Y/n):", true) {
+		if !confirm("This is a summary of the patch to be submitted. Continue?", true) {
 			return nil
 		}
 	}

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -1292,7 +1292,7 @@ func hostRunCommand() cli.Command {
 				}
 
 				if !skipConfirm {
-					if !confirm(fmt.Sprintf("The script will run on %d host(s), \n%s\nContinue? (Y/n): ", len(hostIDs), strings.Join(hostIDs, "\n")), true) {
+					if !confirm(fmt.Sprintf("The script will run on %d host(s), \n%s\nContinue?", len(hostIDs), strings.Join(hostIDs, "\n")), true) {
 						return nil
 					}
 				}
@@ -1680,13 +1680,13 @@ func verifyRsync(localPath, remotePath string, pull bool) bool {
 	remotePathIsDir := strings.HasSuffix(remotePath, "/")
 
 	if localPathIsDir && !pull {
-		ok := confirm(fmt.Sprintf("The local directory '%s' will overwrite any existing contents in the remote directory '%s'. Continue? (y/N)", localPath, remotePath), false)
+		ok := confirm(fmt.Sprintf("The local directory '%s' will overwrite any existing contents in the remote directory '%s'. Continue?", localPath, remotePath), false)
 		if !ok {
 			return false
 		}
 	}
 	if remotePathIsDir && pull {
-		ok := confirm(fmt.Sprintf("The remote directory '%s' will overwrite any existing contents in the local directory '%s'. Continue? (y/N)", remotePath, localPath), false)
+		ok := confirm(fmt.Sprintf("The remote directory '%s' will overwrite any existing contents in the local directory '%s'. Continue?", remotePath, localPath), false)
 		if !ok {
 			return false
 		}

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -159,7 +159,7 @@ func Patch() cli.Command {
 					return errors.Wrap(err, "confirming uncommitted changes")
 				}
 				if keepGoing && utility.StringSliceContains(params.Variants, "all") && utility.StringSliceContains(params.Tasks, "all") {
-					keepGoing = confirm(`For some projects, scheduling all tasks/variants may result in a very large patch build. Continue? (Y/n)`, true)
+					keepGoing = confirm(`For some projects, scheduling all tasks/variants may result in a very large patch build. Continue?`, true)
 				}
 				if !keepGoing {
 					return errors.New("patch aborted")

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -134,7 +134,7 @@ func addModuleToPatch(params *patchParams, args cli.Args, conf *ClientSettings,
 			fmt.Println(diffData.patchSummary)
 		}
 
-		if !confirm("This is a summary of the module patch to be submitted. Include this module's changes? (Y/n):", true) {
+		if !confirm("This is a summary of the module patch to be submitted. Include this module's changes?", true) {
 			return nil
 		}
 	}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -146,7 +146,7 @@ func (p *patchParams) validateSubmission(diffData *localDiff) error {
 		return err
 	}
 	if !p.SkipConfirm && len(diffData.fullPatch) == 0 {
-		if !confirm("Patch submission is empty. Continue? (Y/n)", true) {
+		if !confirm("Patch submission is empty. Continue?", true) {
 			return errors.New("patch aborted")
 		}
 	} else if !p.SkipConfirm && diffData.patchSummary != "" {
@@ -155,7 +155,7 @@ func (p *patchParams) validateSubmission(diffData *localDiff) error {
 			grip.Info(diffData.log)
 		}
 
-		if !confirm("This is a summary of the patch to be submitted. Continue? (Y/n):", true) {
+		if !confirm("This is a summary of the patch to be submitted. Continue?", true) {
 			return errors.New("patch aborted")
 		}
 	}
@@ -581,13 +581,13 @@ func confirmUncommittedChanges(dir string, preserveCommits, includeUncommitedCha
 	}
 
 	if preserveCommits {
-		return confirm("Uncommitted changes are omitted from patches when commits are preserved. Continue? (y/N)", false), nil
+		return confirm("Uncommitted changes are omitted from patches when commits are preserved. Continue?", false), nil
 	}
 
 	if !includeUncommitedChanges {
 		return confirm(fmt.Sprintf(`Uncommitted changes are omitted from patches by default.
 Use the '--%s, -u' flag or set 'patch_uncommitted_changes: true' in your ~/.evergreen.yml file to include uncommitted changes.
-Continue? (Y/n)`, uncommittedChangesFlag), true), nil
+Continue?`, uncommittedChangesFlag), true), nil
 	}
 
 	return true, nil

--- a/operations/prompt.go
+++ b/operations/prompt.go
@@ -20,6 +20,7 @@ func prompt(message string) string {
 
 // confirm asks the user a yes/no question and returns true/false if they reply with y/yes/n/no.
 // if defaultYes is true, allows user to just hit enter without typing an explicit yes.
+// Otherwise we default no.
 func confirm(message string, defaultYes bool) bool {
 	var reply string
 
@@ -28,6 +29,10 @@ func confirm(message string, defaultYes bool) bool {
 
 	if defaultYes {
 		yes = append(yes, "")
+		message = fmt.Sprintf("%s (Y/n)", message)
+	} else {
+		no = append(no, "")
+		message = fmt.Sprintf("%s (y/N)", message)
 	}
 
 	for {


### PR DESCRIPTION
[EVG-17504](https://jira.mongodb.org/browse/EVG-17504)

### Description 
User asked that "set default" prompts default to no bc typing no is annoying. I actually think this is meant to be the default generally since we use the "y/N" terminology for defaults, and not doing something is never the risk, default yes is the one we have to be careful about. 

### Testing 
Tested using a command with a default Yes and default No.
```
Set test as the default alias for project 'evg'? (y/N) 
Enter a description for this patch (optional): 
 config.go                  |  2 +-
 operations/commit_queue.go | 11 ++++++-----
 operations/host_spawn.go   |  6 +++---
 operations/patch.go        |  2 +-
 operations/patch_module.go |  2 +-
 operations/patch_util.go   |  8 ++++----
 operations/prompt.go       |  5 +++++
 7 files changed, 21 insertions(+), 15 deletions(-)
4d22c9871 EVG-17504 have CLI prompts that don't default yes default no"
This is a summary of the patch to be submitted. Continue? (Y/n) 
```