### PR TITLE
EVG-18398 fix periodic builds for repo projects

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2462,8 +2462,6 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 }
 
 // UpdateNextPeriodicBuild updates the periodic build run time for the relevant collection.
-// It assumes that the project given is a branch project, so we can distinguish between
-// what's defined for the project and what's defined for the repo.
 func UpdateNextPeriodicBuild(projectId, definition string, nextRun time.Time) error {
 	// Get the branch project on its own so we can determine where to update the run time.
 	branchProject, err := FindBranchProjectRef(projectId)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -121,8 +121,6 @@ type ProjectRef struct {
 	// Hidden determines whether or not the project is discoverable/tracked in the UI
 	Hidden        *bool  `bson:"hidden,omitempty" json:"hidden,omitempty"`
 	DefaultLogger string `bson:"default_logger,omitempty" json:"default_logger,omitempty"`
-
-	//RepoPeriodicBuilds []PeriodicBuildDefinition `bson:"repo_periodic_builds"`
 }
 
 type CommitQueueParams struct {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1441,14 +1441,14 @@ func TestFindMergedEnabledProjectRefsByOwnerAndRepo(t *testing.T) {
 	assert.NotEqual(t, projectRefs[2].Id, "3")
 }
 
-func TestFindProjectRefsWithCommitQueueEnabled(t *testing.T) {
+func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))
-	projectRefs, err := FindProjectRefsWithCommitQueueEnabled()
+	res, err := FindProjectRefIdsWithCommitQueueEnabled()
 	assert.NoError(err)
-	assert.Empty(projectRefs)
+	assert.Empty(res)
 
 	repoRef := RepoRef{ProjectRef{
 		Id:      "my_repo",
@@ -1464,7 +1464,7 @@ func TestFindProjectRefsWithCommitQueueEnabled(t *testing.T) {
 		Repo:       "mci",
 		Branch:     "main",
 		Identifier: "mci",
-		Id:         "1",
+		Id:         "mci1",
 		RepoRefId:  repoRef.Id,
 		CommitQueue: CommitQueueParams{
 			Enabled: utility.TruePtr(),
@@ -1473,34 +1473,34 @@ func TestFindProjectRefsWithCommitQueueEnabled(t *testing.T) {
 	require.NoError(doc.Insert())
 
 	doc.Branch = "fix"
-	doc.Id = "2"
+	doc.Id = "mci2"
 	require.NoError(doc.Insert())
 
 	doc.Identifier = "grip"
 	doc.Repo = "grip"
-	doc.Id = "3"
+	doc.Id = "mci3"
 	doc.CommitQueue.Enabled = utility.FalsePtr()
 	require.NoError(doc.Insert())
 
-	projectRefs, err = FindProjectRefsWithCommitQueueEnabled()
+	res, err = FindProjectRefIdsWithCommitQueueEnabled()
 	assert.NoError(err)
-	require.Len(projectRefs, 2)
-	assert.Equal("mci", projectRefs[0].Identifier)
-	assert.Equal("mci", projectRefs[1].Identifier)
+	require.Len(res, 2)
+	assert.Equal("mci1", res[0])
+	assert.Equal("mci2", res[1])
 
 	doc.Id = "both_settings_from_repo"
 	doc.Enabled = nil
 	doc.CommitQueue.Enabled = nil
 	assert.NoError(doc.Insert())
-	projectRefs, err = FindProjectRefsWithCommitQueueEnabled()
+	res, err = FindProjectRefIdsWithCommitQueueEnabled()
 	assert.NoError(err)
-	assert.Len(projectRefs, 3)
+	assert.Len(res, 3)
 
 	repoRef.CommitQueue.Enabled = utility.FalsePtr()
 	assert.NoError(repoRef.Upsert())
-	projectRefs, err = FindProjectRefsWithCommitQueueEnabled()
+	res, err = FindProjectRefIdsWithCommitQueueEnabled()
 	assert.NoError(err)
-	assert.Len(projectRefs, 2)
+	assert.Len(res, 2)
 }
 
 func TestValidatePeriodicBuildDefinition(t *testing.T) {
@@ -2304,24 +2304,88 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 
 func TestUpdateNextPeriodicBuild(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.Clear(ProjectRefCollection))
 	now := time.Now().Truncate(time.Second)
-	p := ProjectRef{
-		Id: "proj",
-		PeriodicBuilds: []PeriodicBuildDefinition{
-			{ID: "1", NextRunTime: now},
-			{ID: "2", NextRunTime: now.Add(1 * time.Hour)},
-		},
-	}
-	assert.NoError(p.Insert())
+	later := now.Add(1 * time.Hour)
+	muchLater := now.Add(10 * time.Hour)
+	for name, test := range map[string]func(*testing.T){
+		"updatesProject": func(t *testing.T) {
+			p := ProjectRef{
+				Id: "proj",
+				PeriodicBuilds: []PeriodicBuildDefinition{
+					{ID: "1", NextRunTime: now},
+					{ID: "2", NextRunTime: later},
+				},
+				RepoRefId: "repo",
+			}
+			repoRef := RepoRef{ProjectRef{
+				Id: "repo",
+				PeriodicBuilds: []PeriodicBuildDefinition{
+					{ID: "2", NextRunTime: later},
+				},
+			}}
+			assert.NoError(p.Insert())
+			assert.NoError(repoRef.Upsert())
 
-	assert.NoError(p.UpdateNextPeriodicBuild("2", now.Add(10*time.Hour)))
-	dbProject, err := FindBranchProjectRef(p.Id)
-	assert.NoError(err)
-	assert.True(now.Equal(dbProject.PeriodicBuilds[0].NextRunTime))
-	assert.True(now.Equal(p.PeriodicBuilds[0].NextRunTime))
-	assert.True(now.Add(10 * time.Hour).Equal(dbProject.PeriodicBuilds[1].NextRunTime))
-	assert.True(now.Add(10 * time.Hour).Equal(p.PeriodicBuilds[1].NextRunTime))
+			assert.NoError(p.UpdateNextPeriodicBuild("2", muchLater))
+			dbProject, err := FindBranchProjectRef(p.Id)
+			assert.NoError(err)
+			assert.NotNil(dbProject)
+			assert.True(now.Equal(dbProject.PeriodicBuilds[0].NextRunTime))
+			assert.True(now.Equal(p.PeriodicBuilds[0].NextRunTime))
+			assert.True(muchLater.Equal(dbProject.PeriodicBuilds[1].NextRunTime))
+			assert.True(muchLater.Equal(p.PeriodicBuilds[1].NextRunTime))
+			dbRepo, err := FindOneRepoRef(p.RepoRefId)
+			assert.NoError(err)
+			assert.NotNil(dbRepo)
+			// Repo wasn't updated
+			assert.True(later.Equal(dbRepo.PeriodicBuilds[0].NextRunTime))
+		},
+		"updatesRepo": func(t *testing.T) {
+			p := ProjectRef{
+				Id:             "proj",
+				PeriodicBuilds: nil,
+				RepoRefId:      "repo",
+			}
+			repoRef := RepoRef{ProjectRef{
+				Id: "repo",
+				PeriodicBuilds: []PeriodicBuildDefinition{
+					{ID: "2", NextRunTime: later},
+				},
+			}}
+			assert.NoError(p.Insert())
+			assert.NoError(repoRef.Upsert())
+			assert.NoError(p.UpdateNextPeriodicBuild("2", muchLater))
+			dbRepo, err := FindOneRepoRef(p.RepoRefId)
+			assert.NoError(err)
+			assert.NotNil(dbRepo)
+			assert.True(muchLater.Equal(dbRepo.PeriodicBuilds[0].NextRunTime))
+		},
+		"updatesNothing": func(t *testing.T) {
+			p := ProjectRef{
+				Id:             "proj",
+				PeriodicBuilds: []PeriodicBuildDefinition{},
+				RepoRefId:      "repo",
+			}
+			repoRef := RepoRef{ProjectRef{
+				Id: "repo",
+				PeriodicBuilds: []PeriodicBuildDefinition{
+					{ID: "2", NextRunTime: later},
+				},
+			}}
+			assert.NoError(p.Insert())
+			assert.NoError(repoRef.Upsert())
+			// Should error because definition doesn't really exist for this project.
+			assert.Error(p.UpdateNextPeriodicBuild("2", muchLater))
+			dbRepo, err := FindOneRepoRef(p.RepoRefId)
+			assert.NoError(err)
+			assert.NotNil(dbRepo)
+			assert.True(later.Equal(dbRepo.PeriodicBuilds[0].NextRunTime))
+		},
+	} {
+		assert.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))
+		t.Run(name, test)
+	}
+
 }
 
 func TestGetProjectSetupCommands(t *testing.T) {
@@ -2393,6 +2457,9 @@ func TestFindPeriodicProjects(t *testing.T) {
 	projects, err := FindPeriodicProjects()
 	assert.NoError(t, err)
 	assert.Len(t, projects, 2)
+	for _, p := range projects {
+		assert.Len(t, p.PeriodicBuilds, 1, fmt.Sprintf("project '%s' missing definition", p.Id))
+	}
 }
 
 func TestRemoveAdminFromProjects(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2326,14 +2326,13 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 			assert.NoError(p.Insert())
 			assert.NoError(repoRef.Upsert())
 
-			assert.NoError(p.UpdateNextPeriodicBuild("2", muchLater))
+			assert.NoError(UpdateNextPeriodicBuild("proj", "2", muchLater))
 			dbProject, err := FindBranchProjectRef(p.Id)
 			assert.NoError(err)
 			assert.NotNil(dbProject)
 			assert.True(now.Equal(dbProject.PeriodicBuilds[0].NextRunTime))
-			assert.True(now.Equal(p.PeriodicBuilds[0].NextRunTime))
 			assert.True(muchLater.Equal(dbProject.PeriodicBuilds[1].NextRunTime))
-			assert.True(muchLater.Equal(p.PeriodicBuilds[1].NextRunTime))
+
 			dbRepo, err := FindOneRepoRef(p.RepoRefId)
 			assert.NoError(err)
 			assert.NotNil(dbRepo)
@@ -2354,7 +2353,8 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 			}}
 			assert.NoError(p.Insert())
 			assert.NoError(repoRef.Upsert())
-			assert.NoError(p.UpdateNextPeriodicBuild("2", muchLater))
+			assert.NoError(UpdateNextPeriodicBuild("proj", "2", muchLater))
+
 			dbRepo, err := FindOneRepoRef(p.RepoRefId)
 			assert.NoError(err)
 			assert.NotNil(dbRepo)
@@ -2375,7 +2375,8 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 			assert.NoError(p.Insert())
 			assert.NoError(repoRef.Upsert())
 			// Should error because definition doesn't really exist for this project.
-			assert.Error(p.UpdateNextPeriodicBuild("2", muchLater))
+			assert.Error(UpdateNextPeriodicBuild("proj", "2", muchLater))
+
 			dbRepo, err := FindOneRepoRef(p.RepoRefId)
 			assert.NoError(err)
 			assert.NotNil(dbRepo)

--- a/rest/data/admin.go
+++ b/rest/data/admin.go
@@ -160,15 +160,15 @@ func RestartFailedTasks(queue amboy.Queue, opts model.RestartOptions) (*restMode
 func RestartFailedCommitQueueVersions(opts model.RestartOptions) (*restModel.RestartResponse, error) {
 	totalRestarted := []string{}
 	totalNotRestarted := []string{}
-	pRefs, err := model.FindProjectRefIdsWithCommitQueueEnabled()
+	projectIds, err := model.FindProjectRefIdsWithCommitQueueEnabled()
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project refs with commit queue enabled")
 	}
-	for _, pRef := range pRefs {
-		restarted, notRestarted, err := model.RetryCommitQueueItems(pRef.Id, opts)
+	for _, id := range projectIds {
+		restarted, notRestarted, err := model.RetryCommitQueueItems(id, opts)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"project":    pRef.Id,
+				"project":    id,
 				"start_time": opts.StartTime,
 				"end_time":   opts.EndTime,
 				"message":    "unable to restart failed commit queue versions for project",

--- a/rest/data/admin.go
+++ b/rest/data/admin.go
@@ -160,7 +160,7 @@ func RestartFailedTasks(queue amboy.Queue, opts model.RestartOptions) (*restMode
 func RestartFailedCommitQueueVersions(opts model.RestartOptions) (*restModel.RestartResponse, error) {
 	totalRestarted := []string{}
 	totalNotRestarted := []string{}
-	pRefs, err := model.FindProjectRefsWithCommitQueueEnabled()
+	pRefs, err := model.FindProjectRefIdsWithCommitQueueEnabled()
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project refs with commit queue enabled")
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -372,12 +372,12 @@ func PopulateCommitQueueJobs(env evergreen.Environment) amboy.QueueOperation {
 		catcher := grip.NewBasicCatcher()
 		ts := utility.RoundPartOfHour(1).Format(TSFormat)
 
-		projectRefs, err := model.FindProjectRefIdsWithCommitQueueEnabled()
+		projectIds, err := model.FindProjectRefIdsWithCommitQueueEnabled()
 		if err != nil {
 			return errors.Wrap(err, "finding project refs with commit queue enabled")
 		}
-		for _, p := range projectRefs {
-			catcher.Wrapf(queue.Put(ctx, NewCommitQueueJob(env, p.Id, ts)), "enqueueing commit queue job for project '%s'", p.Identifier)
+		for _, id := range projectIds {
+			catcher.Wrapf(queue.Put(ctx, NewCommitQueueJob(env, id, ts)), "enqueueing commit queue job for project '%s'", id)
 		}
 		return catcher.Resolve()
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -372,7 +372,7 @@ func PopulateCommitQueueJobs(env evergreen.Environment) amboy.QueueOperation {
 		catcher := grip.NewBasicCatcher()
 		ts := utility.RoundPartOfHour(1).Format(TSFormat)
 
-		projectRefs, err := model.FindProjectRefsWithCommitQueueEnabled()
+		projectRefs, err := model.FindProjectRefIdsWithCommitQueueEnabled()
 		if err != nil {
 			return errors.Wrap(err, "finding project refs with commit queue enabled")
 		}

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -67,6 +67,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 	var err error
+	// Use a fully merged project for the rest of the job, since we need it for creating the version
 	j.project, err = model.FindMergedProjectRef(j.ProjectID, "", true)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding project '%s'", j.ProjectID))
@@ -88,7 +89,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		if utility.IsZeroTime(baseTime) {
 			baseTime = time.Now()
 		}
-		err = j.project.UpdateNextPeriodicBuild(definition.ID, baseTime.Add(time.Duration(definition.IntervalHours)*time.Hour))
+		err = model.UpdateNextPeriodicBuild(j.ProjectID, definition.ID, baseTime.Add(time.Duration(definition.IntervalHours)*time.Hour))
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":    "unable to set next periodic build job time",
 			"project":    j.ProjectID,


### PR DESCRIPTION
[EVG-18398](https://jira.mongodb.org/browse/EVG-18398)

### Description 
Fixes three problems:
1) We update the repo with the wrong ID 
2) We update the repo even if the definition is actually in the project (and we used the merged project so there wasn't a good way to distinguish between the two)
3) We  find the periodic builds using an aggregation, but then we reference the definitions, which isn't handled via aggregation. The aggregation was really just meant to find IDs (which I clarified for the commit queue version), and isn't really worth it for this use -- just grabbed all projects and added only the ones that had definitions.

### Testing 
Beefed up the unit tests a lot.