### PR TITLE
EVG-18950 Add reporter to jira tickets created by s3 cred request

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -463,7 +463,7 @@ func (r *mutationResolver) CopyProject(ctx context.Context, project data.CopyPro
 	}
 	if utility.FromBoolPtr(requestS3Creds) {
 		usr := mustHaveUser(ctx)
-		if err = data.RequestS3Creds(*projectRef.Identifier, u.EmailAddress); err != nil {
+		if err = data.RequestS3Creds(*projectRef.Identifier, usr.EmailAddress); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating jira ticket to request AWS access: %s", err.Error()))
 		}
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -434,7 +434,7 @@ func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.
 	}
 
 	if utility.FromBoolPtr(requestS3Creds) {
-		if err = data.RequestS3Creds(*apiProjectRef.Identifier); err != nil {
+		if err = data.RequestS3Creds(*apiProjectRef.Identifier, u.EmailAddress); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating jira ticket to request S3 credentials: %s", err.Error()))
 		}
 	}
@@ -462,7 +462,8 @@ func (r *mutationResolver) CopyProject(ctx context.Context, project data.CopyPro
 		graphql.AddError(ctx, PartialError.Send(ctx, err.Error()))
 	}
 	if utility.FromBoolPtr(requestS3Creds) {
-		if err = data.RequestS3Creds(*projectRef.Identifier); err != nil {
+		u := gimlet.GetUser(ctx).(*user.DBUser)
+		if err = data.RequestS3Creds(*projectRef.Identifier, u.EmailAddress); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating jira ticket to request AWS access: %s", err.Error()))
 		}
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -462,7 +462,7 @@ func (r *mutationResolver) CopyProject(ctx context.Context, project data.CopyPro
 		graphql.AddError(ctx, PartialError.Send(ctx, err.Error()))
 	}
 	if utility.FromBoolPtr(requestS3Creds) {
-		u := gimlet.GetUser(ctx).(*user.DBUser)
+		usr := mustHaveUser(ctx)
 		if err = data.RequestS3Creds(*projectRef.Identifier, u.EmailAddress); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating jira ticket to request AWS access: %s", err.Error()))
 		}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -55,7 +55,7 @@ func FindProjectById(id string, includeRepo bool, includeProjectConfig bool) (*m
 
 // RequestS3Creds creates a JIRA ticket that requests S3 credentials to be added for the specified project.
 // TODO PM-3212: Remove the function after project completion.
-func RequestS3Creds(projectIdentifier string) error {
+func RequestS3Creds(projectIdentifier, userEmail string) error {
 	if projectIdentifier == "" {
 		return errors.New("project identifier cannot be empty")
 	}
@@ -73,6 +73,7 @@ func RequestS3Creds(projectIdentifier string) error {
 		Summary:     summary,
 		Description: description,
 		Components:  []string{"Access"},
+		Reporter:    userEmail,
 	}
 	sub := event.Subscriber{
 		Type: event.JIRAIssueSubscriberType,
@@ -85,6 +86,14 @@ func RequestS3Creds(projectIdentifier string) error {
 	if err != nil {
 		return err
 	}
+
+	subToSub := event.Subscriber{
+		Type: event.EmailSubscriberType,
+		Target: event.EmailSubscriber{
+			Address: userEmail,
+		},
+	}
+	notifyUser := notification.New()
 	err = notification.InsertMany(*n)
 	if err != nil {
 		return errors.Wrap(err, "batch inserting notifications")

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -87,13 +87,6 @@ func RequestS3Creds(projectIdentifier, userEmail string) error {
 		return err
 	}
 
-	subToSub := event.Subscriber{
-		Type: event.EmailSubscriberType,
-		Target: event.EmailSubscriber{
-			Address: userEmail,
-		},
-	}
-	notifyUser := notification.New()
 	err = notification.InsertMany(*n)
 	if err != nil {
 		return errors.Wrap(err, "batch inserting notifications")

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -482,8 +482,8 @@ func TestGetLegacyProjectEvents(t *testing.T) {
 
 func TestRequestS3Creds(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(notification.Collection, evergreen.ConfigCollection))
-	assert.Error(t, RequestS3Creds(""))
-	assert.NoError(t, RequestS3Creds("identifier"))
+	assert.Error(t, RequestS3Creds("", ""))
+	assert.NoError(t, RequestS3Creds("identifier", "user@email.com"))
 	n, err := notification.FindUnprocessed()
 	assert.NoError(t, err)
 	assert.Len(t, n, 0)
@@ -491,7 +491,7 @@ func TestRequestS3Creds(t *testing.T) {
 		JiraProject: "BUILD",
 	}
 	assert.NoError(t, projectCreationConfig.Set())
-	assert.NoError(t, RequestS3Creds("identifier"))
+	assert.NoError(t, RequestS3Creds("identifier", "user@email.com"))
 	n, err = notification.FindUnprocessed()
 	assert.NoError(t, err)
 	assert.Len(t, n, 1)
@@ -505,4 +505,5 @@ func TestRequestS3Creds(t *testing.T) {
 	assert.Equal(t, summary, payload.Summary)
 	assert.Equal(t, description, payload.Description)
 	assert.Equal(t, []string{"Access"}, payload.Components)
+	assert.Equal(t, "user@email.com", payload.Reporter)
 }


### PR DESCRIPTION
EVG-18950 

### Description
it adds a reporter to the jira ticket that is created requesting the s3 creds from build

### Testing
staging
successfully created ticket with reporter and got an email
https://jira.mongodb.org/browse/BUILD-16917?jql=project%20%3D%20BUILD%20ORDER%20BY%20created%20DESC

#### Does this need documentation?
will be part of the document the project ticket