### PR TITLE
EVG-18812 Force the commit queue to respect branch protection rules 

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -320,13 +320,13 @@ func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc C
 
 	if !thirdparty.IsUnblockedGithubStatus(pr.GetMergeableState()) {
 		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", pr.GetMergeableState())
-		grip.Error(message.Fields{
+		grip.Debug(message.Fields{
 			"message":        errMsg,
-			"state":          *pr.MergeableState,
+			"state":          pr.GetMergeableState(),
 			"owner":          userRepo.Owner,
 			"repo":           userRepo.Repo,
-			"pr_title":       *pr.Title,
-			"commit_message": *pr.Number,
+			"pr_title":       pr.GetTitle(),
+			"commit_message": pr.GetNumber(),
 		})
 		sendErr := thirdparty.SendCommitQueueGithubStatus(env, pr, message.GithubStateFailure, errMsg, "")
 

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -319,7 +319,7 @@ func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc C
 	}
 
 	if !thirdparty.IsUnblockedGithubStatus(pr.GetMergeableState()) {
-		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", *pr.MergeableState)
+		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", pr.GetMergeableState())
 		grip.Error(message.Fields{
 			"message":        errMsg,
 			"state":          *pr.MergeableState,

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -318,7 +318,7 @@ func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc C
 		return nil, errors.New("PR contains no base branch label")
 	}
 
-	if !thirdparty.IsUnblockedGithubStatus(*pr.MergeableState) {
+	if !thirdparty.IsUnblockedGithubStatus(pr.GetMergeableState()) {
 		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", *pr.MergeableState)
 		grip.Error(message.Fields{
 			"message":        errMsg,

--- a/rest/data/mock_impl.go
+++ b/rest/data/mock_impl.go
@@ -34,6 +34,7 @@ func (pc *MockGitHubConnectorImpl) GetGitHubPR(ctx context.Context, owner, repo 
 		Head: &github.PullRequestBranch{
 			SHA: github.String("abcdef1234"),
 		},
+		MergeableState: utility.ToStringPtr("clean"),
 	}, nil
 }
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -58,6 +58,7 @@ const (
 	githubPrUnstable  = "unstable"
 )
 
+// IsUnblockedGithubStatus returns true if the status is in the list of unblocked statuses
 func IsUnblockedGithubStatus(status string) bool {
 	return utility.StringSliceContains(UnblockedGithubStatuses, status)
 }
@@ -471,7 +472,7 @@ func GetCommitDiff(ctx context.Context, oauthToken, repoOwner, repo, sha string)
 		}
 	} else {
 		errMsg := fmt.Sprintf("nil response from '%s/%s': sha: '%s': %v", repoOwner, repo, sha, err)
-		grip.Error(message.Fields{
+		grip.Debug(message.Fields{
 			"message": errMsg,
 			"owner":   repoOwner,
 			"repo":    repo,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -36,6 +36,32 @@ const (
 	GithubInvestigation = "Github API Limit Investigation"
 )
 
+var UnblockedGithubStatuses = []string{
+	githubPrBehind,
+	githubPrClean,
+	githubPrDirty,
+	githubPrDraft,
+	githubPrHas_Hooks,
+	githubPrUnknown,
+	githubPrUnstable,
+}
+
+const (
+	// all PR statuses except for "blocked" based on statuses listed here:
+	// https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+	githubPrBehind    = "behind"
+	githubPrClean     = "clean"
+	githubPrDirty     = "dirty"
+	githubPrDraft     = "draft"
+	githubPrHas_Hooks = "has_hooks"
+	githubPrUnknown   = "unknown"
+	githubPrUnstable  = "unstable"
+)
+
+func IsUnblockedGithubStatus(status string) bool {
+	return utility.StringSliceContains(UnblockedGithubStatuses, status)
+}
+
 // GithubPatch stores patch data for patches create from GitHub pull requests
 type GithubPatch struct {
 	PRNumber       int    `bson:"pr_number"`

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -50,7 +50,7 @@ const (
 	// All PR statuses except for "blocked" based on statuses listed here:
 	// https://docs.github.com/en/graphql/reference/enums#mergestatestatus
 	// Because the pr.MergeableState is not documented, it can change without
-	// notice. that's why we want to only allow fields we know to be unblocked
+	// notice. That's why we want to only allow fields we know to be unblocked
 	// rather than simply blocking the "blocked" status. That way if it does
 	// change, it doesn't fail silently.
 	githubPrBehind    = "behind"

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -47,8 +47,12 @@ var UnblockedGithubStatuses = []string{
 }
 
 const (
-	// all PR statuses except for "blocked" based on statuses listed here:
+	// All PR statuses except for "blocked" based on statuses listed here:
 	// https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+	// Because the pr.MergeableState is not documented, it can change without
+	// notice. that's why we want to only allow fields we know to be unblocked
+	// rather than simply blocking the "blocked" status. That way if it does
+	// change, it doesn't fail silently.
 	githubPrBehind    = "behind"
 	githubPrClean     = "clean"
 	githubPrDirty     = "dirty"
@@ -472,7 +476,7 @@ func GetCommitDiff(ctx context.Context, oauthToken, repoOwner, repo, sha string)
 		}
 	} else {
 		errMsg := fmt.Sprintf("nil response from '%s/%s': sha: '%s': %v", repoOwner, repo, sha, err)
-		grip.Debug(message.Fields{
+		grip.Error(message.Fields{
 			"message": errMsg,
 			"owner":   repoOwner,
 			"repo":    repo,


### PR DESCRIPTION
[EVG-18812](https://jira.mongodb.org/browse/EVG-18812)

### Description 
This will block a pr from getting enqueued to the commit queue if branch protection rules are not met. 

### Testing 
![image](https://user-images.githubusercontent.com/13104717/222283346-28eebb1c-c7a1-4da6-8182-4382bdad3183.png)

#### Does this need documentation?
yes: [EVG-19096](https://jira.mongodb.org/browse/EVG-19096) 
