### PR TITLE
EVG-18634 clarify admin restart text (take two)

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2612,8 +2612,8 @@ Admin Settings
 					<i class="fa fa-refresh"></i>
 					<md-card-title-text>
 						<span>Restart Tasks/Commit Queue Versions</span>
-						<span class="md-subhead">Restart failed tasks or commit queue versions that ran between two
-							times. Uses Eastern timezone.</span>
+						<span class="md-subhead">Restart failed tasks or commit queue versions that started or finished
+							between two times. Uses Eastern timezone regardless of configured timezone.</span>
 					</md-card-title-text>
 				</md-card-title>
 				<md-card-content>


### PR DESCRIPTION
[EVG-18634](https://jira.mongodb.org/browse/EVG-18634)

### Description 
Tried clarifying this behavior once but left it vague enough it needed clarifying again. Verified start/finish behavior [in query](https://github.com/evergreen-ci/evergreen/blob/502403c1ceee7548e323a9f130fb5967e57a433b/model/task/db.go#L645).

### Testing 
 Verified timezone by playing around in staging but didn't actually find how this works 🤔 