### PR TITLE
EVG-18436 set if projects track push events more carefully

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -353,7 +353,7 @@ func (r *mutationResolver) AttachProjectToNewRepo(ctx context.Context, project M
 	pRef.Owner = project.NewOwner
 	pRef.Repo = project.NewRepo
 
-	if err = pRef.AttachToNewRepo(ctx, usr); err != nil {
+	if err = pRef.AttachToNewRepo(usr); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error updating owner/repo: %s", err.Error()))
 	}
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1849,7 +1849,10 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 			projectRefTaskSyncKey:              p.TaskSync,
 			ProjectRefDisabledStatsCacheKey:    p.DisabledStatsCache,
 			ProjectRefFilesIgnoredFromCacheKey: p.FilesIgnoredFromCache,
-			ProjectRefTracksPushEventsKey:      p.TracksPushEvents,
+		}
+		// Unlike other fields, this will only be set if we're actually modifying it since it's used by the backend.
+		if p.TracksPushEvents != nil {
+			setUpdate[ProjectRefTracksPushEventsKey] = p.TracksPushEvents
 		}
 		// Allow a user to modify owner and repo only if they are editing an unattached project
 		if !isRepo && !p.UseRepoSettings() && !defaultToRepo {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -292,7 +292,7 @@ func TestGetActivationTimeWithCron(t *testing.T) {
 
 func TestAttachToNewRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
-		evergreen.RoleCollection, user.Collection, evergreen.ConfigCollection))
+		evergreen.RoleCollection, user.Collection, evergreen.ConfigCollection, GithubHooksCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 	pRef := ProjectRef{
@@ -307,6 +307,7 @@ func TestAttachToNewRepo(t *testing.T) {
 			Enabled: utility.TruePtr(),
 		},
 		PRTestingEnabled: utility.TruePtr(),
+		TracksPushEvents: utility.TruePtr(),
 	}
 	assert.NoError(t, pRef.Insert())
 	repoRef := RepoRef{ProjectRef{
@@ -319,7 +320,13 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, u.Insert())
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
-	assert.NoError(t, pRef.AttachToNewRepo(context.Background(), u))
+	hook := GithubHook{
+		HookID: 12,
+		Owner:  pRef.Owner,
+		Repo:   pRef.Repo,
+	}
+	assert.NoError(t, hook.Insert())
+	assert.NoError(t, pRef.AttachToNewRepo(u))
 
 	pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 	assert.NoError(t, err)
@@ -327,6 +334,17 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NotEqual(t, pRefFromDB.RepoRefId, "myRepo")
 	assert.Equal(t, pRefFromDB.Owner, "newOwner")
 	assert.Equal(t, pRefFromDB.Repo, "newRepo")
+	assert.Nil(t, pRefFromDB.TracksPushEvents)
+
+	newRepoRef, err := FindOneRepoRef(pRef.RepoRefId)
+	assert.NoError(t, err)
+	assert.NotNil(t, newRepoRef)
+
+	assert.True(t, newRepoRef.DoesTrackPushEvents())
+
+	mergedRef, err := FindMergedProjectRef(pRef.Id, "", false)
+	assert.NoError(t, err)
+	assert.True(t, mergedRef.DoesTrackPushEvents())
 
 	userFromDB, err := user.FindOneById("me")
 	assert.NoError(t, err)
@@ -350,7 +368,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, pRef.Insert())
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
-	assert.NoError(t, pRef.AttachToNewRepo(context.Background(), u))
+	assert.NoError(t, pRef.AttachToNewRepo(u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
 
@@ -368,7 +386,7 @@ func TestAttachToNewRepo(t *testing.T) {
 
 func TestAttachToRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
-		evergreen.RoleCollection, user.Collection))
+		evergreen.RoleCollection, user.Collection, GithubHooksCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 	pRef := ProjectRef{
@@ -382,9 +400,16 @@ func TestAttachToRepo(t *testing.T) {
 		},
 		GithubChecksEnabled: utility.TruePtr(),
 		Enabled:             utility.TruePtr(),
+		TracksPushEvents:    utility.TruePtr(),
 	}
 	assert.NoError(t, pRef.Insert())
 
+	hook := GithubHook{
+		HookID: 12,
+		Owner:  pRef.Owner,
+		Repo:   pRef.Repo,
+	}
+	assert.NoError(t, hook.Insert())
 	u := &user.DBUser{Id: "me"}
 	assert.NoError(t, u.Insert())
 	// No repo exists, but one should be created.
@@ -400,6 +425,12 @@ func TestAttachToRepo(t *testing.T) {
 	assert.True(t, pRefFromDB.IsEnabled())
 	assert.True(t, pRefFromDB.CommitQueue.IsEnabled())
 	assert.True(t, pRefFromDB.IsGithubChecksEnabled())
+	assert.Nil(t, pRefFromDB.TracksPushEvents)
+
+	repoRef, err := FindOneRepoRef(pRef.RepoRefId)
+	assert.NoError(t, err)
+	require.NotNil(t, repoRef)
+	assert.True(t, repoRef.DoesTrackPushEvents())
 
 	u, err = user.FindOneById("me")
 	assert.NoError(t, err)
@@ -450,7 +481,8 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NotNil(t, pRefFromDB.GitTagVersionsEnabled)
 			assert.True(t, pRefFromDB.IsGitTagVersionsEnabled())
 			assert.True(t, pRefFromDB.IsGithubChecksEnabled())
-			assert.Equal(t, pRefFromDB.GithubTriggerAliases, []string{"my_trigger"}) // why isn't this set to repo :O
+			assert.Equal(t, pRefFromDB.GithubTriggerAliases, []string{"my_trigger"})
+			assert.True(t, pRefFromDB.DoesTrackPushEvents())
 
 			dbUser, err = user.FindOneById("me")
 			assert.NoError(t, err)
@@ -605,6 +637,7 @@ func TestDetachFromRepo(t *testing.T) {
 				Id:                    pRef.RepoRefId,
 				Owner:                 pRef.Owner,
 				Repo:                  pRef.Repo,
+				TracksPushEvents:      utility.TruePtr(),
 				PRTestingEnabled:      utility.TruePtr(),
 				GitTagVersionsEnabled: utility.FalsePtr(),
 				GithubChecksEnabled:   utility.TruePtr(),
@@ -939,7 +972,7 @@ func TestFindProjectRefsByRepoAndBranch(t *testing.T) {
 
 func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, user.Collection,
-		evergreen.ScopeCollection, ProjectVarsCollection, ProjectAliasCollection))
+		evergreen.ScopeCollection, ProjectVarsCollection, ProjectAliasCollection, GithubHooksCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -985,6 +1018,12 @@ func TestCreateNewRepoRef(t *testing.T) {
 	}
 	assert.NoError(t, doc3.Insert())
 
+	hook := GithubHook{
+		HookID: 12,
+		Owner:  "mongodb",
+		Repo:   "mongo",
+	}
+	assert.NoError(t, hook.Insert())
 	projectVariables := []ProjectVars{
 		{
 			Id: doc1.Id,
@@ -1069,7 +1108,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	}
 	u := user.DBUser{Id: "me"}
 	assert.NoError(t, u.Insert())
-	// this will create the new repo ref
+	// This will create the new repo ref
 	assert.NoError(t, doc2.AddToRepoScope(&u))
 	assert.NotEmpty(t, doc2.RepoRefId)
 
@@ -1080,6 +1119,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.Equal(t, "mongodb", repoRef.Owner)
 	assert.Equal(t, "mongo", repoRef.Repo)
 	assert.Equal(t, "main", repoRef.Branch)
+	assert.True(t, repoRef.DoesTrackPushEvents())
 	assert.Contains(t, repoRef.Admins, "bob")
 	assert.Contains(t, repoRef.Admins, "other bob")
 	assert.Contains(t, repoRef.Admins, "me")

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -37,8 +37,7 @@ var (
 )
 
 func (r *RepoRef) Add(creator *user.DBUser) error {
-	err := r.Upsert()
-	if err != nil {
+	if err := r.Upsert(); err != nil {
 		return errors.Wrap(err, "upserting repo ref")
 	}
 	return r.addPermissions(creator)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -83,6 +83,16 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 	existingContainerSecrets := projectRef.ContainerSecrets
 	projectRef.ContainerSecrets = nil
 
+	_, err = model.EnableWebhooks(ctx, projectRef)
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":            "error enabling webhooks",
+			"project_id":         projectRef.Id,
+			"project_identifier": projectRef.Identifier,
+			"owner":              projectRef.Owner,
+			"repo":               projectRef.Repo,
+		}))
+	}
 	err = projectRef.Add(u)
 	if err != nil {
 		return gimlet.ErrorResponse{
@@ -116,16 +126,6 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 		"project_identifier": projectRef.Identifier,
 		"user":               u.DisplayName(),
 	}))
