### PR TITLE
EVG-18957: increase timeout for fetching project files

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -230,7 +230,7 @@ func GetPatchedProject(ctx context.Context, settings *evergreen.Settings, p *pat
 	}
 
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	env := evergreen.GetEnvironment()
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-18957

### Description 
This timeout is used to put a deadline on the process of fetching all the GitHub YAML files (i.e. the main YAML and its includes) and apply the patch diff to them. 10 seconds seems kind of short, especially since YAMLs can be split across many files, so increasing the timeout should reduce such flakiness.

### Testing 
Not really something that's testable since it's a timeout against a third-party app.
    
#### Does this need documentation?
N/A