### PR TITLE
EVG-18417: Use correct Spruce link on legacy host page

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -88,7 +88,7 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	spruceLink := fmt.Sprintf("%s/hosts/%s", uis.Settings.Ui.UIv2Url, h.Id)
+	spruceLink := fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, h.Id)
 	newUILink := ""
 	if len(uis.Settings.Ui.UIv2Url) > 0 {
 		newUILink = spruceLink


### PR DESCRIPTION
[EVG-18417](https://jira.mongodb.org/browse/EVG-18417)

### Description 
The "Open Page in New UI" link on the legacy host page incorrectly links to Spruce's `/hosts/<host_id>` path. It should link to the `/host/<host_id>` path instead.

### Testing
- Manually on staging

