### PR TITLE
EVG-18413 Do not activate generated tasks that depend on explicitly inactive variants

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -340,7 +340,7 @@ func (g *GeneratedProject) getNewTasksWithDependencies(v *Version, p *Project, a
 	}
 
 	var err error
-	newTVPairs.ExecTasks, err = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester, activationInfo, g.BuildVariants)
+	newTVPairs.ExecTasks, err = IncludeDependenciesWithGenerated(p, newTVPairs.ExecTasks, v.Requester, activationInfo, g.BuildVariants)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies for generator",
 		"task":    g.Task.Id,
@@ -461,18 +461,6 @@ func newSpecificActivationInfo() specificActivationInfo {
 	}
 }
 
-func (b *specificActivationInfo) variantExistsInGeneratedProject(variant string, variants []parserBV) bool {
-	if b == nil {
-		return false
-	}
-	for bv := range variants {
-		if variants[bv].Name == variant {
-			return true
-		}
-	}
-	return false
-}
-
 func (b *specificActivationInfo) variantHasSpecificActivation(variant string) bool {
 	return utility.StringSliceContains(b.activationVariants, variant)
 }
@@ -508,6 +496,9 @@ func (b *specificActivationInfo) taskHasSpecificActivation(variant, task string)
 }
 
 func (b *specificActivationInfo) taskOrVariantHasSpecificActivation(variant, task string) bool {
+	if b == nil {
+		return false
+	}
 	return b.taskHasSpecificActivation(variant, task) || b.variantHasSpecificActivation(variant)
 }
 
@@ -625,6 +616,15 @@ func (g *GeneratedProject) addGeneratedProjectToConfig(intermediateProject *Pars
 		}
 	}
 	return intermediateProject, nil
+}
+
+func variantExistsInGeneratedProject(variants []parserBV, variant string) bool {
+	for bv := range variants {
+		if variants[bv].Name == variant {
+			return true
+		}
+	}
+	return false
 }
 
 // projectMaps is a struct of maps of project fields, which allows efficient comparisons of generated projects to projects.

--- a/model/generate.go
+++ b/model/generate.go
@@ -340,7 +340,6 @@ func (g *GeneratedProject) getNewTasksWithDependencies(v *Version, p *Project, a
 	}
 
 	var err error
-	// some comment
 	newTVPairs.ExecTasks, err = IncludeDependencies(p, newTVPairs.ExecTasks, v.Requester, activationInfo)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies for generator",
@@ -447,7 +446,7 @@ type specificActivationInfo struct {
 	stepbackTasks            map[string][]specificStepbackInfo // tasks by variant that are being stepped back, along with the stepback depth to use
 	activationTasks          map[string][]string               // tasks by variant that have batchtime or activate specified
 	activationVariants       []string                          // variants that have batchtime or activate specified
-	generatedProjectVariants []parserBV                        // list of variants that are specified in the generated project
+	generatedProjectVariants []parserBV                        // list of all variants that are specified in the generated project
 }
 
 type specificStepbackInfo struct {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -124,7 +124,7 @@ func ConfigurePatch(ctx context.Context, p *patch.Patch, version *Version, proj 
 
 	addDisplayTasksToPatchReq(&patchUpdateReq, *project)
 	tasks := VariantTasksToTVPairs(patchUpdateReq.VariantsTasks)
-	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester())
+	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester(), nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies for patch",
 		"patch":   p.Id,

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -124,7 +124,7 @@ func ConfigurePatch(ctx context.Context, p *patch.Patch, version *Version, proj 
 
 	addDisplayTasksToPatchReq(&patchUpdateReq, *project)
 	tasks := VariantTasksToTVPairs(patchUpdateReq.VariantsTasks)
-	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester(), nil)
+	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester(), nil, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies for patch",
 		"patch":   p.Id,

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -124,7 +124,7 @@ func ConfigurePatch(ctx context.Context, p *patch.Patch, version *Version, proj 
 
 	addDisplayTasksToPatchReq(&patchUpdateReq, *project)
 	tasks := VariantTasksToTVPairs(patchUpdateReq.VariantsTasks)
-	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester(), nil, nil)
+	tasks.ExecTasks, err = IncludeDependencies(project, tasks.ExecTasks, p.GetRequester(), nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies for patch",
 		"patch":   p.Id,

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -489,20 +489,20 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t1 should remain unchanged", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 1)
 			So(pairs[0], ShouldResemble, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v1/t2 should add t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 2)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v2/t3 should add t1,t2, and v1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -510,10 +510,10 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v2/t5 should be pruned, since its dependency is not patchable", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 0)
 
-			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester)
+			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 2)
 		})
 	})
