### PR TITLE
EVG-14186 Allow PR commit queue enqueuing in UI (revert checkSignedCommit)

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -207,3 +207,12 @@ func ClearAllCommitQueues() (int, error) {
 
 	return clearedCount, nil
 }
+
+// EnqueuePRInfo holds information necessary to enqueue a PR to the commit queue.
+type EnqueuePRInfo struct {
+	Username      string
+	Owner         string
+	Repo          string
+	PR            int
+	CommitMessage string
+}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -525,7 +525,7 @@ func checkSignedCommit(ctx context.Context, settings *evergreen.Settings, userRe
 
 	for _, c := range commits {
 		commit := c.GetCommit()
-		if commit.Verification != nil || !utility.FromBoolPtr(commit.Verification.Verified) ||
+		if commit.Verification != nil && !utility.FromBoolPtr(commit.Verification.Verified) &&
 			utility.FromStringPtr(commit.Verification.Reason) == githubCommitUnsigned {
 			return errors.Errorf("commit '%s' is not signed", utility.FromStringPtr(commit.SHA))
 		}

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +24,11 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+)
+
+const (
+	githubCommitUnsigned = "unsigned"
+	githubReviewApproved = "APPROVED"
 )
 
 type DBCommitQueueConnector struct{}
@@ -48,29 +54,29 @@ func (pc *DBCommitQueueConnector) GetGitHubPR(ctx context.Context, owner, repo s
 	return pr, nil
 }
 
-func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error) {
+func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (*patch.Patch, error) {
 	settings, err := evergreen.GetConfig()
 	if err != nil {
-		return "", errors.Wrap(err, "getting admin settings")
+		return nil, errors.Wrap(err, "getting admin settings")
 	}
 	githubToken, err := settings.GetGithubOauthToken()
 	if err != nil {
-		return "", errors.Wrap(err, "getting GitHub OAuth token from admin settings")
+		return nil, errors.Wrap(err, "getting GitHub OAuth token from admin settings")
 	}
 	pr, err := thirdparty.GetMergeablePullRequest(ctx, prNum, githubToken, projectRef.Owner, projectRef.Repo)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	title := fmt.Sprintf("%s (#%d)", pr.GetTitle(), prNum)
 	patchDoc, err := patch.MakeNewMergePatch(pr, projectRef.Id, evergreen.CommitQueueAlias, title, messageOverride)
 	if err != nil {
-		return "", errors.Wrap(err, "making commit queue patch")
+		return nil, errors.Wrap(err, "making commit queue patch")
 	}
 
 	p, patchSummaries, proj, err := getPatchInfo(ctx, githubToken, patchDoc)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	errs := validator.CheckProjectErrors(proj, false)
@@ -97,11 +103,11 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 			"merge_errs": catcher.Resolve(),
 		}))
 
-		return "", errors.Wrap(catcher.Resolve(), "invalid project configuration file")
+		return nil, errors.Wrap(catcher.Resolve(), "invalid project configuration file")
 	}
 
 	if err = writePatchInfo(patchDoc, patchSummaries, p); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	serviceModules := []commitqueue.Module{}
