### PR TITLE
EVG-18784 Warn users when creating/copying projects at limit

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -415,8 +415,6 @@ func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.
 				if apiErr.StatusCode == http.StatusBadRequest {
 					return nil, InputValidationError.Send(ctx, apiErr.Message)
 				}
-				// StatusNotFound and other error codes are really internal errors bc we determine this input
-				return nil, InternalServerError.Send(ctx, apiErr.Message)
 			}
 			return nil, InternalServerError.Send(ctx, err.Error())
 		}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -408,16 +408,19 @@ func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.
 	}
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 
-	if err := data.CreateProject(ctx, evergreen.GetEnvironment(), dbProjectRef, u); err != nil {
-		apiErr, ok := err.(gimlet.ErrorResponse)
-		if ok {
-			if apiErr.StatusCode == http.StatusBadRequest {
-				return nil, InputValidationError.Send(ctx, apiErr.Message)
+	if created, err := data.CreateProject(ctx, evergreen.GetEnvironment(), dbProjectRef, u); err != nil {
+		if !created {
+			apiErr, ok := err.(gimlet.ErrorResponse)
+			if ok {
+				if apiErr.StatusCode == http.StatusBadRequest {
+					return nil, InputValidationError.Send(ctx, apiErr.Message)
+				}
+				// StatusNotFound and other error codes are really internal errors bc we determine this input
+				return nil, InternalServerError.Send(ctx, apiErr.Message)
 			}
-			// StatusNotFound and other error codes are really internal errors bc we determine this input
-			return nil, InternalServerError.Send(ctx, apiErr.Message)
+			return nil, InternalServerError.Send(ctx, err.Error())
 		}
-		return nil, InternalServerError.Send(ctx, err.Error())
+		graphql.AddError(ctx, PartialError.Send(ctx, err.Error()))
 	}
 
 	projectRef, err := model.FindBranchProjectRef(*project.Identifier)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -929,7 +929,7 @@ func GetNumberOfEnabledProjects() (int, error) {
 	return getNumberOfEnabledProjects("", "")
 }
 
-// GetEnabledProjectsForOwnerRepo returns the number of enabled projects for a given owner/repo.
+// GetNumberOfEnabledProjectsForOwnerRepo returns the number of enabled projects for a given owner/repo.
 func GetNumberOfEnabledProjectsForOwnerRepo(owner, repo string) (int, error) {
 	if owner == "" || repo == "" {
 		return 0, errors.New("owner and repo must be specified")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2032,14 +2032,13 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 // to create our own project settings event  after completing the update.
 func DefaultSectionToRepo(projectId string, section ProjectPageSection, userId string) error {
 	before, err := GetProjectSettingsById(projectId, false)
-
 	if err != nil {
 		return errors.Wrap(err, "getting before project settings event")
 	}
 
 	if section == ProjectPageGeneralSection {
 		newMergedRef, err := GetProjectRefMergedWithRepo(ProjectRef{
-			RepoRefId: projectId,
+			RepoRefId: before.ProjectRef.RepoRefId,
 		})
 		if err != nil {
 			return errors.Wrap(err, "getting merged project ref for validation")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1904,14 +1904,14 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 		if p.TracksPushEvents != nil {
 			setUpdate[ProjectRefTracksPushEventsKey] = p.TracksPushEvents
 		}
-		config, err := evergreen.GetConfig()
+		config, error := evergreen.GetConfig()
 		if !isRepo && !p.UseRepoSettings() && !defaultToRepo {
 			if err != nil {
-				return false, errors.Wrap(err, "getting evergreen config")
+				return false, errors.Wrap(error, "getting evergreen config")
 			}
 			// Allow a user to modify owner and repo only if they are editing an unattached project
-			if err := p.ValidateOwnerAndRepo(config.GithubOrgs); err != nil {
-				return false, errors.Wrap(err, "validating new owner/repo")
+			if error = p.ValidateOwnerAndRepo(config.GithubOrgs); error != nil {
+				return false, errors.Wrap(error, "validating new owner/repo")
 			}
 
 			setUpdate[ProjectRefOwnerKey] = p.Owner
@@ -1919,9 +1919,9 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 
 		}
 		// Cannot enable projects if the project creation limits have been reached.
-		_, err = ValidateProjectCreation(projectId, config, p)
-		if err != nil {
-			return false, errors.Wrap(err, "validating project creation")
+		_, error = ValidateProjectCreation(projectId, config, p)
+		if error != nil {
+			return false, errors.Wrap(error, "validating project creation")
 		}
 		// some fields shouldn't be set to nil when defaulting to the repo
 		if !defaultToRepo {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -923,7 +923,7 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 	return pRef, nil
 }
 
-// GetEnabledProjects returns the current number of enabled projects on evergreen.
+// GetNumberOfEnabledProjects returns the current number of enabled projects on evergreen.
 func GetNumberOfEnabledProjects() (int, error) {
 	// Empty owner and repo will return all enabled project count.
 	return getNumberOfEnabledProjects("", "")

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -273,7 +273,9 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 
 	// Should error when trying to enable an existing project past limits.
 	disabled1.Enabled = utility.TruePtr()
-	statusCode, err := ValidateEnabledProjectsLimit(disabled1.Id, &settings, *disabled1)
+	original, err := FindMergedProjectRef(disabled1.Id, "", false)
+	assert.NoError(t, err)
+	statusCode, err := ValidateEnabledProjectsLimit(disabled1.Id, &settings, original, disabled1)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
@@ -284,7 +286,9 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "repo_exception",
 		Enabled: utility.TruePtr(),
 	}
-	_, err = ValidateEnabledProjectsLimit(enabled1.Id, &settings, *exception)
+	original, err = FindMergedProjectRef(exception.Id, "", false)
+	assert.NoError(t, err)
+	_, err = ValidateEnabledProjectsLimit(enabled1.Id, &settings, original, exception)
 	assert.NoError(t, err)
 
 	// Should error if owner/repo is not part of exception.
@@ -294,7 +298,9 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "mci",
 		Enabled: utility.TruePtr(),
 	}
-	statusCode, err = ValidateEnabledProjectsLimit(notException.Id, &settings, *notException)
+	original, err = FindMergedProjectRef(notException.Id, "", false)
+	assert.NoError(t, err)
+	statusCode, err = ValidateEnabledProjectsLimit(notException.Id, &settings, original, notException)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
@@ -303,19 +309,25 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	assert.NoError(t, disableRepo.Upsert())
 	mergedRef, err := GetProjectRefMergedWithRepo(*disabledByRepo)
 	assert.NoError(t, err)
-	_, err = ValidateEnabledProjectsLimit(disabledByRepo.Id, &settings, *mergedRef)
+	original, err = FindMergedProjectRef(disabledByRepo.Id, "", false)
+	assert.NoError(t, err)
+	_, err = ValidateEnabledProjectsLimit(disabledByRepo.Id, &settings, original, mergedRef)
 	assert.NoError(t, err)
 
 	// Should error on enabled if you try to change owner/repo past limit.
 	enabled2.Owner = "mongodb"
 	enabled2.Repo = "mci"
-	statusCode, err = ValidateEnabledProjectsLimit(enabled2.Id, &settings, *enabled2)
+	original, err = FindMergedProjectRef(enabled2.Id, "", false)
+	assert.NoError(t, err)
+	statusCode, err = ValidateEnabledProjectsLimit(enabled2.Id, &settings, original, enabled2)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
 	// Total project limit cannot be exceeded. Even with the exception.
 	settings.ProjectCreation.TotalProjectLimit = 2
-	statusCode, err = ValidateEnabledProjectsLimit(exception.Id, &settings, *exception)
+	original, err = FindMergedProjectRef(exception.Id, "", false)
+	assert.NoError(t, err)
+	statusCode, err = ValidateEnabledProjectsLimit(exception.Id, &settings, original, exception)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -867,6 +867,16 @@ func TestDetachFromRepo(t *testing.T) {
 func TestDefaultRepoBySection(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, id string){
 		ProjectPageGeneralSection: func(t *testing.T, id string) {
+			repoRef := RepoRef{
+				ProjectRef: ProjectRef{
+					Id:      "repo_ref_id",
+					Owner:   "mongodb",
+					Repo:    "mci",
+					Branch:  "main",
+					Enabled: utility.FalsePtr(),
+				},
+			}
+			assert.NoError(t, repoRef.Upsert())
 			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGeneralSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(id)
@@ -979,7 +989,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.NoError(t, db.ClearCollections(ProjectRefCollection, ProjectVarsCollection, ProjectAliasCollection,
-				event.SubscriptionsCollection, event.EventCollection))
+				event.SubscriptionsCollection, event.EventCollection, RepoRefCollection))
 
 			pRef := ProjectRef{
 				Id:                    "my_project",
@@ -999,6 +1009,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				GitTagAuthorizedUsers: []string{"anna"},
 				NotifyOnBuildFailure:  utility.FalsePtr(),
 				PerfEnabled:           utility.FalsePtr(),
+				RepoRefId:             "repo_ref_id",
 				Triggers: []TriggerDefinition{
 					{Project: "your_project"},
 				},

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -113,12 +113,12 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 	}
 	// Always warn because created projects are never enabled.
 	warningCatcher := grip.NewBasicCatcher()
-	statusCode, err := model.ValidateEnabledProjectsLimit(projectRef.Id, env.Settings(), *projectRef)
+	statusCode, err := model.ValidateEnabledProjectsLimit(projectRef.Id, env.Settings(), nil, projectRef)
 	if err != nil {
 		if statusCode != http.StatusBadRequest {
 			return false, gimlet.ErrorResponse{
 				StatusCode: statusCode,
-				Message:    errors.Wrapf(err, "inserting project '%s'", projectRef.Identifier).Error(),
+				Message:    errors.Wrapf(err, "validating project '%s'", projectRef.Identifier).Error(),
 			}
 		}
 		warningCatcher.Add(err)

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -264,7 +264,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		if err != nil {
 			return nil, errors.Wrap(err, "getting evergreen config")
 		}
-		_, err = model.ValidateEnabledProjectsLimit(projectId, config, *mergedSection)
+		_, err = model.ValidateEnabledProjectsLimit(projectId, config, mergedBeforeRef, mergedSection)
 		if err != nil {
 			return nil, errors.Wrap(err, "validating project creation")
 		}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -260,6 +260,15 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			}
 		}
 
+		config, err := evergreen.GetConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting evergreen config")
+		}
+		_, err = model.ValidateEnabledProjectsLimit(projectId, config, *mergedSection)
+		if err != nil {
+			return nil, errors.Wrap(err, "validating project creation")
+		}
+
 	case model.ProjectPageAccessSection:
 		// For any admins that are only in the original settings, remove access.
 		// For any admins that are only in the updated settings, give them access.

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -260,13 +260,15 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			}
 		}
 
-		config, err := evergreen.GetConfig()
-		if err != nil {
-			return nil, errors.Wrap(err, "getting evergreen config")
-		}
-		_, err = model.ValidateEnabledProjectsLimit(projectId, config, mergedBeforeRef, mergedSection)
-		if err != nil {
-			return nil, errors.Wrap(err, "validating project creation")
+		if mergedSection.IsEnabled() {
+			config, err := evergreen.GetConfig()
+			if err != nil {
+				return nil, errors.Wrap(err, "getting evergreen config")
+			}
+			_, err = model.ValidateEnabledProjectsLimit(projectId, config, mergedBeforeRef, mergedSection)
+			if err != nil {
+				return nil, errors.Wrap(err, "validating project creation")
+			}
 		}
 
 	case model.ProjectPageAccessSection:

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -390,7 +390,9 @@ func TestCreateProject(t *testing.T) {
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, pRef model.ProjectRef, u user.DBUser){
 		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, pRef model.ProjectRef, u user.DBUser) {
-			require.NoError(t, CreateProject(ctx, env, &pRef, &u))
+			created, err := CreateProject(ctx, env, &pRef, &u)
+			require.NoError(t, err)
+			require.True(t, created)
 
 			dbProjRef, err := model.FindBranchProjectRef(pRef.Id)
 			require.NoError(t, err)
@@ -409,7 +411,9 @@ func TestCreateProject(t *testing.T) {
 		},
 		"FailsWithAlreadyExistingID": func(ctx context.Context, t *testing.T, env *mock.Environment, pRef model.ProjectRef, u user.DBUser) {
 			require.NoError(t, pRef.Insert())
-			assert.Error(t, CreateProject(ctx, env, &pRef, &u))
+			created, err := CreateProject(ctx, env, &pRef, &u)
+			require.Error(t, err)
+			require.False(t, created)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -687,7 +687,7 @@ func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	u := gimlet.GetUser(ctx).(*user.DBUser)
 
-	if err = data.CreateProject(ctx, h.env, &dbProjectRef, u); err != nil {
+	if _, err = data.CreateProject(ctx, h.env, &dbProjectRef, u); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating project '%s'", h.projectName))
 	}
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -366,7 +366,8 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting evergreen settings"))
 	}
-	_, err = dbModel.ValidateEnabledProjectsLimit(h.newProjectRef.Id, settings, *mergedProjectRef)
+	originalMergedRef, err := dbModel.GetProjectRefMergedWithRepo(*h.originalProject)
+	_, err = dbModel.ValidateEnabledProjectsLimit(h.newProjectRef.Id, settings, originalMergedRef, mergedProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "validating project creation for project '%s'", h.newProjectRef.Identifier))
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -366,7 +366,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting evergreen settings"))
 	}
-	_, err = dbModel.ValidateProjectCreation(h.newProjectRef.Id, settings, mergedProjectRef)
+	_, err = dbModel.ValidateEnabledProjectsLimit(h.newProjectRef.Id, settings, *mergedProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "validating project creation for project '%s'", h.newProjectRef.Identifier))
 	}

--- a/service/project.go
+++ b/service/project.go
@@ -355,13 +355,13 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	_, err = model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
+	statusCode, err := model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
 		Enabled: utility.ToBoolPtr(responseRef.Enabled),
 		Owner:   responseRef.Owner,
 		Repo:    responseRef.Repo,
 	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), statusCode)
 		return
 	}
 

--- a/service/project.go
+++ b/service/project.go
@@ -355,7 +355,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	statusCode, err := model.ValidateProjectCreation(responseRef.Id, settings, &model.ProjectRef{
+	statusCode, err := model.ValidateEnabledProjectsLimit(responseRef.Id, settings, model.ProjectRef{
 		Enabled: utility.ToBoolPtr(responseRef.Enabled),
 		Owner:   responseRef.Owner,
 		Repo:    responseRef.Repo,

--- a/service/project.go
+++ b/service/project.go
@@ -350,19 +350,21 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	settings, err := evergreen.GetConfig()
-	if err != nil {
-		uis.LoggedError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	statusCode, err := model.ValidateEnabledProjectsLimit(responseRef.Id, settings, &origProjectRef, &model.ProjectRef{
-		Enabled: utility.ToBoolPtr(responseRef.Enabled),
-		Owner:   responseRef.Owner,
-		Repo:    responseRef.Repo,
-	})
-	if err != nil {
-		http.Error(w, err.Error(), statusCode)
-		return
+	if responseRef.Enabled {
+		settings, err := evergreen.GetConfig()
+		if err != nil {
+			uis.LoggedError(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		statusCode, err := model.ValidateEnabledProjectsLimit(responseRef.Id, settings, &origProjectRef, &model.ProjectRef{
+			Enabled: utility.ToBoolPtr(responseRef.Enabled),
+			Owner:   responseRef.Owner,
+			Repo:    responseRef.Repo,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), statusCode)
+			return
+		}
 	}
 
 	errs := []string{}

--- a/service/project.go
+++ b/service/project.go
@@ -355,7 +355,7 @@ func (uis *UIServer) modifyProject(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	statusCode, err := model.ValidateEnabledProjectsLimit(responseRef.Id, settings, model.ProjectRef{
+	statusCode, err := model.ValidateEnabledProjectsLimit(responseRef.Id, settings, &origProjectRef, &model.ProjectRef{
 		Enabled: utility.ToBoolPtr(responseRef.Enabled),
 		Owner:   responseRef.Owner,
 		Repo:    responseRef.Repo,


### PR DESCRIPTION
[EVG-18784](https://jira.mongodb.org/browse/EVG-18784)

### Description 
when creating/copying projects on spruce, users will now receive a warning toast 

the validation function has been updated to return an error code and handle all edge cases that it didn't handle before 
(test has been added for that)

### Testing 
staging
creating and copying projects that are at the limit will warn the users
    
#### Does this need documentation?
eventually (there is a ticket for create project documentation)