### PR TITLE
EVG-18535: put parser project DB methods behind an interface

### DIFF
--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -44,7 +44,7 @@ func TestPatchPluginAPI(t *testing.T) {
 		testCommand := &gitFetchProject{Directory: "dir"}
 		modelData, err := modelutil.SetupAPITestData(settings, "testTask", "testvar", configPath, modelutil.NoPatch)
 		require.NoError(t, err)
-		taskConfig, err := agentutil.MakeTaskConfigFromModelData(settings, modelData)
+		taskConfig, err := agentutil.MakeTaskConfigFromModelData(ctx, settings, modelData)
 		require.NoError(t, err)
 		taskConfig.Expansions = util.NewExpansions(settings.Credentials)
 		taskConfig.Distro = &apimodels.DistroView{CloneMethod: evergreen.CloneMethodOAuth}
@@ -115,7 +115,7 @@ func TestPatchPlugin(t *testing.T) {
 		configPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "plugin_patch.yml")
 		modelData, err := modelutil.SetupAPITestData(settings, "testtask1", "testvar", configPath, modelutil.InlinePatch)
 		require.NoError(t, err)
-		taskConfig, err := agentutil.MakeTaskConfigFromModelData(settings, modelData)
+		taskConfig, err := agentutil.MakeTaskConfigFromModelData(ctx, settings, modelData)
 		require.NoError(t, err)
 		taskConfig.Expansions = util.NewExpansions(settings.Credentials)
 		taskConfig.Distro = &apimodels.DistroView{CloneMethod: evergreen.CloneMethodOAuth}

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -158,7 +158,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig6.BuildVariant.Modules = []string{"evergreen"}
 }
 
-func (s *GitGetProjectSuite) TearDownTest() {
+func (s *GitGetProjectSuite) TearDownSuite() {
 	s.cancel()
 }
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -60,6 +60,7 @@ type GitGetProjectSuite struct {
 	comm   *client.Mock
 	jasper jasper.Manager
 	ctx    context.Context
+	cancel context.CancelFunc
 	suite.Suite
 }
 
@@ -69,14 +70,6 @@ func init() {
 
 func TestGitGetProjectSuite(t *testing.T) {
 	s := new(GitGetProjectSuite)
-	var cancel context.CancelFunc
-	s.ctx, cancel = context.WithCancel(context.Background())
-	defer cancel()
-	env := testutil.NewEnvironment(s.ctx, t)
-	settings := env.Settings()
-
-	testutil.ConfigureIntegrationTest(t, settings, t.Name())
-	s.settings = settings
 	suite.Run(t, s)
 }
 
@@ -86,6 +79,13 @@ func (s *GitGetProjectSuite) SetupSuite() {
 	s.Require().NoError(err)
 
 	s.comm = client.NewMock("http://localhost.com")
+
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	env := testutil.NewEnvironment(s.ctx, s.T())
+	settings := env.Settings()
+
+	testutil.ConfigureIntegrationTest(s.T(), settings, s.T().Name())
+	s.settings = settings
 }
 
 func (s *GitGetProjectSuite) SetupTest() {
@@ -101,18 +101,18 @@ func (s *GitGetProjectSuite) SetupTest() {
 
 	s.modelData1, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath1, modelutil.NoPatch)
 	s.Require().NoError(err)
-	s.taskConfig1, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData1)
+	s.taskConfig1, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData1)
 	s.Require().NoError(err)
 	s.taskConfig1.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
 	s.Require().NoError(err)
 
 	s.modelData2, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath2, modelutil.NoPatch)
 	s.Require().NoError(err)
-	s.taskConfig2, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData2)
+	s.taskConfig2, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData2)
 	s.Require().NoError(err)
 	s.taskConfig2.Expansions = util.NewExpansions(s.settings.Credentials)
 	s.taskConfig2.Expansions.Put("prefixpath", "hello")
-	//SetupAPITestData always creates BuildVariant with no modules so this line works around that
+	// SetupAPITestData always creates BuildVariant with no modules so this line works around that
 	s.taskConfig2.BuildVariant.Modules = []string{"sample"}
 	s.modelData2.Task.Requester = evergreen.PatchVersionRequester
 	err = setupTestPatchData(s.modelData1, patchPath, s.T())
@@ -120,7 +120,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 
 	s.modelData3, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath2, modelutil.NoPatch)
 	s.Require().NoError(err)
-	s.taskConfig3, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData3)
+	s.taskConfig3, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData3)
 	s.Require().NoError(err)
 	s.taskConfig3.Expansions = util.NewExpansions(s.settings.Credentials)
 	s.taskConfig3.GithubPatchData = thirdparty.GithubPatch{
@@ -136,7 +136,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 
 	s.modelData4, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath2, modelutil.MergePatch)
 	s.Require().NoError(err)
-	s.taskConfig4, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData4)
+	s.taskConfig4, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData4)
 	s.Require().NoError(err)
 	s.taskConfig4.Expansions = util.NewExpansions(s.settings.Credentials)
 	s.taskConfig4.GithubPatchData = thirdparty.GithubPatch{
@@ -145,17 +145,21 @@ func (s *GitGetProjectSuite) SetupTest() {
 	}
 	s.modelData5, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath3, modelutil.MergePatch)
 	s.Require().NoError(err)
-	s.taskConfig5, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData5)
+	s.taskConfig5, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData5)
 	s.Require().NoError(err)
 
 	s.modelData6, err = modelutil.SetupAPITestData(s.settings, "testtask1", "linux-64", configPath4, modelutil.InlinePatch)
 	s.Require().NoError(err)
 	s.modelData6.Task.Requester = evergreen.MergeTestRequester
 	s.Require().NoError(err)
-	s.taskConfig6, err = agentutil.MakeTaskConfigFromModelData(s.settings, s.modelData6)
+	s.taskConfig6, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData6)
 	s.Require().NoError(err)
 	s.taskConfig6.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
 	s.taskConfig6.BuildVariant.Modules = []string{"evergreen"}
+}
+
+func (s *GitGetProjectSuite) TearDownTest() {
+	s.cancel()
 }
 
 func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
@@ -1034,7 +1038,7 @@ func TestManifestLoad(t *testing.T) {
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
 		require.NoError(t, err, "failed to setup test data")
 
-		taskConfig, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		taskConfig, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: taskConfig.Task.Id, Secret: taskConfig.Task.Secret}, nil)
 		So(err, ShouldBeNil)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -158,10 +158,6 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig6.BuildVariant.Modules = []string{"evergreen"}
 }
 
