### PR TITLE
EVG-17690 ensure some fields can't be accessed by non project admins

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -91,14 +91,14 @@ func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "paginating response"))
 		}
 	}
-	projects = projects[:lastIndex]
 
+	projects = projects[:lastIndex]
 	for _, proj := range projects {
 		projectModel := &model.APIProjectRef{}
-		if err = projectModel.BuildFromService(proj); err != nil {
+		// Because this is route to accessible to non-admins, only return basic fields.
+		if err = projectModel.BuildPublicFields(proj); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "converting project '%s' to API model", proj.Id))
 		}
-
 		if err = resp.AddData(projectModel); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "adding response data for project '%s'", utility.FromStringPtr(projectModel.Id)))
 		}


### PR DESCRIPTION
EVG-17690

### Description
This ticket was made to super restrict what's returned from this route. I think that's not actually needed -- most things in project settings really don't need to be secret, it's mostly variables that need to be kept apart and those already aren't returned from this route. Modified the route a bit to also hide a few more variables. Theoretically it would be reasonable to extend this thinking to the project permissions and the other project routes but I think that's pretty low priority right now and we'd just end up not getting to that work. I can add it as a future project idea however.

### Testing
Ensured existing tests pass.

#### Does this need documentation?
Yes, I'll add this to the project page documentation and the project rest route documentation.
