### PR TITLE
EVG-18267 Update project creation permissions for UI

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -73,7 +73,6 @@ type DirectiveRoot struct {
 	CanCreateProject          func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	RequireProjectAccess      func(ctx context.Context, obj interface{}, next graphql.Resolver, access ProjectSettingsAccess) (res interface{}, err error)
 	RequireProjectFieldAccess func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
-	RequireSuperUser          func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -70,6 +70,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	CanCreateProject          func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	RequireProjectAccess      func(ctx context.Context, obj interface{}, next graphql.Resolver, access ProjectSettingsAccess) (res interface{}, err error)
 	RequireProjectFieldAccess func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	RequireSuperUser          func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
@@ -8029,9 +8030,24 @@ func (ec *executionContext) field_Mutation_copyProject_args(ctx context.Context,
 	var arg0 data.CopyProjectOpts
 	if tmp, ok := rawArgs["project"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project"))
-		arg0, err = ec.unmarshalNCopyProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋdataᚐCopyProjectOpts(ctx, tmp)
+		directive0 := func(ctx context.Context) (interface{}, error) {
+			return ec.unmarshalNCopyProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋdataᚐCopyProjectOpts(ctx, tmp)
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.CanCreateProject == nil {
+				return nil, errors.New("directive canCreateProject is not implemented")
+			}
+			return ec.directives.CanCreateProject(ctx, rawArgs, directive0)
+		}
+
+		tmp, err = directive1(ctx)
 		if err != nil {
-			return nil, err
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if data, ok := tmp.(data.CopyProjectOpts); ok {
+			arg0 = data
+		} else {
+			return nil, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be github.com/evergreen-ci/evergreen/rest/data.CopyProjectOpts`, tmp))
 		}
 	}
 	args["project"] = arg0
@@ -8053,9 +8069,24 @@ func (ec *executionContext) field_Mutation_createProject_args(ctx context.Contex
 	var arg0 model.APIProjectRef
 	if tmp, ok := rawArgs["project"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project"))
-		arg0, err = ec.unmarshalNCreateProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx, tmp)
+		directive0 := func(ctx context.Context) (interface{}, error) {
+			return ec.unmarshalNCreateProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx, tmp)
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			if ec.directives.CanCreateProject == nil {
+				return nil, errors.New("directive canCreateProject is not implemented")
+			}
+			return ec.directives.CanCreateProject(ctx, rawArgs, directive0)
+		}
+
+		tmp, err = directive1(ctx)
 		if err != nil {
-			return nil, err
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if data, ok := tmp.(model.APIProjectRef); ok {
+			arg0 = data
+		} else {
+			return nil, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be github.com/evergreen-ci/evergreen/rest/model.APIProjectRef`, tmp))
 		}
 	}
 	args["project"] = arg0
@@ -21417,28 +21448,8 @@ func (ec *executionContext) _Mutation_createProject(ctx context.Context, field g
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().CreateProject(rctx, fc.Args["project"].(model.APIProjectRef), fc.Args["requestS3Creds"].(*bool))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.RequireSuperUser == nil {
-				return nil, errors.New("directive requireSuperUser is not implemented")
-			}
-			return ec.directives.RequireSuperUser(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*model.APIProjectRef); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/evergreen-ci/evergreen/rest/model.APIProjectRef`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateProject(rctx, fc.Args["project"].(model.APIProjectRef), fc.Args["requestS3Creds"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21582,28 +21593,8 @@ func (ec *executionContext) _Mutation_copyProject(ctx context.Context, field gra
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().CopyProject(rctx, fc.Args["project"].(data.CopyProjectOpts), fc.Args["requestS3Creds"].(*bool))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.RequireSuperUser == nil {
-				return nil, errors.New("directive requireSuperUser is not implemented")
-			}
-			return ec.directives.RequireSuperUser(ctx, nil, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*model.APIProjectRef); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/evergreen-ci/evergreen/rest/model.APIProjectRef`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CopyProject(rctx, fc.Args["project"].(data.CopyProjectOpts), fc.Args["requestS3Creds"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/permissions_resolver.go
+++ b/graphql/permissions_resolver.go
@@ -5,10 +5,9 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/gimlet"
 )
 
 // CanCreateProject is the resolver for the canCreateProject field.
@@ -17,12 +16,11 @@ func (r *permissionsResolver) CanCreateProject(ctx context.Context, obj *Permiss
 	if err != nil {
 		return false, ResourceNotFound.Send(ctx, "user not found")
 	}
-	return usr.HasPermission(gimlet.PermissionOpts{
-		Resource:      evergreen.SuperUserPermissionsID,
-		ResourceType:  evergreen.SuperUserResourceType,
-		Permission:    evergreen.PermissionProjectCreate,
-		RequiredLevel: evergreen.ProjectCreate.Value,
-	}), nil
+	canCreate, err := usr.HasProjectCreatePermission()
+	if err != nil {
+		return false, InternalServerError.Send(ctx, fmt.Sprintf("Error checking user permission: %s", err.Error()))
+	}
+	return canCreate, nil
 }
 
 // Permissions returns PermissionsResolver implementation.

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -1,9 +1,4 @@
 """
-requireSuperUser is used to restrict certain actions to superusers.
-"""
-directive @requireSuperUser on FIELD_DEFINITION
-
-"""
 canCreateProject is used to restrict certain actions to admins.
 """
 directive @canCreateProject on ARGUMENT_DEFINITION 

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -4,6 +4,11 @@ requireSuperUser is used to restrict certain actions to superusers.
 directive @requireSuperUser on FIELD_DEFINITION
 
 """
+canCreateProject is used to restrict certain actions to admins.
+"""
+directive @canCreateProject on ARGUMENT_DEFINITION 
+
+"""
 requireProjectAccess is used to restrict view and edit access for project settings.
 """
 directive @requireProjectAccess(access: ProjectSettingsAccess!) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | FIELD_DEFINITION

--- a/graphql/schema/mutation.graphql
+++ b/graphql/schema/mutation.graphql
@@ -48,8 +48,8 @@ type Mutation {
   addFavoriteProject(identifier: String!): Project!
   attachProjectToNewRepo(project: MoveProjectInput!): Project!
   attachProjectToRepo(projectId: String! @requireProjectAccess(access: EDIT)): Project!
-  createProject(project: CreateProjectInput!, requestS3Creds: Boolean): Project! @requireSuperUser
-  copyProject(project: CopyProjectInput!, requestS3Creds: Boolean): Project! @requireSuperUser
+  createProject(project: CreateProjectInput! @canCreateProject, requestS3Creds: Boolean): Project! 
+  copyProject(project: CopyProjectInput! @canCreateProject, requestS3Creds: Boolean): Project! 
   defaultSectionToRepo(projectId: String! @requireProjectAccess(access: EDIT), section: ProjectSettingsSection!): String
   detachProjectFromRepo(projectId: String! @requireProjectAccess(access: EDIT)): Project!
   forceRepotrackerRun(projectId: String! @requireProjectAccess(access: EDIT)): Boolean!

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -381,6 +381,21 @@ func (u *DBUser) HasPermission(opts gimlet.PermissionOpts) bool {
 	return false
 }
 
+func (u *DBUser) HasProjectCreatePermission() (bool, error) {
+	roleManager := evergreen.GetEnvironment().RoleManager()
+	roles, err := roleManager.GetRoles(u.Roles())
+	if err != nil {
+		return false, errors.Wrap(err, "getting roles")
+	}
+	for _, role := range roles {
+		level, hasPermission := role.Permissions[evergreen.PermissionProjectSettings]
+		if hasPermission && level >= evergreen.ProjectSettingsEdit.Value {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (u *DBUser) DeleteAllRoles() error {
 	info, err := db.FindAndModify(
 		Collection,

--- a/public/static/js/projects.js
+++ b/public/static/js/projects.js
@@ -3,7 +3,6 @@ mciModule.controller(
   function ($scope, $window, $http, $location, $mdDialog, timeUtil) {
     $scope.availableTriggers = $window.availableTriggers;
     $scope.userId = $window.user.Id;
-    $scope.create = $window.canCreate;
     $scope.slackAppName = $window.slackAppName;
 
     $scope.projectVars = {};
@@ -349,76 +348,6 @@ mciModule.controller(
     $scope.removeGithubTrigger = function (index) {
       $scope.settingsFormData.github_trigger_aliases.splice(index, 1);
       $scope.isDirty = true;
-    };
-
-    $scope.addProject = function () {
-      $scope.modalOpen = false;
-      $("#admin-modal").modal("hide");
-
-      if ($scope.findProject($scope.newProject.identifier)) {
-        console.log("project identifier already exists");
-        $scope.newProjectMessage = "Project with this ID or identifier already exists.";
-        $scope.newProject = {};
-        return;
-      }
-
-      // if copyProject is set, copy the current project
-      if ($scope.newProject.copyProject) {
-        $http
-          .put("/project/" + $scope.newProject.identifier, $scope.newProject)
-          .then(
-            function (resp) {
-              var data_put = resp.data;
-              item = Object.assign({}, $scope.settingsFormData);
-              item.identifier = $scope.newProject.identifier;
-              item.pr_testing_enabled = false;
-              item.manual_pr_testing_enabled = false;
-              item.commit_queue.enabled = false;
-              item.commit_queue.require_signed = false;
-              item.git_tag_versions_enabled = false;
-              item.github_checks_enabled = false;
-              item.enabled = false;
-              item.subscriptions = _.filter($scope.subscriptions, function (d) {
-                return !d.changed;
-              });
-              // project variables will be copied in the route, so that we get private variables correctly
-              item.project_vars = null;
-              item.private_vars = null;
-              $http.post("/project/" + $scope.newProject.identifier, item).then(
-                function (resp) {
-                  $scope.refreshTrackedProjects(data_put.AllProjects);
-                  $scope.loadProject(data_put.ProjectId);
-                  $scope.newProject = {};
-                },
-                function (resp) {
-                  console.log(
-                    "error saving data for new project: " + resp.status
-                  );
-                }
-              );
-            },
-            function (resp) {
-              console.log("error creating new project: " + resp.status);
-            }
-          );
-
-        // otherwise, create a blank project
-      } else {
-        $http
-          .put("/project/" + $scope.newProject.identifier, $scope.newProject)
-          .then(
-            function (resp) {
-              var data = resp.data;
-              $scope.refreshTrackedProjects(data.AllProjects);
-              $scope.loadProject(data.ProjectId);
-              $scope.newProject = {};
-              $scope.settingsFormData.tracks_push_events = true;
-            },
-            function (resp) {
-              console.log("error creating project: " + resp.status);
-            }
-          );
-      }
     };
 
     $scope.loadProject = function (projectId) {

--- a/service/project.go
+++ b/service/project.go
@@ -48,13 +48,11 @@ func (uis *UIServer) projectsPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	opts := gimlet.PermissionOpts{
-		Resource:      evergreen.SuperUserPermissionsID,
-		ResourceType:  evergreen.SuperUserResourceType,
-		Permission:    evergreen.PermissionProjectCreate,
-		RequiredLevel: evergreen.ProjectCreate.Value,
+	canCreate, err := dbUser.HasProjectCreatePermission()
+	if err != nil {
+		uis.LoggedError(w, r, http.StatusInternalServerError, err)
+		return
 	}
-	canCreate := dbUser.HasPermission(opts)
 
 	spruceLink := fmt.Sprintf("%s/projects", uis.Settings.Ui.UIv2Url)
 	newUILink := ""

--- a/service/templates/projects.html
+++ b/service/templates/projects.html
@@ -27,12 +27,6 @@ Evergreen Projects
 <div id="content" class="container-fluid row" ng-controller="ProjectCtrl" ng-show="trackedProjects.length>0">
 <div class="col-lg-2 col-lg-offset-1">
   <h1> Projects</h1>
-  <div class="row" ng-show="create">
-    <div class="col-lg-12">
-      <button class="btn btn-primary" ng-click="openAdminModal('newProject')"> New Project </button>
-      <label>[[newProjectMessage]] </label>
-    </div>
-  </div>
   <div class="row">
     <h3 class="col-lg-12" ng-show="showProject(enabledProjects)" > Enabled </h3>
   </div>

--- a/service/ui.go
+++ b/service/ui.go
@@ -250,7 +250,6 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	ownsHost := gimlet.WrapperMiddleware(uis.ownsHost)
 	vsCodeRunning := gimlet.WrapperMiddleware(uis.vsCodeRunning)
 	adminSettings := route.RequiresSuperUserPermission(evergreen.PermissionAdminSettings, evergreen.AdminSettingsEdit)
-	createProject := route.RequiresSuperUserPermission(evergreen.PermissionProjectCreate, evergreen.ProjectCreate)
 	createDistro := route.RequiresSuperUserPermission(evergreen.PermissionDistroCreate, evergreen.DistroCreate)
 	viewTasks := route.RequiresProjectPermission(evergreen.PermissionTasks, evergreen.TasksView)
 	editTasks := route.RequiresProjectPermission(evergreen.PermissionTasks, evergreen.TasksBasic)
@@ -430,7 +429,6 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/project/{project_id}").Wrap(needsContext, viewProjectSettings).Handler(uis.projectPage).Get()
 	app.AddRoute("/project/{project_id}/events").Wrap(needsContext, viewProjectSettings).Handler(uis.projectEvents).Get()
 	app.AddRoute("/project/{project_id}").Wrap(needsContext, editProjectSettings).Handler(uis.modifyProject).Post()
-	app.AddRoute("/project/{project_id}").Wrap(needsContext, createProject).Handler(uis.addProject).Put()
 	app.AddRoute("/project/{project_id}/repo_revision").Wrap(needsContext, editProjectSettings).Handler(uis.setRevision).Put()
 
 	// Admin routes


### PR DESCRIPTION
EVG-18267

### Description
Created a new directive for the create and copy project mutations. 
The create project button will show up for anyone who is an admin for a project 
Users will not be permitted to duplicate a project that they are not admins for.

Changing this for our rest routes would require new gimlet functions so I think the work should be done in another ticket 

I also think that we shouldn't allow users to create projects on the legacy page anymore because they use a ui project route that we can get rid of

### Testing
Staging 
I can now see create project and duplicate project buttons without super user perms but can only duplicate project that I am an admin in 

#### Does this need documentation?
Update it with doc ticket for this project