### PR TITLE
EVG-18359 always set IN_EVERGREEN for subprocesses

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -199,6 +199,9 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	if _, ok := env["CI"]; !ok {
 		env["CI"] = "true"
 	}
+	if _, ok := env[agentutil.MarkerInEvergreen]; !ok {
+		env[agentutil.MarkerInEvergreen] = "true"
+	}
 
 	return env
 }

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-11-21"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-11-18"
+	AgentVersion = "2022-11-29"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-18359](https://jira.mongodb.org/browse/EVG-18359)

### Description 
Set an environment variable to help processes run with shell.exec and subprocess.exec differentiate between when they're running under evergreen vs. another CI system.

### Testing 
I created [a task in staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu1604_echo_env_patch_91d8ccfe1f069a97bbe9ffd11f38742b4053b894_63867f7cb23736629a824c7e_22_11_29_21_54_13/logs?execution=0) that echos the contents of the variable. It was set.
