### PR TITLE
EVG-18410 remove periodic build from project config

### DIFF
--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -35,7 +35,6 @@ type ProjectConfigFields struct {
 	WorkstationConfig        *WorkstationConfig             `yaml:"workstation_config,omitempty" bson:"workstation_config,omitempty"`
 	TaskSync                 *TaskSyncOptions               `yaml:"task_sync,omitempty" bson:"task_sync,omitempty"`
 	GithubTriggerAliases     []string                       `yaml:"github_trigger_aliases,omitempty" bson:"github_trigger_aliases,omitempty"`
-	PeriodicBuilds           []PeriodicBuildDefinition      `yaml:"periodic_builds,omitempty" bson:"periodic_builds,omitempty"`
 	ContainerSizeDefinitions []ContainerResources           `yaml:"container_size_definitions,omitempty" bson:"container_size_definitions,omitempty"`
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -540,7 +540,6 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 			err = recovery.HandlePanicWithError(recover(), err, "project ref and project config structures do not match")
 		}()
 		pRefToMerge := ProjectRef{
-			PeriodicBuilds:           projectConfig.PeriodicBuilds,
 			GithubTriggerAliases:     projectConfig.GithubTriggerAliases,
 			ContainerSizeDefinitions: projectConfig.ContainerSizeDefinitions,
 		}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2641,6 +2641,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 			TicketCreateProject:  "EVG",
 			TicketSearchProjects: []string{"BF", "BFG"},
 		},
+		PeriodicBuilds: []PeriodicBuildDefinition{{ID: "p1"}},
 	}
 	projectConfig := &ProjectConfig{
 		Id: "version1",
@@ -2675,7 +2676,6 @@ func TestMergeWithProjectConfig(t *testing.T) {
 				BFSuggestionTimeoutSecs: 10,
 			},
 			GithubTriggerAliases: []string{"one", "two"},
-			PeriodicBuilds:       []PeriodicBuildDefinition{{ID: "p1"}},
 		},
 	}
 	assert.NoError(t, projectRef.Insert())

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -143,7 +143,6 @@ var projectErrorValidators = []projectValidator{
 var projectConfigErrorValidators = []projectConfigValidator{
 	validateProjectConfigAliases,
 	validateProjectConfigPlugins,
-	validateProjectConfigPeriodicBuilds,
 	validateProjectConfigContainers,
 }
 
@@ -409,19 +408,6 @@ func tvToTaskUnit(p *model.Project) map[model.TVPair]model.BuildVariantTaskUnit 
 		}
 	}
 	return tasksByNameAndVariant
-}
-
-func validateProjectConfigPeriodicBuilds(pc *model.ProjectConfig) ValidationErrors {
-	validationErrs := ValidationErrors{}
-	for _, periodicBuild := range pc.PeriodicBuilds {
-		if err := periodicBuild.Validate(); err != nil {
-			validationErrs = append(validationErrs, ValidationError{
-				Message: errors.Wrap(err, "error validating periodic builds").Error(),
-				Level:   Error,
-			})
-		}
-	}
-	return validationErrs
 }
 
 func validateProjectConfigAliases(pc *model.ProjectConfig) ValidationErrors {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1042,30 +1042,6 @@ func TestValidateProjectTaskIdsAndTags(t *testing.T) {
 	})
 }
 
-func TestValidatePeriodicBuilds(t *testing.T) {
-	projectConfig := &model.ProjectConfig{
-		Id: "project-1",
-		ProjectConfigFields: model.ProjectConfigFields{
-			PeriodicBuilds: []model.PeriodicBuildDefinition{
-				{
-					ID:            "so_occasional",
-					ConfigFile:    "build.yml",
-					IntervalHours: -1,
-				},
-				{
-					ID:            "more_frequent",
-					ConfigFile:    "",
-					IntervalHours: 1,
-				},
-			},
-		},
-	}
-	validationErrs := validateProjectConfigPeriodicBuilds(projectConfig)
-	assert.Len(t, validationErrs, 2)
-	assert.Contains(t, validationErrs[0].Message, "interval must be a positive integer")
-	assert.Contains(t, validationErrs[1].Message, "a config file must be specified")
-}
-
 func TestValidatePlugins(t *testing.T) {
 	assert := assert.New(t)
 	require.NoError(t, db.Clear(model.ProjectRefCollection),


### PR DESCRIPTION
[EVG-18410](https://jira.mongodb.org/browse/EVG-18410)

### Description 
Periodic build in project config doesn't work, and isn't something we can fix really since run_time needs to be defined somewhere global that we can keep updated and reference. Theoretically if we wanted to support this we could have a new collection that holds onto periodic build run times and require a unique ID for periodic builds but that would be complex, not a great experience for users, and not worth it without further investigation into EVG-16867 considering the main use case people seem interested in for version control are aliases at the moment.

Verified this isn't in use, and will update documentation.

### Testing 
Verify tests pass and merging project ref / project config correctly uses the project ref periodic build.
