### PR TITLE
EVG-17033 End max execution and unschedulable stranded tasks before marking system failed

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1503,15 +1503,7 @@ func (t *Task) MarkFailed() error {
 func (t *Task) MarkSystemFailed(description string) error {
 	t.Status = evergreen.TaskFailed
 	t.FinishTime = time.Now()
-
-	t.Details = apimodels.TaskEndDetail{
-		Status:      evergreen.TaskFailed,
-		Type:        evergreen.CommandTypeSystem,
-		Description: description,
-	}
-	if description == evergreen.TaskDescriptionHeartbeat {
-		t.Details.TimedOut = true
-	}
+	t.Details = GetSystemFailureDetails(description)
 
 	switch t.ExecutionPlatform {
 	case ExecutionPlatformHost:
@@ -1550,6 +1542,18 @@ func (t *Task) MarkSystemFailed(description string) error {
 			},
 		},
 	)
+}
+
+func GetSystemFailureDetails(description string) apimodels.TaskEndDetail {
+	details := apimodels.TaskEndDetail{
+		Status:      evergreen.TaskFailed,
+		Type:        evergreen.CommandTypeSystem,
+		Description: description,
+	}
+	if description == evergreen.TaskDescriptionHeartbeat {
+		details.TimedOut = true
+	}
+	return details
 }
 
 func SetManyAborted(taskIds []string, reason AbortInfo) error {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1544,6 +1544,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 	)
 }
 
+// GetSystemFailureDetails returns a task's end details based on an input description.
 func GetSystemFailureDetails(description string) apimodels.TaskEndDetail {
 	details := apimodels.TaskEndDetail{
 		Status:      evergreen.TaskFailed,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1725,13 +1725,20 @@ func resetSystemFailedTask(t *task.Task, description string) error {
 		return nil
 	}
 
-	if err := t.MarkSystemFailed(description); err != nil {
-		return errors.Wrap(err, "marking task as system failed")
-	}
-
-	if time.Since(t.ActivatedTime) > task.UnschedulableThreshold {
+	unschedulableTask := time.Since(t.ActivatedTime) > task.UnschedulableThreshold
+	maxExecutionTask := t.Execution >= evergreen.MaxTaskExecution
+	if unschedulableTask || maxExecutionTask {
+		failureDetails := task.GetSystemFailureDetails(description)
 		// If the task has already exceeded the unschedulable threshold, we
 		// don't want to restart it, so just mark it as finished.
+		msg := "task exceeded unschedulable threshold"
+		if maxExecutionTask {
+			msg = "task exceeded max execution threshold"
+		}
+		grip.Warning(message.Fields{
+			"message": fmt.Sprintf("%s, marking as finished", msg),
+			"task":    t.Id,
+		})
 		if t.DisplayOnly {
 			execTasks, err := task.FindAll(db.Query(task.ByIds(t.ExecutionTasks)))
 			if err != nil {
@@ -1739,13 +1746,17 @@ func resetSystemFailedTask(t *task.Task, description string) error {
 			}
 			for _, execTask := range execTasks {
 				if !evergreen.IsFinishedTaskStatus(execTask.Status) {
-					if err := MarkEnd(&execTask, evergreen.MonitorPackage, time.Now(), &t.Details, false); err != nil {
+					if err = MarkEnd(&execTask, evergreen.MonitorPackage, time.Now(), &failureDetails, false); err != nil {
 						return errors.Wrap(err, "marking execution task as ended")
 					}
 				}
 			}
 		}
-		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &t.Details, false))
+		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &failureDetails, false))
+	}
+
+	if err := t.MarkSystemFailed(description); err != nil {
+		return errors.Wrap(err, "marking task as system failed")
 	}
 
 	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, true, &t.Details), "resetting task")

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1731,14 +1731,6 @@ func resetSystemFailedTask(t *task.Task, description string) error {
 		failureDetails := task.GetSystemFailureDetails(description)
 		// If the task has already exceeded the unschedulable threshold, we
 		// don't want to restart it, so just mark it as finished.
-		msg := "task exceeded unschedulable threshold"
-		if maxExecutionTask {
-			msg = "task exceeded max execution threshold"
-		}
-		grip.Warning(message.Fields{
-			"message": fmt.Sprintf("%s, marking as finished", msg),
-			"task":    t.Id,
-		})
 		if t.DisplayOnly {
 			execTasks, err := task.FindAll(db.Query(task.ByIds(t.ExecutionTasks)))
 			if err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3537,7 +3537,55 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 		BuildId:       "b",
 		Version:       "version",
 	}
-	assert.NoError(runningTask.Insert())
+	unschedulableTask := &task.Task{
+		Id:            "unschedulableTask",
+		Status:        evergreen.TaskStarted,
+		Activated:     true,
+		ActivatedTime: time.Now().Add(-task.UnschedulableThreshold - time.Minute),
+		BuildId:       "b2",
+		Version:       "version2",
+		Requester:     evergreen.PatchVersionRequester,
+	}
+	dependencyTask := &task.Task{
+		Id:            "dependencyTask",
+		Status:        evergreen.TaskUndispatched,
+		Activated:     true,
+		ActivatedTime: time.Now(),
+		BuildId:       "b2",
+		Version:       "version2",
+		DependsOn: []task.Dependency{
+			{
+				TaskId: unschedulableTask.Id,
+				Status: evergreen.TaskSucceeded,
+			},
+		},
+	}
+	dt := &task.Task{
+		Id:             "displayTask",
+		DisplayName:    "displayTask",
+		BuildId:        "b2",
+		Version:        "version2",
+		Project:        "project",
+		Activated:      false,
+		DisplayOnly:    true,
+		ExecutionTasks: []string{unschedulableTask.Id},
+		Status:         evergreen.TaskStarted,
+		DispatchTime:   time.Now(),
+	}
+	maxExecTask := &task.Task{
+		Id:            "t3",
+		Status:        evergreen.TaskStarted,
+		Activated:     true,
+		ActivatedTime: time.Now(),
+		BuildId:       "b3",
+		Version:       "version3",
+		Execution:     evergreen.MaxTaskExecution,
+	}
+	require.NoError(t, runningTask.Insert())
+	require.NoError(t, maxExecTask.Insert())
+	require.NoError(t, dependencyTask.Insert())
+	require.NoError(t, unschedulableTask.Insert())
+	require.NoError(t, dt.Insert())
 
 	h := &host.Host{
 		Id:          "h1",
@@ -3555,10 +3603,57 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	}
 	assert.NoError(v.Insert())
 
+	b2 := build.Build{
+		Id:      "b2",
+		Version: "version2",
+	}
+	assert.NoError(b2.Insert())
+	v2 := Version{
+		Id: b2.Version,
+	}
+	assert.NoError(v2.Insert())
+
 	assert.NoError(ClearAndResetStrandedHostTask(h))
+
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal(evergreen.TaskUndispatched, runningTask.Status)
+
+	foundBuild, err := build.FindOneId("b")
+	require.NoError(t, err)
+	assert.Equal(evergreen.BuildCreated, foundBuild.Status)
+
+	foundVersion, err := VersionFindOneId(b.Version)
+	require.NoError(t, err)
+	assert.Equal(evergreen.VersionCreated, foundVersion.Status)
+
+	h.RunningTask = "unschedulableTask"
+	assert.NoError(ClearAndResetStrandedHostTask(h))
+
+	unschedulableTask, err = task.FindOne(db.Query(task.ById("unschedulableTask")))
+	require.NoError(t, err)
+	assert.Equal(evergreen.TaskFailed, unschedulableTask.Status)
+
+	dependencyTask, err = task.FindOne(db.Query(task.ById("dependencyTask")))
+	require.NoError(t, err)
+	assert.True(dependencyTask.DependsOn[0].Unattainable)
+	assert.True(dependencyTask.DependsOn[0].Finished)
+
+	dt, err = task.FindOne(db.Query(task.ById("displayTask")))
+	require.NoError(t, err)
+	assert.Equal(dt.Status, evergreen.TaskFailed)
+	assert.Equal(dt.Details, task.GetSystemFailureDetails(evergreen.TaskDescriptionStranded))
+
+	foundBuild, err = build.FindOneId("b2")
+	require.NoError(t, err)
+	assert.Equal(evergreen.BuildFailed, foundBuild.Status)
+
+	foundVersion, err = VersionFindOneId(b2.Version)
+	require.NoError(t, err)
+	assert.Equal(evergreen.VersionFailed, foundVersion.Status)
+
+	h.RunningTask = "t2"
+	assert.NoError(ClearAndResetStrandedHostTask(h))
 }
 
 func TestClearAndResetStaleStrandedHostTask(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3654,6 +3654,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	h.RunningTask = "t2"
 	assert.NoError(ClearAndResetStrandedHostTask(h))
+
 }
 
 func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
