### PR TITLE
EVG-18221 Update to search patch aliases

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1782,28 +1782,29 @@ func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]Proj
 	if err != nil {
 		return nil, errors.Wrap(err, "getting alias from project")
 	}
-	if len(vars) == 0 {
-		pRef, err := FindMergedProjectRef(projectId, "", false)
+	if len(vars) > 0 {
+		return vars, nil
+	}
+	pRef, err := FindMergedProjectRef(projectId, "", false)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting project ref")
+	}
+	if pRef == nil || !pRef.IsVersionControlEnabled() {
+		return vars, nil
+	}
+	if len(patchDoc.PatchedProjectConfig) > 0 {
+		projectConfig, err := CreateProjectConfig([]byte(patchDoc.PatchedProjectConfig), projectId)
 		if err != nil {
-			return nil, errors.Wrap(err, "getting project ref")
+			return nil, errors.Wrap(err, "retrieving aliases from patched config")
 		}
-		if pRef == nil || !pRef.IsVersionControlEnabled() {
-			return vars, nil
+		vars, err = findAliasFromProjectConfig(projectConfig, alias)
+		if err != nil {
+			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}
-		if len(patchDoc.PatchedProjectConfig) > 0 {
-			projectConfig, err := CreateProjectConfig([]byte(patchDoc.PatchedProjectConfig), projectId)
-			if err != nil {
-				return nil, errors.Wrap(err, "retrieving aliases from patched config")
-			}
-			vars, err = findAliasFromProjectConfig(projectConfig, alias)
-			if err != nil {
-				return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
-			}
-		} else if patchDoc.Version != "" {
-			vars, err = getMatchingAliasForVersion(patchDoc.Version, alias)
-			if err != nil {
-				return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
-			}
+	} else if patchDoc.Version != "" {
+		vars, err = getMatchingAliasForVersion(patchDoc.Version, alias)
+		if err != nil {
+			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}
 	}
 	return vars, nil

--- a/model/project.go
+++ b/model/project.go
@@ -1778,11 +1778,11 @@ func (p *Project) IsGenerateTask(taskName string) bool {
 }
 
 func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]ProjectAlias, error) {
-	vars, shouldExit, err := findAliasInProjectOrRepoFromDb(projectId, alias)
+	vars, err := findAliasInProjectOrRepoFromDb(projectId, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting alias from project")
 	}
-	if !shouldExit && len(vars) == 0 {
+	if len(vars) == 0 {
 		pRef, err := FindMergedProjectRef(projectId, "", false)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting project ref")

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -182,9 +182,6 @@ func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
 }
 
 // findMatchingAliasForProjectRef finds all aliases with a given name for a project.
-// Typically FindAliasInProjectRepoOrConfig should be used.
-// Returns true if we have an alias match or the alias doesn't match but
-// other aliases in the category are defined, in which case we shouldn't check other sources.
 func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -215,13 +215,6 @@ func findAliasFromProjectConfig(projectConfig *ProjectConfig, alias string) ([]P
 	return projectConfigAliases[alias], nil
 }
 
-func countPatchAliases(projectID string) (int, error) {
-	return db.Count(ProjectAliasCollection, bson.M{
-		projectIDKey: projectID,
-		aliasKey:     bson.M{"$nin": evergreen.InternalAliases},
-	})
-}
-
 func aliasesToMap(aliases []ProjectAlias) map[string][]ProjectAlias {
 	output := make(map[string][]ProjectAlias)
 	for _, alias := range aliases {

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -185,7 +185,7 @@ func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
 // Typically FindAliasInProjectRepoOrConfig should be used.
 // Returns true if we have an alias match or the alias doesn't match but
 // other aliases in the category are defined, in which case we shouldn't check other sources.
-func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bool, error) {
+func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: projectID,
@@ -193,18 +193,10 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, bo
 	})
 	err := db.FindAllQ(ProjectAliasCollection, q, &out)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "finding project aliases")
+		return nil, errors.Wrap(err, "finding project aliases")
 	}
 
-	if len(out) == 0 && IsPatchAlias(alias) {
-		// return true if any patch aliases are defined
-		numPatchAliases, err := countPatchAliases(projectID)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "counting patch aliases")
-		}
-		return nil, numPatchAliases > 0, nil
-	}
-	return out, len(out) > 0, nil
+	return out, nil
 }
 
 // getMatchingAliasForVersion finds any aliases matching the alias input in the project config.
