### PR TITLE
EVG-18929: put timeout on saving generated tasks

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -196,9 +196,10 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	start = time.Now()
 
 	// Don't use the job's context, because it's better to try finishing than to
-	// exit early after a SIGTERM from app server shutdown. This should probably
-	// use a timeout rather than just the background context.
-	err = g.Save(context.Background(), j.env.Settings(), p, pp, v)
+	// exit early after a SIGTERM from app server shutdown.
+	saveCtx, saveCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer saveCancel()
+	err = g.Save(saveCtx, j.env.Settings(), p, pp, v)
 
 	// If the version or parser project has changed there was a race. Another generator will try again.
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {


### PR DESCRIPTION
EVG-18929

### Description
Add timeout for saving the new configuration, builds, and tasks during generate.tasks. I looked at stats for the maximum runtime in the past month and the slowest runtime for saving was 15 minutes, so I doubled it for padding. This timeout is probably too generous, but I'm not looking to optimize the performance of saving in this PR, just prevent it from running forever.

### Testing
N/A

#### Does this need documentation?
N/A