### PR TITLE
EVG-18288: Add local logkeeper URL

### DIFF
--- a/testdata/local/admin.json
+++ b/testdata/local/admin.json
@@ -7,3 +7,4 @@
 { "_id": "spawnhost", "unexpirable_hosts_per_user": 2, "unexpirable_volumes_per_user": 1, "spawn_hosts_per_user": 6 }
 { "_id": "jira",  "host": "jira.example.com", "basic_auth": { "username": "mohamed.khelif", "password": "password" }, "default_project": "", "oath1": {"private_key": "", "access_token": "", "token_secret": "", "consumer_key": ""} }
 { "_id": "project_creation",  "total_project_limit": 10, "repo_project_limit": 2 }
+{ "_id": "logger_config", "logkeeper_url": "http://localhost:8080" }


### PR DESCRIPTION
Facilitates [EVG-18288](https://jira.mongodb.org/browse/EVG-18288)

### Description 
- Override Logkeeper URL in test environment. This facilitates e2e testing on Spruce by allowing GraphQL to reach a local Logkeeper server with test data.

#### Does this need documentation?
No
