### PR TITLE
EVG-18413 Also deactivate the dependencies of newly deactivated dependencies

### DIFF
--- a/model/dependencies.go
+++ b/model/dependencies.go
@@ -42,7 +42,7 @@ func (di *dependencyIncluder) include(initialDeps []TVPair, activationInfo *spec
 	// handle each pairing, recursively adding and pruning based
 	// on the task's dependencies
 	for _, d := range initialDeps {
-		_, err := di.handle(d, activationInfo, generatedVariants)
+		_, err := di.handle(d, activationInfo, generatedVariants, true)
 		warnings.Add(err)
 	}
 
@@ -58,14 +58,6 @@ func (di *dependencyIncluder) include(initialDeps []TVPair, activationInfo *spec
 	for pair, addToActivationInfo := range di.deactivateGeneratedDeps {
 		if addToActivationInfo {
 			activationInfo.activationTasks[pair.Variant] = append(activationInfo.activationTasks[pair.Variant], pair.TaskName)
-			bvt := di.Project.FindTaskForVariant(pair.TaskName, pair.Variant)
-			// Also need to deactivate the dependencies of the newly deactivated tasks
-			if bvt != nil {
-				deps := di.expandDependencies(pair, bvt.DependsOn)
-				for _, dep := range deps {
-					activationInfo.activationTasks[dep.Variant] = append(activationInfo.activationTasks[dep.Variant], dep.TaskName)
-				}
-			}
 		}
 	}
 	return outPairs, warnings.Resolve()
@@ -74,8 +66,10 @@ func (di *dependencyIncluder) include(initialDeps []TVPair, activationInfo *spec
 // handle finds and includes all tasks that the given task/variant pair depends
 // on. Returns true if the task and all of its dependent tasks can be scheduled
 // for the requester. Returns false if it cannot be scheduled, with an error
-// explaining why
-func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActivationInfo, generatedVariants []parserBV) (bool, error) {
+// explaining why.
+// isRoot denotes whether the function is at its recursive root, and if so we
+// update the deactivateGeneratedDeps map.
+func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActivationInfo, generatedVariants []parserBV, isRoot bool) (bool, error) {
 	if included, ok := di.included[pair]; ok {
 		// we've been here before, so don't redo work
 		return included, nil
@@ -84,7 +78,7 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 	// if the given task is a task group, recurse on each task
 	if tg := di.Project.FindTaskGroup(pair.TaskName); tg != nil {
 		for _, t := range tg.Tasks {
-			ok, err := di.handle(TVPair{TaskName: t, Variant: pair.Variant}, activationInfo, generatedVariants)
+			ok, err := di.handle(TVPair{TaskName: t, Variant: pair.Variant}, activationInfo, generatedVariants, false)
 			if !ok {
 				di.included[pair] = false
 				return false, errors.Wrapf(err, "task group '%s' in variant '%s' contains unschedulable task '%s'", pair.TaskName, pair.Variant, t)
@@ -123,8 +117,10 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 	// also mark this newly generated dependency as inactive.
 	pairSpecifiesActivation := activationInfo.taskOrVariantHasSpecificActivation(pair.Variant, pair.TaskName)
 	for _, dep := range deps {
-		di.updateDeactivationMap(dep, generatedVariants, pairSpecifiesActivation)
-		ok, err := di.handle(dep, activationInfo, generatedVariants)
+		if isRoot {
+			di.updateDeactivationMap(dep, generatedVariants, pairSpecifiesActivation)
+		}
+		ok, err := di.handle(dep, activationInfo, generatedVariants, false)
 		if !ok {
 			di.included[pair] = false
 			return false, errors.Wrapf(err, "task '%s' in variant '%s' has an unschedulable dependency", pair.TaskName, pair.Variant)
@@ -135,15 +131,25 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 	return true, nil
 }
 
-func (di *dependencyIncluder) updateDeactivationMap(dep TVPair, generatedVariants []parserBV, pairSpecifiesActivation bool) {
-	if !variantExistsInGeneratedProject(generatedVariants, dep.Variant) {
+func (di *dependencyIncluder) updateDeactivationMap(pair TVPair, generatedVariants []parserBV, pairSpecifiesActivation bool) {
+	if !variantExistsInGeneratedProject(generatedVariants, pair.Variant) {
 		// If the dependency has not yet been added to deactivateGeneratedDeps, or if the
 		// original pair needs to be active, we update deactivateGeneratedDeps.
 		// We ultimately will only deactivate new dependencies where deactivateGeneratedDeps[pair] = true.
 		// If deactivateGeneratedDeps[pair] = false it signifies that there was at least
 		// one pair that depends on this new dep being active - so we cannot deactivate it.
-		if _, ok := di.deactivateGeneratedDeps[dep]; !ok || !pairSpecifiesActivation {
-			di.deactivateGeneratedDeps[dep] = pairSpecifiesActivation
+		if _, foundPair := di.deactivateGeneratedDeps[pair]; !foundPair || !pairSpecifiesActivation {
+			di.deactivateGeneratedDeps[pair] = pairSpecifiesActivation
+			bvt := di.Project.FindTaskForVariant(pair.TaskName, pair.Variant)
+			// Also need to deactivate the dependencies of the newly deactivated tasks
+			if bvt != nil {
+				deps := di.expandDependencies(pair, bvt.DependsOn)
+				for _, dep := range deps {
+					if _, foundDep := di.deactivateGeneratedDeps[dep]; !foundDep || !pairSpecifiesActivation {
+						di.deactivateGeneratedDeps[dep] = pairSpecifiesActivation
+					}
+				}
+			}
 		}
 	}
 }

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -597,90 +597,8 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 	require.NoError(b2.Insert())
 	require.NoError(b3.Insert())
 
-	//pp := model.ParserProject{}
-	//err := util.UnmarshalYAMLWithFallback([]byte(omitGeneratedTasksConfig), &pp)
-	//require.NoError(err)
-	//pp.Id = "sample_version"
-	//require.NoError(pp.Insert())
-	//generateTask := task.Task{
-	//	Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-	//	Version:               "sample_version",
-	//	BuildId:               "b1",
-	//	Project:               "mci",
-	//	DisplayName:           "version_gen",
-	//	BuildVariant:          "generate-tasks-for-version",
-	//	GeneratedJSONAsString: sampleGeneratedProject2,
-	//	Status:                evergreen.TaskStarted,
-	//}
-	//require.NoError(generateTask.Insert())
-	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
-	require.NoError(projectRef.Insert())
-	//
-	//j := NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
-	//j.Run(context.Background())
-	//assert.NoError(j.Error())
-	//tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
-	//assert.NoError(err)
-	//assert.Len(tasks, 4)
-	//for _, foundTask := range tasks {
-	//	switch foundTask.DisplayName {
-	//	case "version_gen", "dependency_task":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{})
-	//	case "shouldDependOnVersionGen":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{
-	//			{
-	//				TaskId:             "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-	//				Status:             evergreen.TaskSucceeded,
-	//				OmitGeneratedTasks: true,
-	//			},
-	//		})
-	//	case "shouldDependOnDependencyTask":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
-	//	}
-	//}
-	//require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
-	//
-	//// check that the generated tasks are included as dependencies by default
-	//pp = model.ParserProject{}
-	//err = util.UnmarshalYAMLWithFallback([]byte(dependOnGeneratedTasksConfig), &pp)
-	//require.NoError(err)
-	//pp.Id = "sample_version"
-	//require.NoError(pp.Insert())
-	//generateTaskWithoutFlag := task.Task{
-	//	Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-	//	Version:               "sample_version",
-	//	BuildId:               "b1",
-	//	Project:               "mci",
-	//	DisplayName:           "version_gen",
-	//	GeneratedJSONAsString: sampleGeneratedProject2,
-	//	Status:                evergreen.TaskStarted,
-	//}
-	//require.NoError(generateTaskWithoutFlag.Insert())
-	//j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
-	//j.Run(context.Background())
-	//assert.NoError(j.Error())
-	//tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
-	//assert.NoError(err)
-	//assert.Len(tasks, 4)
-	//for _, foundTask := range tasks {
-	//	switch foundTask.DisplayName {
-	//	case "version_gen", "dependency_task":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{})
-	//	case "shouldDependOnVersionGen":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{
-	//			{TaskId: "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
-	//			{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
-	//		})
-	//	case "shouldDependOnDependencyTask":
-	//		assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
-	//	}
-	//}
-
-	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
-
-	// check that the generated tasks are included as dependencies by default
 	pp := model.ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(shouldGenerateNewBVConfig), &pp)
+	err := util.UnmarshalYAMLWithFallback([]byte(omitGeneratedTasksConfig), &pp)
 	require.NoError(err)
 	pp.Id = "sample_version"
 	require.NoError(pp.Insert())
@@ -690,14 +608,96 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 		BuildId:               "b1",
 		Project:               "mci",
 		DisplayName:           "version_gen",
-		GeneratedJSONAsString: sampleGeneratedProject3,
+		BuildVariant:          "generate-tasks-for-version",
+		GeneratedJSONAsString: sampleGeneratedProject2,
 		Status:                evergreen.TaskStarted,
 	}
 	require.NoError(generateTask.Insert())
+	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
+	require.NoError(projectRef.Insert())
+
 	j := NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
+	assert.NoError(err)
+	assert.Len(tasks, 4)
+	for _, foundTask := range tasks {
+		switch foundTask.DisplayName {
+		case "version_gen", "dependency_task":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{})
+		case "shouldDependOnVersionGen":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{
+				{
+					TaskId:             "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+					Status:             evergreen.TaskSucceeded,
+					OmitGeneratedTasks: true,
+				},
+			})
+		case "shouldDependOnDependencyTask":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
+		}
+	}
+	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
+
+	// check that the generated tasks are included as dependencies by default
+	pp = model.ParserProject{}
+	err = util.UnmarshalYAMLWithFallback([]byte(dependOnGeneratedTasksConfig), &pp)
+	require.NoError(err)
+	pp.Id = "sample_version"
+	require.NoError(pp.Insert())
+	generateTaskWithoutFlag := task.Task{
+		Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+		Version:               "sample_version",
+		BuildId:               "b1",
+		Project:               "mci",
+		DisplayName:           "version_gen",
+		GeneratedJSONAsString: sampleGeneratedProject2,
+		Status:                evergreen.TaskStarted,
+	}
+	require.NoError(generateTaskWithoutFlag.Insert())
+	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	j.Run(context.Background())
+	assert.NoError(j.Error())
+	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
+	assert.NoError(err)
+	assert.Len(tasks, 4)
+	for _, foundTask := range tasks {
+		switch foundTask.DisplayName {
+		case "version_gen", "dependency_task":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{})
+		case "shouldDependOnVersionGen":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{
+				{TaskId: "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
+				{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
+			})
+		case "shouldDependOnDependencyTask":
+			assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
+		}
+	}
+
+	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
+
+	// check that the generated tasks are included as dependencies by default
+	pp = model.ParserProject{}
+	err = util.UnmarshalYAMLWithFallback([]byte(shouldGenerateNewBVConfig), &pp)
+	require.NoError(err)
+	pp.Id = "sample_version"
+	require.NoError(pp.Insert())
+	generateTask = task.Task{
+		Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+		Version:               "sample_version",
+		BuildId:               "b1",
+		Project:               "mci",
+		DisplayName:           "version_gen",
+		GeneratedJSONAsString: sampleGeneratedProject3,
+		Status:                evergreen.TaskStarted,
+	}
+	require.NoError(generateTask.Insert())
+	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	j.Run(context.Background())
+	assert.NoError(j.Error())
+	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
 	assert.NoError(err)
 	assert.Len(tasks, 6)
 	for _, foundTask := range tasks {

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -341,6 +341,7 @@ buildvariants:
     tasks:
       - name: dependencyTask
       - name: dependencyTask2
+      - name: shouldNotActivate
 
   - name: testBV5
     display_name: TestBV5
@@ -364,6 +365,8 @@ tasks:
           script: |
             echo "noop2"
   - name: dependencyTask
+    depends_on:
+      - name: shouldNotActivate
     commands:
       - command: shell.exec
         params:
@@ -375,6 +378,12 @@ tasks:
         params:
           script: |
             echo "noop"
+  - name: shouldNotActivate
+    commands:
+      - command: shell.exec
+        params:
+          script: |
+            echo "noop2"
   - name: version_gen
     commands:
       - command: generate.tasks
@@ -588,8 +597,90 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 	require.NoError(b2.Insert())
 	require.NoError(b3.Insert())
 
+	//pp := model.ParserProject{}
+	//err := util.UnmarshalYAMLWithFallback([]byte(omitGeneratedTasksConfig), &pp)
+	//require.NoError(err)
+	//pp.Id = "sample_version"
+	//require.NoError(pp.Insert())
+	//generateTask := task.Task{
+	//	Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+	//	Version:               "sample_version",
+	//	BuildId:               "b1",
+	//	Project:               "mci",
+	//	DisplayName:           "version_gen",
+	//	BuildVariant:          "generate-tasks-for-version",
+	//	GeneratedJSONAsString: sampleGeneratedProject2,
+	//	Status:                evergreen.TaskStarted,
+	//}
+	//require.NoError(generateTask.Insert())
+	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
+	require.NoError(projectRef.Insert())
+	//
+	//j := NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	//j.Run(context.Background())
+	//assert.NoError(j.Error())
+	//tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
+	//assert.NoError(err)
+	//assert.Len(tasks, 4)
+	//for _, foundTask := range tasks {
+	//	switch foundTask.DisplayName {
+	//	case "version_gen", "dependency_task":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{})
+	//	case "shouldDependOnVersionGen":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{
+	//			{
+	//				TaskId:             "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+	//				Status:             evergreen.TaskSucceeded,
+	//				OmitGeneratedTasks: true,
+	//			},
+	//		})
+	//	case "shouldDependOnDependencyTask":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
+	//	}
+	//}
+	//require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
+	//
+	//// check that the generated tasks are included as dependencies by default
+	//pp = model.ParserProject{}
+	//err = util.UnmarshalYAMLWithFallback([]byte(dependOnGeneratedTasksConfig), &pp)
+	//require.NoError(err)
+	//pp.Id = "sample_version"
+	//require.NoError(pp.Insert())
+	//generateTaskWithoutFlag := task.Task{
+	//	Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
+	//	Version:               "sample_version",
+	//	BuildId:               "b1",
+	//	Project:               "mci",
+	//	DisplayName:           "version_gen",
+	//	GeneratedJSONAsString: sampleGeneratedProject2,
+	//	Status:                evergreen.TaskStarted,
+	//}
+	//require.NoError(generateTaskWithoutFlag.Insert())
+	//j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	//j.Run(context.Background())
+	//assert.NoError(j.Error())
+	//tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
+	//assert.NoError(err)
+	//assert.Len(tasks, 4)
+	//for _, foundTask := range tasks {
+	//	switch foundTask.DisplayName {
+	//	case "version_gen", "dependency_task":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{})
+	//	case "shouldDependOnVersionGen":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{
+	//			{TaskId: "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
+	//			{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
+	//		})
+	//	case "shouldDependOnDependencyTask":
+	//		assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
+	//	}
+	//}
+
+	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
+
+	// check that the generated tasks are included as dependencies by default
 	pp := model.ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(omitGeneratedTasksConfig), &pp)
+	err := util.UnmarshalYAMLWithFallback([]byte(shouldGenerateNewBVConfig), &pp)
 	require.NoError(err)
 	pp.Id = "sample_version"
 	require.NoError(pp.Insert())
@@ -599,101 +690,19 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 		BuildId:               "b1",
 		Project:               "mci",
 		DisplayName:           "version_gen",
-		BuildVariant:          "generate-tasks-for-version",
-		GeneratedJSONAsString: sampleGeneratedProject2,
+		GeneratedJSONAsString: sampleGeneratedProject3,
 		Status:                evergreen.TaskStarted,
 	}
 	require.NoError(generateTask.Insert())
-	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
-	require.NoError(projectRef.Insert())
-
 	j := NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
 	j.Run(context.Background())
 	assert.NoError(j.Error())
 	tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
 	assert.NoError(err)
-	assert.Len(tasks, 4)
-	for _, foundTask := range tasks {
-		switch foundTask.DisplayName {
-		case "version_gen", "dependency_task":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{})
-		case "shouldDependOnVersionGen":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{
-				{
-					TaskId:             "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-					Status:             evergreen.TaskSucceeded,
-					OmitGeneratedTasks: true,
-				},
-			})
-		case "shouldDependOnDependencyTask":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
-		}
-	}
-	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
-
-	// check that the generated tasks are included as dependencies by default
-	pp = model.ParserProject{}
-	err = util.UnmarshalYAMLWithFallback([]byte(dependOnGeneratedTasksConfig), &pp)
-	require.NoError(err)
-	pp.Id = "sample_version"
-	require.NoError(pp.Insert())
-	generateTaskWithoutFlag := task.Task{
-		Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-		Version:               "sample_version",
-		BuildId:               "b1",
-		Project:               "mci",
-		DisplayName:           "version_gen",
-		GeneratedJSONAsString: sampleGeneratedProject2,
-		Status:                evergreen.TaskStarted,
-	}
-	require.NoError(generateTaskWithoutFlag.Insert())
-	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
-	j.Run(context.Background())
-	assert.NoError(j.Error())
-	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
-	assert.NoError(err)
-	assert.Len(tasks, 4)
-	for _, foundTask := range tasks {
-		switch foundTask.DisplayName {
-		case "version_gen", "dependency_task":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{})
-		case "shouldDependOnVersionGen":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{
-				{TaskId: "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
-				{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded},
-			})
-		case "shouldDependOnDependencyTask":
-			assert.Equal(foundTask.DependsOn, []task.Dependency{{TaskId: "mci_identifier_testBV2_dependencyTask__01_01_01_00_00_00", Status: evergreen.TaskSucceeded}})
-		}
-	}
-
-	require.NoError(db.ClearCollections(task.Collection, model.ParserProjectCollection))
-
-	// check that the generated tasks are included as dependencies by default
-	pp = model.ParserProject{}
-	err = util.UnmarshalYAMLWithFallback([]byte(shouldGenerateNewBVConfig), &pp)
-	require.NoError(err)
-	pp.Id = "sample_version"
-	require.NoError(pp.Insert())
-	generateTask = task.Task{
-		Id:                    "mci_identifier_generate_tasks_for_version_version_gen__01_01_01_00_00_00",
-		Version:               "sample_version",
-		BuildId:               "b1",
-		Project:               "mci",
-		DisplayName:           "version_gen",
-		GeneratedJSONAsString: sampleGeneratedProject3,
-		Status:                evergreen.TaskStarted,
-	}
-	require.NoError(generateTask.Insert())
-	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
-	j.Run(context.Background())
-	assert.NoError(j.Error())
-	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
-	assert.NoError(err)
-	assert.Len(tasks, 5)
+	assert.Len(tasks, 6)
 	for _, foundTask := range tasks {
 		if foundTask.BuildVariant == "testBV4" {
-			if foundTask.DisplayName == "dependencyTask" {
+			if foundTask.DisplayName == "dependencyTask" || foundTask.DisplayName == "shouldNotActivate" {
 				assert.False(foundTask.Activated)
 			} else {
 				assert.True(foundTask.Activated)


### PR DESCRIPTION
[EVG-18413](https://jira.mongodb.org/browse/EVG-18413)

### Description 
In the[ previous PR](https://github.com/evergreen-ci/evergreen/pull/6111) to address this ticket, the change was to not activate generated tasks that depend on explicitly inactive tasks.  This works in the standard cases I was testing for, but it's not sufficient in the more complex case where the tasks that get deactivated _generate further dependencies_ within the same variant.  

Ex:  

If `generator` generates `taskA` in `variantA` which is set `activate: false`, which has a dependency in the YAML on `taskB` in `variantB`, which then has a dependency on `taskB2` in `variantB`, then the previous PR will correctly prevent `taskB` from being activated, but `taskB2` gets activated incorrectly since `taskB` has not been added to the list of inactive tasks yet at the time of processing `taskB2`. 

### Testing 
Added unit test case to cover this scenario. Also tested in staging by adding a new task `shouldNotActivate` that is a dependency of task `dependencyTask`, which is a task that was added to the list of tasks to deactivate.  

Confirmed that before the change, `shouldNotActivate` [gets activated](https://spruce-staging.corp.mongodb.com/version/6397853b97b1d31ac1eb5bcb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), and with the change it [does not](https://spruce-staging.corp.mongodb.com/version/6397950c9dbe32741ac34564/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).