### PR TITLE
EVG-14528 Exit if the child patch is already finalized

### DIFF
--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -200,7 +200,7 @@ func finalizeChildPatch(sub *event.Subscription) error {
 	if childPatch == nil {
 		return errors.Errorf("child patch '%s' not found", target.ChildPatchId)
 	}
-	// return if patch is already finalized
+	// Return if patch is already finalized
 	if childPatch.Version != "" {
 		return nil
 	}


### PR DESCRIPTION
[EVG-14528](https://jira.mongodb.org/browse/EVG-14528)

### Description 
Exit if the child patch is already finalized. This eliminates panics down the line.

### Testing 
Reasoned about it 