@@ -3666,6 +3667,7 @@ func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
 		Activated:     true,
 		ActivatedTime: utility.ZeroTime,
 		BuildId:       "b",
+		Version:       "version",
 	}
 	assert.NoError(runningTask.Insert())
 
@@ -3677,6 +3679,10 @@ func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
 
 	b := build.Build{Id: "b"}
 	assert.NoError(b.Insert())
+	v := Version{
+		Id: b.Version,
+	}
+	assert.NoError(v.Insert())
 
 	assert.NoError(ClearAndResetStrandedHostTask(h))
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))


### PR DESCRIPTION
[EVG-17033](https://jira.mongodb.org/browse/EVG-17033)

### Description 
There is currently a bug where ending stranded tasks rather than resetting them (either because they have breached the unschedulable threshold or they have breached the max execution) causes `MarkEnd` to return early and not perform the necessary steps of updating dependencies, updating build/version statuses, updating display task statuses, etc.  

Change has been made to not call `MarkSystemFailed` before calling `MarkEnd` in these cases because it would result in a premature return [here](https://github.com/evergreen-ci/evergreen/blob/c2844d0184381b161f61402ddc599253c2b9a248/model/task_lifecycle.go#L477-L483). Passing stranded system failure details to `MarkEnd` will allow it to perform the same function as `MarkSystemFailed` in these cases.  

I also did some light refactoring on how we construct system failed task details based off an input description since I noticed the same logic was used in a couple places.
### Testing 
TDD approach, wrote some extra tests in TestClearAndResetStrandedHostTask, and certified that they failed before the change and succeeded afterwards.