@@ -110,7 +116,7 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	}
 	modulePRs, modulePatches, err := model.GetModulesFromPR(ctx, githubToken, serviceModules, proj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	patchDoc.Patches = append(patchDoc.Patches, modulePatches...)
 
@@ -118,11 +124,11 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 	proj.BuildProjectTVPairs(patchDoc, patchDoc.Alias)
 
 	if err = units.AddMergeTaskAndVariant(patchDoc, proj, &projectRef, commitqueue.SourcePullRequest); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if err = patchDoc.Insert(); err != nil {
-		return "", errors.Wrap(err, "inserting patch")
+		return nil, errors.Wrap(err, "inserting patch")
 	}
 
 	catcher = grip.NewBasicCatcher()
@@ -130,7 +136,7 @@ func (pc *DBCommitQueueConnector) AddPatchForPr(ctx context.Context, projectRef 
 		catcher.Add(thirdparty.SendCommitQueueGithubStatus(evergreen.GetEnvironment(), modulePR, message.GithubStatePending, "added to queue", patchDoc.Id.Hex()))
 	}
 
-	return patchDoc.Id.Hex(), catcher.Resolve()
+	return patchDoc, catcher.Resolve()
 }
 
 func getPatchInfo(ctx context.Context, githubToken string, patchDoc *patch.Patch) (string, []thirdparty.Summary, *model.Project, error) {
@@ -280,6 +286,123 @@ func (pc *DBCommitQueueConnector) IsAuthorizedToPatchAndMerge(ctx context.Contex
 	return hasPermission, nil
 }
 
+// EnqueuePRToCommitQueue enqueues an item to the commit queue to test and merge a PR.
+func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc Connector, info commitqueue.EnqueuePRInfo) (*restModel.APIPatch, error) {
+	settings := env.Settings()
+	userRepo := UserRepoInfo{
+		Username: info.Username,
+		Owner:    info.Owner,
+		Repo:     info.Repo,
+	}
+	authorized, err := sc.IsAuthorizedToPatchAndMerge(ctx, settings, userRepo)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting user info from GitHub API")
+	}
+	if !authorized {
+		return nil, errors.Errorf("user '%s' is not authorized to merge", userRepo.Username)
+	}
+
+	pr, err := sc.GetGitHubPR(ctx, userRepo.Owner, userRepo.Repo, info.PR)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting PR from GitHub API")
+	}
+
+	if pr == nil || pr.Base == nil || pr.Base.Ref == nil {
+		return nil, errors.New("PR contains no base branch label")
+	}
+
+	cqInfo := restModel.ParseGitHubComment(info.CommitMessage)
+	baseBranch := *pr.Base.Ref
+	projectRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(userRepo.Owner, userRepo.Repo, baseBranch)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting project for '%s:%s' tracking branch '%s'", userRepo.Owner, userRepo.Repo, baseBranch)
+	}
+	if projectRef == nil {
+		return nil, errors.Errorf("no project with commit queue enabled for '%s:%s' tracking branch '%s'", userRepo.Owner, userRepo.Repo, baseBranch)
+	}
+
+	patchDoc, errMsg, err := tryEnqueueItemForPR(ctx, settings, sc, projectRef, userRepo, info.PR, cqInfo)
+	if err != nil {
+		sendErr := thirdparty.SendCommitQueueGithubStatus(env, pr, message.GithubStateFailure, errMsg, "")
+		grip.Error(message.WrapError(sendErr, message.Fields{
+			"message": "error sending patch creation failure to github",
+			"owner":   userRepo.Owner,
+			"repo":    userRepo.Repo,
+			"pr":      info.PR,
+		}))
+		return nil, errors.Wrap(err, "enqueueing item to commit queue for PR")
+	}
+
+	if pr == nil || pr.Head == nil || pr.Head.SHA == nil {
+		return nil, errors.New("PR contains no head branch SHA")
+	}
+	pushJob := units.NewGithubStatusUpdateJobForPushToCommitQueue(userRepo.Owner, userRepo.Repo, *pr.Head.SHA, info.PR, patchDoc.Id.Hex())
+	q := env.LocalQueue()
+	if err = q.Put(ctx, pushJob); err != nil {
+		return nil, errors.Wrapf(err, "queueing notification for commit queue push for item '%d'", info.PR)
+	}
+	apiPatch := &restModel.APIPatch{}
+	if err = apiPatch.BuildFromService(*patchDoc, nil); err != nil {
+		return nil, errors.Wrap(err, "converting patch to API model")
+	}
+	return apiPatch, nil
+}
+
+// tryEnqueueItemForPR attempts to enqueue an item for a PR after checking it is in a valid state to enqueue. It returns the enqueued patch,
+// and in the failure case it will return an error and a short error message to be sent to GitHub.
+func tryEnqueueItemForPR(ctx context.Context, settings *evergreen.Settings, sc Connector, projectRef *model.ProjectRef, userRepo UserRepoInfo, prNum int, cqInfo restModel.GithubCommentCqData) (*patch.Patch, string, error) {
+	if utility.FromBoolPtr(projectRef.CommitQueue.RequireSigned) {
+		if err := checkSignedCommit(ctx, settings, userRepo, prNum); err != nil {
+			return nil, "can't enqueue with unsigned commits", errors.Wrapf(err, "checking commit signing")
+		}
+	}
+	if requiredApprovalCount := projectRef.CommitQueue.RequiredApprovalCount; requiredApprovalCount != 0 {
+		if err := checkPRApprovals(ctx, settings, userRepo, prNum, requiredApprovalCount); err != nil {
+			return nil, "can't enqueue without required number of approvals", errors.Wrapf(err, "checking pull request approvals")
+		}
+	}
+	patchDoc, err := sc.AddPatchForPr(ctx, *projectRef, prNum, cqInfo.Modules, cqInfo.MessageOverride)
+	if err != nil {
+		return nil, "failed to create patch", errors.Wrap(err, "adding patch for PR")
+	}
+
+	item := restModel.APICommitQueueItem{
+		Issue:           utility.ToStringPtr(strconv.Itoa(prNum)),
+		MessageOverride: &cqInfo.MessageOverride,
+		Modules:         cqInfo.Modules,
+		Source:          utility.ToStringPtr(commitqueue.SourcePullRequest),
+		PatchId:         utility.ToStringPtr(patchDoc.Id.Hex()),
+	}
+	if _, err = EnqueueItem(projectRef.Id, item, false); err != nil {
+		return nil, "failed to enqueue commit item", errors.Wrap(err, "enqueueing commit queue item")
+	}
+	return patchDoc, "", nil
+}
+
+func checkPRApprovals(ctx context.Context, settings *evergreen.Settings, userRepo UserRepoInfo, prNum, requiredApprovalCount int) error {
+	githubToken, err := settings.GetGithubOauthToken()
+	if err != nil {
+		return errors.Wrap(err, "getting GitHub OAuth token from settings")
+	}
+
+	reviews, err := thirdparty.GetGithubPullRequestReviews(ctx, githubToken, userRepo.Owner, userRepo.Repo, prNum)
+	if err != nil {
+		return errors.Wrap(err, "getting GitHub PR reviews")
+	}
+
+	var numApprovals int
+	for _, r := range reviews {
+		if r.GetState() == githubReviewApproved {
+			numApprovals += 1
+		}
+	}
+
+	if numApprovals < requiredApprovalCount {
+		return errors.Errorf("PR %d does not have enough approvals. %d approval(s) required", prNum, requiredApprovalCount)
+	}
+	return nil
+}
+
 func CreatePatchForMerge(ctx context.Context, existingPatchID, commitMessage string) (*restModel.APIPatch, error) {
 	existingPatch, err := patch.FindOneId(existingPatchID)
 	if err != nil {
@@ -387,4 +510,26 @@ func GetAdditionalPatches(patchId string) ([]string, error) {
 		StatusCode: http.StatusNotFound,
 		Message:    errors.Errorf("patch '%s' not found in commit queue", patchId).Error(),
 	}
+}
+
+func checkSignedCommit(ctx context.Context, settings *evergreen.Settings, userRepo UserRepoInfo, prNum int) error {
+	githubToken, err := settings.GetGithubOauthToken()
+	if err != nil {
+		return errors.Wrap(err, "getting GitHub OAuth token from settings")
+	}
+
+	commits, err := thirdparty.GetGithubPullRequestCommits(ctx, githubToken, userRepo.Owner, userRepo.Repo, prNum)
+	if err != nil {
+		return errors.Wrap(err, "getting GitHub commits")
+	}
+
+	for _, c := range commits {
+		commit := c.GetCommit()
+		if commit.Verification != nil || !utility.FromBoolPtr(commit.Verification.Verified) ||
+			utility.FromStringPtr(commit.Verification.Reason) == githubCommitUnsigned {
+			return errors.Errorf("commit '%s' is not signed", utility.FromStringPtr(commit.SHA))
+		}
+
+	}
+	return nil
 }

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/google/go-github/v34/github"
@@ -41,6 +42,6 @@ type Connector interface {
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata) (*model.Version, error)
 	FindTestsByTaskId(FindTestsByTaskIdOpts) ([]testresult.TestResult, error)
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
-	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error)
+	AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (*patch.Patch, error)
 	IsAuthorizedToPatchAndMerge(context.Context, *evergreen.Settings, UserRepoInfo) (bool, error)
 }

