### PR TITLE
EVG-7440 Do not call checks API on MarkEnd unless patch status changes

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -426,11 +426,18 @@ func restartTasks(allFinishedTasks []task.Task, caller, versionId string) error 
 		}
 	}
 
+	buildIdsMap := map[string]bool{}
+	var buildIds []string
+	for _, t := range allFinishedTasks {
+		buildIdsMap[t.BuildId] = true
+	}
+	for buildId := range buildIdsMap {
+		buildIds = append(buildIds, buildId)
+	}
 	if err := build.SetBuildStartedForTasks(allFinishedTasks, caller); err != nil {
 		return errors.Wrap(err, "setting builds started")
 	}
-
-	return errors.Wrap(setVersionStatus(versionId, evergreen.VersionStarted), "changing version status")
+	return errors.Wrap(UpdateVersionAndPatchStatusForBuilds(buildIds), "updating version status")
 }
 
 // RestartVersions restarts selected tasks for a set of versions.

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -345,7 +345,7 @@ func RestartVersion(versionId string, taskIds []string, abortInProgress bool, ca
 	if len(allFinishedTasks) == 0 {
 		return nil
 	}
-	return restartTasks(allFinishedTasks, caller, versionId)
+	return restartTasks(allFinishedTasks, caller)
 }
 
 // getTasksToReset returns all finished tasks that should be reset given an initial input list of
