### PR TITLE
EVG-18006 Use select statement for agent commands at risk of blocked goroutines

### DIFF
--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -91,8 +91,12 @@ func (c *tarballCreate) Execute(ctx context.Context,
 	filesArchived := -1
 	go func() {
 		defer func() {
-			errChan <- recovery.HandlePanicWithError(recover(), nil,
-				"making archive")
+			select {
+			case errChan <- recovery.HandlePanicWithError(recover(), nil, "making archive"):
+				return
+			case <-ctx.Done():
+				return
+			}
 		}()
 		var err error
 		filesArchived, err = c.makeArchive(ctx, logger.Execution())

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -71,7 +71,14 @@ func (c *xunitResults) Execute(ctx context.Context,
 
 	errChan := make(chan error)
 	go func() {
-		errChan <- c.parseAndUploadResults(ctx, conf, logger, comm)
+		err := c.parseAndUploadResults(ctx, conf, logger, comm)
+		select {
+		case errChan <- err:
+			return
+		case <-ctx.Done():
+			logger.Task().Infof("Context canceled waiting to parse and upload results: %s.", ctx.Err())
+			return
+		}
 	}()
 
 	select {

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -307,7 +307,14 @@ func (s3pc *s3put) Execute(ctx context.Context,
 
 	errChan := make(chan error)
 	go func() {
-		errChan <- errors.WithStack(s3pc.putWithRetry(ctx, comm, logger))
+		err := errors.WithStack(s3pc.putWithRetry(ctx, comm, logger))
+		select {
+		case errChan <- err:
+			return
+		case <-ctx.Done():
+			logger.Task().Infof("Context canceled waiting for s3 put: %s.", ctx.Err())
+			return
+		}
 	}()
 
 	select {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-25"
+	AgentVersion = "2023-01-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-18006](https://jira.mongodb.org/browse/EVG-18006)
### Description 
Some agent commands utilize blocking channels when performing key operations, without protection from the possibility that a value may never get sent to the channel. This would cause an indefinite blocking of the command.

Introduced a `select` statement to these goroutines to handle potential context cancellation.

### Testing 
