### PR TITLE
EVG-17334 Add and option to preserve the folder structure for s3 put 

### DIFF
--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -285,7 +285,7 @@ func TestExpandS3PutParams(t *testing.T) {
 			cmd = &s3put{}
 
 			for _, v := range []string{"", "false", "False", "0", "F", "f", "${foo|false}", "${foo|}", "${foo}"} {
-				cmd.skipMissing = true
+				cmd.SkipExisting = "true"
 				cmd.Optional = v
 				So(cmd.expandParams(conf), ShouldBeNil)
 				So(cmd.skipMissing, ShouldBeFalse)

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -432,7 +432,6 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 func TestPreservePath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	var err error
 
 	dir := t.TempDir()
 	f, err := os.Create(filepath.Join(dir, "foo"))
@@ -455,7 +454,7 @@ func TestPreservePath(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	// Create the files in the assetes/images directory
+	// Create the files in the assets/images directory
 	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "images", "image1"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -428,3 +428,86 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestPreservePath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var err error
+
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "foo"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Create the directories
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets", "images"), 0755))
+
+	// Create the files in in the assets directory
+	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "asset1"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "asset2"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "asset3"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Create the files in the assetes/images directory
+	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "images", "image1"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	f, err = os.Create(filepath.Join(dir, "myWebsite", "assets", "images", "image2"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	s := s3put{
+		AwsKey:                  "key",
+		AwsSecret:               "secret",
+		Bucket:                  "bucket",
+		BuildVariants:           []string{},
+		ContentType:             "content-type",
+		LocalFilesIncludeFilter: []string{"*"},
+		Permissions:             s3.BucketCannedACLPublicRead,
+		RemoteFile:              "remote",
+		PreservePath:            "true",
+	}
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0755))
+	opts := pail.LocalOptions{
+		Path: filepath.Join(dir, "destination"),
+	}
+	s.bucket, err = pail.NewLocalBucket(opts)
+	require.NoError(t, err)
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		Expansions:   &util.Expansions{},
+		Task:         &task.Task{Id: "mock_id", Secret: "mock_secret"},
+		Project:      &model.Project{},
+		WorkDir:      dir,
+		BuildVariant: &model.BuildVariant{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Execute(ctx, comm, logger, conf))
+	it, err := s.bucket.List(ctx, "")
+	require.NoError(t, err)
+	expected := map[string]bool{
+		"remote/foo":                            false,
+		"remote/myWebsite/assets/asset1":        false,
+		"remote/myWebsite/assets/asset2":        false,
+		"remote/myWebsite/assets/asset3":        false,
+		"remote/myWebsite/assets/images/image1": false,
+		"remote/myWebsite/assets/images/image2": false,
+	}
+	for it.Next(ctx) {
+		expected[it.Item().Name()] = true
+	}
+
+	for item, exists := range expected {
+		require.True(t, exists, item)
+	}
+
+}

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-25"
+	AgentVersion = "2023-01-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-17334](https://jira.mongodb.org/browse/EVG-17334)

### Description 
For users that rely on symlinks, adding all files that match a filter to one root folder breaks those links. I added this as an option instead of changing the existing behavior because users who are currently using may rely on the current behavior. 

### Testing 
Added a test 
