### PR TITLE
EVG-14528 Add TriggerFamilyOutcome type to events

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -387,6 +387,21 @@ func VersionStatusToPatchStatus(versionStatus string) (string, error) {
 	}
 }
 
+func PatchStatusToVersionStatus(patchStatus string) (string, error) {
+	switch patchStatus {
+	case PatchCreated:
+		return VersionCreated, nil
+	case PatchStarted:
+		return VersionStarted, nil
+	case PatchFailed:
+		return VersionFailed, nil
+	case PatchSucceeded:
+		return VersionSucceeded, nil
+	default:
+		return "", errors.Errorf("unknown patch status: %s", patchStatus)
+	}
+}
+
 type ModificationAction string
 
 const (

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -22,7 +22,7 @@ const (
 	SubscriptionsCollection = "subscriptions"
 )
 
-//nolint: deadcode, megacheck, unused
+// nolint: deadcode, megacheck, unused
 var (
 	subscriptionIDKey             = bsonutil.MustHaveTag(Subscription{}, "ID")
 	subscriptionResourceTypeKey   = bsonutil.MustHaveTag(Subscription{}, "ResourceType")
@@ -75,9 +75,12 @@ const (
 	ObjectPatch   = "patch"
 
 	TriggerOutcome                   = "outcome"
+	TriggerFamilyOutcome             = "family-outcome"
 	TriggerGithubCheckOutcome        = "github-check-outcome"
 	TriggerFailure                   = "failure"
+	TriggerFamilyFailure             = "family-failure"
 	TriggerSuccess                   = "success"
+	TriggerFamilySuccess             = "family-success"
 	TriggerRegression                = "regression"
 	TriggerExceedsDuration           = "exceeds-duration"
 	TriggerRuntimeChangeByPercent    = "runtime-change"
@@ -734,6 +737,7 @@ func CreateOrUpdateGeneralSubscription(resourceType string, id string,
 
 		sub.OwnerType = OwnerTypePerson
 		sub.Owner = user
+
 		if err := sub.Upsert(); err != nil {
 			return nil, errors.Wrap(err, "upserting subscription")
 		}
@@ -805,7 +809,7 @@ func NewParentPatchSubscription(id string, sub Subscriber) Subscription {
 }
 
 func NewPatchOutcomeSubscriptionByOwner(owner string, sub Subscriber) Subscription {
-	return NewSubscriptionByOwner(owner, sub, ResourceTypePatch, TriggerOutcome)
+	return NewSubscriptionByOwner(owner, sub, ResourceTypePatch, TriggerFamilyOutcome)
 }
 
 func NewSpawnhostExpirationSubscription(owner string, sub Subscriber) Subscription {

--- a/model/event/version_event.go
+++ b/model/event/version_event.go
@@ -11,6 +11,7 @@ func init() {
 	registry.AddType(ResourceTypeVersion, versionEventDataFactory)
 	registry.AllowSubscription(ResourceTypeVersion, VersionStateChange)
 	registry.AllowSubscription(ResourceTypeVersion, VersionGithubCheckFinished)
+	registry.AllowSubscription(ResourceTypeVersion, VersionChildrenCompletion)
 }
 
 func versionEventDataFactory() interface{} {
@@ -21,11 +22,13 @@ const (
 	ResourceTypeVersion        = "VERSION"
 	VersionStateChange         = "STATE_CHANGE"
 	VersionGithubCheckFinished = "GITHUB_CHECK_FINISHED"
+	VersionChildrenCompletion  = "CHILDREN_FINISHED"
 )
 
 type VersionEventData struct {
 	Status            string `bson:"status,omitempty" json:"status,omitempty"`
 	GithubCheckStatus string `bson:"github_check_status,omitempty" json:"github_check_status,omitempty"`
+	Author            string `bson:"author,omitempty" json:"author,omitempty"`
 }
 
 func LogVersionStateChangeEvent(id, newStatus string) {
@@ -56,6 +59,27 @@ func LogVersionGithubCheckFinishedEvent(id, newStatus string) {
 		EventType:    VersionGithubCheckFinished,
 		Data: &VersionEventData{
 			GithubCheckStatus: newStatus,
+		},
+	}
+
+	if err := event.Log(); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"resource_type": ResourceTypeVersion,
+			"message":       "error logging event",
+			"source":        "event-log-fail",
+		}))
+	}
+}
+
+func LogVersionChildrenCompletionEvent(id, status, author string) {
+	event := EventLogEntry{
+		Timestamp:    time.Now().Truncate(0).Round(time.Millisecond),
+		ResourceId:   id,
+		ResourceType: ResourceTypeVersion,
+		EventType:    VersionChildrenCompletion,
+		Data: &VersionEventData{
+			Status: status,
+			Author: author,
 		},
 	}
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -725,6 +725,32 @@ func (p *Patch) IsChild() bool {
 	return p.Triggers.ParentPatch != ""
 }
 
+func (p *Patch) CollectiveStatus() (string, error) {
+	parentPatch := p
+	if p.IsChild() {
+		parentPatch, err := FindOneId(p.Triggers.ParentPatch)
+		if err != nil {
+			return "", errors.Wrap(err, "getting parent patch")
+		}
+		if parentPatch == nil {
+			return "", errors.Errorf(fmt.Sprintf("parent patch '%s' does not exist", p.Triggers.ParentPatch))
+		}
+	}
+	allStatuses := []string{parentPatch.Status}
+	for _, childPatchId := range parentPatch.Triggers.ChildPatches {
+		cp, err := FindOneId(childPatchId)
+		if err != nil {
+			return "", errors.Wrapf(err, "getting child patch '%s' ", childPatchId)
+		}
+		if cp == nil {
+			return "", errors.Wrapf(err, "child patch '%s' not found", childPatchId)
+		}
+		allStatuses = append(allStatuses, cp.Status)
+	}
+
+	return GetCollectiveStatus(allStatuses), nil
+}
+
 func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
 }
@@ -752,6 +778,65 @@ func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 	return -1, nil
 }
 
+func (p *Patch) GetFamilyInformation() (bool, *Patch, error) {
+	if !p.IsChild() && !p.IsParent() {
+		if evergreen.IsFinishedPatchStatus(p.Status) {
+			return true, nil, nil
+		} else {
+			return false, nil, nil
+		}
+	}
+
+	isDone := false
+	childrenOrSiblings, parentPatch, err := p.GetPatchFamily()
+	if err != nil {
+		return isDone, parentPatch, errors.Wrap(err, "getting child or sibling patches")
+	}
+
+	// make sure the parent is done, if not, wait for the parent
+	if p.IsChild() {
+		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
+			return isDone, parentPatch, nil
+		}
+	}
+	childrenStatus, err := GetChildrenOrSiblingsReadiness(childrenOrSiblings)
+	if err != nil {
+		return isDone, parentPatch, errors.Wrap(err, "getting child or sibling information")
+	}
+	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
+		return isDone, parentPatch, nil
+	} else {
+		isDone = true
+	}
+
+	return isDone, parentPatch, err
+}
+
+func GetChildrenOrSiblingsReadiness(childrenOrSiblings []string) (string, error) {
+	if len(childrenOrSiblings) == 0 {
+		return "", nil
+	}
+	childrenStatus := evergreen.PatchSucceeded
+	for _, childPatch := range childrenOrSiblings {
+		childPatchDoc, err := FindOneId(childPatch)
+		if err != nil {
+			return "", errors.Wrapf(err, "getting tasks for child patch '%s'", childPatch)
+		}
+
+		if childPatchDoc == nil {
+			return "", errors.Errorf("child patch '%s' not found", childPatch)
+		}
+		if childPatchDoc.Status == evergreen.PatchFailed {
+			childrenStatus = evergreen.PatchFailed
+		}
+		if !evergreen.IsFinishedPatchStatus(childPatchDoc.Status) {
+			return childPatchDoc.Status, nil
+		}
+	}
+
+	return childrenStatus, nil
+
+}
 func (p *Patch) GetPatchFamily() ([]string, *Patch, error) {
 	var childrenOrSiblings []string
 	var parentPatch *Patch
@@ -770,6 +855,7 @@ func (p *Patch) GetPatchFamily() ([]string, *Patch, error) {
 		}
 		childrenOrSiblings = parentPatch.Triggers.ChildPatches
 	}
