### PR TITLE
EVG-16926  Make max retries configurable for system failed tasks on the commit queue 

### DIFF
--- a/config_commitqueue.go
+++ b/config_commitqueue.go
@@ -9,17 +9,19 @@ import (
 )
 
 type CommitQueueConfig struct {
-	MergeTaskDistro string `yaml:"merge_task_distro" bson:"merge_task_distro" json:"merge_task_distro"`
-	CommitterName   string `yaml:"committer_name" bson:"committer_name" json:"committer_name"`
-	CommitterEmail  string `yaml:"committer_email" bson:"committer_email" json:"committer_email"`
-	BatchSize       int    `yaml:"batch_size" bson:"batch_size" json:"batch_size"`
+	MergeTaskDistro            string `yaml:"merge_task_distro" bson:"merge_task_distro" json:"merge_task_distro"`
+	CommitterName              string `yaml:"committer_name" bson:"committer_name" json:"committer_name"`
+	CommitterEmail             string `yaml:"committer_email" bson:"committer_email" json:"committer_email"`
+	BatchSize                  int    `yaml:"batch_size" bson:"batch_size" json:"batch_size"`
+	MaxSystemFailedTaskRetries int    `yaml:"max_system_failed_task_retries" bson:"max_system_failed_task_retries" json:"max_system_failed_task_retries"`
 }
 
 var (
-	mergeTaskDistroKey      = bsonutil.MustHaveTag(CommitQueueConfig{}, "MergeTaskDistro")
-	committerNameKey        = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterName")
-	committerEmailKey       = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterEmail")
-	commitQueueBatchSizeKey = bsonutil.MustHaveTag(CommitQueueConfig{}, "BatchSize")
+	mergeTaskDistroKey            = bsonutil.MustHaveTag(CommitQueueConfig{}, "MergeTaskDistro")
+	committerNameKey              = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterName")
+	committerEmailKey             = bsonutil.MustHaveTag(CommitQueueConfig{}, "CommitterEmail")
+	commitQueueBatchSizeKey       = bsonutil.MustHaveTag(CommitQueueConfig{}, "BatchSize")
+	maxSystemFailedTaskRetriesKey = bsonutil.MustHaveTag(CommitQueueConfig{}, "MaxSystemFailedTaskRetries")
 )
 
 func (c *CommitQueueConfig) SectionId() string { return "commit_queue" }
@@ -55,10 +57,11 @@ func (c *CommitQueueConfig) Set() error {
 
 	_, err := coll.UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			mergeTaskDistroKey:      c.MergeTaskDistro,
-			committerNameKey:        c.CommitterName,
-			committerEmailKey:       c.CommitterEmail,
-			commitQueueBatchSizeKey: c.BatchSize,
+			mergeTaskDistroKey:            c.MergeTaskDistro,
+			committerNameKey:              c.CommitterName,
+			committerEmailKey:             c.CommitterEmail,
+			commitQueueBatchSizeKey:       c.BatchSize,
+			maxSystemFailedTaskRetriesKey: c.MaxSystemFailedTaskRetries,
 		},
 	}, options.Update().SetUpsert(true))
 	return errors.Wrapf(err, "updating config section '%s'", c.SectionId())

--- a/globals.go
+++ b/globals.go
@@ -331,6 +331,14 @@ var TaskNonGenericFailureStatuses = []string{
 	TaskSystemTimedOut,
 }
 
+var TaskSystemFailures = []string{
+	TaskSystemFailed,
+	TaskTimedOut,
+	TaskSystemUnresponse,
+	TaskSystemTimedOut,
+	TaskTestTimedOut,
+}
+
 // TaskFailureStatuses represent all the ways that a completed task can fail,
 // inclusive of display statuses such as system failures.
 var TaskFailureStatuses = append([]string{TaskFailed}, TaskNonGenericFailureStatuses...)
