### PR TITLE
EVG-19162 restore the test count route

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -234,6 +234,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/manifest").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetManifestHandler())
 	app.AddRoute("/tasks/{task_id}/restart").Version(2).Post().Wrap(addProject, requireUser, editTasks).RouteHandler(makeTaskRestartHandler())
 	app.AddRoute("/tasks/{task_id}/tests").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestsForTask(env, sc))
+	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask())
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncPathGetHandler())
 	app.AddRoute("/tasks/{task_id}/set_results_info").Version(2).Post().Wrap(requireTask).RouteHandler(makeTaskSetResultsInfoHandler())
 	// TODO (EVG-18632): Remove this route once all agents are updated.


### PR DESCRIPTION
[EVG-19162](https://jira.mongodb.org/browse/EVG-19162)

### Description
In https://github.com/evergreen-ci/evergreen/pull/6269 we removed [the test count route](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-the-test-count-from-a-task). I think this was inadvertent so this PR will restore the route using the new framework for test stats.

### Testing
I'll put it up in staging when staging becomes available. I intend to try it out for a task that ran before the re-architecture and a task that ran after it.

#### Does this need documentation?
N/A