-func (s *GitGetProjectSuite) TearDownSuite() {
-	s.cancel()
-}
-
 func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
 	c := &gitFetchProject{
 		Directory: "dir",
@@ -820,6 +816,7 @@ func (s *GitGetProjectSuite) TearDownSuite() {
 	if s.taskConfig2 != nil {
 		s.NoError(os.RemoveAll(s.taskConfig2.WorkDir))
 	}
+	s.cancel()
 }
 
 func (s *GitGetProjectSuite) TestAllowsEmptyPatches() {

--- a/agent/command/keyval_test.go
+++ b/agent/command/keyval_test.go
@@ -31,7 +31,7 @@ func TestIncKey(t *testing.T) {
 
 		modelData, err := modelutil.SetupAPITestData(testConfig, "testinc", "rhel55", configPath, modelutil.NoPatch)
 		require.NoError(t, err)
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 
 		Convey("Inc command should increment a key successfully", func() {

--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -36,7 +36,7 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 		configPath := filepath.Join(currentDirectory, "testdata", "gotest", "bad.yml")
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
 		require.NoError(t, err)
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 		So(err, ShouldBeNil)
@@ -96,7 +96,7 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
 		require.NoError(t, err)
 
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		comm := client.NewMock("http://localhost.com")
 

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -42,7 +42,7 @@ func TestAttachResults(t *testing.T) {
 		require.NoError(t, err)
 		So(err, ShouldBeNil)
 
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		conf.WorkDir = "."
 
@@ -93,7 +93,7 @@ func TestAttachRawResults(t *testing.T) {
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configFile, modelutil.NoPatch)
 		require.NoError(t, err)
 
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		conf.WorkDir = "."
 		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -39,7 +39,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 		modelData, err := modelutil.SetupAPITestData(testConfig, "test", "rhel55", configPath, modelutil.NoPatch)
 		require.NoError(t, err)
 
-		conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		conf.WorkDir = "."
 		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
@@ -150,7 +150,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 	comm := client.NewMock("/dev/null")
 	modelData, err := modelutil.SetupAPITestData(testConfig, "aggregation", "rhel55", WildcardConfig, modelutil.NoPatch)
 	require.NoError(t, err, "failed to setup test data")
-	conf, err := agentutil.MakeTaskConfigFromModelData(testConfig, modelData)
+	conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 	require.NoError(t, err)
 	conf.WorkDir = filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "xunit")
 

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -1,6 +1,8 @@
 package testutil
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -10,12 +12,12 @@ import (
 )
 
 // MakeTaskConfigFromModelData converts an API TestModelData to a TaskConfig.
-func MakeTaskConfigFromModelData(settings *evergreen.Settings, data *testutil.TestModelData) (*internal.TaskConfig, error) {
+func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settings, data *testutil.TestModelData) (*internal.TaskConfig, error) {
 	oauthToken, err := settings.GetGithubOauthToken()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
-	exp, err := model.PopulateExpansions(data.Task, data.Host, oauthToken)
+	exp, err := model.PopulateExpansions(ctx, data.Task, data.Host, oauthToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "populating expansions")
 	}

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-12-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-12-21"
+	AgentVersion = "2023-01-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -933,7 +933,7 @@ func getHostRequestOptions(ctx context.Context, usr *user.DBUser, spawnHostInput
 		if t == nil {
 			return nil, ResourceNotFound.Send(ctx, "A valid task id must be supplied when SpawnHostsStartedByTask is set to true")
 		}
-		if err = data.CreateHostsFromTask(t, *usr, spawnHostInput.PublicKey.Key); err != nil {
+		if err = data.CreateHostsFromTask(ctx, t, *usr, spawnHostInput.PublicKey.Key); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("spawning hosts from task %s: %s", *spawnHostInput.TaskID, err))
 		}
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -166,7 +166,7 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 		return mongo.ErrNoDocuments
 	}
 
-	if err := updateParserProject(v, pp, t.Id); err != nil {
+	if err := updateParserProject(ctx, v, pp, t.Id); err != nil {
 		return errors.WithStack(err)
 	}
 
@@ -177,13 +177,13 @@ func (g *GeneratedProject) Save(ctx context.Context, p *Project, pp *ParserProje
 }
 
 // updateParserProject updates the parser project along with generated task ID and updated config number
-func updateParserProject(v *Version, pp *ParserProject, taskId string) error {
+func updateParserProject(ctx context.Context, v *Version, pp *ParserProject, taskId string) error {
 	if utility.StringSliceContains(pp.UpdatedByGenerators, taskId) {
 		// This generator has already updated the parser project so continue.
 		return nil
 	}
 	pp.UpdatedByGenerators = append(pp.UpdatedByGenerators, taskId)
-	if err := pp.UpsertWithConfigNumber(pp.ConfigUpdateNumber + 1); err != nil {
+	if err := GetParserProjectStorage(v.ProjectStorageMethod).UpsertOne(ctx, pp); err != nil {
 		return errors.Wrapf(err, "upserting parser project '%s'", pp.Id)
 	}
 	return nil

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -687,7 +687,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g := sampleGeneratedProject
 	g.Task = genTask
 
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "proj", v.ProjectStorageMethod)
+	p, pp, err := FindAndTranslateProjectForVersion(v, "proj")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)
@@ -779,7 +779,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert())
 	// Setup parser project to be partially generated.
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
+	p, pp, err := FindAndTranslateProjectForVersion(v, "")
 	s.NoError(err)
 
 	g := partiallyGeneratedProject
@@ -864,7 +864,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.Task = &tasksThatExist[0]
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
+	p, pp, err := FindAndTranslateProjectForVersion(v, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -971,7 +971,7 @@ buildvariants:
 		},
 	}
 
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
+	p, pp, err := FindAndTranslateProjectForVersion(v, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -1023,7 +1023,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.Task = &taskThatExists
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
+	p, pp, err := FindAndTranslateProjectForVersion(v, "")
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -687,7 +687,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g := sampleGeneratedProject
 	g.Task = genTask
 
-	p, pp, err := FindAndTranslateProjectForVersion(v, "proj")
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)
@@ -779,7 +779,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert())
 	// Setup parser project to be partially generated.
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	s.NoError(err)
 
 	g := partiallyGeneratedProject
@@ -864,7 +864,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.Task = &tasksThatExist[0]
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -971,7 +971,7 @@ buildvariants:
 		},
 	}
 
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -1023,7 +1023,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.Task = &taskThatExists
-	p, pp, err := FindAndTranslateProjectForVersion(v, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1049,9 +1049,9 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	tasks := []task.Task{}
 	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks))
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{"display_name": "my_display_task_gen"}), &tasks))
+	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task_gen"}), &tasks))
 	s.Len(tasks, 1)
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{"display_name": "my_display_task"}), &tasks))
+	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task"}), &tasks))
 	s.Len(tasks, 1)
 	s.Len(tasks[0].ExecutionTasks, 1)
 }

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -687,7 +687,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	g := sampleGeneratedProject
 	g.Task = genTask
 
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "proj")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "proj", v.ProjectStorageMethod)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)
@@ -775,7 +775,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert())
 	// Setup parser project to be partially generated.
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
 	s.NoError(err)
 
 	g := partiallyGeneratedProject
@@ -860,7 +860,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 
 	g := sampleGeneratedProjectAddToBVOnly
 	g.Task = &tasksThatExist[0]
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -958,7 +958,7 @@ buildvariants:
 		},
 	}
 
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.NoError(err)
@@ -1010,7 +1010,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 
 	g := smallGeneratedProject
 	g.Task = &taskThatExists
-	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "")
+	p, pp, err := FindAndTranslateProjectForVersion(v.Id, "", v.ProjectStorageMethod)
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(p, pp, v)
 	s.Require().NoError(err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -870,7 +870,6 @@ func (e *EnqueuePatch) String() string {
 	return fmt.Sprintf("enqueue patch '%s'", e.PatchID)
 }
 
-// kim: NOTE: this is to fulfill the grip sender interface.
 func (e *EnqueuePatch) Send() error {
 	existingPatch, err := patch.FindOneId(e.PatchID)
 	if err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -924,9 +924,6 @@ func MakeMergePatchFromExisting(ctx context.Context, existingPatch *patch.Patch,
 		return nil, errors.WithStack(err)
 	}
 
-	// kim: QUESTION: not sure if parser project storage matters here? It
-	// depends on whether PatchedParserProject is guaranteed to be set or not
-	// here.
 	project, pp, err := FindAndTranslateProjectForPatch(ctx, existingPatch)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading existing project")

--- a/model/project.go
+++ b/model/project.go
@@ -1226,7 +1226,7 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Errorf("version '%s' not found", versionStr)
 	}
 
-	project, _, err := FindAndTranslateProjectForVersion(ver, ver.Identifier)
+	project, _, err := FindAndTranslateProjectForVersion(ver)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading project config for version '%s'", versionStr)
 	}
