### PR TITLE
EVG-18898 Upgrade self-tests to 6.0

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -619,7 +619,7 @@ buildvariants:
       nodebin: /opt/node/bin
       GOROOT: /opt/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.5.tgz
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
       sign_macos: true
     tasks:
@@ -643,7 +643,7 @@ buildvariants:
     expansions:
       GOROOT: /opt/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.5.tgz
       race_detector: true
       test_timeout: 15m
     tasks:
@@ -668,7 +668,7 @@ buildvariants:
     expansions:
       GOROOT: c:/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-5.0.14.zip
+      mongodb_url: https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-6.0.5.zip
       extension: ".exe"
       archiveExt: ".zip"
     tasks:
@@ -686,7 +686,7 @@ buildvariants:
       goos: linux
       GOROOT: /opt/golang/go1.19
       RUN_EC2_SPECIFIC_TESTS: true
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-5.0.14.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-ubuntu1804-6.0.5.tgz
     tasks:
       - name: ".agent .test"
 
@@ -697,7 +697,7 @@ buildvariants:
       - macos-1014
     expansions:
       GOROOT: /opt/golang/go1.19
-      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-5.0.14.tgz
+      mongodb_url: https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-6.0.5.tgz
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description
The first step towards upgrading to 6.0 will be to make sure our tests still pass reliably. If this succeeds the next step will be to upgrade staging.
I'll open a parallel PR for spruce.

### Testing
I'll add all the affected variants to this PR.

#### Does this need documentation?
N/A
