### PR TITLE
EVG-8093: remove distro Docker settings

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -25,9 +25,6 @@ type ProviderSettings interface {
 //Manager is an interface which handles creating new hosts or modifying
 //them via some third-party API.
 type Manager interface {
-	// Returns a pointer to the manager's configuration settings struct
-	GetSettings() ProviderSettings
-
 	// Load credentials or other settings from the config file
 	Configure(context.Context, *evergreen.Settings) error
 
@@ -131,6 +128,8 @@ type ManagerOpts struct {
 	ProviderSecret string
 }
 
+// GetSettings returns an uninitialized ProviderSettings based on the given
+// provider.
 func GetSettings(provider string) (ProviderSettings, error) {
 	switch provider {
 	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Fleet:

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -10,11 +10,9 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 // dockerManager implements the Manager interface for Docker.
@@ -23,44 +21,15 @@ type dockerManager struct {
 	env    evergreen.Environment
 }
 
-// ProviderSettings specifies the settings used to configure a host instance.
-type dockerSettings struct {
-	// ImageURL is the url of the Docker image to use when building the container.
-	ImageURL string `mapstructure:"image_url" json:"image_url" bson:"image_url"`
-}
+// dockerSettings are an empty placeholder to fulfill the ProviderSettings
+// interface.
+type dockerSettings struct{}
 
-// nolint
-var (
-	// bson fields for the ProviderSettings struct
-	imageURLKey = bsonutil.MustHaveTag(dockerSettings{}, "ImageURL")
-)
+// Validate is a no-op.
+func (*dockerSettings) Validate() error { return nil }
 
-// Validate checks that the settings from the config file are sane.
-func (settings *dockerSettings) Validate() error {
-	if settings.ImageURL == "" {
-		return errors.New("image must not be empty")
-	}
-
-	return nil
-}
-
-func (s *dockerSettings) FromDistroSettings(d distro.Distro, _ string) error {
-	if len(d.ProviderSettingsList) != 0 {
-		bytes, err := d.ProviderSettingsList[0].MarshalBSON()
-		if err != nil {
-			return errors.Wrap(err, "marshalling provider setting into BSON")
-		}
-		if err := bson.Unmarshal(bytes, s); err != nil {
-			return errors.Wrap(err, "unmarshalling BSON into provider settings")
-		}
-	}
-	return nil
-}
-
-// GetSettings returns an empty ProviderSettings struct.
-func (*dockerManager) GetSettings() ProviderSettings {
-	return &dockerSettings{}
-}
+// FromDistroSettings is a no-op.
+func (*dockerSettings) FromDistroSettings(distro.Distro, string) error { return nil }
 
 // SpawnHost creates and starts a new Docker container
 func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, error) {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -288,11 +288,6 @@ type ec2Manager struct {
 	settings    *evergreen.Settings
 }
 
-// GetSettings returns a pointer to the manager's configuration settings struct.
-func (m *ec2Manager) GetSettings() ProviderSettings {
-	return &EC2ProviderSettings{}
-}
-
 // Configure loads credentials or other settings from the config file.
 func (m *ec2Manager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	m.settings = settings

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -93,10 +93,6 @@ type ec2FleetManager struct {
 	env         evergreen.Environment
 }
 
-func (m *ec2FleetManager) GetSettings() ProviderSettings {
-	return &EC2ProviderSettings{}
-}
-
 func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	m.settings = settings
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -281,10 +281,6 @@ func (s *EC2Suite) TestMakeDeviceMappingsTemplate() {
 	s.Equal("snapshot-1", *b[0].Ebs.SnapshotId)
 }
 
-func (s *EC2Suite) TestGetSettings() {
-	s.Equal(&EC2ProviderSettings{}, s.onDemandManager.GetSettings())
-}
-
 func (s *EC2Suite) TestConfigure() {
 	settings := &evergreen.Settings{}
 	ctx, cancel := context.WithCancel(s.ctx)

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -82,12 +82,6 @@ func (opts *GCESettings) FromDistroSettings(d distro.Distro, _ string) error {
 	return nil
 }
 
-// GetSettings returns an empty GCESettings struct since settings are configured on
-// instance creation.
-func (m *gceManager) GetSettings() ProviderSettings {
-	return &GCESettings{}
-}
-
 // Configure loads the necessary credentials from the global config object.
 func (m *gceManager) Configure(ctx context.Context, s *evergreen.Settings) error {
 	config := s.Providers.GCE

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -253,10 +253,6 @@ func (m *mockManager) GetDNSName(ctx context.Context, host *host.Host) (string, 
 	return instance.DNSName, nil
 }
 
-func (_ *mockManager) GetSettings() ProviderSettings {
-	return &MockProviderSettings{}
-}
-
 // terminate an instance
 func (m *mockManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	l := m.mutex

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -64,12 +64,6 @@ func (opts *openStackSettings) FromDistroSettings(d distro.Distro, _ string) err
 	return nil
 }
 
-// GetSettings returns an empty ProviderSettings struct since settings are configured on
-// instance creation.
-func (m *openStackManager) GetSettings() ProviderSettings {
-	return &openStackSettings{}
-}
-
 // Configure loads the necessary credentials from the global config object.
 func (m *openStackManager) Configure(ctx context.Context, s *evergreen.Settings) error {
 	config := s.Providers.OpenStack

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -117,10 +117,6 @@ func (staticMgr *staticManager) StartInstance(ctx context.Context, host *host.Ho
 	return errors.New("StartInstance is not supported for static provider")
 }
 
-func (staticMgr *staticManager) GetSettings() ProviderSettings {
-	return &StaticSettings{}
-}
-
 func (staticMgr *staticManager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	//no-op. maybe will need to load something from settings in the future.
 	return nil

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -63,12 +63,6 @@ func (opts *vsphereSettings) FromDistroSettings(d distro.Distro, _ string) error
 	return nil
 }
 
-// GetSettings returns an empty vsphereSettings struct
-// since settings are configured on instance creation.
-func (m *vsphereManager) GetSettings() ProviderSettings {
-	return &vsphereSettings{}
-}
-
 // Configure loads the necessary credentials from the global config object.
 func (m *vsphereManager) Configure(ctx context.Context, s *evergreen.Settings) error {
 	ao := authOptions(s.Providers.VSphere)

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -53,11 +53,15 @@ type Distro struct {
 	IceCreamSettings      IceCreamSettings      `bson:"icecream_settings,omitempty" json:"icecream_settings,omitempty" mapstructure:"icecream_settings,omitempty"`
 }
 
+// DistroData is the same as a distro, with the only difference being that all
+// the provider settings are stored as maps instead of Birch BSON documents.
 type DistroData struct {
 	Distro              Distro                   `bson:",inline"`
 	ProviderSettingsMap []map[string]interface{} `bson:"provider_settings_list" json:"provider_settings_list"`
 }
 
+// NewDistroData creates distro data from this distro. The provider settings are
+// converted into maps instead of Birch BSON documents.
 func (d *Distro) NewDistroData() DistroData {
 	res := DistroData{ProviderSettingsMap: []map[string]interface{}{}}
 	res.Distro = *d

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -215,7 +215,9 @@ func GetPortMap(m nat.PortMap) PortMap {
 	return res
 }
 
-// DockerOptions contains options for starting a container
+// DockerOptions contains options for starting a container. This fulfills the
+// ProviderSettings interface to populate container information from the distro
+// settings.
 type DockerOptions struct {
 	// Optional parameters to define a registry name and authentication
 	RegistryName     string `mapstructure:"docker_registry_name" bson:"docker_registry_name,omitempty" json:"docker_registry_name,omitempty"`
@@ -239,6 +241,8 @@ type DockerOptions struct {
 	EnvironmentVars []string `mapstructure:"environment_vars" bson:"environment_vars,omitempty" json:"environment_vars,omitempty"`
 }
 
+// FromDistroSettings loads the Docker container options from the provider
+// settings.
 func (opts *DockerOptions) FromDistroSettings(d distro.Distro, _ string) error {
 	if len(d.ProviderSettingsList) != 0 {
 		bytes, err := d.ProviderSettingsList[0].MarshalBSON()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -61,7 +61,7 @@ func runTunablePlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOpti
 func runLegacyPlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOptions) ([]task.Task, error) {
 	runnableTasks, versions, err := FilterTasksWithVersionCache(tasks)
 	if err != nil {
-		return nil, errors.Wrap(err, "error while filtering tasks against the versions' cache")
+		return nil, errors.Wrap(err, "filtering tasks against the versions' cache")
 	}
 
 	ds := &distroScheduler{
@@ -75,7 +75,7 @@ func runLegacyPlanner(d *distro.Distro, tasks []task.Task, opts TaskPlannerOptio
 
 	prioritizedTasks, err := ds.scheduleDistro(d.Id, runnableTasks, versions, d.GetTargetTime(), opts.IsSecondaryQueue)
 	if err != nil {
-		return nil, errors.Wrapf(err, "problem calculating distro plan for distro '%s'", d.Id)
+		return nil, errors.Wrapf(err, "calculating distro plan for distro '%s'", d.Id)
 	}
 
 	return prioritizedTasks, nil
@@ -103,7 +103,7 @@ type distroScheduler struct {
 func (s *distroScheduler) scheduleDistro(distroID string, runnableTasks []task.Task, versions map[string]model.Version, maxThreshold time.Duration, isSecondaryQueue bool) ([]task.Task, error) {
 	prioritizedTasks, _, err := s.PrioritizeTasks(distroID, runnableTasks, versions)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error prioritizing tasks for distro '%s'", distroID)
+		return nil, errors.Wrapf(err, "prioritizing tasks for distro '%s'", distroID)
 
 	}
 
@@ -114,7 +114,7 @@ func (s *distroScheduler) scheduleDistro(distroID string, runnableTasks []task.T
 	// persist the queue of tasks and its associated distroQueueInfo
 	err = PersistTaskQueue(distroID, prioritizedTasks, distroQueueInfo)
 	if err != nil {
-		return nil, errors.Wrapf(err, "database error saving the task queue for distro '%s'", distroID)
+		return nil, errors.Wrapf(err, "saving the task queue for distro '%s'", distroID)
 	}
 
 	return prioritizedTasks, nil
@@ -247,11 +247,11 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	if pool != nil {
 		hostOptions, err := getCreateOptionsFromDistro(d)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
+			return nil, errors.Wrapf(err, "getting Docker options from distro '%s'", d.Id)
 		}
 		newContainers, newParents, err := host.MakeContainersAndParents(d, pool, newHostsNeeded, *hostOptions)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Error creating container intents for distro %s", d.Id)
+			return nil, errors.Wrapf(err, "creating container intents for distro '%s'", d.Id)
 		}
 		hostsSpawned = append(hostsSpawned, newContainers...)
 		hostsSpawned = append(hostsSpawned, newParents...)
@@ -269,14 +269,14 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 		for i := 0; i < numHostsToSpawn; i++ {
 			intent, err := generateIntentHost(d, pool)
 			if err != nil {
-				return nil, errors.Wrap(err, "error generating intent host")
+				return nil, errors.Wrap(err, "generating intent host")
 			}
 			hostsSpawned = append(hostsSpawned, *intent)
 		}
 	}
 
 	if err := host.InsertMany(hostsSpawned); err != nil {
-		return nil, errors.Wrap(err, "problem inserting host documents")
+		return nil, errors.Wrap(err, "inserting intent host documents")
 	}
 
 	grip.Info(message.Fields{
@@ -292,7 +292,7 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 func getCreateOptionsFromDistro(d distro.Distro) (*host.CreateOptions, error) {
 	dockerOptions := &host.DockerOptions{}
 	if err := dockerOptions.FromDistroSettings(d, ""); err != nil {
-		return nil, errors.Wrapf(err, "Error getting docker options from distro %s", d.Id)
+		return nil, errors.Wrapf(err, "getting Docker options from distro '%s'", d.Id)
 	}
 	if err := dockerOptions.Validate(); err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-8093

### Description 
The distro-level Docker settings are unused because they distro information is stored in the host document as `DockerOptions`. This is sort of breaking the abstraction layer between the distro provider settings and the host document, but I'm inclined to leave it as-is because we'll be removing the distro container pool feature at some point once the container initiative is generally available.

* Remove unused distro Docker settings.
* Remove unused `GetSettings` method from cloud provider interface.
* Drive-by add a couple small comments in some places for provider settings logic.
* Drive-by clean up a few error messages in the host scheduler.

### Testing
The distro Docker settings is unused/dead code, but I tested in local Evergreen that the distro settings still save/load properly just in case.