@@ -1276,7 +1276,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 			continue
 		}
 		if lastGoodVersion != nil {
-			project, _, err = FindAndTranslateProjectForVersion(lastGoodVersion, projectId)
+			project, _, err = FindAndTranslateProjectForVersion(lastGoodVersion)
 			if err != nil {
 				grip.Critical(message.WrapError(err, message.Fields{
 					"message": "last known good version has malformed config",

--- a/model/project.go
+++ b/model/project.go
@@ -1125,7 +1125,11 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 		}
 	}
 
-	bvExpansions, err := FindExpansionsForVariant(v, t.BuildVariant)
+	// kim: TODO: reconsider putting an untimed context here.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bvExpansions, err := FindExpansionsForVariant(ctx, v, t.BuildVariant)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting expansions for variant")
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1226,7 +1226,7 @@ func FindProjectFromVersionID(versionStr string) (*Project, error) {
 		return nil, errors.Errorf("version '%s' not found", versionStr)
 	}
 
-	project, _, err := FindAndTranslateProjectForVersion(ver.Id, ver.Identifier, ver.ProjectStorageMethod)
+	project, _, err := FindAndTranslateProjectForVersion(ver, ver.Identifier)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading project config for version '%s'", versionStr)
 	}
@@ -1276,7 +1276,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, er
 			continue
 		}
 		if lastGoodVersion != nil {
-			project, _, err = FindAndTranslateProjectForVersion(lastGoodVersion.Id, projectId, lastGoodVersion.ProjectStorageMethod)
+			project, _, err = FindAndTranslateProjectForVersion(lastGoodVersion, projectId)
 			if err != nil {
 				grip.Critical(message.WrapError(err, message.Fields{
 					"message": "last known good version has malformed config",

--- a/model/project.go
+++ b/model/project.go
@@ -979,7 +979,7 @@ var (
 	ProjectTasksKey         = bsonutil.MustHaveTag(Project{}, "Tasks")
 )
 
-func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Expansions, error) {
+func PopulateExpansions(ctx context.Context, t *task.Task, h *host.Host, oauthToken string) (util.Expansions, error) {
 	if t == nil {
 		return nil, errors.New("task cannot be nil")
 	}
@@ -1124,10 +1124,6 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken string) (util.Exp
 			expansions.Put(e.Key, e.Value)
 		}
 	}
-
-	// kim: TODO: reconsider putting an untimed context here.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	bvExpansions, err := FindExpansionsForVariant(ctx, v, t.BuildVariant)
 	if err != nil {

--- a/model/project.go
+++ b/model/project.go
@@ -2124,7 +2124,17 @@ type VariantsAndTasksFromProject struct {
 
 // GetVariantsAndTasksFromPatchProject formats variants and tasks as used by the UI pages.
 func GetVariantsAndTasksFromPatchProject(ctx context.Context, p *patch.Patch) (*VariantsAndTasksFromProject, error) {
-	project, _, err := FindAndTranslateProjectForPatch(ctx, p)
+	var ppStorageMethod ParserProjectStorageMethod
+	if p.Version != "" {
+		v, err := VersionFindOneId(p.Version)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding version '%s' for patch '%s'", p.Version, p.Id.Hex())
+		}
+		if v == nil {
+			return nil, errors.Errorf("version '%s' for patch '%s' not found", p.Version, p.Id.Hex())
+		}
+	}
+	project, _, err := FindAndTranslateProjectForPatch(ctx, p, ppStorageMethod)
 	if err != nil {
 		return nil, err
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -519,8 +519,9 @@ func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Proj
 // Also sets the project ID.
 // kim: TODO: update find one by ID and function parameters to include parser
 // project storage method.
+// func FindAndTranslateProjectForVersion(ctx context.Context, versionId, projectId string, ppStorageMethod ParserProjectStorageMethod) (*Project, *ParserProject, error) {
 func FindAndTranslateProjectForVersion(versionId, projectId string) (*Project, *ParserProject, error) {
-	pp, err := ParserProjectFindOneById(versionId)
+	pp, err := GetParserProjectStorage(ProjectStorageMethodDB).FindOneByID(context.Background(), versionId)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "finding parser project")
 	}
@@ -925,6 +926,14 @@ func (pp *ParserProject) AddBuildVariant(name, displayName, runOn string, batchT
 		bv.RunOn = []string{runOn}
 	}
 	pp.BuildVariants = append(pp.BuildVariants, bv)
+}
+
+func (pp *ParserProject) GetParameters() []patch.Parameter {
+	res := []patch.Parameter{}
+	for _, param := range pp.Parameters {
+		res = append(res, param.Parameter)
+	}
+	return res
 }
 
 // sieveMatrixVariants takes a set of parserBVs and groups them into regular

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -501,6 +501,8 @@ func (bvt *parserBV) hasSpecificActivation() bool {
 
 // FindAndTranslateProjectForPatch translates a parser project for a patch into a project.
 // This assumes that the version may not exist yet; otherwise FindAndTranslateProjectForVersion is equivalent.
+// kim: TODO: need to include parser project storage method somehow using the
+// patch.
 func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Project, *ParserProject, error) {
 	if p.PatchedParserProject == "" {
 		return FindAndTranslateProjectForVersion(p.Version, p.Project)
@@ -515,6 +517,8 @@ func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Proj
 
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID.
+// kim: TODO: update find one by ID and function parameters to include parser
+// project storage method.
 func FindAndTranslateProjectForVersion(versionId, projectId string) (*Project, *ParserProject, error) {
 	pp, err := ParserProjectFindOneById(versionId)
 	if err != nil {
@@ -550,6 +554,7 @@ func LoadProjectInfoForVersion(v *Version, id string) (ProjectInfo, error) {
 			return ProjectInfo{}, errors.Wrap(err, "finding project config")
 		}
 	}
+	// kim: TODO: need to use parser project storage method here.
 	p, pp, err := FindAndTranslateProjectForVersion(v.Id, id)
 	if err != nil {
 		return ProjectInfo{}, errors.Wrap(err, "translating project")

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -53,8 +53,7 @@ const EmptyConfigurationError = "received empty configuration file"
 // to allow for flexible handling.
 type ParserProject struct {
 	// Id and ConfigdUpdateNumber are not pointers because they are only used internally
-	Id                 string `yaml:"_id" bson:"_id"` // should be the same as the version's ID
-	ConfigUpdateNumber int    `yaml:"config_number,omitempty" bson:"config_number,omitempty"`
+	Id string `yaml:"_id" bson:"_id"` // should be the same as the version's ID
 	// UpdatedByGenerators is used to determine if the parser project needs to be re-saved or not.
 	UpdatedByGenerators []string `yaml:"updated_by_generators,omitempty" bson:"updated_by_generators,omitempty"`
 	// List of yamls to merge

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -501,10 +501,9 @@ func (bvt *parserBV) hasSpecificActivation() bool {
 
 // FindAndTranslateProjectForPatch translates a parser project for a patch into a project.
 // This assumes that the version may not exist yet; otherwise FindAndTranslateProjectForVersion is equivalent.
-// kim: TODO: need to include parser project storage method somehow using the
-// patch.
-func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Project, *ParserProject, error) {
+func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch, ppStorageMethod ParserProjectStorageMethod) (*Project, *ParserProject, error) {
 	if p.PatchedParserProject == "" {
+		// kim: TODO: Pass parser project storage method.
 		return FindAndTranslateProjectForVersion(p.Version, p.Project)
 	}
 	project := &Project{}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -509,7 +509,7 @@ func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Proj
 		if v == nil {
 			return nil, nil, errors.Errorf("version '%s' not found for patch '%s'", p.Version, p.Id.Hex())
 		}
-		return FindAndTranslateProjectForVersion(v, p.Project)
+		return FindAndTranslateProjectForVersion(v)
 	}
 	project := &Project{}
 	pp, err := LoadProjectInto(ctx, []byte(p.PatchedParserProject), nil, p.Project, project)
@@ -521,7 +521,7 @@ func FindAndTranslateProjectForPatch(ctx context.Context, p *patch.Patch) (*Proj
 
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID.
-func FindAndTranslateProjectForVersion(v *Version, projectId string) (*Project, *ParserProject, error) {
+func FindAndTranslateProjectForVersion(v *Version) (*Project, *ParserProject, error) {
 	pp, err := GetParserProjectStorage(v.ProjectStorageMethod).FindOneByID(context.Background(), v.Id)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "finding parser project")
@@ -529,7 +529,7 @@ func FindAndTranslateProjectForVersion(v *Version, projectId string) (*Project, 
 	if pp == nil {
 		return nil, nil, errors.Errorf("parser project not found for version '%s'", v.Id)
 	}
-	pp.Identifier = utility.ToStringPtr(projectId)
+	pp.Identifier = utility.ToStringPtr(v.Identifier)
 	var p *Project
 	p, err = TranslateProject(pp)
 	if err != nil {
@@ -556,7 +556,7 @@ func LoadProjectInfoForVersion(v *Version, id string) (ProjectInfo, error) {
 			return ProjectInfo{}, errors.Wrap(err, "finding project config")
 		}
 	}
-	p, pp, err := FindAndTranslateProjectForVersion(v, id)
+	p, pp, err := FindAndTranslateProjectForVersion(v)
 	if err != nil {
 		return ProjectInfo{}, errors.Wrap(err, "translating project")
 	}

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -51,6 +51,7 @@ var (
 )
 
 // ParserProjectFindOneById returns the parser project for the version
+// kim: TODO: put find one by ID behind interface.
 func ParserProjectFindOneById(id string) (*ParserProject, error) {
 	pp, err := ParserProjectFindOne(ParserProjectById(id))
 	if err != nil {
@@ -63,6 +64,7 @@ func ParserProjectFindOneById(id string) (*ParserProject, error) {
 }
 
 // ParserProjectFindOne finds a parser project with a given query.
+// kim: TODO: put find one with fields behind interface.
 func ParserProjectFindOne(query db.Q) (*ParserProject, error) {
 	project := &ParserProject{}
 	err := db.FindOneQ(ParserProjectCollection, query, project)
@@ -78,6 +80,7 @@ func ParserProjectById(id string) db.Q {
 }
 
 // ParserProjectUpsertOne updates one project
+// kim: TODO: put upsert one into interface.
 func ParserProjectUpsertOne(query interface{}, update interface{}) error {
 	_, err := db.Upsert(
 		ParserProjectCollection,
@@ -88,6 +91,8 @@ func ParserProjectUpsertOne(query interface{}, update interface{}) error {
 	return err
 }
 
+// kim: TODO: use parser project storage method to decide how to do find one.
+// kim: TODO: add doc comment
 func FindParametersForVersion(v *Version) ([]patch.Parameter, error) {
 	pp, err := ParserProjectFindOne(ParserProjectById(v.Id).WithFields(ParserProjectParametersKey))
 	if err != nil {
@@ -96,6 +101,8 @@ func FindParametersForVersion(v *Version) ([]patch.Parameter, error) {
 	return pp.GetParameters(), nil
 }
 
+// kim: TODO: use parser project storage method to decide how to do find one.
+// kim: TODO: add doc comment
 func FindExpansionsForVariant(v *Version, variant string) (util.Expansions, error) {
 	pp, err := ParserProjectFindOne(ParserProjectById(v.Id).WithFields(ParserProjectBuildVariantsKey, ParserProjectAxesKey))
 	if err != nil {
@@ -172,3 +179,8 @@ func (pp *ParserProject) GetParameters() []patch.Parameter {
 	}
 	return res
 }
+
+// ParserProjectDBStorage implements the ParserProjectStorage interface to
+// access parser projects from the DB.
+// kim: TODO: implement
+type ParserProjectDBStorage struct{}

--- a/model/project_parser_db_test.go
+++ b/model/project_parser_db_test.go
@@ -62,13 +62,13 @@ func TestFindExpansionsForVariant(t *testing.T) {
 	}
 
 	v := &Version{Id: "v1"}
-	assert.NoError(t, GetParserProjectStorage(ProjectStorageMethodS3).UpsertOne(ctx, &pp))
-	expansions, err := FindExpansionsForVariant(v, "myBV")
+	assert.NoError(t, GetParserProjectStorage(ProjectStorageMethodDB).UpsertOne(ctx, &pp))
+	expansions, err := FindExpansionsForVariant(ctx, v, "myBV")
 	assert.NoError(t, err)
 	assert.Equal(t, expansions["hello"], "world")
 	assert.Equal(t, expansions["goodbye"], "mars")
 	assert.Empty(t, expansions["milky"])
-	expansions, err = FindExpansionsForVariant(v, "test__version~latest_os~windows-64")
+	expansions, err = FindExpansionsForVariant(ctx, v, "test__version~latest_os~windows-64")
 	assert.NoError(t, err)
 	assert.Equal(t, expansions["VERSION"], "latest")
 	assert.Equal(t, expansions["OS"], "windows-64")

--- a/model/project_parser_db_test.go
+++ b/model/project_parser_db_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -9,6 +10,9 @@ import (
 )
 
 func TestFindExpansionsForVariant(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(ParserProjectCollection))
 	pp := ParserProject{
 		Id: "v1",
@@ -58,7 +62,7 @@ func TestFindExpansionsForVariant(t *testing.T) {
 	}
 
 	v := &Version{Id: "v1"}
-	assert.NoError(t, pp.TryUpsert())
+	assert.NoError(t, GetParserProjectStorage(ProjectStorageMethodS3).UpsertOne(ctx, &pp))
 	expansions, err := FindExpansionsForVariant(v, "myBV")
 	assert.NoError(t, err)
 	assert.Equal(t, expansions["hello"], "world")

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -1,0 +1,23 @@
+package model
+
+import "context"
+
+// ParserProjectStorage is an interface for accessing the parser project.
+type ParserProjectStorage interface {
+	// FindOneByID finds a parser project using its unique identifier.
+	// Implementations may or may not respect the context.
+	FindOneByID(ctx context.Context, id string) (*ParserProject, error)
+	// FindOneByIDWithFields finds a parser project using its unique identifier
+	// and returns the parser project with only the requested fields populated.
+	// Implementations may or may not respect the context.
+	FindOneByIDWithFields(ctx context.Context, id string, fields ...string) (*ParserProject, error)
+	// UpsertOneByID replaces a parser project by ID if the parser project given
+	// by the ID already exists. If it does not exist yet, it inserts a new
+	// parser project.
+	UpsertOneByID(ctx context.Context, id string, pp *ParserProject) error
+}
+
+// kim: TODO: implement
+func GetParserProjectStorage(method ParserProjectStorageMethod) ParserProjectStorage {
+	return nil
+}

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -4,20 +4,21 @@ import "context"
 
 // ParserProjectStorage is an interface for accessing the parser project.
 type ParserProjectStorage interface {
-	// FindOneByID finds a parser project using its unique identifier.
-	// Implementations may or may not respect the context.
+	// FindOneByID finds a parser project using its ID. Implementations may or
+	// may not respect the context.
 	FindOneByID(ctx context.Context, id string) (*ParserProject, error)
-	// FindOneByIDWithFields finds a parser project using its unique identifier
-	// and returns the parser project with only the requested fields populated.
+	// FindOneByIDWithFields finds a parser project using its ID and returns the
+	// parser project with only the requested fields populated.
 	// Implementations may or may not respect the context.
 	FindOneByIDWithFields(ctx context.Context, id string, fields ...string) (*ParserProject, error)
-	// UpsertOneByID replaces a parser project by ID if the parser project given
-	// by the ID already exists. If it does not exist yet, it inserts a new
-	// parser project.
-	UpsertOneByID(ctx context.Context, id string, pp *ParserProject) error
+	// UpsertOneByID replaces a parser project if the parser project with the
+	// same ID already exists. If it does not exist yet, it inserts a new parser
+	// project.
+	UpsertOne(ctx context.Context, pp *ParserProject) error
 }
 
-// kim: TODO: implement
+// GetParserProjectStorage returns the parser project storage mechanism to
+// access the persistent copy of it.
 func GetParserProjectStorage(method ParserProjectStorageMethod) ParserProjectStorage {
-	return nil
+	return ParserProjectDBStorage{}
 }

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -11,7 +11,7 @@ type ParserProjectStorage interface {
 	// parser project with only the requested fields populated.
 	// Implementations may or may not respect the context.
 	FindOneByIDWithFields(ctx context.Context, id string, fields ...string) (*ParserProject, error)
-	// UpsertOneByID replaces a parser project if the parser project with the
+	// UpsertOne replaces a parser project if the parser project with the
 	// same ID already exists. If it does not exist yet, it inserts a new parser
 	// project.
 	UpsertOne(ctx context.Context, pp *ParserProject) error

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -284,6 +284,8 @@ func boolPtr(b bool) *bool {
 }
 
 func TestPopulateExpansions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(VersionCollection, patch.Collection, ProjectRefCollection, task.Collection))
 	defer func() {
@@ -352,7 +354,7 @@ buildvariants:
 	}
 	oauthToken, err := settings.GetGithubOauthToken()
 	assert.NoError(err)
-	expansions, err := PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err := PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 24)
 	assert.Equal("0", expansions.Get("execution"))
@@ -390,7 +392,7 @@ buildvariants:
 	}
 	require.NoError(t, p.Insert())
 
-	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err = PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 24)
 	assert.Equal("true", expansions.Get("is_patch"))
@@ -410,7 +412,7 @@ buildvariants:
 		Description: "commit queue message",
 	}
 	require.NoError(t, p.Insert())
-	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err = PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 26)
 	assert.Equal("true", expansions.Get("is_patch"))
@@ -425,7 +427,7 @@ buildvariants:
 		Version: v.Id,
 	}
 	require.NoError(t, p.Insert())
-	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err = PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 27)
 	assert.Equal("true", expansions.Get("is_patch"))
@@ -450,7 +452,7 @@ buildvariants:
 	}
 	assert.NoError(patchDoc.Insert())
 
-	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err = PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 27)
 	assert.Equal("github_pr", expansions.Get("requester"))
@@ -475,7 +477,7 @@ buildvariants:
 	assert.NoError(upstreamProject.Insert())
 	taskDoc.TriggerID = "upstreamTask"
 	taskDoc.TriggerType = ProjectTriggerLevelTask
-	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken)
+	expansions, err = PopulateExpansions(ctx, taskDoc, &h, oauthToken)
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 35)
 	assert.Equal(taskDoc.TriggerID, expansions.Get("trigger_event_identifier"))

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1642,43 +1642,6 @@ func TestLoggerConfigValidate(t *testing.T) {
 	assert.EqualError(config.IsValid(), "invalid system logger config: Splunk logger requires a server URL\nSplunk logger requires a token")
 }
 
-func TestFindContainerFromProject(t *testing.T) {
-	assert := assert.New(t)
-	require.NoError(t, db.ClearCollections(VersionCollection, ParserProjectCollection, ProjectRefCollection))
-	ref := ProjectRef{
-		Id: "p1",
-	}
-
-	pp := ParserProject{
-		Id:         "v1",
-		Identifier: utility.ToStringPtr("p1"),
-		Containers: []Container{
-			{
-				Name: "container1",
-			},
-		},
-	}
-
-	v := &Version{Id: "v1"}
-	require.NoError(t, pp.TryUpsert())
-	require.NoError(t, v.Insert())
-	require.NoError(t, ref.Insert())
-
-	task := task.Task{
-		Version:   "v1",
-		Project:   "p1",
-		Container: "container1",
-	}
-	container, err := FindContainerFromProject(task)
-	require.NoError(t, err)
-	assert.Equal(container.Name, "container1")
-
-	task.Container = "nonexistent"
-	_, err = FindContainerFromProject(task)
-	require.Error(t, err)
-	assert.Equal(err.Error(), "no such container 'nonexistent' defined on project 'p1'")
-}
-
 func TestLoggerMerge(t *testing.T) {
 	assert := assert.New(t)
 

--- a/model/version.go
+++ b/model/version.go
@@ -89,19 +89,19 @@ type Version struct {
 
 	// ProjectStorageMethod describes how the parser project for this version is
 	// stored. If this is empty, the default storage method is StorageMethodDB.
-	ProjectStorageMethod ProjectConfigStorageMethod `bson:"storage_method" json:"storage_method,omitempty"`
+	ProjectStorageMethod ParserProjectStorageMethod `bson:"storage_method" json:"storage_method,omitempty"`
 }
 
-// ProjectConfigStorageMethod represents a means to store the parser project.
-type ProjectConfigStorageMethod string
+// ParserProjectStorageMethod represents a means to store the parser project.
+type ParserProjectStorageMethod string
 
 const (
 	// ProjectStorageMethodDB indicates that the parser project is stored as a
 	// single document in a DB collection.
-	ProjectStorageMethodDB ProjectConfigStorageMethod = "db"
+	ProjectStorageMethodDB ParserProjectStorageMethod = "db"
 	// ProjectStorageMethodS3 indicates that the parser project is stored as a
 	// single object in S3.
-	ProjectStorageMethodS3 ProjectConfigStorageMethod = "s3"
+	ProjectStorageMethodS3 ParserProjectStorageMethod = "s3"
 )
 
 func (v *Version) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(v) }

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -168,7 +168,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, t *task.Task) (*model
 	if v == nil {
 		return nil, nil, errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier, v.ProjectStorageMethod)
+	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading project")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -168,7 +168,7 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if v == nil {
 		return nil, nil, errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier, v.ProjectStorageMethod)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading project")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -168,7 +168,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, t *task.Task) (*model
 	if v == nil {
 		return nil, nil, errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "loading project")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -81,7 +81,7 @@ func ListHostsForTask(ctx context.Context, taskID string) ([]host.Host, error) {
 	return hosts, nil
 }
 
-func CreateHostsFromTask(t *task.Task, user user.DBUser, keyNameOrVal string) error {
+func CreateHostsFromTask(ctx context.Context, t *task.Task, user user.DBUser, keyNameOrVal string) error {
 	if t == nil {
 		return errors.New("no task to create hosts from")
 	}
@@ -90,7 +90,7 @@ func CreateHostsFromTask(t *task.Task, user user.DBUser, keyNameOrVal string) er
 		keyVal = keyNameOrVal
 	}
 
-	proj, expansions, err := makeProjectAndExpansionsFromTask(t)
+	proj, expansions, err := makeProjectAndExpansionsFromTask(ctx, t)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -160,7 +160,7 @@ func CreateHostsFromTask(t *task.Task, user user.DBUser, keyNameOrVal string) er
 	return catcher.Resolve()
 }
 
-func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expansions, error) {
+func makeProjectAndExpansionsFromTask(ctx context.Context, t *task.Task) (*model.Project, *util.Expansions, error) {
 	v, err := model.VersionFindOne(model.VersionById(t.Version))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "finding version '%s'", t.Version)
@@ -184,7 +184,7 @@ func makeProjectAndExpansionsFromTask(t *task.Task) (*model.Project, *util.Expan
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting GitHub OAuth token from admin settings")
 	}
-	expansions, err := model.PopulateExpansions(t, h, oauthToken)
+	expansions, err := model.PopulateExpansions(ctx, t, h, oauthToken)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "populating expansions")
 	}

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -93,6 +93,8 @@ func TestListHostsForTask(t *testing.T) {
 }
 
 func TestCreateHostsFromTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
 	settingsList := []*birch.Document{birch.NewDocument(
 		birch.EC.String("region", "us-east-1"),
@@ -166,7 +168,7 @@ buildvariants:
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
 
-		assert.NoError(t, CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, ""))
+		assert.NoError(t, CreateHostsFromTask(ctx, &t1, user.DBUser{Id: "me"}, ""))
 		createdHosts, err := host.Find(host.IsUninitialized)
 		assert.NoError(t, err)
 		assert.Len(t, createdHosts, 3)
@@ -238,7 +240,7 @@ buildvariants:
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
 
-		err = CreateHostsFromTask(&t2, user.DBUser{Id: "me"}, "")
+		err = CreateHostsFromTask(ctx, &t2, user.DBUser{Id: "me"}, "")
 		assert.NoError(t, err)
 		createdHosts, err := host.Find(host.IsUninitialized)
 		assert.NoError(t, err)
@@ -306,7 +308,7 @@ buildvariants:
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
 
-		assert.NoError(t, CreateHostsFromTask(&t3, user.DBUser{Id: "me"}, ""))
+		assert.NoError(t, CreateHostsFromTask(ctx, &t3, user.DBUser{Id: "me"}, ""))
 		createdHosts, err := host.Find(host.IsUninitialized)
 		assert.NoError(t, err)
 		assert.Len(t, createdHosts, 3)
@@ -327,6 +329,8 @@ buildvariants:
 }
 
 func TestCreateContainerFromTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection,
@@ -422,7 +426,7 @@ buildvariants:
 	}
 	assert.NoError(pvars.Insert())
 
-	assert.NoError(CreateHostsFromTask(&t1, user.DBUser{Id: "me"}, ""))
+	assert.NoError(CreateHostsFromTask(ctx, &t1, user.DBUser{Id: "me"}, ""))
 
 	createdHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -354,7 +354,7 @@ func (h *getExpansionsHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting GitHub OAuth token"))
 	}
 
-	e, err := model.PopulateExpansions(t, foundHost, oauthToken)
+	e, err := model.PopulateExpansions(ctx, t, foundHost, oauthToken)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(err)
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1228,7 +1228,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", task.Version))
 	}
 
-	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier, v.ProjectStorageMethod)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "loading project from version"))
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1228,7 +1228,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", task.Version))
 	}
 
-	project, _, err := model.FindAndTranslateProjectForVersion(v.Id, v.Identifier, v.ProjectStorageMethod)
+	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "loading project from version"))
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -457,9 +457,15 @@ func (h *getParserProjectHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("version '%s' not found", t.Version),
 		})
 	}