@@ -252,14 +244,14 @@ func aliasesFromMap(input map[string]ProjectAliases) []ProjectAlias {
 // FindAliasInProjectRepoOrConfig finds all aliases with a given name for a project.
 // If the project has no aliases, the repo is checked for aliases.
 func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, error) {
-	aliases, shouldExit, err := findAliasInProjectOrRepoFromDb(projectID, alias)
+	aliases, err := findAliasInProjectOrRepoFromDb(projectID, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
 	}
 	// If nothing is defined in the DB, check the project config,
 	// unless the alias defined is a patch alias and there are patch aliases
 	// defined on the project page.
-	if len(aliases) > 0 || shouldExit {
+	if len(aliases) > 0 {
 		return aliases, nil
 	}
 	return getMatchingAliasForVersion(projectID, alias)
@@ -341,11 +333,11 @@ func uncoveredAliasTypes(aliases map[string]ProjectAliases) []string {
 // FindAliasInProjectRepoOrProjectConfig finds all aliases with a given name for a project.
 // If the project has no aliases, the patched config string is checked for the alias as well.
 func FindAliasInProjectRepoOrProjectConfig(projectID, alias string, projectConfig *ProjectConfig) ([]ProjectAlias, error) {
-	aliases, shouldExit, err := findAliasInProjectOrRepoFromDb(projectID, alias)
+	aliases, err := findAliasInProjectOrRepoFromDb(projectID, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
 	}
-	if len(aliases) > 0 || shouldExit || projectConfig == nil {
+	if len(aliases) > 0 || projectConfig == nil {
 		return aliases, nil
 	}
 
@@ -355,42 +347,31 @@ func FindAliasInProjectRepoOrProjectConfig(projectID, alias string, projectConfi
 // findAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
 // If the project has no aliases, the repo is checked for aliases.
 // Returns true if we should continue to look for repos from a different source.
-func findAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, bool, error) {
-	aliases, shouldExit, err := findMatchingAliasForProjectRef(projectID, alias)
+func findAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, error) {
+	aliases, err := findMatchingAliasForProjectRef(projectID, alias)
 	if err != nil {
-		return aliases, false, errors.Wrapf(err, "finding aliases for project ref '%s'", projectID)
-	}
-	if shouldExit {
-		return aliases, true, nil
+		return aliases, errors.Wrapf(err, "finding aliases for project ref '%s'", projectID)
 	}
 	return tryGetRepoAliases(projectID, alias, aliases)
 }
 
-func tryGetRepoAliases(projectID string, alias string, aliases []ProjectAlias) ([]ProjectAlias, bool, error) {
+func tryGetRepoAliases(projectID string, alias string, aliases []ProjectAlias) ([]ProjectAlias, error) {
 	project, err := FindBranchProjectRef(projectID)
 	if err != nil {
-		return aliases, false, errors.Wrapf(err, "finding project '%s'", projectID)
+		return aliases, errors.Wrapf(err, "finding project '%s'", projectID)
 	}
 	if project == nil {
-		return aliases, false, errors.Errorf("project '%s' does not exist", projectID)
+		return aliases, errors.Errorf("project '%s' does not exist", projectID)
 	}
 	if !project.UseRepoSettings() {
-		return aliases, false, nil
+		return aliases, nil
 	}
 
 	aliases, err = findMatchingAliasForRepo(project.RepoRefId, alias)
 	if err != nil {
-		return aliases, false, errors.Wrapf(err, "finding aliases for repo '%s'", project.RepoRefId)
+		return aliases, errors.Wrapf(err, "finding aliases for repo '%s'", project.RepoRefId)
 	}
-	shouldExit := false
-	if IsPatchAlias(alias) {
-		numRepoPatchAliases, err := countPatchAliases(project.RepoRefId)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "counting patch aliases")
-		}
-		shouldExit = numRepoPatchAliases > 0
-	}
-	return aliases, shouldExit, nil
+	return aliases, nil
 }
 
 // HasMatchingGitTagAliasAndRemotePath returns matching git tag aliases that match the given git tag

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -182,6 +182,7 @@ func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
 }
 
 // findMatchingAliasForProjectRef finds all aliases with a given name for a project.
+// Typically FindAliasInProjectRepoOrConfig should be used.
 func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
@@ -238,9 +239,7 @@ func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, er
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
 	}
-	// If nothing is defined in the DB, check the project config,
-	// unless the alias defined is a patch alias and there are patch aliases
-	// defined on the project page.
+	// If nothing is defined in the DB, check the project config.
 	if len(aliases) > 0 {
 		return aliases, nil
 	}
@@ -336,7 +335,6 @@ func FindAliasInProjectRepoOrProjectConfig(projectID, alias string, projectConfi
 
 // findAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
 // If the project has no aliases, the repo is checked for aliases.
-// Returns true if we should continue to look for repos from a different source.
 func findAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, error) {
 	aliases, err := findMatchingAliasForProjectRef(projectID, alias)
 	if err != nil {

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -352,6 +352,9 @@ func findAliasInProjectOrRepoFromDb(projectID, alias string) ([]ProjectAlias, er
 	if err != nil {
 		return aliases, errors.Wrapf(err, "finding aliases for project ref '%s'", projectID)
 	}
+	if len(aliases) > 0 {
+		return aliases, nil
+	}
 	return tryGetRepoAliases(projectID, alias, aliases)
 }
 

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -484,11 +484,6 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
 	s.NoError(err)
 	s.Len(found, 2)
 
-	// Test project doesn't match alias but other patch aliases are defined so we don't continue to repo
-	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-1")
-	s.NoError(err)
-	s.Len(found, 0)
-
 	// Test non-existent project
 	found, err = FindAliasInProjectRepoOrConfig("bad-project", "alias-1")
 	s.Error(err)

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -207,9 +207,8 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.NoError(a2.Upsert())
 	s.NoError(a3.Upsert())
 
-	found, shouldExit, err := findMatchingAliasForProjectRef("project-1", "alias-1")
+	found, err := findMatchingAliasForProjectRef("project-1", "alias-1")
 	s.NoError(err)
-	s.True(shouldExit)
 	s.Len(found, 2)
 }
 
@@ -237,10 +236,16 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 		ProjectID: "project-1",
 		Alias:     "alias-0",
 	}
+	duplicateAlias := ProjectAlias{
+		ProjectID:   "project-1",
+		Alias:       "duplicate",
+		Description: "from UI",
+	}
 	s.NoError(a1.Upsert())
 	s.NoError(a2.Upsert())
 	s.NoError(a3.Upsert())
 	s.NoError(patchAlias.Upsert())
+	s.NoError(duplicateAlias.Upsert())
 
 	projectConfig := &ProjectConfig{
 		Id:      "project-1",
@@ -254,6 +259,11 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 				{
 					ID:    mgobson.NewObjectId(),
 					Alias: "alias-1",
+				},
+				{
+					ID:          mgobson.NewObjectId(),
+					Alias:       "duplicate",
+					Description: "from project config",
 				},
 			},
 			CommitQueueAliases: []ProjectAlias{
@@ -286,29 +296,19 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-0")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
-
-	// Even with version control enabled, we ignore the config aliases
-	// since the project also has patch aliases enabled.
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-1")
-	s.NoError(err)
-	s.Len(projectAliases, 0)
-
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-2")
-	s.NoError(err)
-	s.Len(projectAliases, 0)
-
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "nonexistent")
-	s.NoError(err)
-	s.Len(projectAliases, 0)
-
-	s.NoError(RemoveProjectAlias(patchAlias.ID.Hex()))
-	// Version control patch aliases can now be found
 	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-1")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-2")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
+
+	// If the same alias is defined in both UI and project config,
+	// UI takes precedence.
+	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "duplicate")
+	s.NoError(err)
+	s.Len(projectAliases, 1)
+	s.Equal("from UI", projectAliases[0].Description)
 
 }
 


### PR DESCRIPTION
[EVG-18221](https://jira.mongodb.org/browse/EVG-18221)

### Description 
deleted shouldExit variable when checking for aliases because that was causing us to never search project configs for patch aliases 

New alias behavior that I'm proposing : 
Instead of ignoring everything in project configs when a patch alias is defined on the UI,  we still check the project configs.
The UI will still take precedence over the project config patch alias if an alias with the same name is redefined.
My reasoning for that being that users can more easily change the names of custom patch aliases for their specific patch to not match an existing one if they really wanted. 

### Testing 
staging
unit tests