### PR TITLE
EVG-18385 Refactor taskLogs resolver to fall under task

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -933,6 +933,7 @@ type ComplexityRoot struct {
 		TaskFiles               func(childComplexity int) int
 		TaskGroup               func(childComplexity int) int
 		TaskGroupMaxHosts       func(childComplexity int) int
+		TaskLogs                func(childComplexity int) int
 		TimeTaken               func(childComplexity int) int
 		TotalTestCount          func(childComplexity int) int
 		VersionMetadata         func(childComplexity int) int
@@ -1443,6 +1444,8 @@ type TaskResolver interface {
 
 	Status(ctx context.Context, obj *model.APITask) (string, error)
 	TaskFiles(ctx context.Context, obj *model.APITask) (*TaskFiles, error)
+
+	TaskLogs(ctx context.Context, obj *model.APITask) (*TaskLogs, error)
 
 	TotalTestCount(ctx context.Context, obj *model.APITask) (int, error)
 	VersionMetadata(ctx context.Context, obj *model.APITask) (*model.APIVersion, error)
@@ -6101,6 +6104,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Task.TaskGroupMaxHosts(childComplexity), true
+
+	case "Task.taskLogs":
+		if e.complexity.Task.TaskLogs == nil {
+			break
+		}
+
+		return e.complexity.Task.TaskLogs(childComplexity), true
 
 	case "Task.timeTaken":
 		if e.complexity.Task.TimeTaken == nil {
@@ -14143,6 +14153,8 @@ func (ec *executionContext) fieldContext_GroupedBuildVariant_tasks(ctx context.C
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -20469,6 +20481,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleUndispatchedBaseTasks(
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -22797,6 +22811,8 @@ func (ec *executionContext) fieldContext_Mutation_abortTask(ctx context.Context,
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -22990,6 +23006,8 @@ func (ec *executionContext) fieldContext_Mutation_overrideTaskDependencies(ctx c
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -23183,6 +23201,8 @@ func (ec *executionContext) fieldContext_Mutation_restartTask(ctx context.Contex
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -23376,6 +23396,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleTasks(ctx context.Cont
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -23569,6 +23591,8 @@ func (ec *executionContext) fieldContext_Mutation_setTaskPriority(ctx context.Co
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -23762,6 +23786,8 @@ func (ec *executionContext) fieldContext_Mutation_unscheduleTask(ctx context.Con
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -34076,6 +34102,8 @@ func (ec *executionContext) fieldContext_Query_task(ctx context.Context, field g
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -34269,6 +34297,8 @@ func (ec *executionContext) fieldContext_Query_taskAllExecutions(ctx context.Con
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -40243,6 +40273,8 @@ func (ec *executionContext) fieldContext_Task_baseTask(ctx context.Context, fiel
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -41307,6 +41339,8 @@ func (ec *executionContext) fieldContext_Task_displayTask(ctx context.Context, f
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -41656,6 +41690,8 @@ func (ec *executionContext) fieldContext_Task_executionTasksFull(ctx context.Con
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -43056,6 +43092,68 @@ func (ec *executionContext) fieldContext_Task_taskGroupMaxHosts(ctx context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Task_taskLogs(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Task_taskLogs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Task().TaskLogs(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TaskLogs)
+	fc.Result = res
+	return ec.marshalNTaskLogs2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskLogs(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Task_taskLogs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Task",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "agentLogs":
+				return ec.fieldContext_TaskLogs_agentLogs(ctx, field)
+			case "allLogs":
+				return ec.fieldContext_TaskLogs_allLogs(ctx, field)
+			case "defaultLogger":
+				return ec.fieldContext_TaskLogs_defaultLogger(ctx, field)
+			case "eventLogs":
+				return ec.fieldContext_TaskLogs_eventLogs(ctx, field)
+			case "execution":
+				return ec.fieldContext_TaskLogs_execution(ctx, field)
+			case "systemLogs":
+				return ec.fieldContext_TaskLogs_systemLogs(ctx, field)
+			case "taskId":
+				return ec.fieldContext_TaskLogs_taskId(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_TaskLogs_taskLogs(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TaskLogs", field.Name)
 		},
 	}
 	return fc, nil
@@ -48026,6 +48124,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_task(ctx context.Contex
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -51266,6 +51366,8 @@ func (ec *executionContext) fieldContext_VersionTasks_data(ctx context.Context, 
 				return ec.fieldContext_Task_taskGroup(ctx, field)
 			case "taskGroupMaxHosts":
 				return ec.fieldContext_Task_taskGroupMaxHosts(ctx, field)
+			case "taskLogs":
+				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "timeTaken":
 				return ec.fieldContext_Task_timeTaken(ctx, field)
 			case "totalTestCount":
@@ -64603,6 +64705,26 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = ec._Task_taskGroupMaxHosts(ctx, field, obj)
 
+		case "taskLogs":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Task_taskLogs(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "timeTaken":
 
 			out.Values[i] = ec._Task_timeTaken(ctx, field, obj)

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -199,20 +199,20 @@ func MakeTestsInDirectory(state *AtomicGraphQLState, pathToTests string) func(t 
 	return func(t *testing.T) {
 		dataFilePath := filepath.Join(pathToTests, "tests", state.Directory, "data.json")
 		dataFile, err := ioutil.ReadFile(filepath.Join(pathToTests, "tests", state.Directory, "data.json"))
-		require.NoError(t, errors.Wrapf(err, "error reading data file for %s", dataFilePath))
+		require.NoError(t, errors.Wrapf(err, "reading data file for %s", dataFilePath))
 
 		resultsFilePath := filepath.Join(pathToTests, "tests", state.Directory, "results.json")
 		resultsFile, err := ioutil.ReadFile(resultsFilePath)
-		require.NoError(t, errors.Wrapf(err, "error reading results file for %s", resultsFilePath))
+		require.NoError(t, errors.Wrapf(err, "reading results file for %s", resultsFilePath))
 
 		var testData map[string]json.RawMessage
 		err = json.Unmarshal(dataFile, &testData)
-		require.NoError(t, errors.Wrapf(err, "error unmarshalling data file for %s", dataFilePath))
+		require.NoError(t, errors.Wrapf(err, "unmarshalling data file for %s", dataFilePath))
 		state.TestData = testData
 
 		var tests testsCases
 		err = json.Unmarshal(resultsFile, &tests)
-		require.NoError(t, errors.Wrapf(err, "error unmarshalling results file for %s", resultsFilePath))
+		require.NoError(t, errors.Wrapf(err, "unmarshalling results file for %s", resultsFilePath))
 
 		// Delete exactly the documents added to the task_logg coll instead of dropping task log db
 		// we do this to minimize deleting data that was not added from this test suite

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -197,20 +197,22 @@ func escapeGQLQuery(in string) string {
 
 func MakeTestsInDirectory(state *AtomicGraphQLState, pathToTests string) func(t *testing.T) {
 	return func(t *testing.T) {
+		dataFilePath := filepath.Join(pathToTests, "tests", state.Directory, "data.json")
 		dataFile, err := ioutil.ReadFile(filepath.Join(pathToTests, "tests", state.Directory, "data.json"))
-		require.NoError(t, err)
+		require.NoError(t, errors.Wrapf(err, "error reading data file for %s", dataFilePath))
 
-		resultsFile, err := ioutil.ReadFile(filepath.Join(pathToTests, "tests", state.Directory, "results.json"))
-		require.NoError(t, err)
+		resultsFilePath := filepath.Join(pathToTests, "tests", state.Directory, "results.json")
+		resultsFile, err := ioutil.ReadFile(resultsFilePath)
+		require.NoError(t, errors.Wrapf(err, "error reading results file for %s", resultsFilePath))
 
 		var testData map[string]json.RawMessage
 		err = json.Unmarshal(dataFile, &testData)
-		require.NoError(t, err)
+		require.NoError(t, errors.Wrapf(err, "error unmarshalling data file for %s", dataFilePath))
 		state.TestData = testData
 
 		var tests testsCases
 		err = json.Unmarshal(resultsFile, &tests)
-		require.NoError(t, err)
+		require.NoError(t, errors.Wrapf(err, "error unmarshalling results file for %s", resultsFilePath))
 
 		// Delete exactly the documents added to the task_logg coll instead of dropping task log db
 		// we do this to minimize deleting data that was not added from this test suite

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -282,7 +282,7 @@ type TaskFilterOptions struct {
 	Variant                    *string      `json:"variant"`
 }
 
-// TaskLogs is the return value for the taskLogs query.
+// TaskLogs is the return value for the task.taskLogs query.
 // It contains the logs for a given task on a given execution.
 type TaskLogs struct {
 	AgentLogs     []*apimodels.LogMessage       `json:"agentLogs"`

--- a/graphql/schema/query.graphql
+++ b/graphql/schema/query.graphql
@@ -67,7 +67,7 @@ type Query {
   # task
   task(taskId: String!, execution: Int): Task
   taskAllExecutions(taskId: String!): [Task!]!
-  taskLogs(taskId: String!, execution: Int): TaskLogs!
+  taskLogs(taskId: String!, execution: Int): TaskLogs! @deprecated(reason: "Use task.taskLogs instead")
   taskTests(
     taskId: String!
     execution: Int

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -86,6 +86,9 @@ type Task {
   taskFiles: TaskFiles!
   taskGroup: String
   taskGroupMaxHosts: Int
+  """
+  taskLogs returns the tail 100 lines of the task's logs.
+  """
   taskLogs: TaskLogs!
   timeTaken: Duration
   totalTestCount: Int!

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -86,6 +86,7 @@ type Task {
   taskFiles: TaskFiles!
   taskGroup: String
   taskGroupMaxHosts: Int
+  taskLogs: TaskLogs!
   timeTaken: Duration
   totalTestCount: Int!
   versionMetadata: Version!

--- a/graphql/schema/types/task_logs.graphql
+++ b/graphql/schema/types/task_logs.graphql
@@ -1,6 +1,6 @@
 ###### TYPES ######
 """
-TaskLogs is the return value for the taskLogs query.
+TaskLogs is the return value for the task.taskLogs query.
 It contains the logs for a given task on a given execution.
 """
 type TaskLogs {

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -546,6 +546,27 @@ func (r *taskResolver) TaskFiles(ctx context.Context, obj *restModel.APITask) (*
 	return &taskFiles, nil
 }
 
+// TaskLogs is the resolver for the taskLogs field.
+func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*TaskLogs, error) {
+	// need project to get default logger
+	p, err := data.FindProjectById(*obj.ProjectId, true, true)
+	if err != nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("error finding project '%s': %s", *obj.ProjectId, err.Error()))
+	}
+	if p == nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find project '%s'", *obj.ProjectId))
+	}
+	defaultLogger := p.DefaultLogger
+	if defaultLogger == "" {
+		defaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger
+	}
+
+	// Let the individual TaskLogs resolvers handle fetching logs for the task
+	// We can avoid the overhead of fetching task logs that we will not view
+	// and we can avoid handling errors that we will not see
+	return &TaskLogs{TaskID: *obj.Id, Execution: obj.Execution, DefaultLogger: defaultLogger}, nil
+}
+
 // TotalTestCount is the resolver for the totalTestCount field.
 func (r *taskResolver) TotalTestCount(ctx context.Context, obj *restModel.APITask) (int, error) {
 	if obj.HasCedarResults {

--- a/graphql/tests/task/data.json
+++ b/graphql/tests/task/data.json
@@ -1,4 +1,10 @@
 {
+  "admin": [
+    {
+      "_id": "jira",
+      "host": "jira.mongodb.org"
+    }
+  ],
   "patches": [
     {
       "_id": {
@@ -215,6 +221,39 @@
       "commit_queue": {
         "patch_type": "PR"
       }
+    },
+    {
+      "_id": "curator",
+      "owner_name": "mongodb",
+      "default_logger": "NOT BUILDLOGGER",
+      "repo_name": "curator",
+      "branch_name": "main",
+      "repo_kind": "github",
+      "enabled": false,
+      "private": false,
+      "batch_time": 300,
+      "remote_path": "evergreen.yaml",
+      "identifier": "curator",
+      "display_name": "Curator",
+      "local_config": "",
+      "deactivate_previous": true,
+      "hidden": false,
+      "admins": [
+        "sam.kleinman"
+      ],
+      "repotracker_error": null,
+      "commit_queue": {
+        "enabled": false,
+        "merge_method": "squash"
+      },
+      "disabled_stats_cache": false,
+      "files_ignored_from_cache": null,
+      "notify_on_failure": false,
+      "patching_disabled": false,
+      "periodic_builds": [],
+      "pr_testing_enabled": false,
+      "tracks_push_events": false,
+      "triggers": []
     }
   ],
   "tasks": [
@@ -229,7 +268,12 @@
       "details": {
         "oom_killer": {
           "detected": true,
-          "pids": [1234, 5678, 9101, 1235]
+          "pids": [
+            1234,
+            5678,
+            9101,
+            1235
+          ]
         }
       },
       "depends_on": [
@@ -298,7 +342,9 @@
       "distro": "macos-1014",
       "execution": 1,
       "host_id": "host2",
-      "execution_tasks": ["execution_task"]
+      "execution_tasks": [
+        "execution_task"
+      ]
     },
     {
       "_id": "blocked_display_task",
@@ -314,7 +360,9 @@
       "host_id": "host2",
       "status": "undispatched",
       "display_only": true,
-      "execution_tasks": ["execution_task"],
+      "execution_tasks": [
+        "execution_task"
+      ],
       "depends_on": [
         {
           "_id": "dep1",
@@ -616,6 +664,61 @@
       "build_variant": "ubuntu1604",
       "status": "failed",
       "order": 1
+    },
+    {
+      "_id": "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+      "create_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "injest_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "dispatch_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "scheduled_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "start_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "finish_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "activated_time": {
+        "$date": "2018-01-11T00:01:36.796Z"
+      },
+      "version": "version",
+      "branch": "curator",
+      "gitspec": "revise",
+      "priority": 5,
+      "task_group": "grp",
+      "task_group_max_hosts": 100,
+      "activated": true,
+      "activated_by": "someone",
+      "build_id": "some_thang",
+      "distro": "distro",
+      "build_variant": "variant",
+      "depends_on": [],
+      "display_name": "display name",
+      "host_id": "host",
+      "execution": 0,
+      "order": 5,
+      "r": "something",
+      "status": "started",
+      "details": {
+        "status": "status",
+        "type": "type",
+        "desc": "description",
+        "timed_out": false
+      },
+      "display_only": true,
+      "execution_tasks": [
+        "exec1",
+        "exec2"
+      ],
+      "generate_task": false,
+      "generated_by": "something"
     }
   ],
   "artifact_files": [
@@ -659,7 +762,9 @@
             "ami": "ami-049df09df40fc2c1c",
             "docker_registry_pw": "",
             "region": "us-east-1",
-            "security_group_ids": ["sg-601a6c13"],
+            "security_group_ids": [
+              "sg-601a6c13"
+            ],
             "curator_dir": "/usr/local/bin",
             "mount_points": [
               {
@@ -1227,7 +1332,10 @@
   "distro": [
     {
       "_id": "archlinux-small",
-      "aliases": ["archlinux", "archlinux-test"],
+      "aliases": [
+        "archlinux",
+        "archlinux-test"
+      ],
       "arch": "linux_amd64",
       "work_dir": "/data/mci",
       "provider": "ec2-fleet",
@@ -1242,7 +1350,9 @@
           "ami": "ami-049df09df40fc2c1c",
           "docker_registry_pw": "",
           "region": "us-east-1",
-          "security_group_ids": ["sg-601a6c13"],
+          "security_group_ids": [
+            "sg-601a6c13"
+          ],
           "curator_dir": "/usr/local/bin",
           "mount_points": [
             {
@@ -1455,6 +1565,159 @@
         "format_command": ""
       },
       "icecream_settings": {}
+    }
+  ],
+  "task_logg": [
+    {
+      "_id": "zookeeper_osx_test_edd78c1d581bf757a8araad4qsd685321685a8e67_14_40_40_41_54_48",
+      "t_id": "zookeeper_osx_test_edd78c1d581bf757a8araad4qsd685321685a8e67_14_40_40_41_54_48",
+      "e": 0,
+      "ts": {
+        "$date": "2019-12-07T18:31:29.814Z"
+      },
+      "c": 4,
+      "m": [
+        {
+          "t": "S",
+          "s": "I",
+          "m": "    [javac]     protected void finalize() {",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.393Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "E",
+          "s": "I",
+          "m": "    [javac]                    ^",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.393Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "T",
+          "s": "I",
+          "m": "    [javac] 9 warnings",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.637Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "T",
+          "s": "I",
+          "m": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.637Z"
+          },
+          "v": 1
+        }
+      ]
+    },
+    {
+      "_id": "5debf0021e2d171b386bd19c",
+      "t_id": "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+      "e": 0,
+      "ts": {
+        "$date": "2019-12-07T18:31:29.814Z"
+      },
+      "c": 4,
+      "m": [
+        {
+          "t": "S",
+          "s": "I",
+          "m": "    [javac]     protected void finalize() {",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.393Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "E",
+          "s": "I",
+          "m": "    [javac]                    ^",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.393Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "T",
+          "s": "I",
+          "m": "    [javac] 9 warnings",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.637Z"
+          },
+          "v": 1
+        },
+        {
+          "t": "T",
+          "s": "I",
+          "m": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
+          "ts": {
+            "$date": "2019-12-07T18:31:19.637Z"
+          },
+          "v": 1
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "_id": "5e5e7bb857e85a21ceb53cb0",
+      "r_type": "TASK",
+      "processed_at": {
+        "$date": "2020-03-03T15:46:29.961Z"
+      },
+      "ts": {
+        "$date": "2020-03-03T15:46:00.709Z"
+      },
+      "r_id": "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+      "e_type": "TASK_FINISHED",
+      "data": {
+        "execution": 0,
+        "s": "success"
+      }
+    },
+    {
+      "_id": "5e5e7b972fbabe2b8b27810b",
+      "r_type": "TASK",
+      "processed_at": {
+        "$date": "2015-10-21T23:29:01Z"
+      },
+      "ts": {
+        "$date": "2020-03-03T15:45:27.830Z"
+      },
+      "r_id": "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+      "e_type": "TASK_STARTED",
+      "data": {
+        "execution": 0,
+        "h_id": "hostid",
+        "jira": "an_issue",
+        "pri": 55,
+        "s": "success",
+        "ts": {
+          "$date": "2020-03-03T15:45:27.830Z"
+        },
+        "u_id": "super user"
+      }
+    },
+    {
+      "_id": "5e5e7b97e3c33148df4ea4e5",
+      "r_type": "TASK",
+      "processed_at": {
+        "$date": "2015-10-21T23:29:01Z"
+      },
+      "ts": {
+        "$date": "2020-03-03T15:45:27.543Z"
+      },
+      "r_id": "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+      "e_type": "TASK_DISPATCHED",
+      "data": {
+        "execution": 0,
+        "h_id": "i-08f7b38b217d21c13"
+      }
     }
   ]
 }

--- a/graphql/tests/task/queries/taskLogs-allLogs.graphql
+++ b/graphql/tests/task/queries/taskLogs-allLogs.graphql
@@ -1,0 +1,50 @@
+query {
+  task(
+    taskId: "logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58",
+    execution: 0
+  ) {
+    taskLogs {
+      systemLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      eventLogs {
+        timestamp
+        eventType
+        data {
+          hostId
+          jiraIssue
+          jiraLink
+          priority
+          status
+          timestamp
+          userId
+        }
+      }
+      taskLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      agentLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      allLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+    }
+  }
+}

--- a/graphql/tests/task/queries/taskLogs-unstarted.graphql
+++ b/graphql/tests/task/queries/taskLogs-unstarted.graphql
@@ -1,0 +1,47 @@
+query {
+  task(taskId: "zookeeper_osx_test_edd78c1d581bf757a8araad4qsd685321685a8e67_14_40_40_41_54_48", execution: 4) {
+    taskLogs{
+      systemLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      eventLogs {
+        timestamp
+        eventType
+        data {
+          hostId
+          jiraIssue
+          jiraLink
+          priority
+          status
+          timestamp
+          userId
+        }
+      }
+      taskLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      agentLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+      allLogs {
+        type
+        severity
+        message
+        timestamp
+        version
+      }
+    }
+  }
+}

--- a/graphql/tests/task/results.json
+++ b/graphql/tests/task/results.json
@@ -425,7 +425,12 @@
             "details": {
               "oomTracker": {
                 "detected": true,
-                "pids": [1234, 5678, 9101, 1235]
+                "pids": [
+                  1234,
+                  5678,
+                  9101,
+                  1235
+                ]
               }
             }
           }
@@ -475,9 +480,129 @@
                 {
                   "taskName": "test-thirdparty-docker",
                   "files": [
-                    { "name": "File 1" },
-                    { "name": "File 2" }
+                    {
+                      "name": "File 1"
+                    },
+                    {
+                      "name": "File 2"
+                    }
                   ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "taskLogs-allLogs.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "taskLogs": {
+              "systemLogs": [
+                {
+                  "type": "S",
+                  "severity": "I",
+                  "message": "    [javac]     protected void finalize() {",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "version": 1
+                }
+              ],
+              "eventLogs": [
+                {
+                  "timestamp": "2020-03-03T10:45:27.543-05:00",
+                  "eventType": "TASK_DISPATCHED",
+                  "data": {
+                    "hostId": "i-08f7b38b217d21c13",
+                    "jiraIssue": "",
+                    "jiraLink": "",
+                    "priority": 0,
+                    "status": "",
+                    "timestamp": null,
+                    "userId": ""
+                  }
+                },
+                {
+                  "timestamp": "2020-03-03T10:45:27.83-05:00",
+                  "eventType": "TASK_STARTED",
+                  "data": {
+                    "hostId": "hostid",
+                    "jiraIssue": "an_issue",
+                    "jiraLink": "https://https://jira.mongodb.org/browse/an_issue",
+                    "priority": 55,
+                    "status": "success",
+                    "timestamp": "2020-03-03T10:45:27.83-05:00",
+                    "userId": "super user"
+                  }
+                },
+                {
+                  "timestamp": "2020-03-03T10:46:00.709-05:00",
+                  "eventType": "TASK_FINISHED",
+                  "data": {
+                    "hostId": "",
+                    "jiraIssue": "",
+                    "jiraLink": "",
+                    "priority": 0,
+                    "status": "success",
+                    "timestamp": null,
+                    "userId": ""
+                  }
+                }
+              ],
+              "taskLogs": [
+                {
+                  "type": "T",
+                  "severity": "I",
+                  "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "version": 1
+                },
+                {
+                  "type": "T",
+                  "severity": "I",
+                  "message": "    [javac] 9 warnings",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "version": 1
+                }
+              ],
+              "agentLogs": [
+                {
+                  "type": "E",
+                  "severity": "I",
+                  "message": "    [javac]                    ^",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "version": 1
+                }
+              ],
+              "allLogs": [
+                {
+                  "type": "T",
+                  "severity": "I",
+                  "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "version": 1
+                },
+                {
+                  "type": "T",
+                  "severity": "I",
+                  "message": "    [javac] 9 warnings",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "version": 1
+                },
+                {
+                  "type": "E",
+                  "severity": "I",
+                  "message": "    [javac]                    ^",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "version": 1
+                },
+                {
+                  "type": "S",
+                  "severity": "I",
+                  "message": "    [javac]     protected void finalize() {",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "version": 1
                 }
               ]
             }


### PR DESCRIPTION
[EVG-18385](https://jira.mongodb.org/browse/EVG-18385)

### Description 
Updated atomic test suite code to give better errors on what the problem is.
![image](https://user-images.githubusercontent.com/4605522/220667005-7dba9af1-fac6-4800-ba56-a377cab5e557.png)
Refactored `taskLogs` resolver to fall under `task.taskLogs`

### Testing 
graphql tests    
#### Does this need documentation?
No