-	pp, err := model.ParserProjectFindOneById(t.Version)
+	pp, err := model.GetParserProjectStorage(v.ProjectStorageMethod).FindOneByID(ctx, v.Id)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding parser project '%s'", v.Id))
+	}
+	if pp == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("parser project '%s' not found", v.Id),
+		})
 	}
 	projBytes, err := bson.Marshal(pp)
 	if err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1228,7 +1228,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", task.Version))
 	}
 
-	project, _, err := model.FindAndTranslateProjectForVersion(v, v.Identifier)
+	project, _, err := model.FindAndTranslateProjectForVersion(v)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "loading project from version"))
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -792,7 +792,7 @@ func (h *fetchExpansionsForTaskHandler) Run(ctx context.Context) gimlet.Responde
 			Message:    fmt.Sprintf("version '%s' not found", t.Version),
 		})
 	}
-	projParams, err := model.FindParametersForVersion(v)
+	projParams, err := model.FindParametersForVersion(ctx, v)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -61,8 +61,7 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding tasks in build '%s'", b.buildId))
 		}
 	}
-	// kim: NOTE: had to add a find for the version. Make sure this doesn't need
-	// to fall back to using the patched parser project.
+
 	v, err := serviceModel.VersionFindOneId(foundBuild.Version)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", foundBuild.Version))

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -61,8 +61,8 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding tasks in build '%s'", b.buildId))
 		}
 	}
