### PR TITLE
EVG-18507 increment idle time

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -319,7 +319,7 @@ func (j *hostTerminationJob) incrementIdleTime(ctx context.Context) error {
 	}
 
 	idleTimeStartsAt := j.host.LastTaskCompletedTime
-	if idleTimeStartsAt.IsZero() || idleTimeStartsAt == utility.ZeroTime {
+	if utility.IsZeroTime(idleTimeStartsAt) {
 		idleTimeStartsAt = j.host.StartTime
 	}
 
@@ -329,7 +329,7 @@ func (j *hostTerminationJob) incrementIdleTime(ctx context.Context) error {
 		hostBillingEnds = hostBillingEnds.Add(pad)
 	}
 
-	idleTime := idleTimeStartsAt.Sub(hostBillingEnds)
+	idleTime := hostBillingEnds.Sub(idleTimeStartsAt)
 	return errors.Wrap(j.host.IncIdleTime(idleTime), "incrementing idle time")
 }
 


### PR DESCRIPTION
[EVG-18507](https://jira.mongodb.org/browse/EVG-18507)

### Description 
We used to increment the idle time of a host when we terminated it so the time from when the last task to run until termination time was included in the tally. Right now, though, I think we only increment when we start a task.

I think this might have been a regression in https://github.com/evergreen-ci/evergreen/commit/4a7a32041d8bd02f4784321820eb2655f7476df2 (specifically [here](https://github.com/evergreen-ci/evergreen/commit/4a7a32041d8bd02f4784321820eb2655f7476df2#diff-6dd488a00c797fb521cd37e03c8869d4fb82c17ee75a9c79eec5648ed8f7a05bL364-L366)).

### Testing 
I'll try it out in staging when I get a chance 😄 
