### PR TITLE
EVG-18731 by the second billing for windows

### DIFF
--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1021,12 +1021,13 @@ func (s *EC2Suite) TestTimeTilNextPaymentLinux() {
 	s.Equal(time.Second, s.onDemandManager.TimeTilNextPayment(h))
 }
 
-func (s *EC2Suite) TestTimeTilNextPaymentWindows() {
+func (s *EC2Suite) TestTimeTilNextPaymentSUSE() {
 	now := time.Now()
 	thirtyMinutesAgo := now.Add(-30 * time.Minute)
 	h := &host.Host{
 		Distro: distro.Distro{
-			Arch: "windows",
+			Id:   "suse15-large",
+			Arch: "linux",
 		},
 		CreationTime: thirtyMinutesAgo,
 		StartTime:    thirtyMinutesAgo.Add(time.Minute),

--- a/cloud/ec2_util_test.go
+++ b/cloud/ec2_util_test.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,6 +27,46 @@ func TestCleanLaunchTemplateName(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, params.expected, cleanLaunchTemplateName(params.input))
+		})
+	}
+}
+
+func TestUsesHourlyBilling(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		distro distro.Distro
+		hourly bool
+	}{
+		"ubuntu": {
+			distro: distro.Distro{
+				Id:   "ubuntu",
+				Arch: "linux",
+			},
+			hourly: false,
+		},
+		"windows": {
+			distro: distro.Distro{
+				Id:   "windows-large",
+				Arch: "windows",
+			},
+			hourly: false,
+		},
+		"suse": {
+			distro: distro.Distro{
+				Id:   "suse15-large",
+				Arch: "linux",
+			},
+			hourly: true,
+		},
+		"mac": {
+			distro: distro.Distro{
+				Id:   "macos-1100",
+				Arch: "osx",
+			},
+			hourly: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, UsesHourlyBilling(&testCase.distro), testCase.hourly)
 		})
 	}
 }


### PR DESCRIPTION
[EVG-18731](https://jira.mongodb.org/browse/EVG-18731)

### Description 
Right now Evergreen thinks that Windows is billed by the hour so [we hesitate to terminate idle Windows hosts that aren't close to the end of an hour boundary](https://github.com/evergreen-ci/evergreen/blob/ad9cef43a0f7452cd0ea15aed2565a511429f36d/units/host_monitoring_idle_termination.go#L240-L245). This, in turn, motivates us to limit the Windows host pools so we can minimize idle time. This creates a poor user experience for Windows testing.

We've discovered that AWS switched Windows billing to by-the-second. This PR will make Evergreen terminate them at will. Once this goes in we will be able to raise max hosts for Windows.

### Testing 
Just the unit test. I'll try to get access to the billing info so I can check that this isn't making us spend radically more.