-	_, err = model.EnableWebhooks(ctx, projectRef)
-	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"message":            "error enabling webhooks",
-			"project_id":         projectRef.Id,
-			"project_identifier": projectRef.Identifier,
-			"owner":              projectRef.Owner,
-			"repo":               projectRef.Repo,
-		}))
-	}
 	return nil
 }
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -239,8 +239,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err = handleGithubConflicts(mergedBeforeRef, "Changing owner/repo"); err != nil {
 				return nil, err
 			}
-			// Check if webhook is enabled if the owner/repo has changed
-			_, err = model.EnableWebhooks(ctx, mergedSection)
+			// Check if webhook is enabled if the owner/repo has changed.
+			// Using the new project ref ensures we update tracking at the end.
+			_, err = model.EnableWebhooks(ctx, newProjectRef)
 			if err != nil {
 				return nil, errors.Wrapf(err, "enabling webhooks for project '%s'", projectId)
 			}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -473,7 +473,8 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 		},
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
-			event.SubscriptionsCollection, event.EventCollection, evergreen.ScopeCollection, user.Collection))
+			event.SubscriptionsCollection, event.EventCollection, evergreen.ScopeCollection, user.Collection,
+			model.GithubHooksCollection))
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		pRef := model.ProjectRef{


### PR DESCRIPTION
[EVG-18436](https://jira.mongodb.org/browse/EVG-18436)

### Description 
This ticket highlighted a couple of projects that didn't get TracksPushEvents set for the project or repo, because we'd create the hook but not update the project with it (the new UI neglects to set this field entirely). Made modifications to both update the repo structure when a project is attached/detached and to update the project ref when we check webhooks.

Will need to manually update repos that don't have this field set to ensure that testing works correctly.

### Testing 
Added to unit tests; verified on staging that modifying the general page updates the field correctly (i.e. doesn't update it unless checking the changed owner/repo field -- used https://spruce-staging.corp.mongodb.com/project/annie-copy2/settings/general) 
