### PR TITLE
EVG-17571: fix test-thirdparty flaky test

### DIFF
--- a/model/github_hook.go
+++ b/model/github_hook.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -84,7 +85,9 @@ func FindGithubHookByID(hookID int) (*GithubHook, error) {
 }
 
 func SetupNewGithubHook(ctx context.Context, settings evergreen.Settings, owner string, repo string) (*GithubHook, error) {
-	respHook, err := thirdparty.CreateGithubHook(ctx, settings, owner, repo)
+	githubCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	respHook, err := thirdparty.CreateGithubHook(githubCtx, settings, owner, repo)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +106,9 @@ func SetupNewGithubHook(ctx context.Context, settings evergreen.Settings, owner 
 }
 
 func GetExistingGithubHook(ctx context.Context, settings evergreen.Settings, owner, repo string) (*GithubHook, error) {
-	hook, err := thirdparty.GetExistingGithubHook(ctx, settings, owner, repo)
+	githubCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	hook, err := thirdparty.GetExistingGithubHook(githubCtx, settings, owner, repo)
 	if err != nil {
 		return nil, err
 	}

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -172,8 +172,10 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 		// thinks is the most recent revision) and the most recent commit (i.e. the branch's actual
 		// most recent commit).
 		if firstCommit != nil {
+			githubCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
 			baseRevision, err = thirdparty.GetGithubMergeBaseRevision(
-				ctx,
+				githubCtx,
 				gRepoPoller.OauthToken,
 				gRepoPoller.ProjectRef.Owner,
 				gRepoPoller.ProjectRef.Repo,

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -42,9 +42,7 @@ func (s *githubSuite) SetupTest() {
 	s.token, err = s.config.GetGithubOauthToken()
 	s.NoError(err)
 
-	s.ctx, s.cancel = context.WithTimeout(context.Background(), 10*time.Second)
-	s.Require().NotNil(s.ctx)
-	s.Require().NotNil(s.cancel)
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), 30*time.Second)
 }
 
 func (s *githubSuite) TearDownTest() {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17571

### Description 
Based on [the logs](https://jira.mongodb.org/browse/EVG-17571), the test is flaking because it hits the 10 second timeout in `GetGithubMergeBaseRevision`. I changed the GitHub API helper functions to just rely on the passed-in context rather than hard-code a specific timeout within the functions themselves, to make it easier for tests to configure their own

* Reduce GitHub API test flakiness by increasing timeout.
* Move context timeouts out of the GitHub helper functions and into the callers to allow tests to specify their own timeouts.

### Testing 
Existing test should pass. Flakiness due to slow API responses shouldn't happen as often anymore.