@@ -547,7 +547,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t3 should include t2 and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -555,7 +555,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v3/t4 should include v1, v2, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 7)
 
 			So(pairs, shouldContainPair, TVPair{"v3", "t4"})
@@ -571,7 +571,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v4/t5 should include v1, v2, v3, t4, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 8)
 			So(pairs, shouldContainPair, TVPair{"v4", "t5"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -604,14 +604,14 @@ func TestIncludeDependencies(t *testing.T) {
 
 		Convey("all tasks should be scheduled no matter which is initially added", func() {
 			Convey("for '1'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
 				So(pairs, shouldContainPair, TVPair{"v1", "3"})
 			})
 			Convey("for '2'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 6)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
@@ -621,7 +621,7 @@ func TestIncludeDependencies(t *testing.T) {
 				So(pairs, shouldContainPair, TVPair{"v2", "3"})
 			})
 			Convey("for '3'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v2", "1"})
 				So(pairs, shouldContainPair, TVPair{"v2", "2"})
@@ -648,7 +648,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
-		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester)
+		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil)
 		So(pairs, ShouldHaveLength, 2)
 		So(initDep, ShouldBeIn, pairs)
 	})

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -489,20 +489,20 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t1 should remain unchanged", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 1)
 			So(pairs[0], ShouldResemble, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v1/t2 should add t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 2)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v2/t3 should add t1,t2, and v1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -510,10 +510,10 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v2/t5 should be pruned, since its dependency is not patchable", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 0)
 
-			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester, nil)
+			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 2)
 		})
 	})
@@ -547,7 +547,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t3 should include t2 and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -555,7 +555,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v3/t4 should include v1, v2, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 7)
 
 			So(pairs, shouldContainPair, TVPair{"v3", "t4"})
@@ -571,7 +571,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v4/t5 should include v1, v2, v3, t4, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester, nil, nil)
 			So(len(pairs), ShouldEqual, 8)
 			So(pairs, shouldContainPair, TVPair{"v4", "t5"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -604,14 +604,14 @@ func TestIncludeDependencies(t *testing.T) {
 
 		Convey("all tasks should be scheduled no matter which is initially added", func() {
 			Convey("for '1'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester, nil, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
 				So(pairs, shouldContainPair, TVPair{"v1", "3"})
 			})
 			Convey("for '2'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester, nil, nil)
 				So(len(pairs), ShouldEqual, 6)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
@@ -621,7 +621,7 @@ func TestIncludeDependencies(t *testing.T) {
 				So(pairs, shouldContainPair, TVPair{"v2", "3"})
 			})
 			Convey("for '3'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester, nil, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v2", "1"})
 				So(pairs, shouldContainPair, TVPair{"v2", "2"})
@@ -648,7 +648,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
-		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil)
+		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil, nil)
 		So(pairs, ShouldHaveLength, 2)
 		So(initDep, ShouldBeIn, pairs)
 	})

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -489,20 +489,20 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t1 should remain unchanged", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t1"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 1)
 			So(pairs[0], ShouldResemble, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v1/t2 should add t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t2"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 2)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
 		})
 
 		Convey("a patch against v2/t3 should add t1,t2, and v1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t3"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -510,10 +510,10 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v2/t5 should be pruned, since its dependency is not patchable", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 0)
 
-			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester, nil, nil)
+			pairs, _ = IncludeDependencies(p, []TVPair{{"v2", "t5"}}, evergreen.RepotrackerVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 2)
 		})
 	})
