### PR TITLE
EVG-18584 upgrade our windows distro

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -664,8 +664,8 @@ buildvariants:
   - name: windows
     display_name: Windows
     run_on:
-      - windows-64-vs2017-small
-      - windows-64-vs2017-large
+      - windows-2022-small
+      - windows-2022-large
     expansions:
       GOROOT: c:/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -664,8 +664,8 @@ buildvariants:
   - name: windows
     display_name: Windows
     run_on:
-      - windows-2022-small
-      - windows-2022-large
+      - windows-vsCurrent-small
+      - windows-vsCurrent-large
     expansions:
       GOROOT: c:/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true


### PR DESCRIPTION
[EVG-18584](https://jira.mongodb.org/browse/EVG-18584)

### Description
https://github.com/evergreen-ci/evergreen/commit/e1789d96a1729ae60ad9dd48d6401bb9a2f16cd5 changed the go version to a version that's not present on our old windows version. This will move us to a more recent version.
