### PR TITLE
EVG-18794: remove passwordexpires from Windows host provisioning

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -555,7 +555,6 @@ func (h *Host) SetupServiceUserCommands() (string, error) {
 			cmd(fmt.Sprintf("net user %s %s /add", h.Distro.BootstrapSettings.ServiceUser, h.ServicePassword)),
 			// Add the user to the Administrators group.
 			cmd(fmt.Sprintf("net localgroup Administrators %s /add", h.Distro.BootstrapSettings.ServiceUser)),
-			cmd(fmt.Sprintf(`wmic useraccount where name="%s" set passwordexpires=false`, h.Distro.BootstrapSettings.ServiceUser)),
 			// Allow the user to run the service by granting the "Log on as a
 			// service" right.
 			loginServicePermCmd,


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18794

### Description
When setting up a Windows host (of any kind, like a spawn host or task host), part of the provisioning process requires that we create a service user that runs background services (i.e. Jasper) and processes (i.e. the agent monitor and the agent). As part of running services with that user, we have to know its password.

I originally set up this user to have an unexpirable password (the default password expiration is 42 days for our Windows AMIs) because we initially thought we might use this service user after provisioning was finished (e.g. to run processes on long-running hosts like unexpirable hosts). That idea never really panned out and we still just SSH into those hosts. Therefore, we don't need an unexpirable password because Evergreen doesn't access the host after the initial provisioning.

### Testing 
Tested in staging that a Windows host still provisioned without issue and that the password had the default 42 day expiration.
