### PR TITLE
EVG-18116 Add requesters to project tasks route opts

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -37,11 +37,10 @@ const (
 )
 
 type GetProjectTasksOpts struct {
-	Limit        int    `json:"num_versions"`
-	BuildVariant string `json:"build_variant"`
-	StartAt      int    `json:"start_at"`
-	PatchOnly    bool   `json:"patch_only"`
-	MainlineOnly bool   `json:"mainline_only"`
+	Limit        int      `json:"num_versions"`
+	BuildVariant string   `json:"build_variant"`
+	StartAt      int      `json:"start_at"`
+	Requesters   []string `json:"requesters"`
 }
 
 type Project struct {

--- a/model/project.go
+++ b/model/project.go
@@ -40,6 +40,8 @@ type GetProjectTasksOpts struct {
 	Limit        int    `json:"num_versions"`
 	BuildVariant string `json:"build_variant"`
 	StartAt      int    `json:"start_at"`
+	PatchOnly    bool   `json:"patch_only"`
+	MainlineOnly bool   `json:"mainline_only"`
 }
 
 type Project struct {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1181,10 +1181,10 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 		task.DisplayNameKey: taskName,
 		task.StatusKey:      bson.M{"$in": finishedStatuses},
 	}
-	if opts.MainlineOnly {
+	if len(opts.Requesters) > 0 {
+		match[task.RequesterKey] = bson.M{"$in": opts.Requesters}
+	} else {
 		match[task.RequesterKey] = bson.M{"$in": evergreen.SystemVersionRequesterTypes}
-	} else if opts.PatchOnly {
-		match[task.RequesterKey] = evergreen.PatchVersionRequester
 	}
 	if opts.BuildVariant != "" {
 		match[task.BuildVariantKey] = opts.BuildVariant

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1181,6 +1181,11 @@ func GetTasksWithOptions(projectName string, taskName string, opts GetProjectTas
 		task.DisplayNameKey: taskName,
 		task.StatusKey:      bson.M{"$in": finishedStatuses},
 	}
+	if opts.MainlineOnly {
+		match[task.RequesterKey] = bson.M{"$in": evergreen.SystemVersionRequesterTypes}
+	} else if opts.PatchOnly {
+		match[task.RequesterKey] = evergreen.PatchVersionRequester
+	}
 	if opts.BuildVariant != "" {
 		match[task.BuildVariantKey] = opts.BuildVariant
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2320,41 +2320,40 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 
 	tasks, err := GetTasksWithOptions("my_ident", "t1", opts)
 	assert.NoError(t, err)
-	// Returns 21 tasks because 40 tasks exist within the default version limit,
-	// but 1/2 are undispatched
-	assert.Len(t, tasks, 21)
+	// Returns 7 tasks because 40 tasks exist within the default version limit,
+	// but 1/2 are undispatched and only 1/3 have a system requester
+	assert.Len(t, tasks, 7)
 
 	opts.Limit = 5
 	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
 	assert.NoError(t, err)
-	assert.Len(t, tasks, 6)
-	assert.Equal(t, tasks[0].RevisionOrderNumber, 100)
-	assert.Equal(t, tasks[5].RevisionOrderNumber, 95)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, tasks[0].RevisionOrderNumber, 99)
+	assert.Equal(t, tasks[1].RevisionOrderNumber, 96)
 
 	opts.Limit = 10
 	opts.StartAt = 80
-	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
-	assert.NoError(t, err)
-	assert.Len(t, tasks, 11)
-	assert.Equal(t, tasks[0].RevisionOrderNumber, 80)
-	assert.Equal(t, tasks[10].RevisionOrderNumber, 70)
-
-	opts.PatchOnly = true
-	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
-	assert.NoError(t, err)
-	assert.Len(t, tasks, 8)
-	assert.Equal(t, tasks[0].RevisionOrderNumber, 80)
-	assert.Equal(t, tasks[7].RevisionOrderNumber, 70)
-
-	opts.PatchOnly = false
-	opts.MainlineOnly = true
 	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
 	assert.NoError(t, err)
 	assert.Len(t, tasks, 3)
 	assert.Equal(t, tasks[0].RevisionOrderNumber, 78)
 	assert.Equal(t, tasks[2].RevisionOrderNumber, 72)
 
-	opts.MainlineOnly = false
+	opts.Requesters = []string{evergreen.PatchVersionRequester}
+	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 8)
+	assert.Equal(t, tasks[0].RevisionOrderNumber, 80)
+	assert.Equal(t, tasks[7].RevisionOrderNumber, 70)
+
+	opts.Requesters = []string{evergreen.RepotrackerVersionRequester}
+	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 3)
+	assert.Equal(t, tasks[0].RevisionOrderNumber, 78)
+	assert.Equal(t, tasks[2].RevisionOrderNumber, 72)
+
+	opts.Requesters = []string{}
 	opts.Limit = defaultVersionLimit
 	opts.StartAt = 90
 	opts.BuildVariant = "bv1"

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2307,6 +2307,9 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 		}
 		if i%3 == 0 {
 			myTask.BuildVariant = "bv1"
+			myTask.Requester = evergreen.RepotrackerVersionRequester
+		} else {
+			myTask.Requester = evergreen.PatchVersionRequester
 		}
 		if i%2 == 0 {
 			myTask.Status = evergreen.TaskUndispatched
@@ -2336,6 +2339,22 @@ func TestGetProjectTasksWithOptions(t *testing.T) {
 	assert.Equal(t, tasks[0].RevisionOrderNumber, 80)
 	assert.Equal(t, tasks[10].RevisionOrderNumber, 70)
 
+	opts.PatchOnly = true
+	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 8)
+	assert.Equal(t, tasks[0].RevisionOrderNumber, 80)
+	assert.Equal(t, tasks[7].RevisionOrderNumber, 70)
+
+	opts.PatchOnly = false
+	opts.MainlineOnly = true
+	tasks, err = GetTasksWithOptions("my_ident", "t1", opts)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 3)
+	assert.Equal(t, tasks[0].RevisionOrderNumber, 78)
+	assert.Equal(t, tasks[2].RevisionOrderNumber, 72)
+
+	opts.MainlineOnly = false
 	opts.Limit = defaultVersionLimit
 	opts.StartAt = 90
 	opts.BuildVariant = "bv1"

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -998,9 +998,6 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 	if h.opts.StartAt < 0 {
 		return errors.New("start must be a non-negative integer")
 	}
