### PR TITLE
Add auto-linked Jira tickets to PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,4 @@
-[EVG-<number>](https://jira.mongodb.org/browse/EVG-<number>)
+EVG-NNNNN
 
 ### Description
 < add description, context, thought process, etc >


### PR DESCRIPTION
I added a bit of auto-linking magic to the GitHub settings so that if you just enter the Jira ticket number, it'll automatically link to the Jira ticket if you fill in the number, without needing to write a Markdown-style link. This only works for EVG tickets.