### PR TITLE
EVG-17075 Do not use system activator when aborting a CQ patch

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -770,6 +770,7 @@ func SubscribeOnParentOutcome(parentStatus string, childPatchId string, parentPa
 	return nil
 }
 
+// CancelPatch aborts all of a patch's in-progress tasks and deactivates its undispatched tasks.
 func CancelPatch(p *patch.Patch, reason task.AbortInfo) error {
 	if p.Version != "" {
 		if err := SetVersionActivation(p.Version, false, reason.User); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -830,7 +830,7 @@ func HandleEndTaskForCommitQueueTask(t *task.Task, status string) error {
 		return errors.Errorf("no commit queue found for '%s'", t.Project)
 	}
 	if status != evergreen.TaskSucceeded && !t.Aborted {
-		return dequeueAndRestartWithStepback(cq, t, evergreen.APIServerTaskActivator, fmt.Sprintf("task '%s' failed", t.DisplayName))
+		return dequeueAndRestartWithStepback(cq, t, evergreen.MergeTestRequester, fmt.Sprintf("task '%s' failed", t.DisplayName))
 	} else if status == evergreen.TaskSucceeded {
 		// Query for all cq version tasks after this one; they may have been waiting to see if this
 		// one was the cause of the failure, in which case we should dequeue and restart.


### PR DESCRIPTION
[EVG-17075](https://jira.mongodb.org/browse/EVG-17075)

### Description 
[This patch](https://spruce.mongodb.com/version/62a8b1d62a60ed31b5decec8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) had an issue where there was a failing task, which successfully aborted the in-progress tasks for the CQ patch, however at the time of the failure there were undispatched tasks getting ready to run.  Turns out, because the `HandleEndTaskForCommitQueueTask` function passes in a default system activator, when the caller param get [propagated down](https://github.com/evergreen-ci/evergreen/blob/main/model/lifecycle.go#L79) when we deactivate the CQ patch's undispatched tasks, we add a query for the system activator when looking for tasks to deactivate. This causes us to skip over the undispatched tasks since they are typically activated by a user. 
### Testing 
