### PR TITLE
EVG-19098 refresh status if commit queue merge is blocked

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -309,35 +309,9 @@ func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc C
 		return nil, errors.Errorf("user '%s' is not authorized to merge", userRepo.Username)
 	}
 
-	pr, err := sc.GetGitHubPR(ctx, userRepo.Owner, userRepo.Repo, info.PR)
+	pr, err := getPRAndCheckMergeable(ctx, env, sc, info)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting PR from GitHub API")
-	}
-
-	if pr == nil || pr.Base == nil || pr.Base.Ref == nil {
-		return nil, errors.New("PR contains no base branch label")
-	}
-
-	if !thirdparty.IsUnblockedGithubStatus(pr.GetMergeableState()) {
-		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", pr.GetMergeableState())
-		grip.Debug(message.Fields{
-			"message":        errMsg,
-			"state":          pr.GetMergeableState(),
-			"owner":          userRepo.Owner,
-			"repo":           userRepo.Repo,
-			"pr_title":       pr.GetTitle(),
-			"commit_message": pr.GetNumber(),
-		})
-		sendErr := thirdparty.SendCommitQueueGithubStatus(env, pr, message.GithubStateFailure, errMsg, "")
-
-		grip.Error(message.WrapError(sendErr, message.Fields{
-			"message": "error sending patch creation failure to github",
-			"owner":   userRepo.Owner,
-			"repo":    userRepo.Repo,
-			"pr":      info.PR,
-		}))
-
-		return nil, errors.New(errMsg)
+		return nil, err
 	}
 
 	cqInfo := restModel.ParseGitHubComment(info.CommitMessage)
@@ -375,6 +349,72 @@ func EnqueuePRToCommitQueue(ctx context.Context, env evergreen.Environment, sc C
 		return nil, errors.Wrap(err, "converting patch to API model")
 	}
 	return apiPatch, nil
+}
+
+// getPRAndCheckBase gets the Github PR and verifies that base and base ref is set
+func getPRAndCheckBase(ctx context.Context, sc Connector, info commitqueue.EnqueuePRInfo) (*github.PullRequest, error) {
+	pr, err := sc.GetGitHubPR(ctx, info.Owner, info.Repo, info.PR)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting PR from GitHub API")
+	}
+	if pr == nil || pr.Base == nil || pr.Base.Ref == nil {
+		return nil, errors.New("PR contains no base branch label")
+	}
+	return pr, nil
+}
+
+// getPRAndCheckMergeable gets the Github PR, verifies base, and verifies that the PR is mergeable.
+// Attempts to refresh the status if the PR is marked as blocked but the patch is successful.
+func getPRAndCheckMergeable(ctx context.Context, env evergreen.Environment, sc Connector, info commitqueue.EnqueuePRInfo) (*github.PullRequest, error) {
+	pr, err := getPRAndCheckBase(ctx, sc, info)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the PR is blocked and the patch is successful, refresh status, and re-check PR.
+	if pr.GetMergeableState() == thirdparty.GithubPRBlocked {
+		p, err := patch.FindLatestGithubPRPatch(info.Owner, info.Repo, info.PR)
+		if err != nil {
+			// Not required that such a patch exists, since the commit queue can be enabled without PR checks, so we log at debugging.
+			grip.Debug(message.WrapError(err, message.Fields{
+				"message": "couldn't find latest PR patch when enqueuing PR",
+				"ticket":  "EVG-19098",
+				"owner":   info.Owner,
+				"repo":    info.Repo,
+				"pr":      info.PR,
+			}))
+		} else if p != nil && p.Version != "" && p.Status == evergreen.PatchSucceeded {
+			refreshJob := units.NewGithubStatusRefreshJob(p)
+			refreshJob.Run(ctx)
+			pr, err = getPRAndCheckBase(ctx, sc, info)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if !thirdparty.IsUnblockedGithubStatus(pr.GetMergeableState()) {
+		errMsg := fmt.Sprintf("PR is not mergeable, status: %s", pr.GetMergeableState())
+		grip.Debug(message.Fields{
+			"message":  errMsg,
+			"state":    pr.GetMergeableState(),
+			"owner":    info.Owner,
+			"repo":     info.Repo,
+			"pr_title": pr.GetTitle(),
+			"pr_num":   pr.GetNumber(),
+		})
+		sendErr := thirdparty.SendCommitQueueGithubStatus(env, pr, message.GithubStateFailure, errMsg, "")
+
+		grip.Error(message.WrapError(sendErr, message.Fields{
+			"message": "error sending patch creation failure to github",
+			"owner":   info.Owner,
+			"repo":    info.Repo,
+			"pr":      pr.GetNumber(),
+		}))
+		return nil, errors.New(errMsg)
+	}
+
+	return pr, nil
 }
 
 // tryEnqueueItemForPR attempts to enqueue an item for a PR after checking it is in a valid state to enqueue. It returns the enqueued patch,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -37,29 +37,31 @@ const (
 )
 
 var UnblockedGithubStatuses = []string{
-	githubPrBehind,
-	githubPrClean,
-	githubPrDirty,
-	githubPrDraft,
-	githubPrHas_Hooks,
-	githubPrUnknown,
-	githubPrUnstable,
+	githubPRBehind,
+	githubPRClean,
+	githubPRDirty,
+	githubPRDraft,
+	githubPRHasHooks,
+	githubPRUnknown,
+	githubPRUnstable,
 }
 
 const (
+	GithubPRBlocked = "blocked"
+
 	// All PR statuses except for "blocked" based on statuses listed here:
 	// https://docs.github.com/en/graphql/reference/enums#mergestatestatus
 	// Because the pr.MergeableState is not documented, it can change without
 	// notice. That's why we want to only allow fields we know to be unblocked
 	// rather than simply blocking the "blocked" status. That way if it does
 	// change, it doesn't fail silently.
-	githubPrBehind    = "behind"
-	githubPrClean     = "clean"
-	githubPrDirty     = "dirty"
-	githubPrDraft     = "draft"
-	githubPrHas_Hooks = "has_hooks"
-	githubPrUnknown   = "unknown"
-	githubPrUnstable  = "unstable"
+	githubPRBehind   = "behind"
+	githubPRClean    = "clean"
+	githubPRDirty    = "dirty"
+	githubPRDraft    = "draft"
+	githubPRHasHooks = "has_hooks"
+	githubPRUnknown  = "unknown"
+	githubPRUnstable = "unstable"
 )
 
 // IsUnblockedGithubStatus returns true if the status is in the list of unblocked statuses


### PR DESCRIPTION
EVG-19098

### Description
We added the `evergreen refresh` comment which will be cool but it would also be cool if we automatically refreshed this if we see that a merge is blocked but the patch is successful (this may over-refresh since a merge can be blocked on other things but since this is manually triggered I don't expect it to be too much).

### Testing
Tested with a PR, where the first merge fails because PR status sending is disabled, and the second merge succeeds.
https://github.com/evergreen-ci/commit-queue-sandbox/pull/453

#### Does this need documentation?
Will add to the `evergreen merge` documentation