-	// kim: NOTE: had to add a find for the version. Make sure this doesn't
-	// break anything.
+	// kim: NOTE: had to add a find for the version. Make sure this doesn't need
+	// to fall back to using the patched parser project.
 	v, err := serviceModel.VersionFindOneId(foundBuild.Version)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", foundBuild.Version))

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -61,7 +61,19 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding tasks in build '%s'", b.buildId))
 		}
 	}
-	pp, err := serviceModel.ParserProjectFindOneById(foundBuild.Version)
+	// kim: NOTE: had to add a find for the version. Make sure this doesn't
+	// break anything.
+	v, err := serviceModel.VersionFindOneId(foundBuild.Version)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", foundBuild.Version))
+	}
+	if v == nil {
+		return gimlet.MakeJSONInternalErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("version '%s' not found", foundBuild.Version),
+		})
+	}
+	pp, err := serviceModel.GetParserProjectStorage(v.ProjectStorageMethod).FindOneByID(ctx, v.Id)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting project info"))
 	}

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -158,9 +158,16 @@ func (h *buildsForVersionHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "getting builds"))
 	}
 
-	pp, err := dbModel.ParserProjectFindOneById(h.versionId)
+	v, err := dbModel.VersionFindOneId(h.versionId)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting project info"))
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting version '%s'", h.versionId))
+	}
+	var pp *dbModel.ParserProject
+	if v != nil {
+		pp, err = dbModel.GetParserProjectStorage(v.ProjectStorageMethod).FindOneByID(ctx, h.versionId)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting project info"))
+		}
 	}
 
 	buildModels := []model.APIBuild{}

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -68,7 +68,7 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 	if projCtx.Patch.PatchedParserProject != "" {
 		w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write(projCtx.Patch.PatchedParserProject)
+		_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message":  "could not write patched parser project to response",
 			"patch_id": projCtx.Patch.Id.Hex(),

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -57,7 +57,6 @@ func (restapi restAPI) getPatch(w http.ResponseWriter, r *http.Request) {
 }
 
 // getPatchConfig returns the patched config for a given patch.
-// kim: TODO: check this in staging
 func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveRESTContext(r)
 	if projCtx.Patch == nil {

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -68,7 +68,7 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 	if projCtx.Patch.PatchedParserProject != "" {
 		w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
+		_, err := w.Write(projCtx.Patch.PatchedParserProject)
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message":  "could not write patched parser project to response",
 			"patch_id": projCtx.Patch.Id.Hex(),
@@ -101,7 +101,7 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write([]byte(projBytes))
+	_, err = w.Write(projBytes)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message":  "could not write parser project to response",
 		"patch_id": projCtx.Patch.Id.Hex(),

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -70,21 +70,29 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 		grip.Warning(errors.Wrap(err, "writing patched parser project"))
 		return
 	}
+
 	// kim: NOTE: as part of LoadContext, this loads the version if it exists
 	// (and therefore, will load if the parser project exists).
-	if v := projCtx.Version; v != nil {
-		pp, err := model.GetParserProjectStorage(v.ProjectStorageMethod).FindOneByID(r.Context(), v.Id)
-		if pp != nil {
-			var projBytes []byte
-			projBytes, err = yaml.Marshal(pp)
-			if err == nil {
-				_, err = w.Write(projBytes)
-			}
-			grip.Warning(message.WrapError(err, message.Fields{
-				"message":  "could not marshal and write parser project to response",
-				"route":    "/patches/{patch_id}/config",
-				"patch_id": projCtx.Patch.Id.Hex(),
-			}))
+	if projCtx.Version == nil {
+		grip.Warning(message.Fields{
+			"message":  "cannot get parser project because version is nil",
+			"route":    "/patches/{patch_id}/config",
+			"patch_id": projCtx.Patch.Id.Hex(),
+		})
+		return
+	}
+
+	pp, err := model.GetParserProjectStorage(projCtx.Version.ProjectStorageMethod).FindOneByID(r.Context(), projCtx.Version.Id)
+	if pp != nil {
+		var projBytes []byte
+		projBytes, err = yaml.Marshal(pp)
+		if err == nil {
+			_, err = w.Write(projBytes)
 		}
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message":  "could not marshal and write parser project to response",
+			"route":    "/patches/{patch_id}/config",
+			"patch_id": projCtx.Patch.Id.Hex(),
+		}))
 	}
 }

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -63,16 +63,16 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "patch not found"})
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
+
 	if projCtx.Patch.PatchedParserProject != "" {
 		_, err := w.Write([]byte(projCtx.Patch.PatchedParserProject))
 		grip.Warning(errors.Wrap(err, "writing patched parser project"))
 		return
 	}
 
