### PR TITLE
EVG-16480 Refactor build restarts to share functionality with RestartVersion

### DIFF
--- a/model/build_test.go
+++ b/model/build_test.go
@@ -176,6 +176,6 @@ func (s *BuildConnectorRestartSuite) SetupSuite() {
 }
 
 func (s *BuildConnectorRestartSuite) TestRestart() {
-	err := RestartBuild("build1", []string{}, true, "user1")
+	err := RestartBuild(&build.Build{Id: "build1"}, []string{}, true, "user1")
 	s.NoError(err)
 }

--- a/model/build_test.go
+++ b/model/build_test.go
@@ -176,9 +176,6 @@ func (s *BuildConnectorRestartSuite) SetupSuite() {
 }
 
 func (s *BuildConnectorRestartSuite) TestRestart() {
-	err := RestartAllBuildTasks("build1", "user1")
-	s.NoError(err)
-
-	err = RestartAllBuildTasks("build1", "user1")
+	err := RestartBuild("build1", []string{}, true, "user1")
 	s.NoError(err)
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -426,8 +426,8 @@ func restartTasks(allFinishedTasks []task.Task, caller, versionId string) error 
 		}
 	}
 
-	if err := errors.Wrap(build.SetBuildStartedForTasks(allFinishedTasks, caller), "setting builds started"); err != nil {
-		return err
+	if err := build.SetBuildStartedForTasks(allFinishedTasks, caller); err != nil {
+		return errors.Wrap(err, "setting builds started")
 	}
 
 	return errors.Wrap(setVersionStatus(versionId, evergreen.VersionStarted), "changing version status")

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -345,15 +345,11 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	if len(allFinishedTasks) == 0 {
 		return nil
 	}
-	err = restartTasks(allFinishedTasks, caller)
-	if err != nil {
-		return errors.Wrap(err, "restarting tasks")
-	}
-	return errors.Wrap(setVersionStatus(versionId, evergreen.VersionStarted), "changing version status")
+	return restartTasks(allFinishedTasks, caller, versionId)
 }
 
 // getTasksToReset returns all finished tasks that should be reset given an initial input list of
