### PR TITLE
EVG-17588: add smoke test for expansions.write

### DIFF
--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -1,3 +1,5 @@
+# This project YAML is used to run the smoke test.
+
 command_type: test
 stepback: false
 
@@ -101,6 +103,9 @@ tasks:
             # file to s3.put
             mkdir upload
             echo ${task_name} > upload/s3
+
+            # miscellaneous files written by commands
+            mkdir output
       - command: subprocess.exec
         params:
           working_dir: archive
@@ -148,7 +153,17 @@ tasks:
           file: "src/agent/command/testdata/xunit/junit_4.xml"
       - command: expansions.update
         params:
-          foo: bar
+          updates:
+            - key: foo
+              value: bar
+      - command: expansions.write
+        display_name: "Test expansions.write"
+        params:
+          file: output/expansions.yaml
+      - command: subprocess.exec
+        display_name: "Check updated expansions are in written expansions file"
+        params:
+          command: grep "foo.*bar" output/expansions.yaml
       - command: gotest.parse_files
         params:
           files:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -2,7 +2,6 @@ command_type: test
 stepback: true
 ignore:
   - "*.md" # don't schedule tests if a commit only changes markdown files
-  - "scripts/*" # our scripts are untested, so don't schedule tests for them
   - ".github/*" # github CODEOWNERS configuration
 
 post:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17588

### Description 
I'm also going to clean up some of the smoke test checking logic in a follow-up PR.

* Add expansions.write to the smoke tests.
* Add a grep test to verify that expansions.update and expansions.write works as expected.
* Fix an issue where expansions.write was giving the expansion key-value pair using incorrect syntax (it wasn't actually updating any expansions before this).
* Don't ignore changes to the `scripts` directory since that contains a lot of testing-relevant files.

### Testing 
I tried pointing the smoke test to use my fork's branch with the updated agent.yml. The task itself timed out, but [it did run the grep check successfully](https://parsley.mongodb.com/evergreen/evergreen_ubuntu1604_smoke_test_host_task_patch_1710c8ecaefa268fe34e7f54464f1fb10ac89d5d_63c06cd03627e0752675223b_23_01_12_20_25_52/0/task?bookmarks=0,1835&selectedLine=1261), so I'm inclined to believe that it works because the one thing I changed ran as expected.