### PR TITLE
EVG-16349 add github comment to refresh status

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -348,7 +348,7 @@ func (b *Build) GetFinishedNotificationDescription(tasks []task.Task) string {
 		case t.Status == evergreen.TaskFailed:
 			failed++
 
-		case statusIsSystemFailure(t.Status):
+		case evergreen.IsSystemFailedTaskStatus(t.Status):
 			systemError++
 
 		case utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status):
@@ -379,16 +379,6 @@ func (b *Build) GetFinishedNotificationDescription(tasks []task.Task) string {
 	}
 
 	return b.appendTime(desc)
-}
-
-func statusIsSystemFailure(status string) bool {
-	systemFailures := []string{evergreen.TaskSystemFailed,
-		evergreen.TaskTimedOut,
-		evergreen.TaskSystemUnresponse,
-		evergreen.TaskSystemTimedOut,
-		evergreen.TaskTestTimedOut,
-	}
-	return utility.StringSliceContains(systemFailures, status)
 }
 
 func taskStatusSubformat(n int, verb string) string {

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -296,6 +297,14 @@ func (b *Build) GetTimeSpent() (time.Duration, time.Duration, error) {
 
 	timeTaken, makespan := task.GetTimeSpent(tasks)
 	return timeTaken, makespan, nil
+}
+
+func (b *Build) GetURL(uiBase string) string {
+	url := fmt.Sprintf("%s/build/%s", uiBase, url.PathEscape(b.Id))
+	if evergreen.IsPatchRequester(b.Requester) {
+		url += "?redirect_spruce_users=true"
+	}
+	return url
 }
 
 // Insert writes the b to the db.

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -299,6 +299,7 @@ func (b *Build) GetTimeSpent() (time.Duration, time.Duration, error) {
 	return timeTaken, makespan, nil
 }
 
+// GetURL returns a url to the build page.
 func (b *Build) GetURL(uiBase string) string {
 	url := fmt.Sprintf("%s/build/%s", uiBase, url.PathEscape(b.Id))
 	if evergreen.IsPatchRequester(b.Requester) {

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -301,11 +301,7 @@ func (b *Build) GetTimeSpent() (time.Duration, time.Duration, error) {
 
 // GetURL returns a url to the build page.
 func (b *Build) GetURL(uiBase string) string {
-	url := fmt.Sprintf("%s/build/%s", uiBase, url.PathEscape(b.Id))
-	if evergreen.IsPatchRequester(b.Requester) {
-		url += "?redirect_spruce_users=true"
-	}
-	return url
+	return fmt.Sprintf("%s/build/%s?redirect_spruce_users=true", uiBase, url.PathEscape(b.Id))
 }
 
 // Insert writes the b to the db.

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -2,13 +2,17 @@ package build
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	adb "github.com/mongodb/anser/db"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -316,4 +320,79 @@ func (b Builds) InsertMany(ctx context.Context, ordered bool) error {
 	}
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertMany(ctx, b.getPayload(), &options.InsertManyOptions{Ordered: &ordered})
 	return errors.Wrap(err, "bulk inserting builds")
+}
+
+// GetFinishedNotificationDescription returns a description of successful/failed tasks for the build,
+// to be used by jobs and notification processing.
+func (b *Build) GetFinishedNotificationDescription(tasks []task.Task) string {
+	success := 0
+	failed := 0
+	systemError := 0
+	other := 0
+	noReport := 0
+	for _, t := range tasks {
+		switch {
+		case t.Status == evergreen.TaskSucceeded:
+			success++
+
+		case t.Status == evergreen.TaskFailed:
+			failed++
+
+		case statusIsSystemFailure(t.Status):
+			systemError++
+
+		case utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status):
+			noReport++
+
+		default:
+			other++
+		}
+	}
+
+	grip.ErrorWhen(other > 0, message.Fields{
+		"source":   "status updates",
+		"message":  "unknown task status",
+		"build_id": b.Id,
+	})
+
+	if success == 0 && failed == 0 && systemError == 0 && other == 0 {
+		return "no tasks were run"
+	}
+
+	desc := fmt.Sprintf("%s, %s", taskStatusSubformat(success, "succeeded"),
+		taskStatusSubformat(failed, "failed"))
+	if systemError > 0 {
+		desc += fmt.Sprintf(", %d internal errors", systemError)
+	}
+	if other > 0 {
+		desc += fmt.Sprintf(", %d other", other)
+	}
+
+	return b.appendTime(desc)
+}
+
+func statusIsSystemFailure(status string) bool {
+	systemFailures := []string{evergreen.TaskSystemFailed,
+		evergreen.TaskTimedOut,
+		evergreen.TaskSystemUnresponse,
+		evergreen.TaskSystemTimedOut,
+		evergreen.TaskTestTimedOut,
+	}
+	return utility.StringSliceContains(systemFailures, status)
+}
+
+func taskStatusSubformat(n int, verb string) string {
+	if n == 0 {
+		return fmt.Sprintf("none %s", verb)
+	}
+	return fmt.Sprintf("%d %s", n, verb)
+}
+
+func (b *Build) appendTime(txt string) string {
+	finish := b.FinishTime
+	// In case the build is actually blocked, but we are triggering the finish event
+	if utility.IsZeroTime(b.FinishTime) {
+		finish = time.Now()
+	}
+	return fmt.Sprintf("%s in %s", txt, finish.Sub(b.StartTime).String())
 }

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -350,6 +350,7 @@ func ByGithubPRAndCreatedBefore(t time.Time, owner, repo string, prNumber int) d
 	})
 }
 
