### PR TITLE
EVG-18811  Fix approval being hidden 

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -894,7 +894,10 @@ func GetGithubPullRequestReviews(ctx context.Context, token, owner, repo string,
 
 	client := github.NewClient(httpClient)
 
-	reviews, _, err := client.PullRequests.ListReviews(ctx, owner, repo, prNumber, nil)
+	opts := &github.ListOptions{
+		PerPage: 100,
+	}
+	reviews, _, err := client.PullRequests.ListReviews(ctx, owner, repo, prNumber, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[EVG-18811](https://jira.mongodb.org/browse/EVG-18811)

### Description 
We rely on the list of reviews to know if there is the required number of approvals. The default that listReviews returns is 30. On rare occasions, there will be PRs with more than 30 reviews. For example, today we saw a PR with 37 reviews, and the approval being the 37th. This increases the amount of reviews returned to 100. 

