### PR TITLE
EVG-18530 Suggest a merge conflict is likely if an enqueued CLI patch fails on setup

### DIFF
--- a/model/event/commit_queue_event.go
+++ b/model/event/commit_queue_event.go
@@ -69,6 +69,16 @@ func LogCommitQueueConcludeTest(patchID, status string) {
 	logCommitQueueEvent(patchID, CommitQueueConcludeTest, data)
 }
 
+func LogCommitQueueConcludeWithError(patchID, status string, err error) {
+	data := &CommitQueueEventData{
+		Status: status,
+	}
+	if err != nil {
+		data.Error = err.Error()
+	}
+	logCommitQueueEvent(patchID, CommitQueueConcludeTest, data)
+}
+
 func LogCommitQueueEnqueueFailed(patchID string, err error) {
 	data := &CommitQueueEventData{
 		Status: evergreen.EnqueueFailed,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -930,7 +930,7 @@ func tryDequeueAndAbortCommitQueueVersion(p *patch.Patch, cq commitqueue.CommitQ
 	// If the commit queue merge task failed on setup, there is likely a merge conflict.
 	var mergeError error
 	if t.Details.Type == evergreen.CommandTypeSetup {
-		mergeError = errors.New("merge task failed on setup, which likely means a merge conflict was introduced")
+		mergeError = errors.New("merge task failed on setup, which likely means a merge conflict was introduced, please try merging with the base branch")
 	}
 	event.LogCommitQueueConcludeWithError(p.Id.Hex(), evergreen.MergeTestFailed, mergeError)
 	return errors.Wrap(CancelPatch(p, task.AbortInfo{TaskID: t.Id, User: caller}), "aborting failed commit queue patch")

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -930,7 +930,7 @@ func tryDequeueAndAbortCommitQueueVersion(p *patch.Patch, cq commitqueue.CommitQ
 	// If the commit queue merge task failed on setup, there is likely a merge conflict.
 	var mergeError error
 	if t.Details.Type == evergreen.CommandTypeSetup {
-		mergeError = errors.New("merge task failed on setup, which likely means a merge conflict was introduced, please try merging with the base branch")
+		mergeError = errors.New("Merge task failed on setup, which likely means a merge conflict was introduced. Please try merging with the base branch")
 	}
 	event.LogCommitQueueConcludeWithError(p.Id.Hex(), evergreen.MergeTestFailed, mergeError)
 	return errors.Wrap(CancelPatch(p, task.AbortInfo{TaskID: t.Id, User: caller}), "aborting failed commit queue patch")

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2551,7 +2551,7 @@ func TestTryDequeueAndAbortBlockedCommitQueueVersion(t *testing.T) {
 	assert.NoError(t, t1.Insert())
 	assert.NoError(t, commitqueue.InsertQueue(cq))
 
-	assert.NoError(t, tryDequeueAndAbortCommitQueueVersion(p, *cq, "t1", evergreen.User))
+	assert.NoError(t, tryDequeueAndAbortCommitQueueVersion(p, *cq, t1, evergreen.User))
 	cq, err := commitqueue.FindOneId("my-project")
 	assert.NoError(t, err)
 	assert.Equal(t, cq.FindItem(patchID), -1)
@@ -2635,7 +2635,7 @@ func TestTryDequeueAndAbortCommitQueueVersion(t *testing.T) {
 	assert.NoError(t, m.Insert())
 	assert.NoError(t, commitqueue.InsertQueue(cq))
 
-	assert.NoError(t, tryDequeueAndAbortCommitQueueVersion(p, *cq, "t1", evergreen.User))
+	assert.NoError(t, tryDequeueAndAbortCommitQueueVersion(p, *cq, t1, evergreen.User))
 	cq, err := commitqueue.FindOneId("my-project")
 	assert.NoError(t, err)
 	assert.Equal(t, cq.FindItem("12"), -1)


### PR DESCRIPTION
[EVG-18530](https://jira.mongodb.org/browse/EVG-18530)

### Description 
Unlike Github PRs where we [explicitly check](https://gist.github.com/hadjri/fbb86d69df6cf83c05e03106282d5772#file-github-go-L942) if GitHub has created a valid merge commit without conflicts, there is currently nothing stopping us from staging a CLI patch with a merge conflict in it, and enqueuing it to the commit queue. If this happens, the merge task will fail on the first `git.get_project` command of the task, resulting in a [setup failure](https://spruce-staging.corp.mongodb.com/task/sandbox_commit_queue_merge_merge_patch_patch_c23d49c536277965b729fc5c86c75d86a339ab26_63daecc99dbe32c5d5f54b86_23_02_01_22_51_08/logs?execution=0) with errors in the logs saying `patch does not apply`.

The logic behind this change is, rather than performing a full `git apply` on the target branch based off of all of the file patches in a given patch (which would be slightly complex and increase the already high traffic we're sending to GitHub), we can make the assumption that if a merge task failed on its setup command, there is a high likelihood that it happened due to a merge conflict, so an error mentioning this is included when this occurs so that it gets propagated to the CQ email that gets sent out.
### Testing 
Tested in staging and confirmed that enqueuing a CLI patch with a merge conflict in it causes this error to pop up in the commit queue merge email.