### PR TITLE
EVG-17118 rename route to avoid conflict

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1021,7 +1021,7 @@ func (h *getProjectTasksHandler) Run(ctx context.Context) gimlet.Responder {
 
 ////////////////////////////////////////////////////////////////////////
 //
-// GET /rest/v2/projects/{project_id}/tasks/executions
+// GET /rest/v2/projects/{project_id}/task_executions
 
 type getProjectTaskExecutionsHandler struct {
 	projectName string

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -205,7 +205,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/test_stats").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTestStats(opts.URL, env.PrestoDB()))
 	app.AddRoute("/projects/{project_id}/versions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectVersionsHandler(opts.URL))
 	app.AddRoute("/projects/{project_id}/tasks/{task_name}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTasksHandler(opts.URL))
-	app.AddRoute("/projects/{project_id}/tasks/executions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskExecutionsHandler())
+	app.AddRoute("/projects/{project_id}/task_executions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskExecutionsHandler())
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases())
 	app.AddRoute("/projects/{project_id}/parameters").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchParameters())
 	app.AddRoute("/projects/variables/rotate").Version(2).Put().Wrap(requireUser, createProject).RouteHandler(makeProjectVarsPut())


### PR DESCRIPTION
[EVG-17118](https://jira.mongodb.org/browse/EVG-17118)

### Description 
I guess I forgot to test this end to end 🤦‍♀️  tasks/executions conflicts with the tasks/{task_name} route so renaming.

### Testing 
Tested using evergreen local.