### PR TITLE
EVG-18863 Add validation to project modify routes

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2244,8 +2244,7 @@ func (p *ProjectRef) GetGithubProjectConflicts() (GithubProjectConflicts, error)
 	return res, nil
 }
 
-// ValidateProjectCreation returns an error if the total or owner/repo project limit set by the admin settings has been reached.
-// The boolean returns true if you should error. Otherwise, warn.
+// ValidateProjectCreation returns a boolean if you should surface the error or not.
 func ValidateProjectCreation(projectId string, config *evergreen.Settings, projectRef *ProjectRef) (bool, error) {
 	if config.ProjectCreation.TotalProjectLimit == 0 || config.ProjectCreation.RepoProjectLimit == 0 {
 		return false, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -312,9 +312,6 @@ var (
 )
 
 func (p *ProjectRef) IsEnabled() bool {
-	if p.Enabled == nil {
-
-	}
 	return utility.FromBoolPtr(p.Enabled)
 }
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -272,7 +272,7 @@ func TestValidateProjectCreation(t *testing.T) {
 
 	// Should error when trying to enable an existing project past limits.
 	disabled1.Enabled = utility.TruePtr()
-	err, shouldError := ValidateProjectCreation(disabled1.Id, &settings, disabled1)
+	shouldError, err := ValidateProjectCreation(disabled1.Id, &settings, disabled1)
 	assert.Error(t, err)
 	assert.True(t, shouldError)
 
@@ -283,7 +283,7 @@ func TestValidateProjectCreation(t *testing.T) {
 		Repo:    "repo_exception",
 		Enabled: utility.TruePtr(),
 	}
-	err, _ = ValidateProjectCreation(enabled1.Id, &settings, exception)
+	_, err = ValidateProjectCreation(enabled1.Id, &settings, exception)
 	assert.NoError(t, err)
 
 	// Should error if owner/repo is not part of exception.
@@ -293,19 +293,19 @@ func TestValidateProjectCreation(t *testing.T) {
 		Repo:    "mci",
 		Enabled: utility.TruePtr(),
 	}
-	err, shouldError = ValidateProjectCreation(notException.Id, &settings, notException)
+	shouldError, err = ValidateProjectCreation(notException.Id, &settings, notException)
 	assert.Error(t, err)
 	assert.False(t, shouldError)
 
 	// Should not error if a repo defaulted project is enabled.
 	disabledByRepo.Enabled = utility.TruePtr()
 	assert.NoError(t, disabledByRepo.Upsert())
-	err, _ = ValidateProjectCreation(disabledByRepo.Id, &settings, disabledByRepo)
+	_, err = ValidateProjectCreation(disabledByRepo.Id, &settings, disabledByRepo)
 	assert.NoError(t, err)
 
 	// Total project limit cannot be exceeded. Even with the exception.
 	settings.ProjectCreation.TotalProjectLimit = 2
-	err, shouldError = ValidateProjectCreation(exception.Id, &settings, exception)
+	shouldError, err = ValidateProjectCreation(exception.Id, &settings, exception)
 	assert.Error(t, err)
 	assert.False(t, shouldError)
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -69,7 +69,7 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 		return err
 	}
 	// Always warn because created projects are never enabled.
-	err, _ := model.ValidateProjectCreation(projectRef.Id, env.Settings(), projectRef)
+	_, err := model.ValidateProjectCreation(projectRef.Id, env.Settings(), projectRef)
 	if err != nil {
 		// TODO EVG-18784: Return graphql warning
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -362,6 +362,15 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "merging project ref '%s' with repo settings", h.newProjectRef.Identifier))
 	}
 
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting evergreen settings"))
+	}
+	_, err = dbModel.ValidateProjectCreation(h.newProjectRef.Id, settings, mergedProjectRef)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "validating project creation for project '%s'", h.newProjectRef.Identifier))
+	}
+
 	if h.newProjectRef.IsEnabled() {
 		var hasHook bool
 		hasHook, err = dbModel.EnableWebhooks(ctx, h.newProjectRef)

--- a/service/project.go
+++ b/service/project.go
@@ -350,13 +350,13 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !utility.FromBoolPtr(origProjectRef.Enabled) && responseRef.Enabled {
+	if !origProjectRef.IsEnabled() && responseRef.Enabled {
 		settings, err := evergreen.GetConfig()
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}
-		err, _ = model.ValidateProjectCreation(responseRef.Identifier, settings, &model.ProjectRef{
+		_, err = model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
 			Enabled: utility.ToBoolPtr(responseRef.Enabled),
 			Owner:   responseRef.Owner,
 			Repo:    responseRef.Repo,

--- a/service/project.go
+++ b/service/project.go
@@ -350,21 +350,19 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !origProjectRef.IsEnabled() && responseRef.Enabled {
-		settings, err := evergreen.GetConfig()
-		if err != nil {
-			uis.LoggedError(w, r, http.StatusInternalServerError, err)
-			return
-		}
-		_, err = model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
-			Enabled: utility.ToBoolPtr(responseRef.Enabled),
-			Owner:   responseRef.Owner,
-			Repo:    responseRef.Repo,
-		})
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	_, err = model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
+		Enabled: utility.ToBoolPtr(responseRef.Enabled),
+		Owner:   responseRef.Owner,
+		Repo:    responseRef.Repo,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	errs := []string{}

--- a/service/project.go
+++ b/service/project.go
@@ -350,6 +350,23 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if !utility.FromBoolPtr(origProjectRef.Enabled) && responseRef.Enabled {
+		settings, err := evergreen.GetConfig()
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		err, _ = model.ValidateProjectCreation(responseRef.Identifier, settings, &model.ProjectRef{
+			Enabled: utility.ToBoolPtr(responseRef.Enabled),
+			Owner:   responseRef.Owner,
+			Repo:    responseRef.Repo,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	errs := []string{}
 	errs = append(errs, model.ValidateProjectAliases(responseRef.GitHubPRAliases, "GitHub PR Aliases")...)
 	errs = append(errs, model.ValidateProjectAliases(responseRef.GithubChecksAliases, "Github Checks Aliases")...)


### PR DESCRIPTION
[EVG-18863](https://jira.mongodb.org/browse/EVG-18863)

### Description 
patch project route has validation now

The ui server does not ask for repo and owner to create/copy project so, so I decided not to add validation there. (even if we did, it would only warn and not error because it would never be enabled. )
I added validation to the modify project ui service so users will not be able to enable projects if it does not pass validation

### Testing 
staging 
<img width="530" alt="image" src="https://user-images.githubusercontent.com/26491602/217310497-de7639d4-5360-4a4e-b319-21881e869cad.png">


![image](https://user-images.githubusercontent.com/26491602/217366450-87cf0a8f-de92-49bf-ab8e-eca32c45024d.png)
