### PR TITLE
EVG-14416 Skip mergeable check when submitting to the commit queue

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1026,7 +1026,7 @@ func GetMergeablePullRequest(ctx context.Context, issue int, githubToken, owner,
 		return nil, errors.Wrap(err, "GitHub returned an incomplete PR")
 	}
 
-	if !(utility.FromBoolTPtr(pr.Mergeable)) {
+	if !utility.FromBoolTPtr(pr.Mergeable) {
 		return pr, errors.New("PR is not mergeable")
 	}
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1026,7 +1026,7 @@ func GetMergeablePullRequest(ctx context.Context, issue int, githubToken, owner,
 		return nil, errors.Wrap(err, "GitHub returned an incomplete PR")
 	}
 
-	if !(utility.FromBoolPtr(pr.Mergeable)) {
+	if !(utility.FromBoolTPtr(pr.Mergeable)) {
 		return pr, errors.New("PR is not mergeable")
 	}
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1026,7 +1026,7 @@ func GetMergeablePullRequest(ctx context.Context, issue int, githubToken, owner,
 		return nil, errors.Wrap(err, "GitHub returned an incomplete PR")
 	}
 
-	if !*pr.Mergeable {
+	if !(utility.FromBoolPtr(pr.Mergeable)) {
 		return pr, errors.New("PR is not mergeable")
 	}
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1026,16 +1026,6 @@ func GetMergeablePullRequest(ctx context.Context, issue int, githubToken, owner,
 		return nil, errors.Wrap(err, "GitHub returned an incomplete PR")
 	}
 
-	if pr.Mergeable == nil {
-		if *pr.Merged {
-			return pr, errors.New("PR is already merged")
-		}
-		// GitHub hasn't yet tested if the PR is mergeable.
-		// Check back later
-		// See: https://developer.github.com/v3/pulls/#response-1
-		return pr, errors.New("GitHub hasn't yet generated a merge commit")
-	}
-
 	if !*pr.Mergeable {
 		return pr, errors.New("PR is not mergeable")
 	}


### PR DESCRIPTION
[EVG-14416](https://jira.mongodb.org/browse/EVG-14416)

### Description 
There's already a mergeable check in commit queue tasks, so there's no need to check it here. Checking here can make it so that enqueuing very quickly after pushing a commit fails to enqueue

