### PR TITLE
EVG-18739: remove git clone for GitHub PR merges

### DIFF
--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -20,7 +20,6 @@ import (
 )
 
 type gitMergePr struct {
-	URL   string `mapstructure:"url"`
 	Token string `mapstructure:"token"`
 
 	statusSender send.Sender

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-17"
+	AgentVersion = "2023-01-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -563,9 +563,13 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	}
 
 	mergeTask := model.ProjectTask{
-		Name: evergreen.MergeTaskName,
-		Commands: []model.PluginCommandConf{
-			{
+		Name:      evergreen.MergeTaskName,
+		DependsOn: dependencies,
+	}
+
+	if source == commitqueue.SourceDiff {
+		mergeTask.Commands = append(mergeTask.Commands,
+			model.PluginCommandConf{
 				Command: "git.get_project",
 				Type:    evergreen.CommandTypeSetup,
 				Params: map[string]interface{}{
@@ -574,12 +578,6 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 					"committer_email": settings.CommitQueue.CommitterEmail,
 				},
 			},
-		},
-		DependsOn: dependencies,
-	}
-
-	if source == commitqueue.SourceDiff {
-		mergeTask.Commands = append(mergeTask.Commands,
 			model.PluginCommandConf{
 				Command: "git.push",
 				Params: map[string]interface{}{
@@ -587,6 +585,7 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 				},
 			})
 	} else if source == commitqueue.SourcePullRequest {
+		// kim: TODO: verify that PRs do not need to git clone.
 		mergeTask.Commands = append(mergeTask.Commands,
 			model.PluginCommandConf{
 				Command: "git.merge_pr",

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -589,9 +589,6 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 		mergeTask.Commands = append(mergeTask.Commands,
 			model.PluginCommandConf{
 				Command: "git.merge_pr",
-				Params: map[string]interface{}{
-					"url": fmt.Sprintf("%s/version/%s", settings.Ui.Url, patchDoc.Id.Hex()),
-				},
 			})
 	} else {
 		return errors.Errorf("unknown commit queue source '%s'", source)

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -562,35 +562,15 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 		}
 	}
 
+	mergeTaskCmds, err := getMergeTaskCommands(settings, source)
+	if err != nil {
+		return errors.Wrap(err, "getting merge task commands")
+	}
+
 	mergeTask := model.ProjectTask{
 		Name:      evergreen.MergeTaskName,
 		DependsOn: dependencies,
-	}
-
-	if source == commitqueue.SourceDiff {
-		mergeTask.Commands = append(mergeTask.Commands,
-			model.PluginCommandConf{
-				Command: "git.get_project",
-				Type:    evergreen.CommandTypeSetup,
-				Params: map[string]interface{}{
-					"directory":       "src",
-					"committer_name":  settings.CommitQueue.CommitterName,
-					"committer_email": settings.CommitQueue.CommitterEmail,
-				},
-			},
-			model.PluginCommandConf{
-				Command: "git.push",
-				Params: map[string]interface{}{
-					"directory": "src",
-				},
-			})
-	} else if source == commitqueue.SourcePullRequest {
-		mergeTask.Commands = append(mergeTask.Commands,
-			model.PluginCommandConf{
-				Command: "git.merge_pr",
-			})
-	} else {
-		return errors.Errorf("unknown commit queue source '%s'", source)
+		Commands:  mergeTaskCmds,
 	}
 
 	// Define as part of a task group with no pre to skip
@@ -629,6 +609,37 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 	})
 
 	return nil
+}
+
+func getMergeTaskCommands(settings *evergreen.Settings, source string) ([]model.PluginCommandConf, error) {
+	switch source {
+	case commitqueue.SourceDiff:
+		return []model.PluginCommandConf{
+			{
+				Command: "git.get_project",
+				Type:    evergreen.CommandTypeSetup,
+				Params: map[string]interface{}{
+					"directory":       "src",
+					"committer_name":  settings.CommitQueue.CommitterName,
+					"committer_email": settings.CommitQueue.CommitterEmail,
+				},
+			},
+			{
+				Command: "git.push",
+				Params: map[string]interface{}{
+					"directory": "src",
+				},
+			},
+		}, nil
+	case commitqueue.SourcePullRequest:
+		return []model.PluginCommandConf{
+			{
+				Command: "git.merge_pr",
+			},
+		}, nil
+	default:
+		return nil, errors.Errorf("unknown commit queue source '%s'", source)
+	}
 }
 
 func setDefaultNotification(username string) error {

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -585,7 +585,6 @@ func AddMergeTaskAndVariant(patchDoc *patch.Patch, project *model.Project, proje
 				},
 			})
 	} else if source == commitqueue.SourcePullRequest {
-		// kim: TODO: verify that PRs do not need to git clone.
 		mergeTask.Commands = append(mergeTask.Commands,
 			model.PluginCommandConf{
 				Command: "git.merge_pr",


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18739

### Description 
When testing a PR in the commit queue, the merge task doesn't need to clone the project since it's just calling the GitHub API to merge the PR.

* Remove unneeded `git.get_project` when merging GitHub PRs.
* Remove unused `URL` parameter from `git.merge_pr`.

### Testing 
Tested with [a PR in the commit queue sandbox](https://github.com/evergreen-ci/commit-queue-sandbox/pull/417) in staging that the merge task succeeded without the `git.get_project` and without the URL parameter.