### PR TITLE
EVG-18543 consider only activate: false for specific generate task activation

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -486,17 +486,17 @@ func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) e
 }
 
 // HasSpecificActivation returns if the build variant task specifies an activation condition that
-// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly deactivating it.
 func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
 	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
-		bvt.Activate != nil || utility.FromBoolPtr(bvt.Disable)
+		!utility.FromBoolTPtr(bvt.Activate) || utility.FromBoolPtr(bvt.Disable)
 }
 
 // HasSpecificActivation returns if the build variant specifies an activation condition that
-// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly deactivating it.
 func (bvt *parserBV) hasSpecificActivation() bool {
 	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
-		bvt.Activate != nil || bvt.Disabled
+		!utility.FromBoolTPtr(bvt.Activate) || bvt.Disabled
 }
 
 // FindAndTranslateProjectForPatch translates a parser project for a patch into a project.


### PR DESCRIPTION
[EVG-18543](https://jira.mongodb.org/browse/EVG-18543)

### Description 
It's not typical to add `activate: true` to generate tasks output which is likely why we've never run into this but it's technically valid but really just means the default; we should really only consider if it's explicitly set to false.

