### PR TITLE
EVG-17588: refactor and improve smoke test debugging experience

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
@@ -64,15 +63,6 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 	for idx, cmd := range cmds {
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "canceled while running command list")
-		}
-		if cmd.DisplayName() == "" {
-			grip.Critical(message.Fields{
-				"message": "attempting to run an undefined command",
-				"name":    cmd.Name(),
-				"type":    cmd.Type(),
-				"raw":     fmt.Sprintf("%#v", cmd),
-				"info":    commandInfo,
-			})
 		}
 
 		cmd.SetJasperManager(a.jasper)

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-11"
+	AgentVersion = "2023-01-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/makefile
+++ b/makefile
@@ -150,9 +150,19 @@ $(buildDir)/.load-local-data:$(buildDir)/load-smoke-data
 	./$< -path testdata/local -dbName evergreen_local -amboyDBName amboy_local
 	@touch $@
 smoke-test-agent-monitor:$(localClientBinary) load-smoke-data
+	# Start the smoke test's Evergreen app server.
 	./$< service deploy start-evergreen --web --binary ./$< &
+	# Start the smoke test's agent monitor, which will run the Evergreen agent based on the locally-compiled Evergreen
+	# executable. This agent will coordinate with the app server to run the smoke test's tasks.
+	# It is necessary to set up this locally-running agent because the app server can't actually start hosts to run
+	# tasks.
+	# Note that the distro comes from the smoke test's DB files.
 	./$< service deploy start-evergreen --monitor --binary ./$< --distro localhost &
+	# Run the smoke test's actual tests.
+	# The username/password to is used to authenticate to the app server, and these credentials come from the smoke
+	# test's DB files.
 	./$< service deploy test-endpoints --check-build --username admin --key abb623665fdbf368a1db980dde6ee0f0
+	# Clean up all smoke test Evergreen executable processes.
 	pkill -f $<
 smoke-test-host-task:$(localClientBinary) load-smoke-data
 	./$< service deploy start-evergreen --web --binary ./$< &

--- a/makefile
+++ b/makefile
@@ -136,11 +136,11 @@ $(buildDir)/set-project-var:cmd/set-project-var/set-project-var.go
 	$(gobin) build -o $@ $<
 set-var:$(buildDir)/set-var
 set-project-var:$(buildDir)/set-project-var
-set-smoke-vars:$(buildDir)/.load-smoke-data
-	@./bin/set-project-var -dbName mci_smoke -key aws_key -value $(AWS_KEY)
-	@./bin/set-project-var -dbName mci_smoke -key aws_secret -value $(AWS_SECRET)
-	@./bin/set-var -dbName=mci_smoke -collection=hosts -id=localhost -key=agent_revision -value=$(agentVersion)
-	@./bin/set-var -dbName=mci_smoke -collection=pods -id=localhost -key=agent_version -value=$(agentVersion)
+set-smoke-vars:$(buildDir)/.load-smoke-data $(buildDir)/set-project-var $(buildDir)/set-var
+	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_key -value $(AWS_KEY)
+	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_secret -value $(AWS_SECRET)
+	@$(buildDir)/set-var -dbName=mci_smoke -collection=hosts -id=localhost -key=agent_revision -value=$(agentVersion)
+	@$(buildDir)/set-var -dbName=mci_smoke -collection=pods -id=localhost -key=agent_version -value=$(agentVersion)
 load-smoke-data:$(buildDir)/.load-smoke-data
 load-local-data:$(buildDir)/.load-local-data
 $(buildDir)/.load-smoke-data:$(buildDir)/load-smoke-data

