### PR TITLE
EVG-18940: populate GitHub PR expansions for PR commit queue items

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1110,12 +1110,9 @@ func PopulateExpansions(ctx context.Context, settings *evergreen.Settings, t *ta
 		if v.Requester == evergreen.MergeTestRequester {
 			expansions.Put("is_commit_queue", "true")
 			expansions.Put("commit_message", p.Description)
-			if p.IsPRMergePatch() {
-				expansions.Put("github_pr_number", fmt.Sprintf("%d", p.GithubPatchData.PRNumber))
-			}
 		}
 
-		if v.Requester == evergreen.GithubPRRequester {
+		if p.IsPRMergePatch() || v.Requester == evergreen.GithubPRRequester {
 			expansions.Put("github_pr_number", fmt.Sprintf("%d", p.GithubPatchData.PRNumber))
 			expansions.Put("github_org", p.GithubPatchData.BaseOwner)
 			expansions.Put("github_repo", p.GithubPatchData.BaseRepo)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -382,9 +382,9 @@ buildvariants:
 	assert.Equal("", expansions.Get("is_patch"))
 	assert.False(expansions.Exists("is_commit_queue"))
 	assert.Equal("github_tag", expansions.Get("requester"))
+	assert.False(expansions.Exists("github_pr_number"))
 	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
-	assert.False(expansions.Exists("github_pr_number"))
 	assert.Equal("lie", expansions.Get("cake"))
 
 	assert.NoError(VersionUpdateOne(bson.M{VersionIdKey: v.Id}, bson.M{
@@ -401,9 +401,9 @@ buildvariants:
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("patch", expansions.Get("requester"))
 	assert.False(expansions.Exists("is_commit_queue"))
+	assert.False(expansions.Exists("github_pr_number"))
 	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
-	assert.False(expansions.Exists("github_pr_number"))
 	assert.False(expansions.Exists("triggered_by_git_tag"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
@@ -415,16 +415,24 @@ buildvariants:
 		Description: "commit queue message",
 		GithubPatchData: thirdparty.GithubPatch{
 			PRNumber:       12,
+			BaseOwner:      "potato",
+			BaseRepo:       "tomato",
+			Author:         "hemingway",
+			HeadHash:       "7d2fe4649f50f87cb60c2f80ac2ceda1e5b88522",
 			MergeCommitSHA: "21",
 		},
 	}
 	require.NoError(t, p.Insert())
 	expansions, err = PopulateExpansions(ctx, settings, taskDoc, &h, oauthToken)
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 27)
+	assert.Len(map[string]string(expansions), 29)
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("true", expansions.Get("is_commit_queue"))
 	assert.Equal("12", expansions.Get("github_pr_number"))
+	assert.Equal("wut?", expansions.Get("github_org"))
+	assert.Equal(p.GithubPatchData.BaseRepo, expansions.Get("github_repo"))
+	assert.Equal(p.GithubPatchData.Author, expansions.Get("github_author"))
+	assert.Equal(p.GithubPatchData.HeadHash, expansions.Get("github_commit"))
 	assert.Equal("commit queue message", expansions.Get("commit_message"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18940

### Description 
This is a small follow-on to [EVG-18760](https://jira.mongodb.org/browse/EVG-18760). Instead of populating just the PR number for PR commit queue items, add the other GitHub PR expansions as well.

### Testing 
Added unit test.
    
#### Does this need documentation?
Yes, going to update [the default expansions in the wiki](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#default-expansions) once it's merged.