### PR TITLE
EVG-17642 Use debug compile flags for dist-staging

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -16,6 +16,7 @@ func main() {
 		directory string
 		source    string
 		ldFlags   string
+		gcFlags   string
 		buildName string
 		output    string
 		goBin     string
@@ -38,6 +39,7 @@ func main() {
 	flag.StringVar(&directory, "directory", "", "output directory")
 	flag.StringVar(&source, "source", "", "path to source file")
 	flag.StringVar(&ldFlags, "ldflags", "", "specify any ldflags to pass to go build")
+	flag.StringVar(&gcFlags, "gcflags", "", "specify any gcflags to pass to go build")
 	flag.StringVar(&buildName, "buildName", "", "use GOOS_ARCH to specify target platform")
 	flag.StringVar(&goBin, "goBinary", "go", "specify path to go binary")
 	flag.StringVar(&output, "output", "", "specify the name of executable")
@@ -67,6 +69,10 @@ func main() {
 	ldfQuoted := fmt.Sprintf("-ldflags=\"%s\"", ldFlags)
 	cmd.Args = append(cmd.Args, ldf)
 
+	gcf := fmt.Sprintf("-gcflags=%s", gcFlags)
+	gcfQuoted := fmt.Sprintf("-gcflags=\"%s\"", gcFlags)
+	cmd.Args = append(cmd.Args, gcf)
+
 	cmd.Env = os.Environ()
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
@@ -84,6 +90,7 @@ func main() {
 	cmd.Stderr = os.Stderr
 
 	cmdString := strings.Join(cmd.Args, " ")
+	cmdString = strings.Replace(cmdString, gcf, gcfQuoted, -1)
 	fmt.Println(goos, goarch, strings.Replace(cmdString, ldf, ldfQuoted, -1))
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("problem building %s: %v\n", output, err)

--- a/makefile
+++ b/makefile
@@ -97,6 +97,7 @@ testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*
 currentHash := $(shell git rev-parse HEAD)
 agentVersion := $(shell grep "AgentVersion" config.go | tr -d '\tAgentVersion = ' | tr -d '"')
 ldFlags := $(if $(DEBUG_ENABLED),,-w -s )-X=github.com/evergreen-ci/evergreen.BuildRevision=$(currentHash)
+gcFlags := $(if $(STAGING_ONLY),-N -l,)
 karmaFlags := $(if $(KARMA_REPORTER),--reporters $(KARMA_REPORTER),)
 # end evergreen specific configuration
 
@@ -116,7 +117,7 @@ endif
 cli:$(localClientBinary)
 clis:$(clientBinaries)
 $(clientBuildDir)/%/$(unixBinaryBasename) $(clientBuildDir)/%/$(windowsBinaryBasename):$(buildDir)/build-cross-compile $(srcFiles) go.mod go.sum
-	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -goBinary="$(gobin)" -directory=$(clientBuildDir) -source=$(clientSource) -output=$@
+	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -gcflags="$(gcFlags)" -goBinary="$(gobin)" -directory=$(clientBuildDir) -source=$(clientSource) -output=$@
 # Targets to upload the CLI binaries to S3.
 $(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go
 	@$(gobin) build -o $@ $<


### PR DESCRIPTION
EVG-17642

### Description
For usage of Delve, passing compiler flags `-gcflags="-N -l"` is necessary to disable compiler optimizations, which enables breakpoints and running the application in debug mode. Essentially this ensures that the compiled dist retains all of the necessary debugging information, such as variable names and function boundaries, and that the code behaves more predictably during debugging.

Since we're only debugging staging, I changed the `dist-staging` command to use these flags.

### Testing
Ran `make dist` and `make dist-staging` and confirmed only the latter was compiled with the custom flags.
#### Does this need documentation?
N/A because kernel-tools still needs a PR before remote debugging docs can be written.