+
 	return childrenOrSiblings, parentPatch, nil
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -780,11 +780,7 @@ func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 
 func (p *Patch) GetFamilyInformation() (bool, *Patch, error) {
 	if !p.IsChild() && !p.IsParent() {
-		if evergreen.IsFinishedPatchStatus(p.Status) {
-			return true, nil, nil
-		} else {
-			return false, nil, nil
-		}
+		return evergreen.IsFinishedPatchStatus(p.Status), nil, nil
 	}
 
 	isDone := false
@@ -794,10 +790,8 @@ func (p *Patch) GetFamilyInformation() (bool, *Patch, error) {
 	}
 
 	// make sure the parent is done, if not, wait for the parent
-	if p.IsChild() {
-		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-			return isDone, parentPatch, nil
-		}
+	if p.IsChild() && !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
+		return isDone, parentPatch, nil
 	}
 	childrenStatus, err := GetChildrenOrSiblingsReadiness(childrenOrSiblings)
 	if err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1206,6 +1206,7 @@ func UpdatePatchStatus(p *patch.Patch, versionStatus, buildVariant string) error
 	}
 
 	event.LogPatchStateChangeEvent(p.Version, patchStatus)
+
 	if evergreen.IsFinishedPatchStatus(patchStatus) {
 		if err = p.MarkFinished(patchStatus, time.Now()); err != nil {
 			return errors.Wrapf(err, "marking patch '%s' as finished with status '%s'", p.Id.Hex(), patchStatus)
@@ -1227,6 +1228,22 @@ func UpdatePatchStatus(p *patch.Patch, versionStatus, buildVariant string) error
 			if err = thirdparty.SendVersionStatusToGithub(input); err != nil {
 				return errors.Wrapf(err, "sending patch '%s' status to Github", p.Id.Hex())
 			}
+		}
+	}
+
+	isDone, parentPatch, err := p.GetFamilyInformation()
+	if err != nil {
+		return errors.Wrapf(err, "getting family information for patch '%s'", p.Id.Hex())
+	}
+	if isDone {
+		collectiveStatus, err := p.CollectiveStatus()
+		if err != nil {
+			return errors.Wrapf(err, "getting collective status for patch '%s'", p.Id.Hex())
+		}
+		if parentPatch != nil {
+			event.LogPatchChildrenCompletionEvent(parentPatch.Id.Hex(), collectiveStatus, parentPatch.Author)
+		} else {
+			event.LogPatchChildrenCompletionEvent(p.Id.Hex(), collectiveStatus, p.Author)
 		}
 	}
 
