### PR TITLE
EVG-18394 Make options fields required to prevent panics

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1127,8 +1127,8 @@ type ComplexityRoot struct {
 		BaseTaskStatuses  func(childComplexity int) int
 		BaseVersion       func(childComplexity int) int
 		Branch            func(childComplexity int) int
-		BuildVariantStats func(childComplexity int, options *BuildVariantOptions) int
-		BuildVariants     func(childComplexity int, options *BuildVariantOptions) int
+		BuildVariantStats func(childComplexity int, options BuildVariantOptions) int
+		BuildVariants     func(childComplexity int, options BuildVariantOptions) int
 		ChildVersions     func(childComplexity int) int
 		CreateTime        func(childComplexity int) int
 		FinishTime        func(childComplexity int) int
@@ -1149,9 +1149,9 @@ type ComplexityRoot struct {
 		StartTime         func(childComplexity int) int
 		Status            func(childComplexity int) int
 		TaskCount         func(childComplexity int) int
-		TaskStatusStats   func(childComplexity int, options *BuildVariantOptions) int
+		TaskStatusStats   func(childComplexity int, options BuildVariantOptions) int
 		TaskStatuses      func(childComplexity int) int
-		Tasks             func(childComplexity int, options *TaskFilterOptions) int
+		Tasks             func(childComplexity int, options TaskFilterOptions) int
 		UpstreamProject   func(childComplexity int) int
 		VersionTiming     func(childComplexity int) int
 	}
@@ -1446,8 +1446,8 @@ type VersionResolver interface {
 	BaseTaskStatuses(ctx context.Context, obj *model.APIVersion) ([]string, error)
 	BaseVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
 
-	BuildVariants(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error)
-	BuildVariantStats(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error)
+	BuildVariants(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) ([]*GroupedBuildVariant, error)
+	BuildVariantStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error)
 	ChildVersions(ctx context.Context, obj *model.APIVersion) ([]*model.APIVersion, error)
 
 	IsPatch(ctx context.Context, obj *model.APIVersion) (bool, error)
@@ -1460,9 +1460,9 @@ type VersionResolver interface {
 
 	Status(ctx context.Context, obj *model.APIVersion) (string, error)
 	TaskCount(ctx context.Context, obj *model.APIVersion) (*int, error)
-	Tasks(ctx context.Context, obj *model.APIVersion, options *TaskFilterOptions) (*VersionTasks, error)
+	Tasks(ctx context.Context, obj *model.APIVersion, options TaskFilterOptions) (*VersionTasks, error)
 	TaskStatuses(ctx context.Context, obj *model.APIVersion) ([]string, error)
-	TaskStatusStats(ctx context.Context, obj *model.APIVersion, options *BuildVariantOptions) (*task.TaskStats, error)
+	TaskStatusStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) (*task.TaskStats, error)
 	UpstreamProject(ctx context.Context, obj *model.APIVersion) (*UpstreamProject, error)
 	VersionTiming(ctx context.Context, obj *model.APIVersion) (*VersionTiming, error)
 }
