### PR TITLE
EVG-18505 fix evergreen validate using all-configs input

### DIFF
--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -55,7 +55,7 @@ func (pc *ProjectConfig) isEmpty() bool {
 	for i := 0; i < reflectedConfig.NumField(); i++ {
 		field := reflectedConfig.Field(i)
 		name := types.Field(i).Name
-		if name != "Id" && name != "Identifier" {
+		if name != "Id" && name != "Identifier" && name != "CreateTime" {
 			if !util.IsFieldUndefined(field) {
 				return false
 			}

--- a/model/project_configs.go
+++ b/model/project_configs.go
@@ -49,16 +49,13 @@ func (pc *ProjectConfig) MarshalBSON() ([]byte, error) {
 }
 
 func (pc *ProjectConfig) isEmpty() bool {
-	reflectedConfig := reflect.ValueOf(pc).Elem()
-	types := reflect.TypeOf(pc).Elem()
+	// ProjectConfig values outside of ProjectConfigFields are metadata, so we don't want to check those.
+	reflectedConfig := reflect.ValueOf(pc.ProjectConfigFields)
 
 	for i := 0; i < reflectedConfig.NumField(); i++ {
 		field := reflectedConfig.Field(i)
-		name := types.Field(i).Name
-		if name != "Id" && name != "Identifier" && name != "CreateTime" {
-			if !util.IsFieldUndefined(field) {
-				return false
-			}
+		if !util.IsFieldUndefined(field) {
+			return false
 		}
 	}
 	return true

--- a/model/project_configs_test.go
+++ b/model/project_configs_test.go
@@ -16,6 +16,7 @@ task_groups:
   - command: shell.exec
     params:
       script: "echo hi"
+create_time: 2022-12-15T17:18:32Z
 `
 	pc, err := CreateProjectConfig([]byte(projYml), "")
 	assert.Nil(t, err)


### PR DESCRIPTION
[EVG-18505](https://jira.mongodb.org/browse/EVG-18505)

### Description 
I think that because all-configs returns create_time, and this is used by both ProjectConfig and ParserProject it was throwing everything off.

### Testing 
Verified that this works with validate and added a test to handle create_time, which failed before these changes.
