### PR TITLE
EVG-15417 add handling for repos to help text

### DIFF
--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -495,12 +495,12 @@ func TestGetHelpTextFromProjects(t *testing.T) {
 		Id:      "disabled",
 		Enabled: utility.FalsePtr(),
 	}
-	repoRefWithPRTesting := &model.RepoRef{model.ProjectRef{
+	repoRefWithPRTesting := &model.RepoRef{ProjectRef: model.ProjectRef{
 		Id:                     "enabled",
 		PRTestingEnabled:       utility.TruePtr(),
 		ManualPRTestingEnabled: utility.TruePtr(),
 	}}
-	repoRefWithoutPRTesting := &model.RepoRef{model.ProjectRef{
+	repoRefWithoutPRTesting := &model.RepoRef{ProjectRef: model.ProjectRef{
 		Id:               "notEnabled",
 		PRTestingEnabled: nil,
 	}}


### PR DESCRIPTION
EVG-15417

### Description
Realized a couple of things about the help text as I started documenting.
1) even though `evergreen retry` and `evergreen patch` technically do the same work in the backend, we only do the action based on what's enabled in the project, so separated these commands and added some context.
2) added consideration for if there are no enabled PR testing projects for the branch, but the repo is enabled, since we do allow PR testing then.

### Testing
Added unit tests

#### Does this need documentation?
Yes added to https://github.com/evergreen-ci/evergreen/wiki/Github-Integrations