### PR TITLE
EVG-17307 Use pointer in UpdateVersion so that logs are up to date 

### DIFF
--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -159,13 +159,14 @@ func (q *CommitQueue) Remove(issue string) (*CommitQueueItem, error) {
 	return &item, nil
 }
 
-func (q *CommitQueue) UpdateVersion(item CommitQueueItem) error {
+func (q *CommitQueue) UpdateVersion(item *CommitQueueItem) error {
 	for i, currentEntry := range q.Queue {
 		if currentEntry.Issue == item.Issue {
 			q.Queue[i].Version = item.Version
+			q.Queue[i].ProcessingStartTime = item.ProcessingStartTime
 		}
 	}
-	return errors.Wrap(addVersionID(q.ProjectID, item), "updating version")
+	return errors.Wrap(addVersionAndTime(q.ProjectID, *item), "updating version")
 }
 
 func (q *CommitQueue) FindItem(issue string) int {

--- a/model/commitqueue/commit_queue_test.go
+++ b/model/commitqueue/commit_queue_test.go
@@ -106,7 +106,7 @@ func (s *CommitQueueSuite) TestEnqueueAtFront() {
 
 	// check that it's enqueued at the end of the processing items
 	item.Version = "critical1"
-	s.NoError(dbq.UpdateVersion(item))
+	s.NoError(dbq.UpdateVersion(&item))
 	item = sampleCommitQueueItem
 	item.Issue = "critical2"
 	pos, err = dbq.EnqueueAtFront(item)
@@ -142,7 +142,7 @@ func (s *CommitQueueSuite) TestUpdateVersion() {
 	item := s.q.Queue[0]
 	item.Version = "my_version"
 	now := time.Now()
-	s.NoError(s.q.UpdateVersion(item))
+	s.NoError(s.q.UpdateVersion(&item))
 
 	dbq, err := FindOneId("mci")
 	s.NoError(err)

--- a/model/commitqueue/db.go
+++ b/model/commitqueue/db.go
@@ -91,7 +91,7 @@ func addAtPosition(id string, queue []CommitQueueItem, item CommitQueueItem, pos
 	return err
 }
 
-func addVersionID(id string, item CommitQueueItem) error {
+func addVersionAndTime(id string, item CommitQueueItem) error {
 	return updateOne(
 		bson.M{
 			IdKey: id,

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -219,7 +219,7 @@ func (s *CommitQueueSuite) TestListContentsForPRs() {
 	}
 	s.Require().NoError(commitqueue.InsertQueue(cq))
 	cq.Queue[0].Version = "my_version"
-	s.NoError(cq.UpdateVersion(cq.Queue[0]))
+	s.NoError(cq.UpdateVersion(&cq.Queue[0]))
 	pRef := &model.ProjectRef{
 		Id:    "mci",
 		Owner: "evergreen-ci",

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1620,7 +1620,7 @@ func TestHandleEndTaskForCommitQueueTask(t *testing.T) {
 			require.Len(t, cq.Queue, 3)
 			itemToChange := cq.Queue[1]
 			itemToChange.Version = ""
-			assert.NoError(t, cq.UpdateVersion(itemToChange))
+			assert.NoError(t, cq.UpdateVersion(&itemToChange))
 			assert.Empty(t, cq.Queue[1].Version)
 
 			taskA.Status = evergreen.TaskSucceeded

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -171,12 +171,11 @@ func (j *commitQueueJob) Run(ctx context.Context) {
 			j.AddError(j.addMergeTaskDependencies(*cq))
 			return
 		}
-
 		// create a version with the item and subscribe to its completion
 		if nextItem.Source == commitqueue.SourcePullRequest {
-			j.processGitHubPRItem(ctx, cq, nextItem, projectRef, githubToken)
+			j.processGitHubPRItem(ctx, cq, &nextItem, projectRef, githubToken)
 		} else if nextItem.Source == commitqueue.SourceDiff {
-			j.processCLIPatchItem(ctx, cq, nextItem, projectRef, githubToken)
+			j.processCLIPatchItem(ctx, cq, &nextItem, projectRef, githubToken)
 		} else {
 			grip.Error(message.Fields{
 				"message": "commit queue entry has unknown source",
@@ -353,15 +352,15 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 	}
 }
 
-func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueue.CommitQueue, nextItem commitqueue.CommitQueueItem, projectRef *model.ProjectRef, githubToken string) {
+func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueue.CommitQueue, nextItem *commitqueue.CommitQueueItem, projectRef *model.ProjectRef, githubToken string) {
 	pr, dequeue, err := checkPR(ctx, githubToken, nextItem.Issue, projectRef.Owner, projectRef.Repo)
 	if err != nil {
-		j.logError(err, "PR not valid for merge", nextItem)
+		j.logError(err, "PR not valid for merge", *nextItem)
 		if dequeue {
 			if pr != nil {
 				j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "PR not valid for merge", ""))
 			}
-			j.dequeue(cq, nextItem)
+			j.dequeue(cq, *nextItem)
 		}
 		return
 	}
@@ -370,33 +369,34 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding patch '%s'", nextItem.Version))
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "no patch found", ""))
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 	if patchDoc == nil {
 		j.AddError(errors.Errorf("patch '%s' not found", nextItem.Version))
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "no patch found", ""))
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 	projectConfig, _, err := model.GetPatchedProject(ctx, j.env.Settings(), patchDoc, githubToken)
 	if err != nil {
-		j.logError(err, "problem getting patched project", nextItem)
-		j.dequeue(cq, nextItem)
+		j.logError(err, "problem getting patched project", *nextItem)
+		j.dequeue(cq, *nextItem)
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't get project config", ""))
 	}
 
 	v, err := model.FinalizePatch(ctx, patchDoc, evergreen.MergeTestRequester, githubToken)
 	if err != nil {
-		j.logError(err, "can't finalize patch", nextItem)
-		j.dequeue(cq, nextItem)
+		j.logError(err, "can't finalize patch", *nextItem)
+		j.dequeue(cq, *nextItem)
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't finalize patch", ""))
 		return
 	}
 	nextItem.Version = v.Id
+	nextItem.ProcessingStartTime = time.Now()
 	if err = cq.UpdateVersion(nextItem); err != nil {
-		j.logError(err, "problem saving version", nextItem)
-		j.dequeue(cq, nextItem)
+		j.logError(err, "problem saving version", *nextItem)
+		j.dequeue(cq, *nextItem)
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't update commit queue item", ""))
 		return
 	}
@@ -404,9 +404,9 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStatePending, "preparing to test merge", v.Id))
 	modulePRs, _, err := model.GetModulesFromPR(ctx, githubToken, nextItem.Modules, projectConfig)
 	if err != nil {
-		j.logError(err, "can't get modules", nextItem)
+		j.logError(err, "can't get modules", *nextItem)
 		j.AddError(thirdparty.SendCommitQueueGithubStatus(j.env, pr, message.GithubStateFailure, "can't get modules", ""))
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 	for _, modulePR := range modulePRs {
@@ -416,59 +416,62 @@ func (j *commitQueueJob) processGitHubPRItem(ctx context.Context, cq *commitqueu
 	event.LogCommitQueueStartTestEvent(v.Id)
 }
 
-func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueue.CommitQueue, nextItem commitqueue.CommitQueueItem, projectRef *model.ProjectRef, githubToken string) {
+func (j *commitQueueJob) processCLIPatchItem(ctx context.Context, cq *commitqueue.CommitQueue, nextItem *commitqueue.CommitQueueItem, projectRef *model.ProjectRef, githubToken string) {
 	patchDoc, err := patch.FindOneId(nextItem.Issue)
 	if err != nil {
-		j.logError(err, "can't find patch", nextItem)
+		j.logError(err, "can't find patch", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 	if patchDoc == nil {
-		j.logError(err, "patch not found", nextItem)
+		j.logError(err, "patch not found", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 
 	project, err := updatePatch(ctx, j.env.Settings(), githubToken, projectRef, patchDoc)
 	if err != nil {
-		j.logError(err, "can't update patch", nextItem)
+		j.logError(err, "can't update patch", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 
 	if err = AddMergeTaskAndVariant(patchDoc, project, projectRef, commitqueue.SourceDiff); err != nil {
-		j.logError(err, "can't set patch project config", nextItem)
+		j.logError(err, "can't set patch project config", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 
 	if err = patchDoc.UpdateGithashProjectAndTasks(); err != nil {
-		j.logError(err, "can't update patch in db", nextItem)
+		j.logError(err, "can't update patch in db", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 
 	v, err := model.FinalizePatch(ctx, patchDoc, evergreen.MergeTestRequester, githubToken)
 	if err != nil {
-		j.logError(err, "can't finalize patch", nextItem)
+		j.logError(err, "can't finalize patch", *nextItem)
 		event.LogCommitQueueEnqueueFailed(nextItem.Issue, err)
-		j.dequeue(cq, nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
+
 	nextItem.Version = v.Id
+	nextItem.ProcessingStartTime = time.Now()
 	if err = cq.UpdateVersion(nextItem); err != nil {
-		j.logError(err, "problem saving version", nextItem)
-		j.dequeue(cq, nextItem)
+
+		j.logError(err, "problem saving version", *nextItem)
+		j.dequeue(cq, *nextItem)
 		return
 	}
 
 	if err = setDefaultNotification(patchDoc.Author); err != nil {
-		j.logError(err, "failed to set default notification", nextItem)
+		j.logError(err, "failed to set default notification", *nextItem)
 	}
 	event.LogCommitQueueStartTestEvent(v.Id)
 }


### PR DESCRIPTION
[EVG-17307](https://jira.mongodb.org/browse/EVG-17307)

### Description 
In order for [these CQ item processing logs](https://github.com/evergreen-ci/evergreen/blob/main/units/commit_queue.go#L193) to show the updated state of the commit queue item, we need to pass it as a pointer to updateVersion. 

### Testing 
Existing tests 
