### PR TITLE
EVG-18632: TODO clean up

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -237,8 +237,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask())
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncPathGetHandler())
 	app.AddRoute("/tasks/{task_id}/set_results_info").Version(2).Post().Wrap(requireTask).RouteHandler(makeTaskSetResultsInfoHandler())
-	// TODO (EVG-18632): Remove this route once all agents are updated.
-	app.AddRoute("/tasks/{task_id}/set_has_cedar_results").Version(2).Post().Wrap(requireTask).RouteHandler(makeTaskSetResultsInfoHandler())
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(requireUser).RouteHandler(makeSetUserConfig())

--- a/service/task.go
+++ b/service/task.go
@@ -878,7 +878,7 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 			}))
 		}
 	} else {
-		// TODO: EVG-17974 Replace this with a more permanent option.
+		// TODO (EVG-17662): Replace this with a more permanent option.
 		// Fallback to legacy test results.
 		// Direct link to a log document in the database.
 		testLog, err = model.FindOneTestLog(testName, taskID, taskExec)


### PR DESCRIPTION
EVG-18632

### Description
Clean up TODOs from ticket.
- Removes cedar test results agent route now that all agents are updated.

### Testing
N/A

#### Does this need documentation?
N/A