-	// kim: NOTE: as part of LoadContext, this loads the version if it exists
-	// (and therefore, will load if the parser project exists).
 	if projCtx.Version == nil {
 		grip.Warning(message.Fields{
 			"message":  "cannot get parser project because version is nil",
@@ -89,10 +89,10 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			_, err = w.Write(projBytes)
 		}
-		grip.Warning(message.WrapError(err, message.Fields{
-			"message":  "could not marshal and write parser project to response",
-			"route":    "/patches/{patch_id}/config",
-			"patch_id": projCtx.Patch.Id.Hex(),
-		}))
 	}
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message":  "could not marshal and write parser project to response",
+		"route":    "/patches/{patch_id}/config",
+		"patch_id": projCtx.Patch.Id.Hex(),
+	}))
 }

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	yaml "gopkg.in/20210107192922/yaml.v3"
@@ -289,7 +290,7 @@ func (restapi restAPI) getVersionConfig(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 
 	var config []byte
-	pp, err := model.ParserProjectFindOneById(projCtx.Version.Id)
+	pp, err := model.GetParserProjectStorage(projCtx.Version.ProjectStorageMethod).FindOneByID(r.Context(), projCtx.Version.Id)
 	if err != nil {
 		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem finding parser project"})
 		return
@@ -300,27 +301,35 @@ func (restapi restAPI) getVersionConfig(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	_, err = w.Write(config)
-	grip.Warning(errors.Wrap(err, "problem writing response"))
+	grip.Warning(message.WrapError(err, message.Fields{
+		"message":    "could not write parser project to response",
+		"version_id": projCtx.Version.Id,
+		"route":      "/versions/{version_id}/config",
+	}))
 }
 
 // Returns a JSON response with the marshaled output of the version
 // specified in the request.
 func (restapi restAPI) getVersionProject(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveRESTContext(r)
-	srcVersion := projCtx.Version
-	if srcVersion == nil {
+	if projCtx.Version == nil {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "version not found"})
 		return
 	}
 
-	pp, err := model.ParserProjectFindOneById(projCtx.Version.Id)
+	pp, err := model.GetParserProjectStorage(projCtx.Version.ProjectStorageMethod).FindOneByID(r.Context(), projCtx.Version.Id)
 	if err != nil {
 		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem finding parser project"})
 		return
 	}
+	if pp == nil {
+		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: fmt.Sprintf("parser project '%s' not found", projCtx.Version.Id)})
+	}
+
 	bytes, err := bson.Marshal(pp)
 	if err != nil {
 		gimlet.WriteJSONResponse(w, http.StatusInternalServerError, responseError{Message: "problem reading to bson"})
+		return
 	}
 	gimlet.WriteBinary(w, bytes)
 }

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -310,7 +310,7 @@ func (uis *UIServer) requestNewHost(w http.ResponseWriter, r *http.Request) {
 			uis.LoggedError(w, r, http.StatusBadRequest, errors.New("task not found"))
 			return
 		}
