### PR TITLE
EVG-19187: treat no reservation as nonexistent when getting fleet instance status

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1056,7 +1056,7 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 
 	instance, err := m.client.GetInstanceInfo(ctx, id)
 	if err != nil {
-		if err == noReservationError {
+		if isEC2InstanceNotFound(err) {
 			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/evergreen"
@@ -236,8 +235,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
-
-		if ec2Err, ok := errors.Cause(err).(awserr.Error); ok && ec2Err.Code() == EC2ErrorNotFound {
+		if isEC2InstanceNotFound(err) {
 			return StatusNonExistent, nil
 		}
 		grip.Error(message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -57,11 +57,18 @@ func TestFleet(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
-		"GetInstanceStatusNonExistent": func(*testing.T) {
+		"GetInstanceStatusNonExistentInstance": func(*testing.T) {
 			awsError := awserr.New(EC2ErrorNotFound, "The instance ID 'test-id' does not exist", nil)
 			wrappedAwsError := errors.Wrap(awsError, "EC2 API returned error for DescribeInstances")
 			mockClient := m.client.(*awsClientMock)
 			mockClient.RequestGetInstanceInfoError = wrappedAwsError
+			status, err := m.GetInstanceStatus(context.Background(), h)
+			assert.NoError(t, err)
+			assert.Equal(t, StatusNonExistent, status)
+		},
+		"GetInstanceStatusNonExistentReservation": func(*testing.T) {
+			mockClient := m.client.(*awsClientMock)
+			mockClient.RequestGetInstanceInfoError = noReservationError
 			status, err := m.GetInstanceStatus(context.Background(), h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -629,3 +629,15 @@ func Gp2EquivalentIOPSForGp3(volumeSize int) int {
 
 	return iops
 }
+
+// isEC2InstanceNotFound returns whether or not the given error is due to the
+// EC2 instance not being found.
+func isEC2InstanceNotFound(err error) bool {
+	if err == noReservationError {
+		return true
+	}
+	if ec2Err, ok := errors.Cause(err).(awserr.Error); ok && ec2Err.Code() == EC2ErrorNotFound {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
EVG-19187

### Description
Spawning spot hosts via fleet can result in `noReservationError` when the instance no longer exists, so `GetInstanceStatus` has to handle that explicitly.

### Testing
Added unit test.

#### Does this need documentation?
No.