@@ -355,6 +363,10 @@ func IsFinishedTaskStatus(status string) bool {
 
 func IsFailedTaskStatus(status string) bool {
 	return utility.StringSliceContains(TaskFailureStatuses, status)
+}
+
+func IsSystemFailedTaskStatus(status string) bool {
+	return utility.StringSliceContains(TaskSystemFailures, status)
 }
 
 func IsValidTaskEndStatus(status string) bool {
@@ -830,6 +842,10 @@ func IsGitHubPatchRequester(requester string) bool {
 
 func IsGitTagRequester(requester string) bool {
 	return requester == GitTagRequester
+}
+
+func IsCommitQueueRequester(requester string) bool {
+	return requester == MergeTestRequester
 }
 
 func ShouldConsiderBatchtime(requester string) bool {

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -882,7 +882,7 @@ func (r *mutationResolver) RestartTask(ctx context.Context, taskID string, faile
 	if t == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("cannot find task with id '%s'", taskID))
 	}
-	if err := model.ResetTaskOrDisplayTask(t, username, evergreen.UIPackage, failedOnly, nil); err != nil {
+	if err := model.ResetTaskOrDisplayTask(evergreen.GetEnvironment().Settings(), t, username, evergreen.UIPackage, failedOnly, nil); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error restarting task '%s': %s", taskID, err.Error()))
 	}
 	t, err = task.FindOneIdAndExecutionWithDisplayStatus(taskID, nil)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -87,7 +87,7 @@ func setManyTasksScheduled(ctx context.Context, url string, isActive bool, taskI
 		return nil, err
 	}
 	for _, t := range tasks {
-		if t.Requester == evergreen.MergeTestRequester && isActive {
+		if evergreen.IsCommitQueueRequester(t.Requester) && isActive {
 			return nil, InputValidationError.Send(ctx, "commit queue tasks cannot be manually scheduled")
 		}
 	}

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -317,7 +317,7 @@ func (pd *PodDispatcher) RemovePod(ctx context.Context, env evergreen.Environmen
 		// The last pod is about to be removed, so there will be no pod
 		// remaining to run the tasks still in the dispatch queue.
 
-		if err := model.MarkUnallocatableContainerTasksSystemFailed(pd.TaskIDs); err != nil {
+		if err := model.MarkUnallocatableContainerTasksSystemFailed(env.Settings(), pd.TaskIDs); err != nil {
 			return errors.Wrap(err, "marking unallocatable container tasks as system-failed")
 		}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -293,7 +293,7 @@ func resetManyTasks(tasks []task.Task, caller string) error {
 // TryResetTask resets a task. Individual execution tasks cannot be reset - to
 // reset an execution task, the given task ID must be that of its parent display
 // task.
-func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) error {
+func TryResetTask(settings *evergreen.Settings, taskId, user, origin string, detail *apimodels.TaskEndDetail) error {
 	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return errors.WithStack(err)
@@ -310,7 +310,7 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 	maxExecution := evergreen.MaxTaskExecution
 
 	if evergreen.IsCommitQueueRequester(t.Requester) && evergreen.IsSystemFailedTaskStatus(t.Status) {
-		maxSystemFailedTaskRetries := evergreen.GetEnvironment().Settings().CommitQueue.MaxSystemFailedTaskRetries
+		maxSystemFailedTaskRetries := settings.CommitQueue.MaxSystemFailedTaskRetries
 		if maxSystemFailedTaskRetries != 0 {
 			maxExecution = maxSystemFailedTaskRetries
 		}
@@ -330,12 +330,12 @@ func TryResetTask(taskId, user, origin string, detail *apimodels.TaskEndDetail) 
 						if err != nil {
 							return errors.Wrap(err, "finding execution task")
 						}
-						if err = MarkEnd(execTask, origin, time.Now(), detail, false); err != nil {
+						if err = MarkEnd(settings, execTask, origin, time.Now(), detail, false); err != nil {
 							return errors.Wrap(err, "marking execution task as ended")
 						}
 					}
 				}
-				return errors.WithStack(MarkEnd(t, origin, time.Now(), detail, false))
+				return errors.WithStack(MarkEnd(settings, t, origin, time.Now(), detail, false))
 			} else {
 				grip.Critical(message.Fields{
 					"message":     "TryResetTask called with nil TaskEndDetail",
@@ -577,7 +577,7 @@ func doStepback(t *task.Task) error {
 }
 
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status
-func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
+func MarkEnd(settings *evergreen.Settings, t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
 	deactivatePrevious bool) error {
 
 	const slowThreshold = time.Second
@@ -676,7 +676,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 		if err != nil {
 			return errors.Wrap(err, "getting display task")
 		}
-		if err = checkResetDisplayTask(dt); err != nil {
+		if err = checkResetDisplayTask(settings, dt); err != nil {
 			return errors.Wrap(err, "checking display task reset")
 		}
 	} else {
@@ -708,7 +708,7 @@ func MarkEnd(t *task.Task, caller string, finishTime time.Time, detail *apimodel
 	}
 
 	if (t.ResetWhenFinished || t.ResetFailedWhenFinished) && !t.IsPartOfDisplay() && !t.IsPartOfSingleHostTaskGroup() {
-		return TryResetTask(t.Id, evergreen.APIServerTaskActivator, "", detail)
+		return TryResetTask(settings, t.Id, evergreen.APIServerTaskActivator, "", detail)
 	}
 
 	return nil
@@ -1673,7 +1673,7 @@ func doRestartFailedTasks(tasks []string, user string, results RestartResults) R
 	var tasksErrored []string
 
 	for _, id := range tasks {
-		if err := TryResetTask(id, user, evergreen.RESTV2Package, nil); err != nil {
+		if err := TryResetTask(evergreen.GetEnvironment().Settings(), id, user, evergreen.RESTV2Package, nil); err != nil {
 			tasksErrored = append(tasksErrored, id)
 			grip.Error(message.Fields{
 				"task":    id,
@@ -1776,7 +1776,7 @@ func BlockTaskGroupTasks(taskID string) error {
 // finished and, if necessary, a new execution is created to restart the task.
 // TODO (PM-2618): should probably block single-container task groups once
 // they're supported.
-func ClearAndResetStrandedContainerTask(p *pod.Pod) error {
+func ClearAndResetStrandedContainerTask(settings *evergreen.Settings, p *pod.Pod) error {
 	runningTaskID := p.TaskRuntimeInfo.RunningTaskID
 	runningTaskExecution := p.TaskRuntimeInfo.RunningTaskExecution
 	if runningTaskID == "" {
@@ -1810,7 +1810,7 @@ func ClearAndResetStrandedContainerTask(p *pod.Pod) error {
 		return nil
 	}
 
-	if err := resetSystemFailedTask(t, evergreen.TaskDescriptionStranded); err != nil {
+	if err := resetSystemFailedTask(settings, t, evergreen.TaskDescriptionStranded); err != nil {
 		return errors.Wrapf(err, "resetting stranded task '%s'", t.Id)
 	}
 
@@ -1828,7 +1828,7 @@ func ClearAndResetStrandedContainerTask(p *pod.Pod) error {
 // to being stranded on a bad host (e.g. one that has been terminated). It also
 // marks the current task execution as finished and, if possible, a new
 // execution is created to restart the task.
-func ClearAndResetStrandedHostTask(h *host.Host) error {
+func ClearAndResetStrandedHostTask(settings *evergreen.Settings, h *host.Host) error {
 	if h.RunningTask == "" {
 		return nil
 	}
@@ -1849,7 +1849,7 @@ func ClearAndResetStrandedHostTask(h *host.Host) error {
 		return errors.Wrapf(err, "clearing running task from host '%s'", h.Id)
 	}
 
-	if err := resetSystemFailedTask(t, evergreen.TaskDescriptionStranded); err != nil {
+	if err := resetSystemFailedTask(settings, t, evergreen.TaskDescriptionStranded); err != nil {
 		return errors.Wrapf(err, "resetting stranded task '%s'", t.Id)
 	}
 
@@ -1867,7 +1867,7 @@ func ClearAndResetStrandedHostTask(h *host.Host) error {
 // The current task execution is marked as finished and, if the task was not
 // aborted, the task is reset. If the task was aborted, we do not reset the task
 // and it is just marked as failed alongside other necessary updates to finish the task.
-func FixStaleTask(t *task.Task) error {
+func FixStaleTask(settings *evergreen.Settings, t *task.Task) error {
 	err := UpdateBlockedDependencies(t)
 	if err != nil {
 		return errors.Wrapf(err, "updating blocked dependencies for task '%s'", t.Id)
@@ -1876,11 +1876,11 @@ func FixStaleTask(t *task.Task) error {
 	failureDesc := evergreen.TaskDescriptionHeartbeat
 	if t.Aborted {
 		failureDesc = evergreen.TaskDescriptionAborted
-		if err := finishStaleAbortedTask(t); err != nil {
+		if err := finishStaleAbortedTask(settings, t); err != nil {
 			return errors.Wrapf(err, "finishing stale aborted task '%s'", t.Id)
 		}
 	} else {
-		if err := resetSystemFailedTask(t, failureDesc); err != nil {
+		if err := resetSystemFailedTask(settings, t, failureDesc); err != nil {
 			return errors.Wrap(err, "resetting heartbeat task")
 		}
 	}
@@ -1896,7 +1896,7 @@ func FixStaleTask(t *task.Task) error {
 	return nil
 }
 
-func finishStaleAbortedTask(t *task.Task) error {
+func finishStaleAbortedTask(settings *evergreen.Settings, t *task.Task) error {
 	failureDetails := &apimodels.TaskEndDetail{
 		Status:      evergreen.TaskFailed,
 		Type:        evergreen.CommandTypeSystem,
@@ -1909,7 +1909,7 @@ func finishStaleAbortedTask(t *task.Task) error {
 	if projectRef == nil {
 		return errors.Errorf("project ref for task '%s' not found", t.Id)
 	}
-	if err = MarkEnd(t, evergreen.APIServerTaskActivator, time.Now(), failureDetails, utility.FromBoolPtr(projectRef.DeactivatePrevious)); err != nil {
+	if err = MarkEnd(settings, t, evergreen.APIServerTaskActivator, time.Now(), failureDetails, utility.FromBoolPtr(projectRef.DeactivatePrevious)); err != nil {
 		return errors.Wrapf(err, "calling mark finish on task '%s'", t.Id)
 	}
 	return nil
@@ -1918,7 +1918,7 @@ func finishStaleAbortedTask(t *task.Task) error {
 // resetSystemFailedTask resets a task that has encountered a system failure
 // such as being stranded on a terminated host/container or failing to send a
 // heartbeat.
-func resetSystemFailedTask(t *task.Task, description string) error {
+func resetSystemFailedTask(settings *evergreen.Settings, t *task.Task, description string) error {
 	if t.IsFinished() {
 		return nil
 	}
@@ -1927,7 +1927,7 @@ func resetSystemFailedTask(t *task.Task, description string) error {
 	maxExecutionTask := t.Execution >= evergreen.MaxTaskExecution
 
 	if evergreen.IsCommitQueueRequester(t.Requester) && evergreen.IsSystemFailedTaskStatus(t.Status) {
-		maxSystemFailedTaskRetries := evergreen.GetEnvironment().Settings().CommitQueue.MaxSystemFailedTaskRetries
+		maxSystemFailedTaskRetries := settings.CommitQueue.MaxSystemFailedTaskRetries
 		if maxSystemFailedTaskRetries != 0 {
 			maxExecutionTask = t.Execution >= maxSystemFailedTaskRetries
 		}
@@ -1944,26 +1944,26 @@ func resetSystemFailedTask(t *task.Task, description string) error {
 			}
 			for _, execTask := range execTasks {
 				if !evergreen.IsFinishedTaskStatus(execTask.Status) {
-					if err = MarkEnd(&execTask, evergreen.MonitorPackage, time.Now(), &failureDetails, false); err != nil {
+					if err = MarkEnd(settings, &execTask, evergreen.MonitorPackage, time.Now(), &failureDetails, false); err != nil {
 						return errors.Wrap(err, "marking execution task as ended")
 					}
 				}
 			}
 		}
-		return errors.WithStack(MarkEnd(t, evergreen.MonitorPackage, time.Now(), &failureDetails, false))
+		return errors.WithStack(MarkEnd(settings, t, evergreen.MonitorPackage, time.Now(), &failureDetails, false))
 	}
 
 	if err := t.MarkSystemFailed(description); err != nil {
 		return errors.Wrap(err, "marking task as system failed")
 	}
 
-	return errors.Wrap(ResetTaskOrDisplayTask(t, evergreen.User, evergreen.MonitorPackage, true, &t.Details), "resetting task")
+	return errors.Wrap(ResetTaskOrDisplayTask(settings, t, evergreen.User, evergreen.MonitorPackage, true, &t.Details), "resetting task")
 }
 
 // ResetTaskOrDisplayTask is a wrapper for TryResetTask that handles execution and display tasks that are restarted
 // from sources separate from marking the task finished. If an execution task, attempts to restart the display task instead.
 // Marks display tasks as reset when finished and then check if it can be reset immediately.
-func ResetTaskOrDisplayTask(t *task.Task, user, origin string, failedOnly bool, detail *apimodels.TaskEndDetail) error {
+func ResetTaskOrDisplayTask(settings *evergreen.Settings, t *task.Task, user, origin string, failedOnly bool, detail *apimodels.TaskEndDetail) error {
 	taskToReset := *t
 	if taskToReset.IsPartOfDisplay() { // if given an execution task, attempt to restart the full display task
 		dt, err := taskToReset.GetDisplayTask()
@@ -1984,10 +1984,10 @@ func ResetTaskOrDisplayTask(t *task.Task, user, origin string, failedOnly bool, 
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		}
-		return errors.Wrap(checkResetDisplayTask(&taskToReset), "checking display task reset")
+		return errors.Wrap(checkResetDisplayTask(settings, &taskToReset), "checking display task reset")
 	}
 
-	return errors.Wrap(TryResetTask(t.Id, user, origin, detail), "resetting task")
+	return errors.Wrap(TryResetTask(settings, t.Id, user, origin, detail), "resetting task")
 }
 
 // UpdateDisplayTaskForTask updates the status of the given execution task's display task
@@ -2145,7 +2145,7 @@ func checkResetSingleHostTaskGroup(t *task.Task, caller string) error {
 // checkResetDisplayTask attempts to reset all tasks that are under the same
 // parent display task as t once all tasks under the display task are finished
 // running.
-func checkResetDisplayTask(t *task.Task) error {
+func checkResetDisplayTask(setting *evergreen.Settings, t *task.Task) error {
 	if !t.ResetWhenFinished && !t.ResetFailedWhenFinished {
 		return nil
 	}
@@ -2166,13 +2166,13 @@ func checkResetDisplayTask(t *task.Task) error {
 			Status: evergreen.TaskFailed,
 		}
 	}
-	return errors.Wrap(TryResetTask(t.Id, evergreen.User, evergreen.User, details), "resetting display task")
+	return errors.Wrap(TryResetTask(setting, t.Id, evergreen.User, evergreen.User, details), "resetting display task")
 }
 
 // MarkUnallocatableContainerTasksSystemFailed marks any container task within
 // the candidate task IDs that needs to re-allocate a container but has used up
 // all of its container allocation attempts as finished due to system failure.
-func MarkUnallocatableContainerTasksSystemFailed(candidateTaskIDs []string) error {
+func MarkUnallocatableContainerTasksSystemFailed(settings *evergreen.Settings, candidateTaskIDs []string) error {
 	var unallocatableTasks []task.Task
 	for _, taskID := range candidateTaskIDs {
 		tsk, err := task.FindOneId(taskID)
@@ -2202,7 +2202,7 @@ func MarkUnallocatableContainerTasksSystemFailed(candidateTaskIDs []string) erro
 			Type:        evergreen.CommandTypeSystem,
 			Description: evergreen.TaskDescriptionContainerUnallocatable,
 		}
-		if err := MarkEnd(&tsk, evergreen.APIServerTaskActivator, time.Now(), &details, false); err != nil {
+		if err := MarkEnd(settings, &tsk, evergreen.APIServerTaskActivator, time.Now(), &details, false); err != nil {
 			catcher.Wrapf(err, "marking task '%s' as a failure due to inability to allocate", tsk.Id)
 		}
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -311,7 +311,7 @@ func TryResetTask(settings *evergreen.Settings, taskId, user, origin string, det
 
 	if evergreen.IsCommitQueueRequester(t.Requester) && evergreen.IsSystemFailedTaskStatus(t.Status) {
 		maxSystemFailedTaskRetries := settings.CommitQueue.MaxSystemFailedTaskRetries
-		if maxSystemFailedTaskRetries != 0 {
+		if maxSystemFailedTaskRetries > 0 {
 			maxExecution = maxSystemFailedTaskRetries
 		}
 	}
@@ -1928,7 +1928,7 @@ func resetSystemFailedTask(settings *evergreen.Settings, t *task.Task, descripti
 
 	if evergreen.IsCommitQueueRequester(t.Requester) && evergreen.IsSystemFailedTaskStatus(t.Status) {
 		maxSystemFailedTaskRetries := settings.CommitQueue.MaxSystemFailedTaskRetries
-		if maxSystemFailedTaskRetries != 0 {
+		if maxSystemFailedTaskRetries > 0 {
 			maxExecutionTask = t.Execution >= maxSystemFailedTaskRetries
 		}
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1605,6 +1605,11 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 	}
 	assert.NoError(t, projRef.Insert())
 
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	Convey("With a successful task one failed test should result in a task failure", t, func() {
 		displayName := "testName"
 
@@ -1659,7 +1664,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 
 		Convey("task should not fail if there are no failed test, also logs should be updated", func() {
 			reset()
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1690,7 +1695,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 				},
 			})
 			So(err, ShouldBeNil)
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1715,7 +1720,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 
 			So(err, ShouldBeNil)
 			detail.Status = evergreen.TaskFailed
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1736,7 +1741,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			testTask.CedarResultsFailed = true
 
 			detail.Status = evergreen.TaskSucceeded
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1756,7 +1761,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			testTask.HasCedarResults = true
 
 			detail.Status = evergreen.TaskSucceeded
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1777,7 +1782,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			testTask.CedarResultsFailed = true
 
 			detail.Status = evergreen.TaskSucceeded
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1808,7 +1813,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 			detail.Status = evergreen.TaskFailed
-			So(MarkEnd(testTask, "", time.Now(), detail, true), ShouldBeNil)
+			So(MarkEnd(settings, testTask, "", time.Now(), detail, true), ShouldBeNil)
 
 			v, err := VersionFindOneId(v.Id)
 			So(err, ShouldBeNil)
@@ -1876,7 +1881,12 @@ func TestMarkEnd(t *testing.T) {
 	details := apimodels.TaskEndDetail{
 		Status: evergreen.TaskFailed,
 	}
-	assert.NoError(MarkEnd(&testTask, userName, time.Now(), &details, false))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(MarkEnd(settings, &testTask, userName, time.Now(), &details, false))
 
 	b, err := build.FindOneId(b.Id)
 	assert.NoError(err)
@@ -1934,7 +1944,7 @@ func TestMarkEnd(t *testing.T) {
 			Status: evergreen.TaskSucceeded,
 		}
 		endTime := time.Now().Round(time.Second)
-		So(MarkEnd(t1, "test", endTime, detail, false), ShouldBeNil)
+		So(MarkEnd(settings, t1, "test", endTime, detail, false), ShouldBeNil)
 		t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskSucceeded)
@@ -1944,7 +1954,7 @@ func TestMarkEnd(t *testing.T) {
 
 		// Ensure that calling MarkEnd on a non-aborted finished task returns early
 		// by checking that its finish_time hasn't changed
-		So(MarkEnd(t1, "test", time.Now().Add(time.Minute), detail, false), ShouldBeNil)
+		So(MarkEnd(settings, t1, "test", time.Now().Add(time.Minute), detail, false), ShouldBeNil)
 		t1FromDb, err = task.FindOne(db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.FinishTime, ShouldEqual, endTime)
@@ -1955,7 +1965,7 @@ func TestMarkEnd(t *testing.T) {
 		t2FromDb, err := task.FindOne(db.Query(task.ById(t2.Id)))
 		So(err, ShouldBeNil)
 		So(t2FromDb.FinishTime, ShouldEqual, time.Time{})
-		So(MarkEnd(t2FromDb, "test", endTime, &t2FromDb.Details, false), ShouldBeNil)
+		So(MarkEnd(settings, t2FromDb, "test", endTime, &t2FromDb.Details, false), ShouldBeNil)
 		t2FromDb, err = task.FindOne(db.Query(task.ById(t2.Id)))
 		So(err, ShouldBeNil)
 		So(t2FromDb.FinishTime, ShouldEqual, endTime)
@@ -1995,9 +2005,14 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 	detail := &apimodels.TaskEndDetail{
 		Status: evergreen.TaskFailed,
 	}
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	for name, test := range map[string]func(*testing.T){
 		"NotResetWhenFinished": func(t *testing.T) {
-			assert.NoError(t, MarkEnd(runningTask, "test", time.Now(), detail, false))
+			assert.NoError(t, MarkEnd(settings, runningTask, "test", time.Now(), detail, false))
 			runningTaskDB, err := task.FindOneId(runningTask.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, runningTaskDB)
@@ -2005,7 +2020,7 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 		},
 		"ResetWhenFinished": func(t *testing.T) {
 			assert.NoError(t, runningTask.SetResetWhenFinished())
-			assert.NoError(t, MarkEnd(runningTask, "test", time.Now(), detail, false))
+			assert.NoError(t, MarkEnd(settings, runningTask, "test", time.Now(), detail, false))
 
 			runningTaskDB, err := task.FindOneId(runningTask.Id)
 			assert.NoError(t, err)
@@ -2059,9 +2074,14 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 }
 
 func TestTryResetTask(t *testing.T) {
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	Convey("With a task that does not exist", t, func() {
 		require.NoError(t, db.ClearCollections(task.Collection))
-		So(TryResetTask("id", "username", "", nil), ShouldNotBeNil)
+		So(TryResetTask(settings, "id", "username", "", nil), ShouldNotBeNil)
 	})
 	Convey("With a task, a build, version and a project", t, func() {
 		Convey("resetting a task without a max number of executions", func() {
@@ -2121,7 +2141,7 @@ func TestTryResetTask(t *testing.T) {
 			So(dependentTask.Insert(), ShouldBeNil)
 			So(v.Insert(), ShouldBeNil)
 			Convey("should reset and add a task to the old tasks collection", func() {
-				So(TryResetTask(testTask.Id, userName, "", detail), ShouldBeNil)
+				So(TryResetTask(settings, testTask.Id, userName, "", detail), ShouldBeNil)
 				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Details, ShouldResemble, apimodels.TaskEndDetail{})
@@ -2166,7 +2186,7 @@ func TestTryResetTask(t *testing.T) {
 				So(containerTask.Insert(), ShouldBeNil)
 
 				Convey("should reset task state specific to containers", func() {
-					So(TryResetTask(containerTask.Id, userName, "source", detail), ShouldBeNil)
+					So(TryResetTask(settings, containerTask.Id, userName, "source", detail), ShouldBeNil)
 
 					dbTask, err := task.FindOneId(containerTask.Id)
 					So(err, ShouldBeNil)
@@ -2228,7 +2248,7 @@ func TestTryResetTask(t *testing.T) {
 			So(v.Insert(), ShouldBeNil)
 			So(anotherTask.Insert(), ShouldBeNil)
 
-			commitQueueMax := evergreen.GetEnvironment().Settings().CommitQueue.MaxSystemFailedTaskRetries
+			commitQueueMax := settings.CommitQueue.MaxSystemFailedTaskRetries
 			commitQueueTask := &task.Task{
 				Id:          "commit_queue_task",
 				DisplayName: displayName,
@@ -2245,19 +2265,19 @@ func TestTryResetTask(t *testing.T) {
 			var err error
 
 			Convey("should reset if ui package tries to reset", func() {
-				So(TryResetTask(testTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
+				So(TryResetTask(settings, testTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
 				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
 				So(testTask.Status, ShouldEqual, evergreen.TaskUndispatched)
 			})
 			Convey("should not reset if an origin other than the ui package tries to reset", func() {
-				So(TryResetTask(testTask.Id, userName, "", detail), ShouldBeNil)
+				So(TryResetTask(settings, testTask.Id, userName, "", detail), ShouldBeNil)
 				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Details, ShouldNotResemble, *detail)
 				So(testTask.Status, ShouldNotEqual, detail.Status)
 			})
 			Convey("should reset and use detail information if the UI package passes in a detail ", func() {
-				So(TryResetTask(anotherTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
+				So(TryResetTask(settings, anotherTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
 				a, err := task.FindOne(db.Query(task.ById(anotherTask.Id)))
 				So(err, ShouldBeNil)
 				So(a.Details, ShouldResemble, apimodels.TaskEndDetail{})
@@ -2265,7 +2285,7 @@ func TestTryResetTask(t *testing.T) {
 				So(a.FinishTime, ShouldResemble, utility.ZeroTime)
 			})
 			Convey("merge tasks not reset if they've reached the admin setting limit", func() {
-				So(TryResetTask(commitQueueTask.Id, userName, "", detail), ShouldBeNil)
+				So(TryResetTask(settings, commitQueueTask.Id, userName, "", detail), ShouldBeNil)
 				commitQueueTask, err = task.FindOne(db.Query(task.ById(commitQueueTask.Id)))
 				So(err, ShouldBeNil)
 				So(commitQueueTask.Details, ShouldNotResemble, *detail)
@@ -2305,7 +2325,7 @@ func TestTryResetTask(t *testing.T) {
 		}
 		So(t1.Insert(), ShouldBeNil)
 
-		So(TryResetTask(dt.Id, "user", "test", nil), ShouldBeNil)
+		So(TryResetTask(settings, dt.Id, "user", "test", nil), ShouldBeNil)
 		t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskUndispatched)
@@ -2343,16 +2363,22 @@ func TestTryResetTaskWithTaskGroup(t *testing.T) {
 	}
 	assert.NoError(d.Insert())
 
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+
 	for name, test := range map[string]func(*testing.T, *task.Task, string){
 		"NotFinished": func(t *testing.T, t1 *task.Task, t2Id string) {
-			assert.NoError(TryResetTask(t2Id, "user", "test", nil))
-			err := TryResetTask(t1.Id, "user", evergreen.UIPackage, nil)
+			assert.NoError(TryResetTask(settings, t2Id, "user", "test", nil))
+			err := TryResetTask(settings, t1.Id, "user", evergreen.UIPackage, nil)
 			require.Error(err)
 			assert.Contains(err.Error(), "cannot reset task in this status")
 		},
 		"CanResetTaskGroup": func(t *testing.T, t1 *task.Task, t2Id string) {
 			assert.NoError(t1.MarkFailed())
-			assert.NoError(TryResetTask(t2Id, "user", "test", nil))
+			assert.NoError(TryResetTask(settings, t2Id, "user", "test", nil))
 
 			var err error
 			t1, err = task.FindOneId(t1.Id)
@@ -3734,7 +3760,13 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Type:   evergreen.CommandTypeSystem,
 	}
 
-	assert.NoError(MarkEnd(testTask, "", time.Now(), details, false))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+
+	assert.NoError(MarkEnd(settings, testTask, "", time.Now(), details, false))
 	var err error
 	v, err = VersionFindOneId(v.Id)
 	assert.NoError(err)
@@ -3744,7 +3776,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildStarted, b.Status)
 
-	assert.NoError(MarkEnd(anotherTask, "", time.Now(), details, false))
+	assert.NoError(MarkEnd(settings, anotherTask, "", time.Now(), details, false))
 	v, err = VersionFindOneId(v.Id)
 	assert.NoError(err)
 	assert.Equal(evergreen.VersionStarted, v.Status)
@@ -3753,7 +3785,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildStarted, b.Status)
 
-	assert.NoError(MarkEnd(exeTask0, "", time.Now(), details, false))
+	assert.NoError(MarkEnd(settings, exeTask0, "", time.Now(), details, false))
 	v, err = VersionFindOneId(v.Id)
 	assert.NoError(err)
 	assert.Equal(evergreen.VersionStarted, v.Status)
@@ -3764,7 +3796,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 
 	exeTask1.DisplayTask = nil
 	assert.NoError(err)
-	assert.NoError(MarkEnd(exeTask1, "", time.Now(), details, false))
+	assert.NoError(MarkEnd(settings, exeTask1, "", time.Now(), details, false))
 	v, err = VersionFindOneId(v.Id)
 	assert.NoError(err)
 	assert.Equal(evergreen.VersionFailed, v.Status)
@@ -3833,7 +3865,13 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 		Type:   "test",
 	}
 
-	assert.NoError(MarkEnd(&testTask, "", time.Now(), details, false))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+
+	assert.NoError(MarkEnd(settings, &testTask, "", time.Now(), details, false))
 	var err error
 	v, err = VersionFindOneId(v.Id)
 	assert.NoError(err)
@@ -3903,7 +3941,12 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 		Status: evergreen.TaskFailed,
 		Type:   "test",
 	}
-	assert.NoError(MarkEnd(&testTask, "", time.Now(), details, false))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(MarkEnd(settings, &testTask, "", time.Now(), details, false))
 
 	var err error
 	v, err = VersionFindOneId(v.Id)
@@ -4007,7 +4050,12 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	}
 	assert.NoError(v2.Insert())
 
-	assert.NoError(ClearAndResetStrandedHostTask(h))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(ClearAndResetStrandedHostTask(settings, h))
 
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))
 	require.NoError(t, err)
@@ -4022,7 +4070,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.Equal(evergreen.VersionCreated, foundVersion.Status)
 
 	h.RunningTask = "unschedulableTask"
-	assert.NoError(ClearAndResetStrandedHostTask(h))
+	assert.NoError(ClearAndResetStrandedHostTask(settings, h))
 
 	unschedulableTask, err = task.FindOne(db.Query(task.ById("unschedulableTask")))
 	require.NoError(t, err)
@@ -4047,7 +4095,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.Equal(evergreen.VersionFailed, foundVersion.Status)
 
 	h.RunningTask = "t2"
-	assert.NoError(ClearAndResetStrandedHostTask(h))
+	assert.NoError(ClearAndResetStrandedHostTask(settings, h))
 
 }
 
@@ -4078,7 +4126,12 @@ func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
 	}
 	assert.NoError(v.Insert())
 
-	assert.NoError(ClearAndResetStrandedHostTask(h))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(ClearAndResetStrandedHostTask(settings, h))
 	runningTask, err := task.FindOne(db.Query(task.ById("t")))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, runningTask.Status)
@@ -4135,8 +4188,12 @@ func TestClearAndResetStrandedHostTaskFailedOnly(t *testing.T) {
 		Id: "version",
 	}
 	assert.NoError(t, v.Insert())
-
-	assert.NoError(t, ClearAndResetStrandedHostTask(h))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(t, ClearAndResetStrandedHostTask(settings, h))
 	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)
@@ -4160,13 +4217,18 @@ func TestClearAndResetStrandedHostTaskFailedOnly(t *testing.T) {
 }
 
 func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.EventCollection))
 	}()
 	for tName, tCase := range map[string]func(t *testing.T, tsk task.Task, b build.Build, v Version){
 		"SystemFailsTaskWithNoRemainingAllocationAttempts": func(t *testing.T, tsk task.Task, b build.Build, v Version) {
 			require.NoError(t, tsk.Insert())
-			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed([]string{tsk.Id}))
+			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed(settings, []string{tsk.Id}))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4186,7 +4248,7 @@ func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
 		"NoopsWithTaskThatHasRemainingAllocationAttempts": func(t *testing.T, tsk task.Task, b build.Build, v Version) {
 			tsk.ContainerAllocationAttempts = 0
 			require.NoError(t, tsk.Insert())
-			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed([]string{tsk.Id}))
+			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed(settings, []string{tsk.Id}))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4210,7 +4272,7 @@ func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
 			tsk1.ContainerAllocationAttempts = 0
 			require.NoError(t, tsk1.Insert())
 
-			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed([]string{tsk0.Id, tsk1.Id}))
+			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed(settings, []string{tsk0.Id, tsk1.Id}))
 
 			dbTask0, err := task.FindOneId(tsk0.Id)
 			require.NoError(t, err)
@@ -4226,7 +4288,7 @@ func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
 			tsk.ExecutionPlatform = task.ExecutionPlatformHost
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed([]string{tsk.Id}))
+			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed(settings, []string{tsk.Id}))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4234,7 +4296,7 @@ func TestMarkUnallocatableContainerTasksSystemFailed(t *testing.T) {
 			assert.False(t, dbTask.IsFinished())
 		},
 		"NoopsWithNonexistentTasks": func(t *testing.T, tsk task.Task, b build.Build, v Version) {
-			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed([]string{tsk.Id}))
+			require.NoError(t, MarkUnallocatableContainerTasksSystemFailed(settings, []string{tsk.Id}))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			assert.NoError(t, err)
@@ -4311,7 +4373,13 @@ func TestClearAndResetExecTask(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 
-	assert.NoError(t, ClearAndResetStrandedHostTask(h))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+
+	assert.NoError(t, ClearAndResetStrandedHostTask(settings, h))
 	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)
@@ -4321,6 +4389,11 @@ func TestClearAndResetExecTask(t *testing.T) {
 }
 
 func TestClearAndResetStrandedContainerTask(t *testing.T) {
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	defer func() {
 		assert.NoError(t, db.ClearCollections(pod.Collection, task.Collection, task.OldCollection, build.Collection, VersionCollection))
 	}()
@@ -4330,7 +4403,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			require.NoError(t, p.Insert())
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -4384,7 +4457,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			require.NoError(t, tsk.Insert())
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbDisplayTask, err := task.FindOneId(dt.Id)
 			require.NoError(t, err)
@@ -4415,7 +4488,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			require.NoError(t, tsk.Insert())
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -4435,13 +4508,13 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			p.TaskRuntimeInfo.RunningTaskID = tsk.Id
 			require.NoError(t, tsk.Insert())
 
-			assert.Error(t, ClearAndResetStrandedContainerTask(&p))
+			assert.Error(t, ClearAndResetStrandedContainerTask(settings, &p))
 		},
 		"ClearsNonexistentTaskFromPod": func(t *testing.T, p pod.Pod, tsk task.Task) {
 			p.TaskRuntimeInfo.RunningTaskID = "nonexistent_task"
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -4454,7 +4527,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			p.TaskRuntimeInfo.RunningTaskExecution = 0
 			require.NoError(t, p.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
 			require.NotZero(t, dbPod)
@@ -4466,7 +4539,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			tsk.ActivatedTime = time.Now().Add(-10 * task.UnschedulableThreshold)
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -4505,7 +4578,7 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 			require.NoError(t, p.Insert())
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, ClearAndResetStrandedContainerTask(&p))
+			require.NoError(t, ClearAndResetStrandedContainerTask(settings, &p))
 
 			dbPod, err := pod.FindOneByID(p.ID)
 			require.NoError(t, err)
@@ -4575,6 +4648,11 @@ func TestClearAndResetStrandedContainerTask(t *testing.T) {
 }
 
 func TestResetStaleTask(t *testing.T) {
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
 	defer func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection))
 	}()
@@ -4583,7 +4661,7 @@ func TestResetStaleTask(t *testing.T) {
 		"SuccessfullyRestartsStaleTask": func(t *testing.T, tsk task.Task) {
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, FixStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(settings, &tsk))
 
 			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
 			require.NoError(t, err)
@@ -4615,7 +4693,7 @@ func TestResetStaleTask(t *testing.T) {
 		"SuccessfullySystemFailsAbortedTask": func(t *testing.T, tsk task.Task) {
 			tsk.Aborted = true
 			require.NoError(t, tsk.Insert())
-			require.NoError(t, FixStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(settings, &tsk))
 
 			dbArchivedTask, err := task.FindOneOldByIdAndExecution(tsk.Id, 1)
 			require.NoError(t, err)
@@ -4649,7 +4727,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.DisplayTaskId = utility.ToStringPtr(dt.Id)
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, FixStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(settings, &tsk))
 
 			dbDisplayTask, err := task.FindOneId(dt.Id)
 			require.NoError(t, err)
@@ -4679,7 +4757,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.ActivatedTime = time.Now().Add(-10 * task.UnschedulableThreshold)
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, FixStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(settings, &tsk))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4711,7 +4789,7 @@ func TestResetStaleTask(t *testing.T) {
 			tsk.Execution = execNum
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, FixStaleTask(&tsk))
+			require.NoError(t, FixStaleTask(settings, &tsk))
 
 			dbTask, err := task.FindOneId(tsk.Id)
 			require.NoError(t, err)
@@ -4812,7 +4890,12 @@ func TestMarkEndWithNoResults(t *testing.T) {
 		Type:   "test",
 	}
 
-	err := MarkEnd(&testTask1, "", time.Now(), details, false)
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	err := MarkEnd(settings, &testTask1, "", time.Now(), details, false)
 	assert.NoError(t, err)
 	dbTask, err := task.FindOneId(testTask1.Id)
 	assert.NoError(t, err)
@@ -4824,7 +4907,7 @@ func TestMarkEndWithNoResults(t *testing.T) {
 		TaskID: testTask2.Id,
 	}
 	assert.NoError(t, results.Insert())
-	err = MarkEnd(&testTask2, "", time.Now(), details, false)
+	err = MarkEnd(settings, &testTask2, "", time.Now(), details, false)
 	assert.NoError(t, err)
 	dbTask, err = task.FindOneId(testTask2.Id)
 	assert.NoError(t, err)
@@ -5110,6 +5193,12 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 	}
 	assert.NoError(v.Insert())
 
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+
 	// request that the task restarts when it's done
 	assert.NoError(dt.SetResetWhenFinished())
 	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
@@ -5118,7 +5207,7 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
 
 	// end the final task so that it restarts
-	assert.NoError(checkResetDisplayTask(&dt))
+	assert.NoError(checkResetDisplayTask(settings, &dt))
 	dbTask, err = task.FindOne(db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
@@ -5156,7 +5245,12 @@ func TestAbortedTaskDelayedRestart(t *testing.T) {
 	detail := &apimodels.TaskEndDetail{
 		Status: evergreen.TaskFailed,
 	}
-	assert.NoError(t, MarkEnd(&task1, "test", time.Now(), detail, false))
+	settings := &evergreen.Settings{
+		CommitQueue: evergreen.CommitQueueConfig{
+			MaxSystemFailedTaskRetries: 2,
+		},
+	}
+	assert.NoError(t, MarkEnd(settings, &task1, "test", time.Now(), detail, false))
 	newTask, err := task.FindOneId(task1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, newTask.Status)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1396,10 +1396,11 @@ func (a *APICloudProviders) ToService() (interface{}, error) {
 }
 
 type APICommitQueueConfig struct {
-	MergeTaskDistro *string `json:"merge_task_distro"`
-	CommitterName   *string `json:"committer_name"`
-	CommitterEmail  *string `json:"committer_email"`
-	BatchSize       int     `json:"batch_size"`
+	MergeTaskDistro            *string `json:"merge_task_distro"`
+	CommitterName              *string `json:"committer_name"`
+	CommitterEmail             *string `json:"committer_email"`
+	BatchSize                  int     `json:"batch_size"`
+	MaxSystemFailedTaskRetries int     `json:"max_system_failed_task_retries"`
 }
 
 func (a *APICommitQueueConfig) BuildFromService(h interface{}) error {
@@ -1408,6 +1409,7 @@ func (a *APICommitQueueConfig) BuildFromService(h interface{}) error {
 		a.CommitterName = utility.ToStringPtr(v.CommitterName)
 		a.CommitterEmail = utility.ToStringPtr(v.CommitterEmail)
 		a.BatchSize = v.BatchSize
+		a.MaxSystemFailedTaskRetries = v.MaxSystemFailedTaskRetries
 
 		return nil
 	}
@@ -1417,10 +1419,11 @@ func (a *APICommitQueueConfig) BuildFromService(h interface{}) error {
 
 func (a *APICommitQueueConfig) ToService() (interface{}, error) {
 	return evergreen.CommitQueueConfig{
-		MergeTaskDistro: utility.FromStringPtr(a.MergeTaskDistro),
-		CommitterName:   utility.FromStringPtr(a.CommitterName),
-		CommitterEmail:  utility.FromStringPtr(a.CommitterEmail),
-		BatchSize:       a.BatchSize,
+		MergeTaskDistro:            utility.FromStringPtr(a.MergeTaskDistro),
+		CommitterName:              utility.FromStringPtr(a.CommitterName),
+		CommitterEmail:             utility.FromStringPtr(a.CommitterEmail),
+		BatchSize:                  a.BatchSize,
+		MaxSystemFailedTaskRetries: a.MaxSystemFailedTaskRetries,
 	}, nil
 }
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1272,7 +1272,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Description: evergreen.TaskDescriptionAborted,
 		}
 	}
-	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, details, deactivatePrevious)
+	err = model.MarkEnd(h.env.Settings(), t, evergreen.APIServerTaskActivator, finishTime, details, deactivatePrevious)
 	if err != nil {
 		err = errors.Wrapf(err, "calling mark finish on task '%s'", t.Id)
 		return gimlet.MakeJSONInternalErrorResponder(err)

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1278,7 +1278,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
-	if t.Requester == evergreen.MergeTestRequester {
+	if evergreen.IsCommitQueueRequester(t.Requester) {
 		if err = model.HandleEndTaskForCommitQueueTask(t, h.details.Status); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -520,7 +520,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
 	}
 
-	if t.Requester == evergreen.MergeTestRequester {
+	if evergreen.IsCommitQueueRequester(t.Requester) {
 		if err = model.HandleEndTaskForCommitQueueTask(t, h.details.Status); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -515,7 +515,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
-	err = model.MarkEnd(t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
+	err = model.MarkEnd(h.env.Settings(), t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
 	}

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -69,7 +69,7 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 // Execute calls the data ResetTask function and returns the refreshed
 // task from the service.
 func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
-	err := resetTask(trh.taskId, trh.username, trh.FailedOnly)
+	err := resetTask(evergreen.GetEnvironment().Settings(), trh.taskId, trh.username, trh.FailedOnly)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
@@ -95,7 +95,7 @@ func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
 
 // resetTask sets the task to be in an unexecuted state and prepares it to be run again.
 // If given an execution task, marks the display task for reset.
-func resetTask(taskId, username string, failedOnly bool) error {
+func resetTask(settings *evergreen.Settings, taskId, username string, failedOnly bool) error {
 	t, err := task.FindOneId(taskId)
 	if err != nil {
 		return gimlet.ErrorResponse{
@@ -109,5 +109,5 @@ func resetTask(taskId, username string, failedOnly bool) error {
 			Message:    fmt.Sprintf("task '%s' not found", taskId),
 		}
 	}
-	return errors.Wrapf(serviceModel.ResetTaskOrDisplayTask(t, username, evergreen.RESTV2Package, failedOnly, nil), "resetting task '%s'", taskId)
+	return errors.Wrapf(serviceModel.ResetTaskOrDisplayTask(settings, t, username, evergreen.RESTV2Package, failedOnly, nil), "resetting task '%s'", taskId)
 }

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -275,7 +275,7 @@ func (unit *Unit) info() unitInfo {
 	}
 
 	for _, t := range unit.tasks {
-		if t.Requester == evergreen.MergeTestRequester {
+		if evergreen.IsCommitQueueRequester(t.Requester) {
 			info.ContainsInCommitQueue = true
 		} else if evergreen.IsPatchRequester(t.Requester) {
 			info.ContainsInPatch = true

--- a/service/task.go
+++ b/service/task.go
@@ -698,7 +698,7 @@ func (uis *UIServer) taskModify(w http.ResponseWriter, r *http.Request) {
 	// determine what action needs to be taken
 	switch putParams.Action {
 	case evergreen.RestartAction:
-		if err = model.TryResetTask(projCtx.Task.Id, authName, evergreen.UIPackage, nil); err != nil {
+		if err = model.TryResetTask(uis.env.Settings(), projCtx.Task.Id, authName, evergreen.UIPackage, nil); err != nil {
 			http.Error(w, fmt.Sprintf("Error restarting task %v: %v", projCtx.Task.Id, err), http.StatusInternalServerError)
 			return
 		}

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -885,6 +885,10 @@ Admin Settings
 											<label>Batch Size</label>
 											<input type="number" ng-model="Settings.commit_queue.batch_size">
 										</md-input-container>
+										<md-input-container class="control" style="width:45%;">
+											<label>Max Retries For System Failed Tasks</label>
+											<input type="number" ng-model="Settings.commit_queue.max_system_failed_task_retries">
+										</md-input-container>
 										<button ng-click="clearCommitQueues()" class="md-raised md-button">Clear Commit
 											Queues</button>
 									</md-card-content>

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -37,7 +37,7 @@ func (t *buildTriggers) taskStatusToDesc() string {
 		case t.Status == evergreen.TaskFailed:
 			failed++
 
-		case statusIsSystemFailure(t.Status):
+		case evergreen.IsSystemFailedTaskStatus(t.Status):
 			systemError++
 
 		case utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status):
@@ -68,16 +68,6 @@ func (t *buildTriggers) taskStatusToDesc() string {
 	}
 
 	return appendTime(t.build, desc)
-}
-
-func statusIsSystemFailure(status string) bool {
-	systemFailures := []string{evergreen.TaskSystemFailed,
-		evergreen.TaskTimedOut,
-		evergreen.TaskSystemUnresponse,
-		evergreen.TaskSystemTimedOut,
-		evergreen.TaskTestTimedOut,
-	}
-	return utility.StringSliceContains(systemFailures, status)
 }
 
 func taskStatusSubformat(n int, verb string) string {

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -187,7 +187,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task":     j.host.RunningTask,
 			})
 
-			j.AddError(model.ClearAndResetStrandedHostTask(j.host))
+			j.AddError(model.ClearAndResetStrandedHostTask(j.env.Settings(), j.host))
 		} else {
 			return
 		}
@@ -212,7 +212,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				if tasks[len(tasks)-1].Id != lastTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,
 					// because later tasks in the group need to run on the same host as the earlier ones.
-					j.AddError(errors.Wrapf(model.TryResetTask(lastTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", lastTask.Id))
+					j.AddError(errors.Wrapf(model.TryResetTask(j.env.Settings(), lastTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", lastTask.Id))
 				}
 			}
 		}
@@ -254,7 +254,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task":     j.host.RunningTask,
 			})
 
-			j.AddError(errors.Wrapf(model.ClearAndResetStrandedHostTask(j.host), "fixing stranded task '%s'", j.host.RunningTask))
+			j.AddError(errors.Wrapf(model.ClearAndResetStrandedHostTask(j.env.Settings(), j.host), "fixing stranded task '%s'", j.host.RunningTask))
 		} else {
 			return
 		}

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -103,7 +103,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	if j.task.RemainingContainerAllocationAttempts() == 0 {
 		// A task that has used up all of its container allocation attempts
 		// should not try to allocate again.
-		if err := model.MarkUnallocatableContainerTasksSystemFailed([]string{j.TaskID}); err != nil {
+		if err := model.MarkUnallocatableContainerTasksSystemFailed(j.env.Settings(), []string{j.TaskID}); err != nil {
 			j.AddRetryableError(errors.Wrap(err, "marking unallocatable container task as system-failed"))
 		}
 

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -237,7 +237,7 @@ func (j *podTerminationJob) fixStrandedRunningTask(ctx context.Context) error {
 		return errors.Wrapf(err, "marking stranded container task '%s' execution %d running on pod '%s' as deallocated", j.pod.TaskRuntimeInfo.RunningTaskID, j.pod.TaskRuntimeInfo.RunningTaskExecution, j.pod.ID)
 	}
 
-	if err := model.ClearAndResetStrandedContainerTask(j.pod); err != nil {
+	if err := model.ClearAndResetStrandedContainerTask(j.env.Settings(), j.pod); err != nil {
 		return errors.Wrapf(err, "resetting stranded container task '%s' execution %d running on pod '%s'", j.pod.TaskRuntimeInfo.RunningTaskID, j.pod.TaskRuntimeInfo.RunningTaskExecution, j.pod.ID)
 	}
 

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -155,7 +155,7 @@ func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error
 			}
 		}
 
-		return errors.Wrapf(model.FixStaleTask(j.task), "resetting stale task '%s'", j.task.Id)
+		return errors.Wrapf(model.FixStaleTask(j.env.Settings(), j.task), "resetting stale task '%s'", j.task.Id)
 	}
 
 	host, err := host.FindOne(host.ById(j.task.HostId))
@@ -197,7 +197,7 @@ func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error
 		}
 	}
 
-	if err := model.FixStaleTask(j.task); err != nil {
+	if err := model.FixStaleTask(j.env.Settings(), j.task); err != nil {
 		return errors.Wrapf(err, "resetting stale task '%s'", j.task.Id)
 	}
 

--- a/units/task_stranded_cleanup.go
+++ b/units/task_stranded_cleanup.go
@@ -74,7 +74,7 @@ func (j *taskStrandedCleanupJob) fixTasksStrandedOnTerminatedHosts() error {
 		taskIDs = append(taskIDs, h.RunningTask)
 		hostIDs = append(hostIDs, h.Id)
 
-		catcher.Wrapf(model.ClearAndResetStrandedHostTask(&h), "fixing stranded host task '%s' on host '%s'", h.RunningTask, h.Id)
+		catcher.Wrapf(model.ClearAndResetStrandedHostTask(evergreen.GetEnvironment().Settings(), &h), "fixing stranded host task '%s' on host '%s'", h.RunningTask, h.Id)
 	}
 
 	grip.Info(message.Fields{
@@ -108,7 +108,7 @@ func (j *taskStrandedCleanupJob) fixTasksStuckDispatching() error {
 				Status:      evergreen.TaskFailed,
 				Description: evergreen.TaskDescriptionStranded,
 			}
-			catcher.Wrapf(model.TryResetTask(t.Id, evergreen.User, j.ID(), details), "resetting task '%s'", t.Id)
+			catcher.Wrapf(model.TryResetTask(evergreen.GetEnvironment().Settings(), t.Id, evergreen.User, j.ID(), details), "resetting task '%s'", t.Id)
 			tasksReset = append(tasksReset, t)
 		}
 	}

--- a/units/util.go
+++ b/units/util.go
@@ -55,7 +55,7 @@ func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment
 		return errors.Wrap(err, "enqueueing decohost notify job")
 	}
 
-	return model.ClearAndResetStrandedHostTask(h)
+	return model.ClearAndResetStrandedHostTask(env.Settings(), h)
 }
 
 // EnqueueHostReprovisioningJob enqueues a job to reprovision a host. For hosts


### PR DESCRIPTION
[EVG-16926](https://jira.mongodb.org/browse/EVG-16926)

### Description 
We've seen a situation where a task in the commit queue ran a full 10 times because it caused system unresponsive failures, which caused the next batch to wait practically overnight. To avoid situations like that, we want to lower the amount of times system failed tasks can be restarted on the commit queue. This will be configurable on the admin page, and will be set to 5 to start out with.  

### Testing 
Set to five and merged something on staging to make sure it didn't break it.  
