### PR TITLE
EVG-19080 Prevent tasks query from failing on large generated tasks.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	golang.org/x/crypto v0.1.0
-	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.4.0
 	golang.org/x/tools v0.1.12
 	gonum.org/v1/gonum v0.12.0
@@ -167,6 +166,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	golang.org/x/crypto v0.1.0
+	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.4.0
 	golang.org/x/tools v0.1.12
 	gonum.org/v1/gonum v0.12.0
@@ -166,7 +167,6 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -250,7 +250,7 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, pa
 		IncludeBaseTasks:               false,
 		IncludeBuildVariantDisplayName: false,
 	}
-	tasks, _, err := task.GetTasksByVersion(patchID, opts)
+	tasks, _, err := task.GetTasksByVersion(ctx, patchID, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch: %s ", err.Error()))
 	}

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -187,7 +187,7 @@ func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatc
 		IncludeBaseTasks:               false,
 		IncludeBuildVariantDisplayName: false,
 	}
-	tasks, _, err := task.GetTasksByVersion(*obj.Id, opts)
+	tasks, _, err := task.GetTasksByVersion(ctx, *obj.Id, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version tasks: %s", err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -324,7 +324,7 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 			IncludeBaseTasks:               false,
 			IncludeBuildVariantDisplayName: false,
 		}
-		tasks, _, err := task.GetTasksByVersion(id, opts)
+		tasks, _, err := task.GetTasksByVersion(ctx, id, opts)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for patch: %s ", err.Error()))
 		}
