### PR TITLE
EVG-18208: fix flaky repotracker test

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -264,7 +264,7 @@ type ActivationStatus struct {
 }
 
 func (s *ActivationStatus) ShouldActivate(now time.Time) bool {
-	return !s.Activated && now.After(s.ActivateAt) && !s.ActivateAt.IsZero() && !utility.IsZeroTime(s.ActivateAt)
+	return !s.Activated && now.After(s.ActivateAt) && !utility.IsZeroTime(s.ActivateAt)
 }
 
 // VersionMetadata is used to pass information about upstream versions to downstream version creation

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -343,7 +343,7 @@ tasks:
 		},
 		NewMockRepoPoller(pp, revisions),
 	}
-	assert.NoError(t, repoTracker.StoreRevisions(context.TODO(), revisions))
+	assert.NoError(t, repoTracker.StoreRevisions(ctx, revisions))
 	v, err := model.VersionFindOne(model.VersionByMostRecentSystemRequester("testproject"))
 	assert.NoError(t, err)
 	assert.NotNil(t, v)
@@ -371,7 +371,9 @@ tasks:
 	// now we should update just the task even though the build is activated already
 	for i, bv := range v.BuildVariants {
 		if bv.BuildVariant == "bv1" {
-			v.BuildVariants[i].BatchTimeTasks[0].ActivateAt = time.Now()
+			// Set the activation time before the current timestamp to ensure
+			// that it is already elapsed.
+			v.BuildVariants[i].BatchTimeTasks[0].ActivateAt = time.Now().Add(-time.Millisecond)
 		}
 	}
 	ok, err = model.ActivateElapsedBuildsAndTasks(v)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18208

### Description 
`TestBatchtimeForTasks` was being flaky because it checked if the `time.Now()` timestamp was strictly after the task's `ActivateAt`. Sometimes, the Go test will run so quickly, that the `time.Now()` when `ActivateAt` is set (right before calling `model.ActivateElapsedBuildsAndTasks`) was identical to the `time.Now()` comparison timestamp in `model.ActivateElapsedBuildsAndTasks`. To fix this timing issue, I made the `ActivateAt` timestamp slightly before `time.Now()` to ensure that it gets activated.

* Fix `TestBatchtimeForTasks`.
* Remove redundant zero time check (because `utility.IsZeroTime` checks both Unix and Go zero time already).

### Testing 
Ran `TestBatchtimeForTasks` locally a bunch to ensure it's really not flaky anymore.