### PR TITLE
EVG-18036: move container environment variables from pod definition to override options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20221025163056-0ded9f1be935
+	github.com/evergreen-ci/cocoa v0.0.0-20221213160430-8eeec9035d31
 	github.com/evergreen-ci/gimlet v0.0.0-20220419172609-b882e01673e7
 	github.com/evergreen-ci/go-test2json v0.0.0-20180702150328-5b6cfd2e8cb0
 	github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908

--- a/go.sum
+++ b/go.sum
@@ -130,7 +130,6 @@ github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.43.30/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.89/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.109/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.127 h1:IoO2VfuIQg1aMXnl8l6OpNUKT4Qq5CnJMOyIWoTYXj0=
 github.com/aws/aws-sdk-go v1.44.127/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aybabtme/iocontrol v0.0.0-20150809002002-ad15bcfc95a0 h1:0NmehRCgyk5rljDQLKUO+cRJCnduDyn11+zGZIc9Z48=
@@ -366,8 +365,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20221025163056-0ded9f1be935 h1:QuQIgZvlXmlB1Xd4kRAHc4oYrxLq+BtzTdhh7CQF4pk=
-github.com/evergreen-ci/cocoa v0.0.0-20221025163056-0ded9f1be935/go.mod h1:4RjGgSZH0H3Am9AGrr5S72YGHIUXNz5vEQrcghjHi3E=
+github.com/evergreen-ci/cocoa v0.0.0-20221213160430-8eeec9035d31 h1:ZqqC7MAeWo1UgXYwXM80gKCtRXzln0HmJKIjkLiAn7Q=
+github.com/evergreen-ci/cocoa v0.0.0-20221213160430-8eeec9035d31/go.mod h1:9loFu7XeSsMF9tCQyJyUyjrVGkhQAEoOTgwniVzFzVI=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -836,7 +836,9 @@ func TestTaskContainerCreationOptionsHash(t *testing.T) {
 		baseHash := baseOpts.Hash()
 
 		t.Run("ReturnsSameValueForSameInput", func(t *testing.T) {
-			assert.Equal(t, baseHash, baseOpts.Hash())
+			for i := 0; i < 5; i++ {
+				assert.Equal(t, baseHash, baseOpts.Hash(), "hash attempt %d produced different hash value", i)
+			}
 		})
 		t.Run("ChangesForImage", func(t *testing.T) {
 			var opts TaskContainerCreationOptions
@@ -883,7 +885,7 @@ func TestTaskContainerCreationOptionsHash(t *testing.T) {
 			opts.EnvVars = map[string]string{
 				"ENV_VAR": "value",
 			}
-			assert.NotEqual(t, baseHash, opts.Hash(), "env vars should affect hash")
+			assert.Equal(t, baseHash, opts.Hash(), "env vars should not affect hash")
 		})
 		t.Run("ReturnsSameValueForSameUnorderedEnvVars", func(t *testing.T) {
 			var opts TaskContainerCreationOptions
@@ -894,7 +896,8 @@ func TestTaskContainerCreationOptionsHash(t *testing.T) {
 			}
 			h0 := opts.Hash()
 			h1 := opts.Hash()
-			assert.Equal(t, h0, h1, "order of env vars should not affect hash")
+			assert.Equal(t, baseHash, h0, "env vars should not affect hash")
+			assert.Equal(t, h0, h1, "env vars should not affect hash")
 		})
 		t.Run("ReturnsSameValueForSameUnorderedEnvSecrets", func(t *testing.T) {
 			var opts TaskContainerCreationOptions

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -165,6 +165,23 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusDecommissioned, dbPod.Status, "intent pod should have been decommissioned after pod definition creation failed")
 		},
+		"CreatesSamePodDefinitionForSameInput": func(ctx context.Context, t *testing.T, j *podDefinitionCreationJob, p *pod.Pod) {
+			// opts := pod.TaskContainerCreationOptions{
+			//     Image:    "hadjri/evg-e2e-test-ubuntu",
+			//     MemoryMB: 8192,
+			//     CPU:      4096,
+			//     OS:       "linux",
+			//     Arch:     "amd64",
+			//     // kim: NOTE: because POD_ID is always changing for each new
+			//     // pod, it results in a different pod definition.
+			//     // kim: NOTE: could be resolved by only writing the environment
+			//     // variables in the TaskOverrides to RunTask (and possibly other
+			//     // things like CPU/memory, if we want those to be more
+			//     // dynamically configurable).
+			//     EnvVars: map[string]string{"POD_ID": "638a5a9b99727b1e61a2636e"},
+			//     // EnvSecrets: l
+			// }
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -88,14 +88,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			assert.NotZero(t, containerDef.Command)
 			assert.Equal(t, j.ContainerOpts.Image, utility.FromStringPtr(containerDef.Image))
 
-			assert.Len(t, containerDef.Environment, len(j.ContainerOpts.EnvVars))
-			for _, envVar := range containerDef.Environment {
-				name := utility.FromStringPtr(envVar.Name)
-				expectedVal, ok := j.ContainerOpts.EnvVars[name]
-				if assert.True(t, ok, "unexpected environment variable '%s'", name) {
-					assert.Equal(t, expectedVal, utility.FromStringPtr(envVar.Value), "incorrect value for environment variable '%s'", name)
-				}
-			}
+			assert.Empty(t, containerDef.Environment, "pod definition should not contain plaintext environment variables")
 
 			assert.Len(t, containerDef.Secrets, len(j.ContainerOpts.EnvSecrets))
 			for _, secret := range containerDef.Secrets {

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -165,23 +165,6 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			require.NotZero(t, dbPod)
 			assert.Equal(t, pod.StatusDecommissioned, dbPod.Status, "intent pod should have been decommissioned after pod definition creation failed")
 		},
-		"CreatesSamePodDefinitionForSameInput": func(ctx context.Context, t *testing.T, j *podDefinitionCreationJob, p *pod.Pod) {
-			// opts := pod.TaskContainerCreationOptions{
-			//     Image:    "hadjri/evg-e2e-test-ubuntu",
-			//     MemoryMB: 8192,
-			//     CPU:      4096,
-			//     OS:       "linux",
-			//     Arch:     "amd64",
-			//     // kim: NOTE: because POD_ID is always changing for each new
-			//     // pod, it results in a different pod definition.
-			//     // kim: NOTE: could be resolved by only writing the environment
-			//     // variables in the TaskOverrides to RunTask (and possibly other
-			//     // things like CPU/memory, if we want those to be more
-			//     // dynamically configurable).
-			//     EnvVars: map[string]string{"POD_ID": "638a5a9b99727b1e61a2636e"},
-			//     // EnvSecrets: l
-			// }
-		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18036

### Description 
The reason the tasks were not reusing the same pod definition was because the pod definition also included the pod ID environment variable, which is unique to each pod. The pod ID can simply be moved to the override options so that pod definitions do not have any pod-unique parameters. The general steps now are to 1. create the pod definition (with no environment variables set initially), then 2. set the environment variables when the pod is started from the template pod definition (to set the pod ID environment variable).

* Upgrade Cocoa.
* Move environment variables so that they're set when the pod is started (via override options) instead of setting them on the pod definition.

### Testing 
I updated the automated tests to remove the assumption that environment variables are part of the pod definition. I also manually tested in staging and the task consistently reused the same pod definition across several pod creation attempts.