### PR TITLE
EVG-18744 add more host fields to termination logging

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -298,6 +298,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		"total_uptime_secs":  j.host.TerminationTime.Sub(j.host.CreationTime).Seconds(),
 		"termination_time":   j.host.TerminationTime,
 		"creation_time":      j.host.CreationTime,
+		"started_by":         j.host.StartedBy,
 	}
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
 		terminationMessage["total_billable_secs"] = j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -299,6 +299,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		"termination_time":   j.host.TerminationTime,
 		"creation_time":      j.host.CreationTime,
 		"started_by":         j.host.StartedBy,
+		"user_host":          j.host.UserHost,
 	}
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
 		terminationMessage["total_billable_secs"] = j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()


### PR DESCRIPTION
[EVG-18744](https://jira.mongodb.org/browse/EVG-18744)

### Description 
Add `started_by` to the `host successfully terminated` message so we can filter out non-`mci` started hosts when looking at idle time. Add `user_host` so we can differentiate between non-`mci` hosts that are started by users from those started by tasks.
