### PR TITLE
EVG-18827: allow building hosts to be terminated

### DIFF
--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -80,7 +80,10 @@ func TestCloudStatusJob(t *testing.T) {
 	mockState.Reset()
 	for _, h := range hosts {
 		require.NoError(h.Insert())
-		mockState.Set(h.Id, cloud.MockInstance{DNSName: "dns_name"})
+		mockState.Set(h.Id, cloud.MockInstance{
+			Status:  cloud.StatusRunning,
+			DNSName: "dns_name",
+		})
 	}
 
 	ctx := context.Background()

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -340,12 +340,12 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 		catcher := grip.NewBasicCatcher()
 		catcher.Add(errors.Wrap(err, "getting cloud host instance status"))
 		if !utility.StringSliceContains(evergreen.UpHostStatus, oldStatus) {
-			catcher.Wrap(j.host.Terminate(evergreen.User, "unable to get cloud status for host"), "marking host as terminated")
+			catcher.Wrap(j.host.Terminate(evergreen.User, j.TerminationReason), "marking host as terminated")
 		}
 		return catcher.Resolve()
 	}
 	if cloudStatus == cloud.StatusNonExistent {
-		return j.host.Terminate(evergreen.User, "cloud host does not exist")
+		return errors.Wrap(j.host.Terminate(evergreen.User, j.TerminationReason), "marking nonexistent host as terminated")
 	}
 
 	if cloudStatus == cloud.StatusTerminated {

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -155,6 +155,22 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
+		"MarksBuildingIntentHostAsTerminated": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
+			h.Status = evergreen.HostBuilding
+			require.NoError(t, h.Insert())
+
+			j := NewHostTerminationJob(env, h, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: "foo",
+			})
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			dbHost, err := host.FindOneId(h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
+		},
 		"MarksBuildingFailedIntentHostAsTerminated": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			h.Status = evergreen.HostBuildingFailed
 			require.NoError(t, h.Insert())

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -16,6 +16,28 @@ import (
 )
 
 func TestHostTerminationJob(t *testing.T) {
+	checkTerminationEvent := func(t *testing.T, hostID, reason string) {
+		events, err := event.Find(event.MostRecentHostEvents(hostID, "", 50))
+		require.NoError(t, err)
+		require.NotEmpty(t, events)
+		var foundTerminationEvent bool
+		for _, e := range events {
+			if e.EventType != event.EventHostStatusChanged {
+				continue
+			}
+			data, ok := e.Data.(*event.HostEventData)
+			require.True(t, ok)
+			if data.NewStatus != evergreen.HostTerminated {
+				continue
+			}
+
+			assert.Equal(t, reason, data.Logs, "event log termination reason should match expected reason")
+
+			foundTerminationEvent = true
+		}
+		assert.True(t, foundTerminationEvent, "expected host termination event to be logged")
+	}
+
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host){
 		"TerminatesRunningHost": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			require.NoError(t, h.Insert())
@@ -24,9 +46,10 @@ func TestHostTerminationJob(t *testing.T) {
 				Status: cloud.StatusRunning,
 			})
 
+			const reason = "some termination message"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "some termination message",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
@@ -36,13 +59,7 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 
-			events, err := event.Find(event.MostRecentHostEvents(h.Id, "", 50))
-			require.NoError(t, err)
-			require.NotEmpty(t, events)
-			assert.Equal(t, event.EventHostStatusChanged, events[0].EventType)
-			data, ok := events[0].Data.(*event.HostEventData)
-			require.True(t, ok)
-			assert.Equal(t, "some termination message", data.Logs)
+			checkTerminationEvent(t, h.Id, reason)
 
 			cloudHost := mcp.Get(h.Id)
 			require.NotZero(t, cloudHost)
@@ -55,10 +72,11 @@ func TestHostTerminationJob(t *testing.T) {
 				Status: cloud.StatusRunning,
 			})
 
+			const reason = "some termination message"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:          true,
 				SkipCloudHostTermination: true,
-				TerminationReason:        "some termination message",
+				TerminationReason:        reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
@@ -68,13 +86,7 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 
-			events, err := event.Find(event.MostRecentHostEvents(h.Id, "", 50))
-			require.NoError(t, err)
-			require.NotEmpty(t, events)
-			assert.Equal(t, event.EventHostStatusChanged, events[0].EventType)
-			data, ok := events[0].Data.(*event.HostEventData)
-			require.True(t, ok)
-			assert.Equal(t, "some termination message", data.Logs)
+			checkTerminationEvent(t, h.Id, reason)
 
 			cloudHost := mcp.Get(h.Id)
 			require.NotZero(t, cloudHost)
@@ -117,22 +129,32 @@ func TestHostTerminationJob(t *testing.T) {
 				Status: cloud.StatusRunning,
 			})
 
+			const reason = "foo"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "foo",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
+
+			// Don't check the host events for termination since the host is
+			// already in a terminated state.
+
+			mockInstance := mcp.Get(h.Id)
+			assert.Equal(t, cloud.StatusTerminated, mockInstance.Status)
 		},
 		"TerminatesDBHostWithoutCloudHost": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			require.NoError(t, h.Insert())
 
+			const reason = "foo"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "foo",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
-			require.Error(t, j.Error())
+			require.NoError(t, j.Error())
+
+			checkTerminationEvent(t, h.Id, reason)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
@@ -143,12 +165,15 @@ func TestHostTerminationJob(t *testing.T) {
 			h.Status = evergreen.HostUninitialized
 			require.NoError(t, h.Insert())
 
+			const reason = "foo"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "foo",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
+
+			checkTerminationEvent(t, h.Id, reason)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
@@ -159,12 +184,15 @@ func TestHostTerminationJob(t *testing.T) {
 			h.Status = evergreen.HostBuilding
 			require.NoError(t, h.Insert())
 
+			const reason = "foo"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "foo",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
+
+			checkTerminationEvent(t, h.Id, reason)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
@@ -175,12 +203,15 @@ func TestHostTerminationJob(t *testing.T) {
 			h.Status = evergreen.HostBuildingFailed
 			require.NoError(t, h.Insert())
 
+			const reason = "foo"
 			j := NewHostTerminationJob(env, h, HostTerminationOptions{
 				TerminateIfBusy:   true,
-				TerminationReason: "foo",
+				TerminationReason: reason,
 			})
 			j.Run(ctx)
 			require.NoError(t, j.Error())
+
+			checkTerminationEvent(t, h.Id, reason)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18827

### Description 
There was an assumption that a host that's building would never be sent directly to the host termination job and would instead be [marked as building-failed first by the host allocator before going to the host termination job](https://github.com/evergreen-ci/evergreen/blob/46c9842829d6dba1d8fa7b194660a7199bc6c5f2/units/host_allocator.go#L123). This assumption of building -> building-failed -> terminated isn't really necessary, so I relaxed some of the logging in the host termination job to not warn when a building host is being terminated.

* Do not log warnings in host termination job for terminating a building host.
* Slightly improve the host termination job to ensure that the event log populates the original reason for termination rather than any errors it encounters along the way. Any errors in the job will still appear in Splunk.
* Do some drive-by mock cloud manager improvements so that it conforms better to the cloud manager interface.

### Testing 
Updated existing tests for the host termination job.