-		err = data.CreateHostsFromTask(t, *authedUser, putParams.PublicKey)
+		err = data.CreateHostsFromTask(ctx, t, *authedUser, putParams.PublicKey)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message": "error creating hosts from task",

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -85,7 +85,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, parserProject, err := model.FindAndTranslateProjectForVersion(v, t.Project)
+	project, parserProject, err := model.FindAndTranslateProjectForVersion(v)
 	if err != nil {
 		return errors.Wrapf(err, "loading project for version '%s'", t.Version)
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -81,7 +81,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, parserProject, err := model.FindAndTranslateProjectForVersion(v.Id, t.Project)
+	project, parserProject, err := model.FindAndTranslateProjectForVersion(v.Id, t.Project, v.ProjectStorageMethod)
 	if err != nil {
 		return errors.Wrapf(err, "loading project for version '%s'", t.Version)
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -85,7 +85,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, parserProject, err := model.FindAndTranslateProjectForVersion(v.Id, t.Project, v.ProjectStorageMethod)
+	project, parserProject, err := model.FindAndTranslateProjectForVersion(v, t.Project)
 	if err != nil {
 		return errors.Wrapf(err, "loading project for version '%s'", t.Version)
 	}

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -554,7 +554,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p, _, err := model.FindAndTranslateProjectForVersion(v, "mci")
+	p, _, err := model.FindAndTranslateProjectForVersion(v)
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
@@ -565,7 +565,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p, _, err = model.FindAndTranslateProjectForVersion(v, "mci")
+	p, _, err = model.FindAndTranslateProjectForVersion(v)
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 6)

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -554,7 +554,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p, _, err := model.FindAndTranslateProjectForVersion(v.Id, "mci")
+	p, _, err := model.FindAndTranslateProjectForVersion(v.Id, "mci", v.ProjectStorageMethod)
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
@@ -565,7 +565,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p, _, err = model.FindAndTranslateProjectForVersion(v.Id, "mci")
+	p, _, err = model.FindAndTranslateProjectForVersion(v.Id, "mci", v.ProjectStorageMethod)
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 6)

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -554,7 +554,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Make sure first project was not changed
 	v, err := model.VersionFindOneId("random_version")
 	assert.NoError(err)
