### PR TITLE
EVG-18001: allow agent to clean up working directory containing read-only files

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -174,7 +174,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		return errors.Wrap(err, "starting status server")
 	}
 	if a.opts.Cleanup {
-		tryCleanupDirectory(a.opts.WorkingDirectory)
+		a.tryCleanupDirectory(a.opts.WorkingDirectory)
 	}
 
 	return errors.Wrap(a.loop(ctx), "executing main agent loop")

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-11-30"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-11-30"
+	AgentVersion = "2022-12-01"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18001

### Description 
When the agent starts up, it tries to clean up its working directory before running tasks. This is useful for static hosts, which keep reusing the same directory repeatedly to run tasks, to avoid slowly filling up the disk over time. However, some tasks may create read-only files (e.g. the Go mod cache) and `os.RemoveAll` does not have permission to delete these. Using the `removeAll` helper edits the read-only files to be writeable so that they can be cleaned up.

### Testing 
Updated existing unit test.