### PR TITLE
EVG-17206 Add help text to set-module and patch-set-module

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-12-14"
+	ClientVersion = "2022-12-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-12-05"

--- a/operations/model.go
+++ b/operations/model.go
@@ -222,9 +222,12 @@ func (s *ClientSettings) getModule(patchId, moduleName string) (*model.Module, e
 	if err != nil {
 		return nil, err
 	}
+
+	helpText := "Note: In order to set a module, you need to be in the directory for the module project, not the directory for the project that the module is being applied onto."
+
 	if len(proj.Modules) == 0 {
-		return nil, errors.Errorf("Project has no configured modules. Specify different project or " +
-			"see the evergreen configuration file for module configuration.")
+		return nil, errors.Errorf("Project has no configured modules. Specify different project or "+
+			"see the evergreen configuration file for module configuration.\n %s", helpText)
 	}
 	module, err := model.GetModuleByName(proj.Modules, moduleName)
 	if err != nil {
@@ -232,8 +235,8 @@ func (s *ClientSettings) getModule(patchId, moduleName string) (*model.Module, e
 		for _, m := range proj.Modules {
 			moduleNames = append(moduleNames, m.Name)
 		}
-		return nil, errors.Errorf("Could not find module named '%s' for project; specify different project or select correct module from:\n\t%s",
-			moduleName, strings.Join(moduleNames, "\n\t"))
+		return nil, errors.Errorf("Could not find module named '%s' for project; specify different project or select correct module from:\n\t%s\n%s",
+			moduleName, strings.Join(moduleNames, "\n\t"), helpText)
 	}
 	return module, nil
 }

--- a/operations/model.go
+++ b/operations/model.go
@@ -223,7 +223,7 @@ func (s *ClientSettings) getModule(patchId, moduleName string) (*model.Module, e
 		return nil, err
 	}
 
-	helpText := "Note: In order to set a module, you need to be in the directory for the module project, not the directory for the project that the module is being applied onto."
+	const helpText = "Note: In order to set a module, you need to be in the directory for the module project, not the directory for the project that the module is being applied onto."
 
 	if len(proj.Modules) == 0 {
 		return nil, errors.Errorf("Project has no configured modules. Specify different project or "+


### PR DESCRIPTION
[EVG-17206](https://jira.mongodb.org/browse/EVG-17206)

### Description 
It's easy to forget which directory you have to log which command in. This help text should be helpful if someone runs set-module in the wrong project directory.  

### Testing 
Ran one of the commands locally 
