### PR TITLE
EVG-17305 Deactivate BVs with no active tasks when generating tasks 

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -550,7 +550,7 @@ func RefreshTasksCache(buildId string) error {
 
 // addTasksToBuild creates/activates the tasks for the given build of a project
 func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
-	// find the build variant for this project/build
+	// Find the build variant for this project/build
 	creationInfo.BuildVariant = creationInfo.Project.FindBuildVariant(creationInfo.Build.BuildVariant)
 	if creationInfo.BuildVariant == nil {
 		return nil, nil, errors.Errorf("finding build '%s' in project file '%s'",
@@ -641,7 +641,7 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 	if len(creationInfo.Aliases) > 0 && len(creationInfo.TaskNames) == 0 {
 		return nil, nil, nil
 	}
-	// find the build variant for this project/build
+	// Find the build variant for this project/build
 	buildVariant := creationInfo.Project.FindBuildVariant(creationInfo.BuildVariantName)
 	if buildVariant == nil {
 		return nil, nil, errors.Errorf("could not find build '%s' in project file '%s'", creationInfo.BuildVariantName, creationInfo.Project.Identifier)
@@ -700,23 +700,19 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 		return nil, nil, errors.Wrapf(err, "creating tasks for build '%s'", b.Id)
 	}
 
-	for _, t := range tasksForBuild {
-		if t.IsGithubCheck {
-			b.IsGithubCheck = true
-		}
-		break
-	}
-
 	// create task caches for all of the tasks, and place them into the build
 	tasks := []task.Task{}
 	containsActivatedTask := false
 
 	for _, taskP := range tasksForBuild {
-		if taskP.IsPartOfDisplay() {
-			continue // don't add execution parts of display tasks to the UI cache
+		if taskP.IsGithubCheck {
+			b.IsGithubCheck = true
 		}
 		if taskP.Activated {
 			containsActivatedTask = true
+		}
+		if taskP.IsPartOfDisplay() {
+			continue // don't add execution parts of display tasks to the UI cache
 		}
 		tasks = append(tasks, *taskP)
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -550,7 +550,7 @@ func RefreshTasksCache(buildId string) error {
 
 // addTasksToBuild creates/activates the tasks for the given build of a project
 func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
-	// Find the build variant for this project/build
+	// find the build variant for this project/build
 	creationInfo.BuildVariant = creationInfo.Project.FindBuildVariant(creationInfo.Build.BuildVariant)
 	if creationInfo.BuildVariant == nil {
 		return nil, nil, errors.Errorf("finding build '%s' in project file '%s'",
@@ -709,14 +709,19 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 
 	// create task caches for all of the tasks, and place them into the build
 	tasks := []task.Task{}
+	containsActivatedTask := false
+
 	for _, taskP := range tasksForBuild {
 		if taskP.IsPartOfDisplay() {
 			continue // don't add execution parts of display tasks to the UI cache
 		}
+		if taskP.Activated {
+			containsActivatedTask = true
+		}
 		tasks = append(tasks, *taskP)
 	}
 	b.Tasks = CreateTasksCache(tasks)
-
+	b.Activated = containsActivatedTask
 	return b, tasksForBuild, nil
 }
 


### PR DESCRIPTION
[EVG-17305](https://jira.mongodb.org/browse/EVG-17305)

### Description 
This solves the bug we were seeing where patches remained in the "running" status despite having finished running. 

### Testing 
A patch with the same setup [before](https://spruce-staging.corp.mongodb.com/version/6386871297b1d36bb9fbf1e0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and [after](https://spruce-staging.corp.mongodb.com/version/6387b174b237365ae87d5f9d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the changes.  The problem is more visible in the legacy UI where you can see the build variants with inactive tasks. 