@@ -547,7 +547,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		Convey("a patch against v1/t3 should include t2 and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "t3"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 3)
 			So(pairs, shouldContainPair, TVPair{"v1", "t2"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -555,7 +555,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v3/t4 should include v1, v2, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v3", "t4"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 7)
 
 			So(pairs, shouldContainPair, TVPair{"v3", "t4"})
@@ -571,7 +571,7 @@ func TestIncludeDependencies(t *testing.T) {
 		})
 
 		Convey("a patch against v4/t5 should include v1, v2, v3, t4, t3, t2, and t1", func() {
-			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester, nil, nil)
+			pairs, _ := IncludeDependencies(p, []TVPair{{"v4", "t5"}}, evergreen.PatchVersionRequester, nil)
 			So(len(pairs), ShouldEqual, 8)
 			So(pairs, shouldContainPair, TVPair{"v4", "t5"})
 			So(pairs, shouldContainPair, TVPair{"v1", "t1"})
@@ -604,14 +604,14 @@ func TestIncludeDependencies(t *testing.T) {
 
 		Convey("all tasks should be scheduled no matter which is initially added", func() {
 			Convey("for '1'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester, nil, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "1"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
 				So(pairs, shouldContainPair, TVPair{"v1", "3"})
 			})
 			Convey("for '2'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester, nil, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v1", "2"}, {"v2", "2"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 6)
 				So(pairs, shouldContainPair, TVPair{"v1", "1"})
 				So(pairs, shouldContainPair, TVPair{"v1", "2"})
@@ -621,7 +621,7 @@ func TestIncludeDependencies(t *testing.T) {
 				So(pairs, shouldContainPair, TVPair{"v2", "3"})
 			})
 			Convey("for '3'", func() {
-				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester, nil, nil)
+				pairs, _ := IncludeDependencies(p, []TVPair{{"v2", "3"}}, evergreen.PatchVersionRequester, nil)
 				So(len(pairs), ShouldEqual, 3)
 				So(pairs, shouldContainPair, TVPair{"v2", "1"})
 				So(pairs, shouldContainPair, TVPair{"v2", "2"})
@@ -648,7 +648,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(p, ShouldNotBeNil)
 
 		initDep := TVPair{TaskName: "a", Variant: "initial-variant"}
-		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil, nil)
+		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil)
 		So(pairs, ShouldHaveLength, 2)
 		So(initDep, ShouldBeIn, pairs)
 	})

--- a/model/project.go
+++ b/model/project.go
@@ -1687,7 +1687,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 	pairs = p.extractDisplayTasks(pairs)
 	if includeDeps {
 		var err error
-		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester)
+		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "error including dependencies",
 			"project": p.Identifier,
@@ -1919,7 +1919,7 @@ func (p *Project) VariantTasksForSelectors(definitions []patch.PatchTriggerDefin
 		return nil, errors.Wrap(err, "getting pairs matching patch aliases")
 	}
 	pairs = p.extractDisplayTasks(pairs)
-	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester)
+	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": p.Identifier,

--- a/model/project.go
+++ b/model/project.go
@@ -1687,7 +1687,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 	pairs = p.extractDisplayTasks(pairs)
 	if includeDeps {
 		var err error
-		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
+		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil, nil)
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "error including dependencies",
 			"project": p.Identifier,
@@ -1919,7 +1919,7 @@ func (p *Project) VariantTasksForSelectors(definitions []patch.PatchTriggerDefin
 		return nil, errors.Wrap(err, "getting pairs matching patch aliases")
 	}
 	pairs = p.extractDisplayTasks(pairs)
-	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
+	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": p.Identifier,

--- a/model/project.go
+++ b/model/project.go
@@ -1687,7 +1687,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 	pairs = p.extractDisplayTasks(pairs)
 	if includeDeps {
 		var err error
-		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil, nil)
+		pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "error including dependencies",
 			"project": p.Identifier,
@@ -1919,7 +1919,7 @@ func (p *Project) VariantTasksForSelectors(definitions []patch.PatchTriggerDefin
 		return nil, errors.Wrap(err, "getting pairs matching patch aliases")
 	}
 	pairs = p.extractDisplayTasks(pairs)
-	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil, nil)
+	pairs.ExecTasks, err = IncludeDependencies(p, pairs.ExecTasks, requester, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": p.Identifier,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -935,7 +935,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 	}
 
-	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester)
+	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": projectInfo.Project.Identifier,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -935,7 +935,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 	}
 
-	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester, nil, nil)
+	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": projectInfo.Project.Identifier,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -935,7 +935,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 	}
 
-	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester, nil)
+	pairsToCreate, err = model.IncludeDependencies(projectInfo.Project, pairsToCreate, v.Requester, nil, nil)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error including dependencies",
 		"project": projectInfo.Project.Identifier,


### PR DESCRIPTION
[EVG-18413](https://jira.mongodb.org/browse/EVG-18413)

### Description 
Currently, generated dependencies of generated tasks that don't have their variant defined in the generator JSON get activated by default, because the way Evergreen determines the activation of a generated task is from the generated JSON, i.e. setting `"activate": false` on a variant.  If Evergreen can't find the variant, it assumes the variant will be active.

Change has been made to determine which generated dependency tasks do not have their variant defined in the generated JSON, and if the generated tasks that depend on them are all deactivated, then it is safe / necessary to also deactivate this newly generated variant.
### Testing 
Tested in staging and confirmed that a generated task that isn't set anywhere in the original generated JSON does not get activated by default.