### PR TITLE
EVG-18732 surface if a patch isn't created bc all files are ignored

### DIFF
--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -37,7 +37,10 @@ const (
 	// GitHub intent processing errors
 	ProjectDisabled        = "project was disabled"
 	PatchingDisabled       = "patching was disabled"
+	commitQueueDisabled    = "commit queue was disabled"
+	ignoredFiles           = "all patched files are ignored"
 	PatchTaskSyncDisabled  = "task sync was disabled for patches"
+	invalidAlias           = "alias not found"
 	NoTasksOrVariants      = "no tasks/variants were configured"
 	NoSyncTasksOrVariants  = "no tasks/variants were configured for sync"
 	GitHubInternalError    = "GitHub returned an error"

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -25,7 +25,7 @@ const (
 	githubStatusUpdateJobName = "github-status-update"
 
 	githubUpdateTypeNewPatch              = "new-patch"
-	githubUpdateTypeMessage               = "send-message"
+	githubUpdateTypeSuccessMessage        = "success-message"
 	githubUpdateTypeRequestAuth           = "request-auth"
 	githubUpdateTypePushToCommitQueue     = "commit-queue-push"
 	githubUpdateTypeDeleteFromCommitQueue = "commit-queue-delete"
@@ -83,11 +83,11 @@ func makeGithubStatusUpdateJob() *githubStatusUpdateJob {
 	return j
 }
 
-// NewGithubStatusUpdateJobWithMessage creates a job to send a passing status to Github with a message.
-func NewGithubStatusUpdateJobWithMessage(githubContext, owner, repo, ref, description string) amboy.Job {
+// NewGithubStatusUpdateJobWithSuccessMessage creates a job to send a passing status to Github with a message.
+func NewGithubStatusUpdateJobWithSuccessMessage(githubContext, owner, repo, ref, description string) amboy.Job {
 	job := makeGithubStatusUpdateJob()
 	job.GithubContext = githubContext
-	job.UpdateType = githubUpdateTypeMessage
+	job.UpdateType = githubUpdateTypeSuccessMessage
 	job.Owner = owner
 	job.Repo = repo
 	job.Ref = ref
@@ -207,7 +207,7 @@ func (j *githubStatusUpdateJob) fetch() (*message.GithubStatus, error) {
 		status.State = message.GithubStateFailure
 		status.Description = j.Description
 
-	} else if j.UpdateType == githubUpdateTypeMessage {
+	} else if j.UpdateType == githubUpdateTypeSuccessMessage {
 		status.Context = commitqueue.GithubContext
 		status.State = message.GithubStateSuccess
 		status.Description = j.Description


### PR DESCRIPTION
EVG-18732

### Description
Right now we log if a patch isn't created bc files are ignored but we don't tell the user; this is really confusing and often means we need to look at splunk logs to tell the user what happened. We should instead return a successful status with a message.
Cleaned up some other stuff as I went.

### Testing
Tested with a PR https://github.com/evergreen-ci/commit-queue-sandbox/pull/448
<img width="879" alt="image" src="https://user-images.githubusercontent.com/26798134/221019071-f30c112f-5a32-4427-ad71-704b11815650.png">

#### Does this need documentation?
Document that no patch will be created for a PR containing only ignored file changes. 
