### PR TITLE
EVG-18775 activate triggered versions at creation time

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -276,7 +276,7 @@ func (s *ActivationStatus) ShouldActivate(now time.Time) bool {
 	return !s.Activated && now.After(s.ActivateAt) && !utility.IsZeroTime(s.ActivateAt)
 }
 
-// VersionMetadata is used to pass information about upstream versions to downstream version creation
+// VersionMetadata is used to pass information about version creation
 type VersionMetadata struct {
 	Revision            Revision
 	TriggerID           string
@@ -285,6 +285,7 @@ type VersionMetadata struct {
 	TriggerDefinitionID string
 	SourceVersion       *Version
 	IsAdHoc             bool
+	Activate            bool
 	User                *user.DBUser
 	Message             string
 	Alias               string

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -276,20 +276,6 @@ func VersionBySuccessfulBeforeRevision(project string, beforeRevision int) db.Q 
 	)
 }
 
-func VersionsByRequesterOrdered(project, requester string, limit, startOrder int) db.Q {
-	q := bson.M{
-		VersionIdentifierKey: project,
-		VersionRequesterKey:  requester,
-	}
-
-	if startOrder > 0 {
-		q[VersionRevisionOrderNumberKey] = bson.M{
-			"$lt": startOrder,
-		}
-	}
-	return db.Query(q).Limit(limit).Sort([]string{"-" + VersionRevisionOrderNumberKey})
-}
-
 func VersionFindOne(query db.Q) (*Version, error) {
 	version := &Version{}
 	err := db.FindOneQ(VersionCollection, query, version)

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -38,7 +38,7 @@ type Connector interface {
 	GetURL() string
 	SetURL(string)
 	GetProjectFromFile(context.Context, model.ProjectRef, string, string) (model.ProjectInfo, error)
-	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata, bool) (*model.Version, error)
+	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata) (*model.Version, error)
 	FindTestsByTaskId(FindTestsByTaskIdOpts) ([]testresult.TestResult, error)
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
 	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error)

--- a/rest/data/mock_impl.go
+++ b/rest/data/mock_impl.go
@@ -80,7 +80,7 @@ tasks:
 	}, err
 }
 
-func (mvc *MockGitHubConnectorImpl) CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo, metadata model.VersionMetadata, active bool) (*model.Version, error) {
+func (mvc *MockGitHubConnectorImpl) CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo, metadata model.VersionMetadata) (*model.Version, error) {
 	return &model.Version{
 		Requester:         evergreen.GitTagRequester,
 		TriggeredByGitTag: metadata.GitTag,

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -227,22 +227,12 @@ func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStar
 }
 
 func (vc *DBVersionConnector) CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo,
-	metadata model.VersionMetadata, active bool) (*model.Version, error) {
+	metadata model.VersionMetadata) (*model.Version, error) {
 	newVersion, err := repotracker.CreateVersionFromConfig(ctx, projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "creating version from config").Error(),
-		}
-	}
-
-	if active {
-		err := model.ActivateBuildsAndTasks(newVersion.BuildIds, true, evergreen.DefaultTaskActivator)
-		if err != nil {
-			return nil, gimlet.ErrorResponse{
-				StatusCode: http.StatusInternalServerError,
-				Message:    errors.Wrap(err, "activating builds").Error(),
-			}
 		}
 	}
 

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -303,12 +303,13 @@ func TestCreateVersionFromConfig(t *testing.T) {
 		Ref:                 &ref,
 	}
 	metadata := model.VersionMetadata{
-		Message: "my message",
-		User:    &u,
-		IsAdHoc: true,
+		Message:  "my message",
+		User:     &u,
+		IsAdHoc:  true,
+		Activate: true,
 	}
 	dc := DBVersionConnector{}
-	newVersion, err := dc.CreateVersionFromConfig(ctx, projectInfo, metadata, true)
+	newVersion, err := dc.CreateVersionFromConfig(ctx, projectInfo, metadata)
 	assert.NoError(err)
 	assert.Equal("my message", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)
@@ -349,11 +350,12 @@ tasks:
 	projectInfo.Project = p
 	projectInfo.IntermediateProject = pp
 	metadata = model.VersionMetadata{
-		Message: "message 2",
-		User:    &u,
-		IsAdHoc: true,
+		Message:  "message 2",
+		User:     &u,
+		IsAdHoc:  true,
+		Activate: true,
 	}
-	newVersion, err = dc.CreateVersionFromConfig(context.Background(), projectInfo, metadata, true)
+	newVersion, err = dc.CreateVersionFromConfig(context.Background(), projectInfo, metadata)
 	assert.NoError(err)
 	assert.Equal("message 2", newVersion.Message)
 	assert.Equal(evergreen.VersionCreated, newVersion.Status)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -501,6 +501,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		Revision:   revision,
 		GitTag:     tag,
 		RemotePath: remotePath,