@@ -370,7 +370,7 @@ func getTasksToReset(taskIds []string) ([]task.Task, error) {
 
 // restartTasks restarts all finished tasks in the given list that are not part of
 // a single host task group.
-func restartTasks(allFinishedTasks []task.Task, caller, versionId string) error {
+func restartTasks(allFinishedTasks []task.Task, caller string) error {
 	toArchive := []task.Task{}
 	for _, t := range allFinishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() {
@@ -467,7 +467,7 @@ func RestartBuild(build *build.Build, taskIds []string, abortInProgress bool, ca
 	if len(tasksToReset) == 0 {
 		return nil
 	}
-	return errors.Wrap(restartTasks(tasksToReset, caller, build.Version), "restarting tasks")
+	return errors.Wrap(restartTasks(tasksToReset, caller), "restarting tasks")
 }
 
 func CreateTasksCache(tasks []task.Task) []build.TaskCache {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1127,6 +1127,36 @@ func updateBuildGithubStatus(b *build.Build, buildTasks []task.Task) error {
 	return b.UpdateGithubCheckStatus(buildStatus.status)
 }
 
+// checkUpdateBuildPRStatus checks if the build is coming from a PR, and if so
+// sends its updated status to GitHub to reflect the status of the build.
+func checkUpdateBuildPRStatus(b *build.Build) error {
+	if !evergreen.IsGitHubPatchRequester(b.Requester) {
+		return nil
+	}
+	p, err := patch.FindOneId(b.Version)
+	if err != nil {
+		return errors.Wrapf(err, "finding patch '%s'", b.Version)
+	}
+	if p == nil {
+		return errors.Errorf("patch '%s' not found", b.Version)
+	}
+	if p.IsGithubPRPatch() && !evergreen.IsFinishedPatchStatus(p.Status) {
+		input := thirdparty.SendGithubStatusInput{
+			VersionId: p.Id.Hex(),
+			Owner:     p.GithubPatchData.BaseOwner,
+			Repo:      p.GithubPatchData.BaseRepo,
+			Ref:       p.GithubPatchData.HeadHash,
+			Desc:      "patch status change",
+			Caller:    "pr-task-reset",
+			Context:   fmt.Sprintf("evergreen/%s", b.BuildVariant),
+		}
+		if err = thirdparty.SendVersionStatusToGithub(input); err != nil {
+			return errors.Wrapf(err, "sending patch '%s' status to Github", p.Id.Hex())
+		}
+	}
+	return nil
+}
+
 // updateBuildStatus updates the status of the build based on its tasks' statuses
 // Returns true if the build's status has changed or if all of the build's tasks become blocked.
 func updateBuildStatus(b *build.Build) (bool, error) {
@@ -1301,7 +1331,9 @@ func updateVersionStatus(v *Version) (string, error) {
 	return versionStatus, nil
 }
 
-func UpdatePatchStatus(p *patch.Patch, versionStatus, buildVariant string) error {
+// UpdatePatchStatus updates the status of a patch. For PR patches, the build associated
+// with the passed in buildVariant has its GitHub status updated.
+func UpdatePatchStatus(p *patch.Patch, versionStatus string) error {
 	patchStatus, err := evergreen.VersionStatusToPatchStatus(versionStatus)
 	if err != nil {
 		return errors.Wrapf(err, "getting patch status from version status '%s'", versionStatus)
@@ -1317,24 +1349,8 @@ func UpdatePatchStatus(p *patch.Patch, versionStatus, buildVariant string) error
 		if err = p.MarkFinished(patchStatus, time.Now()); err != nil {
 			return errors.Wrapf(err, "marking patch '%s' as finished with status '%s'", p.Id.Hex(), patchStatus)
 		}
-	} else {
-		if err = p.UpdateStatus(patchStatus); err != nil {
-			return errors.Wrapf(err, "updating patch '%s' with status '%s'", p.Id.Hex(), patchStatus)
-		}
-		if p.IsGithubPRPatch() {
-			input := thirdparty.SendGithubStatusInput{
-				VersionId: p.Id.Hex(),
-				Owner:     p.GithubPatchData.BaseOwner,
-				Repo:      p.GithubPatchData.BaseRepo,
-				Ref:       p.GithubPatchData.HeadHash,
-				Desc:      "patch status change",
-				Caller:    "pr-task-reset",
-				Context:   fmt.Sprintf("evergreen/%s", buildVariant),
-			}
-			if err = thirdparty.SendVersionStatusToGithub(input); err != nil {
-				return errors.Wrapf(err, "sending patch '%s' status to Github", p.Id.Hex())
-			}
-		}
+	} else if err = p.UpdateStatus(patchStatus); err != nil {
+		return errors.Wrapf(err, "updating patch '%s' with status '%s'", p.Id.Hex(), patchStatus)
 	}
 
 	isDone, parentPatch, err := p.GetFamilyInformation()
@@ -1376,6 +1392,10 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 		return nil
 	}
 
+	if err = checkUpdateBuildPRStatus(taskBuild); err != nil {
+		return errors.Wrapf(err, "updating build '%s' PR status", taskBuild.Id)
+	}
+
 	taskVersion, err := VersionFindOneId(t.Version)
 	if err != nil {
 		return errors.Wrapf(err, "getting version '%s' for task '%s'", t.Version, t.Id)
@@ -1397,7 +1417,7 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 		if p == nil {
 			return errors.Errorf("no patch found for version '%s'", taskVersion.Id)
 		}
-		if err = UpdatePatchStatus(p, newVersionStatus, taskBuild.BuildVariant); err != nil {
+		if err = UpdatePatchStatus(p, newVersionStatus); err != nil {
 			return errors.Wrapf(err, "updating patch '%s' status", p.Id.Hex())
 		}
 
@@ -1427,6 +1447,8 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	return nil
 }
 
+// UpdateVersionAndPatchStatusForBuilds updates the status of all versions, patches and
+// builds associated with the given input list of build IDs.
 func UpdateVersionAndPatchStatusForBuilds(buildIds []string) error {
 	if len(buildIds) == 0 {
 		return nil
@@ -1436,8 +1458,9 @@ func UpdateVersionAndPatchStatusForBuilds(buildIds []string) error {
 		return errors.Wrapf(err, "fetching builds")
 	}
 
-	versionsToUpdate := make(map[string]string)
-	bvMap := make(map[string]string)
+	// Maintain a list of builds for each version because we may
+	// be updating many builds for the same version.
+	versionSet := make(map[string]bool)
 	for _, build := range builds {
 		buildStatusChanged, err := updateBuildStatus(&build)
 		if err != nil {
@@ -1447,17 +1470,18 @@ func UpdateVersionAndPatchStatusForBuilds(buildIds []string) error {
 		if !buildStatusChanged {
 			continue
 		}
-
-		versionsToUpdate[build.Version] = build.Id
-		bvMap[build.Id] = build.BuildVariant
+		if err = checkUpdateBuildPRStatus(&build); err != nil {
+			return errors.Wrapf(err, "updating build '%s' PR status", build.Id)
+		}
+		versionSet[build.Version] = true
 	}
-	for versionId, buildId := range versionsToUpdate {
+	for versionId := range versionSet {
 		buildVersion, err := VersionFindOneId(versionId)
 		if err != nil {
-			return errors.Wrapf(err, "getting version '%s' for build '%s'", versionId, buildId)
+			return errors.Wrapf(err, "getting version '%s'", versionId)
 		}
 		if buildVersion == nil {
-			return errors.Errorf("no version '%s' found for build '%s'", versionId, buildId)
+			return errors.Errorf("no version '%s' found", versionId)
 		}
 		newVersionStatus, err := updateVersionStatus(buildVersion)
 		if err != nil {
@@ -1472,7 +1496,7 @@ func UpdateVersionAndPatchStatusForBuilds(buildIds []string) error {
 			if p == nil {
 				return errors.Errorf("no patch found for version '%s'", buildVersion.Id)
 			}
-			if err = UpdatePatchStatus(p, newVersionStatus, bvMap[buildId]); err != nil {
+			if err = UpdatePatchStatus(p, newVersionStatus); err != nil {
 				return errors.Wrapf(err, "updating patch '%s' status", p.Id.Hex())
 			}
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1392,10 +1392,6 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 		return nil
 	}
 
-	if err = checkUpdateBuildPRStatus(taskBuild); err != nil {
-		return errors.Wrapf(err, "updating build '%s' PR status", taskBuild.Id)
-	}
-
 	taskVersion, err := VersionFindOneId(t.Version)
 	if err != nil {
 		return errors.Wrapf(err, "getting version '%s' for task '%s'", t.Version, t.Id)
@@ -1407,6 +1403,12 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	newVersionStatus, err := updateVersionStatus(taskVersion)
 	if err != nil {
 		return errors.Wrapf(err, "updating version '%s' status", taskVersion.Id)
+	}
+
+	if newVersionStatus != taskVersion.Status {
+		if err = checkUpdateBuildPRStatus(taskBuild); err != nil {
+			return errors.Wrapf(err, "updating build '%s' PR status", taskBuild.Id)
+		}
 	}
 
 	if evergreen.IsPatchRequester(taskVersion.Requester) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1289,9 +1289,9 @@ func TestUpdateVersionAndPatchStatusForBuilds(t *testing.T) {
 
 	sender := send.MakeInternalLogger()
 	assert.NoError(t, grip.SetSender(sender))
-	defer func(s send.Sender) {
-		assert.NoError(t, grip.SetSender(s))
-	}(grip.GetSender())
+	defer func() {
+		assert.NoError(t, grip.SetSender(send.MakeNative()))
+	}()
 
 	b := &build.Build{
 		Id:        "buildtest",

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -22,9 +22,12 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1277,6 +1280,84 @@ func TestUpdateBuildStatusForTask(t *testing.T) {
 		})
 	}
 
+}
+
+func TestUpdateVersionAndPatchStatusForBuilds(t *testing.T) {
+	require.NoError(t, db.ClearCollections(build.Collection, patch.Collection, task.Collection, VersionCollection))
+	uiConfig := evergreen.UIConfig{Url: "http://localhost"}
+	require.NoError(t, uiConfig.Set())
+	sender := send.MakeInternalLogger()
+	assert.NoError(t, grip.SetSender(sender))
+	b := &build.Build{
+		Id:        "buildtest",
+		Status:    evergreen.BuildFailed,
+		Requester: evergreen.GithubPRRequester,
+		Version:   "aaaaaaaaaaff001122334455",
+		Activated: true,
+	}
+	p := &patch.Patch{
+		Id:              patch.NewId(b.Version),
+		Status:          evergreen.PatchFailed,
+		GithubPatchData: thirdparty.GithubPatch{HeadOwner: "q"},
+	}
+	v := &Version{
+		Id:        b.Version,
+		Status:    evergreen.VersionFailed,
+		Requester: evergreen.GithubPRRequester,
+	}
+	testTask := task.Task{
+		Id:        "testone",
+		Activated: true,
+		BuildId:   b.Id,
+		Project:   "sample",
+		Status:    evergreen.TaskUndispatched,
+		Version:   b.Version,
+	}
+	anotherTask := task.Task{
+		Id:        "two",
+		Activated: true,
+		BuildId:   b.Id,
+		Project:   "sample",
+		Status:    evergreen.TaskFailed,
+		StartTime: time.Now().Add(-time.Hour),
+		Version:   b.Version,
+	}
+
+	assert.NoError(t, b.Insert())
+	assert.NoError(t, p.Insert())
+	assert.NoError(t, v.Insert())
+	assert.NoError(t, testTask.Insert())
+	assert.NoError(t, anotherTask.Insert())
+
+	assert.NoError(t, UpdateVersionAndPatchStatusForBuilds([]string{b.Id}))
+	// Confirm that the build status was updated to pending in the PR by checking for appropriate Splunk logs
+	messageString, ok := sender.GetMessageSafe()
+	require.True(t, ok)
+	assert.Contains(t, messageString.Message.String(), "called github status send")
+	dbBuild, err := build.FindOneId(b.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.BuildStarted, dbBuild.Status)
+	dbPatch, err := patch.FindOneId(p.Id.Hex())
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.PatchStarted, dbPatch.Status)
+
+	err = task.UpdateOne(
+		bson.M{task.IdKey: testTask.Id},
+		bson.M{"$set": bson.M{task.StatusKey: evergreen.TaskFailed}},
+	)
+	assert.NoError(t, err)
+	assert.NoError(t, UpdateVersionAndPatchStatusForBuilds([]string{b.Id}))
+	// Confirm that the build status was not updated to pending in the PR because the build
+	// should have changed to failed.
+	messageString, ok = sender.GetMessageSafe()
+	require.True(t, ok)
+	assert.NotContains(t, messageString.Message.String(), "called github status send")
+	dbBuild, err = build.FindOneId(b.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.BuildFailed, dbBuild.Status)
+	dbPatch, err = patch.FindOneId(p.Id.Hex())
+	assert.NoError(t, err)
+	assert.Equal(t, evergreen.PatchFailed, dbPatch.Status)
 }
 
 func TestUpdateBuildStatusForTaskReset(t *testing.T) {

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -52,13 +52,15 @@ func TestRestartVersion(t *testing.T) {
 	// Insert data for the test paths
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
 	versions := []*Version{
-		{Id: "version3"},
+		{Id: "version1"},
 	}
 	tasks := []*task.Task{
-		{Id: "task5", Version: "version3", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build1"},
+		{Id: "task1", Version: "version1", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build1"},
+		{Id: "task2", Version: "version1", Aborted: false, Status: evergreen.TaskSucceeded, BuildId: "build2"},
 	}
 	builds := []*build.Build{
-		{Id: "build1"},
+		{Id: "build1", Version: "version1"},
+		{Id: "build2", Version: "version1"},
 	}
 	for _, item := range versions {
 		require.NoError(t, item.Insert())
@@ -70,21 +72,21 @@ func TestRestartVersion(t *testing.T) {
 		require.NoError(t, item.Insert())
 	}
 
-	versionId := "version3"
-	err := RestartTasksInVersion(versionId, true, "caller3")
+	versionId := "version1"
+	err := RestartTasksInVersion(versionId, true, "caller")
 	assert.NoError(t, err)
 
 	// When a version is restarted, all of its completed tasks should be reset.
 	// (task.Status should be undispatched)
-	t5, _ := task.FindOneId("task5")
-	assert.Equal(t, versionId, t5.Version)
-	assert.Equal(t, evergreen.TaskUndispatched, t5.Status)
+	t1, _ := task.FindOneId("task1")
+	assert.Equal(t, versionId, t1.Version)
+	assert.Equal(t, evergreen.TaskUndispatched, t1.Status)
 
 	// Build status for all builds containing the tasks that we touched
 	// should be updated.
 	b1, _ := build.FindOneId("build1")
-	assert.Equal(t, evergreen.BuildStarted, b1.Status)
-	assert.Equal(t, "caller3", b1.ActivatedBy)
+	assert.Equal(t, evergreen.BuildCreated, b1.Status)
+	assert.Equal(t, "caller", b1.ActivatedBy)
 }
 
 func TestFindVersionByIdFail(t *testing.T) {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -486,7 +486,7 @@ func addGithubCheckSubscriptions(v *model.Version) error {
 		Caller:    RunnerName,
 		Context:   "evergreen",
 	}
-	err := thirdparty.SendVersionStatusToGithub(input)
+	err := thirdparty.SendPendingStatusToGithub(input)
 	if err != nil {
 		catcher.Wrap(err, "failed to send version status to github")
 	}

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1656,7 +1656,8 @@ func TestHandleEndTaskForCommitQueueTask(t *testing.T) {
 			}
 			assert.NoError(t, version3.Insert())
 			b := &build.Build{
-				Id: "build",
+				Id:      "build",
+				Version: p1,
 			}
 			assert.NoError(t, b.Insert())
 			patch1 := patch.Patch{

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -52,7 +52,7 @@ type GithubPatch struct {
 	CommitMessage  string `bson:"commit_message"`
 }
 
-// SendGithubStatusInput is the input to the SendVersionStatusToGithub function and contains
+// SendGithubStatusInput is the input to the SendPendingStatusToGithub function and contains
 // all the information associated with a version necessary to send a status to GitHub.
 type SendGithubStatusInput struct {
 	VersionId string
@@ -295,9 +295,9 @@ func GetGithubFile(ctx context.Context, oauthToken, owner, repo, path, ref strin
 	return file, nil
 }
 
-// SendVersionStatusToGithub sends a pending status to a Github PR patch
+// SendPendingStatusToGithub sends a pending status to a Github PR patch
 // associated with a given version.
-func SendVersionStatusToGithub(input SendGithubStatusInput) error {
+func SendPendingStatusToGithub(input SendGithubStatusInput) error {
 	flags, err := evergreen.GetServiceFlags()
 	if err != nil {
 		return errors.Wrap(err, "error retrieving admin settings")


### PR DESCRIPTION
[EVG-7440](https://jira.mongodb.org/browse/EVG-7440)

### Description 
The [previous PR](https://github.com/evergreen-ci/evergreen/pull/6155) decoupled PR status updating from the `UpdatePatchStatus` function for understandability purposes, yet when the new `checkUpdateBuildPRStatus` was placed in `UpdateBuildAndVersionStatusForTask` it would only perform the PR status update if the task's [build status had changed](https://github.com/evergreen-ci/evergreen/pull/6155/files#diff-4bef865c41d6d16e1056e61806c23fb8bbc896b3739472dd60f0dd463ef5d2b9R1377), not if the patch status had changed.  This means that every time a build in a PR changed status (whether it was a restart, or simply `MarkEnd` calling) we were calling the GitHub checks API, rather than only when the overall PR changed status. 

Although I think this isn't necessarily wrong it caused an increase in GitHub checks API usage and made it more likely for us to breach our GitHub API budget.

Since the purpose of this ticket was to address UX during manual restarts of builds & versions, I've reverted the logic in `UpdateBuildAndVersionStatusForTask` [to only do a PR update when the patch status changes ](https://github.com/evergreen-ci/evergreen/pull/6270/files#diff-4bef865c41d6d16e1056e61806c23fb8bbc896b3739472dd60f0dd463ef5d2b9R1408)to reduce GitHub API usage. This is the only difference between this PR and the previous PR.
### Testing 
Tested in staging    
#### Does this need documentation?
N/A