@@ -1277,6 +1294,28 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 		if err = UpdatePatchStatus(p, newVersionStatus, taskBuild.BuildVariant); err != nil {
 			return errors.Wrapf(err, "updating patch '%s' status", p.Id.Hex())
 		}
+
+		isDone, parentPatch, err := p.GetFamilyInformation()
+		if err != nil {
+			return errors.Wrapf(err, "getting family information for patch '%s'", p.Id.Hex())
+		}
+		if isDone {
+			collectiveStatus, err := p.CollectiveStatus()
+			if err != nil {
+				return errors.Wrapf(err, "getting collective status for patch '%s'", p.Id.Hex())
+			}
+			versionStatus, err := evergreen.PatchStatusToVersionStatus(collectiveStatus)
+			if err != nil {
+				return errors.Wrapf(err, "getting version status")
+			}
+			if parentPatch != nil {
+				event.LogVersionChildrenCompletionEvent(parentPatch.Id.Hex(), versionStatus, parentPatch.Author)
+			} else {
+				event.LogVersionChildrenCompletionEvent(p.Id.Hex(), versionStatus, p.Author)
+			}
+
+		}
+
 	}
 
 	return nil

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -3,10 +3,8 @@ package data
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/evergreen-ci/evergreen/model/event"
-	"github.com/evergreen-ci/evergreen/model/patch"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/trigger"
 	"github.com/evergreen-ci/gimlet"
@@ -61,39 +59,11 @@ func SaveSubscriptions(owner string, subscriptions []restModel.APISubscription, 
 				Message:    errors.Wrap(err, "invalid subscription").Error(),
 			}
 		}
+		if dbSubscription.ResourceType == event.ResourceTypeVersion && isEndTrigger(dbSubscription.Trigger) {
+			dbSubscription.Trigger = triggerToFamilyTrigger(dbSubscription.Trigger)
+		}
 
 		dbSubscriptions = append(dbSubscriptions, dbSubscription)
