### PR TITLE
EVG-19100: increase repotracker timeout for fetching project files

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -203,7 +203,7 @@ func addDisplayTasksToPatchReq(req *PatchUpdate, p Project) {
 }
 
 func getPatchedProjectYAML(ctx context.Context, projectRef *ProjectRef, opts *GetProjectOpts, p *patch.Patch) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, fetchProjectFilesTimeout)
 	defer cancel()
 	env := evergreen.GetEnvironment()
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -816,7 +816,16 @@ func getFileForPatchDiff(ctx context.Context, opts GetProjectOpts) ([]byte, erro
 	return projectFileBytes, nil
 }
 
+// fetchProjectFilesTimeout is the maximum timeout to fetch project
+// configuration files from its source.
+const fetchProjectFilesTimeout = time.Minute
+
+// GetProjectFromFile fetches project configuration files from its source (e.g.
+// from a patch diff, GitHub, etc).
 func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, fetchProjectFilesTimeout)
+	defer cancel()
+
 	fileContents, err := retrieveFile(ctx, opts)
 	if err != nil {
 		return ProjectInfo{}, err

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -58,10 +58,6 @@ func githubCommitToRevision(repoCommit *github.RepositoryCommit) model.Revision 
 // GetRemoteConfig fetches the contents of a remote github repository's
 // configuration data as at a given revision
 func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, projectFileRevision string) (model.ProjectInfo, error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	// find the project configuration file for the given repository revision
 	projectRef := gRepoPoller.ProjectRef
 	opts := model.GetProjectOpts{

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -177,7 +177,7 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 		err = repoTracker.StoreRevisions(ctx, revisions)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
-				"message":            "problem sorting revisions for repository",
+				"message":            "problem storing revisions for repository",
 				"runner":             RunnerName,
 				"project":            projectRef.Id,
 				"project_identifier": projectRef.Identifier,

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -2,7 +2,6 @@ package trigger
 
 import (
 	"context"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -124,7 +123,5 @@ func makeDownstreamProjectFromFile(ref model.ProjectRef, file string) (model.Pro
 		return model.ProjectInfo{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
-	return model.GetProjectFromFile(ctx, opts)
+	return model.GetProjectFromFile(context.Background(), opts)
 }


### PR DESCRIPTION
EVG-19100

### Description
Based on [Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22repotracker%20encountered%20error%22%20OR%20%22problem%20sorting%20revisions%20for%20repository%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-7d%40h&latest=now&sid=1679500771.2192487), it seems like the repotracker is occasionally running out of time to request some GitHub files for projects that split their YAMLs into many smaller ones. We can apply the same rules as we did in #6267 (EVG-18957) for patch project fetches to the repotracker and increase the timeout to match.

* Increase and standardize timeout for fetching project configuration files from their source.
* Small function docs improvement and spelling fix.

### Testing
Not really worth adding more testing since it's a timeout increase.

#### Does this need documentation?
No.
