### PR TITLE
EVG-16853 Don't allow restarting non-finished aborted tasks

### DIFF
--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -268,7 +268,7 @@
             "canRestart": false
           },
           "abortedTask": {
-            "canRestart": true
+            "canRestart": false
           }
         }
       }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -431,13 +431,8 @@ func canRestartTask(t *task.Task) bool {
 	}
 	// It is possible to restart blocked display tasks. Later tasks in a display task could be blocked on
 	// earlier tasks in the display task, in which case restarting the entire display task may unblock them.
-	if t.DisplayStatus == evergreen.TaskStatusBlocked && t.DisplayOnly {
-		return true
-	}
-	if !utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status) {
-		return true
-	}
-	return t.Aborted
+	return (t.DisplayStatus == evergreen.TaskStatusBlocked && t.DisplayOnly) ||
+		!utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status)
 }
 
 func canScheduleTask(t *task.Task) bool {

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -135,7 +135,7 @@ func TestCanRestartTask(t *testing.T) {
 		Aborted:       true,
 	}
 	canRestart = canRestartTask(abortedTask)
-	assert.Equal(t, canRestart, true)
+	assert.Equal(t, canRestart, false)
 }
 
 func TestCanScheduleTask(t *testing.T) {


### PR DESCRIPTION
[EVG-16853](https://jira.mongodb.org/browse/EVG-16853)

### Description 
When "Abort" is hit in the UI, it marks the task as `abort: true`, but does not fail the task immediately. It is the agent that fails the task once it sees it was aborted, and this usually takes a few seconds. Hence, if you click "Abort" and then immediately click "Restart", the agent might not have had time to fail the task that had its aborted field set and we get the error that is screenshotted on the ticket.

Change introduced will cause the "Restart" button to be greyed out for aborted tasks until the agent actually finishes the task (which you'd be able to tell from the logs as well).
### Testing 
Tested on local evergreen