@@ -332,7 +332,7 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 		if len(patch.ChildPatches) > 0 {
 			for _, cp := range patch.ChildPatches {
 				// add the child patch tasks to tasks so that we can consider their status
-				childPatchTasks, _, err := task.GetTasksByVersion(*cp.Id, opts)
+				childPatchTasks, _, err := task.GetTasksByVersion(ctx, *cp.Id, opts)
 				if err != nil {
 					return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch tasks for child patch: %s ", err.Error()))
 				}
@@ -908,7 +908,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 
 		// If the version was created before we started caching activation status we must manually verify it and cache that value.
 		if v.Activated == nil {
-			err = setVersionActivationStatus(&v)
+			err = setVersionActivationStatus(ctx, &v)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting version activation status: %s", err.Error()))
 			}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -270,7 +270,7 @@ func getAPITaskFromTask(ctx context.Context, url string, task task.Task) (*restM
 }
 
 // Takes a version id and some filter criteria and returns the matching associated tasks grouped together by their build variant.
-func generateBuildVariants(versionId string, buildVariantOpts BuildVariantOptions, requester string, logURL string) ([]*GroupedBuildVariant, error) {
+func generateBuildVariants(ctx context.Context, versionId string, buildVariantOpts BuildVariantOptions, requester string, logURL string) ([]*GroupedBuildVariant, error) {
 	var variantDisplayName = map[string]string{}
 	var tasksByVariant = map[string][]*restModel.APITask{}
 	defaultSort := []task.TasksSortOrder{
@@ -292,7 +292,7 @@ func generateBuildVariants(versionId string, buildVariantOpts BuildVariantOption
 	}
 
 	start := time.Now()
-	tasks, _, err := task.GetTasksByVersion(versionId, opts)
+	tasks, _, err := task.GetTasksByVersion(ctx, versionId, opts)
 	if err != nil {
 		return nil, errors.Wrapf(err, fmt.Sprintf("Error getting tasks for patch `%s`", versionId))
 	}
@@ -603,7 +603,7 @@ func applyVolumeOptions(ctx context.Context, volume host.Volume, volumeOptions r
 	return nil
 }
 
-func setVersionActivationStatus(version *model.Version) error {
+func setVersionActivationStatus(ctx context.Context, version *model.Version) error {
 	defaultSort := []task.TasksSortOrder{
 		{Key: task.DisplayNameKey, Order: 1},
 	}
@@ -612,7 +612,7 @@ func setVersionActivationStatus(version *model.Version) error {
 		IncludeBaseTasks:               false,
 		IncludeBuildVariantDisplayName: false,
 	}
-	tasks, _, err := task.GetTasksByVersion(version.Id, opts)
+	tasks, _, err := task.GetTasksByVersion(ctx, version.Id, opts)
 	if err != nil {
 		return errors.Wrapf(err, "getting tasks for version '%s'", version.Id)
 	}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -65,7 +65,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error fetching version: %s : %s", *obj.Id, err.Error()))
 		}
-		if err = setVersionActivationStatus(version); err != nil {
+		if err = setVersionActivationStatus(ctx, version); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error setting version activation status: %s", err.Error()))
 		}
 		obj.Activated = version.Activated
@@ -74,7 +74,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 	if obj.IsPatchRequester() && !utility.FromBoolPtr(obj.Activated) {
 		return nil, nil
 	}
-	groupedBuildVariants, err := generateBuildVariants(utility.FromStringPtr(obj.Id), options, utility.FromStringPtr(obj.Requester), r.sc.GetURL())
+	groupedBuildVariants, err := generateBuildVariants(ctx, utility.FromStringPtr(obj.Id), options, utility.FromStringPtr(obj.Requester), r.sc.GetURL())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error generating build variants for version %s : %s", *obj.Id, err.Error()))
 	}
@@ -302,7 +302,7 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 		IncludeBuildVariantDisplayName: true,
 		IsMainlineCommit:               !evergreen.IsPatchRequester(v.Requester),
 	}
-	tasks, count, err := task.GetTasksByVersion(versionId, opts)
+	tasks, count, err := task.GetTasksByVersion(ctx, versionId, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting tasks for version with id '%s': %s", versionId, err.Error()))
 	}
@@ -334,7 +334,7 @@ func (r *versionResolver) TaskStatuses(ctx context.Context, obj *restModel.APIVe
 		FieldsToProject:                []string{task.DisplayStatusKey},
 		IncludeBuildVariantDisplayName: false,
 	}
-	tasks, _, err := task.GetTasksByVersion(*obj.Id, opts)
+	tasks, _, err := task.GetTasksByVersion(ctx, *obj.Id, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting version tasks: %s", err.Error()))
 	}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
-	"golang.org/x/net/context"
 )
 
 func checkStatuses(t *testing.T, expected string, toCheck Task) {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"golang.org/x/net/context"
 )
 
 func checkStatuses(t *testing.T, expected string, toCheck Task) {
@@ -910,9 +911,10 @@ func TestGetTasksByVersionExecTasks(t *testing.T) {
 	}
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4, dt))
 
+	ctx := context.TODO()
 	// execution tasks have been filtered outs
 	opts := GetTasksByVersionOptions{}
-	tasks, count, err := GetTasksByVersion("v1", opts)
+	tasks, count, err := GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, count, 3)
 	// alphabetical order
@@ -932,14 +934,16 @@ func TestGetTasksByVersionIncludeNeverActivatedTasks(t *testing.T) {
 
 	assert.NoError(t, inactiveTask.Insert())
 
+	ctx := context.TODO()
+
 	// inactive tasks should be included
 	opts := GetTasksByVersionOptions{IncludeNeverActivatedTasks: true}
-	_, count, err := GetTasksByVersion("v1", opts)
+	_, count, err := GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, count, 1)
 	// inactive tasks should be excluded
 	opts = GetTasksByVersionOptions{IncludeNeverActivatedTasks: false}
-	_, count, err = GetTasksByVersion("v1", opts)
+	_, count, err = GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, count, 0)
 }
@@ -976,8 +980,10 @@ func TestGetTasksByVersionAnnotations(t *testing.T) {
 	}
 	assert.NoError(t, a.Upsert())
 
+	ctx := context.TODO()
+
 	opts := GetTasksByVersionOptions{}
-	tasks, count, err := GetTasksByVersion("v1", opts)
+	tasks, count, err := GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, count, 3)
 	assert.Equal(t, tasks[0].Id, "t1")
