### PR TITLE
EVG-17196 avoid setting defaults when reusing definitions

### DIFF
--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -221,28 +221,31 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		grip.Warningf("warning - failed to set default project: %v\n", err)
 	}
 
-	if err := p.setLocalAliases(conf); err != nil {
-		grip.Warningf("warning - setting local aliases")
-	}
+	// If reusing a previous definition, ignore defaults.
+	if !p.RepeatFailed && !p.RepeatDefinition {
+		if err := p.setLocalAliases(conf); err != nil {
+			grip.Warningf("warning - setting local aliases")
+		}
 
-	if err := p.loadAlias(conf); err != nil {
-		grip.Warningf("warning - failed to set default alias: %v\n", err)
-	}
+		if err := p.loadAlias(conf); err != nil {
+			grip.Warningf("warning - failed to set default alias: %v\n", err)
+		}
 
-	if err := p.loadVariants(conf); err != nil {
-		grip.Warningf("warning - failed to set default variants: %v\n", err)
-	}
+		if err := p.loadVariants(conf); err != nil {
+			grip.Warningf("warning - failed to set default variants: %v\n", err)
+		}
 
-	if err := p.loadTasks(conf); err != nil {
-		grip.Warningf("warning - failed to set default tasks: %v\n", err)
+		if err := p.loadTasks(conf); err != nil {
+			grip.Warningf("warning - failed to set default tasks: %v\n", err)
+		}
+
+		if err := p.loadTriggerAliases(conf); err != nil {
+			grip.Warningf("warning - failed to set default trigger aliases: %v\n", err)
+		}
 	}
 
 	if err := p.loadParameters(conf); err != nil {
 		grip.Warningf("warning - failed to set default parameters: %v\n", err)
-	}
-
-	if err := p.loadTriggerAliases(conf); err != nil {
-		grip.Warningf("warning - failed to set default trigger aliases: %v\n", err)
 	}
 
 	if p.Uncommitted || conf.UncommittedChanges {


### PR DESCRIPTION
[EVG-17196](https://jira.mongodb.org/browse/EVG-17196 )

### Description 
Reuse doesn't work if any defaults are set for the user. 
### Testing 
Verified that this happens in prod and not with the changes.
```
evergreen [EVG-17196] $ eg patch -u --reuse     
Enter a description for this patch (optional): test
can't define tasks/variants when reusing previous patch's tasks and variants

evergreen [EVG-17196] $ egss patch --reuse          
<success>
```