### PR TITLE
EVG-18537: implement parser project S3 storage

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -474,26 +474,25 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	}
 
 	patchVersion := &Version{
-		Id:                  p.Id.Hex(),
-		CreateTime:          time.Now(),
-		Identifier:          p.Project,
-		Revision:            p.Githash,
-		Author:              p.Author,
-		Message:             p.Description,
-		BuildIds:            []string{},
-		BuildVariants:       []VersionBuildStatus{},
-		Status:              evergreen.PatchCreated,
-		Requester:           requester,
-		ParentPatchID:       p.Triggers.ParentPatch,
-		ParentPatchNumber:   parentPatchNumber,
-		Branch:              projectRef.Branch,
-		RevisionOrderNumber: p.PatchNumber,
-		AuthorID:            p.Author,
-		Parameters:          params,
-		Activated:           utility.TruePtr(),
-		AuthorEmail:         authorEmail,
-		// kim: TODO: revert back to DB when done testing.
-		ProjectStorageMethod: ProjectStorageMethodS3,
+		Id:                   p.Id.Hex(),
+		CreateTime:           time.Now(),
+		Identifier:           p.Project,
+		Revision:             p.Githash,
+		Author:               p.Author,
+		Message:              p.Description,
+		BuildIds:             []string{},
+		BuildVariants:        []VersionBuildStatus{},
+		Status:               evergreen.PatchCreated,
+		Requester:            requester,
+		ParentPatchID:        p.Triggers.ParentPatch,
+		ParentPatchNumber:    parentPatchNumber,
+		Branch:               projectRef.Branch,
+		RevisionOrderNumber:  p.PatchNumber,
+		AuthorID:             p.Author,
+		Parameters:           params,
+		Activated:            utility.TruePtr(),
+		AuthorEmail:          authorEmail,
+		ProjectStorageMethod: ProjectStorageMethodDB,
 	}
 	intermediateProject.CreateTime = patchVersion.CreateTime
 
@@ -599,20 +598,16 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	}
 	defer session.EndSession(ctx)
 