--- a/rest/data/mock_impl.go
+++ b/rest/data/mock_impl.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -36,8 +37,8 @@ func (pc *MockGitHubConnectorImpl) GetGitHubPR(ctx context.Context, owner, repo 
 	}, nil
 }
 
-func (pc *MockGitHubConnectorImpl) AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (string, error) {
-	return "", nil
+func (pc *MockGitHubConnectorImpl) AddPatchForPr(ctx context.Context, projectRef model.ProjectRef, prNum int, modules []restModel.APIModule, messageOverride string) (*patch.Patch, error) {
+	return &patch.Patch{}, nil
 }
 
 func (pc *MockGitHubConnectorImpl) IsAuthorizedToPatchAndMerge(ctx context.Context, settings *evergreen.Settings, args UserRepoInfo) (bool, error) {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -221,7 +221,7 @@ func (apiPatch *APIPatch) buildBasePatch(p patch.Patch) {
 	}
 
 	apiPatch.PatchedParserProject = utility.ToStringPtr(p.PatchedParserProject)
-	apiPatch.CanEnqueueToCommitQueue = p.HasValidGitInfo()
+	apiPatch.CanEnqueueToCommitQueue = p.HasValidGitInfo() || p.IsGithubPRPatch()
 	apiPatch.GithubPatchData.BuildFromService(p.GithubPatchData)
 }
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -13,9 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/thirdparty"
-	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v34/github"
@@ -30,8 +28,6 @@ const (
 	githubActionOpened      = "opened"
 	githubActionSynchronize = "synchronize"
 	githubActionReopened    = "reopened"
-	githubCommitUnsigned    = "unsigned"
-	githubReviewApproved    = "APPROVED"
 
 	retryComment = "evergreen retry"
 	patchComment = "evergreen patch"
@@ -221,7 +217,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 					"user":      *event.Sender.Login,
 					"message":   "commit queue triggered",
 				})
