### PR TITLE
EVG-12819 Disambiguate the push command 

### DIFF
--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -157,7 +157,7 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 
 	jpm := c.JasperManager()
 	stdErr := noopWriteCloser{&bytes.Buffer{}}
-	pushCommand := fmt.Sprintf("git push origin %s", p.branch)
+	pushCommand := fmt.Sprintf("git push origin refs/heads/%s", p.branch)
 	logger.Execution().Debugf("git push command: %s", pushCommand)
 	cmd := jpm.CreateCommand(ctx).Directory(p.directory).Append(pushCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr)

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -77,7 +77,7 @@ func TestGitPush(t *testing.T) {
 
 			commands := []string{
 				"git checkout main",
-				"git push origin main",
+				"git push origin refs/heads/main",
 			}
 
 			assert.Len(t, manager.Procs, len(commands))
@@ -152,7 +152,7 @@ func TestGitPush(t *testing.T) {
 
 			assert.NoError(t, c.pushPatch(context.Background(), logger, params))
 			commands := []string{
-				"git push origin main",
+				"git push origin refs/heads/main",
 			}
 			require.Len(t, manager.Procs, len(commands))
 			for i, proc := range manager.Procs {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2022-12-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2022-12-21"
+	AgentVersion = "2023-01-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-12819](https://jira.mongodb.org/browse/EVG-12819)

### Description 
When pushing with `git push origin <name>`, it can refer to either a branch name or a tag name. Since the push command specifically uses the branch name, we should use `git push origin refs/heads/<name>` instead so that it specifically refers to the branch only. 

### Testing 
Merged something on staging to make sure it still works as expected. 
