### PR TITLE
EVG-18970: allow attach.xunit_results to use absolute path containing working directory

### DIFF
--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
@@ -97,7 +98,9 @@ func getFilePaths(workDir string, files []string) ([]string, error) {
 	out := []string{}
 
 	for _, fileSpec := range files {
-		paths, err := filepath.Glob(filepath.Join(workDir, fileSpec))
+		relativeToWorkDir := strings.TrimPrefix(filepath.ToSlash(fileSpec), filepath.ToSlash(workDir))
+		path := filepath.Join(workDir, relativeToWorkDir)
+		paths, err := filepath.Glob(path)
 		catcher.Add(err)
 		out = append(out, paths...)
 	}


### PR DESCRIPTION
EVG-18970

### Description
`file`/`files` for `attach.xunit_results` is assumed to be a relatively path. This allows a file to be an absolute path as long as its prefixed by a subdirectory of the task working directory.

### Testing
Added unit tests.

#### Does this need documentation?
Will update wiki docs for `attach.xunit_results`.