### PR TITLE
EVG-18393 Hide parsley links on legacy ui

### DIFF
--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -468,12 +468,12 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
                             <div class="progress [[progressBarClass]]" test-result-bar="test.test_result" style="width: [[barWidth]]%"></div>
                           </td>
                           <td class="col-lg-3">
-                            <div class="url-link nowrap" id="parsley-link">
-                                <a ng-href="[[test.url_parsley]]" ng-hide="[[test.url_parsley == '']]">
-                                  Parsley
+                            <div class="url-link nowrap" id="lobster-link">
+                                <a ng-href="[[test.url_lobster]]" ng-hide="[[test.url_lobster == '']]">
+                                  Lobster
                                 </a>
                               </div>
-                              <div id="separator" ng-hide="[[test.url_parsley == '']]">
+                              <div id="separator" ng-hide="[[test.url_lobster == '']]">
                                 <b>&middot;</b>
                               </div>
                             <div class="url-link nowrap" id="html-link">


### PR DESCRIPTION
[EVG-18393](https://jira.mongodb.org/browse/EVG-18393)

### Description 
I accidentally exposed the links to parsley on the legacy UI in [this PR ](https://github.com/evergreen-ci/evergreen/pull/6085/files). This just hides them until we are ready to launch. Once we launch this commit can just be reverted.

