### PR TITLE
EVG-18391 use latest commit version for periodic build creation

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -630,7 +630,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 }
 
 const (
-	ReadfromGithub    = "github"
+	ReadFromGithub    = "github"
 	ReadFromLocal     = "local"
 	ReadFromPatch     = "patch"
 	ReadFromPatchDiff = "patch_diff"
@@ -742,7 +742,7 @@ func retrieveFileForModule(ctx context.Context, opts GetProjectOpts, modules Mod
 		RemotePath:   opts.RemotePath,
 		Revision:     module.Branch,
 		Token:        opts.Token,
-		ReadFileFrom: ReadfromGithub,
+		ReadFileFrom: ReadFromGithub,
 		Identifier:   moduleName,
 	}
 	return retrieveFile(ctx, moduleOpts)

--- a/rest/route/version_create.go
+++ b/rest/route/version_create.go
@@ -58,7 +58,7 @@ func (h *versionCreateHandler) Run(ctx context.Context) gimlet.Responder {
 	p := &model.Project{}
 	opts := &model.GetProjectOpts{
 		Ref:          projectInfo.Ref,
-		ReadFileFrom: model.ReadfromGithub,
+		ReadFileFrom: model.ReadFromGithub,
 	}
 	projectInfo.IntermediateProject, err = model.LoadProjectInto(ctx, h.Config, opts, projectInfo.Ref.Id, p)
 	if err != nil {

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -154,7 +154,7 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.Peri
 		return "", errors.Wrap(err, "getting GitHub OAuth token")
 	}
 
-	mostRecentVersion, err := model.VersionFindOne(model.VersionByMostRecentSystemRequester(j.ProjectID))
+	mostRecentVersion, err := model.FindVersionByLastKnownGoodConfig(j.ProjectID, -1)
 	if err != nil {
 		return "", errors.Wrapf(err, "finding most recent version for project '%s'", j.ProjectID)
 	}

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -99,6 +99,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 	mostRecentRevision, err := model.FindLatestRevisionForProject(j.ProjectID)
 	if err != nil {
 		j.AddError(err)
+		return
 	}
 	versionID, versionErr := j.addVersion(ctx, *definition, mostRecentRevision)
 


### PR DESCRIPTION
[EVG-18391](https://jira.mongodb.org/browse/EVG-18391)

### Description 
This periodic build was defined with an error, so we created a stub version.
https://evergreen.mongodb.com/version/637d2a40a4cf472bcc36d583
However, the stub version ends up having no revision since we don't add it to the metadata. (This is also why https://jira.mongodb.org/browse/EVG-18390 occurred, because we use the revision for the link.) 

Because we just get the latest version (instead of the latest version with a valid config), we end up getting the broken periodic build, which has an empty revision, and so when we call GetGithubFile we get the master branch yaml instead of the v6.1 yaml. 

### Testing 
Not tested but reasoned about.
