### PR TITLE
EVG-18391 sort revisions for project

### DIFF
--- a/model/version_db.go
+++ b/model/version_db.go
@@ -96,7 +96,8 @@ func byLatestProjectVersion(projectId string) bson.M {
 
 // FindLatestRevisionForProject returns the latest revision for the project, and returns an error if it's not found.
 func FindLatestRevisionForProject(projectId string) (string, error) {
-	v, err := VersionFindOne(db.Query(byLatestProjectVersion(projectId)).WithFields(VersionRevisionKey))
+	v, err := VersionFindOne(db.Query(byLatestProjectVersion(projectId)).
+		Sort([]string{"-" + VersionRevisionOrderNumberKey}).WithFields(VersionRevisionKey))
 	if err != nil {
 		return "", errors.Wrapf(err, "finding most recent version for project '%s'", projectId)
 	}


### PR DESCRIPTION
[EVG-18391](https://jira.mongodb.org/browse/EVG-18391)

### Description 
We forget to actually sort so we aren't necessarily getting the latest revision for the project.

### Testing 
We actually already have a test that covers multiple revisions but theoretically it would only fail flakely. Verified via shell for the project in question.

