### PR TITLE
EVG-7029 Error when multi-word commit message is provided without quotes in CLI

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2023-02-08"
+	ClientVersion = "2023-02-14"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-02-08"

--- a/operations/before.go
+++ b/operations/before.go
@@ -62,6 +62,16 @@ var (
 		return c.Set(hostFlagName, host)
 	}
 
+	checkCommitMessageFlagFlag = func(c *cli.Context) error {
+		message := c.String(commitMessageFlag)
+		if message != "" {
+			if c.NArg() > 1 {
+				return errors.New("multiple arguments passed in for commit message, please consider using quotations")
+			}
+		}
+		return nil
+	}
+
 	requireProjectFlag = func(c *cli.Context) error {
 		if c.String(projectFlagName) == "" {
 			return errors.New("must specify a project")

--- a/operations/before.go
+++ b/operations/before.go
@@ -62,7 +62,7 @@ var (
 		return c.Set(hostFlagName, host)
 	}
 
-	checkCommitMessageFlagFlag = func(c *cli.Context) error {
+	checkCommitMessageFlag = func(c *cli.Context) error {
 		message := c.String(commitMessageFlag)
 		if message != "" {
 			if c.NArg() > 1 {

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -257,7 +257,7 @@ func enqueuePatch() cli.Command {
 		)),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
-			checkCommitMessageFlagFlag,
+			checkCommitMessageFlag,
 			requirePatchIDFlag,
 			setPlainLogger,
 		),

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -257,6 +257,7 @@ func enqueuePatch() cli.Command {
 		)),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
+			checkCommitMessageFlagFlag,
 			requirePatchIDFlag,
 			setPlainLogger,
 		),


### PR DESCRIPTION
[EVG-7029](https://jira.mongodb.org/browse/EVG-7029)

### Description 
Currently the `commit-message` flag available in the `enqueue-patch` CLI command does not provide any error that unused parameters have been passed in.  For example, running `enqueue-patch --commit-message hello world` will result in the commit message being just "hello".

Added a change to check if there are more than 1 arguments passed to the `commit-message` flag, and error if so.
### Testing 
Built CLI locally and confirmed that passing in a commit message phrase without quotes causes an error, and succeeds otherwise.
    
#### Does this need documentation?
N/A
