### PR TITLE
EVG-18199 Restore resmoke lobster urls

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -456,12 +456,15 @@ func (tr TestResult) GetLogURL(viewer evergreen.LogViewer) string {
 		// Evergreen-hosted lobster does not support external logs nor
 		// logs stored in the database.
 		if tr.URL != "" || tr.URLRaw != "" || tr.LogId != "" {
-			return ""
-		}
-		for _, url := range deprecatedLobsterURLs {
-			if strings.Contains(tr.URL, url) {
-				return strings.Replace(tr.URL, url, root+"/lobster", 1)
+			if tr.URL != "" || tr.URLRaw != "" || tr.LogId != "" {
+				for _, url := range deprecatedLobsterURLs {
+					if strings.Contains(tr.URL, url) {
+						return strings.Replace(tr.URL, url, root+"/lobster", 1)
+					}
+				}
+				return ""
 			}
+			return ""
 		}
 
 		return fmt.Sprintf("%s/lobster/evergreen/test/%s/%d/%s/%s#shareLine=%d",


### PR DESCRIPTION
[EVG-18199](https://jira.mongodb.org/browse/EVG-18199)

### Description 
https://github.com/evergreen-ci/evergreen/commit/ac7b6296beb96fdc6a3350f5db31743fbd262758 Broke evergreens functionality to return lobster links for resmoke logs
