### PR TITLE
EVG-18878 Initialize newly created projects as private

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -467,8 +467,9 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 	if p.Id == "" {
 		p.Id = mgobson.NewObjectId().Hex()
 	}
-	// Ensure that any new project is originally explicitly disabled.
+	// Ensure that any new project is originally explicitly disabled and set to private.
 	p.Enabled = utility.FalsePtr()
+	p.Private = utility.TruePtr()
 
 	// if a hidden project exists for this configuration, use that ID
 	if p.Owner != "" && p.Repo != "" && p.Branch != "" {


### PR DESCRIPTION
EVG-18878

### Description
Change to set all incoming created projects as `Private: true` by default.