-	if h.opts.MainlineOnly && h.opts.PatchOnly {
-		return errors.New("cannot specify both mainline and patch only")
-	}
 
 	return nil
 }
@@ -1060,11 +1057,11 @@ func (p *GetProjectAliasResultsHandler) Run(ctx context.Context) gimlet.Responde
 	return gimlet.NewJSONResponse(variantTasks)
 }
 
-////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////
 //
 // Handler for the patch trigger aliases defined for project
 //
-//    /projects/{project_id}/patch_trigger_aliases
+//	/projects/{project_id}/patch_trigger_aliases
 type GetPatchTriggerAliasHandler struct {
 	projectID string
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -998,6 +998,9 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 	if h.opts.StartAt < 0 {
 		return errors.New("start must be a non-negative integer")
 	}
+	if h.opts.MainlineOnly && h.opts.PatchOnly {
+		return errors.New("cannot specify both mainline and patch only")
+	}
 
 	return nil
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -998,6 +998,11 @@ func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) err
 	if h.opts.StartAt < 0 {
 		return errors.New("start must be a non-negative integer")
 	}
+	for _, requester := range h.opts.Requesters {
+		if !utility.StringSliceContains(evergreen.AllRequesterTypes, requester) {
+			return errors.Errorf("'%s' is not a valid requester type", requester)
+		}
+	}
 
 	return nil
 }

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -845,6 +845,7 @@ func TestGetProjectTasks(t *testing.T) {
 			DisplayName:         "t1",
 			Project:             projectId,
 			Status:              evergreen.TaskSucceeded,
+			Requester:           evergreen.RepotrackerVersionRequester,
 		}
 		assert.NoError(myTask.Insert())
 	}


### PR DESCRIPTION
[EVG-18116](https://jira.mongodb.org/browse/EVG-18116)

### Description 
added flags to only show mainline or patch tasks to get tasks by project endpoint

### Testing 
unit tests