@@ -1026,12 +1032,14 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 	}
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3))
 
+	ctx := context.TODO()
+
 	// Normal Patch builds
 	opts := GetTasksByVersionOptions{
 		IncludeBaseTasks: true,
 		IsMainlineCommit: false,
 	}
-	tasks, count, err := GetTasksByVersion("v2", opts)
+	tasks, count, err := GetTasksByVersion(ctx, "v2", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.Equal(t, "t2", tasks[0].Id)
@@ -1045,7 +1053,7 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 		IncludeBaseTasks: true,
 		IsMainlineCommit: true,
 	}
-	tasks, count, err = GetTasksByVersion("v3", opts)
+	tasks, count, err = GetTasksByVersion(ctx, "v3", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 	assert.Equal(t, "t3", tasks[0].Id)
@@ -1105,13 +1113,15 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4))
 
+	ctx := context.TODO()
+
 	// Sort by display name, asc
 	opts := GetTasksByVersionOptions{
 		Sorts: []TasksSortOrder{
 			{Key: DisplayNameKey, Order: 1},
 		},
 	}
-	tasks, count, err := GetTasksByVersion("v1", opts)
+	tasks, count, err := GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, count)
 	assert.Equal(t, "t2", tasks[0].Id)
@@ -1125,7 +1135,7 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 			{Key: BuildVariantKey, Order: 1},
 		},
 	}
-	tasks, count, err = GetTasksByVersion("v1", opts)
+	tasks, count, err = GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, count)
 	assert.Equal(t, "t2", tasks[0].Id)
@@ -1139,7 +1149,7 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 			{Key: DisplayStatusKey, Order: 1},
 		},
 	}
-	tasks, count, err = GetTasksByVersion("v1", opts)
+	tasks, count, err = GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, count)
 	assert.Equal(t, "t2", tasks[0].Id)
@@ -1153,7 +1163,7 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 			{Key: BaseTaskStatusKey, Order: 1},
 		},
 	}
-	tasks, count, err = GetTasksByVersion("v1", opts)
+	tasks, count, err = GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, count)
 	assert.Equal(t, "t2", tasks[0].Id)
@@ -1167,7 +1177,7 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 			{Key: TimeTakenKey, Order: 1},
 		},
 	}
-	tasks, count, err = GetTasksByVersion("v1", opts)
+	tasks, count, err = GetTasksByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, count)
 	assert.Equal(t, "t1", tasks[0].Id)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3492,24 +3492,25 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 	s.NoError(annotationWithSuspectedIssue.Upsert())
 	s.NoError(annotationWithEmptyIssues.Upsert())
 
+	ctx := context.TODO()
 	opts := GetTasksByVersionOptions{}
-	t, _, err := GetTasksByVersion("version_known", opts)
+	t, _, err := GetTasksByVersion(ctx, "version_known", opts)
 	s.NoError(err)
 	// ignore annotation for successful task
 	s.Equal(evergreen.TaskSucceeded, t[0].DisplayStatus)
 
 	// test with empty issues list
-	t, _, err = GetTasksByVersion("version_not_known", opts)
+	t, _, err = GetTasksByVersion(ctx, "version_not_known", opts)
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, t[0].DisplayStatus)
 
 	// test with no annotation document
-	t, _, err = GetTasksByVersion("version_no_annotation", opts)
+	t, _, err = GetTasksByVersion(ctx, "version_no_annotation", opts)
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, t[0].DisplayStatus)
 
 	// test with empty issues
-	t, _, err = GetTasksByVersion("version_with_empty_issues", opts)
+	t, _, err = GetTasksByVersion(ctx, "version_with_empty_issues", opts)
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, t[0].DisplayStatus)
 }


### PR DESCRIPTION
EVG-19080

### Description
The GetTasksByVersion query was failing despite only returning 10 entries due to a large generated_json field in each document. This projects that field out to prevent the query from OOMing.

Also passes context to the queries so they can be picked up in the OTEL traces. (Helped me narrow down the bug) 
### Testing
Tested the patch in the ticket and it now works.