-
-		if dbSubscription.ResourceType == event.ResourceTypeVersion && isEndTrigger(dbSubscription.Trigger) {
-			var versionId string
-			for _, selector := range dbSubscription.Selectors {
-				if selector.Type == event.SelectorID {
-					versionId = selector.Data
-				}
-			}
-			children, err := getVersionChildren(versionId)
-			if err != nil {
-				return gimlet.ErrorResponse{
-					StatusCode: http.StatusInternalServerError,
-					Message:    errors.Wrapf(err, "retrieving child versions for version '%s'", versionId).Error(),
-				}
-			}
-
-			for _, childPatchId := range children {
-				childDbSubscription := dbSubscription
-				childDbSubscription.LastUpdated = time.Now()
-				childDbSubscription.Filter.ID = childPatchId
-				var selectors []event.Selector
-				for _, selector := range dbSubscription.Selectors {
-					if selector.Type == event.SelectorID {
-						selector.Data = childPatchId
-					}
-					selectors = append(selectors, selector)
-				}
-				childDbSubscription.Selectors = selectors
-				dbSubscriptions = append(dbSubscriptions, childDbSubscription)
-			}
-		}
 
 	}
 
@@ -105,18 +75,20 @@ func SaveSubscriptions(owner string, subscriptions []restModel.APISubscription, 
 }
 
 func isEndTrigger(trigger string) bool {
-	return trigger == event.TriggerFailure || trigger == event.TriggerSuccess || trigger == event.TriggerOutcome
+	return trigger == event.TriggerFailure || trigger == event.TriggerSuccess || trigger == event.TriggerOutcome || trigger == event.TriggerFamilyOutcome
 }
 
-func getVersionChildren(versionId string) ([]string, error) {
-	patchDoc, err := patch.FindOne(patch.ByVersion(versionId))
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding patch for version '%s'", versionId)
+func triggerToFamilyTrigger(t string) string {
+	var trigger string
+	switch t {
+	case event.TriggerSuccess:
+		trigger = event.TriggerFamilySuccess
+	case event.TriggerOutcome:
+		trigger = event.TriggerFamilyOutcome
+	case event.TriggerFailure:
+		trigger = event.TriggerFamilyFailure
 	}
-	if patchDoc == nil {
-		return nil, errors.Wrapf(err, "patch for version '%s' not found", versionId)
-	}
-	return patchDoc.Triggers.ChildPatches, nil
+	return trigger
 
 }
 

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -79,17 +79,16 @@ func isEndTrigger(trigger string) bool {
 }
 
 func triggerToFamilyTrigger(t string) string {
-	var trigger string
 	switch t {
 	case event.TriggerSuccess:
-		trigger = event.TriggerFamilySuccess
+		return event.TriggerFamilySuccess
 	case event.TriggerOutcome:
-		trigger = event.TriggerFamilyOutcome
+		return event.TriggerFamilyOutcome
 	case event.TriggerFailure:
-		trigger = event.TriggerFamilyFailure
+		return event.TriggerFamilyFailure
+	default:
+		return t
 	}
-	return trigger
-
 }
 
 // GetSubscriptions returns the subscriptions that belong to a user

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -122,18 +122,17 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 			// get the children or siblings to wait on
 			childrenOrSiblings, parentPatch, err := t.patch.GetPatchFamily()
 			if err != nil {
-				return nil, errors.Wrap(err, "error getting child or sibling patches")
+				return nil, errors.Wrap(err, "getting child or sibling patches")
 			}
 
 			// make sure the parent is done, if not, wait for the parent
-			if t.patch.IsChild() {
-				if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
+			if t.patch.IsChild() && !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
 					return nil, nil
 				}
 			}
 			childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
 			if err != nil {
-				return nil, errors.Wrap(err, "error getting child or sibling information")
+				return nil, errors.Wrap(err, "getting child or sibling information")
 			}
 			if !evergreen.IsFinishedPatchStatus(childrenStatus) {
 				return nil, nil
@@ -377,11 +376,7 @@ func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notificati
 }
 
 func (t *patchTriggers) patchFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
