### PR TITLE
EVG-18561 Fix wrong collective status 

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -1125,6 +1125,17 @@ func (p PatchesByCreateTime) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
 }
 
+func CollectiveStatus(patchId string) (string, error) {
+	p, err := FindOneId(patchId)
+	if err != nil {
+		return "", errors.Wrapf(err, "getting patch for version '%s'", patchId)
+	}
+	if p == nil {
+		return "", errors.Errorf("no patch found for version '%s'", patchId)
+	}
+	return p.CollectiveStatus()
+}
+
 // GetCollectiveStatus answers the question of what the patch status should be
 // when the patch status and the status of it's children are different
 func GetCollectiveStatus(statuses []string) string {

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -190,6 +190,10 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 	if api.ProjectIdentifier != nil {
 		projectName = utility.FromStringPtr(api.ProjectIdentifier)
 	}
+	collectiveStatus, err := patch.CollectiveStatus(t.patch.Id.Hex())
+	if err != nil {
+		return nil, errors.Wrap(err, "getting collective status for patch")
+	}
 
 	data := commonTemplateData{
 		ID:                t.patch.Id.Hex(),
@@ -199,7 +203,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		Description:       t.patch.Description,
 		Object:            event.ObjectPatch,
 		Project:           projectName,
-		PastTenseStatus:   t.data.Status,
+		PastTenseStatus:   collectiveStatus,
 		apiModel:          &api,
 		githubState:       message.GithubStatePending,
 		githubDescription: "tasks are running",
@@ -236,14 +240,16 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 	if utility.IsZeroTime(finishTime) {
 		finishTime = time.Now()
 	}
-	if t.data.Status == evergreen.PatchSucceeded {
+
+	if collectiveStatus == evergreen.PatchSucceeded {
 		slackColor = evergreenSuccessColor
 		data.githubState = message.GithubStateSuccess
 		data.githubDescription = fmt.Sprintf("patch finished in %s", finishTime.Sub(t.patch.StartTime).String())
-	} else if t.data.Status == evergreen.PatchFailed {
+	} else if collectiveStatus == evergreen.PatchFailed {
 		data.githubState = message.GithubStateFailure
 		data.githubDescription = fmt.Sprintf("patch finished in %s", finishTime.Sub(t.patch.StartTime).String())
 	}
+
 	if t.patch.IsGithubPRPatch() {
 		data.slack = append(data.slack, message.SlackAttachment{
 			Title:     "GitHub Pull Request",

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -249,7 +249,6 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		data.githubState = message.GithubStateFailure
 		data.githubDescription = fmt.Sprintf("patch finished in %s", finishTime.Sub(t.patch.StartTime).String())
 	}
-
 	if t.patch.IsGithubPRPatch() {
 		data.slack = append(data.slack, message.SlackAttachment{
 			Title:     "GitHub Pull Request",

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -106,6 +107,11 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 		projectName = utility.FromStringPtr(api.ProjectIdentifier)
 	}
 
+	collectiveStatus, err := patch.CollectiveStatus(t.version.Id)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting collective status for patch")
+	}
+
 	data := commonTemplateData{
 		ID:             t.version.Id,
 		EventID:        t.event.ID,
@@ -119,7 +125,7 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 			hasPatch:  evergreen.IsPatchRequester(t.version.Requester),
 			isChild:   false,
 		}),
-		PastTenseStatus:   t.data.Status,
+		PastTenseStatus:   collectiveStatus,
 		apiModel:          &api,
 		githubState:       message.GithubStatePending,
 		githubContext:     "evergreen",


### PR DESCRIPTION
[EVG-18561](https://jira.mongodb.org/browse/EVG-18561)

### Description 
Every now and then a PR will send a notification with the wrong collective status. The bug is not reproducible. The bug doesn't even happen again if the problematic patch is restarted. 

Checking the collective status before sending the notification will hopefully solve it. 

### Testing 
  < add a description of how you tested it >
