### PR TITLE
EVG-17650 enable "setup failed" statuses for tasks that fail their pre-commands

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -738,6 +738,7 @@ task_groups:
 		},
 		Project: p,
 		WorkDir: s.tc.taskDirectory,
+		Timeout: &internal.Timeout{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/agent/command.go
+++ b/agent/command.go
@@ -90,7 +90,7 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			tc.taskConfig.Expansions.Put(key, newVal)
 		}
 
-		if options.isTaskCommands {
+		if options.isTaskCommands || options.failPreAndPost {
 			tc.setCurrentCommand(cmd)
 			tc.setCurrentIdleTimeout(cmd)
 			a.comm.UpdateLastMessageTime()

--- a/agent/internal/client/testdata/pre_error.yaml
+++ b/agent/internal/client/testdata/pre_error.yaml
@@ -1,0 +1,33 @@
+command_type: system
+pre_error_fails_task: true
+
+pre:
+  - func: foo
+
+functions:
+  "foo":
+    - command: shell.exec
+      type: setup
+      params:
+        shell: bash
+        script: |
+          exit 1
+
+
+tasks:
+  - name: build
+    commands:
+      - command: shell.exec
+        params:
+          working_dir: src
+          script: |
+            echo "noop"
+
+
+buildvariants:
+  - name: mock_build_variant
+    display_name: Mock Buildvariant
+    run_on:
+      - mock_distro_id
+    tasks: ["*"]
+

--- a/agent/internal/client/testdata/pre_error.yaml
+++ b/agent/internal/client/testdata/pre_error.yaml
@@ -10,8 +10,7 @@ functions:
       type: setup
       params:
         shell: bash
-        script: |
-          exit 1
+        script: exit 1
 
 
 tasks:
@@ -20,8 +19,7 @@ tasks:
       - command: shell.exec
         params:
           working_dir: src
-          script: |
-            echo "noop"
+          script: echo "noop"
 
 
 buildvariants:

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2023-01-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-01-26a"
+	AgentVersion = "2023-01-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-17650](https://jira.mongodb.org/browse/EVG-17650)

### Description 
There is currently a bug where if a task fails due to a `pre` command failure, the task itself will get marked as `setup.initial` being the command that failed, which is incorrect. This is because pre & post commands do not ever get set as the current command.

Added a change so that if a task is configured to fail if its pre/post block fails, set each pre & post task as the current command when it runs so that its failure details get correctly propagated up.

### Testing 
Added unit test confirming a failed `pre` command with `pre_error_fails_task` set results in a failure based off the specific `pre` command.

In staging, recreated a simple version of the problem in the ticket. System failure [without change](https://spruce-staging.corp.mongodb.com/version/63d937269dbe321c5d9c69e8/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), setup failure [with the change](https://spruce-staging.corp.mongodb.com/task/sandbox_git_env_test_validate_commit_message_patch_37dbc82858fa1d557a1b1989db8fb6ce1f5e0d6d_63d998379dbe3242f84bac69_23_01_31_22_37_43/logs?execution=0).