### PR TITLE
EVG-18738 Fix commit queue document not being created for old projects 

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -317,7 +317,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 		// At project creation we now insert a commit queue, however older projects still may not have one
 		// so we need to validate that this exists if the feature is being toggled on.
-		if mergedBeforeRef.CommitQueue.IsEnabled() && mergedSection.CommitQueue.IsEnabled() {
+		if !mergedBeforeRef.CommitQueue.IsEnabled() && mergedSection.CommitQueue.IsEnabled() {
 			if err = commitqueue.EnsureCommitQueueExistsForProject(mergedSection.Id); err != nil {
 				return nil, err
 			}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -343,6 +343,18 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, apiProjectRef.BuildFromService(changes))
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
+				Aliases: []restModel.APIProjectAlias{
+					{
+						Alias:   utility.ToStringPtr(evergreen.CommitQueueAlias),
+						Task:    utility.ToStringPtr("new_task"),
+						Variant: utility.ToStringPtr("new_variant"),
+					},
+					{
+						Alias:   utility.ToStringPtr(evergreen.GithubPRAlias),
+						Task:    utility.ToStringPtr("new_task"),
+						Variant: utility.ToStringPtr("new_variant"),
+					},
+				},
 			}
 			_, err := SaveProjectSettingsForSection(ctx, changes.Id, apiChanges, model.ProjectPageGithubAndCQSection, false, "me")
 			assert.NoError(t, err)

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -324,6 +324,32 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotContains(t, err.Error(), "the commit queue")
 			assert.NotContains(t, err.Error(), "commit checks")
 		},
+		"a commit queue document exists after the feature is turned on": func(t *testing.T, ref model.ProjectRef) {
+			oldRef := model.ProjectRef{
+				Owner:   ref.Owner,
+				Repo:    ref.Repo,
+				Branch:  ref.Branch,
+				Enabled: utility.TruePtr(),
+			}
+			assert.NoError(t, oldRef.Insert())
+
+			changes := model.ProjectRef{
+				Id: ref.Id,
+				CommitQueue: model.CommitQueueParams{
+					Enabled: utility.TruePtr(),
+				},
+			}
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(changes))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			_, err := SaveProjectSettingsForSection(ctx, changes.Id, apiChanges, model.ProjectPageGithubAndCQSection, false, "me")
+			assert.NoError(t, err)
+			cq, err := commitqueue.FindOneId(ref.Id)
+			assert.NoError(t, err)
+			assert.NotNil(t, cq)
+		},
 		model.ProjectPageAccessSection: func(t *testing.T, ref model.ProjectRef) {
 			newAdmin := user.DBUser{
 				Id: "newAdmin",


### PR DESCRIPTION
[EVG-18738](https://jira.mongodb.org/browse/EVG-18738)

### Description 
If an old project enabled the commit queue on the new project page, the commit queue document wasn't being created. This boolean needs to be flipped. 

### Testing 
Reasoned about it. 
