### PR TITLE
EVG-18956 clear roles when offboarding user

### DIFF
--- a/model/user/db.go
+++ b/model/user/db.go
@@ -486,9 +486,14 @@ func ClearLoginCache(user gimlet.User) error {
 	return nil
 }
 
-// ClearUserSettings clears one user's settings
-func ClearUserSettings(userId string) error {
-	update := bson.M{"$set": bson.M{SettingsKey: bson.M{}}}
+// ClearUser clears one user's settings, roles, and login cache.
+func ClearUser(userId string) error {
+	update := bson.M{
+		"$unset": bson.M{
+			SettingsKey:   1,
+			RolesKey:      1,
+			LoginCacheKey: 1,
+		}}
 	query := bson.M{IdKey: userId}
 	if err := UpdateOne(query, update); err != nil {
 		return errors.Wrap(err, "unsetting user settings")

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -24,7 +24,7 @@ type UserTestSuite struct {
 	users []*DBUser
 }
 
-func TestDBUser(t *testing.T) {
+func TestUserTestSuite(t *testing.T) {
 	s := &UserTestSuite{}
 	suite.Run(t, s)
 }
@@ -38,7 +38,7 @@ func (s *UserTestSuite) SetupTest() {
 	s.NoError(db.ClearCollections(Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	s.Require().NoError(db.CreateCollections(evergreen.ScopeCollection))
 	s.users = []*DBUser{
-		&DBUser{
+		{
 			Id:     "Test1",
 			APIKey: "12345",
 			Settings: UserSettings{
@@ -56,7 +56,7 @@ func (s *UserTestSuite) SetupTest() {
 				TTL:          time.Now(),
 			},
 		},
-		&DBUser{
+		{
 			Id: "Test2",
 			PubKeys: []PubKey{
 				{
@@ -71,7 +71,7 @@ func (s *UserTestSuite) SetupTest() {
 				TTL:   time.Now().Add(-time.Hour),
 			},
 		},
-		&DBUser{
+		{
 			Id: "Test3",
 			PubKeys: []PubKey{
 				{
@@ -82,14 +82,14 @@ func (s *UserTestSuite) SetupTest() {
 			},
 			APIKey: "67890",
 		},
-		&DBUser{
+		{
 			Id: "Test4",
 			LoginCache: LoginCache{
 				Token: "5678",
 				TTL:   time.Now(),
 			},
 		},
-		&DBUser{
+		{
 			Id:     "Test5",
 			APIKey: "api",
 			LoginCache: LoginCache{
@@ -99,7 +99,7 @@ func (s *UserTestSuite) SetupTest() {
 				TTL:          time.Now(),
 			},
 		},
-		&DBUser{
+		{
 			Id: "Test6",
 			PubKeys: []PubKey{
 				{
@@ -810,7 +810,7 @@ func TestViewableProjectSettings(t *testing.T) {
 
 func (s *UserTestSuite) TestClearUserSettings() {
 	// Error on non-existent user
-	s.Error(ClearUserSettings("asdf"))
+	s.Error(ClearUser("asdf"))
 
 	emptySettings := UserSettings{
 		Timezone: "", Region: "", GithubUser: GithubUser{UID: 0, LastKnownAs: ""},
@@ -826,13 +826,16 @@ func (s *UserTestSuite) TestClearUserSettings() {
 	s.NotNil(u)
 	s.NotEqual(u.Settings, emptySettings)
 	s.Equal("Test1", u.Id)
+	s.NoError(u.AddRole("r1p1"))
 
-	s.NoError(ClearUserSettings(u.Id))
+	s.NoError(ClearUser(u.Id))
 
-	// settings should now be empty
+	// Settings and roles should now be empty
 	u, err = FindOneById(s.users[0].Id)
 	s.NoError(err)
 	s.NotNil(u)
 
 	s.Equal(u.Settings, emptySettings)
+	s.Empty(u.Settings)
+	s.Empty(u.Roles())
 }

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -808,25 +808,17 @@ func TestViewableProjectSettings(t *testing.T) {
 	assert.NotContains(t, projects, "other")
 }
 
-func (s *UserTestSuite) TestClearUserSettings() {
+func (s *UserTestSuite) TestClearUser() {
 	// Error on non-existent user
 	s.Error(ClearUser("asdf"))
-
-	emptySettings := UserSettings{
-		Timezone: "", Region: "", GithubUser: GithubUser{UID: 0, LastKnownAs: ""},
-		SlackUsername: "", SlackMemberId: "", Notifications: NotificationPreferences{BuildBreak: "",
-			BuildBreakID: "", PatchFinish: "", PatchFinishID: "", PatchFirstFailure: "",
-			PatchFirstFailureID: "", SpawnHostExpiration: "", SpawnHostExpirationID: "",
-			SpawnHostOutcome: "", SpawnHostOutcomeID: "", CommitQueue: "", CommitQueueID: ""},
-		UseSpruceOptions: UseSpruceOptions{PatchPage: false, SpruceV1: false, HasUsedSpruceBefore: false, HasUsedMainlineCommitsBefore: false},
-	}
 
 	u, err := FindOneById(s.users[0].Id)
 	s.NoError(err)
 	s.NotNil(u)
-	s.NotEqual(u.Settings, emptySettings)
+	s.NotEmpty(u.Settings)
 	s.Equal("Test1", u.Id)
 	s.NoError(u.AddRole("r1p1"))
+	s.NotEmpty(u.SystemRoles)
 
 	s.NoError(ClearUser(u.Id))
 
@@ -835,7 +827,7 @@ func (s *UserTestSuite) TestClearUserSettings() {
 	s.NoError(err)
 	s.NotNil(u)
 
-	s.Equal(u.Settings, emptySettings)
 	s.Empty(u.Settings)
 	s.Empty(u.Roles())
+	s.Empty(u.LoginCache)
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -405,8 +405,8 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 			"context": "user offboarding",
 			"user":    ch.user,
 		}))
-		err = user.ClearUserSettings(ch.user)
-		catcher.Wrapf(err, "clearing user settings for user '%s'", ch.user)
+		err = user.ClearUser(ch.user)
+		catcher.Wrapf(err, "clearing user '%s'", ch.user)
 	}
 
 	if catcher.HasErrors() {


### PR DESCRIPTION
[EVG-18956](https://jira.mongodb.org/browse/EVG-18956)

### Description 
We don't delete the user doc to keep pages from breaking but we don't need to keep the roles; removing them keeps the results from querying for users of a role clean.

### Testing 
Added unit test.
    
#### Does this need documentation?
Will add to the documentation for the offboard route.
