### PR TITLE
EVG-19103 add param and author flags to patch-file

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// Commandline Version String; used to control auto-updating.
-	ClientVersion = "2023-03-20"
+	ClientVersion = "2023-03-23"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-03-22"

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -29,6 +29,7 @@ const (
 	commitShaFlag       = "commit-sha"
 	commitMessageFlag   = "commit-message"
 	githubAuthorFlag    = "author"
+	patchAuthorFlag     = "author"
 
 	noCommits             = "No Commits Added"
 	commitQueuePatchLabel = "Commit Queue Merge:"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -92,6 +92,7 @@ func addProjectFlag(flags ...cli.Flag) []cli.Flag {
 		Usage: "specify the name of an existing Evergreen project",
 	})
 }
+
 func addLargeFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.BoolFlag{
 		Name:  joinFlagNames(largeFlagName, "l"),

--- a/operations/http.go
+++ b/operations/http.go
@@ -546,6 +546,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		RepeatFailed      bool               `json:"repeat_failed"`
 		RepeatPatchId     string             `json:"repeat_patch_id"`
 		GithubAuthor      string             `json:"github_author"`
+		PatchAuthor       string             `json:"patch_author"`
 	}{
 		Description:       incomingPatch.description,
 		Project:           incomingPatch.projectName,
@@ -570,6 +571,7 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 		RepeatFailed:      incomingPatch.repeatFailed,
 		RepeatPatchId:     incomingPatch.repeatPatchId,
 		GithubAuthor:      incomingPatch.githubAuthor,
+		PatchAuthor:       incomingPatch.patchAuthor,
 	}
 
 	rPipe, wPipe := io.Pipe()

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -284,6 +284,11 @@ func PatchFile() cli.Command {
 				Name:  diffPathFlagName,
 				Usage: "path to a file for diff of the patch",
 			},
+			cli.StringFlag{
+				Name: patchAuthorFlag,
+				Usage: "optionally define the patch author by providing an Evergreen username; " +
+					"if not found or provided, will default to the submitter",
+			},
 		),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
@@ -304,9 +309,16 @@ func PatchFile() cli.Command {
 				ShowSummary:     c.Bool(patchVerboseFlagName),
 				Large:           c.Bool(largeFlagName),
 				SyncTasks:       utility.SplitCommas(c.StringSlice(syncTasksFlagName)),
+				PatchAuthor:     c.String(patchAuthorFlag),
 			}
+			var err error
 			diffPath := c.String(diffPathFlagName)
 			base := c.String(baseFlagName)
+			paramsPairs := c.StringSlice(parameterFlagName)
+			params.Parameters, err = getParametersFromInput(paramsPairs)
+			if err != nil {
+				return err
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -85,6 +85,7 @@ type patchParams struct {
 	RepeatFailed      bool
 	RepeatPatchId     string
 	GithubAuthor      string
+	PatchAuthor       string
 }
 
 type patchSubmission struct {
@@ -111,6 +112,7 @@ type patchSubmission struct {
 	repeatFailed      bool
 	repeatPatchId     string
 	githubAuthor      string
+	patchAuthor       string
 }
 
 func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch.Patch, error) {
@@ -138,6 +140,7 @@ func (p *patchParams) createPatch(ac *legacyClient, diffData *localDiff) (*patch
 		repeatPatchId:     p.RepeatPatchId,
 		path:              p.Path,
 		githubAuthor:      p.GithubAuthor,
+		patchAuthor:       p.PatchAuthor,
 	}
 
 	newPatch, err := ac.PutPatch(patchSub)

--- a/service/api.go
+++ b/service/api.go
@@ -349,7 +349,7 @@ func (as *APIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/projects").Wrap(requireUser).Handler(as.listProjects).Get()
 
 	// Patches
-	app.PrefixRoute("/patches").Route("/").Wrap(requireUser).Handler(as.submitPatch).Put()
+	app.PrefixRoute("/patches").Route("/").Wrap(requireUser, submitPatch).Handler(as.submitPatch).Put()
 	app.PrefixRoute("/patches").Route("/mine").Wrap(requireUser).Handler(as.listPatches).Get()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}").Wrap(requireUser, viewTasks).Handler(as.summarizePatch).Get()
 	app.PrefixRoute("/patches").Route("/{patchId:\\w+}").Wrap(requireUser, submitPatch).Handler(as.existingPatchRequest).Post()

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -35,8 +35,8 @@ type PatchAPIResponse struct {
 	Patch   *patch.Patch `json:"patch"`
 }
 
-// getAuthor returns the author for the patch. If githubAuthor or patchAuthor is provided and exists, will use this instead
-// of the submitter if the submitter is authorized to submit patches on behalf of users.
+// getAuthor returns the author for the patch. If githubAuthor or patchAuthor is provided and exists, will use that
+// author instead of the submitter if the submitter is authorized to submit patches on behalf of users.
 // Returns the author, status code, and error.
 func (as *APIServer) getAuthor(data patchData, dbUser *user.DBUser, projectId, patchID string) (string, int, error) {
 	author := dbUser.Id
@@ -57,7 +57,7 @@ func (as *APIServer) getAuthor(data patchData, dbUser *user.DBUser, projectId, p
 	if data.GithubAuthor != "" {
 		specifiedUser, err := user.FindByGithubName(data.GithubAuthor)
 		if err != nil {
-			return "", http.StatusInternalServerError, errors.Wrap(err, "error looking for specified author")
+			return "", http.StatusInternalServerError, errors.Wrapf(err, "error looking for github author '%s'", data.GithubAuthor)
 		}
 		if specifiedUser != nil {
 			grip.Info(message.Fields{
@@ -77,7 +77,7 @@ func (as *APIServer) getAuthor(data patchData, dbUser *user.DBUser, projectId, p
 	} else if data.PatchAuthor != "" {
 		specifiedUser, err := user.FindOneById(data.PatchAuthor)
 		if err != nil {
-			return "", http.StatusInternalServerError, errors.Wrap(err, "error looking for specified author")
+			return "", http.StatusInternalServerError, errors.Wrapf(err, "error looking for author '%s'", data.PatchAuthor)
 		}
 		if specifiedUser != nil {
 			grip.Info(message.Fields{


### PR DESCRIPTION
EVG-19103 

### Description
To support a simpler profiling workflow, Jeff's team needs a way to re-run tasks with different parameters; we settled on creating a new patch with an existing diff, and allowing them to pass in the patch author (as the person who clicks the button to run this workflow). 

### Testing
Created https://spruce-staging.corp.mongodb.com/version/6421fb86b23736777fc2d89e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC using `egss patch-file --diff-file  test_diff_file --param hello=world --base 0c0255c06 --variants ubuntu2004 --tasks test-model --project evg --author bynn.lee` (egss -> staging shortcut). This command failed before I added permissions to myself to submit on behalf of other users.

#### Does this need documentation?
No bc CLI command but I'll add some details to the ticket for Jeff