### PR TITLE
EVG-14549 avoid overwriting variable with the empty string

### DIFF
--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -242,6 +242,12 @@ func UpdateProjectVars(projectId string, varsModel *restModel.APIProjectVars, ov
 	vars := varsModel.ToService()
 	vars.Id = projectId
 
+	// Avoid accidentally overwriting private variables, for example if the GET route is used to populate PATCH.
+	for key, val := range varsModel.Vars {
+		if val == "" {
+			delete(varsModel.Vars, key)
+		}
+	}
 	if overwrite {
 		if _, err := vars.Upsert(); err != nil {
 			return errors.Wrapf(err, "overwriting variables for project '%s'", vars.Id)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -129,7 +129,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 
 		vars := &model.ProjectVars{
 			Id:          projectId,
-			Vars:        map[string]string{"a": "1", "b": "3"},
+			Vars:        map[string]string{"a": "1", "b": "3", "d": "4"},
 			PrivateVars: map[string]bool{"b": true},
 		}
 		s.NoError(vars.Insert())
@@ -256,13 +256,14 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	//successful update
 	varsToDelete := []string{"a"}
 	newVars := restModel.APIProjectVars{
-		Vars:         map[string]string{"b": "2", "c": "3"},
+		Vars:         map[string]string{"b": "2", "c": "3", "d": ""},
 		PrivateVars:  map[string]bool{"b": false, "c": true},
 		VarsToDelete: varsToDelete,
 	}
 	s.NoError(UpdateProjectVars(projectId, &newVars, false))
 	s.Equal(newVars.Vars["b"], "") // can't unredact previously redacted  variables
 	s.Equal(newVars.Vars["c"], "")
+	s.Equal(newVars.Vars["d"], "4") // can't overwrite a value with the empty string
 	_, ok := newVars.Vars["a"]
 	s.False(ok)
 


### PR DESCRIPTION
[EVG-14549](https://jira.mongodb.org/browse/EVG-14549)

### Description 
This is primarily to guard against an accidental overwrite of a private variable fetched from the GET route, but also we don't allow empty private variables (on the UI anyway, although it doesn't really matter since they don't do anything) and we have the "delete" option for that.

Will add to the documentation.

### Testing 
Added to unit test