### PR TITLE
EVG-18971 retry merge and properly handle failure

### DIFF
--- a/agent/command/git_merge_pr.go
+++ b/agent/command/git_merge_pr.go
@@ -93,7 +93,8 @@ func (c *gitMergePr) Execute(ctx context.Context, comm client.Communicator, logg
 		DontDefaultIfBlank: true, // note this means that we will never merge with the default message (concatenated commit messages)
 	}
 
-	// do the merge
-	return thirdparty.MergePullRequest(githubCtx, token, conf.ProjectRef.Owner, conf.ProjectRef.Repo,
+	// Do the merge and assign to error so the defer statement handles this correctly.
+	err = thirdparty.MergePullRequest(githubCtx, token, conf.ProjectRef.Owner, conf.ProjectRef.Repo,
 		patchDoc.GithubPatchData.CommitMessage, patchDoc.GithubPatchData.PRNumber, mergeOpts)
+	return err
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-03-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-03-13"
+	AgentVersion = "2023-03-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-18971 

### Description
Two things identified here:
1) we don't assign the error from trying to merge the pull request, so we don't properly handle this error in the defer statement, so we mistakenly send a green status.
2) Geoff's merge returns an error "405 Base branch was modified. Review and try the merge again". I think this happens when we merge CQ patches in a batch sequentially (i.e. all tasks are finished except the merge), because the previous commit queue item was merged less than a minute before this task began. From some googling, it seems like it can take Github a few seconds to get things back in a mergeable state, so we should retry this merge.

### Testing
Not sure of a good way to test this / if it really needs it, since it's a small change that can be reasoned about.
