### PR TITLE
EVG-16982 respect disabled for cron

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -499,7 +499,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 	res := newSpecificActivationInfo()
 	for _, bv := range g.BuildVariants {
 		// Only consider batchtime for certain requesters
-		if evergreen.ShouldConsiderBatchtime(requester) && (bv.BatchTime != nil || bv.CronBatchTime != "") {
+		if evergreen.ShouldConsiderBatchtime(requester) && bv.hasSpecificActivation() {
 			res.activationVariants = append(res.activationVariants, bv.name())
 		} else if bv.Activate != nil {
 			res.activationVariants = append(res.activationVariants, bv.name())
@@ -513,7 +513,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 				res.stepbackTasks[bv.Name] = append(res.stepbackTasks[bv.Name], stepbackInfo)
 				continue // Don't consider batchtime/activation if we're stepping back this generated task
 			}
-			if evergreen.ShouldConsiderBatchtime(requester) && (bvt.BatchTime != nil || bvt.CronBatchTime != "") {
+			if evergreen.ShouldConsiderBatchtime(requester) && bvt.hasSpecificActivation() {
 				batchTimeTasks = append(batchTimeTasks, bvt.Name)
 			} else if bvt.Activate != nil {
 				batchTimeTasks = append(batchTimeTasks, bvt.Name)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -550,14 +550,13 @@ func RefreshTasksCache(buildId string) error {
 
 // addTasksToBuild creates/activates the tasks for the given build of a project
 func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
-	// find the build variant for this project/build
+	// Find the build variant for this project/build
 	creationInfo.BuildVariant = creationInfo.Project.FindBuildVariant(creationInfo.Build.BuildVariant)
 	if creationInfo.BuildVariant == nil {
 		return nil, nil, errors.Errorf("finding build '%s' in project file '%s'",
 			creationInfo.Build.BuildVariant, creationInfo.Project.Identifier)
 	}
 
-	// create the new tasks for the build
 	createTime, err := getTaskCreateTime(creationInfo)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "getting create time for tasks in version '%s'", creationInfo.Version.Id)
@@ -575,6 +574,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 	}
 	creationInfo.GithubChecksAliases = githubCheckAliases
 	creationInfo.TaskCreateTime = createTime
+	// Create the new tasks for the build
 	tasks, err := createTasksForBuild(creationInfo)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "creating tasks for build '%s'", creationInfo.Build.Id)

--- a/model/project.go
+++ b/model/project.go
@@ -1293,7 +1293,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 		"last good version for project '%s'", lastGoodVersion.Identifier)
 }
 
-// HasSpecificActivation returns if the build variant specifies an overriding activation,
+// HasSpecificActivation returns if the build variant task specifies an overriding activation,
 // such as cron/batchtime, disabling the task, or explicitly activating it.
 func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
 	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()

--- a/model/project.go
+++ b/model/project.go
@@ -1293,8 +1293,8 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 		"last good version for project '%s'", lastGoodVersion.Identifier)
 }
 
-// HasSpecificActivation returns if the build variant task specifies an overriding activation,
-// such as cron/batchtime, disabling the task, or explicitly activating it.
+// HasSpecificActivation returns if the build variant task specifies an activation condition that
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
 func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
 	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()
 }

--- a/model/project.go
+++ b/model/project.go
@@ -1293,8 +1293,10 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 		"last good version for project '%s'", lastGoodVersion.Identifier)
 }
 
-func (bvt *BuildVariantTaskUnit) HasBatchTime() bool {
-	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil
+// HasSpecificActivation returns if the build variant specifies an overriding activation,
+// such as cron/batchtime, disabling the task, or explicitly activating it.
+func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
+	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()
 }
 
 func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -484,6 +484,20 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 	return nil
 }
 
+// hasSpecificActivation returns if the build variant task unit specifies an overriding activation,
+// such as cron/batchtime, disabling the task, or explicitly activating it.
+func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
+	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
+		bvt.Activate != nil || utility.FromBoolPtr(bvt.Disable)
+}
+
+// hasSpecificActivation returns if the build variant specifies an overriding activation,
+// such as cron/batchtime, disabling the task, or explicitly activating it.
+func (bvt *parserBV) hasSpecificActivation() bool {
+	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
+		bvt.Activate != nil || bvt.Disabled
+}
+
 // FindAndTranslateProjectForPatch translates a parser project for a patch into a project.
 // This assumes that the version may not exist yet; otherwise FindAndTranslateProjectForVersion is equivalent.
 func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Project, *ParserProject, error) {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -484,15 +484,15 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 	return nil
 }
 
-// hasSpecificActivation returns if the build variant task unit specifies an overriding activation,
-// such as cron/batchtime, disabling the task, or explicitly activating it.
+// HasSpecificActivation returns if the build variant task specifies an activation condition that
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
 func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
 	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
 		bvt.Activate != nil || utility.FromBoolPtr(bvt.Disable)
 }
 
-// hasSpecificActivation returns if the build variant specifies an overriding activation,
-// such as cron/batchtime, disabling the task, or explicitly activating it.
+// HasSpecificActivation returns if the build variant specifies an activation condition that
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
 func (bvt *parserBV) hasSpecificActivation() bool {
 	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
 		bvt.Activate != nil || bvt.Disabled

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2082,7 +2082,7 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the build, set batchtime to the zero time
-	if !utility.FromBoolTPtr(variant.Activate) {
+	if !utility.FromBoolTPtr(variant.Activate) || variant.Disabled {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {
@@ -2117,7 +2117,7 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the task, set batchtime to the zero time
-	if !utility.FromBoolTPtr(t.Activate) {
+	if !utility.FromBoolTPtr(t.Activate) || t.IsDisabled() {
 		return utility.ZeroTime, nil
 	}
 	if t.CronBatchTime != "" {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2123,7 +2123,7 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 	if t.CronBatchTime != "" {
 		return GetActivationTimeWithCron(time.Now(), t.CronBatchTime)
 	}
-	// if activated explicitly set to true and we don't have batchtime, then we want to just activate now
+	// If activated explicitly set to true and we don't have batchtime, then we want to just activate now
 	if utility.FromBoolPtr(t.Activate) && t.BatchTime == nil {
 		return time.Now(), nil
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -180,6 +180,11 @@ func TestGetActivationTimeForTask(t *testing.T) {
 		Name:      "myTask",
 		Variant:   "bv1",
 	}
+	bvt2 := &BuildVariantTaskUnit{
+		Name:    "notMyTask",
+		Variant: "bv1",
+		Disable: utility.TruePtr(),
+	}
 
 	versionWithoutTask := Version{
 		Id:         "v1",
@@ -229,6 +234,10 @@ func TestGetActivationTimeForTask(t *testing.T) {
 	activationTime, err := projectRef.GetActivationTimeForTask(bvt)
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(prevTime.Add(time.Hour)))
+
+	activationTime, err = projectRef.GetActivationTimeForTask(bvt2)
+	assert.NoError(t, err)
+	assert.True(t, activationTime.Equal(utility.ZeroTime))
 }
 
 func TestGetActivationTimeWithCron(t *testing.T) {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1009,7 +1009,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
 				tId, ok := taskNameToId[bvt.Name]
-				if !ok || !bvt.HasBatchTime() {
+				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
 				bvt.Variant = buildvariant.Name


### PR DESCRIPTION
[EVG-16982](https://jira.mongodb.org/browse/EVG-16982)

### Description 
Activation right now checks activate but not disabled. Additionally, there are a few places where we short circuit if cron/batchtime aren't defined, but we don't check either activate or disabled before we do that.

### Testing 
Added a test.
