### PR TITLE
EVG-19025 Add documentation for GraphQL API

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,0 +1,163 @@
+# Evergreen GraphQL API
+
+Welcome to the beta version of the Evergreen GraphQL API! This API provides both
+read and write access to various pieces of data found in Evergreen. You can use
+the GraphQL Playground to experiment with the API, which can be found at
+https://evergreen.mongodb.com/graphql.
+
+You can read more about GraphQL [here](https://graphql.org/learn/).
+
+## Getting Started
+
+To get started with the API, visit the GraphQL Playground at
+https://evergreen.mongodb.com/graphql. Here, you can explore the available data,
+execute queries, and see the results.
+
+To use the API in your own code, you can use the endpoint
+https://evergreen.mongodb.com/graphql/query. You can also leverage code
+generation to generate typings in your own language of choice.
+
+## Authentication
+
+To access any GraphQL endpoint, you must pass the mci-token cookie with your
+request. This cookie is used to authenticate your session with the Evergreen
+API. Without it, you will not be able to access any data.
+
+## Directives
+
+Evergreen's GraphQL API includes a few directives that manage permissions for
+certain pieces of data. Directives in GraphQL are used to add additional
+functionality to fields and types.
+
+For example, a common directive used in Evergreen GraphQL API is
+`@requireProjectAccess`. This directive checks whether the user has access to a
+given project. So you should ensure that the caller has permissions to view a
+project before calling a query that has this directive. You can find the other
+directives
+[here](https://github.com/evergreen-ci/evergreen/blob/d96942bcf0c26b158b8b1313bd27786f7a7c31a7/graphql/schema/directives.graphql)
+
+## Documentation
+
+The Evergreen GraphQL API is self-documenting, meaning that you can explore the
+available data and fields using the GraphQL Playground. Additionally, we are
+working on more comprehensive documentation to help you get started and make the
+most of the API.
+
+### Examples
+
+Below is an example of a GraphQL query to fetch the test result log URLs for the
+5 most recent mainline commits. The query filters on successful e2e_test tasks.
+Normally, this would require several API calls, as well as some app-side logic
+to fetch this data. With this query, however, all of the necessary information
+can be retrieved in just one request.
+
+```graphql
+{
+  mainlineCommits(
+    options: {projectIdentifier: "spruce", limit: 5}
+    buildVariantOptions: {tasks: "e2e_test", statuses: "success"}
+  ) {
+    versions {
+      version {
+        id
+        buildVariants(options: {tasks: "e2e_test"}) {
+          tasks {
+            displayName
+            execution
+            tests {
+              testResults {
+                testFile
+                status
+                logs {
+                  urlParsley
+                  urlRaw
+                }
+              }
+              totalTestCount
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Traditionally, fetching the base task and task for a given task would have
+required at least 2 fetch requests using the REST API. With GraphQL, this can
+now be achieved in just one request, simplifying the process and improving
+efficiency.
+
+```graphql
+{
+  task(taskId:"<task_id>", execution:0){
+    id
+    status
+    execution
+    displayName
+    baseTask {
+      id 
+      execution
+      status
+      displayName
+    }
+  }
+}
+```
+
+## Type Safety and Code Generation
+
+One of the key benefits of using GraphQL is that it provides strong type safety.
+GraphQL uses a type system to define the shape of the data available in the API.
+This means that you can know exactly what data you can expect to receive from
+the API, and you can catch errors related to missing or incorrect data at
+compile time.
+
+To make use of this type safety, you can generate client-side code in your own
+programming language. This can be done using a variety of code generation tools
+available in the GraphQL ecosystem, such as
+[graphql-codegen](https://the-guild.dev/graphql/codegen/docs/getting-started).
+
+Code generation tools can generate strongly typed APIs based on our GraphQL
+schema. This means that you can write code that directly interacts with the API,
+without having to manually parse the response data or worry about type
+mismatches.
+
+## Limitations and future improvements.
+
+The Evergreen GraphQL API is currently in beta and is not intended for public
+use. As such, we cannot guarantee that fields will not be changed in future
+releases. However, when we do deprecate a field, we typically mark it with the
+@deprecated directive. You can configure your GraphQL client to issue warnings
+when using these fields. Additionally, GraphQL's type safety ensures that you
+will be notified if any fields change. We recommend that you stay up to date
+with our API changes to ensure that your applications remain compatible with
+Evergreen.
+
+### SLA's and SLO's
+
+We cannot guarantee the performance of our GraphQL API since queries are
+determined by the client, and the performance may vary from request to request.
+However, we typically aim to have a response time of less than 2 seconds for
+most requests. More complex or resource-intensive queries may take longer to
+complete. While we currently monitor the overall performance of queries, we plan
+to introduce field-level monitoring in the future. This will allow us to
+identify which parts of queries are slower and make targeted performance
+improvements. We recommend that you optimize your queries to minimize their
+impact on performance and consider caching where appropriate to improve
+performance.
+
+Currently, almost all queries have a tracing parameter attached, which enables
+the exposure of field-level performance data for each requested resolver. This
+uses the
+[apollo-tracing format](https://github.com/apollographql/apollo-tracing). To
+better design your queries, you can utilize a Chrome extension tool called
+[Apollo Tracing](https://chrome.google.com/webstore/detail/apollo-tracing/cekcgnaofolhdeamjcghebalfmjodgeh?hl=en-US)
+which provides a visual representation of field level performance
+characteristics.
+
+## Feedback and Support
+
+We welcome your feedback and support as we continue to develop and improve the
+Evergreen GraphQL API. If you encounter any issues or have any suggestions,
+please let us know by reaching out to the evergreen team.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -5,9 +5,9 @@ and write access to various pieces of data found in Evergreen. You can use the
 GraphQL Playground, which can be found at https://evergreen.mongodb.com/graphql,
 to experiment with and explore the available data.
 
-To use the API in your own code, you can use the endpoint
-https://evergreen.mongodb.com/graphql/query, or alternatively, leverage code
-generation to generate typings in your preferred language.
+If you intend to use this API for production-level code, we ask that you get in
+touch with us to ensure proper support. However, if you wish to perform
+exploratory operations, there is no need to seek prior authorization.
 
 ## Authentication
 
@@ -23,6 +23,16 @@ types. A common directive used in Evergreen's GraphQL API is
 `@requireProjectAccess`. Before calling a query that has this directive, ensure
 the caller has permissions to view a project. You can find the other directives
 [here](https://github.com/evergreen-ci/evergreen/blob/d96942bcf0c26b158b8b1313bd27786f7a7c31a7/graphql/schema/directives.graphql).
+
+## Limitations and Future Improvements
+
+The Evergreen GraphQL API is currently in beta and not intended for public use,
+so we cannot guarantee field consistency between releases. However, when we
+deprecate a field, we mark it with the @deprecated directive. You can configure
+your GraphQL client to issue warnings when using these fields. Additionally,
+GraphQL's type safety ensures that you will be notified if fields change. We
+recommend staying up to date with our API changes to ensure application
+compatibility with Evergreen.
 
 ## Documentation
 
@@ -43,15 +53,15 @@ logic utilizing the traditional REST API. However, with our GraphQL API, it can
 be accomplished in a single declarative request.
 
 ```graphql
-{
-  mainlineCommits(
-    options: {projectIdentifier: "spruce", limit: 5}
-    buildVariantOptions: {tasks: "e2e_test", statuses: "success"}
-  ) {
+# Query with variables defined
+query ($options: MainlineCommitsOptions!, $buildVariantOptions: BuildVariantOptions!) {
+  # Pass in the options to the mainlineCommits query
+  mainlineCommits(options: $options, buildVariantOptions: $buildVariantOptions) {
     versions {
       version {
         id
-        buildVariants(options: {tasks: "e2e_test"}) {
+        # Pass in the options to the buildVariants query
+        buildVariants(options: $buildVariantOptions) {
           tasks {
             displayName
             execution
@@ -70,6 +80,20 @@ be accomplished in a single declarative request.
         }
       }
     }
+  }
+}
+```
+
+```json
+// Query Variables
+{
+  "options": {
+    "projectIdentifier": "spruce",
+    "limit": 5
+  },
+  "buildVariantOptions": {
+    "tasks": ["e2e_test"],
+    "statuses": ["success"]
   }
 }
 ```
@@ -109,16 +133,6 @@ Code generation tools are available in the GraphQL ecosystem, including
 which generate strongly typed APIs based on our GraphQL schema. This means you
 can write code that directly interacts with the API without manually parsing the
 response data or worrying about type mismatches.
-
-## Limitations and Future Improvements
-
-The Evergreen GraphQL API is currently in beta and not intended for public use,
-so we cannot guarantee field consistency between releases. However, when we
-deprecate a field, we mark it with the @deprecated directive. You can configure
-your GraphQL client to issue warnings when using these fields. Additionally,
-GraphQL's type safety ensures that you will be notified if fields change. We
-recommend staying up to date with our API changes to ensure application
-compatibility with Evergreen.
 
 ## SLA's and SLO's
 

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -1,55 +1,46 @@
 # Evergreen GraphQL API
 
-Welcome to the beta version of the Evergreen GraphQL API! This API provides both
-read and write access to various pieces of data found in Evergreen. You can use
-the GraphQL Playground to experiment with the API, which can be found at
-https://evergreen.mongodb.com/graphql.
-
-You can read more about GraphQL [here](https://graphql.org/learn/).
-
-## Getting Started
-
-To get started with the API, visit the GraphQL Playground at
-https://evergreen.mongodb.com/graphql. Here, you can explore the available data,
-execute queries, and see the results.
+Welcome to the beta version of the Evergreen GraphQL API! This API provides read
+and write access to various pieces of data found in Evergreen. You can use the
+GraphQL Playground, which can be found at https://evergreen.mongodb.com/graphql,
+to experiment with and explore the available data.
 
 To use the API in your own code, you can use the endpoint
-https://evergreen.mongodb.com/graphql/query. You can also leverage code
-generation to generate typings in your own language of choice.
+https://evergreen.mongodb.com/graphql/query, or alternatively, leverage code
+generation to generate typings in your preferred language.
 
 ## Authentication
 
-To access any GraphQL endpoint, you must pass the mci-token cookie with your
-request. This cookie is used to authenticate your session with the Evergreen
-API. Without it, you will not be able to access any data.
+To access any GraphQL endpoint, ensure you pass the mci-token cookie along with
+your request to authenticate your session with the Evergreen API, providing read
+and/or write access as required.
 
 ## Directives
 
-Evergreen's GraphQL API includes a few directives that manage permissions for
-certain pieces of data. Directives in GraphQL are used to add additional
-functionality to fields and types.
-
-For example, a common directive used in Evergreen GraphQL API is
-`@requireProjectAccess`. This directive checks whether the user has access to a
-given project. So you should ensure that the caller has permissions to view a
-project before calling a query that has this directive. You can find the other
-directives
-[here](https://github.com/evergreen-ci/evergreen/blob/d96942bcf0c26b158b8b1313bd27786f7a7c31a7/graphql/schema/directives.graphql)
+Evergreen's GraphQL API includes directives that manage permissions for specific
+pieces of data. These directives add additional functionality to fields and
+types. A common directive used in Evergreen's GraphQL API is
+`@requireProjectAccess`. Before calling a query that has this directive, ensure
+the caller has permissions to view a project. You can find the other directives
+[here](https://github.com/evergreen-ci/evergreen/blob/d96942bcf0c26b158b8b1313bd27786f7a7c31a7/graphql/schema/directives.graphql).
 
 ## Documentation
 
-The Evergreen GraphQL API is self-documenting, meaning that you can explore the
-available data and fields using the GraphQL Playground. Additionally, we are
-working on more comprehensive documentation to help you get started and make the
-most of the API.
+The Evergreen GraphQL API is self-documenting, meaning that you can use the
+GraphQL Playground to explore the available data and fields. More comprehensive
+documentation is currently being created to help fully utilize the API.
 
-### Examples
+## Examples
 
-Below is an example of a GraphQL query to fetch the test result log URLs for the
-5 most recent mainline commits. The query filters on successful e2e_test tasks.
-Normally, this would require several API calls, as well as some app-side logic
-to fetch this data. With this query, however, all of the necessary information
-can be retrieved in just one request.
+GraphQL queries offer efficient ways to retrieve information in single requests,
+compared to its REST counterpart. Below are a couple of examples:
+
+This query retrieves the latest 5 mainline commits and filters the tasks to only
+include those with a successful `e2e_test` task. Additionally, it fetches the
+log links for each test associated with these tasks. Previously, achieving this
+functionality would require multiple synchronous API calls and application-level
+logic utilizing the traditional REST API. However, with our GraphQL API, it can
+be accomplished in a single declarative request.
 
 ```graphql
 {
@@ -83,9 +74,9 @@ can be retrieved in just one request.
 }
 ```
 
-Traditionally, fetching the base task and task for a given task would have
-required at least 2 fetch requests using the REST API. With GraphQL, this can
-now be achieved in just one request, simplifying the process and improving
+Traditionally, fetching the desired data would have required a minimum of two
+fetch requests for a given task using the REST API. With GraphQL, however, it
+can be achieved in just one request, simplifying the process and improving
 efficiency.
 
 ```graphql
@@ -107,57 +98,47 @@ efficiency.
 
 ## Type Safety and Code Generation
 
-One of the key benefits of using GraphQL is that it provides strong type safety.
-GraphQL uses a type system to define the shape of the data available in the API.
-This means that you can know exactly what data you can expect to receive from
-the API, and you can catch errors related to missing or incorrect data at
-compile time.
+One of the key benefits of using GraphQL is its strong type safety. GraphQL uses
+a type system to define the shape of the data available in the API. This means
+you can catch errors related to missing or incorrect data at compile time. To
+utilize this type safety, you can generate client-side code in your preferred
+programming language.
 
-To make use of this type safety, you can generate client-side code in your own
-programming language. This can be done using a variety of code generation tools
-available in the GraphQL ecosystem, such as
-[graphql-codegen](https://the-guild.dev/graphql/codegen/docs/getting-started).
+Code generation tools are available in the GraphQL ecosystem, including
+[graphql-codegen](https://the-guild.dev/graphql/codegen/docs/getting-started),
+which generate strongly typed APIs based on our GraphQL schema. This means you
+can write code that directly interacts with the API without manually parsing the
+response data or worrying about type mismatches.
 
-Code generation tools can generate strongly typed APIs based on our GraphQL
-schema. This means that you can write code that directly interacts with the API,
-without having to manually parse the response data or worry about type
-mismatches.
+## Limitations and Future Improvements
 
-## Limitations and future improvements.
-
-The Evergreen GraphQL API is currently in beta and is not intended for public
-use. As such, we cannot guarantee that fields will not be changed in future
-releases. However, when we do deprecate a field, we typically mark it with the
-@deprecated directive. You can configure your GraphQL client to issue warnings
-when using these fields. Additionally, GraphQL's type safety ensures that you
-will be notified if any fields change. We recommend that you stay up to date
-with our API changes to ensure that your applications remain compatible with
-Evergreen.
+The Evergreen GraphQL API is currently in beta and not intended for public use,
+so we cannot guarantee field consistency between releases. However, when we
+deprecate a field, we mark it with the @deprecated directive. You can configure
+your GraphQL client to issue warnings when using these fields. Additionally,
+GraphQL's type safety ensures that you will be notified if fields change. We
+recommend staying up to date with our API changes to ensure application
+compatibility with Evergreen.
 
 ### SLA's and SLO's
 
-We cannot guarantee the performance of our GraphQL API since queries are
-determined by the client, and the performance may vary from request to request.
-However, we typically aim to have a response time of less than 2 seconds for
-most requests. More complex or resource-intensive queries may take longer to
-complete. While we currently monitor the overall performance of queries, we plan
-to introduce field-level monitoring in the future. This will allow us to
-identify which parts of queries are slower and make targeted performance
-improvements. We recommend that you optimize your queries to minimize their
-impact on performance and consider caching where appropriate to improve
-performance.
+As queries are determined by the client, we cannot guarantee the performance of
+our GraphQL API. We aim for a response time of less than 2 seconds for most
+requests, complex or resource-intensive queries may take longer. Although we
+currently monitor query performance, we plan to introduce field-level monitoring
+for targeted performance improvements. Optimizing queries to minimize
+performance impact and caching (if appropriate) is advisable.
 
-Currently, almost all queries have a tracing parameter attached, which enables
-the exposure of field-level performance data for each requested resolver. This
-uses the
-[apollo-tracing format](https://github.com/apollographql/apollo-tracing). To
-better design your queries, you can utilize a Chrome extension tool called
+Due to tracing parameters included almost all queries, exposing field-level
+performance data for each requested resolver using the
+[apollo-tracing format](https://github.com/apollographql/apollo-tracing), you
+can utilize a Chrome extension tool called
 [Apollo Tracing](https://chrome.google.com/webstore/detail/apollo-tracing/cekcgnaofolhdeamjcghebalfmjodgeh?hl=en-US)
-which provides a visual representation of field level performance
-characteristics.
+to better design queries, providing a helpful visual representation of
+field-level performance characteristics.
 
 ## Feedback and Support
 
-We welcome your feedback and support as we continue to develop and improve the
-Evergreen GraphQL API. If you encounter any issues or have any suggestions,
-please let us know by reaching out to the evergreen team.
+We welcome your feedback and support during Evergreen GraphQL API development.
+If an issue arises or you have any suggestions or feedback, please contact the
+Evergreen team.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -120,7 +120,7 @@ GraphQL's type safety ensures that you will be notified if fields change. We
 recommend staying up to date with our API changes to ensure application
 compatibility with Evergreen.
 
-### SLA's and SLO's
+## SLA's and SLO's
 
 As queries are determined by the client, we cannot guarantee the performance of
 our GraphQL API. We aim for a response time of less than 2 seconds for most


### PR DESCRIPTION
EVG-19025

### Description
Adds documentation for the GraphQL API. Summarizing the comments from the scope of PM-3106. 

#### Does this need documentation?
Yes, on the docs site. Tagging @bsamek  to ensure this gets added to the docs site.