### PR TITLE
EVG-16663 Suppress general notifications for aborted patches

### DIFF
--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -104,7 +104,7 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 		if successOutcome || failureOutcome || anyOutcome {
 			aborted, err := model.IsAborted(t.patch.Id.Hex())
 			if err != nil {
-				return nil, errors.Errorf("getting aborted status for patch '%s'", t.patch.Id.Hex())
+				return nil, errors.Wrapf(err, "getting aborted status for patch '%s'", t.patch.Id.Hex())
 			}
 			if aborted {
 				return nil, nil
@@ -383,10 +383,10 @@ func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notificati
 		return nil, nil
 	}
 
-	//Don't notify the user of the patch outcome if they aborted the patch
+	// Don't notify the user of the patch outcome if they aborted the patch
 	aborted, err := model.IsAborted(t.patch.Id.Hex())
 	if err != nil {
-		return nil, errors.Errorf("getting aborted status for patch '%s'", t.patch.Id.Hex())
+		return nil, errors.Wrapf(err, "getting aborted status for patch '%s'", t.patch.Id.Hex())
 	}
 	if aborted {
 		return nil, nil

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -382,6 +382,16 @@ func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notificati
 	if t.event.EventType != event.PatchChildrenCompletion {
 		return nil, nil
 	}
+
+	//Don't notify the user of the patch outcome if they aborted the patch
+	aborted, err := model.IsAborted(t.patch.Id.Hex())
+	if err != nil {
+		return nil, errors.Errorf("getting aborted status for patch '%s'", t.patch.Id.Hex())
+	}
+	if aborted {
+		return nil, nil
+	}
+
 	return t.generate(sub)
 }
 


### PR DESCRIPTION
[EVG-16663](https://jira.mongodb.org/browse/EVG-16663)

### Description 
Users do not wish to receive notifications for aborted patches from the general patch notification setting. 
![image](https://user-images.githubusercontent.com/13104717/207137057-badd9402-0d53-490c-90a0-3a36d4dfaa7c.png)

The only notification related to patch outcomes  that someone can sign up for is patch-finish, which is handled by the function changed in this PR. So they will continue to receive notifications if they explicitly sign up for it by clicking on notify me on that specific version page. 

### Testing 
Tested the behavior on staging. 
