### PR TITLE
EVG-19135: Improve patch validate error message

### DIFF
--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -68,13 +68,13 @@ func GitApplyNumstat(patch string) (*bytes.Buffer, error) {
 
 	// this should never happen if patch is initially validated
 	if err := cmd.Start(); err != nil {
-		return nil, errors.Wrapf(err, "starting `git apply --numstat`: 424 - %v",
+		return nil, errors.Wrapf(err, "starting 'git apply --numstat': 424 - %v",
 			summaryBuffer.String())
 	}
 
 	// this should never happen if patch is initially validated
 	if err := cmd.Wait(); err != nil {
-		return nil, errors.Wrapf(err, "running `git apply --numstat`: 562 - %v",
+		return nil, errors.Wrapf(err, "running 'git apply --numstat': 562 - %v",
 			summaryBuffer.String())
 	}
 	return &summaryBuffer, nil

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -35,7 +35,7 @@ type Commit struct {
 func GitApplyNumstat(patch string) (*bytes.Buffer, error) {
 	handle, err := os.CreateTemp("", utility.RandomString())
 	if err != nil {
-		return nil, errors.New("Unable to create local patch file")
+		return nil, errors.Wrapf(err, "creating local patch file")
 	}
 	defer func() {
 		grip.Error(handle.Close())
@@ -48,14 +48,14 @@ func GitApplyNumstat(patch string) (*bytes.Buffer, error) {
 		// read a chunk
 		n, err := buffer.Read(buf)
 		if err != nil && err != io.EOF {
-			return nil, errors.New("Unable to read supplied patch file")
+			return nil, errors.Wrapf(err, "reading supplied patch file")
 		}
 		if n == 0 {
 			break
 		}
 		// write a chunk
 		if _, err := handle.Write(buf[:n]); err != nil {
-			return nil, errors.New("Unable to write supplied patch file")
+			return nil, errors.Wrapf(err, "writing supplied patch file")
 		}
 	}
 
@@ -68,13 +68,13 @@ func GitApplyNumstat(patch string) (*bytes.Buffer, error) {
 
 	// this should never happen if patch is initially validated
 	if err := cmd.Start(); err != nil {
-		return nil, errors.Wrapf(err, "Error validating patch: 424 - %v",
+		return nil, errors.Wrapf(err, "starting `git apply --numstat`: 424 - %v",
 			summaryBuffer.String())
 	}
 
 	// this should never happen if patch is initially validated
 	if err := cmd.Wait(); err != nil {
-		return nil, errors.Wrapf(err, "Error waiting on patch: 562 - %v",
+		return nil, errors.Wrapf(err, "running `git apply --numstat`: 562 - %v",
 			summaryBuffer.String())
 	}
 	return &summaryBuffer, nil
@@ -138,15 +138,15 @@ func GetPatchSummaries(patchContent string) ([]Summary, error) {
 	if patchContent != "" {
 		gitOutput, err := GitApplyNumstat(patchContent)
 		if err != nil {
-			return nil, errors.Wrap(err, "couldn't validate patch")
+			return nil, errors.Wrap(err, "validating patch")
 		}
 		if gitOutput == nil {
-			return nil, errors.New("couldn't validate patch: git apply --numstat returned empty")
+			return nil, errors.New("validating patch: `git apply --numstat` returned empty")
 		}
 
 		summaries, err = ParseGitSummary(gitOutput)
 		if err != nil {
-			return nil, errors.Wrap(err, "couldn't parse git summary")
+			return nil, errors.Wrap(err, "parsing git summary")
 		}
 	}
 	return summaries, nil


### PR DESCRIPTION
EVG-19135

### Description
Improve error messages when `git apply --numstat` fails to make it more clear to users why their patch fails.

[Slack archive](https://mongodb.slack.com/archives/C0V896UV8/p1678303811935539)

### Testing
N/A

#### Does this need documentation?
No.
