### PR TITLE
EVG-18443: enable pod debugging

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -274,7 +274,11 @@ func exportECSPodContainerDef(settings *evergreen.Settings, opts pod.TaskContain
 // ExportECSPodExecutionOptions exports the ECS configuration into
 // cocoa.ECSPodExecutionOptions.
 func ExportECSPodExecutionOptions(ecsConfig evergreen.ECSConfig, containerOpts pod.TaskContainerCreationOptions) (*cocoa.ECSPodExecutionOptions, error) {
-	execOpts := cocoa.NewECSPodExecutionOptions()
+	execOpts := cocoa.NewECSPodExecutionOptions().
+		// This enables the ability to connect directly to a running container
+		// in ECS (e.g. similar to SSH'ing into a host), which is convenient for
+		// debugging issues.
+		SetSupportsDebugMode(true)
 
 	if len(ecsConfig.AWSVPC.Subnets) != 0 || len(ecsConfig.AWSVPC.SecurityGroups) != 0 {
 		execOpts.SetAWSVPCOptions(*cocoa.NewAWSVPCOptions().


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18443

### Description 
Allowing `aws ecs exec` is convenient so that we can debug containers when they encounter issues. Ideally, we'll have a better logging setup in the future so that we can debug with logs rather than rely on exec'ing into containers.

### Testing 
This isn't really something that can be tested since it's an ECS feature for running containers.