### PR TITLE
EVG-18381 Refactor Github child patch subscriptions

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -190,11 +190,6 @@ type GithubPullRequestSubscriber struct {
 	Type     string `bson:"type"`
 }
 
-const (
-	WaitOnChild           = "wait-on-child"
-	SendChildPatchOutcome = "send-child-patch-outcome"
-)
-
 func (s *GithubPullRequestSubscriber) String() string {
 	return fmt.Sprintf("%s-%s-%d-%s-%s", s.Owner, s.Repo, s.PRNumber, s.Ref, s.ChildId)
 }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -791,6 +791,12 @@ func NewVersionGithubCheckOutcomeSubscription(id string, sub Subscriber) Subscri
 }
 
 func NewExpiringPatchOutcomeSubscription(id string, sub Subscriber) Subscription {
+	subscription := NewSubscriptionByID(ResourceTypePatch, TriggerFamilyOutcome, id, sub)
+	subscription.LastUpdated = time.Now()
+	return subscription
+}
+
+func NewExpiringPatchChildOutcomeSubscription(id string, sub Subscriber) Subscription {
 	subscription := NewSubscriptionByID(ResourceTypePatch, TriggerOutcome, id, sub)
 	subscription.LastUpdated = time.Now()
 	return subscription

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -74,7 +74,9 @@ const (
 	ObjectHost    = "host"
 	ObjectPatch   = "patch"
 
-	TriggerOutcome                   = "outcome"
+	TriggerOutcome = "outcome"
+	// TriggerFamilyOutcome indicates that a patch or version completed,
+	// and all their child patches (if there are any) have also completed.
 	TriggerFamilyOutcome             = "family-outcome"
 	TriggerGithubCheckOutcome        = "github-check-outcome"
 	TriggerFailure                   = "failure"

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -117,42 +117,6 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 			return nil, nil
 		}
 	}
-
-	if sub.Subscriber.Type == event.GithubPullRequestSubscriberType {
-		target, ok := sub.Subscriber.Target.(*event.GithubPullRequestSubscriber)
-		if !ok {
-			return nil, errors.Errorf("target '%s' didn't not have expected type", sub.Subscriber.Target)
-		}
-		subType := target.Type
-
-		if t.patch.IsParent() || (t.patch.IsChild() && subType == event.WaitOnChild) {
-			// get the children or siblings to wait on
-			childrenOrSiblings, parentPatch, err := t.patch.GetPatchFamily()
-			if err != nil {
-				return nil, errors.Wrap(err, "getting child or sibling patches")
-			}
-
-			// make sure the parent is done, if not, wait for the parent
-			if t.patch.IsChild() && !evergreen.IsFinishedPatchStatus(parentPatch.Status) {
-				return nil, nil
-			}
-			childrenStatus, err := getChildrenOrSiblingsReadiness(childrenOrSiblings)
-			if err != nil {
-				return nil, errors.Wrap(err, "getting child or sibling information")
-			}
-			if !evergreen.IsFinishedPatchStatus(childrenStatus) {
-				return nil, nil
-			}
-			if childrenStatus == evergreen.PatchFailed {
-				t.data.Status = evergreen.PatchFailed
-			}
-
-			if t.patch.IsChild() {
-				// we want the subscription to be on the parent. now that the children are done, the parent can be considered done.
-				t.patch = parentPatch
-			}
-		}
-	}
 	return t.generate(sub)
 }
 
@@ -162,30 +126,6 @@ func (t *patchTriggers) patchFailure(sub *event.Subscription) (*notification.Not
 	}
 
 	return t.generate(sub)
-}
-
-func getChildrenOrSiblingsReadiness(childrenOrSiblings []string) (string, error) {
-	childrenStatus := evergreen.PatchSucceeded
-	if len(childrenOrSiblings) == 0 {
-		return "", nil
-	}
-	for _, childPatch := range childrenOrSiblings {
-		childPatchDoc, err := patch.FindOneId(childPatch)
-		if err != nil {
-			return "", errors.Wrapf(err, "getting tasks for child patch '%s'", childPatch)
-		}
-		if childPatchDoc == nil {
-			return "", errors.Errorf("child patch '%s' not found", childPatch)
-		}
-		if childPatchDoc.Status == evergreen.PatchFailed {
-			childrenStatus = evergreen.PatchFailed
-		}
-		if !evergreen.IsFinishedPatchStatus(childPatchDoc.Status) {
-			return childPatchDoc.Status, nil
-		}
-	}
-	return childrenStatus, nil
-
 }
 
 func finalizeChildPatch(sub *event.Subscription) error {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -367,13 +367,6 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		if err = buildSub.Upsert(); err != nil {
 			catcher.Wrap(err, "inserting build subscription for GitHub PR")
 		}
-		waitOnChilSub := event.NewGithubStatusAPISubscriber(event.GithubPullRequestSubscriber{
-			Owner:    patchDoc.GithubPatchData.BaseOwner,
-			Repo:     patchDoc.GithubPatchData.BaseRepo,
-			PRNumber: patchDoc.GithubPatchData.PRNumber,
-			Ref:      patchDoc.GithubPatchData.HeadHash,
-			Type:     event.WaitOnChild,
-		})
 		if patchDoc.IsParent() {
 			// add a subscription on each child patch to report it's status to github when it's done.
 			for _, childPatch := range patchDoc.Triggers.ChildPatches {
@@ -383,18 +376,11 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 					PRNumber: patchDoc.GithubPatchData.PRNumber,
 					Ref:      patchDoc.GithubPatchData.HeadHash,
 					ChildId:  childPatch,
-					Type:     event.SendChildPatchOutcome,
 				})
-				patchSub := event.NewExpiringPatchOutcomeSubscription(childPatch, childGhStatusSub)
+				patchSub := event.NewExpiringPatchChildOutcomeSubscription(childPatch, childGhStatusSub)
 				if err = patchSub.Upsert(); err != nil {
 					catcher.Wrap(err, "isnerting child patch subscription for GitHub PR")
 				}
-				// add subscription so that the parent can wait on the children
-				patchSub = event.NewExpiringPatchOutcomeSubscription(childPatch, waitOnChilSub)
-				if err = patchSub.Upsert(); err != nil {
-					catcher.Wrap(err, "inserting patch subscription for GitHub PR")
-				}
-
 			}
 		}
 	}


### PR DESCRIPTION
[EVG-18381](https://jira.mongodb.org/browse/EVG-18381)

### Description 
We no longer need to subscribe on all github pr child patches so that we can wait on it. We can use the family-outcom trigger instead. 

### Testing 
[Tested on staging ](https://github.com/evergreen-ci/commit-queue-sandbox/pull/376)
