### PR TITLE
EVG-14528 Filter out aborted patches from the RunChildPatchSubscriberType subscription generation 

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
@@ -758,17 +757,6 @@ func (p *Patch) CollectiveStatus() (string, error) {
 
 func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
-}
-
-func (p *Patch) IsAborted() (bool, error) {
-	v, err := model.VersionFindOne(model.VersionById(p.Id.Hex()))
-	if err != nil {
-		return false, errors.Errorf("finding version '%s'", p.Id.Hex())
-	}
-	if v == nil {
-		return false, errors.Errorf("version '%s' not found", p.Id.Hex())
-	}
-	return v.Aborted, nil
 }
 
 // ShouldPatchFileWithDiff returns true if the patch should read with diff

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
@@ -757,6 +758,17 @@ func (p *Patch) CollectiveStatus() (string, error) {
 
 func (p *Patch) IsParent() bool {
 	return len(p.Triggers.ChildPatches) > 0
+}
+
+func (p *Patch) IsAborted() (bool, error) {
+	v, err := model.VersionFindOne(model.VersionById(p.Id.Hex()))
+	if err != nil {
+		return false, errors.Errorf("finding version '%s'", p.Id.Hex())
+	}
+	if v == nil {
+		return false, errors.Errorf("version '%s' not found", p.Id.Hex())
+	}
+	return v.Aborted, nil
 }
 
 // ShouldPatchFileWithDiff returns true if the patch should read with diff

--- a/model/version.go
+++ b/model/version.go
@@ -305,6 +305,17 @@ type DuplicateVersions struct {
 	Versions []Version           `bson:"versions"`
 }
 
+func IsAborted(id string) (bool, error) {
+	v, err := VersionFindOne(VersionById(id))
+	if err != nil {
+		return false, errors.Errorf("finding version '%s'", id)
+	}
+	if v == nil {
+		return false, errors.Errorf("version '%s' not found", id)
+	}
+	return v.Aborted, nil
+}
+
 func VersionGetHistory(versionId string, N int) ([]Version, error) {
 	v, err := VersionFindOne(VersionById(versionId))
 	if err != nil {

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -102,7 +102,7 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 		anyOutcome := ps == evergreen.PatchAllOutcomes
 
 		if successOutcome || failureOutcome || anyOutcome {
-			aborted, err := t.patch.IsAborted()
+			aborted, err := model.IsAborted(t.patch.Id.Hex())
 			if err != nil {
 				return nil, errors.Errorf("getting aborted status for patch '%s'", t.patch.Id.Hex())
 			}

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -102,7 +102,14 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 		anyOutcome := ps == evergreen.PatchAllOutcomes
 
 		if successOutcome || failureOutcome || anyOutcome {
-			err := finalizeChildPatch(sub)
+			aborted, err := t.patch.IsAborted()
+			if err != nil {
+				return nil, errors.Errorf("getting aborted status for patch '%s'", t.patch.Id.Hex())
+			}
+			if aborted {
+				return nil, nil
+			}
+			err = finalizeChildPatch(sub)
 
 			if err != nil {
 				return nil, errors.Wrap(err, "finalizing child patch")

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen/model"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 
 	"github.com/evergreen-ci/evergreen"
@@ -36,7 +37,7 @@ func (s *patchSuite) SetupSuite() {
 }
 
 func (s *patchSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.EventCollection, patch.Collection, event.SubscriptionsCollection, dbModel.ProjectRefCollection))
+	s.NoError(db.ClearCollections(event.EventCollection, patch.Collection, event.SubscriptionsCollection, dbModel.ProjectRefCollection, model.VersionCollection))
 	startTime := time.Now().Truncate(time.Millisecond)
 
 	patchID := mgobson.ObjectIdHex("5aeb4514f27e4f9984646d97")
@@ -83,6 +84,17 @@ func (s *patchSuite) SetupTest() {
 		},
 	}
 	s.NoError(childPatch.Insert())
+
+	version := model.Version{
+		Id:      s.patch.Id.Hex(),
+		Aborted: false,
+	}
+	s.NoError(version.Insert())
+	childVersion := model.Version{
+		Id:      childPatchId,
+		Aborted: false,
+	}
+	s.NoError(childVersion.Insert())
 
 	s.data = &event.PatchEventData{
 		Status: evergreen.PatchCreated,


### PR DESCRIPTION
[EVG-14528](https://jira.mongodb.org/browse/EVG-14528)


