### PR TITLE
EVG-17505 Remove WorkDir from DistroView

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -333,5 +333,4 @@ type GeneratePollResponse struct {
 type DistroView struct {
 	CloneMethod         string `json:"clone_method"`
 	DisableShallowClone bool   `json:"disable_shallow_clone"`
-	WorkDir             string `json:"work_dir"`
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -504,7 +504,6 @@ func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
 	dv := apimodels.DistroView{
 		CloneMethod:         host.Distro.CloneMethod,
 		DisableShallowClone: host.Distro.DisableShallowClone,
-		WorkDir:             host.Distro.WorkDir,
 	}
 	return gimlet.NewJSONResponse(dv)
 }


### PR DESCRIPTION
[EVG-17505](https://jira.mongodb.org/browse/EVG-17505)

### Description 
Removing as a follow up from [this PR](https://github.com/evergreen-ci/evergreen/pull/5853) now that all hosts have rolled over.