-// finished taskIds.
+// finished taskIds. If a display task is in the list, its execution tasks are removed if they also exist.
 func getTasksToReset(taskIds []string) ([]task.Task, error) {
 	finishedTasks, err := task.FindAll(db.Query(task.ByIdsAndStatus(taskIds, evergreen.TaskCompletedStatuses)))
 	if err != nil {
@@ -363,8 +359,6 @@ func getTasksToReset(taskIds []string) ([]task.Task, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	// Remove execution tasks in case the caller passed both display and execution tasks.
-	// The functions below are expected to work if just the display task is passed.
 	for i := len(allFinishedTasks) - 1; i >= 0; i-- {
 		t := allFinishedTasks[i]
 		if t.DisplayTask != nil {
@@ -374,8 +368,9 @@ func getTasksToReset(taskIds []string) ([]task.Task, error) {
 	return allFinishedTasks, nil
 }
 
-// restartTasks restarts all the finished tasks associated with a given build.
-func restartTasks(allFinishedTasks []task.Task, caller string) error {
+// restartTasks restarts all finished tasks in the given list that are not part of
+// a single host task group.
+func restartTasks(allFinishedTasks []task.Task, caller, versionId string) error {
 	toArchive := []task.Task{}
 	for _, t := range allFinishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() {
@@ -406,12 +401,12 @@ func restartTasks(allFinishedTasks []task.Task, caller string) error {
 				Build:     t.BuildId,
 				TaskGroup: t.TaskGroup,
 			}] = t
-			continue
-		}
-		// Only restart non-single host task group tasks
-		restartIds = append(restartIds, t.Id)
-		if t.DisplayOnly {
-			restartIds = append(restartIds, t.ExecutionTasks...)
+		} else {
+			// Only restart non-single host task group tasks
+			restartIds = append(restartIds, t.Id)
+			if t.DisplayOnly {
+				restartIds = append(restartIds, t.ExecutionTasks...)
+			}
 		}
 	}
 
@@ -431,7 +426,11 @@ func restartTasks(allFinishedTasks []task.Task, caller string) error {
 		}
 	}
 
-	return errors.Wrap(build.SetBuildStartedForTasks(allFinishedTasks, caller), "setting builds started")
+	if err := errors.Wrap(build.SetBuildStartedForTasks(allFinishedTasks, caller), "setting builds started"); err != nil {
+		return err
+	}
+
+	return errors.Wrap(setVersionStatus(versionId, evergreen.VersionStarted), "changing version status")
 }
 
 // RestartVersions restarts selected tasks for a set of versions.
@@ -447,10 +446,10 @@ func RestartVersions(versionsToRestart []*VersionToRestart, abortInProgress bool
 
 // RestartBuild restarts completed tasks associated with a given buildId.
 // If abortInProgress is true, it also sets the abort flag on any in-progress tasks.
-func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller string) error {
+func RestartBuild(build *build.Build, taskIds []string, abortInProgress bool, caller string) error {
 	if abortInProgress {
 		// abort in-progress tasks in this build
-		if err := task.AbortAndMarkResetTasksForBuild(buildId, taskIds, caller); err != nil {
+		if err := task.AbortAndMarkResetTasksForBuild(build.Id, taskIds, caller); err != nil {
 			return errors.WithStack(err)
 		}
 	}
@@ -461,7 +460,7 @@ func RestartBuild(buildId string, taskIds []string, abortInProgress bool, caller
 	if len(tasksToReset) == 0 {
 		return nil
 	}
-	return restartTasks(tasksToReset, caller)
+	return errors.Wrap(restartTasks(tasksToReset, caller, build.Version), "restarting tasks")
 }
 
 func CreateTasksCache(tasks []task.Task) []build.TaskCache {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -219,12 +219,12 @@ func TestBuildRestart(t *testing.T) {
 	// Running a multi-document transaction requires the collections to exist
 	// first before any documents can be inserted.
 	require.NoError(t, db.CreateCollections(task.Collection, task.OldCollection, VersionCollection, build.Collection))
+	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection))
 	v := &Version{Id: "version"}
 	require.NoError(t, v.Insert())
 	b := &build.Build{Id: "build", Version: "version"}
 	require.NoError(t, b.Insert())
 	Convey("Restarting a build", t, func() {
-		require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection))
 		Convey("with task abort should update the status of"+
 			" non in-progress tasks and abort in-progress ones and mark them to be reset", func() {
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -246,7 +246,7 @@ func TestBuildRestart(t *testing.T) {
 			}
 			So(taskTwo.Insert(), ShouldBeNil)
 
-			So(RestartBuild(b.Id, []string{"task1", "task2"}, true, evergreen.DefaultTaskActivator), ShouldBeNil)
+			So(RestartBuild(b, []string{"task1", "task2"}, true, evergreen.DefaultTaskActivator), ShouldBeNil)
 			var err error
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
@@ -286,7 +286,7 @@ func TestBuildRestart(t *testing.T) {
 			}
 			So(taskFour.Insert(), ShouldBeNil)
 
-			So(RestartBuild(b.Id, []string{"task3", "task4"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
+			So(RestartBuild(b, []string{"task3", "task4"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
 			var err error
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
@@ -337,7 +337,7 @@ func TestBuildRestart(t *testing.T) {
 			}
 			So(taskSeven.Insert(), ShouldBeNil)
 
-			So(RestartBuild(b.Id, []string{"task5", "task6", "task7"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
+			So(RestartBuild(b, []string{"task5", "task6", "task7"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
 			var err error
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
@@ -386,7 +386,7 @@ func TestBuildRestart(t *testing.T) {
 			}
 			So(taskNine.Insert(), ShouldBeNil)
 
-			So(RestartBuild(b.Id, []string{"task8", "task9"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
+			So(RestartBuild(b, []string{"task8", "task9"}, false, evergreen.DefaultTaskActivator), ShouldBeNil)
 			var err error
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
@@ -2104,7 +2104,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 
 	// test restarting a build
 	assert.NoError(resetTaskData())
-	assert.NoError(RestartBuild("build3", displayTasks, false, "test"))
+	assert.NoError(RestartBuild(&build.Build{Id: "build3"}, displayTasks, false, "test"))
 	tasks, err = task.FindAll(db.Query(task.ByIds(allTasks)))
 	assert.NoError(err)
 	assert.Len(tasks, 3)

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -224,11 +224,9 @@ func TestBuildRestart(t *testing.T) {
 	b := &build.Build{Id: "build", Version: "version"}
 	require.NoError(t, b.Insert())
 	Convey("Restarting a build", t, func() {
-
+		require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection))
 		Convey("with task abort should update the status of"+
 			" non in-progress tasks and abort in-progress ones and mark them to be reset", func() {
-
-			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
 
 			taskOne := &task.Task{
 				Id:          "task1",

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1969,7 +1969,8 @@ func TestVersionRestart(t *testing.T) {
 	assert.True(dbTask.ResetWhenFinished)
 	dbVersion, err = VersionFindOneId("version")
 	assert.NoError(err)
-	assert.Equal(evergreen.VersionStarted, dbVersion.Status)
+	// Version status should not update if only aborting tasks
+	assert.Equal("", dbVersion.Status)
 
 	// test that not aborting in-progress tasks does not reset them
 	assert.NoError(resetTaskData())
@@ -1982,7 +1983,8 @@ func TestVersionRestart(t *testing.T) {
 	assert.Equal(evergreen.TaskDispatched, dbTask.Status)
 	dbVersion, err = VersionFindOneId("version")
 	assert.NoError(err)
-	assert.Equal(evergreen.VersionStarted, dbVersion.Status)
+	// Version status should not update if no tasks are being reset.
+	assert.Equal("", dbVersion.Status)
 }
 
 func TestDisplayTaskRestart(t *testing.T) {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1852,7 +1852,8 @@ func updateAllMatchingDependenciesForTask(taskId, dependencyId string, unattaina
 	return res.Err()
 }
 
-func AbortTasksForBuild(buildId string, taskIds []string, caller string) error {
+// AbortAndMarkResetTasksForBuild aborts and marks tasks for a build to reset when finished.
+func AbortAndMarkResetTasksForBuild(buildId string, taskIds []string, caller string) error {
 	q := bson.M{
 		BuildIdKey: buildId,
 		StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
@@ -1864,8 +1865,9 @@ func AbortTasksForBuild(buildId string, taskIds []string, caller string) error {
 		q,
 		bson.M{
 			"$set": bson.M{
-				AbortedKey:   true,
-				AbortInfoKey: AbortInfo{User: caller},
+				AbortedKey:           true,
+				AbortInfoKey:         AbortInfo{User: caller},
+				ResetWhenFinishedKey: true,
 			},
 		},
 	)

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -232,7 +232,11 @@ func (b *buildRestartHandler) Parse(ctx context.Context, r *http.Request) error 
 
 func (b *buildRestartHandler) Run(ctx context.Context) gimlet.Responder {
 	usr := MustHaveUser(ctx)
-	err := serviceModel.RestartAllBuildTasks(b.buildId, usr.Id)
+	taskIds, err := task.FindAllTaskIDsFromBuild(b.buildId)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting tasks for build '%s'", b.buildId))
+	}
+	err = serviceModel.RestartBuild(b.buildId, taskIds, true, usr.Id)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "restarting all tasks in build '%s'", b.buildId))
 	}

--- a/rest/route/build_test.go
+++ b/rest/route/build_test.go
@@ -289,14 +289,16 @@ func TestBuildRestartSuite(t *testing.T) {
 }
 
 func (s *BuildRestartSuite) SetupSuite() {
-	s.NoError(db.ClearCollections(build.Collection))
+	s.NoError(db.ClearCollections(build.Collection, serviceModel.VersionCollection))
 	builds := []build.Build{
-		{Id: "build1", Project: "branch"},
-		{Id: "build2", Project: "notbranch"},
+		{Id: "build1", Project: "branch", Version: "version"},
+		{Id: "build2", Project: "notbranch", Version: "version"},
 	}
 	for _, item := range builds {
 		s.Require().NoError(item.Insert())
 	}
+	v := &serviceModel.Version{Id: "version"}
+	s.Require().NoError(v.Insert())
 }
 
 func (s *BuildRestartSuite) SetupTest() {

--- a/service/build.go
+++ b/service/build.go
@@ -267,7 +267,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	case evergreen.RestartAction:
-		if err = model.RestartBuild(projCtx.Build.Id, putParams.TaskIds, putParams.Abort, user.Id); err != nil {
+		if err = model.RestartBuild(projCtx.Build, putParams.TaskIds, putParams.Abort, user.Id); err != nil {
 			http.Error(w, fmt.Sprintf("Error restarting build %v", projCtx.Build.Id), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
[EVG-16480](https://jira.mongodb.org/browse/EVG-16480)

### Description 
- `RestartVersion` has special logic for restarting single host task group tasks in that instead of archiving/restarting them immediately, it marks the task group to reset when all tasks in the group finish, so they can restart together. `RestartBuild` does not have any of this logic although it should, so I've modularized the logic of `RestartVersion` into some helper functions that can be used by both.  
- Made a change to `AbortTasksForBuild` to mark the in-progress tasks it is aborting to restart when they are finished. This is how it works for `RestartVersion`, whereas when we restart a build we simply abort the in-progress tasks (which results in a partial restart of the build which is incorrect).
- Removed `RestartAllBuildTasks` and replaced its invocations with `RestartBuild`
### Testing 
Updated & added unit tests.
