### PR TITLE
EVG-18570 Clean up PR comments and make them more resilient to whitespace 

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -415,6 +415,29 @@ func PatchStatusToVersionStatus(patchStatus string) (string, error) {
 	}
 }
 
+// Constants for pull request comments.
+const (
+	RetryComment   = "evergreen retry"
+	PatchComment   = "evergreen patch"
+	TriggerComment = "evergreen merge"
+)
+
+func trimComment(comment string) string {
+	return strings.Join(strings.Fields(strings.ToLower(comment)), " ")
+}
+
+func IsRetryComment(comment string) bool {
+	return trimComment(comment) == RetryComment
+}
+func IsPatchComment(comment string) bool {
+	return trimComment(comment) == PatchComment
+}
+
+// The trigger comment may be followed by a newline and a message.
+func ContainsTriggerComment(comment string) bool {
+	return strings.HasPrefix(trimComment(comment), "evergreen merge")
+}
+
 type ModificationAction string
 
 const (

--- a/model/commitqueue/commit_queue.go
+++ b/model/commitqueue/commit_queue.go
@@ -1,9 +1,9 @@
 package commitqueue
 
 import (
-	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	triggerComment    = "evergreen merge"
 	SourcePullRequest = "PR"
 	SourceDiff        = "diff"
 	GithubContext     = "evergreen/commitqueue"
@@ -197,7 +196,7 @@ func TriggersCommitQueue(commentAction string, comment string) bool {
 	if commentAction == "deleted" {
 		return false
 	}
-	return strings.HasPrefix(comment, triggerComment)
+	return evergreen.ContainsTriggerComment(comment)
 }
 
 func ClearAllCommitQueues() (int, error) {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -29,9 +29,7 @@ const (
 	githubActionSynchronize = "synchronize"
 	githubActionReopened    = "reopened"
 
-	retryComment = "evergreen retry"
-	patchComment = "evergreen patch"
-	refTags      = "refs/tags/"
+	refTags = "refs/tags/"
 )
 
 type githubHookApi struct {
@@ -608,15 +606,15 @@ func triggersPatch(action, comment string) (bool, string) {
 	if action == "deleted" {
 		return false, ""
 	}
-	comment = strings.TrimSpace(comment)
-	switch comment {
-	case patchComment:
+
+	if evergreen.IsPatchComment(comment) {
 		return true, patch.ManualCaller
-	case retryComment:
-		return true, patch.AllCallers
-	default:
-		return false, ""
 	}
+	if evergreen.IsRetryComment(comment) {
+		return true, patch.AllCallers
+	}
+
+	return false, ""
 }
 
 func isTag(ref string) bool {


### PR DESCRIPTION
[EVG-18570](https://jira.mongodb.org/browse/EVG-18570)

### Description 
This makes our handling of PR comments a bit cleaner and adds more allowance for variations and user error such as extra spaces and newlines and uppercase. 

### Testing 
[tested here ](https://go.dev/play/p/QNHX1uc2gDU)
