### PR TITLE
EVG-17302 Do not allow aliases when --reuse or --repeat failed is used

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2022-12-19"
+	ClientVersion = "2022-12-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2022-12-05"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -178,8 +178,8 @@ func Patch() cli.Command {
 			}
 			params.Description = params.getDescription()
 
-			if (params.RepeatDefinition || params.RepeatFailed) && (len(params.Tasks) > 0 || len(params.Variants) > 0) {
-				return errors.Errorf("can't define tasks/variants when reusing previous patch's tasks and variants")
+			if (params.RepeatDefinition || params.RepeatFailed) && (len(params.Tasks) > 0 || len(params.Variants) > 0 || len(params.Alias) > 0) {
+				return errors.Errorf("can't define tasks, variants or aliases when reusing previous patch's tasks and variants")
 			}
 
 			diffData, err := loadGitData("", ref.Branch, params.Ref, "", params.PreserveCommits, args...)

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -178,8 +178,12 @@ func Patch() cli.Command {
 			}
 			params.Description = params.getDescription()
 
-			if (params.RepeatDefinition || params.RepeatFailed) && (len(params.Tasks) > 0 || len(params.Variants) > 0 || len(params.Alias) > 0) {
-				return errors.Errorf("can't define tasks, variants or aliases when reusing previous patch's tasks and variants")
+			isReusing := params.RepeatDefinition || params.RepeatFailed
+			hasTasksOrVariants := len(params.Tasks) > 0 || len(params.Variants) > 0
+			hasRegexTasksOrVariants := len(params.RegexTasks) > 0 || len(params.RegexVariants) > 0
+
+			if isReusing && (hasTasksOrVariants || hasRegexTasksOrVariants || len(params.Alias) > 0) {
+				return errors.Errorf("can't define tasks, variants, regex tasks, regex variants or aliases when reusing previous patch's tasks and variants")
 			}
 
 			diffData, err := loadGitData("", ref.Branch, params.Ref, "", params.PreserveCommits, args...)


### PR DESCRIPTION
[EVG-17302](https://jira.mongodb.org/browse/EVG-17302)

### Description 
Do not allow aliases when --reuse or --repeat failed is used.

### Testing 
Tested locally 
