### PR TITLE
EVG-19138 reintroduce webhook logging

### DIFF
--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -168,6 +169,19 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			return true, errors.Errorf("response was %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
 		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return true, errors.Wrap(err, "reading webhook response")
+		}
+
+		grip.Info(message.Fields{
+			"message":         "send webhook notification",
+			"notification_id": raw.NotificationID,
+			"url":             raw.URL,
+			"response_code":   resp.StatusCode,
+			"response_body":   body,
+		})
 
 		return false, nil
 	}, utility.RetryOptions{

--- a/util/webhook_grip_test.go
+++ b/util/webhook_grip_test.go
@@ -220,7 +220,7 @@ func (t *mockWebhookTransport) RoundTrip(req *http.Request) (*http.Response, err
 	t.lastUrl = req.URL.String()
 	resp := &http.Response{
 		StatusCode: http.StatusNoContent,
-		Body:       io.NopCloser(nil),
+		Body:       http.NoBody,
 	}
 
 	if t.attemptCount < t.minAttempts {


### PR DESCRIPTION
[EVG-19138](https://jira.mongodb.org/browse/EVG-19138)

### Description
https://github.com/evergreen-ci/evergreen/pull/6313 introduced explicit logging when a webhook is sent. It was reverted because [test-util was failing](https://spruce.mongodb.com/task/evergreen_ubuntu2004_test_util_a023440dc412a3870b9a6177c189296f0e4c412a_23_03_09_16_50_32/tests?execution=1&sortBy=STATUS&sortDir=ASC). This was because the test uses a mock transport that sends a `nil` body. Since [the actual transport guarantees the body will never be nil](https://pkg.go.dev/net/http#Response) it makes sense to me to make the mock consistent with that and return the same thing the http transport will.

This PR cherry-picks the previous change and fixes the test.

### Testing
The test-util test passes now (hopefully it will pass in evergreen too 😅)

#### Does this need documentation?
N/A
