### PR TITLE
EVG-7440 Allow updating github statuses for multiple builds at once

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -409,6 +409,19 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 			event.LogTaskRestarted(t.Id, t.Execution, caller)
 		}
 	}
+
+	buildIdsMap := map[string]bool{}
+	var buildIds []string
+	for _, t := range tasksToRestart {
+		buildIdsMap[t.BuildId] = true
+	}
+	for buildId := range buildIdsMap {
+		buildIds = append(buildIds, buildId)
+	}
+	if err = UpdateVersionAndPatchStatusForBuilds(buildIds); err != nil {
+		return errors.Wrapf(err, "updating build and version status for version '%s'", versionId)
+	}
+
 	if err = build.SetBuildStartedForTasks(tasksToRestart, caller); err != nil {
 		return errors.Wrap(err, "setting builds started")
 	}

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -45,13 +45,15 @@ func TestRestartVersion(t *testing.T) {
 	// Insert data for the test paths
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
 	versions := []*Version{
-		{Id: "version3"},
+		{Id: "version1"},
 	}
 	tasks := []*task.Task{
-		{Id: "task5", Version: "version3", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build1"},
+		{Id: "task1", Version: "version1", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build1"},
+		{Id: "task2", Version: "version1", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build2"},
 	}
 	builds := []*build.Build{
-		{Id: "build1"},
+		{Id: "build1", Version: "version1"},
+		{Id: "build2", Version: "version1"},
 	}
 	for _, item := range versions {
 		require.NoError(t, item.Insert())
@@ -63,21 +65,21 @@ func TestRestartVersion(t *testing.T) {
 		require.NoError(t, item.Insert())
 	}
 
-	versionId := "version3"
-	err := RestartTasksInVersion(versionId, true, "caller3")
+	versionId := "version1"
+	err := RestartTasksInVersion(versionId, true, "caller")
 	assert.NoError(t, err)
 
 	// When a version is restarted, all of its completed tasks should be reset.
 	// (task.Status should be undispatched)
-	t5, _ := task.FindOneId("task5")
-	assert.Equal(t, versionId, t5.Version)
-	assert.Equal(t, evergreen.TaskUndispatched, t5.Status)
+	t1, _ := task.FindOneId("task1")
+	assert.Equal(t, versionId, t1.Version)
+	assert.Equal(t, evergreen.TaskUndispatched, t1.Status)
 
 	// Build status for all builds containing the tasks that we touched
 	// should be updated.
 	b1, _ := build.FindOneId("build1")
 	assert.Equal(t, evergreen.BuildStarted, b1.Status)
-	assert.Equal(t, "caller3", b1.ActivatedBy)
+	assert.Equal(t, "caller", b1.ActivatedBy)
 }
 
 func TestFindVersionByIdFail(t *testing.T) {


### PR DESCRIPTION
[EVG-7440](https://jira.mongodb.org/browse/EVG-7440)

### Description 
< add description, context, thought process, etc >

### Testing 
Tested in staging. Confirmed that restarting a PR version changes all builds to status "pending" in the GitHub UI, and that manually restarting two or more separate builds accurately changes each corresponding build variant in the GitHub UI to "pending" as well.
