### PR TITLE
EVG-18285: Spinning our wheels on host/task cleanup

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1228,7 +1228,7 @@ type awsClientMock struct { //nolint
 	*ec2.Instance
 	*ec2.DescribeSpotInstanceRequestsOutput
 	*ec2.DescribeInstancesOutput
-	requestGetInstanceInfoError error
+	RequestGetInstanceInfoError error
 	*ec2.DescribeInstanceTypeOfferingsOutput
 
 	launchTemplates []*ec2.LaunchTemplate
@@ -1530,8 +1530,8 @@ func (c *awsClientMock) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpc
 }
 
 func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.Instance, error) {
-	if c.requestGetInstanceInfoError != nil {
-		return nil, c.requestGetInstanceInfoError
+	if c.RequestGetInstanceInfoError != nil {
+		return nil, c.RequestGetInstanceInfoError
 	}
 
 	if c.Instance != nil {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1228,6 +1228,7 @@ type awsClientMock struct { //nolint
 	*ec2.Instance
 	*ec2.DescribeSpotInstanceRequestsOutput
 	*ec2.DescribeInstancesOutput
+	requestGetInstanceInfoError error
 	*ec2.DescribeInstanceTypeOfferingsOutput
 
 	launchTemplates []*ec2.LaunchTemplate
@@ -1529,6 +1530,10 @@ func (c *awsClientMock) DescribeVpcs(ctx context.Context, input *ec2.DescribeVpc
 }
 
 func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*ec2.Instance, error) {
+	if c.requestGetInstanceInfoError != nil {
+		return nil, c.requestGetInstanceInfoError
+	}
+
 	if c.Instance != nil {
 		return c.Instance, nil
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -241,7 +241,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
 
-		if ec2err, ok := errors.Cause(err).(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
+		if ec2Err, ok := errors.Cause(err).(awserr.Error); ok && ec2Err.Code() == EC2ErrorNotFound {
 			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -241,7 +241,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
 
-		if ec2err, ok := errors.Cause(errors.Cause(err)).(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
+		if ec2err, ok := errors.Cause(err).(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
 			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -240,7 +240,8 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
+
+		if ec2err, ok := errors.Cause(errors.Cause(err)).(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
 			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -240,15 +240,15 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
+		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
+			return StatusNonExistent, nil
+		}
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "error getting instance info",
 			"host_id":       h.Id,
 			"host_provider": h.Distro.Provider,
 			"distro":        h.Distro.Id,
 		}))
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == EC2ErrorNotFound {
-			return StatusNonExistent, nil
-		}
 		return status, errors.Wrap(err, "getting instance info")
 	}
 

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -58,12 +58,10 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"GetInstanceStatusNonExistent": func(*testing.T) {
-			aws_error := awserr.New(EC2ErrorNotFound, "The instance ID 'test-id' does not exist", nil)
-			wrapped_aws_error := errors.Wrap(
-				errors.Wrap(aws_error, "after 6 attempts, operation failed"),
-				"EC2 API returned error for DescribeInstances")
+			awsError := awserr.New(EC2ErrorNotFound, "The instance ID 'test-id' does not exist", nil)
+			wrappedAwsError := errors.Wrap(awsError, "EC2 API returned error for DescribeInstances")
 			mockClient := m.client.(*awsClientMock)
-			mockClient.requestGetInstanceInfoError = wrapped_aws_error
+			mockClient.RequestGetInstanceInfoError = wrappedAwsError
 			status, err := m.GetInstanceStatus(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -2,6 +2,9 @@ package cloud
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,8 +17,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestFleet(t *testing.T) {

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -58,7 +58,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
 		"GetInstanceStatusNonExistent": func(*testing.T) {
-			aws_error := awserr.New(EC2ErrorNotFound, "Test error for Insufficient Capacity", nil)
+			aws_error := awserr.New(EC2ErrorNotFound, "The instance ID 'test-id' does not exist", nil)
 			wrapped_aws_error := errors.Wrap(
 				errors.Wrap(aws_error, "after 6 attempts, operation failed"),
 				"EC2 API returned error for DescribeInstances")
@@ -67,11 +67,6 @@ func TestFleet(t *testing.T) {
 			status, err := m.GetInstanceStatus(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)
-
-			assert.Equal(t, "", h.Zone)
-			hDb, err := host.FindOneId("h1")
-			assert.NoError(t, err)
-			assert.Equal(t, "", hDb.Zone)
 		},
 		"TerminateInstance": func(*testing.T) {
 			assert.NoError(t, m.TerminateInstance(context.Background(), h, "evergreen", ""))

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -65,9 +64,6 @@ func TestFleet(t *testing.T) {
 			mockClient := m.client.(*awsClientMock)
 			mockClient.requestGetInstanceInfoError = wrapped_aws_error
 			status, err := m.GetInstanceStatus(context.Background(), h)
-			fmt.Print("---------------")
-			fmt.Print(err)
-			fmt.Print("---------------")
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)
 


### PR DESCRIPTION
[EVG-18285](https://jira.mongodb.org/browse/EVG-18285)

### Description 
The Splunk error is not the reason why the host was not removed. Based on the conversation with @Kimchelly, the background cleanup job that was supposed to clean up these hosts doesn't handle the InvalidInstanceID.NotFound error yet. We already have a ticket - [EVG-18388](https://jira.mongodb.org/browse/EVG-18388) to fix this.

In this case, the error is reported even though `InvalidInstanceID.NotFound` is handled. I have fixed this part. This will fix the wrong Splunk error.
