### PR TITLE
EVG-18900 sort hosts on distro _id

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/plank"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	werrors "github.com/pkg/errors"
@@ -220,7 +221,7 @@ func (r *queryResolver) Hosts(ctx context.Context, hostID *string, distroID *str
 		case HostSortByCurrentTask:
 			sorter = host.RunningTaskKey
 		case HostSortByDistro:
-			sorter = host.DistroKey
+			sorter = bsonutil.GetDottedKeyName(host.DistroKey, distro.IdKey)
 		case HostSortByElapsed:
 			sorter = "task_full.start_time"
 		case HostSortByID:


### PR DESCRIPTION
[EVG-18900](https://jira.mongodb.org/browse/EVG-18900)

### Description 
I don't know why it was working better on 4.2 (maybe it really does have to do with [the change in sort algo](https://www.mongodb.com/docs/manual/release-notes/4.4/#-sort-changes)). It's interesting that with 6.0 it was also working for me without the change in this PR. I didn't see anything in the intervening release notes that looked related. 🤷 

It seems like the issue is the sort on the entire distro doc (they get compared with [this](https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/#objects)) vs. a sort on the distro id. I think the sort on distro id is what we're really after anyway.

### Testing 
In local-evergreen the distro sort fails without the change and succeeds with the change.
    
#### Does this need documentation?
No