+// FindLatestGithubPRPatch returns the latest PR patch for the given PR, if there is one.
 func FindLatestGithubPRPatch(owner, repo string, prNumber int) (*Patch, error) {
 	patches, err := Find(db.Query(bson.M{
 		AliasKey: bson.M{"$ne": evergreen.CommitQueueAlias},

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -350,6 +350,22 @@ func ByGithubPRAndCreatedBefore(t time.Time, owner, repo string, prNumber int) d
 	})
 }
 
+func FindLatestGithubPRPatch(owner, repo string, prNumber int) (*Patch, error) {
+	patches, err := Find(db.Query(bson.M{
+		AliasKey: bson.M{"$ne": evergreen.CommitQueueAlias},
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseOwnerKey): owner,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseRepoKey):  repo,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchPRNumberKey):  prNumber,
+	}).Sort([]string{"-" + CreateTimeKey}).Limit(1))
+	if err != nil {
+		return nil, err
+	}
+	if len(patches) == 0 {
+		return nil, nil
+	}
+	return &patches[0], nil
+}
+
 func FindProjectForPatch(patchID mgobson.ObjectId) (string, error) {
 	p, err := FindOne(ById(patchID).Project(bson.M{ProjectKey: 1}))
 	if err != nil {

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -815,14 +815,14 @@ func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 
 // GetGithubContextForChildPatch returns the github context for the given child patch, to be used in github statuses.
 func GetGithubContextForChildPatch(projectIdentifier string, parentPatch, childPatch *Patch) (string, error) {
-	var githubContext string
 	patchIndex, err := childPatch.GetPatchIndex(parentPatch)
 	if err != nil {
 		return "", errors.Wrap(err, "getting child patch index")
 	}
-	if patchIndex == 0 || patchIndex == -1 {
-		githubContext = fmt.Sprintf("evergreen/%s", projectIdentifier)
-	} else {
+	githubContext := fmt.Sprintf("evergreen/%s", projectIdentifier)
+	// If there are multiple child patches, add the index to ensure these don't overlap,
+	// since there can be multiple for the same child project.
+	if patchIndex > 0 {
 		githubContext = fmt.Sprintf("evergreen/%s/%d", projectIdentifier, patchIndex)
 	}
 	return githubContext, nil

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -270,9 +270,13 @@ func (p *Patch) GetURL(uiHost string) string {
 	var url string
 	if p.Activated {
 		url = uiHost + "/version/" + p.Id.Hex()
+		if p.IsChild() {
+			url += "/downstream-tasks"
+		}
 	} else {
 		url = uiHost + "/patch/" + p.Id.Hex()
 	}
+
 	if p.DisplayNewUI {
 		url = url + "?redirect_spruce_users=true"
 	}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -808,6 +808,7 @@ func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 	return -1, nil
 }
 
+// GetGithubContextForChildPatch returns the github context for the given child patch, to be used in github statuses.
 func GetGithubContextForChildPatch(projectIdentifier string, parentPatch, childPatch *Patch) (string, error) {
 	var githubContext string
 	patchIndex, err := childPatch.GetPatchIndex(parentPatch)

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -808,6 +808,20 @@ func (p *Patch) GetPatchIndex(parentPatch *Patch) (int, error) {
 	return -1, nil
 }
 
+func GetGithubContextForChildPatch(projectIdentifier string, parentPatch, childPatch *Patch) (string, error) {
+	var githubContext string
+	patchIndex, err := childPatch.GetPatchIndex(parentPatch)
+	if err != nil {
+		return "", errors.Wrap(err, "getting child patch index")
+	}
+	if patchIndex == 0 || patchIndex == -1 {
+		githubContext = fmt.Sprintf("evergreen/%s", projectIdentifier)
+	} else {
+		githubContext = fmt.Sprintf("evergreen/%s/%d", projectIdentifier, patchIndex)
+	}
+	return githubContext, nil
+}
+
 func (p *Patch) GetFamilyInformation() (bool, *Patch, error) {
 	if !p.IsChild() && !p.IsParent() {
 		return evergreen.IsFinishedPatchStatus(p.Status), nil, nil

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -347,9 +347,6 @@ func (s *CommitQueueSuite) TestCommentTrigger() {
 
 	comment = triggerComment
 	s.True(triggersCommitQueue(comment))
-
-	action = "deleted"
-	s.False(triggersCommitQueue(comment))
 }
 
 func (s *CommitQueueSuite) TestCommentCleanup() {

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -309,16 +309,7 @@ func (s *GithubWebhookRouteSuite) TestRetryCommentTrigger() {
 }
 
 func (s *GithubWebhookRouteSuite) TestRefreshStatusTrigger() {
-	event, err := github.ParseWebHook("issue_comment", []byte(refreshStatusComment))
-	s.NoError(err)
-	s.NotNil(event)
-
-	issueComment, ok := event.(*github.IssueCommentEvent)
-	s.True(ok)
-	commentString := issueComment.Comment.GetBody()
-	s.Equal(retryComment, commentString)
-
-	s.True(triggersPatch(commentString))
+	s.True(triggersPatch(refreshStatusComment))
 	s.False(triggersPatch(retryComment))
 
 	//test whitespace trimming

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -320,7 +320,7 @@ func (s *GithubWebhookRouteSuite) TestRefreshStatusTrigger() {
 
 	s.True(triggersPatch(commentString))
 	s.False(triggersPatch(retryComment))
-	
+
 	//test whitespace trimming
 	s.True(triggersPatch("  evergreen refresh "))
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -302,11 +302,27 @@ func (s *GithubWebhookRouteSuite) TestRetryCommentTrigger() {
 	commentString := issueComment.Comment.GetBody()
 	s.Equal(retryComment, commentString)
 
-	s.True(triggersPatch("created", commentString))
-	s.False(triggersPatch("deleted", commentString))
+	s.True(triggersPatch(commentString))
 
 	//test whitespace trimming
-	s.True(triggersPatch("created", "  evergreen retry "))
+	s.True(triggersPatch("  evergreen retry "))
+}
+
+func (s *GithubWebhookRouteSuite) TestRefreshStatusTrigger() {
+	event, err := github.ParseWebHook("issue_comment", []byte(refreshStatusComment))
+	s.NoError(err)
+	s.NotNil(event)
+
+	issueComment, ok := event.(*github.IssueCommentEvent)
+	s.True(ok)
+	commentString := issueComment.Comment.GetBody()
+	s.Equal(retryComment, commentString)
+
+	s.True(triggersPatch(commentString))
+	s.False(triggersPatch(retryComment))
+	
+	//test whitespace trimming
+	s.True(triggersPatch("  evergreen refresh "))
 }
 
 func (s *GithubWebhookRouteSuite) TestPatchCommentTrigger() {
@@ -319,23 +335,21 @@ func (s *GithubWebhookRouteSuite) TestPatchCommentTrigger() {
 	commentString := issueComment.Comment.GetBody()
 	s.Equal(patchComment, commentString)
 
-	s.True(triggersPatch("created", commentString))
-	s.False(triggersPatch("deleted", commentString))
+	s.True(triggersPatch(commentString))
 
 	//test whitespace trimming
-	s.True(triggersPatch("created", "  evergreen patch "))
+	s.True(triggersPatch("  evergreen patch "))
 }
 
 func (s *CommitQueueSuite) TestCommentTrigger() {
 	comment := "no dice"
-	action := "created"
-	s.False(triggersCommitQueue(action, comment))
+	s.False(triggersCommitQueue(comment))
 
 	comment = triggerComment
-	s.True(triggersCommitQueue(action, comment))
+	s.True(triggersCommitQueue(comment))
 
 	action = "deleted"
-	s.False(triggersCommitQueue(action, comment))
+	s.False(triggersCommitQueue(comment))
 }
 
 func (s *CommitQueueSuite) TestCommentCleanup() {
@@ -343,11 +357,11 @@ func (s *CommitQueueSuite) TestCommentCleanup() {
 	patch := " \n Evergreen       \n  Patch \n "
 	retry := " \n Evergreen       \n  Retry \n "
 
-	s.False(containsTriggerComment(patch))
+	s.False(triggersCommitQueue(patch))
 	s.False(isPatchComment(retry))
 	s.False(isRetryComment(trigger))
 
-	s.True(containsTriggerComment(trigger))
+	s.True(triggersCommitQueue(trigger))
 	s.True(isPatchComment(patch))
 	s.True(isRetryComment(retry))
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -309,11 +309,11 @@ func (s *GithubWebhookRouteSuite) TestRetryCommentTrigger() {
 }
 
 func (s *GithubWebhookRouteSuite) TestRefreshStatusTrigger() {
-	s.True(triggersPatch(refreshStatusComment))
-	s.False(triggersPatch(retryComment))
+	s.True(triggersStatusRefresh(refreshStatusComment))
+	s.False(triggersStatusRefresh(retryComment))
 
 	//test whitespace trimming
-	s.True(triggersPatch("  evergreen refresh "))
+	s.True(triggersStatusRefresh("  evergreen refresh "))
 }
 
 func (s *GithubWebhookRouteSuite) TestPatchCommentTrigger() {

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -268,7 +268,7 @@ func (t *buildTriggers) makeData(sub *event.Subscription, pastTenseOverride stri
 		DisplayName:     t.build.DisplayName,
 		Object:          event.ObjectBuild,
 		Project:         projectName,
-		URL:             buildLink(t.uiConfig.Url, t.build.Id, evergreen.IsPatchRequester(t.build.Requester)),
+		URL:             t.build.GetURL(t.uiConfig.Url),
 		PastTenseStatus: t.data.Status,
 		apiModel:        &api,
 	}

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -278,7 +278,7 @@ func (t *buildTriggers) makeData(sub *event.Subscription, pastTenseOverride stri
 	}
 	if t.build.Requester == evergreen.GithubPRRequester || t.build.Requester == evergreen.RepotrackerVersionRequester {
 		data.githubContext = fmt.Sprintf("evergreen/%s", t.build.BuildVariant)
-		data.githubDescription = t.taskStatusToDesc()
+		data.githubDescription = t.build.GetFinishedNotificationDescription(t.tasks)
 	}
 	if data.PastTenseStatus == evergreen.BuildFailed {
 		data.githubState = message.GithubStateFailure
@@ -301,7 +301,7 @@ func (t *buildTriggers) buildAttachments(data *commonTemplateData) []message.Sla
 	attachments = append(attachments, message.SlackAttachment{
 		Title:     fmt.Sprintf("Build: %s", t.build.DisplayName),
 		TitleLink: data.URL,
-		Text:      t.taskStatusToDesc(),
+		Text:      t.build.GetFinishedNotificationDescription(t.tasks),
 		Fields: []*message.SlackAttachmentField{
 			{
 				Title: "Version",

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -9,7 +9,6 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/event"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -233,41 +232,6 @@ func (s *buildSuite) TestGithubCheckOutcome() {
 	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
-}
-
-func (s *buildSuite) TestTaskStatusToDesc() {
-	buildTrigger := makeBuildTriggers().(*buildTriggers)
-	buildTrigger.build = &build.Build{
-		Id:           mgobson.NewObjectId().Hex(),
-		BuildVariant: "testvariant",
-		Version:      "testversion",
-		Status:       evergreen.BuildFailed,
-		StartTime:    time.Time{},
-		FinishTime:   time.Time{}.Add(10 * time.Second),
-	}
-
-	s.Equal("no tasks were run", buildTrigger.taskStatusToDesc())
-
-	buildTrigger.tasks = []task.Task{
-		{
-			Status: evergreen.TaskSucceeded,
-		},
-	}
-	s.Equal("1 succeeded, none failed in 10s", buildTrigger.taskStatusToDesc())
-
-	buildTrigger.tasks = []task.Task{
-		{
-			Status: evergreen.TaskSystemFailed,
-		},
-	}
-	s.Equal("none succeeded, none failed, 1 internal errors in 10s", buildTrigger.taskStatusToDesc())
-
-	buildTrigger.tasks = []task.Task{
-		{
-			Status: evergreen.TaskFailed,
-		},
-	}
-	s.Equal("none succeeded, 1 failed in 10s", buildTrigger.taskStatusToDesc())
 }
 
 func (s *buildSuite) TestBuildExceedsTime() {

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -482,9 +482,7 @@ func versionLink(i versionLinkInput) string {
 	if i.isChild {
 		url += "/downstream-tasks"
 	}
-	if i.hasPatch {
-		url += "?redirect_spruce_users=true"
-	}
+	url += "?redirect_spruce_users=true"
 	return url
 }
 

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -470,14 +470,6 @@ func taskLogLink(uiBase string, taskID string, execution int) string {
 	return fmt.Sprintf("%s/task_log_raw/%s/%d?type=T", uiBase, url.PathEscape(taskID), execution)
 }
 
-func buildLink(uiBase string, buildID string, hasPatch bool) string {
-	url := fmt.Sprintf("%s/build/%s", uiBase, url.PathEscape(buildID))
-	if hasPatch {
-		url += "?redirect_spruce_users=true"
-	}
-	return url
-}
-
 type versionLinkInput struct {
 	uiBase    string
 	versionID string

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -226,7 +226,6 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 	if buildDoc == nil {
 		return nil, errors.Errorf("build '%s' not found while building email payload", t.task.BuildId)
 	}
-	hasPatch := evergreen.IsPatchRequester(buildDoc.Requester)
 
 	projectRef, err := model.FindMergedProjectRef(t.task.Project, t.task.Version, true)
 	if err != nil {
@@ -278,7 +277,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 	attachmentFields := []*message.SlackAttachmentField{
 		{
 			Title: "Build",
-			Value: fmt.Sprintf("<%s|%s>", buildLink(t.uiConfig.Url, t.task.BuildId, hasPatch), t.task.BuildVariant),
+			Value: fmt.Sprintf("<%s|%s>", buildDoc.GetURL(t.uiConfig.Url), t.task.BuildVariant),
 		},
 		{
 			Title: "Version",
@@ -286,7 +285,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 				versionLinkInput{
 					uiBase:    t.uiConfig.Url,
 					versionID: t.task.Version,
-					hasPatch:  hasPatch,
+					hasPatch:  evergreen.IsPatchRequester(buildDoc.Requester),
 					isChild:   false,
 				},
 			), t.task.Version),

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -37,7 +37,7 @@ func TestGithubStatusUpdate(t *testing.T) {
 }
 
 func (s *githubStatusUpdateSuite) SetupTest() {
-	s.NoError(db.ClearCollections(evergreen.ConfigCollection, patch.Collection, patch.IntentCollection, model.ProjectRefCollection, evergreen.ConfigCollection))
+	s.NoError(db.ClearCollections(patch.Collection, patch.IntentCollection, model.ProjectRefCollection, evergreen.ConfigCollection))
 
 	uiConfig := evergreen.UIConfig{}
 	uiConfig.Url = "https://example.com"

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -31,6 +31,7 @@ func init() {
 	registry.AddJobType(githubStatusUpdateJobName, func() amboy.Job { return makeGithubStatusRefreshJob() })
 }
 
+// NewGithubStatusRefreshJob is a job that re-sends github statuses to the PR associated with the given patch.
 func NewGithubStatusRefreshJob(p *patch.Patch) amboy.Job {
 	job := makeGithubStatusRefreshJob()
 	job.FetchID = p.Version

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -1,0 +1,242 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	"github.com/mongodb/grip/sometimes"
+	"github.com/pkg/errors"
+)
+
+const (
+	githubStatusRefreshJobName = "github-status-refresh"
+)
+
+func init() {
+	registry.AddJobType(githubStatusUpdateJobName, func() amboy.Job { return makeGithubStatusRefreshJob() })
+}
+
+func NewGithubStatusRefreshJob(p *patch.Patch) amboy.Job {
+	job := makeGithubStatusRefreshJob()
+	job.FetchID = p.Version
+	job.patch = p
+
+	job.SetID(fmt.Sprintf("%s:%s-%s", githubStatusRefreshJobName, p.Version, time.Now().String()))
+	return job
+}
+
+type githubStatusRefreshJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	env      evergreen.Environment
+	sender   send.Sender
+
+	urlBase      string
+	patch        *patch.Patch
+	builds       []build.Build
+	childPatches []patch.Patch
+
+	FetchID string `bson:"fetch_id" json:"fetch_id" yaml:"fetch_id"`
+}
+
+func makeGithubStatusRefreshJob() *githubStatusRefreshJob {
+	j := &githubStatusRefreshJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    githubStatusUpdateJobName,
+				Version: 0,
+			},
+		},
+	}
+	j.SetPriority(1)
+	return j
+}
+
+func (j *githubStatusRefreshJob) shouldUpdate() (bool, error) {
+	flags, err := evergreen.GetServiceFlags()
+	if err != nil {
+		return false, errors.Wrap(err, "error retrieving admin settings")
+	}
+	if flags.GithubStatusAPIDisabled {
+		grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
+			"job":     j.Name,
+			"message": "GitHub status updates are disabled, not updating status",
+		})
+		return false, nil
+	}
+	return true, nil
+}
+
+func (j *githubStatusRefreshJob) fetch() error {
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+	uiConfig := evergreen.UIConfig{}
+	var err error
+	if err := uiConfig.Get(j.env); err != nil {
+		return errors.Wrap(err, "retrieving UI config")
+	}
+	urlBase := uiConfig.Url
+	if urlBase == "" {
+		return errors.New("url base doesn't exist")
+	}
+	j.urlBase = urlBase
+	if j.sender == nil {
+		var err error
+		j.sender, err = j.env.GetSender(evergreen.SenderGithubStatus)
+		if err != nil {
+			return err
+		}
+	}
+	if j.patch == nil {
+		j.patch, err = patch.FindOneId(j.FetchID)
+		if err != nil {
+			return errors.Wrap(err, "finding patch")
+		}
+		if j.patch == nil {
+			return errors.New("patch not found")
+		}
+	}
+
+	j.builds, err = build.Find(build.ByVersion(j.FetchID))
+	if err != nil {
+		return errors.Wrap(err, "finding builds")
+	}
+
+	if len(j.patch.Triggers.ChildPatches) > 0 {
+		j.childPatches, err = patch.Find(patch.ByStringIds(j.patch.Triggers.ChildPatches))
+		if err != nil {
+			return errors.Wrap(err, "finding child patches")
+		}
+	}
+	return nil
+}
+
+func (j *githubStatusRefreshJob) sendStatus(status *message.GithubStatus) {
+	grip.Info(message.Fields{
+		"ticket":  "EVG-16349",
+		"message": "sending status",
+		"status":  status,
+	})
+	c := message.MakeGithubStatusMessageWithRepo(*status)
+	if !c.Loggable() {
+		grip.Info(message.Fields{
+			"ticket":  "EVG-16349",
+			"message": "invalid status",
+		})
+		j.AddError(errors.Errorf("status message is invalid: %+v", status))
+		return
+	}
+	j.AddError(c.SetPriority(level.Notice))
+
+	j.sender.Send(c)
+	grip.Info(message.Fields{
+		"ticket":  thirdparty.GithubInvestigation,
+		"message": "called github status refresh",
+		"caller":  githubStatusRefreshJobName,
+	})
+	grip.Debug(message.Fields{
+		"ticket":  "EVG-16349",
+		"message": "sent status",
+		"status":  status,
+	})
+}
+
+func (j *githubStatusRefreshJob) Run(ctx context.Context) {
+	shouldUpdate, err := j.shouldUpdate()
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+	if !shouldUpdate {
+		return
+	}
+	if err = j.fetch(); err != nil {
+		j.AddError(err)
+		return
+	}
+
+	status := &message.GithubStatus{
+		// TODO: remove refreshed_status=true
+		URL:     fmt.Sprintf("%s/version/%s?redirect_spruce_users=true&refreshed_status=true", j.urlBase, j.FetchID),
+		Context: evergreenContext,
+		Owner:   j.patch.GithubPatchData.BaseOwner,
+		Repo:    j.patch.GithubPatchData.BaseRepo,
+		Ref:     j.patch.GithubPatchData.HeadHash,
+	}
+
+	// Send patch status
+	patchDuration := j.patch.FinishTime.Sub(j.patch.StartTime).String()
+	status.Description = fmt.Sprintf("version finished in %s", patchDuration)
+	if j.patch.Status == evergreen.VersionSucceeded {
+		status.State = message.GithubStateSuccess
+	} else if j.patch.Status == evergreen.VersionFailed {
+		status.State = message.GithubStateFailure
+	} else {
+		status.State = message.GithubStatePending
+		status.Description = "tasks are running"
+	}
+	grip.Debug(message.Fields{
+		"ticket":  "EVG-16349",
+		"message": "sending patch status",
+		"status":  status,
+	})
+	j.sendStatus(status)
+
+	// TODO: handle child patches; might need to move https://github.com/evergreen-ci/evergreen/blob/89e55638c41cc4a76b0667a78aaf4cd6a778f93f/trigger/patch.go#L292 elsewhere
+	//for _, p := range j.childPatches {
+	//	childPatchDuration := j.patch.FinishTime.Sub(j.patch.StartTime).String()
+	//	status.Description = fmt.Sprintf("patch finished ")
+	//}
+	// For each build, send build status.
+	for _, b := range j.builds {
+		grip.Info(message.Fields{
+			"ticket":        "EVG-16349",
+			"message":       "iterating through builds",
+			"current_build": b.Id,
+		})
+		status.Context = fmt.Sprintf("%s/%s", evergreenContext, b.BuildVariant)
+		buildDuration := b.FinishTime.Sub(b.StartTime).String()
+		status.Description = fmt.Sprintf("build finished in %s", buildDuration)
+		fetchTasks := true
+
+		if b.Status == evergreen.BuildSucceeded {
+			status.State = message.GithubStateSuccess
+		} else if b.Status == evergreen.BuildFailed {
+			status.State = message.GithubStateFailure
+		} else {
+			status.State = message.GithubStatePending
+			status.Description = "tasks are running"
+			fetchTasks = false
+		}
+		if fetchTasks {
+			query := db.Query(task.ByBuildId(b.Id)).WithFields(task.StatusKey, task.DependsOnKey)
+			tasks, err := task.FindAll(query)
+			if err != nil {
+				j.AddError(errors.Wrapf(err, "finding tasks in build '%s'", b.Id))
+				continue
+			}
+			status.Description = b.GetFinishedNotificationDescription(tasks)
+		}
+		grip.Info(message.Fields{
+			"ticket":        "EVG-16349",
+			"message":       "sending build status",
+			"current_build": b.Id,
+			"description":   status.Description,
+		})
+		j.sendStatus(status)
+	}
+}

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -58,7 +58,7 @@ func makeGithubStatusRefreshJob() *githubStatusRefreshJob {
 	j := &githubStatusRefreshJob{
 		Base: job.Base{
 			JobType: amboy.JobType{
-				Name:    githubStatusUpdateJobName,
+				Name:    githubStatusRefreshJobName,
 				Version: 0,
 			},
 		},

--- a/units/github_status_refresh_test.go
+++ b/units/github_status_refresh_test.go
@@ -1,0 +1,322 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	"github.com/stretchr/testify/suite"
+)
+
+type githubStatusRefreshSuite struct {
+	env      *mock.Environment
+	patchDoc *patch.Patch
+	builds   []build.Build
+	tasks    []task.Task
+
+	cancel context.CancelFunc
+	suite.Suite
+}
+
+func TestGithubStatusRefresh(t *testing.T) {
+	suite.Run(t, new(githubStatusRefreshSuite))
+}
+
+func (s *githubStatusRefreshSuite) SetupTest() {
+	s.NoError(db.ClearCollections(patch.Collection, build.Collection, task.Collection, model.ProjectRefCollection, evergreen.ConfigCollection))
+
+	uiConfig := evergreen.UIConfig{}
+	uiConfig.Url = "https://example.com"
+	s.Require().NoError(uiConfig.Set())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+
+	s.env = &mock.Environment{}
+	s.Require().NoError(s.env.Configure(ctx))
+
+	pRef := model.ProjectRef{
+		Id:         "myChildProject",
+		Identifier: "myChildProjectIdentifier",
+	}
+	s.NoError(pRef.Insert())
+
+	startTime := time.Now().Truncate(time.Millisecond)
+	id := mgobson.NewObjectId()
+	s.patchDoc = &patch.Patch{
+		Id:           id,
+		Version:      id.Hex(),
+		Activated:    true,
+		DisplayNewUI: true,
+		Status:       evergreen.PatchStarted,
+		StartTime:    startTime,
+		FinishTime:   startTime.Add(10 * time.Minute),
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			HeadOwner: "tychoish",
+			HeadRepo:  "evergreen",
+			PRNumber:  448,
+			HeadHash:  "776f608b5b12cd27b8d931c8ee4ca0c13f857299",
+		},
+	}
+	s.NoError(s.patchDoc.Insert())
+
+}
+
+func (s *githubStatusRefreshSuite) TearDownTest() {
+	s.cancel()
+}
+
+func (s *githubStatusRefreshSuite) TestRunInDegradedMode() {
+	flags := evergreen.ServiceFlags{
+		GithubStatusAPIDisabled: true,
+	}
+	s.Require().NoError(evergreen.SetServiceFlags(flags))
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	job.env = s.env
+	job.Run(context.Background())
+
+	s.False(job.HasErrors())
+}
+
+func (s *githubStatusRefreshSuite) TestFetch() {
+	b := build.Build{
+		Id:      "b1",
+		Version: s.patchDoc.Version,
+		Status:  evergreen.BuildStarted,
+	}
+	s.NoError(b.Insert())
+	childPatch := patch.Patch{
+		Id: mgobson.NewObjectId(),
+	}
+	s.NoError(childPatch.Insert())
+	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
+	s.NoError(s.patchDoc.SetChildPatches())
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	s.Require().NotNil(job.patch)
+	job.env = s.env
+
+	s.NoError(job.fetch())
+	s.NotEmpty(job.urlBase)
+	s.Len(job.builds, 1)
+	s.Len(job.childPatches, 1)
+}
+
+func (s *githubStatusRefreshSuite) TestStatusPending() {
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "myBuild",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildStarted,
+	}
+	s.NoError(b.Insert())
+
+	childPatch := patch.Patch{
+		Id:        mgobson.NewObjectId(),
+		Status:    evergreen.PatchStarted,
+		Project:   "myChildProject",
+		Activated: true,
+		Triggers: patch.TriggerInfo{
+			ParentPatch: s.patchDoc.Id.Hex(),
+		},
+		DisplayNewUI: true,
+	}
+	s.NoError(childPatch.Insert())
+	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	s.Require().NotNil(job.patch)
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s?redirect_spruce_users=true", s.patchDoc.Version), status.URL)
+	s.Equal("evergreen", status.Context)
+	s.Equal(message.GithubStatePending, status.State)
+	s.Equal("tasks are running", status.Description)
+
+	// Child patch status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
+	s.Equal(message.GithubStatePending, status.State)
+	s.Equal("tasks are running", status.Description)
+
+	// Build status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/build/%s?redirect_spruce_users=true", b.Id), status.URL)
+	s.Equal("evergreen/myBuild", status.Context)
+	s.Equal(message.GithubStatePending, status.State)
+	s.Equal("tasks are running", status.Description)
+}
+
+func (s *githubStatusRefreshSuite) TestStatusSucceeded() {
+	startTime := time.Now()
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "myBuild",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildSucceeded,
+		StartTime:    startTime,
+		FinishTime:   startTime.Add(time.Minute),
+	}
+	s.NoError(b.Insert())
+	t1 := task.Task{
+		Id:      "t1",
+		Version: s.patchDoc.Version,
+		BuildId: b.Id,
+		Status:  evergreen.TaskSucceeded,
+	}
+	s.NoError(t1.Insert())
+
+	childPatch := patch.Patch{
+		Id:         mgobson.NewObjectId(),
+		Status:     evergreen.PatchSucceeded,
+		Project:    "myChildProject",
+		Activated:  true,
+		StartTime:  startTime,
+		FinishTime: startTime.Add(12 * time.Minute),
+		Triggers: patch.TriggerInfo{
+			ParentPatch: s.patchDoc.Id.Hex(),
+		},
+		DisplayNewUI: true,
+	}
+	s.NoError(childPatch.Insert())
+	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
+	s.patchDoc.Status = evergreen.PatchSucceeded
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	s.Require().NotNil(job.patch)
+
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
+	if job.HasErrors() {
+		fmt.Println(job.Error())
+	}
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s?redirect_spruce_users=true", s.patchDoc.Version), status.URL)
+	s.Equal("evergreen", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+	s.Equal("version finished in 10m0s", status.Description)
+
+	// Child patch status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+	s.Equal("child patch finished in 12m0s", status.Description)
+
+	// Build status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/build/%s?redirect_spruce_users=true", b.Id), status.URL)
+	s.Equal("evergreen/myBuild", status.Context)
+	s.Equal("1 succeeded, none failed in 1m0s", status.Description)
+	s.Equal(message.GithubStateSuccess, status.State)
+}
+
+func (s *githubStatusRefreshSuite) TestStatusFailed() {
+	startTime := time.Now()
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "myBuild",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildFailed,
+		StartTime:    startTime,
+		FinishTime:   startTime.Add(time.Minute),
+	}
+	s.NoError(b.Insert())
+	t1 := task.Task{
+		Id:      "t1",
+		Version: s.patchDoc.Version,
+		BuildId: b.Id,
+		Status:  evergreen.TaskFailed,
+	}
+	s.NoError(t1.Insert())
+
+	childPatch := patch.Patch{
+		Id:         mgobson.NewObjectId(),
+		Status:     evergreen.PatchFailed,
+		Project:    "myChildProject",
+		Activated:  true,
+		StartTime:  startTime,
+		FinishTime: startTime.Add(12 * time.Minute),
+		Triggers: patch.TriggerInfo{
+			ParentPatch: s.patchDoc.Id.Hex(),
+		},
+		DisplayNewUI: true,
+	}
+	s.NoError(childPatch.Insert())
+	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
+	s.patchDoc.Status = evergreen.PatchSucceeded
+
+	s.patchDoc.Status = evergreen.PatchFailed
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().NotNil(job)
+	s.Require().True(ok)
+	s.Require().NotNil(job.patch)
+
+	job.env = s.env
+	job.Run(context.Background())
+	s.False(job.HasErrors())
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s?redirect_spruce_users=true", s.patchDoc.Version), status.URL)
+	s.Equal("evergreen", status.Context)
+	s.Equal(message.GithubStateFailure, status.State)
+	s.Equal("version finished in 10m0s", status.Description)
+
+	// Child patch status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
+	s.Equal(message.GithubStateFailure, status.State)
+	s.Equal("child patch finished in 12m0s", status.Description)
+
+	// Build status
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal(fmt.Sprintf("https://example.com/build/%s?redirect_spruce_users=true", b.Id), status.URL)
+	s.Equal("evergreen/myBuild", status.Context)
+	s.Equal("none succeeded, 1 failed in 1m0s", status.Description)
+	s.Equal(message.GithubStateFailure, status.State)
+}
+
+func (s *githubStatusRefreshSuite) getAndValidateStatus(sender *send.InternalSender) *message.GithubStatus {
+	msg, ok := sender.GetMessageSafe()
+	s.Require().True(ok)
+	raw := msg.Message
+	s.Require().NotNil(raw)
+	status, ok := raw.Raw().(*message.GithubStatus)
+	s.Require().True(ok)
+
+	s.Equal("evergreen-ci", status.Owner)
+	s.Equal("evergreen", status.Repo)
+	s.Equal("776f608b5b12cd27b8d931c8ee4ca0c13f857299", status.Ref)
+	return status
+}

--- a/units/github_status_refresh_test.go
+++ b/units/github_status_refresh_test.go
@@ -23,8 +23,6 @@ import (
 type githubStatusRefreshSuite struct {
 	env      *mock.Environment
 	patchDoc *patch.Patch
-	builds   []build.Build
-	tasks    []task.Task
 
 	cancel context.CancelFunc
 	suite.Suite


### PR DESCRIPTION
EVG-16349

### Description
Add `github status` to allow for refreshing checks. I'm torn between status, checks, and refresh for the language here. Any preferences?

Refactored a number of trigger things so they could be used in units.

### Testing
Tested a lot on staging. 
Created to test general functionality https://github.com/evergreen-ci/commit-queue-sandbox/pull/448
and https://github.com/evergreen-ci/commit-queue-sandbox/pull/449 to test child patches.
Added &refreshed_status=true to these to make it clearer that they were just generated.
(Build links aren't correct here but that was fixed in cleanup and isn't a huge deal either way)

#### Does this need documentation?
Yes -- I don't think we have a documentation page about evergreen github commands; if not I'll add one, otherwise i'll add to it.