### PR TITLE
EVG-18634 change range to consider started or failed within time range

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -318,8 +318,7 @@ func PatchesByProject(projectId string, ts time.Time, limit int) db.Q {
 	}).Sort([]string{"-" + CreateTimeKey}).Limit(limit)
 }
 
-// FindFailedCommitQueuePatchesInTimeRange returns failed patches if they started within range,
-// or if they were never started but finished within time range. (i.e. timed out)
+// FindFailedCommitQueuePatchesInTimeRange returns failed patches if they started or failed within range.
 func FindFailedCommitQueuePatchesInTimeRange(projectID string, startTime, endTime time.Time) ([]Patch, error) {
 	query := bson.M{
 		ProjectKey: projectID,
@@ -331,7 +330,6 @@ func FindFailedCommitQueuePatchesInTimeRange(projectID string, startTime, endTim
 				{StartTimeKey: bson.M{"$gte": startTime}},
 			}},
 			{"$and": []bson.M{
-				{StartTimeKey: time.Time{}},
 				{FinishTimeKey: bson.M{"$lte": endTime}},
 				{FinishTimeKey: bson.M{"$gte": startTime}},
 			}},

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -716,11 +716,11 @@ func TestVariantTasksToTVPairs(t *testing.T) {
 	assert := assert.New(t)
 
 	input := []patch.VariantTasks{
-		patch.VariantTasks{
+		{
 			Variant: "variant",
 			Tasks:   []string{"task1", "task2", "task3"},
 			DisplayTasks: []patch.DisplayTask{
-				patch.DisplayTask{
+				{
 					Name: "displaytask1",
 				},
 			},
@@ -767,13 +767,13 @@ func TestAddNewPatch(t *testing.T) {
 	proj := &Project{
 		Identifier: "project",
 		BuildVariants: []BuildVariant{
-			BuildVariant{
+			{
 				Name: "variant",
 				Tasks: []BuildVariantTaskUnit{
 					{Name: "task1"}, {Name: "task2"}, {Name: "task3"},
 				},
 				DisplayTasks: []patch.DisplayTask{
-					patch.DisplayTask{
+					{
 						Name:      "displaytask1",
 						ExecTasks: []string{"task1", "task2"},
 					},
@@ -782,15 +782,15 @@ func TestAddNewPatch(t *testing.T) {
 			},
 		},
 		Tasks: []ProjectTask{
-			ProjectTask{Name: "task1"}, ProjectTask{Name: "task2"}, ProjectTask{Name: "task3"},
+			{Name: "task1"}, {Name: "task2"}, {Name: "task3"},
 		},
 	}
 	tasks := VariantTasksToTVPairs([]patch.VariantTasks{
-		patch.VariantTasks{
+		{
 			Variant: "variant",
 			Tasks:   []string{"task1", "task2", "task3"},
 			DisplayTasks: []patch.DisplayTask{
-				patch.DisplayTask{
+				{
 					Name: "displaytask1",
 				},
 			},
@@ -856,13 +856,13 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 	proj := &Project{
 		Identifier: "project",
 		BuildVariants: []BuildVariant{
-			BuildVariant{
+			{
 				Name: "variant",
 				Tasks: []BuildVariantTaskUnit{
 					{Name: "task1"}, {Name: "task2"}, {Name: "task3"},
 				},
 				DisplayTasks: []patch.DisplayTask{
-					patch.DisplayTask{
+					{
 						Name:      "displaytask1",
 						ExecTasks: []string{"task1", "task2"},
 					},
@@ -871,15 +871,15 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 			},
 		},
 		Tasks: []ProjectTask{
-			ProjectTask{Name: "task1"}, ProjectTask{Name: "task2"}, ProjectTask{Name: "task3"},
+			{Name: "task1"}, {Name: "task2"}, {Name: "task3"},
 		},
 	}
 	tasks := VariantTasksToTVPairs([]patch.VariantTasks{
-		patch.VariantTasks{
+		{
 			Variant: "variant",
 			Tasks:   []string{"task1", "task2", "task3"},
 			DisplayTasks: []patch.DisplayTask{
-				patch.DisplayTask{
+				{
 					Name: "displaytask1",
 				},
 			},
@@ -1010,15 +1010,14 @@ func TestRetryCommitQueueItems(t *testing.T) {
 			require.Len(t, cq.Queue, 1)
 			assert.Equal(t, "123", cq.Queue[0].Issue)
 		},
-		"UnstartedPatch": func(*testing.T) {
+		"FinishedPatch": func(*testing.T) {
 			assert.NoError(t, projectRef.Insert())
 
-			// not started but terminated within time range
 			p := patch.Patch{
 				Id:         mgobson.NewObjectId(),
 				Project:    projectRef.Id,
 				Githash:    patchedRevision,
-				StartTime:  time.Time{},
+				StartTime:  startTime.Add(-30 * time.Minute), // started out of range
 				FinishTime: startTime.Add(30 * time.Minute),
 				Status:     evergreen.PatchFailed,
 				Alias:      evergreen.CommitQueueAlias,
@@ -1051,19 +1050,6 @@ func TestRetryCommitQueueItems(t *testing.T) {
 					Author:      "me",
 					GithubPatchData: thirdparty.GithubPatch{
 						PRNumber: 123,
-					},
-					Patches: []patch.ModulePatch{
-						{
-							Githash:    "revision",
-							ModuleName: "name",
-							PatchSet: patch.PatchSet{
-								Patch: "456",
-								Summary: []thirdparty.Summary{
-									{Name: configFilePath, Additions: 4, Deletions: 80},
-									{Name: "random.txt", Additions: 6, Deletions: 0},
-								},
-							},
-						},
 					},
 				},
 				{ // within time frame, not failed

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -640,8 +640,7 @@ func ByBeforeRevisionWithStatusesAndRequesters(revisionOrder int, statuses []str
 	}
 }
 
-// ByTimeStartedAndFailed returns all failed tasks that started between 2 given times
-// If task not started (but is failed), returns if finished within the time range
+// ByTimeStartedAndFailed returns all failed tasks that started or finished between 2 given times
 func ByTimeStartedAndFailed(startTime, endTime time.Time, commandTypes []string) bson.M {
 	query := bson.M{
 		"$or": []bson.M{
@@ -650,7 +649,6 @@ func ByTimeStartedAndFailed(startTime, endTime time.Time, commandTypes []string)
 				{StartTimeKey: bson.M{"$gte": startTime}},
 			}},
 			{"$and": []bson.M{
-				{StartTimeKey: time.Time{}},
 				{FinishTimeKey: bson.M{"$lte": endTime}},
 				{FinishTimeKey: bson.M{"$gte": startTime}},
 			}},

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1604,12 +1604,12 @@ func MarkTasksReset(taskIds []string) error {
 	return catcher.Resolve()
 }
 
-// RestartFailedTasks attempts to restart failed tasks that started between 2 times
+// RestartFailedTasks attempts to restart failed tasks that started or failed between 2 times.
 // It returns a slice of task IDs that were successfully restarted as well as a slice
-// of task IDs that failed to restart
-// opts.dryRun will return the tasks that will be restarted if sent true
+// of task IDs that failed to restart.
+// opts.dryRun will return the tasks that will be restarted if set to true.
 // opts.red and opts.purple will only restart tasks that were failed due to the test
-// or due to the system, respectively
+// or due to the system, respectively.
 func RestartFailedTasks(opts RestartOptions) (RestartResults, error) {
 	results := RestartResults{}
 	if !opts.IncludeTestFailed && !opts.IncludeSysFailed && !opts.IncludeSetupFailed {


### PR DESCRIPTION
[EVG-18634 ](https://jira.mongodb.org/browse/EVG-18634 )

### Description 
It looks like I originally very purposefully made this query only check for things that either started in range or failed in range but had no start time? I don't understand than scenario 😅 and I don't see anything enlightening [in the PR](https://github.com/evergreen-ci/evergreen/pull/2472). 

### Testing 
Added unit tests.