+		Activate:   true,
 	}
 	var projectInfo model.ProjectInfo
 	if remotePath != "" {
@@ -524,7 +525,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		metadata.Alias = evergreen.GitTagAlias
 	}
 	projectInfo.Ref = &pRef
-	return gh.sc.CreateVersionFromConfig(ctx, &projectInfo, metadata, true)
+	return gh.sc.CreateVersionFromConfig(ctx, &projectInfo, metadata)
 }
 
 func validatePushTagEvent(event *github.PushEvent) error {

--- a/rest/route/version_create.go
+++ b/rest/route/version_create.go
@@ -42,9 +42,10 @@ func (h *versionCreateHandler) Parse(ctx context.Context, r *http.Request) error
 func (h *versionCreateHandler) Run(ctx context.Context) gimlet.Responder {
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 	metadata := model.VersionMetadata{
-		Message: h.Message,
-		IsAdHoc: h.IsAdHoc,
-		User:    u,
+		Message:  h.Message,
+		IsAdHoc:  h.IsAdHoc,
+		User:     u,
+		Activate: h.Active,
 	}
 	projectInfo := &model.ProjectInfo{}
 	var err error
@@ -71,7 +72,7 @@ func (h *versionCreateHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 	projectInfo.Project = p
-	newVersion, err := h.sc.CreateVersionFromConfig(ctx, projectInfo, metadata, h.Active)
+	newVersion, err := h.sc.CreateVersionFromConfig(ctx, projectInfo, metadata)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "creating version from config for project '%s'", h.ProjectID))
 	}

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -315,6 +315,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	require.Len(dbVersions, 1)
 	versions := []model.Version{downstreamVersions[0], dbVersions[0]}
 	for _, v := range versions {
+		assert.True(utility.FromBoolPtr(v.Activated))
 		assert.Equal("downstream_abc_def1", v.Id)
 		assert.Equal(downstreamRevision, v.Revision)
 		assert.Equal(evergreen.VersionCreated, v.Status)
@@ -328,6 +329,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	assert.NoError(err)
 	assert.True(len(builds) > 0)
 	for _, b := range builds {
+		assert.True(b.Activated)
 		assert.Equal(downstreamProjectRef.Id, b.Project)
 		assert.Equal(evergreen.TriggerRequester, b.Requester)
 		assert.Equal(evergreen.BuildCreated, b.Status)
@@ -340,6 +342,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	assert.NoError(err)
 	assert.True(len(tasks) > 0)
 	for _, t := range tasks {
+		assert.True(t.Activated)
 		assert.Equal(downstreamProjectRef.Id, t.Project)
 		assert.Equal(evergreen.TriggerRequester, t.Requester)
 		assert.Equal(evergreen.TaskUndispatched, t.Status)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -79,11 +79,6 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "adding build break subscriptions")
 	}
-	_, err = model.DoProjectActivation(args.DownstreamProject.Id, time.Now())
-	if err != nil {
-		return nil, errors.Wrapf(err, "activating downstream project '%s'", args.DownstreamProject.Id)
-	}
-
 	return v, nil
 }
 

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -37,12 +37,17 @@ func TestMetadataFromVersion(t *testing.T) {
 	assert.NoError(err)
 	assert.NoError(model.UpdateLastRevision(ref.Id, "def"))
 
-	metadata, err := metadataFromVersion(source, ref)
+	args := ProcessorArgs{
+		SourceVersion:     &source,
+		DownstreamProject: ref,
+	}
+	metadata, err := metadataFromVersion(args)
 	assert.NoError(err)
 	assert.Equal(source.Author, metadata.Revision.Author)
 	assert.Equal(source.CreateTime, metadata.Revision.CreateTime)
 	assert.Equal("def", metadata.Revision.Revision)
 	assert.Equal(123, metadata.Revision.AuthorGithubUID)
+	assert.True(metadata.Activate)
 }
 
 func TestMakeDownstreamConfigFromFile(t *testing.T) {


### PR DESCRIPTION
[EVG-18775](https://jira.mongodb.org/browse/EVG-18775)

### Description 
It was always the behavior that we activated triggered versions right away since we ignore batchtime for them, but for some reason we did this with DoProjectActivation instead of just activating everything when we create the version so this broke when we changed DoProjectActivation to only consider repotracker things.

Did a little refactor to also activate everything when we create the version for other things that call this (git tags, rest created versions, and periodic builds).

### Testing 
Added activate to unit test (failed before adding changes). Will verify existing unit tests pass.