-	if t.data.Status != evergreen.PatchSucceeded {
-		return nil, nil
-	}
-
-	if t.event.EventType != event.PatchChildrenCompletion {
+	if t.data.Status != evergreen.PatchSucceeded || t.event.EventType != event.PatchChildrenCompletion{
 		return nil, nil
 	}
 

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -127,8 +127,7 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 
 			// make sure the parent is done, if not, wait for the parent
 			if t.patch.IsChild() && !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-					return nil, nil
-				}
+				return nil, nil
 			}
 			childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
 			if err != nil {
@@ -376,7 +375,7 @@ func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notificati
 }
 
 func (t *patchTriggers) patchFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
-	if t.data.Status != evergreen.PatchSucceeded || t.event.EventType != event.PatchChildrenCompletion{
+	if t.data.Status != evergreen.PatchSucceeded || t.event.EventType != event.PatchChildrenCompletion {
 		return nil, nil
 	}
 

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -30,10 +30,13 @@ type patchTriggers struct {
 func makePatchTriggers() eventHandler {
 	t := &patchTriggers{}
 	t.base.triggers = map[string]trigger{
-		event.TriggerOutcome:      t.patchOutcome,
-		event.TriggerFailure:      t.patchFailure,
-		event.TriggerSuccess:      t.patchSuccess,
-		event.TriggerPatchStarted: t.patchStarted,
+		event.TriggerFamilyOutcome: t.patchFamilyOutcome,
+		event.TriggerFamilyFailure: t.patchFamilyFailure,
+		event.TriggerFamilySuccess: t.patchFamilySuccess,
+		event.TriggerOutcome:       t.patchOutcome,
+		event.TriggerFailure:       t.patchFailure,
+		event.TriggerSuccess:       t.patchSuccess,
+		event.TriggerPatchStarted:  t.patchStarted,
 	}
 	return t
 }
@@ -64,11 +67,16 @@ func (t *patchTriggers) Fetch(e *event.EventLogEntry) error {
 }
 
 func (t *patchTriggers) Attributes() event.Attributes {
+	owner := []string{t.patch.Author}
+	if t.event.EventType == event.PatchChildrenCompletion {
+		eventData := t.event.Data.(*event.PatchEventData)
+		owner = []string{eventData.Author}
+	}
 	return event.Attributes{
 		ID:      []string{t.patch.Id.Hex()},
 		Object:  []string{event.ObjectPatch},
 		Project: []string{t.patch.Project},
-		Owner:   []string{t.patch.Author},
+		Owner:   owner,
 		Status:  []string{t.patch.Status},
 	}
 }
@@ -103,79 +111,44 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 		}
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings(sub)
-	if err != nil {
-		return nil, err
-	}
-	if !isReady {
-		return nil, nil
-	}
+	if sub.Subscriber.Type == event.GithubPullRequestSubscriberType {
+		target, ok := sub.Subscriber.Target.(*event.GithubPullRequestSubscriber)
+		if !ok {
+			return nil, errors.Errorf("target '%s' didn't not have expected type", sub.Subscriber.Target)
+		}
+		subType := target.Type
 
-	return t.generate(sub)
-}
+		if t.patch.IsParent() || (t.patch.IsChild() && subType == event.WaitOnChild) {
+			// get the children or siblings to wait on
+			childrenOrSiblings, parentPatch, err := t.patch.GetPatchFamily()
+			if err != nil {
+				return nil, errors.Wrap(err, "error getting child or sibling patches")
+			}
 
-func (t *patchTriggers) waitOnChildrenOrSiblings(sub *event.Subscription) (bool, error) {
-	if sub.Subscriber.Type != event.GithubPullRequestSubscriberType {
-		return true, nil
-	}
-	target, ok := sub.Subscriber.Target.(*event.GithubPullRequestSubscriber)
-	if !ok {
-		return false, errors.Errorf("target '%s' had unexpected type %T", sub.Subscriber.Target, sub.Subscriber.Target)
-	}
-	subType := target.Type
+			// make sure the parent is done, if not, wait for the parent
+			if t.patch.IsChild() {
+				if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
+					return nil, nil
+				}
+			}
+			childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
+			if err != nil {
+				return nil, errors.Wrap(err, "error getting child or sibling information")
+			}
+			if !evergreen.IsFinishedPatchStatus(childrenStatus) {
+				return nil, nil
+			}
+			if childrenStatus == evergreen.PatchFailed {
+				t.data.Status = evergreen.PatchFailed
+			}
 
-	// notifications are only delayed if the patch is either a parent, or a child that is of subType event.WaitOnChild.
-	// we don't always wait on siblings when it is a childpatch, since childpatches need to let github know when they
-	// are done running so their status can be displayed to the user as they finish
-	if !(t.patch.IsParent() || (t.patch.IsChild() && subType == event.WaitOnChild)) {
-		return true, nil
-	}
-	// get the children or siblings to wait on
-	isReady, parentPatch, isFailingStatus, err := checkPatchStatus(t.patch)
-	if err != nil {
-		return false, errors.Wrapf(err, "getting status for patch '%s'", t.patch.Id)
-	}
-
-	if isFailingStatus {
-		t.data.Status = evergreen.PatchFailed
-	}
-
-	if t.patch.IsChild() {
-		// we want the subscription to be on the parent
-		// now that the children are done, the parent can be considered done.
-		t.patch = parentPatch
-	}
-	return isReady, nil
-}
-
-func checkPatchStatus(p *patch.Patch) (bool, *patch.Patch, bool, error) {
-	isReady := false
-	childrenOrSiblings, parentPatch, err := p.GetPatchFamily()
-	if err != nil {
-		return isReady, parentPatch, false, errors.Wrap(err, "getting child or sibling patches")
-	}
-
-	// make sure the parent is done, if not, wait for the parent
-	if p.IsChild() {
-		if !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-			return isReady, parentPatch, false, nil
+			if t.patch.IsChild() {
+				// we want the subscription to be on the parent. now that the children are done, the parent can be considered done.
+				t.patch = parentPatch
+			}
 		}
 	}
-	childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
-	if err != nil {
-		return isReady, parentPatch, false, errors.Wrap(err, "getting child or sibling information")
-	}
-	if !evergreen.IsFinishedPatchStatus(childrenStatus) {
-		return isReady, parentPatch, false, nil
-	}
-	isReady = true
-
-	isFailingStatus := false
-	if childrenStatus == evergreen.PatchFailed || (p.IsChild() && parentPatch.Status == evergreen.PatchFailed) {
-		isFailingStatus = true
-	}
-	return isReady, parentPatch, isFailingStatus, err
-
+	return t.generate(sub)
 }
 
 func (t *patchTriggers) patchFailure(sub *event.Subscription) (*notification.Notification, error) {
@@ -188,6 +161,9 @@ func (t *patchTriggers) patchFailure(sub *event.Subscription) (*notification.Not
 
 func getChildrenOrSiblingsReadiness(childrenOrSiblings []string) (string, error) {
 	childrenStatus := evergreen.PatchSucceeded
+	if len(childrenOrSiblings) == 0 {
+		return "", nil
+	}
 	for _, childPatch := range childrenOrSiblings {
 		childPatchDoc, err := patch.FindOneId(childPatch)
 		if err != nil {
@@ -388,4 +364,37 @@ func (t *patchTriggers) getGithubContext() (string, error) {
 		githubContext = fmt.Sprintf("evergreen/%s/%d", projectIdentifier, patchIndex)
 	}
 	return githubContext, nil
+}
+
+func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.PatchSucceeded && t.data.Status != evergreen.PatchFailed {
+		return nil, nil
+	}
+	if t.event.EventType != event.VersionChildrenCompletion {
+		return nil, nil
+	}
+	return t.generate(sub)
+}
+
+func (t *patchTriggers) patchFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.PatchSucceeded {
+		return nil, nil
+	}
+
+	if t.event.EventType != event.PatchChildrenCompletion {
+		return nil, nil
+	}
+
+	return t.generate(sub)
+}
+
+func (t *patchTriggers) patchFamilyFailure(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.PatchFailed {
+		return nil, nil
+	}
+
+	if t.event.EventType != event.PatchChildrenCompletion {
+		return nil, nil
+	}
+	return t.generate(sub)
 }

--- a/trigger/registry.go
+++ b/trigger/registry.go
@@ -17,6 +17,7 @@ var registry = triggerRegistry{
 
 func init() {
 	registry.registerEventHandler(event.ResourceTypePatch, event.PatchStateChange, makePatchTriggers)
+	registry.registerEventHandler(event.ResourceTypePatch, event.PatchChildrenCompletion, makePatchTriggers)
 }
 
 type registryKey struct {

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -246,10 +246,7 @@ func (t *versionTriggers) versionFamilyOutcome(sub *event.Subscription) (*notifi
 }
 
 func (t *versionTriggers) versionFamilyFailure(sub *event.Subscription) (*notification.Notification, error) {
-	if t.data.Status != evergreen.VersionFailed {
-		return nil, nil
-	}
-	if t.event.EventType != event.VersionChildrenCompletion {
+	if t.data.Status != evergreen.VersionFailed || t.event.EventType != event.VersionChildrenCompletion {
 		return nil, nil
 	}
 	failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersion(t.version.Id)))
@@ -273,11 +270,7 @@ func (t *versionTriggers) versionFamilyFailure(sub *event.Subscription) (*notifi
 }
 
 func (t *versionTriggers) versionFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
-	if t.data.Status != evergreen.VersionSucceeded {
-		return nil, nil
-	}
-
-	if t.event.EventType != event.VersionChildrenCompletion {
+	if t.data.Status != evergreen.VersionSucceeded || t.event.EventType != event.VersionChildrenCompletion {
 		return nil, nil
 	}
 

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
-	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -21,6 +20,7 @@ import (
 func init() {
 	registry.registerEventHandler(event.ResourceTypeVersion, event.VersionStateChange, makeVersionTriggers)
 	registry.registerEventHandler(event.ResourceTypeVersion, event.VersionGithubCheckFinished, makeVersionTriggers)
+	registry.registerEventHandler(event.ResourceTypeVersion, event.VersionChildrenCompletion, makeVersionTriggers)
 }
 
 type versionTriggers struct {
@@ -35,6 +35,9 @@ type versionTriggers struct {
 func makeVersionTriggers() eventHandler {
 	t := &versionTriggers{}
 	t.base.triggers = map[string]trigger{
+		event.TriggerFamilyOutcome:          t.versionFamilyOutcome,
+		event.TriggerFamilySuccess:          t.versionFamilySuccess,
+		event.TriggerFamilyFailure:          t.versionFamilyFailure,
 		event.TriggerOutcome:                t.versionOutcome,
 		event.TriggerGithubCheckOutcome:     t.versionGithubCheckOutcome,
 		event.TriggerFailure:                t.versionFailure,
@@ -82,7 +85,15 @@ func (t *versionTriggers) Attributes() event.Attributes {
 		attributes.Requester = append(attributes.Requester, evergreen.RepotrackerVersionRequester)
 	}
 	if t.version.AuthorID != "" {
-		attributes.Owner = append(attributes.Owner, t.version.AuthorID)
+		owner := t.version.AuthorID
+
+		// If the author is not explicitly set, it will be parent-patch on patches containing children
+		if t.event.EventType == event.VersionChildrenCompletion {
+			eventData := t.event.Data.(*event.VersionEventData)
+			owner = eventData.Author
+		}
+
+		attributes.Owner = append(attributes.Owner, owner)
 	}
 	return attributes
 }
@@ -158,19 +169,11 @@ func (t *versionTriggers) generate(sub *event.Subscription, pastTenseOverride st
 
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
-
 func (t *versionTriggers) versionOutcome(sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionSucceeded && t.data.Status != evergreen.VersionFailed {
 		return nil, nil
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings()
-	if err != nil {
-		return nil, err
-	}
-	if !isReady {
-		return nil, nil
-	}
 	return t.generate(sub, "")
 }
 
@@ -202,14 +205,6 @@ func (t *versionTriggers) versionFailure(sub *event.Subscription) (*notification
 	if skipNotification {
 		return nil, nil
 	}
-
-	isReady, err := t.waitOnChildrenOrSiblings()
-	if err != nil {
-		return nil, err
-	}
-	if !isReady {
-		return nil, nil
-	}
 	return t.generate(sub, "")
 }
 
@@ -218,13 +213,6 @@ func (t *versionTriggers) versionSuccess(sub *event.Subscription) (*notification
 		return nil, nil
 	}
 
-	isReady, err := t.waitOnChildrenOrSiblings()
-	if err != nil {
-		return nil, err
-	}
-	if !isReady {
-		return nil, nil
-	}
 	return t.generate(sub, "")
 }
 
@@ -246,6 +234,54 @@ func (t *versionTriggers) versionExceedsDuration(sub *event.Subscription) (*noti
 		return nil, nil
 	}
 	return t.generate(sub, fmt.Sprintf("exceeded %d seconds", threshold))
+}
+func (t *versionTriggers) versionFamilyOutcome(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.VersionSucceeded && t.data.Status != evergreen.VersionFailed {
+		return nil, nil
+	}
+	if t.event.EventType != event.VersionChildrenCompletion {
+		return nil, nil
+	}
+	return t.generate(sub, "")
+}
+
+func (t *versionTriggers) versionFamilyFailure(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.VersionFailed {
+		return nil, nil
+	}
+	if t.event.EventType != event.VersionChildrenCompletion {
+		return nil, nil
+	}
+	failedTasks, err := task.FindAll(db.Query(task.FailedTasksByVersion(t.version.Id)))
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting failed tasks in version '%s'", t.version.Id)
+	}
+	skipNotification := false
+	for _, failedTask := range failedTasks {
+		if !failedTask.Aborted {
+			skipNotification = false
+			break
+		} else {
+			skipNotification = true
+		}
+	}
+	if skipNotification {
+		return nil, nil
+	}
+
+	return t.generate(sub, "")
+}
+
+func (t *versionTriggers) versionFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
+	if t.data.Status != evergreen.VersionSucceeded {
+		return nil, nil
+	}
+
+	if t.event.EventType != event.VersionChildrenCompletion {
+		return nil, nil
+	}
+
+	return t.generate(sub, "")
 }
 
 func (t *versionTriggers) versionRuntimeChange(sub *event.Subscription) (*notification.Notification, error) {
@@ -297,48 +333,4 @@ func (t *versionTriggers) versionRegression(sub *event.Subscription) (*notificat
 		}
 	}
 	return nil, nil
-}
-
-func (t *versionTriggers) waitOnChildrenOrSiblings() (bool, error) {
-	// only patches have to wait on children/siblings
-	if !evergreen.IsPatchRequester(t.version.Requester) {
-		return true, nil
-	}
-	isReady := false
-	patchDoc, err := patch.FindOne(patch.ByVersion(t.version.Id))
-	if err != nil {
-		return isReady, errors.Wrapf(err, "getting patch '%s'", t.version.Id)
-	}
-	if patchDoc == nil {
-		return isReady, errors.Errorf("patch '%s' not found", t.version.Id)
-	}
-
-	// don't wait on children or siblings if the patch is a regular patch
-	if !(patchDoc.IsParent() || patchDoc.IsChild()) {
-		return true, nil
-	}
-
-	// get the collective status
-	isReady, _, isFailingStatus, err := checkPatchStatus(patchDoc)
-	if err != nil {
-		return false, errors.Wrapf(err, "getting status for patch '%s'", patchDoc.Id)
-	}
-
-	if isFailingStatus {
-		t.data.Status = evergreen.PatchFailed
-	}
-
-	if t.version.IsChild() {
-		parentVersion, err := t.version.GetParentVersion()
-		if err != nil {
-			return isReady, errors.Wrapf(err, "getting parent version for child '%s'", t.version.Id)
-		}
-		if parentVersion == nil {
-			return isReady, errors.Errorf("parent version for child '%s' not found", t.version.Id)
-		}
-		t.version = parentVersion
-
-	}
-
-	return isReady, nil
 }


### PR DESCRIPTION
[EVG-14528](https://jira.mongodb.org/browse/EVG-14528)

### Description 
Before this change, when a patch or version was done, we would check in the trigger outcome to see if the children are done, and if they were not, we would exit.

What this does instead, is it creates an event when the children and parent are both done and subscribes on that event in situations where we only want to do something once everything is done. 


### Note 1 
Now that the family trigger is set up, the way we process Github child patch triggers can be optimized as well. I created [EVG-18381](https://jira.mongodb.org/browse/EVG-18381) to track that. 

### Note 2
In order for patch outcome notifications (the ones set up [here](https://spruce-staging.corp.mongodb.com/preferences/notifications)) to work after this change, the existing subscription db entries need to be updated. I will track that work [here](https://jira.mongodb.org/browse/EVG-18382). 


### Testing 
Tested on staging
