### PR TITLE
EVG-15470 Introduce auto-description flag to the CLI

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2023-01-11"
+	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-01-11"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -54,7 +54,7 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 				Usage: "description for the patch",
 			},
 			cli.BoolFlag{
-				Name:  autoDescriptionFlag,
+				Name:  joinFlagNames(autoDescriptionFlag, "ad"),
 				Usage: "use last commit message as the patch description",
 			},
 			cli.BoolFlag{

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -74,6 +74,7 @@ type patchParams struct {
 	Browse            bool
 	Large             bool
 	ShowSummary       bool
+	AutoDescription   bool
 	Uncommitted       bool
 	PreserveCommits   bool
 	Ref               string
@@ -409,7 +410,7 @@ func (p *patchParams) loadVariants(conf *ClientSettings) error {
 	return nil
 }
 
-//Option to set default parameters no longer supported to prevent unwanted parameters from persisting within future patches
+// Option to set default parameters no longer supported to prevent unwanted parameters from persisting within future patches
 func (p *patchParams) loadParameters(conf *ClientSettings) error {
 	if len(p.Parameters) == 0 {
 		p.Parameters = conf.FindDefaultParameters(p.Project)
@@ -455,6 +456,12 @@ func (p *patchParams) loadTasks(conf *ClientSettings) error {
 func (p *patchParams) getDescription() string {
 	if p.Description != "" {
 		return p.Description
+	} else if p.AutoDescription {
+		description, err := getDefaultDescription()
+		if err != nil {
+			grip.Error(err)
+		}
+		return description
 	}
 
 	description := ""


### PR DESCRIPTION
[EVG-15470](https://jira.mongodb.org/browse/EVG-15470)

### Description 
Introduced `auto-description` flag name, which is a bool flag and if set will retrieve the most recent commit message for a `patch` command and skip the description prompt altogether. If this patch is enqueued to the commit queue later this description carries over as well. Lastly, made it such that the `auto-description` and `description` flag are mutually exclusive.
### Testing 
Built and tested CLI locally