### PR TITLE
EVG-15703: Require failedOnly argument in restartTask mutation

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -438,7 +438,7 @@ type ComplexityRoot struct {
 		RemoveVolume                  func(childComplexity int, volumeID string) int
 		ReprovisionToNew              func(childComplexity int, hostIds []string) int
 		RestartJasper                 func(childComplexity int, hostIds []string) int
-		RestartTask                   func(childComplexity int, taskID string, failedOnly *bool) int
+		RestartTask                   func(childComplexity int, taskID string, failedOnly bool) int
 		RestartVersions               func(childComplexity int, versionID string, abort bool, versionsToRestart []*model1.VersionToRestart) int
 		SaveProjectSettingsForSection func(childComplexity int, projectSettings *model.APIProjectSettings, section ProjectSettingsSection) int
 		SaveRepoSettingsForSection    func(childComplexity int, repoSettings *model.APIProjectSettings, section ProjectSettingsSection) int
@@ -1265,7 +1265,7 @@ type MutationResolver interface {
 	UpdateVolume(ctx context.Context, updateVolumeInput UpdateVolumeInput) (bool, error)
 	AbortTask(ctx context.Context, taskID string) (*model.APITask, error)
 	OverrideTaskDependencies(ctx context.Context, taskID string) (*model.APITask, error)
-	RestartTask(ctx context.Context, taskID string, failedOnly *bool) (*model.APITask, error)
+	RestartTask(ctx context.Context, taskID string, failedOnly bool) (*model.APITask, error)
 	ScheduleTasks(ctx context.Context, taskIds []string) ([]*model.APITask, error)
 	SetTaskPriority(ctx context.Context, taskID string, priority int) (*model.APITask, error)
 	UnscheduleTask(ctx context.Context, taskID string) (*model.APITask, error)
@@ -3233,7 +3233,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.RestartTask(childComplexity, args["taskId"].(string), args["failedOnly"].(*bool)), true
+		return e.complexity.Mutation.RestartTask(childComplexity, args["taskId"].(string), args["failedOnly"].(bool)), true
 
 	case "Mutation.restartVersions":
 		if e.complexity.Mutation.RestartVersions == nil {
@@ -8245,10 +8245,10 @@ func (ec *executionContext) field_Mutation_restartTask_args(ctx context.Context,
 		}
 	}
 	args["taskId"] = arg0
-	var arg1 *bool
+	var arg1 bool
 	if tmp, ok := rawArgs["failedOnly"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("failedOnly"))
-		arg1, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg1, err = ec.unmarshalNBoolean2bool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -22230,7 +22230,7 @@ func (ec *executionContext) _Mutation_restartTask(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().RestartTask(rctx, fc.Args["taskId"].(string), fc.Args["failedOnly"].(*bool))
+		return ec.resolvers.Mutation().RestartTask(rctx, fc.Args["taskId"].(string), fc.Args["failedOnly"].(bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -872,7 +872,7 @@ func (r *mutationResolver) OverrideTaskDependencies(ctx context.Context, taskID 
 }
 
 // RestartTask is the resolver for the restartTask field.
-func (r *mutationResolver) RestartTask(ctx context.Context, taskID string, failedOnly *bool) (*restModel.APITask, error) {
+func (r *mutationResolver) RestartTask(ctx context.Context, taskID string, failedOnly bool) (*restModel.APITask, error) {
 	usr := mustHaveUser(ctx)
 	username := usr.Username()
 	t, err := task.FindOneId(taskID)
@@ -882,8 +882,7 @@ func (r *mutationResolver) RestartTask(ctx context.Context, taskID string, faile
 	if t == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id '%s'", taskID))
 	}
-	// TODO (EVG-15703): Convert *bool to bool once UI has been deployed.
-	if err := model.ResetTaskOrDisplayTask(t, username, evergreen.UIPackage, utility.FromBoolPtr(failedOnly), nil); err != nil {
+	if err := model.ResetTaskOrDisplayTask(t, username, evergreen.UIPackage, failedOnly, nil); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error restarting task '%s': %s", taskID, err.Error()))
 	}
 	t, err = task.FindOneIdAndExecutionWithDisplayStatus(taskID, nil)

--- a/graphql/schema/mutation.graphql
+++ b/graphql/schema/mutation.graphql
@@ -73,7 +73,7 @@ type Mutation {
   # task
   abortTask(taskId: String!): Task!
   overrideTaskDependencies(taskId: String!): Task!
-  restartTask(taskId: String!, failedOnly: Boolean): Task!
+  restartTask(taskId: String!, failedOnly: Boolean!): Task!
   scheduleTasks(taskIds: [String!]!): [Task!]!
   setTaskPriority(taskId: String!, priority: Int!): Task!
   unscheduleTask(taskId: String!): Task!

--- a/graphql/tests/restartTask/queries/error-invalid-task_id.graphql
+++ b/graphql/tests/restartTask/queries/error-invalid-task_id.graphql
@@ -1,5 +1,5 @@
 mutation {
-  restartTask(taskId: "nonexistent") {
+  restartTask(taskId: "nonexistent", failedOnly: false) {
     status
     id
   }

--- a/graphql/tests/restartTask/queries/success.graphql
+++ b/graphql/tests/restartTask/queries/success.graphql
@@ -1,5 +1,5 @@
 mutation {
-  restartTask(taskId: "task1") {
+  restartTask(taskId: "task1", failedOnly: false) {
     status
     id
   }


### PR DESCRIPTION
[EVG-15703](https://jira.mongodb.org/browse/EVG-15703)

### Description 
- Make `failedOnly` param non-nilable now that the front end is including it in `restartTask` function calls.

### Testing 
- Update unit tests

To be deployed after https://github.com/evergreen-ci/spruce/pull/1582