### PR TITLE
EVG-19082 Do not activate disabled tasks in repotracker job

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -132,8 +132,9 @@ func setTaskActivationForBuilds(buildIds []string, active, withDependencies bool
 	// If activating a task, set the ActivatedBy field to be the caller
 	if active {
 		q := bson.M{
-			task.BuildIdKey: bson.M{"$in": buildIds},
-			task.StatusKey:  evergreen.TaskUndispatched,
+			task.BuildIdKey:  bson.M{"$in": buildIds},
+			task.StatusKey:   evergreen.TaskUndispatched,
+			task.PriorityKey: bson.M{"$gt": evergreen.DisabledTaskPriority},
 		}
 		if len(ignoreTasks) > 0 {
 			q[task.IdKey] = bson.M{"$nin": ignoreTasks}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -124,7 +124,7 @@ func ActivateBuildsAndTasks(buildIds []string, active bool, caller string) error
 		"setting task activation for builds '%v'", buildIds)
 }
 
-// setTaskActivationForBuilds updates the "active" state of all tasks in buildIds.
+// setTaskActivationForBuilds updates the "active" state of all non-disabled tasks in buildIds.
 // It also updates the task cache for the build document.
 // If withDependencies is true, also set dependencies. Don't need to do this when the entire version is affected.
 // If tasks are given to ignore, then we don't activate those tasks.

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -282,6 +282,7 @@ buildvariants:
   - name: t1
     batchtime: 30
   - name: t2
+  - name: t3
 - name: bv2
   display_name: bv2_display
   run_on: d2
@@ -292,6 +293,7 @@ tasks:
   priority: 3
 - name: t2
   priority: -1
+- name: t3
 `
 
 	previouslyActivatedVersion := &model.Version{
@@ -375,9 +377,18 @@ tasks:
 
 	// neither batchtime task nor disabled task should be activated
 	tasks, err := task.Find(task.ByBuildId(build1.Id))
-	assert.Len(t, tasks, 2)
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 3)
 	for _, tsk := range tasks {
-		assert.False(t, tsk.Activated)
+		if tsk.DisplayName == "t1" {
+			assert.False(t, tsk.Activated)
+		}
+		if tsk.DisplayName == "t2" {
+			assert.False(t, tsk.Activated)
+		}
+		if tsk.DisplayName == "t3" {
+			assert.True(t, tsk.Activated)
+		}
 	}
 
 	// now we should update just the task even though the build is activated already


### PR DESCRIPTION
EVG-19082

### Description
The version activation done by repotracker jobs has a [bug](https://gist.github.com/hadjri/dc7854c1bc80233cf3252684ca5eebef#file-lifecycle-go-L135) where it does not ignore disabled tasks when doing activation. Therefore,  setting `priority: -1 in YAML` would not have any effect for mainline versions because they get [un-disabled ](https://gist.github.com/hadjri/3e7b9681daeebadb310db6bc0fc3b2e8#file-db-go-L2687)during activation, which is behavior we don't want. Reproduced this bug in staging.

Added a change to not query disabled tasks when performing activation.
### Testing
Added new unit test affirming this, also tested in staging.
#### Does this need documentation?
N/A