--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -13,7 +13,15 @@ import (
 
 // this is about a month.
 const oneMonthIsh = 30 * 24 * time.Hour
-const durationIndex = "branch_1_build_variant_1_display_name_1_status_1_finish_time_1_start_time_1"
+
+var DurationIndex = bson.D{
+	{Key: ProjectKey, Value: 1},
+	{Key: BuildVariantKey, Value: 1},
+	{Key: DisplayNameKey, Value: 1},
+	{Key: StatusKey, Value: 1},
+	{Key: FinishTimeKey, Value: 1},
+	{Key: StartTimeKey, Value: 1},
+}
 
 type expectedDurationResults struct {
 	DisplayName      string  `bson:"_id"`
@@ -73,7 +81,7 @@ func getExpectedDurationsForWindow(name, project, buildvariant string, start, en
 	coll := evergreen.GetEnvironment().DB().Collection(Collection)
 	ctx, cancel := evergreen.GetEnvironment().Context()
 	defer cancel()
-	cursor, err := coll.Aggregate(ctx, pipeline, &options.AggregateOptions{Hint: durationIndex})
+	cursor, err := coll.Aggregate(ctx, pipeline, &options.AggregateOptions{Hint: DurationIndex})
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating task average duration")
 	}

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -164,7 +164,7 @@ func triggerRepotracker(username, key string, client *http.Client) error {
 }
 
 // getAndCheckBuilds gets build information from the Evergreen app server's REST
-// API for the builds that it expects to be eventaully created. These checks are
+// API for the builds that it expects to be eventually created. These checks are
 // assuming that, by triggering the repotracker to run, a version should
 // eventually be created for the latest commit to Evergreen.
 func getAndCheckBuilds(username, key string, client *http.Client) ([]apimodels.APIBuild, error) {

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -73,7 +73,7 @@ func (td smokeEndpointTestDefinitions) waitForEvergreen(client *http.Client) err
 		return nil
 	}
 
-	return errors.Errorf("Evergreen was not up after %d check attempts.", attempts)
+	return errors.Errorf("Evergreen app server was not up after %d check attempts.", attempts)
 }
 
 // getLatestGithubCommit gets the latest commit on the main branch of Evergreen.
@@ -110,6 +110,8 @@ func checkContainerTask(username, key string) error {
 	return checkTaskStatusAndLogs(client, agent.PodMode, []string{smokeContainerTaskID}, username, key)
 }
 
+// checkHostTaskByCommit runs host tasks in the smoke test based on the project
+// YAML (agent.yml).
 func checkHostTaskByCommit(username, key string) error {
 	client := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(client)
@@ -132,10 +134,15 @@ func checkHostTaskByCommit(username, key string) error {
 }
 
 // triggerRepotracker makes a request to the Evergreen app server's REST API to
-// run the repotracker. Note that this returning success means that the
-// repotracker will run eventually. It does *not* guarantee that it has already
-// run, nor that it has actually managed to pick up the latest commits from
-// GitHub.
+// run the repotracker. This is a necessary entry point to create the smoke
+// test's tasks.
+// Note that this returning success means that the repotracker will run
+// eventually. It does *not* guarantee that it has already run, nor that it has
+// actually managed to pick up the latest commits from GitHub.
+// Also note that because it picks up commits from GitHub to make the versions
+// to run for the smoke test, the project YAML it will use (agent.yml) is based
+// on the latest committed YAML on the project's tracked branch, *not* the
+// locally-modified project YAML.
 func triggerRepotracker(username, key string, client *http.Client) error {
 	grip.Info("Attempting to trigger repotracker to run.")
 

--- a/scripts/setup-smoke-config.sh
+++ b/scripts/setup-smoke-config.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Edit the smoke test's admin settings so they have the necessary GitHub credentials to run the smoke test.
 set -o errexit
 
 mkdir -p clients

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -108,10 +108,6 @@ variables:
       - func: get-project-and-modules
       - func: setup-mongodb
       - func: run-make
-        vars: { target: "set-var" }
-      - func: run-make
-        vars: { target: "set-project-var" }
-      - func: run-make
         vars: { target: "load-smoke-data" }
       - command: subprocess.exec
         params:
@@ -124,6 +120,19 @@ variables:
       - func: run-make
         vars:
           target: "${task_name}"
+      - command: s3.put
+        display_name: Upload app server logs to S3
+        type: system
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          local_file: evergreen/server_logs.txt
+          remote_file: evergreen/${task_id}/app_server_logs.txt
+          bucket: mciuploads
+          content_type: text/plain
+          permissions: public-read
+          display_name: Evergreen test application server logs
+
   - &version-constants
     nodejs_version: "6.11.1"
   - &run-generate-lint

--- a/testdata/smoke_config.yml
+++ b/testdata/smoke_config.yml
@@ -1,4 +1,8 @@
-# This file contains the admin settings used for the smoke test application server.
+# This file contains the admin settings used for the smoke test's app server.
+# This does not contain the entire configuration that will be used in the smoke
+# test, because it excludes the sensitive credentials necessary for the smoke
+# test to run (which are populated during task runtime).
+
 log_path: "server_logs.txt"
 
 database:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17588

### Description 
This is a mish-mash of improvements to the smoke test.

* Refactor the smoke test logic for readability, including cleaning up the many loops and simplifying down some unnecessarily complicated old logic.
* Add a bunch of doc comments on what the smoke test is testing and how it expects those tests to work in terms of mental model.
* Fix some issues where the smoke test logs things repeatedly, which can lead to confusion when reading the smoke test's task logs.
* Upload the test app server's log file to S3 so that devs can read it to cross-reference what the app server is doing during the smoke test.
* Add some indexes that the app server needed to run some queries. This was producing some spurious errors in the app server logs.
* Remove a debug log in the agent which is not actually necessary and seems like it can be removed.

### Testing 
Ran the smoke test in a patch and checked that it passed, the task logs were cleaner, and the app server file was uploaded.

`verify-client-version-update` is complaining, but it's spurious since no users other of Evergreen devs use the smoke sub-commands in the CLI. I'm not bumping the version since this doesn't affect users.