### PR TITLE
Ignore non-repotracker versions when activating versions

### DIFF
--- a/model/version_db.go
+++ b/model/version_db.go
@@ -248,14 +248,12 @@ func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
 	return db.Query(q).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
-// ByMostRecentNonIgnored finds all non-ignored versions within a project,
+// VersionByMostRecentNonIgnored finds all non-ignored versions within a project,
 // ordered by most recently created to oldest, before a given time.
 func VersionByMostRecentNonIgnored(projectId string, ts time.Time) db.Q {
 	return db.Query(
 		bson.M{
-			VersionRequesterKey: bson.M{
-				"$in": evergreen.SystemVersionRequesterTypes,
-			},
+			VersionRequesterKey:  evergreen.RepotrackerVersionRequester,
 			VersionIdentifierKey: projectId,
 			VersionIgnoredKey:    bson.M{"$ne": true},
 			VersionCreateTimeKey: bson.M{"$lte": ts},

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -19,7 +19,7 @@ func TestVersionByMostRecentNonIgnored(t *testing.T) {
 		Id:         "v1",
 		Identifier: "proj",
 		Requester:  evergreen.RepotrackerVersionRequester,
-		CreateTime: ts,
+		CreateTime: ts.Add(-1 * time.Second),
 	}
 	v2 := Version{
 		Id:         "v2",
@@ -31,10 +31,17 @@ func TestVersionByMostRecentNonIgnored(t *testing.T) {
 		Id:         "v3",
 		Identifier: "proj",
 		Requester:  evergreen.RepotrackerVersionRequester,
-		CreateTime: ts.Add(time.Second), // created too late
+		CreateTime: ts.Add(time.Minute), // created too late
+	}
+	// Should not get picked even though it is the most recent
+	v4 := Version{
+		Id:         "v4",
+		Identifier: "proj",
+		Requester:  evergreen.AdHocRequester,
+		CreateTime: ts,
 	}
 
-	assert.NoError(t, db.InsertMany(VersionCollection, v1, v2, v3))
+	assert.NoError(t, db.InsertMany(VersionCollection, v1, v2, v3, v4))
 
 	v, err := VersionFindOne(VersionByMostRecentNonIgnored("proj", ts))
 	assert.NoError(t, err)


### PR DESCRIPTION
[EVG-18673](https://jira.mongodb.org/browse/EVG-18673)

### Description 
There is an [issue](https://mongodb.slack.com/archives/C0V896UV8/p1673021506764289) in the way activating tasks based on batchtime / cron works because the version activation job looks for the most recent version with one of the `SystemVersionRequesterTypes` which also includes periodic builds, git tags and triggers.  

If a non-repotracker version is the most recent one found at the time of version activation, and it doesn't contain the cron / batchtime tasks, then the cron / batchtime tasks from the most recent repotracker version will get skipped and will never be activated.

Updated to only look for repotracker versions.

### Testing 
Updated unit test.