### PR TITLE
EVG-18518: produce diffable YAMLs via evergreen evaluate

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-12-13"
+	ClientVersion = "2022-12-14"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-12-05"

--- a/model/project.go
+++ b/model/project.go
@@ -206,8 +206,31 @@ func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask) {
 	if bvt.Stepback == nil {
 		bvt.Stepback = pt.Stepback
 	}
-
 }
+
+// BuildVariantsByName represents a slice of project config build variants that
+// can be sorted by name.
+type BuildVariantsByName []BuildVariant
+
+func (b BuildVariantsByName) Len() int           { return len(b) }
+func (b BuildVariantsByName) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b BuildVariantsByName) Less(i, j int) bool { return b[i].Name < b[j].Name }
+
+// ProjectTasksByName represents a slice of project config tasks that can be
+// sorted by name.
+type ProjectTasksByName []ProjectTask
+
+func (pt ProjectTasksByName) Len() int           { return len(pt) }
+func (pt ProjectTasksByName) Swap(i, j int)      { pt[i], pt[j] = pt[j], pt[i] }
+func (pt ProjectTasksByName) Less(i, j int) bool { return pt[i].Name < pt[j].Name }
+
+// TaskGroupsByName represents a slice of project config task grups that can be
+// sorted by name.
+type TaskGroupsByName []TaskGroup
+
+func (tg TaskGroupsByName) Len() int           { return len(tg) }
+func (tg TaskGroupsByName) Swap(i, j int)      { tg[i], tg[j] = tg[j], tg[i] }
+func (tg TaskGroupsByName) Less(i, j int) bool { return tg[i].Name < tg[j].Name }
 
 // UnmarshalYAML allows tasks to be referenced as single selector strings.
 // This works by first attempting to unmarshal the YAML into a string

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -72,12 +72,22 @@ func Evaluate() cli.Command {
 				}{}
 				if showTasks {
 					tmp.Functions = p.Functions
-					tmp.Tasks = p.Tasks
+					if diffable {
+						sortTasksByName := model.ProjectTasksByName(p.Tasks)
+						sort.Sort(sortTasksByName)
+						tmp.Tasks = sortTasksByName
+					} else {
+						tmp.Tasks = p.Tasks
+					}
 				}
 				if showVariants {
-					sortByName := model.BuildVariantsByName(p.BuildVariants)
-					sort.Sort(sortByName)
-					tmp.Variants = sortByName
+					if diffable {
+						sortBVsByName := model.BuildVariantsByName(p.BuildVariants)
+						sort.Sort(sortBVsByName)
+						tmp.Variants = sortBVsByName
+					} else {
+						tmp.Variants = p.BuildVariants
+					}
 				}
 				out = tmp
 			} else if diffable {

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"sort"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	yaml "gopkg.in/20210107192922/yaml.v3"
+	upgradedYAML "gopkg.in/yaml.v3"
 )
 
 func Evaluate() cli.Command {
 	const (
 		taskFlagName     = "tasks"
 		variantsFlagName = "variants"
+		diffableFlagName = "diffable"
 	)
 
 	return cli.Command{
@@ -28,12 +31,21 @@ func Evaluate() cli.Command {
 			cli.BoolFlag{
 				Name:  variantsFlagName,
 				Usage: "only show variant definitions",
-			}),
+			}, cli.BoolFlag{
+				Name:  useUpgradedYAMLFlagName,
+				Usage: "use upgraded YAML version",
+			}, cli.BoolFlag{
+				Name:  diffableFlagName,
+				Usage: "show the project configuration in an ordered, diff-friendly format",
+			},
+		),
 		Before: mergeBeforeFuncs(requirePathFlag),
 		Action: func(c *cli.Context) error {
 			path := c.String(pathFlagName)
 			showTasks := c.Bool(taskFlagName)
 			showVariants := c.Bool(variantsFlagName)
+			useUpgradedYAML := c.Bool(useUpgradedYAMLFlagName)
+			diffable := c.Bool(diffableFlagName)
 
 			configBytes, err := ioutil.ReadFile(path)
 			if err != nil {
@@ -43,7 +55,8 @@ func Evaluate() cli.Command {
 			p := &model.Project{}
 			ctx := context.Background()
 			opts := &model.GetProjectOpts{
-				ReadFileFrom: model.ReadFromLocal,
+				ReadFileFrom:    model.ReadFromLocal,
+				UseUpgradedYAML: useUpgradedYAML,
 			}
 			_, err = model.LoadProjectInto(ctx, configBytes, opts, "", p)
 			if err != nil {
@@ -62,16 +75,96 @@ func Evaluate() cli.Command {
 					tmp.Tasks = p.Tasks
 				}
 				if showVariants {
-					tmp.Variants = p.BuildVariants
+					sortByName := model.BuildVariantsByName(p.BuildVariants)
+					sort.Sort(sortByName)
+					tmp.Variants = sortByName
 				}
+				out = tmp
+			} else if diffable {
+				// TODO (EVG-17291): remove the diffable and useUpgradedYAML
+				// flags once the YAML is upgraded.
+				//
+				// Include all fields in the project config that potentially
+				// have nested maps because those are affected by the bug fixed
+				// in the YAML upgrade.
+
+				tmp := struct {
+					Functions  interface{} `yaml:"functions,omitempty"`
+					Tasks      interface{} `yaml:"tasks,omitempty"`
+					Variants   interface{} `yaml:"buildvariants,omitempty"`
+					TaskGroups interface{} `yaml:"task_groups,omitempty"`
+					Parameters interface{} `yaml:"parameters,omitempty"`
+					Pre        interface{} `yaml:"pre,omitempty"`
+					Post       interface{} `yaml:"post,omitempty"`
+					Timeout    interface{} `yaml:"timeout,omitempty"`
+				}{}
+
+				// In order to make the project config easily diffable,
+				// evergreen evaluate has to always produce the same output for
+				// the same input (i.e. if you pass in the same YAML file
+				// multiple times, it should always produce the same output).
+				// LoadProjectInto does not provide this kind of guarantee, and
+				// may produce some out-of-order results for unordered lists.
+				//
+				// To consistently produce the same output, sort fields that are
+				// lists where order may be shuffled by LoadProjectInto. For
+				// example, build variants are a list where order is not
+				// important, and LoadProjectInto shuffles the order. In
+				// contrast, Pre commands are an ordered list, so they already
+				// retain their ordering.
+
+				if p.Functions != nil {
+					tmp.Functions = p.Functions
+				}
+
+				if p.Tasks != nil {
+					sortTasksByName := model.ProjectTasksByName(p.Tasks)
+					sort.Sort(sortTasksByName)
+					tmp.Tasks = sortTasksByName
+				}
+
+				if p.BuildVariants != nil {
+					sortBVsByName := model.BuildVariantsByName(p.BuildVariants)
+					sort.Sort(sortBVsByName)
+					tmp.Variants = sortBVsByName
+				}
+
+				if p.TaskGroups != nil {
+					sortTaskGroupsByName := model.TaskGroupsByName(p.TaskGroups)
+					sort.Sort(sortTaskGroupsByName)
+					tmp.TaskGroups = sortTaskGroupsByName
+				}
+
+				if p.Parameters != nil {
+					tmp.Parameters = p.Parameters
+				}
+
+				if p.Pre != nil {
+					tmp.Pre = p.Pre
+				}
+				if p.Post != nil {
+					tmp.Post = p.Post
+				}
+				if p.Timeout != nil {
+					tmp.Timeout = p.Timeout
+				}
+
 				out = tmp
 			} else {
 				out = p
 			}
 
-			outYAML, err := yaml.Marshal(out)
-			if err != nil {
-				return errors.Wrap(err, "marshalling evaluated project YAML")
+			var outYAML []byte
+			if useUpgradedYAML {
+				outYAML, err = upgradedYAML.Marshal(out)
+				if err != nil {
+					return errors.Wrap(err, "marshalling evaluated project YAML with upgraded YAML version")
+				}
+			} else {
+				outYAML, err = yaml.Marshal(out)
+				if err != nil {
+					return errors.Wrap(err, "marshalling evaluated project YAML")
+				}
 			}
 
 			fmt.Println(string(outYAML))


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18518

### Description 
Apologies for the long description, but this change has a bunch of context. The tl;dr is that `evergreen evaluate` now produces output consistently and also outputs more fields.

This is a follow-on to #6002 and is related to #6017. The downside of #6017 was that `evergreen validate` can only check if the upgraded YAML passes validation, but can't check that some runtime values (like expansions) would be exactly the same pre-upgrade and post-upgrade. Unfortunately, the YAML upgrade _may_ change the YAML parsing behavior such that the YAML is still syntactically valid, just different. Users would be most interested in knowing if their YAML is parsed _differently_, rather than simply knowing if their YAML is valid, because this can result in different behavior when the task actually runs.

This change provides a temporary tool that makes it easy for users to figure out exactly "what will change" for a given project YAML after the YAML upgrade in [EVG-17291](https://jira.mongodb.org/browse/EVG-17291) rolls out by adding a temporary feature enhancement to `evergreen evaluate`. This enhancement makes it easier to produce a side-by-side file diff of the pre-upgraded and post-upgraded YAML (similar to a `git diff` of changes, except for YAML). `evergreen evaluate` already produces the YAML after things such as Evergreen tags and YAML aliases are resolved, but currently does so in such a way that shuffles the ordering of some YAML fields (like the order of the `buildvariants:` section). For example, if you ran `evergreen evaluate` before this change, the build variants order was shuffled, so running `evergreen evaluate` multiple times on the same file would produce differently-ordered YAML results. For example:
```yaml
# Original YAML lists build variants in order: bv0, bv1, bv2
buildvariants:
    - name: bv0
    - name: bv1
    - name: bv2
```
```yaml
# evergreen evaluate YAML result lists build variants in a different order:
buildvariants:
    - name: bv2
    - name: bv0
    - name: bv1
```
This makes it difficult to compare two results from `evergreen evaluate` because it does not produce consistent output for the same input. I enhanced `evergreen evaluate` to ensure that it will produce the same output consistently, thus enabling users to "diff" what will happen pre-upgrade and post-upgrade for their YAML.

* Add `--use_upgraded_yaml` flag to `evergreen evaluate` to use the upgraded YAML version rather than the current one.
* Add `--diffable` flag to `evergreen evaluate` to produce side-by-side diffable YAMLs. This is achieved by doing the following:
    * Sort fields in `evergreen evaluate` according to their name for cases where it uses unordered lists.
    * Ensure all fields that can contain nested maps are included in `evergreen evaluate`. These fields are included because nested map aliases are the ones affected by the YAML upgrade.

### Testing 
I didn't think it was worth adding automated tests because it's a temporary feature until the YAML upgrade is rolled out. Instead, I tested this manually on our self-tests YAML and on the server YAML. For example, for the server's YAML, I ran this:
```sh
# Outputs the parsed YAML pre-upgrade
evergreen evaluate --diffable etc/evergreen.yml

# Outputs the parsed YAML post-upgrade
evergreen evaluate --use_upgraded_yaml --diffable etc/evergreen.yml
```

I verified the two desired properties:
1. `evergreen evaluate` always produces the same output for the same exact input.
2. The fields are sorted so that using a diffing tool (like `diff` or `vimdiff`) produces side-by-side results that show _only_ the different fields.