@@ -6936,7 +6936,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Version.BuildVariantStats(childComplexity, args["options"].(*BuildVariantOptions)), true
+		return e.complexity.Version.BuildVariantStats(childComplexity, args["options"].(BuildVariantOptions)), true
 
 	case "Version.buildVariants":
 		if e.complexity.Version.BuildVariants == nil {
@@ -6948,7 +6948,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Version.BuildVariants(childComplexity, args["options"].(*BuildVariantOptions)), true
+		return e.complexity.Version.BuildVariants(childComplexity, args["options"].(BuildVariantOptions)), true
 
 	case "Version.childVersions":
 		if e.complexity.Version.ChildVersions == nil {
@@ -7100,7 +7100,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Version.TaskStatusStats(childComplexity, args["options"].(*BuildVariantOptions)), true
+		return e.complexity.Version.TaskStatusStats(childComplexity, args["options"].(BuildVariantOptions)), true
 
 	case "Version.taskStatuses":
 		if e.complexity.Version.TaskStatuses == nil {
@@ -7119,7 +7119,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Version.Tasks(childComplexity, args["options"].(*TaskFilterOptions)), true
+		return e.complexity.Version.Tasks(childComplexity, args["options"].(TaskFilterOptions)), true
 
 	case "Version.upstreamProject":
 		if e.complexity.Version.UpstreamProject == nil {
@@ -9445,10 +9445,10 @@ func (ec *executionContext) field_User_patches_args(ctx context.Context, rawArgs
 func (ec *executionContext) field_Version_buildVariantStats_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *BuildVariantOptions
+	var arg0 BuildVariantOptions
 	if tmp, ok := rawArgs["options"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
-		arg0, err = ec.unmarshalOBuildVariantOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
+		arg0, err = ec.unmarshalNBuildVariantOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9460,10 +9460,10 @@ func (ec *executionContext) field_Version_buildVariantStats_args(ctx context.Con
 func (ec *executionContext) field_Version_buildVariants_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *BuildVariantOptions
+	var arg0 BuildVariantOptions
 	if tmp, ok := rawArgs["options"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
-		arg0, err = ec.unmarshalOBuildVariantOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
+		arg0, err = ec.unmarshalNBuildVariantOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9475,10 +9475,10 @@ func (ec *executionContext) field_Version_buildVariants_args(ctx context.Context
 func (ec *executionContext) field_Version_taskStatusStats_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *BuildVariantOptions
+	var arg0 BuildVariantOptions
 	if tmp, ok := rawArgs["options"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
-		arg0, err = ec.unmarshalOBuildVariantOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
+		arg0, err = ec.unmarshalNBuildVariantOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -9490,10 +9490,10 @@ func (ec *executionContext) field_Version_taskStatusStats_args(ctx context.Conte
 func (ec *executionContext) field_Version_tasks_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 *TaskFilterOptions
+	var arg0 TaskFilterOptions
 	if tmp, ok := rawArgs["options"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
-		arg0, err = ec.unmarshalOTaskFilterOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFilterOptions(ctx, tmp)
+		arg0, err = ec.unmarshalNTaskFilterOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFilterOptions(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -47295,7 +47295,7 @@ func (ec *executionContext) _Version_buildVariants(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Version().BuildVariants(rctx, obj, fc.Args["options"].(*BuildVariantOptions))
+		return ec.resolvers.Version().BuildVariants(rctx, obj, fc.Args["options"].(BuildVariantOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -47355,7 +47355,7 @@ func (ec *executionContext) _Version_buildVariantStats(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Version().BuildVariantStats(rctx, obj, fc.Args["options"].(*BuildVariantOptions))
+		return ec.resolvers.Version().BuildVariantStats(rctx, obj, fc.Args["options"].(BuildVariantOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48533,7 +48533,7 @@ func (ec *executionContext) _Version_tasks(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Version().Tasks(rctx, obj, fc.Args["options"].(*TaskFilterOptions))
+		return ec.resolvers.Version().Tasks(rctx, obj, fc.Args["options"].(TaskFilterOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -48638,7 +48638,7 @@ func (ec *executionContext) _Version_taskStatusStats(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Version().TaskStatusStats(rctx, obj, fc.Args["options"].(*BuildVariantOptions))
+		return ec.resolvers.Version().TaskStatusStats(rctx, obj, fc.Args["options"].(BuildVariantOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -64841,6 +64841,11 @@ func (ec *executionContext) marshalNBuildBaronSettings2githubᚗcomᚋevergreen�
 	return ec._BuildBaronSettings(ctx, sel, &v)
 }
 
+func (ec *executionContext) unmarshalNBuildVariantOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐBuildVariantOptions(ctx context.Context, v interface{}) (BuildVariantOptions, error) {
+	res, err := ec.unmarshalInputBuildVariantOptions(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalNChildPatchAlias2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIChildPatchAlias(ctx context.Context, sel ast.SelectionSet, v model.APIChildPatchAlias) graphql.Marshaler {
 	return ec._ChildPatchAlias(ctx, sel, &v)
 }
@@ -66773,6 +66778,11 @@ func (ec *executionContext) marshalNTaskFiles2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return ec._TaskFiles(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTaskFilterOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFilterOptions(ctx context.Context, v interface{}) (TaskFilterOptions, error) {
+	res, err := ec.unmarshalInputTaskFilterOptions(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNTaskLogLinks2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐLogLinks(ctx context.Context, sel ast.SelectionSet, v model.LogLinks) graphql.Marshaler {
@@ -69646,14 +69656,6 @@ func (ec *executionContext) unmarshalOTaskAnnotationSettingsInput2githubᚗcom�
 
 func (ec *executionContext) marshalOTaskEndDetail2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐApiTaskEndDetail(ctx context.Context, sel ast.SelectionSet, v model.ApiTaskEndDetail) graphql.Marshaler {
 	return ec._TaskEndDetail(ctx, sel, &v)
-}
-
-func (ec *executionContext) unmarshalOTaskFilterOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskFilterOptions(ctx context.Context, v interface{}) (*TaskFilterOptions, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalInputTaskFilterOptions(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOTaskInfo2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐTaskInfo(ctx context.Context, sel ast.SelectionSet, v model.TaskInfo) graphql.Marshaler {

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -43,8 +43,8 @@ type Version {
   baseTaskStatuses: [String!]!
   baseVersion: Version
   branch: String!
-  buildVariants(options: BuildVariantOptions): [GroupedBuildVariant]
-  buildVariantStats(options: BuildVariantOptions): [GroupedTaskStatusCount!]
+  buildVariants(options: BuildVariantOptions!): [GroupedBuildVariant]
+  buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]
   childVersions: [Version]
   createTime: Time!
   finishTime: Time
@@ -64,9 +64,9 @@ type Version {
   startTime: Time
   status: String!
   taskCount: Int
-  tasks(options: TaskFilterOptions): VersionTasks!
+  tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
-  taskStatusStats(options: BuildVariantOptions): TaskStats
+  taskStatusStats(options: BuildVariantOptions!): TaskStats
   upstreamProject: UpstreamProject
   versionTiming: VersionTiming
 }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -57,7 +57,7 @@ func (r *versionResolver) BaseVersion(ctx context.Context, obj *restModel.APIVer
 }
 
 // BuildVariants is the resolver for the buildVariants field.
-func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIVersion, options *BuildVariantOptions) ([]*GroupedBuildVariant, error) {
+func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) ([]*GroupedBuildVariant, error) {
 	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
 	if obj.Activated == nil {
 		version, err := model.VersionFindOne(model.VersionById(*obj.Id))
@@ -73,7 +73,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 	if obj.IsPatchRequester() && !utility.FromBoolPtr(obj.Activated) {
 		return nil, nil
 	}
-	groupedBuildVariants, err := generateBuildVariants(utility.FromStringPtr(obj.Id), *options, utility.FromStringPtr(obj.Requester))
+	groupedBuildVariants, err := generateBuildVariants(utility.FromStringPtr(obj.Id), options, utility.FromStringPtr(obj.Requester))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error generating build variants for version %s : %s", *obj.Id, err.Error()))
 	}
@@ -81,7 +81,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 }
 
 // BuildVariantStats is the resolver for the buildVariantStats field.
-func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *restModel.APIVersion, options *BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error) {
+func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error) {
 	opts := task.GetTasksByVersionOptions{
 		TaskNames:                      options.Tasks,
 		Variants:                       options.Variants,
@@ -244,7 +244,7 @@ func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersi
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, options *TaskFilterOptions) (*VersionTasks, error) {
+func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, options TaskFilterOptions) (*VersionTasks, error) {
 	versionId := utility.FromStringPtr(obj.Id)
 	pageParam := 0
 	if options.Page != nil {
@@ -351,7 +351,7 @@ func (r *versionResolver) TaskStatuses(ctx context.Context, obj *restModel.APIVe
 }
 
 // TaskStatusStats is the resolver for the taskStatusStats field.
-func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.APIVersion, options *BuildVariantOptions) (*task.TaskStats, error) {
+func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) (*task.TaskStats, error) {
 	opts := task.GetTasksByVersionOptions{
 		IncludeBaseTasks:      false,
 		IncludeExecutionTasks: false,


### PR DESCRIPTION
[EVG-18394](https://jira.mongodb.org/browse/EVG-18394)

### Description 
This would panic whenever options would not be passed in because we try to access some of its sub-fields. options should probably always be passed in. 
