### PR TITLE
EVG-17605 upgrade warning for empty shell.exec script to error

### DIFF
--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -85,7 +85,6 @@ func (c *shellExec) ParseParams(params map[string]interface{}) error {
 	if params == nil {
 		return errors.New("params cannot be nil")
 	}
-	// Existing projects rely on having a missing script breaking the validation, so we will not error on that case
 
 	err := mapstructure.Decode(params, c)
 	if err != nil {
@@ -96,7 +95,9 @@ func (c *shellExec) ParseParams(params map[string]interface{}) error {
 		c.IgnoreStandardError = true
 		c.IgnoreStandardOutput = true
 	}
-
+	if c.Script == "" {
+		return errors.New("must specify a script")
+	}
 	if c.Shell == "" {
 		c.Shell = "sh"
 	}

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -74,6 +74,7 @@ func (s *shellExecuteCommandSuite) TearDownTest() {
 func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
 	cmd := &shellExec{
 		WorkingDir: testutil.GetDirectoryOfFile(),
+		Script:     "my script",
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.Empty(cmd.Shell)
@@ -83,7 +84,9 @@ func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
 }
 
 func (s *shellExecuteCommandSuite) TestSilentAndRedirectToStdOutError() {
-	cmd := &shellExec{}
+	cmd := &shellExec{
+		Script: "my script",
+	}
 
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
 	s.False(cmd.IgnoreStandardError)
@@ -138,7 +141,7 @@ func (s *shellExecuteCommandSuite) TestTerribleQuotingIsHandledProperly() {
 	}
 }
 
-func (s *shellExecuteCommandSuite) TestShellIsntChangedDuringExecution() {
+func (s *shellExecuteCommandSuite) TestShellIsNotChangedDuringExecution() {
 	for _, sh := range s.shells {
 		cmd := &shellExec{Shell: sh, WorkingDir: testutil.GetDirectoryOfFile()}
 		cmd.SetJasperManager(s.jasper)

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -74,7 +74,7 @@ func (s *shellExecuteCommandSuite) TearDownTest() {
 func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
 	cmd := &shellExec{
 		WorkingDir: testutil.GetDirectoryOfFile(),
-		Script:     "my script",
+		Script:     "exit 0",
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.Empty(cmd.Shell)
@@ -85,7 +85,7 @@ func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
 
 func (s *shellExecuteCommandSuite) TestSilentAndRedirectToStdOutError() {
 	cmd := &shellExec{
-		Script: "my script",
+		Script: "exit 0",
 	}
 
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-12-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-12-05"
+	AgentVersion = "2022-12-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1193,12 +1193,6 @@ func validateCommands(section string, project *model.Project,
 				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'", cmd.Command, cmd.Function),
 			})
 		}
-		if cmd.Command == evergreen.ShellExecCommandName && cmd.Params["script"] == nil {
-			errs = append(errs, ValidationError{
-				Level:   Warning,
-				Message: fmt.Sprintf("%s section: command '%s' specified without a script.", section, cmd.Command),
-			})
-		}
 	}
 	return errs
 }

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1751,7 +1751,7 @@ tasks:
 			So(len(validationErrs.AtLevel(Error)), ShouldEqual, 1)
 			So(validationErrs.AtLevel(Error)[0].Message, ShouldContainSubstring, "params cannot be nil")
 		})
-		Convey("an warning should return if a shell.exec command is missing a script", func() {
+		Convey("an error should return if a shell.exec command is missing a script", func() {
 			project := &model.Project{
 				Functions: map[string]*model.YAMLCommandSet{
 					"funcOne": {
@@ -1767,8 +1767,8 @@ tasks:
 			}
 			validationErrs := validatePluginCommands(project)
 			So(validationErrs, ShouldNotResemble, ValidationErrors{})
-			So(len(validationErrs.AtLevel(Warning)), ShouldEqual, 1)
-			So(validationErrs.AtLevel(Warning)[0].Message, ShouldContainSubstring, "specified without a script")
+			So(len(validationErrs.AtLevel(Error)), ShouldEqual, 1)
+			So(validationErrs.AtLevel(Error)[0].Message, ShouldContainSubstring, "must specify a script")
 		})
 		Convey("an error should not be thrown if a shell.exec command is defined with a script", func() {
 			project := &model.Project{


### PR DESCRIPTION
[EVG-17605 ](https://jira.mongodb.org/browse/EVG-17605)

### Description 
I think we didn't make this required bc at the time it would've affected a lot of projects? But it's only v4.0 and curatorbin now; reached out to those project owners. (Added https://github.com/evergreen-ci/curatorbin/pull/9 for curatorbin)

### Testing 
Updated test.
