### PR TITLE
EVG-18577: do not put context timeout on inserting tasks/builds for generate.tasks

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -167,7 +167,9 @@ func (g *GeneratedProject) Save(ctx context.Context, settings *evergreen.Setting
 		return mongo.ErrNoDocuments
 	}
 
-	if err := updateParserProject(ctx, settings, v, pp, t.Id); err != nil {
+	ppCtx, ppCancel := context.WithTimeout(ctx, DefaultParserProjectAccessTimeout)
+	defer ppCancel()
+	if err := updateParserProject(ppCtx, settings, v, pp, t.Id); err != nil {
 		if db.IsDocumentLimit(err) {
 			// The parser project has reached the DB document size limit, so put
 			// it in S3.

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -196,10 +196,9 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	start = time.Now()
 
 	// Don't use the job's context, because it's better to try finishing than to
-	// exit early after a SIGTERM from app server shutdown.
-	ctx, cancel := context.WithTimeout(context.Background(), model.DefaultParserProjectAccessTimeout)
-	defer cancel()
-	err = g.Save(ctx, j.env.Settings(), p, pp, v)
+	// exit early after a SIGTERM from app server shutdown. This should probably
+	// use a timeout rather than just the background context.
+	err = g.Save(context.Background(), j.env.Settings(), p, pp, v)
 
 	// If the version or parser project has changed there was a race. Another generator will try again.
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18577

### Description 
Inserting tasks/builds is very expensive and oftentimes takes several minutes to finish for full server generators, so I reverted it back to the old logic of letting the insertion run for an unlimited amount of time. Probably not that great long term, but I'm not looking to optimize the build/task insertion right now.

### Testing
Don't really think a context timeout modification is worth figuring out a test.