### PR TITLE
EVG-17046: fix race in TestMergeMultiplePatches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20211025143051-a8d91b2e29fd
 	github.com/evergreen-ci/timber v0.0.0-20220809215118-028567bbef72
-	github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118
+	github.com/evergreen-ci/utility v0.0.0-20221202215218-c980e8dea464
 	github.com/google/go-github/v34 v34.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gophercloud/gophercloud v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,9 @@ github.com/evergreen-ci/timber v0.0.0-20220809215118-028567bbef72/go.mod h1:wGsp
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220302150552-3f7a1a268ea7/go.mod h1:EXIwZ5mlP/g0UrWPWX7oRTKQ8nD/ghE3lPCKQ8JMjbk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
-github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118 h1:VgLiqOcQvltQVJtkKF5GSKJSA0ZyFGynxn8A0y7fHww=
 github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
+github.com/evergreen-ci/utility v0.0.0-20221202215218-c980e8dea464 h1:tZQca3T3iM9IbUo368QGas+Em0VqZb4lphuNFz4xFBs=
+github.com/evergreen-ci/utility v0.0.0-20221202215218-c980e8dea464/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17046

### Description 
The comment explains most of the rationale, but basically, this test was failing because git clone could sometimes be slow and the existing logic didn't handle possibility that the context could error (e.g. due to a timeout). If the context errors, `(jasper.Command).Run` exits early while the concurrently-running git command is still potentially writing to the buffer. Reading a `bytes.Buffer` via `String` is not safe when it's still being written by the git command.

* Use thread-safe wrapper for bytes.Buffer.
* Increase context timeout on test to reduce the possibility of the git commands timing out.

### Testing 
I updated the existing test slightly and ran this test a bunch of times on my computer with the race detector enabled.