-	// kim: TODO: delete this temp code probably
-	if err := ParserProjectUpsertOne(ctx, env.Settings(), patchVersion.ProjectStorageMethod, intermediateProject); err != nil {
-		return nil, errors.Wrapf(err, "inserting parser project for version '%s'", patchVersion.Id)
-	}
 	txFunc := func(sessCtx mongo.SessionContext) (interface{}, error) {
 		db := env.DB()
 		_, err = db.Collection(VersionCollection).InsertOne(sessCtx, patchVersion)
 		if err != nil {
 			return nil, errors.Wrapf(err, "inserting version '%s'", patchVersion.Id)
 		}
-		// _, err = db.Collection(ParserProjectCollection).InsertOne(sessCtx, intermediateProject)
-		// if err != nil {
-		//     return nil, errors.Wrapf(err, "inserting parser project for version '%s'", patchVersion.Id)
-		// }
+		_, err = db.Collection(ParserProjectCollection).InsertOne(sessCtx, intermediateProject)
+		if err != nil {
+			return nil, errors.Wrapf(err, "inserting parser project for version '%s'", patchVersion.Id)
+		}
 		if config != nil {
 			_, err = db.Collection(ProjectConfigCollection).InsertOne(sessCtx, config)
 			if err != nil {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -40,7 +40,7 @@ const DefaultParserProjectAccessTimeout = 60 * time.Second
 // The ParserProject's internal types define custom YAML unmarshal hooks, allowing
 // users to do things like offer a single definition where we expect a list, e.g.
 //   `tags: "single_tag"` instead of the more verbose `tags: ["single_tag"]`
-// or refer to task by a single selector. Custom YAML handling allows us to
+// or refer to a task by a single selector. Custom YAML handling allows us to
 // add other useful features like detecting fatal errors and reporting them
 // through the YAML parser's error code, which supplies helpful line number information
 // that we would lose during validation against already-parsed data. In the future,
@@ -58,6 +58,15 @@ const DefaultParserProjectAccessTimeout = 60 * time.Second
 // ParserProject serves as an intermediary struct for parsing project
 // configuration YAML. It implements the Unmarshaler interface
 // to allow for flexible handling.
+// From a mental model perspective, the ParserProject is the project
+// configuration after YAML rules have been evaluated (e.g. matching YAML fields
+// to Go struct fields, evaluating YAML anchors and aliases), but before any
+// Evergreen-specific evaluation rules have been applied. For example, Evergreen
+// has a custom feature to support tagging a set of tasks and expanding those
+// tags into a list of tasks under the build variant's list of tasks (i.e.
+// ".tagname" syntax). In the ParserProject, these are stored as the unexpanded
+// tag text (i.e. ".tagname"), and these tags are not evaluated until the
+// ParserProject is turned into a final Project.
 type ParserProject struct {
 	// Id and ConfigdUpdateNumber are not pointers because they are only used internally
 	Id string `yaml:"_id" bson:"_id"` // should be the same as the version's ID

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -26,16 +26,16 @@ type ParserProjectS3Storage struct {
 // NewParserProjectS3Storage sets up access to parser projects stored in S3.
 // If this returns a non-nil ParserProjectS3Storage, callers are expected to
 // call Close when they are finished with it.
-func NewParserProjectS3Storage(awsConf evergreen.AWSConfig) (*ParserProjectS3Storage, error) {
+func NewParserProjectS3Storage(ppConf evergreen.ParserProjectS3Config) (*ParserProjectS3Storage, error) {
 	c := utility.GetHTTPClient()
 
 	var creds *credentials.Credentials
-	if awsConf.ParserProject.Key != "" && awsConf.ParserProject.Secret != "" {
-		creds = pail.CreateAWSCredentials(awsConf.ParserProject.Key, awsConf.ParserProject.Secret, "")
+	if ppConf.Key != "" && ppConf.Secret != "" {
+		creds = pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, "")
 	}
 	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
-		Name:        awsConf.ParserProject.Bucket,
-		Prefix:      awsConf.ParserProject.Prefix,
+		Name:        ppConf.Bucket,
+		Prefix:      ppConf.Prefix,
 		Region:      endpoints.UsEast1RegionID,
 		Credentials: creds,
 	})

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -31,7 +31,7 @@ func NewParserProjectS3Storage(awsConf evergreen.AWSConfig) (*ParserProjectS3Sto
 
 	var creds *credentials.Credentials
 	if awsConf.ParserProject.Key != "" && awsConf.ParserProject.Secret != "" {
-		creds = pail.CreateAWSCredentials(awsConf.ParserProject.Key, awsConf.ParserProject.Bucket, "")
+		creds = pail.CreateAWSCredentials(awsConf.ParserProject.Key, awsConf.ParserProject.Secret, "")
 	}
 	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
 		Name:        awsConf.ParserProject.Bucket,

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// ParserProjectS3Storage implements the ParserProjectStorage interface to
+// access parser projects stored in S3.
+type ParserProjectS3Storage struct {
+	bucket pail.Bucket
+	client *http.Client
+	closed bool
+}
+
+// NewParserProjectS3Storage sets up access to parser projects stored in S3.
+// If this returns a non-nil ParserProjectS3Storage, callers are expected to
+// call Close when they are finished with it.
+func NewParserProjectS3Storage(awsConf evergreen.AWSConfig) (*ParserProjectS3Storage, error) {
+	c := utility.GetHTTPClient()
+	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
+		// kim: TODO: remove temporary testing namespace once
+		// evergreen-projects-test is set up a way to access it.
+		// Name: bucket,
+		Name: "boxes.10gen.com",
+		// kim: TODO: may need a prefix to handle self-testing in
+		// staging/production projects.
+		Prefix: "kim.tao/parser-projects-test",
+		// kim: TODO: need to add admin setting for region.
+		Region: "us-east-1",
+		// kim: TODO: remove credentials and replace with the ones for testing.
+		Credentials: pail.CreateAWSCredentials("", "", ""),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "setting up S3 multipart bucket")
+	}
+	s := ParserProjectS3Storage{
+		bucket: b,
+		client: c,
+	}
+	return &s, nil
+}
+
+// FindOneByID finds a parser project in S3 using its ID. If the context errors,
+// it will return the context error.
+func (s *ParserProjectS3Storage) FindOneByID(ctx context.Context, id string) (*ParserProject, error) {
+	if s.closed {
+		return nil, errors.New("cannot access parser project S3 storage when it is closed")
+	}
+
+	r, err := s.bucket.Get(ctx, id)
+	if pail.IsKeyNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting parser project '%s'", id)
+	}
+	defer r.Close()
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading parser project '%s'", id)
+	}
+
+	var pp ParserProject
+	if err := bson.Unmarshal(b, &pp); err != nil {
+		return nil, errors.Wrapf(err, "unmarshalling parser project '%s' from BSON", id)
+	}
+
+	// TODO: this is in the equivalent DB method, but is it necessary?
+	if pp.Functions == nil {
+		pp.Functions = map[string]*YAMLCommandSet{}
+	}
+
+	return &pp, nil
+}
+
+// FindOneByIDWithFields finds a parser project using its ID from S3 and returns
+// the parser project with only the requested fields populated. This is not any
+// more efficient than FindOneByID. If the context errors, it will return the
+// context error.
+func (s *ParserProjectS3Storage) FindOneByIDWithFields(ctx context.Context, id string, fields ...string) (*ParserProject, error) {
+	return s.FindOneByID(ctx, id)
+}
+
+// UpsertOne replaces a parser project if the parser project in S3 with the same
+// ID already exists. If it does not exist yet, it inserts a new parser project.
+func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProject) error {
+	if s.closed {
+		return errors.New("cannot access parser project S3 storage when it is closed")
+	}
+
+	b, err := bson.Marshal(pp)
+	if err != nil {
+		return errors.Wrapf(err, "marshalling parser project '%s' to BSON", pp.Id)
+	}
+
+	r := bytes.NewBuffer(b)
+	if err := s.bucket.Put(ctx, pp.Id, r); err != nil {
+		return errors.Wrapf(err, "upserting parser project '%s'", pp.Id)
+	}
+
+	return nil
+}
+
+// Close returns the HTTP client that is being used back to the client pool.
+func (s *ParserProjectS3Storage) Close(ctx context.Context) error {
+	if s.closed {
+		return nil
+	}
+
+	utility.PutHTTPClient(s.client)
+	s.closed = true
+
+	return nil
+}

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -75,7 +75,6 @@ func (s *ParserProjectS3Storage) FindOneByID(ctx context.Context, id string) (*P
 		return nil, errors.Wrapf(err, "unmarshalling parser project '%s' from BSON", id)
 	}
 
-	// TODO: this is in the equivalent DB method, but is it necessary?
 	if pp.Functions == nil {
 		pp.Functions = map[string]*YAMLCommandSet{}
 	}

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -9,11 +9,16 @@ import (
 
 // ParserProjectStorage is an interface for accessing the parser project.
 type ParserProjectStorage interface {
-	// FindOneByID finds a parser project using its ID. Implementations may or
-	// may not respect the context.
+	// FindOneByID finds a parser project using its ID. If the parser project
+	// does not exist in the underlying storage, implementations must return a
+	// nil parser project and nil error. Implementations may or may not respect
+	// the context.
 	FindOneByID(ctx context.Context, id string) (*ParserProject, error)
 	// FindOneByIDWithFields finds a parser project using its ID and returns the
-	// parser project with only the requested fields populated.
+	// parser project with at least the requested fields populated.
+	// Implementations may choose to return more fields than those explicitly
+	// requested. If the parser project does not exist in the underlying
+	// storage, implementations must return a nil parser project and nil error.
 	// Implementations may or may not respect the context.
 	FindOneByIDWithFields(ctx context.Context, id string, fields ...string) (*ParserProject, error)
 	// UpsertOne replaces a parser project if the parser project with the
@@ -34,7 +39,7 @@ func GetParserProjectStorage(settings *evergreen.Settings, method ParserProjectS
 	case "", ProjectStorageMethodDB:
 		return ParserProjectDBStorage{}, nil
 	case ProjectStorageMethodS3:
-		return nil, errors.New("TODO (EVG-17537): implement")
+		return NewParserProjectS3Storage(settings.Providers.AWS)
 	default:
 		return nil, errors.Errorf("unrecognized parser project storage method '%s'", method)
 	}

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -39,7 +39,7 @@ func GetParserProjectStorage(settings *evergreen.Settings, method ParserProjectS
 	case "", ProjectStorageMethodDB:
 		return ParserProjectDBStorage{}, nil
 	case ProjectStorageMethodS3:
-		return NewParserProjectS3Storage(settings.Providers.AWS)
+		return NewParserProjectS3Storage(settings.Providers.AWS.ParserProject)
 	default:
 		return nil, errors.Errorf("unrecognized parser project storage method '%s'", method)
 	}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1587,7 +1587,9 @@ func TestParserProjectStorage(t *testing.T) {
 		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
 	})
 	require.NoError(t, err)
-	defer bucket.RemovePrefix(ctx, ppConf.Prefix)
+	defer func() {
+		assert.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
+	}()
 
 	for methodName, ppStorageMethod := range map[string]ParserProjectStorageMethod{
 		"DB": ProjectStorageMethodDB,

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -11,11 +11,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -1569,6 +1572,23 @@ func TestParserProjectStorage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
+
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
+
+	ppConf := env.Settings().Providers.AWS.ParserProject
+	bucket, err := pail.NewS3BucketWithHTTPClient(c, pail.S3Options{
+		Name:        ppConf.Bucket,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
+	})
+	require.NoError(t, err)
+	defer bucket.RemovePrefix(ctx, ppConf.Prefix)
+
 	for methodName, ppStorageMethod := range map[string]ParserProjectStorageMethod{
 		"DB": ProjectStorageMethodDB,
 		"S3": ProjectStorageMethodS3,
@@ -1627,47 +1647,8 @@ func TestParserProjectStorage(t *testing.T) {
 					require.NotNil(t, pp)
 					assert.Equal(t, "you", utility.FromStringPtr(pp.Owner))
 				},
-			} {
-				t.Run(testName, func(t *testing.T) {
-					require.NoError(t, db.ClearCollections(ParserProjectCollection))
-					// kim: TODO: clear the S3 bucket
-					env := &mock.Environment{}
-					require.NoError(t, env.Configure(ctx))
-					testCase(ctx, t, env)
-				})
-			}
-		})
-	}
-}
-
-func TestParserProjectRoundtrip(t *testing.T) {
-	filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
-	yml, err := ioutil.ReadFile(filepath)
-	assert.NoError(t, err)
-
-	original, err := createIntermediateProject(yml, false, false)
-	assert.NoError(t, err)
-
-	// to and from yaml
-	yamlBytes, err := yaml.Marshal(original)
-	assert.NoError(t, err)
-	pp := &ParserProject{}
-	assert.NoError(t, yaml.Unmarshal(yamlBytes, pp))
-
-	// to and from BSON
-	bsonBytes, err := bson.Marshal(original)
-	assert.NoError(t, err)
-	bsonPP := &ParserProject{}
-	assert.NoError(t, bson.Unmarshal(bsonBytes, bsonPP))
-
-	// ensure bson actually worked
-	newBytes, err := yaml.Marshal(bsonPP)
-	assert.NoError(t, err)
-	assert.True(t, bytes.Equal(yamlBytes, newBytes))
-}
-
-func TestParserProjectPersists(t *testing.T) {
-	simpleYaml := `
+				"PersistsSimpleYAML": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+					simpleYAML := `
 loggers:
   agent:
     - type: something
@@ -1713,39 +1694,27 @@ buildvariants:
     - name: "task_1"
       batchtime: 60
 `
-
-	for methodName, method := range map[string]ParserProjectStorageMethod{
-		"DB": ProjectStorageMethodDB,
-	} {
-		t.Run("ParserProjectStorageMethod"+methodName, func(t *testing.T) {
-			for name, test := range map[string]func(t *testing.T){
-				"simpleYaml": func(t *testing.T) {
-					checkProjectPersists(t, []byte(simpleYaml), method)
+					checkProjectPersists(ctx, t, env, []byte(simpleYAML), ppStorageMethod)
 				},
-				"self-tests.yml": func(t *testing.T) {
+				"PersistsEvergreenSelfTestsYAML": func(ctx context.Context, t *testing.T, env *mock.Environment) {
 					filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
-
 					yml, err := ioutil.ReadFile(filepath)
 					assert.NoError(t, err)
-					checkProjectPersists(t, yml, method)
+					checkProjectPersists(ctx, t, env, yml, ppStorageMethod)
 				},
 			} {
-				t.Run(name, func(t *testing.T) {
-					assert.NoError(t, db.ClearCollections(ParserProjectCollection))
-					test(t)
+				t.Run(testName, func(t *testing.T) {
+					require.NoError(t, db.ClearCollections(ParserProjectCollection))
+					require.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
+
+					testCase(ctx, t, env)
 				})
 			}
 		})
 	}
 }
 
-func checkProjectPersists(t *testing.T, yml []byte, ppStorageMethod ParserProjectStorageMethod) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx))
-
+func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Environment, yml []byte, ppStorageMethod ParserProjectStorageMethod) {
 	pp, err := createIntermediateProject(yml, false, false)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
@@ -1792,6 +1761,32 @@ func checkProjectPersists(t *testing.T, yml []byte, ppStorageMethod ParserProjec
 	}
 }
 
+func TestParserProjectRoundtrip(t *testing.T) {
+	filepath := filepath.Join(testutil.GetDirectoryOfFile(), "..", "self-tests.yml")
+	yml, err := ioutil.ReadFile(filepath)
+	assert.NoError(t, err)
+
+	original, err := createIntermediateProject(yml, false, false)
+	assert.NoError(t, err)
+
+	// to and from yaml
+	yamlBytes, err := yaml.Marshal(original)
+	assert.NoError(t, err)
+	pp := &ParserProject{}
+	assert.NoError(t, yaml.Unmarshal(yamlBytes, pp))
+
+	// to and from BSON
+	bsonBytes, err := bson.Marshal(original)
+	assert.NoError(t, err)
+	bsonPP := &ParserProject{}
+	assert.NoError(t, bson.Unmarshal(bsonBytes, bsonPP))
+
+	// ensure bson actually worked
+	newBytes, err := yaml.Marshal(bsonPP)
+	assert.NoError(t, err)
+	assert.True(t, bytes.Equal(yamlBytes, newBytes))
+}
+
 func TestMergeUnorderedUnique(t *testing.T) {
 	main := &ParserProject{
 		Tasks: []parserTask{
@@ -1824,12 +1819,12 @@ func TestMergeUnorderedUnique(t *testing.T) {
 			},
 		},
 		Functions: map[string]*YAMLCommandSet{
-			"func1": &YAMLCommandSet{
+			"func1": {
 				SingleCommand: &PluginCommandConf{
 					Command: "single_command",
 				},
 			},
-			"func2": &YAMLCommandSet{
+			"func2": {
 				MultiCommand: []PluginCommandConf{
 					{
 						Command: "multi_command1",

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script sets up the SETTINGS_OVERRIDE file used as the admin settings when
-# running an integration test that requires sensitive credentials.
+# running an integration test that requires secret credentials.
 
 set -o errexit
 

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script sets up the SETTINGS_OVERRIDE file used as the admin settings when
+# running an integration test that requires sensitive credentials.
+
 set -o errexit
 
 echo "building creds file!"
@@ -46,6 +49,11 @@ jira:
 
 providers:
   aws:
+    parser_project:
+      key: "$AWS_KEY"
+      secret: "$AWS_SECRET"
+      bucket: "evergreen-projects-testing"
+      prefix: "$PARSER_PROJECT_S3_PREFIX"
     ec2_keys:
       - region: "us-east-1"
         key: "$AWS_KEY"

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -230,11 +230,11 @@ functions:
         CROWD_SERVER: ${crowdserver}
         AWS_KEY: ${aws_key}
         AWS_SECRET: ${aws_secret}
+        PARSER_PROJECT_S3_PREFIX: ${task_id}
         JIRA_PRIVATE_KEY: ${jira_private_key}
         JIRA_ACCESS_TOKEN: ${jira_access_token}
         JIRA_TOKEN_SECRET: ${jira_token_secret}
         JIRA_CONSUMER_KEY: ${jira_consumer_key}
-        PARSER_PROJECT_S3_PREFIX: ${task_id}/
       command: bash scripts/setup-credentials.sh
   setup-mongodb:
     - command: subprocess.exec

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -234,6 +234,7 @@ functions:
         JIRA_ACCESS_TOKEN: ${jira_access_token}
         JIRA_TOKEN_SECRET: ${jira_token_secret}
         JIRA_CONSUMER_KEY: ${jira_consumer_key}
+        PARSER_PROJECT_S3_PREFIX: ${task_id}/
       command: bash scripts/setup-credentials.sh
   setup-mongodb:
     - command: subprocess.exec

--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -46,7 +46,7 @@ func ConfigureIntegrationTest(t *testing.T, testSettings *evergreen.Settings, te
 
 	// grab the file with the integration test settings
 	integrationSettings, err := evergreen.NewSettings(*settingsOverride)
-	require.NoError(t, err, "Error opening settings override file %s", *settingsOverride)
+	require.NoError(t, err, "Error opening settings override file '%s'", *settingsOverride)
 
 	testSettings.Providers = integrationSettings.Providers
 	testSettings.Credentials = integrationSettings.Credentials

--- a/util/yaml_test.go
+++ b/util/yaml_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,6 +65,5 @@ pieces:
 	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &largeStruct)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
-	fmt.Println(err)
 
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18537

### Description 
* Implement parser project storage in S3. It's not used anywhere for now, there will be a follow-up to actually use it.
* Add some more docs about the `model.ParserProject` and how it's different from the `model.Project`.

### Testing
* Add integration tests for storing/retrieving parser projects from S3.
* Tested in staging by making a patch that kept its parser project in S3, then verified that generate.tasks worked with the S3 parser project.