### PR TITLE
EVG-18365 Rename parser BV "disabled" to "disable"

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -674,7 +674,7 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 
 func isNonZeroBV(bv parserBV) bool {
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
-		bv.Disabled || len(bv.Tags) > 0 || bv.Push ||
+		bv.Disable || len(bv.Tags) > 0 || bv.Push ||
 		bv.BatchTime != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
 		return true
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -293,7 +293,7 @@ type BuildVariant struct {
 	DisplayName string            `yaml:"display_name,omitempty" bson:"display_name"`
 	Expansions  map[string]string `yaml:"expansions,omitempty" bson:"expansions"`
 	Modules     []string          `yaml:"modules,omitempty" bson:"modules"`
-	Disabled    bool              `yaml:"disabled,omitempty" bson:"disabled"`
+	Disable     bool              `yaml:"disable,omitempty" bson:"disable"`
 	Tags        []string          `yaml:"tags,omitempty" bson:"tags"`
 	Push        bool              `yaml:"push,omitempty" bson:"push"`
 
@@ -1616,7 +1616,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 	if len(bvs) == 1 && bvs[0] == "all" {
 		bvs = []string{}
 		for _, bv := range p.BuildVariants {
-			if bv.Disabled {
+			if bv.Disable {
 				continue
 			}
 			bvs = append(bvs, bv.Name)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -319,7 +319,7 @@ type parserBV struct {
 	Expansions    util.Expansions    `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
 	Tags          parserStringSlice  `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
 	Modules       parserStringSlice  `yaml:"modules,omitempty" bson:"modules,omitempty"`
-	Disabled      bool               `yaml:"disabled,omitempty" bson:"disabled,omitempty"`
+	Disable       bool               `yaml:"disable,omitempty" bson:"disable,omitempty"`
 	Push          bool               `yaml:"push,omitempty" bson:"push,omitempty"`
 	BatchTime     *int               `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
 	CronBatchTime string             `yaml:"cron,omitempty" bson:"cron,omitempty"`
@@ -386,7 +386,7 @@ func (pbv *parserBV) canMerge() bool {
 		pbv.Expansions == nil &&
 		pbv.Tags == nil &&
 		pbv.Modules == nil &&
-		!pbv.Disabled &&
+		!pbv.Disable &&
 		!pbv.Push &&
 		pbv.BatchTime == nil &&
 		pbv.CronBatchTime == "" &&
@@ -511,7 +511,7 @@ func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
 // overrides the default, such as cron/batchtime, disabling the task, or explicitly deactivating it.
 func (bvt *parserBV) hasSpecificActivation() bool {
 	return bvt.BatchTime != nil || bvt.CronBatchTime != "" ||
-		!utility.FromBoolTPtr(bvt.Activate) || bvt.Disabled
+		!utility.FromBoolTPtr(bvt.Activate) || bvt.Disable
 }
 
 // FindAndTranslateProjectForPatch translates a parser project for a patch into a project.
@@ -1040,7 +1040,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			Name:          pbv.Name,
 			Expansions:    pbv.Expansions,
 			Modules:       pbv.Modules,
-			Disabled:      pbv.Disabled,
+			Disable:       pbv.Disable,
 			Push:          pbv.Push,
 			BatchTime:     pbv.BatchTime,
 			CronBatchTime: pbv.CronBatchTime,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2144,7 +2144,7 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the build, set batchtime to the zero time
-	if !utility.FromBoolTPtr(variant.Activate) || variant.Disabled {
+	if !utility.FromBoolTPtr(variant.Activate) || variant.Disable {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -638,8 +638,8 @@ func (s *projectSuite) SetupTest() {
 				},
 			},
 			{
-				Name:     "bv_3",
-				Disabled: true,
+				Name:    "bv_3",
+				Disable: true,
 				Tasks: []BuildVariantTaskUnit{
 					{
 						Name: "disabled_task",

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -811,7 +811,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		if ctx.Err() != nil {
 			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
 		}
-		if buildvariant.Disabled {
+		if buildvariant.Disable {
 			continue
 		}
 		if len(aliases) > 0 {


### PR DESCRIPTION
[EVG-18365](https://jira.mongodb.org/browse/EVG-18365)

### Description 
A query on the DB indicates that this field is not used, probably due to the fact that it was not documented on the Wiki. [I've since added it](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants) to the BV section and the [limiting when tasks will run](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#limiting-when-a-task-will-run) section.

I expect this renaming to be a safe operation and we won't need to support `disable` and `disabled` concurrently during a deprecation phase.