### PR TITLE
Revert "EVG-18630: set default value for XDG_CACHE_HOME in agent commands"

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -199,9 +199,6 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	if _, ok := env["CI"]; !ok {
 		env["CI"] = "true"
 	}
-	if _, ok := env["XDG_CACHE_HOME"]; !ok {
-		env["XDG_CACHE_HOME"] = filepath.Join(opts.workingDir, ".xdgcache")
-	}
 
 	return env
 }

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -363,6 +363,7 @@ func (s *execCmdSuite) TestEnvIsSetAndDefaulted() {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
 	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 8)
 	s.Contains(cmd.Env, agentutil.MarkerTaskID)
 	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
 	s.Contains(cmd.Env, "TEMP")
@@ -370,7 +371,6 @@ func (s *execCmdSuite) TestEnvIsSetAndDefaulted() {
 	s.Contains(cmd.Env, "TMPDIR")
 	s.Contains(cmd.Env, "GOCACHE")
 	s.Contains(cmd.Env, "CI")
-	s.Contains(cmd.Env, "XDG_CACHE_HOME")
 	s.Contains(cmd.Env, "foo")
 }
 
@@ -389,6 +389,7 @@ func (s *execCmdSuite) TestEnvAddsExpansionsAndDefaults() {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
 	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 9)
 	s.Contains(cmd.Env, agentutil.MarkerTaskID)
 	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
 	s.Contains(cmd.Env, "TEMP")
@@ -396,7 +397,6 @@ func (s *execCmdSuite) TestEnvAddsExpansionsAndDefaults() {
 	s.Contains(cmd.Env, "TMPDIR")
 	s.Contains(cmd.Env, "GOCACHE")
 	s.Contains(cmd.Env, "CI")
-	s.Contains(cmd.Env, "XDG_CACHE_HOME")
 	for k, v := range s.conf.Expansions.Map() {
 		s.Equal(v, cmd.Env[k])
 	}
@@ -445,24 +445,24 @@ func TestDefaultAndApplyExpansionsToEnv(t *testing.T) {
 				tmpDir:     "tmp_dir",
 			}
 			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+			assert.Len(t, env, 7)
 			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
 			assert.Contains(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
 			assert.Contains(t, opts.tmpDir, env["TEMP"])
 			assert.Contains(t, opts.tmpDir, env["TMP"])
 			assert.Contains(t, opts.tmpDir, env["TMPDIR"])
 			assert.Equal(t, filepath.Join(opts.workingDir, ".gocache"), env["GOCACHE"])
-			assert.Equal(t, filepath.Join(opts.workingDir, ".xdgcache"), env["XDG_CACHE_HOME"])
 			assert.Equal(t, "true", env["CI"])
 		},
 		"SetsDefaultAndRequiredEnvEvenWhenStandardValuesAreZero": func(t *testing.T, exp util.Expansions) {
 			env := defaultAndApplyExpansionsToEnv(map[string]string{}, modifyEnvOptions{})
+			assert.Len(t, env, 7)
 			assert.Contains(t, env, agentutil.MarkerTaskID)
 			assert.Contains(t, env, agentutil.MarkerAgentPID)
 			assert.Contains(t, env, "TEMP")
 			assert.Contains(t, env, "TMP")
 			assert.Contains(t, env, "TMPDIR")
 			assert.Equal(t, ".gocache", env["GOCACHE"])
-			assert.Equal(t, ".xdgcache", env["XDG_CACHE_HOME"])
 			assert.Equal(t, "true", env["CI"])
 		},
 		"AgentEnvVarsOverridesExplicitlySetEnvVars": func(t *testing.T, exp util.Expansions) {

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -195,6 +195,7 @@ func (s *shellExecuteCommandSuite) TestEnvIsSetAndDefaulted() {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
 	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 8)
 	s.Contains(cmd.Env, agentutil.MarkerTaskID)
 	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
 	s.Contains(cmd.Env, "TEMP")
@@ -202,7 +203,6 @@ func (s *shellExecuteCommandSuite) TestEnvIsSetAndDefaulted() {
 	s.Contains(cmd.Env, "TMPDIR")
 	s.Contains(cmd.Env, "GOCACHE")
 	s.Contains(cmd.Env, "CI")
-	s.Contains(cmd.Env, "XDG_CACHE_HOME")
 	s.Contains(cmd.Env, "foo")
 }
 
@@ -221,6 +221,7 @@ func (s *shellExecuteCommandSuite) TestEnvAddsExpansionsAndDefaults() {
 	ctx, cancel := context.WithTimeout(s.ctx, time.Second)
 	defer cancel()
 	s.Require().NoError(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	s.Len(cmd.Env, 9)
 	s.Contains(cmd.Env, agentutil.MarkerTaskID)
 	s.Contains(cmd.Env, agentutil.MarkerAgentPID)
 	s.Contains(cmd.Env, "TEMP")
@@ -228,7 +229,6 @@ func (s *shellExecuteCommandSuite) TestEnvAddsExpansionsAndDefaults() {
 	s.Contains(cmd.Env, "TMPDIR")
 	s.Contains(cmd.Env, "GOCACHE")
 	s.Contains(cmd.Env, "CI")
-	s.Contains(cmd.Env, "XDG_CACHE_HOME")
 	for k, v := range s.conf.Expansions.Map() {
 		s.Equal(v, cmd.Env[k])
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-03-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-03-27"
+	AgentVersion = "2023-03-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
Reverts evergreen-ci/evergreen#6342 due to an issue where a project was relying on `XDG_CACHE_HOME`.