### PR TITLE
EVG-14441 Wrap long commit queue commit messages

### DIFF
--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -101,20 +101,32 @@ func ParseGitHubComment(comment string) GithubCommentCqData {
 // wrapString manually splits a string into smaller chunks and appends them to a new string.
 func wrapString(str string, limit int) string {
 	var b strings.Builder
-	words := strings.Fields(str)
 	currentLine := ""
-	for _, word := range words {
-		if len(currentLine+" "+word) > limit {
-			b.WriteString(currentLine + "\n")
+	lines := strings.Split(str, "\n")
+	for i, line := range lines {
+		words := strings.Fields(line)
+		for _, word := range words {
+			lineLength := len(currentLine + word)
+			// Only factor in spaces if the current line is not empty.
+			if len(currentLine) > 0 {
+				lineLength += 1
+			}
+			if lineLength > limit {
+				b.WriteString(currentLine + "\n")
+				currentLine = ""
+			}
+			if currentLine == "" {
+				currentLine += word
+			} else {
+				currentLine += " " + word
+			}
+		}
+		b.WriteString(currentLine)
+		if i < len(lines)-1 {
+			b.WriteString("\n")
 			currentLine = ""
 		}
-		if currentLine == "" {
-			currentLine += word
-		} else {
-			currentLine += " " + word
-		}
 	}
-	b.WriteString(currentLine)
 	return b.String()
 }
 

--- a/rest/model/commit_queue.go
+++ b/rest/model/commit_queue.go
@@ -101,9 +101,9 @@ func ParseGitHubComment(comment string) GithubCommentCqData {
 // wrapString manually splits a string into smaller chunks and appends them to a new string.
 func wrapString(str string, limit int) string {
 	var b strings.Builder
-	currentLine := ""
 	lines := strings.Split(str, "\n")
 	for i, line := range lines {
+		var currentLine string
 		words := strings.Fields(line)
 		for _, word := range words {
 			lineLength := len(currentLine + word)
@@ -112,7 +112,9 @@ func wrapString(str string, limit int) string {
 				lineLength += 1
 			}
 			if lineLength > limit {
-				b.WriteString(currentLine + "\n")
+				if len(currentLine) > 0 {
+					b.WriteString(currentLine + "\n")
+				}
 				currentLine = ""
 			}
 			if currentLine == "" {
@@ -124,7 +126,6 @@ func wrapString(str string, limit int) string {
 		b.WriteString(currentLine)
 		if i < len(lines)-1 {
 			b.WriteString("\n")
-			currentLine = ""
 		}
 	}
 	return b.String()

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -162,4 +162,12 @@ Singlewordthatis72characterslonganditshouldntbebrokenupbythewrappingfunc`
 	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
 	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
 	assert.Equal("Singlewordthatis72characterslonganditshouldntbebrokenupbythewrappingfunc", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+Singlewordthatis73characterslonganditshouldnotbebrokenupbythewrappingfunc`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("Singlewordthatis73characterslonganditshouldnotbebrokenupbythewrappingfunc", data.MessageOverride)
 }

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -89,7 +89,9 @@ some more lines
 	assert.Len(data.Modules, 1)
 	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
 	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
-	assert.Equal("this is my commit message some more lines extra whitespace", data.MessageOverride)
+	assert.Equal(`this is my commit message
+some more lines
+extra whitespace`, data.MessageOverride)
 
 	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
 This is a very long string that needs to be wrapped around 72 characters for readability.
@@ -100,5 +102,64 @@ Here is another shorter line.
 	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
 	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
 	assert.Equal(`This is a very long string that needs to be wrapped around 72 characters
-for readability. Here is another shorter line. Whitespace over here.`, data.MessageOverride)
+for readability.
+Here is another shorter line.
+Whitespace over here.`, data.MessageOverride)
+
+	comment = "evergreen merge --unknown-option blah_blah --module module1:1234\nEVG-123: Some commit header.\n\nAdds some logging and random functions. They are named ```TestFunc1()``` that returns ```stdout```, ```stderr```, and the actual command executed. All output is formatted and printed after execution in the order of its input."
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("EVG-123: Some commit header.\n\nAdds some logging and random functions. They are named ```TestFunc1()```\nthat returns ```stdout```, ```stderr```, and the actual command\nexecuted. All output is formatted and printed after execution in the\norder of its input.", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+This is a 71 character statement which hopefully won't have any issues.`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("This is a 71 character statement which hopefully won't have any issues.", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+This is a 72 character statement which hopefully won't have any issues..`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("This is a 72 character statement which hopefully won't have any issues..", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+This is a 73 character statement which hopefully won't have any issues...`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal(`This is a 73 character statement which hopefully won't have any
+issues...`, data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+A much shorter line.`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("A much shorter line.", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+A message with a word that is longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal(`A message with a word that is
+longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg`, data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+Singlewordthatis72characterslonganditshouldntbebrokenupbythewrappingfunc`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal("Singlewordthatis72characterslonganditshouldntbebrokenupbythewrappingfunc", data.MessageOverride)
 }

--- a/rest/model/commit_queue_test.go
+++ b/rest/model/commit_queue_test.go
@@ -89,7 +89,16 @@ some more lines
 	assert.Len(data.Modules, 1)
 	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
 	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
-	assert.Equal(`this is my commit message
-some more lines
-    extra whitespace  `, data.MessageOverride)
+	assert.Equal("this is my commit message some more lines extra whitespace", data.MessageOverride)
+
+	comment = `evergreen merge --unknown-option blah_blah --module module1:1234 
+This is a very long string that needs to be wrapped around 72 characters for readability.
+Here is another shorter line.
+											Whitespace over here.`
+	data = ParseGitHubComment(comment)
+	assert.Len(data.Modules, 1)
+	assert.Equal(utility.ToStringPtr("module1"), data.Modules[0].Module)
+	assert.Equal(utility.ToStringPtr("1234"), data.Modules[0].Issue)
+	assert.Equal(`This is a very long string that needs to be wrapped around 72 characters
+for readability. Here is another shorter line. Whitespace over here.`, data.MessageOverride)
 }


### PR DESCRIPTION
[EVG-14441](https://jira.mongodb.org/browse/EVG-14441)

### Description 
Long commit queue messages don't get wrapped which is poor for readability in `git log`.  Made it such that every 72 characters the message will wrap in a way that prevents words from being chopped up in an inconvenient way. Chose 72 characters since it seems to be a [common reccommendation](https://stackoverflow.com/questions/2290016/git-commit-messages-50-72-formatting).
### Testing 
Added new unit tests confirming that long messages will get wrapped cleanly regardless of extra whitespace.