### PR TITLE
Vert: "EVG-18607 Include the IamInstanceProfile field in the RunInstancesInput struct" 

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -323,6 +323,7 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		ImageId:             &ec2Settings.AMI,
 		KeyName:             &ec2Settings.KeyName,
 		InstanceType:        &ec2Settings.InstanceType,
+		IamInstanceProfile:  &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		BlockDeviceMappings: blockDevices,
 		TagSpecifications:   makeTagSpecifications(makeTags(h)),
 	}
@@ -522,6 +523,7 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 			KeyName:             aws.String(ec2Settings.KeyName),
 			InstanceType:        aws.String(ec2Settings.InstanceType),
 			BlockDeviceMappings: blockDevices,
+			IamInstanceProfile:  &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		},
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -323,9 +323,12 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		ImageId:             &ec2Settings.AMI,
 		KeyName:             &ec2Settings.KeyName,
 		InstanceType:        &ec2Settings.InstanceType,
-		IamInstanceProfile:  &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		BlockDeviceMappings: blockDevices,
 		TagSpecifications:   makeTagSpecifications(makeTags(h)),
+	}
+
+	if ec2Settings.IAMInstanceProfileARN != "" {
+		input.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
 	if ec2Settings.IsVpc {
@@ -523,8 +526,11 @@ func (m *ec2Manager) spawnSpotHost(ctx context.Context, h *host.Host, ec2Setting
 			KeyName:             aws.String(ec2Settings.KeyName),
 			InstanceType:        aws.String(ec2Settings.InstanceType),
 			BlockDeviceMappings: blockDevices,
-			IamInstanceProfile:  &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		},
+	}
+
+	if ec2Settings.IAMInstanceProfileARN != "" {
+		spotRequest.LaunchSpecification.IamInstanceProfile = &ec2.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
 	if ec2Settings.IsVpc {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -466,10 +466,13 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 	launchTemplate := &ec2.RequestLaunchTemplateData{
 		ImageId:             aws.String(ec2Settings.AMI),
 		KeyName:             aws.String(ec2Settings.KeyName),
-		IamInstanceProfile:  &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		InstanceType:        aws.String(ec2Settings.InstanceType),
 		BlockDeviceMappings: blockDevices,
 		TagSpecifications:   makeTagTemplate(makeTags(h)),
+	}
+
+	if ec2Settings.IAMInstanceProfileARN != "" {
+		launchTemplate.IamInstanceProfile = &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
 	if ec2Settings.IsVpc {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -466,6 +466,7 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 	launchTemplate := &ec2.RequestLaunchTemplateData{
 		ImageId:             aws.String(ec2Settings.AMI),
 		KeyName:             aws.String(ec2Settings.KeyName),
+		IamInstanceProfile:  &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)},
 		InstanceType:        aws.String(ec2Settings.InstanceType),
 		BlockDeviceMappings: blockDevices,
 		TagSpecifications:   makeTagTemplate(makeTags(h)),

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -96,7 +96,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "ht_1", *mockClient.DeleteLaunchTemplateInput.LaunchTemplateName)
 		},
 		"RequestFleet": func(*testing.T) {
-			ec2Settings := &EC2ProviderSettings{VpcName: "my_vpc", InstanceType: "instanceType0"}
+			ec2Settings := &EC2ProviderSettings{VpcName: "my_vpc", InstanceType: "instanceType0", IAMInstanceProfileARN: "my-profile"}
 
 			instanceID, err := m.requestFleet(context.Background(), h, ec2Settings)
 			assert.NoError(t, err)
@@ -108,7 +108,8 @@ func TestFleet(t *testing.T) {
 		},
 		"MakeOverrides": func(*testing.T) {
 			ec2Settings := &EC2ProviderSettings{
-				InstanceType: "instanceType0",
+				InstanceType:          "instanceType0",
+				IAMInstanceProfileARN: "my-profile",
 			}
 			overrides, err := m.makeOverrides(context.Background(), ec2Settings)
 			assert.NoError(t, err)
@@ -123,8 +124,9 @@ func TestFleet(t *testing.T) {
 			assert.Nil(t, overrides)
 
 			ec2Settings = &EC2ProviderSettings{
-				InstanceType: "instanceType0",
-				SubnetId:     "subnet-654321",
+				InstanceType:          "instanceType0",
+				IAMInstanceProfileARN: "my-profile",
+				SubnetId:              "subnet-654321",
 			}
 			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
 			assert.NoError(t, err)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -338,6 +338,7 @@ func (s *EC2Suite) TestSpawnHostClassicOnDemand() {
 		birch.EC.String("user_data", someUserData),
 		birch.EC.String("region", evergreen.DefaultEC2Region),
 		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.Array("mount_points", birch.NewArray(
 			birch.VC.Document(birch.NewDocument(
 				birch.EC.String("device_name", "device"),
@@ -366,6 +367,7 @@ func (s *EC2Suite) TestSpawnHostClassicOnDemand() {
 	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)
 	s.Equal("sg-123456", *runInput.SecurityGroups[0])
+	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
 	s.Nil(runInput.SecurityGroupIds)
 	s.Nil(runInput.SubnetId)
 	s.Equal(base64OfSomeUserData, *runInput.UserData)
@@ -378,6 +380,7 @@ func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", "keyName"),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -408,6 +411,7 @@ func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
 	runInput := *mock.RunInstancesInput
 	s.Equal("ami", *runInput.ImageId)
 	s.Equal("instanceType", *runInput.InstanceType)
+	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
 	s.Equal("keyName", *runInput.KeyName)
 	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)
@@ -424,6 +428,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", "keyName"),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -453,6 +458,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpot() {
 	requestInput := *mock.RequestSpotInstancesInput
 	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
 	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
+	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
 	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
 	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
@@ -469,6 +475,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", "keyName"),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -505,6 +512,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	requestInput := *mock.RequestSpotInstancesInput
 	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
 	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
+	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
 	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
 	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
@@ -518,6 +526,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
 	runInput := *mock.RunInstancesInput
 	s.Equal("ami", *runInput.ImageId)
 	s.Equal("instanceType", *runInput.InstanceType)
+	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
 	s.Equal("keyName", *runInput.KeyName)
 	s.Require().Len(runInput.BlockDeviceMappings, 1)
 	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
@@ -535,6 +544,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", "keyName"),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -571,6 +581,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
 	requestInput := *mock.RequestSpotInstancesInput
 	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
 	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
+	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
 	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
 	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
@@ -584,6 +595,7 @@ func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
 	runInput := *mock.RunInstancesInput
 	s.Equal("ami", *runInput.ImageId)
 	s.Equal("instanceType", *runInput.InstanceType)
+	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
 	s.Equal("keyName", *runInput.KeyName)
 	s.Require().Len(runInput.BlockDeviceMappings, 1)
 	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
@@ -601,6 +613,7 @@ func (s *EC2Suite) TestSpawnHostVPCSpot() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", "keyName"),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -630,6 +643,7 @@ func (s *EC2Suite) TestSpawnHostVPCSpot() {
 	requestInput := *mock.RequestSpotInstancesInput
 	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
 	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
+	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
 	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
 	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
@@ -646,6 +660,7 @@ func (s *EC2Suite) TestNoKeyAndNotSpawnHostForTaskShouldFail() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", ""),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -675,6 +690,7 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
 		birch.EC.String("ami", "ami"),
 		birch.EC.String("instance_type", "instanceType"),
+		birch.EC.String("iam_instance_profile_arn", "my_profile"),
 		birch.EC.String("key_name", ""),
 		birch.EC.String("subnet_id", "subnet-123456"),
 		birch.EC.String("user_data", someUserData),
@@ -723,6 +739,7 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 	runInput := *mock.RunInstancesInput
 	s.Equal("ami", *runInput.ImageId)
 	s.Equal("instanceType", *runInput.InstanceType)
+	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
 	s.Equal("evg_auto_evergreen", *runInput.KeyName)
 	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
 	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)


### PR DESCRIPTION
[EVG-18607](https://jira.mongodb.org/browse/EVG-18607)

### Description
This is the Vert (revert of the [revert](https://github.com/evergreen-ci/evergreen/pull/6354)) for "EVG-18607 Include the IamInstanceProfile field in the RunInstancesInput struct" with the addition of a check that makes sure we are not trying to launch something with an empty ARN. 

### Testing
Tested on staging with 3 different scenarios. 

#### Does this need documentation?
no 
