### PR TITLE
EVG-18567 Avoid triggering a children_finished event when a task is restarted 

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -446,6 +446,7 @@ func TestBuildSetActivated(t *testing.T) {
 					Activated:    true,
 					BuildVariant: "bv",
 					Version:      vID,
+					Status:       evergreen.BuildStarted,
 				}
 				So(b.Insert(), ShouldBeNil)
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1164,6 +1164,16 @@ func updateBuildStatus(b *build.Build) (bool, error) {
 
 	event.LogBuildStateChangeEvent(b.Id, buildStatus.status)
 
+	notBlockedOrUnscheduled := !buildStatus.allTasksBlocked && !buildStatus.allTasksUnscheduled
+
+	// if the status has changed, re-activate the build if it's not blocked
+	if !b.Activated && notBlockedOrUnscheduled {
+		if err = b.SetActivated(true); err != nil {
+			return true, errors.Wrapf(err, "setting build '%s' as active", b.Id)
+		}
+
+	}
+
 	if evergreen.IsFinishedBuildStatus(buildStatus.status) {
 		if err = b.MarkFinished(buildStatus.status, time.Now()); err != nil {
 			return true, errors.Wrapf(err, "marking build as finished with status '%s'", buildStatus.status)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1164,10 +1164,10 @@ func updateBuildStatus(b *build.Build) (bool, error) {
 
 	event.LogBuildStateChangeEvent(b.Id, buildStatus.status)
 
-	notBlockedOrUnscheduled := !buildStatus.allTasksBlocked && !buildStatus.allTasksUnscheduled
+	shouldActivate := !buildStatus.allTasksBlocked && !buildStatus.allTasksUnscheduled
 
 	// if the status has changed, re-activate the build if it's not blocked
-	if notBlockedOrUnscheduled {
+	if shouldActivate {
 		if err = b.SetActivated(true); err != nil {
 			return true, errors.Wrapf(err, "setting build '%s' as active", b.Id)
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1167,11 +1167,10 @@ func updateBuildStatus(b *build.Build) (bool, error) {
 	notBlockedOrUnscheduled := !buildStatus.allTasksBlocked && !buildStatus.allTasksUnscheduled
 
 	// if the status has changed, re-activate the build if it's not blocked
-	if !b.Activated && notBlockedOrUnscheduled {
+	if notBlockedOrUnscheduled {
 		if err = b.SetActivated(true); err != nil {
 			return true, errors.Wrapf(err, "setting build '%s' as active", b.Id)
 		}
-
 	}
 
 	if evergreen.IsFinishedBuildStatus(buildStatus.status) {


### PR DESCRIPTION
[EVG-18567](https://jira.mongodb.org/browse/EVG-18567) 

### Description 
We hit an edge case on an aborted patch with a deactivated and aborted build. When a task in that build was restarted, because the build was not reactivated, it appeared as though the version is in a "done" state, triggering a children_finished event to be logged. 

This change fixes that edge case by checking in updateBuildStatus if a build that was previously deactivated needs to be activated. 

### Testing 
Tested on staging 
