### PR TITLE
EVG-18700: get project config with unfinalized patches from legacy route

### DIFF
--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -77,24 +77,35 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if projCtx.Version == nil {
-		gimlet.WriteJSONInternalError(w, fmt.Sprintf("cannot get parser project for patch '%s' because version is nil", projCtx.Patch.Id.Hex()))
-		return
-	}
-
 	settings := restapi.GetSettings()
-	pp, err := model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Version.Id)
-	if err != nil {
-		gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "finding parser project '%s' for patch '%s'", projCtx.Version.Id, projCtx.Patch.Id.Hex()))
-		return
-	}
-	if pp == nil {
-		gimlet.WriteJSONInternalError(w, fmt.Sprintf("parser project '%s' for patch '%s' not found", projCtx.Version.Id, projCtx.Patch.Id.Hex()))
+	var pp *model.ParserProject
+	if projCtx.Patch.ProjectStorageMethod != "" {
+		pp, err := model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Patch.Id.Hex())
+		if err != nil {
+			gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "finding parser project for patch '%s'", projCtx.Patch.Id.Hex()))
+			return
+		}
+		if pp == nil {
+			gimlet.WriteJSONInternalError(w, fmt.Sprintf("parser project for patch '%s' not found", projCtx.Patch.Id.Hex()))
+			return
+		}
+	} else if projCtx.Version != nil {
+		pp, err := model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Version.Id)
+		if err != nil {
+			gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "finding parser project '%s' for version '%s'", projCtx.Version.Id, projCtx.Version.Id))
+			return
+		}
+		if pp == nil {
+			gimlet.WriteJSONInternalError(w, fmt.Sprintf("parser project '%s' for patch '%s' not found", projCtx.Version.Id, projCtx.Patch.Id.Hex()))
+			return
+		}
+	} else {
+		gimlet.WriteJSONInternalError(w, fmt.Sprintf("cannot get parser project for patch '%s' because patch has no associated parser project and version is nil", projCtx.Patch.Id.Hex()))
 		return
 	}
 
 	var projBytes []byte
-	projBytes, err = yaml.Marshal(pp)
+	projBytes, err := yaml.Marshal(pp)
 	if err != nil {
 		gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "marshalling parser project '%s' to YAML", pp.Id))
 		return

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -79,8 +79,9 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 
 	settings := restapi.GetSettings()
 	var pp *model.ParserProject
+	var err error
 	if projCtx.Patch.ProjectStorageMethod != "" {
-		pp, err := model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Patch.Id.Hex())
+		pp, err = model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Patch.Id.Hex())
 		if err != nil {
 			gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "finding parser project for patch '%s'", projCtx.Patch.Id.Hex()))
 			return
@@ -90,7 +91,7 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else if projCtx.Version != nil {
-		pp, err := model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Version.Id)
+		pp, err = model.ParserProjectFindOneByID(r.Context(), &settings, projCtx.Version.ProjectStorageMethod, projCtx.Version.Id)
 		if err != nil {
 			gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "finding parser project '%s' for version '%s'", projCtx.Version.Id, projCtx.Version.Id))
 			return
@@ -104,7 +105,6 @@ func (restapi restAPI) getPatchConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var projBytes []byte
 	projBytes, err := yaml.Marshal(pp)
 	if err != nil {
 		gimlet.WriteJSONInternalError(w, errors.Wrapf(err, "marshalling parser project '%s' to YAML", pp.Id))


### PR DESCRIPTION
EVG-18700

### Description
I missed that `getPatchConfig` in the legacy route depends on the `PatchedParserProject`, and that route is used by the legacy CLI client to get parser project info.

### Testing
This function already doesn't have testing, I don't want to add tests for a hotfix.

#### Does this need documentation?
N/A