### PR TITLE
EVG-17291: upgrade gopkg.in/yaml.v3

### DIFF
--- a/agent/command/downstream_expansions_set.go
+++ b/agent/command/downstream_expansions_set.go
@@ -11,7 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 // setExpansions takes a file of key value pairs and

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -10,7 +10,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/cmd/codegen/core/codegen_test.go
+++ b/cmd/codegen/core/codegen_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/99designs/gqlgen/codegen/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCodegen(t *testing.T) {

--- a/cmd/codegen/entry.go
+++ b/cmd/codegen/entry.go
@@ -8,7 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/cmd/codegen/core"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -33,10 +33,10 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2023-01-31"
+	ClientVersion = "2023-02-08"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-02-01"
+	AgentVersion = "2023-02-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,6 @@ module github.com/evergreen-ci/evergreen
 
 go 1.16
 
-// We need to keep this old YAML version because upgrading from this specific revision to any newer one somehow breaks
-// project validation.
-replace gopkg.in/20210107192922/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-
 require (
 	github.com/99designs/gqlgen v0.17.20
 	github.com/PuerkitoBio/rehttp v1.1.0
@@ -68,6 +64,5 @@ require (
 	github.com/mongodb/jasper v0.0.0-20220214215554-82e5a72cff6b
 	github.com/shirou/gopsutil/v3 v3.22.9
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
-	gopkg.in/20210107192922/yaml.v3 v3.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1705,7 +1705,6 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/jasper/remote"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const OutputBufferSize = 1000

--- a/model/project.go
+++ b/model/project.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	ignore "github.com/sabhiram/go-gitignore"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,7 +41,7 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, err := createIntermediateProject([]byte(axes), true, false)
+			p, err := createIntermediateProject([]byte(axes), true)
 			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
@@ -77,7 +77,7 @@ buildvariants:
     - blue
     - green
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
@@ -108,7 +108,7 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -836,7 +836,7 @@ func createIntermediateProject(yml []byte, unmarshalStrict bool) (*ParserProject
 			// to a non-existent variables field.
 			Variables interface{} `yaml:"variables,omitempty" bson:"-"`
 		}{}
-		if err := util.UnmarshalYAMLWithFallback(yml, &strictProjectWithVariables); err != nil {
+		if err := util.UnmarshalYAMLStrictWithFallback(yml, &strictProjectWithVariables); err != nil {
 			return nil, err
 		}
 		p = strictProjectWithVariables.ParserProject

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -597,12 +597,10 @@ func GetProjectFromBSON(data []byte) (*Project, error) {
 // opts is used to look up files on github if the main parser project has an Include.
 func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, identifier string, project *Project) (*ParserProject, error) {
 	unmarshalStrict := false
-	useUpgradedYAML := false
 	if opts != nil {
 		unmarshalStrict = opts.UnmarshalStrict
-		useUpgradedYAML = opts.UseUpgradedYAML
 	}
-	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, useUpgradedYAML)
+	intermediateProject, err := createIntermediateProject(data, unmarshalStrict)
 	if err != nil {
 		return nil, errors.Wrapf(err, LoadProjectError)
 	}
@@ -632,7 +630,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		if err != nil {
 			return intermediateProject, errors.Wrapf(err, "%s: retrieving file '%s'", LoadProjectError, path.FileName)
 		}
-		add, err := createIntermediateProject(yaml, opts.UnmarshalStrict, opts.UseUpgradedYAML)
+		add, err := createIntermediateProject(yaml, opts.UnmarshalStrict)
 		if err != nil {
 			return intermediateProject, errors.Wrapf(err, "%s: loading file '%s'", LoadProjectError, path.FileName)
 		}
@@ -669,7 +667,6 @@ type GetProjectOpts struct {
 	ReadFileFrom    string
 	Identifier      string
 	UnmarshalStrict bool
-	UseUpgradedYAML bool
 }
 
 type PatchOpts struct {
@@ -829,9 +826,9 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, 
 // intermediate project representation (i.e. before selectors or
 // matrix logic has been evaluated).
 // If unmarshalStrict is true, use the strict version of unmarshalling.
-func createIntermediateProject(yml []byte, unmarshalStrict, useUpgradedYAML bool) (*ParserProject, error) {
+func createIntermediateProject(yml []byte, unmarshalStrict bool) (*ParserProject, error) {
 	p := ParserProject{}
-	if useUpgradedYAML && unmarshalStrict {
+	if unmarshalStrict {
 		strictProjectWithVariables := struct {
 			ParserProject       `yaml:"pp,inline"`
 			ProjectConfigFields `yaml:"pc,inline"`
@@ -839,28 +836,10 @@ func createIntermediateProject(yml []byte, unmarshalStrict, useUpgradedYAML bool
 			// to a non-existent variables field.
 			Variables interface{} `yaml:"variables,omitempty" bson:"-"`
 		}{}
-		if err := util.UnmarshalUpgradedYAMLStrictWithFallback(yml, &strictProjectWithVariables); err != nil {
+		if err := util.UnmarshalYAMLWithFallback(yml, &strictProjectWithVariables); err != nil {
 			return nil, err
 		}
 		p = strictProjectWithVariables.ParserProject
-	} else if unmarshalStrict {
-		strictProjectWithVariables := struct {
-			ParserProject       `yaml:"pp,inline"`
-			ProjectConfigFields `yaml:"pc,inline"`
-			// Variables is only used to suppress yaml unmarshalling errors related
-			// to a non-existent variables field.
-			Variables interface{} `yaml:"variables,omitempty" bson:"-"`
-		}{}
-
-		if err := util.UnmarshalYAMLStrictWithFallback(yml, &strictProjectWithVariables); err != nil {
-			return nil, err
-		}
-		p = strictProjectWithVariables.ParserProject
-	} else if useUpgradedYAML {
-		if err := util.UnmarshalUpgradedYAMLWithFallback(yml, &p); err != nil {
-			yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
-			return nil, errors.Wrap(yamlErr, "unmarshalling parser project from YAML")
-		}
 	} else {
 		if err := util.UnmarshalYAMLWithFallback(yml, &p); err != nil {
 			yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // ShouldContainResembling tests whether a slice contains an element that DeepEquals

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -63,7 +63,7 @@ tasks:
     status: "failed"
     patch_optional: true
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "compile")
@@ -80,7 +80,7 @@ tasks:
 - name: task1
   depends_on: task0
 `
-			p, err := createIntermediateProject([]byte(single), false, false)
+			p, err := createIntermediateProject([]byte(single), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "task0")
@@ -92,7 +92,7 @@ tasks:
 - name: "compile"
   depends_on: ""
 `
-				p, err := createIntermediateProject([]byte(nameless), false, false)
+				p, err := createIntermediateProject([]byte(nameless), false)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -104,7 +104,7 @@ tasks:
   - name: "task1"
   - status: "failed" #this has no task attached
 `
-				p, err := createIntermediateProject([]byte(nameless), false, false)
+				p, err := createIntermediateProject([]byte(nameless), false)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -113,7 +113,7 @@ tasks:
 tasks:
 - name: "compile"
 `
-				p, err := createIntermediateProject([]byte(nameless), false, false)
+				p, err := createIntermediateProject([]byte(nameless), false)
 				So(p, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 			})
@@ -142,7 +142,7 @@ buildvariants:
     stepback: false
     priority: 77
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -167,7 +167,7 @@ buildvariants:
   - name: "t2"
     depends_on: "t3"
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -185,7 +185,7 @@ buildvariants:
   tasks:
     name: "t1"
 `
-			p, err := createIntermediateProject([]byte(simple), false, false)
+			p, err := createIntermediateProject([]byte(simple), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
@@ -209,7 +209,7 @@ buildvariants:
   run_on: "distro1"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(single), false, false)
+			p, err := createIntermediateProject([]byte(single), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.Ignore), ShouldEqual, 1)
@@ -230,7 +230,7 @@ buildvariants:
   - name: "t1"
     run_on: "test"
 `
-			p, err := createIntermediateProject([]byte(single), false, false)
+			p, err := createIntermediateProject([]byte(single), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.BuildVariants[0].Tasks[0].RunOn[0], ShouldEqual, "test")
@@ -245,7 +245,7 @@ buildvariants:
     run_on: "test"
     distros: "asdasdasd"
 `
-			p, err := createIntermediateProject([]byte(single), false, false)
+			p, err := createIntermediateProject([]byte(single), false)
 			So(p, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
@@ -257,7 +257,7 @@ buildvariants:
   - name: "t1"
     commit_queue_merge: true
 `
-			p, err := createIntermediateProject([]byte(single), false, false)
+			p, err := createIntermediateProject([]byte(single), false)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -281,7 +281,7 @@ buildvariants:
   - name: "t1"
     activate: true
 `
-	p, err := createIntermediateProject([]byte(yml), false, false)
+	p, err := createIntermediateProject([]byte(yml), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	bv := p.BuildVariants[0]
@@ -573,7 +573,7 @@ tasks:
 - name: execTask3
 - name: execTask4
 `
-	p, err := createIntermediateProject([]byte(yml), false, false)
+	p, err := createIntermediateProject([]byte(yml), false)
 
 	// check that display tasks in bv1 parsed correctly
 	assert.NoError(err)
@@ -602,7 +602,7 @@ parameters:
 - key: buggy
   value: driver
 `
-	p, err := createIntermediateProject([]byte(yml), false, false)
+	p, err := createIntermediateProject([]byte(yml), false)
 	assert.NoError(t, err)
 	require.Len(t, p.Parameters, 2)
 	assert.Equal(t, "iter_count", p.Parameters[0].Key)
@@ -954,7 +954,7 @@ tasks:
 - name: execTask4
   tags: [ "even" ]
 `
-	pp, err := createIntermediateProject([]byte(tagYml), false, false)
+	pp, err := createIntermediateProject([]byte(tagYml), false)
 	assert.NotNil(pp)
 	assert.NoError(err)
 	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
@@ -1717,7 +1717,7 @@ buildvariants:
 }
 
 func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Environment, yml []byte, ppStorageMethod ParserProjectStorageMethod) {
-	pp, err := createIntermediateProject(yml, false, false)
+	pp, err := createIntermediateProject(yml, false)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("old-project-identifier")
@@ -1741,7 +1741,7 @@ func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Envir
 	assert.True(t, bytes.Equal(newYaml, yamlToCompare))
 
 	// ensure that updating with the re-parsed project doesn't error
-	pp, err = createIntermediateProject(newYaml, false, false)
+	pp, err = createIntermediateProject(newYaml, false)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("new-project-identifier")
@@ -1768,7 +1768,7 @@ func TestParserProjectRoundtrip(t *testing.T) {
 	yml, err := ioutil.ReadFile(filepath)
 	assert.NoError(t, err)
 
-	original, err := createIntermediateProject(yml, false, false)
+	original, err := createIntermediateProject(yml, false)
 	assert.NoError(t, err)
 
 	// to and from yaml
@@ -2433,10 +2433,10 @@ ignore:
   - ".github/*"
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, false)
+	p1, err := createIntermediateProject([]byte(mainYaml), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(smallYaml), false, false)
+	p2, err := createIntermediateProject([]byte(smallYaml), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -2482,13 +2482,13 @@ buildvariants:
       - name: task3
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, false)
+	p1, err := createIntermediateProject([]byte(mainYaml), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(succeed), false, false)
+	p2, err := createIntermediateProject([]byte(succeed), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
-	p3, err := createIntermediateProject([]byte(fail), false, false)
+	p3, err := createIntermediateProject([]byte(fail), false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p3)
 	err = p1.mergeMultipleParserProjects(p2)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1277,7 +1277,7 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, err := createIntermediateProject([]byte(projYml), false, false)
+	intermediate, err := createIntermediateProject([]byte(projYml), false)
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {

--- a/model/testutil/integration_test_setup.go
+++ b/model/testutil/integration_test_setup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 // Creates a project ref local config that can be used for testing, with the string identifier given

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func Admin() cli.Command {

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 var testConfig = testutil.TestConfig()

--- a/operations/commit_queue_test.go
+++ b/operations/commit_queue_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 type CommitQueueSuite struct {

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -4,20 +4,17 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"sort"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	yaml "gopkg.in/20210107192922/yaml.v3"
-	upgradedYAML "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func Evaluate() cli.Command {
 	const (
 		taskFlagName     = "tasks"
 		variantsFlagName = "variants"
-		diffableFlagName = "diffable"
 	)
 
 	return cli.Command{
@@ -31,12 +28,6 @@ func Evaluate() cli.Command {
 			cli.BoolFlag{
 				Name:  variantsFlagName,
 				Usage: "only show variant definitions",
-			}, cli.BoolFlag{
-				Name:  useUpgradedYAMLFlagName,
-				Usage: "use upgraded YAML version",
-			}, cli.BoolFlag{
-				Name:  diffableFlagName,
-				Usage: "show the project configuration in an ordered, diff-friendly format",
 			},
 		),
 		Before: mergeBeforeFuncs(requirePathFlag),
@@ -44,8 +35,6 @@ func Evaluate() cli.Command {
 			path := c.String(pathFlagName)
 			showTasks := c.Bool(taskFlagName)
 			showVariants := c.Bool(variantsFlagName)
-			useUpgradedYAML := c.Bool(useUpgradedYAMLFlagName)
-			diffable := c.Bool(diffableFlagName)
 
 			configBytes, err := ioutil.ReadFile(path)
 			if err != nil {
@@ -55,8 +44,7 @@ func Evaluate() cli.Command {
 			p := &model.Project{}
 			ctx := context.Background()
 			opts := &model.GetProjectOpts{
-				ReadFileFrom:    model.ReadFromLocal,
-				UseUpgradedYAML: useUpgradedYAML,
+				ReadFileFrom: model.ReadFromLocal,
 			}
 			_, err = model.LoadProjectInto(ctx, configBytes, opts, "", p)
 			if err != nil {
@@ -72,109 +60,19 @@ func Evaluate() cli.Command {
 				}{}
 				if showTasks {
 					tmp.Functions = p.Functions
-					if diffable {
-						sortTasksByName := model.ProjectTasksByName(p.Tasks)
-						sort.Sort(sortTasksByName)
-						tmp.Tasks = sortTasksByName
-					} else {
-						tmp.Tasks = p.Tasks
-					}
+					tmp.Tasks = p.Tasks
 				}
 				if showVariants {
-					if diffable {
-						sortBVsByName := model.BuildVariantsByName(p.BuildVariants)
-						sort.Sort(sortBVsByName)
-						tmp.Variants = sortBVsByName
-					} else {
-						tmp.Variants = p.BuildVariants
-					}
+					tmp.Variants = p.BuildVariants
 				}
-				out = tmp
-			} else if diffable {
-				// TODO (EVG-17291): remove the diffable and useUpgradedYAML
-				// flags once the YAML is upgraded.
-				//
-				// Include all fields in the project config that potentially
-				// have nested maps because those are affected by the bug fixed
-				// in the YAML upgrade.
-
-				tmp := struct {
-					Functions  interface{} `yaml:"functions,omitempty"`
-					Tasks      interface{} `yaml:"tasks,omitempty"`
-					Variants   interface{} `yaml:"buildvariants,omitempty"`
-					TaskGroups interface{} `yaml:"task_groups,omitempty"`
-					Parameters interface{} `yaml:"parameters,omitempty"`
-					Pre        interface{} `yaml:"pre,omitempty"`
-					Post       interface{} `yaml:"post,omitempty"`
-					Timeout    interface{} `yaml:"timeout,omitempty"`
-				}{}
-
-				// In order to make the project config easily diffable,
-				// evergreen evaluate has to always produce the same output for
-				// the same input (i.e. if you pass in the same YAML file
-				// multiple times, it should always produce the same output).
-				// LoadProjectInto does not provide this kind of guarantee, and
-				// may produce some out-of-order results for unordered lists.
-				//
-				// To consistently produce the same output, sort fields that are
-				// lists where order may be shuffled by LoadProjectInto. For
-				// example, build variants are a list where order is not
-				// important, and LoadProjectInto shuffles the order. In
-				// contrast, Pre commands are an ordered list, so they already
-				// retain their ordering.
-
-				if p.Functions != nil {
-					tmp.Functions = p.Functions
-				}
-
-				if p.Tasks != nil {
-					sortTasksByName := model.ProjectTasksByName(p.Tasks)
-					sort.Sort(sortTasksByName)
-					tmp.Tasks = sortTasksByName
-				}
-
-				if p.BuildVariants != nil {
-					sortBVsByName := model.BuildVariantsByName(p.BuildVariants)
-					sort.Sort(sortBVsByName)
-					tmp.Variants = sortBVsByName
-				}
-
-				if p.TaskGroups != nil {
-					sortTaskGroupsByName := model.TaskGroupsByName(p.TaskGroups)
-					sort.Sort(sortTaskGroupsByName)
-					tmp.TaskGroups = sortTaskGroupsByName
-				}
-
-				if p.Parameters != nil {
-					tmp.Parameters = p.Parameters
-				}
-
-				if p.Pre != nil {
-					tmp.Pre = p.Pre
-				}
-				if p.Post != nil {
-					tmp.Post = p.Post
-				}
-				if p.Timeout != nil {
-					tmp.Timeout = p.Timeout
-				}
-
 				out = tmp
 			} else {
 				out = p
 			}
 
-			var outYAML []byte
-			if useUpgradedYAML {
-				outYAML, err = upgradedYAML.Marshal(out)
-				if err != nil {
-					return errors.Wrap(err, "marshalling evaluated project YAML with upgraded YAML version")
-				}
-			} else {
-				outYAML, err = yaml.Marshal(out)
-				if err != nil {
-					return errors.Wrap(err, "marshalling evaluated project YAML")
-				}
+			outYAML, err := yaml.Marshal(out)
+			if err != nil {
+				return errors.Wrap(err, "marshalling evaluated project YAML")
 			}
 
 			fmt.Println(string(outYAML))

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -17,7 +17,6 @@ const (
 	patchIDFlagName           = "patch"
 	moduleFlagName            = "module"
 	localModulesFlagName      = "local_modules"
-	useUpgradedYAMLFlagName   = "use_upgraded_yaml"
 	skipConfirmFlagName       = "skip_confirm"
 	yesFlagName               = "yes"
 	variantsFlagName          = "variants"

--- a/operations/generate.go
+++ b/operations/generate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/evergreen-ci/shrub"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 // Generate creates a cli.Command to use the Jasper metabuild system.

--- a/operations/http.go
+++ b/operations/http.go
@@ -147,13 +147,12 @@ func (ac *legacyClient) modifyExisting(patchId, action string) error {
 }
 
 // ValidateLocalConfig validates the local project config with the server
-func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong, useUpgradedYAML bool, projectID string) (validator.ValidationErrors, error) {
+func (ac *legacyClient) ValidateLocalConfig(data []byte, quiet, includeLong bool, projectID string) (validator.ValidationErrors, error) {
 	input := validator.ValidationInput{
-		ProjectYaml:     data,
-		Quiet:           quiet,
-		IncludeLong:     includeLong,
-		ProjectID:       projectID,
-		UseUpgradedYAML: useUpgradedYAML,
+		ProjectYaml: data,
+		Quiet:       quiet,
+		IncludeLong: includeLong,
+		ProjectID:   projectID,
 	}
 	rPipe, wPipe := io.Pipe()
 	encoder := json.NewEncoder(wPipe)

--- a/operations/model.go
+++ b/operations/model.go
@@ -18,7 +18,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const localConfigPath = ".evergreen.local.yml"

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -20,7 +20,7 @@ import (
 	"github.com/mongodb/jasper/remote"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func setupSmokeTest(err error) cli.BeforeFunc {

--- a/rest/route/build_test.go
+++ b/rest/route/build_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 ////////////////////////////////////////////////////////////////////////

--- a/service/api.go
+++ b/service/api.go
@@ -213,8 +213,7 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	var projectConfig *model.ProjectConfig
 	ctx := context.Background()
 	opts := &model.GetProjectOpts{
-		ReadFileFrom:    model.ReadFromLocal,
-		UseUpgradedYAML: input.UseUpgradedYAML,
+		ReadFileFrom: model.ReadFromLocal,
 	}
 	validationErr := validator.ValidationError{}
 	if _, err = model.LoadProjectInto(ctx, input.ProjectYaml, opts, "", project); err != nil {

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 type RestPatch struct {

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const NumRecentVersions = 10

--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
-	"gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const (

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/amboy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 func TestTaskExecutionTimeoutJob(t *testing.T) {

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
-	yaml "gopkg.in/20210107192922/yaml.v3"
 	yaml2 "gopkg.in/yaml.v2"
-	upgradedYAML "gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v3"
 )
 
 const UnmarshalStrictError = "error unmarshalling yaml strict"
@@ -33,36 +32,6 @@ func UnmarshalYAMLStrictWithFallback(in []byte, out interface{}) error {
 	d.KnownFields(true)
 	if err := d.Decode(out); err != nil {
 		if err2 := yaml2.UnmarshalStrict(in, out); err2 != nil {
-			return errors.Wrap(err, UnmarshalStrictError)
-		}
-	}
-	return nil
-}
-
-// UnmarshalUpgradedYAMLWithFallback is identical to UnmarshalYAMLWithFallback but uses the upgraded YAML version
-// (v3.0.1) instead of the current YAML version.
-// This should only be used for user validation to see if their project's YAML hypothetically produces a valid config
-// should the YAML version be upgraded.
-func UnmarshalUpgradedYAMLWithFallback(in []byte, out interface{}) error {
-	if err := upgradedYAML.Unmarshal(in, out); err != nil {
-		// try the older version of yaml before erroring, in case it's just an outdated yaml
-		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// UnmarshalUpgradedYAMLStrictWithFallback is identical to UnmarshalYAMLStrictWithFallback but uses the upgraded YAML
-// version (v3.0.1) instead of the current YAML version.
-// This should only be used for user validation to see if their project's YAML hypothetically produces a valid config
-// should the YAML version be upgraded.
-func UnmarshalUpgradedYAMLStrictWithFallback(in []byte, out interface{}) error {
-	d := upgradedYAML.NewDecoder(bytes.NewReader(in))
-	d.KnownFields(true)
-	if err := d.Decode(out); err != nil {
-		// try the older version of yaml before erroring, in case it's just an outdated yaml
-		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
 			return errors.Wrap(err, UnmarshalStrictError)
 		}
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -110,11 +110,10 @@ func (v ValidationErrors) HasError() bool {
 }
 
 type ValidationInput struct {
-	ProjectYaml     []byte `json:"project_yaml" yaml:"project_yaml"`
-	Quiet           bool   `json:"quiet" yaml:"quiet"`
-	IncludeLong     bool   `json:"include_long" yaml:"include_long"`
-	UseUpgradedYAML bool   `json:"use_upgraded_yaml" yaml:"use_upgraded_yaml"`
-	ProjectID       string `json:"project_id" yaml:"project_id"`
+	ProjectYaml []byte `json:"project_yaml" yaml:"project_yaml"`
+	Quiet       bool   `json:"quiet" yaml:"quiet"`
+	IncludeLong bool   `json:"include_long" yaml:"include_long"`
+	ProjectID   string `json:"project_id" yaml:"project_id"`
 }
 
 // Functions used to validate the syntax of a project configuration file.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-17291

### Description 
The YAML upgrade is scheduled to be deployed on Feb 13, which means we can remove the old version of the YAML package and the temporary logic to help users detect YAML compatibility. I'm going to merge this on Friday in preparation for Monday's deploy.

* Upgrade gopkg.in/yaml.v3 and remove old version from modules.
* Remove temporary code introduced for users to verify their YAMLs for the upgrade.

### Testing 
Existing unit tests pass.