### PR TITLE
EVG-18724: add debug log for conclude merge 500 error

### DIFF
--- a/rest/route/commit_queue.go
+++ b/rest/route/commit_queue.go
@@ -16,6 +16,8 @@ import (
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -267,6 +269,13 @@ func (p *commitQueueConcludeMerge) Parse(ctx context.Context, r *http.Request) e
 func (p *commitQueueConcludeMerge) Run(ctx context.Context) gimlet.Responder {
 	err := data.ConcludeMerge(p.patchId, p.Status)
 	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":      "failed to conclude commit queue merge",
+			"route":        "/rest/v2/commit_queue/{patch_id}/conclude_merge",
+			"patch":        p.patchId,
+			"patch_status": p.Status,
+			"jira_ticket":  "EVG-18724",
+		}))
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "concluding merge"))
 	}
 


### PR DESCRIPTION
EVG-18724

### Description
Based on Splunk, users seem to be receiving multiple commit queue merge notifications because the agent gets a 500 from this route and retries the request (which results in an event log for each error attempt). I don't know specifically which line in `ConcludeMerge` is causing the 500, so I added a debug log so that the next time it happens, I can see what errored.

### Testing
N/A

#### Does this need documentation?
N/A
