### PR TITLE
EVG-17448 configurable webhook retries

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -156,7 +156,7 @@ func (s *WebhookSubscriber) validate() error {
 	catcher.AddWhen(len(s.Secret) == 0, errors.New("secret cannot be empty"))
 
 	catcher.AddWhen(s.Retries < 0, errors.New("retries cannot be negative"))
-	catcher.AddWhen(s.Retries > webhookRetryLimit, errors.Errorf("retries cannot be greater than %d", webhookRetryLimit))
+	catcher.AddWhen(s.Retries > webhookRetryLimit, errors.Errorf("cannot retry more than %d times", webhookRetryLimit))
 
 	catcher.AddWhen(s.MinDelayMS < 0, errors.New("min delay cannot be negative"))
 	catcher.AddWhen(s.MinDelayMS > webhookMinDelayLimit, errors.Errorf("min delay cannot be greater than %d ms", webhookMinDelayLimit))

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -122,6 +122,7 @@ type WebhookSubscriber struct {
 	Secret     []byte          `bson:"secret"`
 	Retries    int             `bson:"retries"`
 	MinDelayMS int             `bson:"min_delay_ms"`
+	TimeoutMS  int             `bson:"timeout_ms"`
 	Headers    []WebhookHeader `bson:"headers"`
 }
 

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -35,7 +35,7 @@ var SubscriberTypes = []string{
 	RunChildPatchSubscriberType,
 }
 
-//nolint: deadcode, megacheck, unused
+// nolint: deadcode, megacheck, unused
 var (
 	subscriberTypeKey   = bsonutil.MustHaveTag(Subscriber{}, "Type")
 	subscriberTargetKey = bsonutil.MustHaveTag(Subscriber{}, "Target")
@@ -118,9 +118,11 @@ func (s *Subscriber) Validate() error {
 }
 
 type WebhookSubscriber struct {
-	URL     string          `bson:"url"`
-	Secret  []byte          `bson:"secret"`
-	Headers []WebhookHeader `bson:"headers"`
+	URL        string          `bson:"url"`
+	Secret     []byte          `bson:"secret"`
+	Retries    int             `bson:"retries"`
+	MinDelayMS int             `bson:"min_delay_ms"`
+	Headers    []WebhookHeader `bson:"headers"`
 }
 
 type WebhookHeader struct {

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -109,11 +109,13 @@ func (n *Notification) Composer(env evergreen.Environment) (message.Composer, er
 		payload.Secret = sub.Secret
 		payload.URL = sub.URL
 		payload.NotificationID = n.ID
+		payload.Retries = sub.Retries
+		payload.MinDelayMS = sub.MinDelayMS
 		for _, header := range sub.Headers {
 			payload.Headers.Add(header.Key, header.Value)
 		}
 
-		return util.NewWebhookMessageWithStruct(*payload), nil
+		return util.NewWebhookMessage(*payload), nil
 
 	case event.EmailSubscriberType:
 		sub, ok := n.Subscriber.Target.(*string)

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -111,6 +111,7 @@ func (n *Notification) Composer(env evergreen.Environment) (message.Composer, er
 		payload.NotificationID = n.ID
 		payload.Retries = sub.Retries
 		payload.MinDelayMS = sub.MinDelayMS
+		payload.TimeoutMS = sub.TimeoutMS
 		for _, header := range sub.Headers {
 			payload.Headers.Add(header.Key, header.Value)
 		}

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -44,6 +44,7 @@ type APIWebhookSubscriber struct {
 	Secret     *string            `json:"secret" mapstructure:"secret"`
 	Retries    int                `json:"retries" mapstructure:"retries"`
 	MinDelayMS int                `json:"min_delay_ms" mapstructure:"min_delay_ms"`
+	TimeoutMS  int                `json:"timeout_ms" mapstructure:"timeout_ms"`
 	Headers    []APIWebhookHeader `json:"headers" mapstructure:"headers"`
 }
 
@@ -243,6 +244,7 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 		s.Headers = []APIWebhookHeader{}
 		s.Retries = v.Retries
 		s.MinDelayMS = v.MinDelayMS
+		s.TimeoutMS = v.TimeoutMS
 		for _, header := range v.Headers {
 			apiHeader := APIWebhookHeader{}
 			apiHeader.BuildFromService(header)
@@ -263,6 +265,7 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 		Headers:    []event.WebhookHeader{},
 		Retries:    s.Retries,
 		MinDelayMS: s.MinDelayMS,
+		TimeoutMS:  s.TimeoutMS,
 	}
 	for _, apiHeader := range s.Headers {
 		sub.Headers = append(sub.Headers, apiHeader.ToService())

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -40,9 +40,11 @@ type APIPRInfo struct {
 }
 
 type APIWebhookSubscriber struct {
-	URL     *string            `json:"url" mapstructure:"url"`
-	Secret  *string            `json:"secret" mapstructure:"secret"`
-	Headers []APIWebhookHeader `json:"headers" mapstructure:"headers"`
+	URL        *string            `json:"url" mapstructure:"url"`
+	Secret     *string            `json:"secret" mapstructure:"secret"`
+	Retries    int                `json:"retries" mapstructure:"retries"`
+	MinDelayMS int                `json:"min_delay_ms" mapstructure:"min_delay_ms"`
+	Headers    []APIWebhookHeader `json:"headers" mapstructure:"headers"`
 }
 
 type APIWebhookHeader struct {
@@ -239,6 +241,8 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 		s.URL = utility.ToStringPtr(v.URL)
 		s.Secret = utility.ToStringPtr(string(v.Secret))
 		s.Headers = []APIWebhookHeader{}
+		s.Retries = v.Retries
+		s.MinDelayMS = v.MinDelayMS
 		for _, header := range v.Headers {
 			apiHeader := APIWebhookHeader{}
 			apiHeader.BuildFromService(header)
@@ -254,9 +258,11 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 
 func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 	sub := event.WebhookSubscriber{
-		URL:     utility.FromStringPtr(s.URL),
-		Secret:  []byte(utility.FromStringPtr(s.Secret)),
-		Headers: []event.WebhookHeader{},
+		URL:        utility.FromStringPtr(s.URL),
+		Secret:     []byte(utility.FromStringPtr(s.Secret)),
+		Headers:    []event.WebhookHeader{},
+		Retries:    s.Retries,
+		MinDelayMS: s.MinDelayMS,
 	}
 	for _, apiHeader := range s.Headers {
 		sub.Headers = append(sub.Headers, apiHeader.ToService())

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -51,9 +51,12 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 	assert := assert.New(t)
 
 	target := event.WebhookSubscriber{
-		URL:     "foo",
-		Secret:  []byte("bar"),
-		Headers: []event.WebhookHeader{},
+		URL:        "foo",
+		Secret:     []byte("bar"),
+		Retries:    3,
+		MinDelayMS: 500,
+		TimeoutMS:  10000,
+		Headers:    []event.WebhookHeader{},
 	}
 	webhookSubscriber := event.Subscriber{
 		Type:   event.EvergreenWebhookSubscriberType,
@@ -73,8 +76,11 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 	incoming := APISubscriber{
 		Type: utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
 		Target: map[string]interface{}{
-			"url":    "foo",
-			"secret": "bar",
+			"url":          "foo",
+			"secret":       "bar",
+			"retries":      3,
+			"min_delay_ms": 500,
+			"timeout_ms":   10000,
 		},
 	}
 

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -21,13 +21,13 @@ const (
 )
 
 type EvergreenWebhook struct {
-	NotificationID string        `bson:"notification_id"`
-	URL            string        `bson:"url"`
-	Secret         []byte        `bson:"secret"`
-	Body           []byte        `bson:"body"`
-	Headers        http.Header   `bson:"headers"`
-	Retries        int           `bson:"retries"`
-	MinDelay       time.Duration `bson:"min_delay"`
+	NotificationID string      `bson:"notification_id"`
+	URL            string      `bson:"url"`
+	Secret         []byte      `bson:"secret"`
+	Body           []byte      `bson:"body"`
+	Headers        http.Header `bson:"headers"`
+	Retries        int         `bson:"retries"`
+	MinDelayMS     int         `bson:"min_delay"`
 }
 
 type evergreenWebhookMessage struct {
@@ -36,21 +36,9 @@ type evergreenWebhookMessage struct {
 	message.Base
 }
 
-func NewWebhookMessageWithStruct(raw EvergreenWebhook) message.Composer {
+func NewWebhookMessage(raw EvergreenWebhook) message.Composer {
 	return &evergreenWebhookMessage{
 		raw: raw,
-	}
-}
-
-func NewWebhookMessage(id string, url string, secret []byte, body []byte, headers map[string][]string) message.Composer {
-	return &evergreenWebhookMessage{
-		raw: EvergreenWebhook{
-			NotificationID: id,
-			URL:            url,
-			Secret:         secret,
-			Body:           body,
-			Headers:        headers,
-		},
 	}
 }
 
@@ -165,7 +153,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 		return false, nil
 	}, utility.RetryOptions{
 		MaxAttempts: raw.Retries + 1,
-		MinDelay:    raw.MinDelay,
+		MinDelay:    time.Duration(raw.MinDelayMS) * time.Millisecond,
 	})
 
 	return nil

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -145,7 +145,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 	}
 
 	var client *http.Client = w.client
-	utility.Retry(context.Background(), func() (bool, error) {
+	return utility.Retry(context.Background(), func() (bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		req = req.WithContext(ctx)
@@ -171,8 +171,6 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 		MaxAttempts: raw.Retries + 1,
 		MinDelay:    minDelay,
 	})
-
-	return nil
 }
 
 func (w *evergreenWebhookLogger) Flush(_ context.Context) error { return nil }

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -97,6 +97,10 @@ func (w *EvergreenWebhook) request() (*http.Request, error) {
 		}
 	}
 
+	// Deduplicate the evergreen headers.
+	req.Header.Del(evergreenHMACHeader)
+	req.Header.Del(evergreenNotificationIDHeader)
+
 	req.Header.Add(evergreenHMACHeader, hash)
 	req.Header.Add(evergreenNotificationIDHeader, w.NotificationID)
 
@@ -137,7 +141,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 
 	timeout := defaultWebhookTimeout
 	if raw.TimeoutMS > 0 {
-		timeout = time.Duration(raw.TimeoutMS)
+		timeout = time.Duration(raw.TimeoutMS) * time.Millisecond
 	}
 	minDelay := defaultMinDelay
 	if raw.MinDelayMS > 0 {

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -147,7 +147,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 			return true, errors.Wrap(err, "sending webhook data")
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return false, errors.Errorf("response was %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+			return true, errors.Errorf("response was %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
 
 		return false, nil

--- a/util/webhook_grip_test.go
+++ b/util/webhook_grip_test.go
@@ -16,20 +16,32 @@ import (
 func TestEvergreenWebhookComposer(t *testing.T) {
 	assert := assert.New(t)
 
-	m := NewWebhookMessage("", "", nil, nil, nil)
+	m := NewWebhookMessage(EvergreenWebhook{})
 	assert.False(m.Loggable())
 
 	url := "https://example.com"
 	header := http.Header{
 		"test": []string{},
 	}
-	m = NewWebhookMessage("evergreen", url, []byte("hi"), []byte("something important"), header)
+	m = NewWebhookMessage(EvergreenWebhook{
+		NotificationID: "evergreen",
+		URL:            url,
+		Secret:         []byte("hi"),
+		Body:           []byte("something important"),
+		Headers:        header,
+	})
 	assert.False(m.Loggable())
 
 	header = http.Header{
 		"Test": []string{"test1", "test2"},
 	}
-	m = NewWebhookMessage("evergreen", url, []byte("hi"), []byte("something important"), header)
+	m = NewWebhookMessage(EvergreenWebhook{
+		NotificationID: "evergreen",
+		URL:            url,
+		Secret:         []byte("hi"),
+		Body:           []byte("something important"),
+		Headers:        header,
+	})
 	assert.True(m.Loggable())
 	m2, ok := m.(*evergreenWebhookMessage)
 	assert.True(ok)
@@ -42,7 +54,13 @@ func TestEvergreenWebhookComposer(t *testing.T) {
 	assert.Contains(m2.raw.Headers["Test"], "test1")
 	assert.Contains(m2.raw.Headers["Test"], "test2")
 
-	m = NewWebhookMessage("evergreen", url, []byte("hi"), []byte("something important"), nil)
+	m = NewWebhookMessage(EvergreenWebhook{
+		NotificationID: "evergreen",
+		URL:            url,
+		Secret:         []byte("hi"),
+		Body:           []byte("something important"),
+		Headers:        nil,
+	})
 	assert.True(m.Loggable())
 }
 
@@ -53,7 +71,13 @@ func TestEvergreenWebhookSender(t *testing.T) {
 		"test": []string{"test1", "test2"},
 	}
 
-	m := NewWebhookMessage("evergreen", "https://example.com", []byte("hi"), []byte("something important"), header)
+	m := NewWebhookMessage(EvergreenWebhook{
+		NotificationID: "evergreen",
+		URL:            "https://example.com",
+		Secret:         []byte("hi"),
+		Body:           []byte("something important"),
+		Headers:        header,
+	})
 	assert.True(m.Loggable())
 	assert.NotNil(m)
 
@@ -84,7 +108,7 @@ func TestEvergreenWebhookSender(t *testing.T) {
 	assert.Contains(transport.header["Test"], "test2")
 
 	// unloggable message shouldn't send
-	m = NewWebhookMessage("", "", nil, nil, nil)
+	m = NewWebhookMessage(EvergreenWebhook{})
 	s.Send(m)
 	assert.NotEqual("", transport.lastUrl)
 }
@@ -92,7 +116,13 @@ func TestEvergreenWebhookSender(t *testing.T) {
 func TestEvergreenWebhookSenderWithBadSecret(t *testing.T) {
 	assert := assert.New(t)
 
-	m := NewWebhookMessage("evergreen", "https://example.com", []byte("bye"), []byte("something forged"), nil)
+	m := NewWebhookMessage(EvergreenWebhook{
+		NotificationID: "evergreen",
+		URL:            "https://example.com",
+		Secret:         []byte("bye"),
+		Body:           []byte("something forged"),
+		Headers:        nil,
+	})
 	assert.True(m.Loggable())
 	assert.NotNil(m)
 


### PR DESCRIPTION
[EVG-17448](https://jira.mongodb.org/browse/EVG-17448)

### Description 
Allow users to configure retries and timeout for a webhook notification.
We thought to just make it retry by default, but that would have caused minor issues with the pr bot.

My plan is to open a UI ticket to surface the new fields in the project settings. In the meantime, I'll set them in the db for the subscriptions referenced in the ticket.

I skipped adding the new fields to the old UI. I think this is our current posture? If not I can add them there.

### Testing 
Unit tests for the new fields in the subscriber/API subscriber and for retries.
I'll try it out in staging when I see an opening there.