### PR TITLE
EVG-18584 run dist-staging on ubuntu

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -346,7 +346,9 @@ tasks:
   - <<: *run-build
     name: dist-staging
     patch_only: true
-    run_on: archlinux-new-small
+    run_on:
+      - ubuntu2004-small
+      - ubuntu2004-large
   - <<: *run-build
     name: dist
   - <<: *run-build

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -346,9 +346,6 @@ tasks:
   - <<: *run-build
     name: dist-staging
     patch_only: true
-    run_on:
-      - ubuntu2004-small
-      - ubuntu2004-large
   - <<: *run-build
     name: dist
   - <<: *run-build


### PR DESCRIPTION
[EVG-18584](https://jira.mongodb.org/browse/EVG-18584)

### Description
https://github.com/evergreen-ci/evergreen/pull/6285 moved the remaining stuff off archlinux because it doesn't have go1.19 on it (because it's hard for build to build images for). It missed dist-staging. This PR moves dist-staging to ubuntu2004.

### Testing
I'll add dist-staging to this PR

#### Does this need documentation?
N/A