-				if err := gh.commitQueueEnqueue(ctx, gh.settings, event); err != nil {
+				if _, err := data.EnqueuePRToCommitQueue(ctx, evergreen.GetEnvironment(), gh.sc, createEnqueuePRInfo(event)); err != nil {
 					grip.Error(message.WrapError(err, message.Fields{
 						"source":    "GitHub hook",
 						"msg_id":    gh.msgID,
@@ -551,158 +547,6 @@ func validatePushTagEvent(event *github.PushEvent) error {
 	return nil
 }
 
-func (gh *githubHookApi) commitQueueEnqueue(ctx context.Context, settings *evergreen.Settings, event *github.IssueCommentEvent) error {
-	userRepo := data.UserRepoInfo{
-		Username: *event.Comment.User.Login,
-		Owner:    *event.Repo.Owner.Login,
-		Repo:     *event.Repo.Name,
-	}
-	authorized, err := gh.sc.IsAuthorizedToPatchAndMerge(ctx, gh.settings, userRepo)
-	if err != nil {
-		return errors.Wrap(err, "getting user info from GitHub API")
-	}
-	if !authorized {
-		return errors.Errorf("user '%s' is not authorized to merge", userRepo.Username)
-	}
-
-	prNum := *event.Issue.Number
-	pr, err := gh.sc.GetGitHubPR(ctx, userRepo.Owner, userRepo.Repo, prNum)
-	if err != nil {
-		return errors.Wrap(err, "getting PR from GitHub API")
-	}
-
-	if pr == nil || pr.Base == nil || pr.Base.Ref == nil {
-		return errors.New("PR contains no base branch label")
-	}
-
-	cqInfo := restModel.ParseGitHubComment(*event.Comment.Body)
-	baseBranch := *pr.Base.Ref
-	projectRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(userRepo.Owner, userRepo.Repo, baseBranch)
-	if err != nil {
-		return errors.Wrapf(err, "getting project for '%s:%s' tracking branch '%s'", userRepo.Owner, userRepo.Repo, baseBranch)
-	}
-	if projectRef == nil {
-		return errors.Errorf("no project with commit queue enabled for '%s:%s' tracking branch '%s'", userRepo.Owner, userRepo.Repo, baseBranch)
-	}
-
-	if utility.FromBoolPtr(projectRef.CommitQueue.RequireSigned) {
-		err = gh.requireSigned(ctx, settings, userRepo, prNum)
-		if err != nil {
-			sendErr := thirdparty.SendCommitQueueGithubStatus(evergreen.GetEnvironment(), pr, message.GithubStateFailure, "can't enqueue with unsigned commits", "")
-			grip.Error(message.WrapError(sendErr, message.Fields{
-				"message": "error sending patch creation failure to github",
-				"owner":   userRepo.Owner,
-				"repo":    userRepo.Repo,
-				"pr":      prNum,
-			}))
-			return errors.Wrapf(err, "checking commit signing")
-		}
-	}
-
-	requiredApprovalCount := projectRef.CommitQueue.RequiredApprovalCount
-	if requiredApprovalCount != 0 {
-		err = gh.checkPRApprovals(ctx, settings, userRepo, prNum, requiredApprovalCount)
-		if err != nil {
-			sendErr := thirdparty.SendCommitQueueGithubStatus(evergreen.GetEnvironment(), pr, message.GithubStateFailure, "can't enqueue without required number of approvals", "")
-			grip.Error(message.WrapError(sendErr, message.Fields{
-				"message": "error sending patch creation failure to github",
-				"owner":   userRepo.Owner,
-				"repo":    userRepo.Repo,
-				"pr":      prNum,
-			}))
-			return errors.Wrapf(err, "checking pull request approvals")
-		}
-	}
-
-	patchId, err := gh.sc.AddPatchForPr(ctx, *projectRef, prNum, cqInfo.Modules, cqInfo.MessageOverride)
-	if err != nil {
-		sendErr := thirdparty.SendCommitQueueGithubStatus(evergreen.GetEnvironment(), pr, message.GithubStateFailure, "failed to create patch", "")
-		grip.Error(message.WrapError(sendErr, message.Fields{
-			"message": "error sending patch creation failure to github",
-			"owner":   userRepo.Owner,
-			"repo":    userRepo.Repo,
-			"pr":      prNum,
-		}))
-		return errors.Wrap(err, "adding patch for PR")
-	}
-
-	item := restModel.APICommitQueueItem{
-		Issue:           utility.ToStringPtr(strconv.Itoa(prNum)),
-		MessageOverride: &cqInfo.MessageOverride,
-		Modules:         cqInfo.Modules,
-		Source:          utility.ToStringPtr(commitqueue.SourcePullRequest),
-		PatchId:         &patchId,
-	}
-	_, err = data.EnqueueItem(projectRef.Id, item, false)
-	if err != nil {
-		return errors.Wrap(err, "enqueueing commit queue item")
-	}
-
-	if pr == nil || pr.Head == nil || pr.Head.SHA == nil {
-		return errors.New("PR contains no head branch SHA")
-	}
-	pushJob := units.NewGithubStatusUpdateJobForPushToCommitQueue(userRepo.Owner, userRepo.Repo, *pr.Head.SHA, prNum, patchId)
-	q := evergreen.GetEnvironment().LocalQueue()
-	grip.Error(message.WrapError(q.Put(ctx, pushJob), message.Fields{
-		"source":  "GitHub hook",
-		"msg_id":  gh.msgID,
-		"event":   gh.eventType,
-		"action":  event.Action,
-		"owner":   userRepo.Owner,
-		"repo":    userRepo.Repo,
-		"item":    prNum,
-		"message": "failed to queue notification for commit queue push",
-	}))
-
-	return nil
-}
-
-func (gh *githubHookApi) requireSigned(ctx context.Context, settings *evergreen.Settings, userRepo data.UserRepoInfo, prNum int) error {
-	githubToken, err := settings.GetGithubOauthToken()
-	if err != nil {
-		return errors.Wrap(err, "getting GitHub OAuth token from settings")
-	}
-
-	commits, err := thirdparty.GetGithubPullRequestCommits(ctx, githubToken, userRepo.Owner, userRepo.Repo, prNum)
-	if err != nil {
-		return errors.Wrap(err, "getting GitHub commits")
-	}
-
-	for _, c := range commits {
-		commit := c.GetCommit()
-		if commit.Verification != nil && !utility.FromBoolPtr(commit.Verification.Verified) &&
-			utility.FromStringPtr(commit.Verification.Reason) == githubCommitUnsigned {
-			return errors.Errorf("commit '%s' is not signed", utility.FromStringPtr(commit.SHA))
-		}
-
-	}
-	return nil
-}
-
-func (gh *githubHookApi) checkPRApprovals(ctx context.Context, settings *evergreen.Settings, userRepo data.UserRepoInfo, prNum, requiredApprovalCount int) error {
-	githubToken, err := settings.GetGithubOauthToken()
-	if err != nil {
-		return errors.Wrap(err, "getting GitHub OAuth token from settings")
-	}
-
-	reviews, err := thirdparty.GetGithubPullRequestReviews(ctx, githubToken, userRepo.Owner, userRepo.Repo, prNum)
-	if err != nil {
-		return errors.Wrap(err, "getting GitHub PR reviews")
-	}
-
-	var numApprovals int
-	for _, r := range reviews {
-		if r.GetState() == githubReviewApproved {
-			numApprovals += 1
-		}
-	}
-
-	if numApprovals < requiredApprovalCount {
-		return errors.Errorf("PR %d does not have enough approvals. %d approval(s) required", prNum, requiredApprovalCount)
-	}
-	return nil
-}
-
 // Because the PR isn't necessarily on a commit queue, we only error if item is on the queue and can't be removed correctly
 func (gh *githubHookApi) tryDequeueCommitQueueItemForPR(pr *github.PullRequest) error {
 	err := thirdparty.ValidatePR(pr)
@@ -730,6 +574,16 @@ func (gh *githubHookApi) tryDequeueCommitQueueItemForPR(pr *github.PullRequest) 
 		return errors.Wrapf(err, "can't remove item %d from commit queue for project '%s'", *pr.Number, projRef.Id)
 	}
 	return nil
+}
+
+func createEnqueuePRInfo(event *github.IssueCommentEvent) commitqueue.EnqueuePRInfo {
+	return commitqueue.EnqueuePRInfo{
+		Username:      *event.Comment.User.Login,
+		Owner:         *event.Repo.Owner.Login,
+		Repo:          *event.Repo.Name,
+		PR:            *event.Issue.Number,
+		CommitMessage: *event.Comment.Body,
+	}
 }
 
 func isItemOnCommitQueue(id, item string) (bool, error) {


### PR DESCRIPTION
[EVG-14186](https://jira.mongodb.org/browse/EVG-14186)

### Description 
Same implementation as the [previous PR](https://github.com/evergreen-ci/evergreen/pull/6198/files/d50817b174f9d1dbd8c5af4c2b9bfacf339ea2dc), with the only difference being that [checkSignedCommit](https://github.com/evergreen-ci/evergreen/pull/6198/files/d50817b174f9d1dbd8c5af4c2b9bfacf339ea2dc#r1082854073) has been reverted to its old behavior of using `&&` rather than `||`.

Created [EVG-18824](https://jira.mongodb.org/browse/EVG-18824) to take a look into the behavior we observed where some commits retrieved were coming up empty.
### Testing 
