### PR TITLE
EVG-18735: standardize the command name in the task log

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-11"
+	AgentVersion = "2023-01-13"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18735

### Description 
The full command string that's shown when a command starts/ends (e.g. `Running 'subprocess.exec' (step 1 of 1)`) is weirdly inconsistent when it comes to using the display name (e.g. `("The display name goes here") 'subprocess.exec' (step 1 of 1)`), using the function name, and mixing up single and double quotes. It's not a big deal, but I feel like it does trip me up a bit over "what's this command called", "is this the function name or the command's display name", "why does a command in a function not show the display name", etc. all the time. My proposal is to display it as something more like this:
`Running 'subprocess.exec' (step 1 of 1).`
`Running 'Wao such cool display name' ('subprocess.exec') (step 1 of 1).`
`Running 'Wao such cool display name' ('subprocess.exec') in function 'wao so great function name kim' (step 1.1 of 2).`

There's some non-zero possibility that some user out there is relying on the exact command string format somehow or is going to protest greatly, but I'm 100% willing to take any heat for this.

### Testing 
Existing agent suite tests the full command string.