### PR TITLE
EVG-18218: fix local alias interaction with default variants/tasks

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-12-14"
+	ClientVersion = "2022-12-19"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-12-05"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -178,10 +178,6 @@ func Patch() cli.Command {
 			}
 			params.Description = params.getDescription()
 
-			if err = params.setLocalAliases(conf); err != nil {
-				return errors.Wrap(err, "setting local aliases")
-			}
-
 			if (params.RepeatDefinition || params.RepeatFailed) && (len(params.Tasks) > 0 || len(params.Variants) > 0) {
 				return errors.Errorf("can't define tasks/variants when reusing previous patch's tasks and variants")
 			}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18218

### Description 
When referencing a local alias (i.e. using `evergreen patch --alias <alias>`), setting the local alias also unsets the `patchParams.Alias field`, which makes the CLI command [later fall back to also adding the default variants/tasks](https://github.com/evergreen-ci/evergreen/blob/604a52175507056ab009f0acecdd409d311784a4/operations/patch_util.go#L391-L393). It seems like what we actually want it to do is for the local alias to take precedence - if the alias matches a local alias, then use the variants/tasks defined for that local alias, instead of the default alias/variants/tasks.

I also fixed some tiny issues with the local aliases, such as not logging an error when it fails to load local aliases, and removing some unnecessary local aliases code.

### Testing 
* Added unit tests for local alias and defaulting logic.
* Tested against staging to verify that local aliases select the expected variants/tasks and don't use the defaults.