-	p, _, err := model.FindAndTranslateProjectForVersion(v.Id, "mci", v.ProjectStorageMethod)
+	p, _, err := model.FindAndTranslateProjectForVersion(v, "mci")
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 2)
@@ -565,7 +565,7 @@ func TestGenerateTasks(t *testing.T) {
 	// Verify second project was changed
 	v, err = model.VersionFindOneId("sample_version")
 	assert.NoError(err)
-	p, _, err = model.FindAndTranslateProjectForVersion(v.Id, "mci", v.ProjectStorageMethod)
+	p, _, err = model.FindAndTranslateProjectForVersion(v, "mci")
 	assert.NoError(err)
 	require.NotNil(p)
 	assert.Len(p.Tasks, 6)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -894,6 +894,16 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(patchDoc *patch.Patch) error
 	}
 
 	patchDoc.Githash = v.Revision
+	// kim: TODO: make ticket for this issue.
+	// TODO (EVG-XXX): This is storing the entire parser project of the latest
+	// version on the waterfall into the patch document, which is not really an
+	// intended usage of the patched parser project field. The patched parser
+	// project is supposed to be the parser project directly from the YAML file
+	// before generate.tasks. The version this trigger is based off of may have
+	// already run generate.tasks, which can result in a very large parser
+	// project. Therefore, it is not possible to stuff the entire parser project
+	// with generated tasks into the patch document like this, because it may
+	// exceed the 16 MB document limit.
 	patchDoc.PatchedParserProject = string(yamlBytes)
 	patchDoc.VariantsTasks = matchingTasks
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -894,8 +894,7 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(patchDoc *patch.Patch) error
 	}
 
 	patchDoc.Githash = v.Revision
-	// kim: TODO: make ticket for this issue.
-	// TODO (EVG-XXX): This is storing the entire parser project of the latest
+	// TODO (EVG-18700): This is storing the entire parser project of the latest
 	// version on the waterfall into the patch document, which is not really an
 	// intended usage of the patched parser project field. The patched parser
 	// project is supposed to be the parser project directly from the YAML file

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -31,6 +31,7 @@ import (
 type PatchIntentUnitsSuite struct {
 	sender *send.InternalSender
 	env    *mock.Environment
+	ctx    context.Context
 	cancel context.CancelFunc
 
 	repo            string
@@ -58,9 +59,8 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 	s.sender = send.MakeInternalLogger()
 	s.env = &mock.Environment{}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancel = cancel
-	s.Require().NoError(s.env.Configure(ctx))
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.Require().NoError(s.env.Configure(s.ctx))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), "TestPatchIntentUnitsSuite")
 	s.NotNil(s.env.Settings())
@@ -178,9 +178,6 @@ func (s *PatchIntentUnitsSuite) TearDownTest() {
 }
 
 func (s *PatchIntentUnitsSuite) makeJobAndPatch(intent patch.Intent, patchedParserProject string) *patchIntentProcessor {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
 	s.Require().NoError(err)
 
@@ -192,7 +189,7 @@ func (s *PatchIntentUnitsSuite) makeJobAndPatch(intent patch.Intent, patchedPars
 		patchDoc.PatchedParserProject = patchedParserProject
 		patchDoc.Patches = append(patchDoc.Patches, patch.ModulePatch{ModuleName: "sandbox"})
 	}
-	s.NoError(j.finishPatch(ctx, patchDoc, githubOauthToken))
+	s.NoError(j.finishPatch(s.ctx, patchDoc, githubOauthToken))
 	s.NoError(j.Error())
 	s.False(j.HasErrors())
 
@@ -200,9 +197,6 @@ func (s *PatchIntentUnitsSuite) makeJobAndPatch(intent patch.Intent, patchedPars
 }
 
 func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithNoTasksAndVariants() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	resp, err := http.Get(s.diffURL)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -229,15 +223,12 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithNoTasksAndVariants() {
 	j.env = s.env
 
 	patchDoc := intent.NewPatch()
-	err = j.finishPatch(ctx, patchDoc, githubOauthToken)
+	err = j.finishPatch(s.ctx, patchDoc, githubOauthToken)
 	s.Require().Error(err)
 	s.Equal("patch has no build variants or tasks", err.Error())
 }
 
 func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithBadAlias() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	resp, err := http.Get(s.diffURL)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -264,15 +255,12 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithBadAlias() {
 	j.env = s.env
 
 	patchDoc := intent.NewPatch()
-	err = j.finishPatch(ctx, patchDoc, githubOauthToken)
+	err = j.finishPatch(s.ctx, patchDoc, githubOauthToken)
 	s.Require().Error(err)
 	s.Equal("alias 'typo' could not be found on project 'mci'", err.Error())
 }
 
 func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVariants() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	resp, err := http.Get(s.diffURL)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -305,7 +293,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVari
 	j.env = s.env
 
 	patchDoc := intent.NewPatch()
-	err = j.finishPatch(ctx, patchDoc, githubOauthToken)
+	err = j.finishPatch(s.ctx, patchDoc, githubOauthToken)
 	s.Require().Error(err)
 	s.Equal("patch has no build variants or tasks", err.Error())
 }
@@ -1045,7 +1033,7 @@ func (s *PatchIntentUnitsSuite) verifyPatchDoc(patchDoc *patch.Patch, expectedPa
 }
 
 func (s *PatchIntentUnitsSuite) projectExists(projectId string) {
-	pp, err := model.ParserProjectFindOneById(projectId)
+	pp, err := model.GetParserProjectStorage(model.ProjectStorageMethodDB).FindOneByID(s.ctx, projectId)
 	s.NoError(err)
 	s.NotNil(pp)
 }
@@ -1250,15 +1238,12 @@ func (s *PatchIntentUnitsSuite) TestProcessTriggerAliases() {
 	}
 	s.NoError(u.Insert())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	projectRef, err := model.FindBranchProjectRef(s.project)
 	s.NotNil(projectRef)
 	s.NoError(err)
 
 	s.Len(p.Triggers.ChildPatches, 0)
-	s.NoError(ProcessTriggerAliases(ctx, p, projectRef, s.env, []string{"patch-alias"}))
+	s.NoError(ProcessTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
 	s.Len(p.Triggers.ChildPatches, 1)
 
 	dbPatch, err := patch.FindOneId(p.Id.Hex())


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18535

### Description
This PR is kinda long, but it's mostly search+replace.

The parser project needs to be accessed from either the DB or from S3, so I put the current read/write DB functions into an interface. For now, the only implementation is the one that uses the DB, but there will be future work to implement an alternative one that uses S3.

* Add interface and DB implementation for parser project access.
* Refactor existing usages of parser project DB functions so that they use the interface instead. As part of this, I had to add some version lookups (to get the parser project storage method) and pass more contexts around (to satisfy the interface), but the logic should be the same.
* Remove config update number from the parser project and logic around handling parser project races in generate.tasks. This field was used as a lock back when the generate.tasks jobs could race to modify the same parser project, but that should not be possible now that the job uses a scope as the locking mechanism.
* Clean up a bit of old code, including some messy legacy REST v1 route logic, moving some parser project methods around, and removing an unused function.

### Testing 
* Updated unit tests.
* Tested a patch in staging and a few of the REST routes to ensure they still work the same.
