### PR TITLE
EVG-19270 Pass context to mainline commits db queries

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -856,7 +856,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 		Requesters:      requesters,
 	}
 
-	versions, err := model.GetMainlineCommitVersionsWithOptions(projectId, opts)
+	versions, err := model.GetMainlineCommitVersionsWithOptions(ctx, projectId, opts)
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Error getting activated versions: %s", err.Error()))
 	}
@@ -866,7 +866,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 
 	// We only want to return the PrevPageOrderNumber if a user is not on the first page
 	if options.SkipOrderNumber != nil {
-		prevPageCommit, err := model.GetPreviousPageCommitOrderNumber(projectId, utility.FromIntPtr(options.SkipOrderNumber), limit, requesters)
+		prevPageCommit, err := model.GetPreviousPageCommitOrderNumber(ctx, projectId, utility.FromIntPtr(options.SkipOrderNumber), limit, requesters)
 
 		if err != nil {
 			// This shouldn't really happen, but if it does, we should return an error and log it
@@ -924,7 +924,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 				Statuses:                   getValidTaskStatusesFilter(buildVariantOptions.Statuses),
 				IncludeNeverActivatedTasks: true,
 			}
-			hasTasks, err := task.HasMatchingTasks(v.Id, opts)
+			hasTasks, err := task.HasMatchingTasks(ctx, v.Id, opts)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error checking if version has tasks: %s", err.Error()))
 			}
@@ -970,7 +970,7 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 				Requesters:      requesters,
 			}
 
-			versions, err = model.GetMainlineCommitVersionsWithOptions(projectId, opts)
+			versions, err = model.GetMainlineCommitVersionsWithOptions(ctx, projectId, opts)
 			if err != nil {
 				return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Error getting activated versions: %s", err.Error()))
 			}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2393,7 +2393,7 @@ type HasMatchingTasksOptions struct {
 }
 
 // HasMatchingTasks returns true if the version has tasks with the given statuses
-func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, error) {
+func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTasksOptions) (bool, error) {
 	options := GetTasksByVersionOptions{
 		TaskNames:                      opts.TaskNames,
 		Variants:                       opts.Variants,
@@ -2410,12 +2410,11 @@ func HasMatchingTasks(versionID string, opts HasMatchingTasksOptions) (bool, err
 	}
 	pipeline = append(pipeline, bson.M{"$count": "count"})
 	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
 	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return false, err
 	}
+
 	type Count struct {
 		Count int `bson:"count"`
 	}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1500,20 +1500,21 @@ func TestHasMatchingTasks(t *testing.T) {
 	opts := HasMatchingTasksOptions{
 		Statuses: []string{evergreen.TaskFailed},
 	}
-	hasMatchingTasks, err := HasMatchingTasks("v1", opts)
+	ctx := context.TODO()
+	hasMatchingTasks, err := HasMatchingTasks(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.True(t, hasMatchingTasks)
 
 	opts.Statuses = []string{evergreen.TaskWillRun}
 
-	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	hasMatchingTasks, err = HasMatchingTasks(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.False(t, hasMatchingTasks)
 
 	opts = HasMatchingTasksOptions{
 		Variants: []string{"bv1"},
 	}
-	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	hasMatchingTasks, err = HasMatchingTasks(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.True(t, hasMatchingTasks)
 
@@ -1524,7 +1525,7 @@ func TestHasMatchingTasks(t *testing.T) {
 	// assert.True(t, hasMatchingTasks)
 
 	opts.Variants = []string{"DNE"}
-	hasMatchingTasks, err = HasMatchingTasks("v1", opts)
+	hasMatchingTasks, err = HasMatchingTasks(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.False(t, hasMatchingTasks)
 }

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -445,7 +446,8 @@ func TestGetMainlineCommitVersionsWithOptions(t *testing.T) {
 		Limit:      4,
 		Requesters: evergreen.SystemVersionRequesterTypes,
 	}
-	versions, err := GetMainlineCommitVersionsWithOptions(p.Id, opts)
+	ctx := context.TODO()
+	versions, err := GetMainlineCommitVersionsWithOptions(ctx, p.Id, opts)
 	assert.NoError(t, err)
 	assert.Len(t, versions, 4)
 	assert.EqualValues(t, "my_version", versions[0].Id)
@@ -458,7 +460,7 @@ func TestGetMainlineCommitVersionsWithOptions(t *testing.T) {
 		SkipOrderNumber: 10,
 		Requesters:      evergreen.SystemVersionRequesterTypes,
 	}
-	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)
+	versions, err = GetMainlineCommitVersionsWithOptions(ctx, p.Id, opts)
 	assert.NoError(t, err)
 	assert.Len(t, versions, 3)
 	assert.EqualValues(t, "your_version", versions[0].Id)
@@ -470,7 +472,7 @@ func TestGetMainlineCommitVersionsWithOptions(t *testing.T) {
 		SkipOrderNumber: 8,
 		Requesters:      evergreen.SystemVersionRequesterTypes,
 	}
-	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)
+	versions, err = GetMainlineCommitVersionsWithOptions(ctx, p.Id, opts)
 	assert.NoError(t, err)
 	assert.Len(t, versions, 1)
 	assert.EqualValues(t, "yet_another_version", versions[0].Id)
@@ -479,7 +481,7 @@ func TestGetMainlineCommitVersionsWithOptions(t *testing.T) {
 		Limit:      4,
 		Requesters: []string{"Not a real requester"},
 	}
-	versions, err = GetMainlineCommitVersionsWithOptions(p.Id, opts)
+	versions, err = GetMainlineCommitVersionsWithOptions(ctx, p.Id, opts)
 	assert.Nil(t, versions)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("invalid requesters %s", opts.Requesters))
@@ -529,17 +531,18 @@ func TestGetPreviousPageCommit(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 	}
 	assert.NoError(t, v.Insert())
+	ctx := context.TODO()
 	// If you are viewing the latest commit it should return nil to indicate that there is no previous page.
-	orderNumber, err := GetPreviousPageCommitOrderNumber(p.Id, 10, 2, evergreen.SystemVersionRequesterTypes)
+	orderNumber, err := GetPreviousPageCommitOrderNumber(ctx, p.Id, 10, 2, evergreen.SystemVersionRequesterTypes)
 	assert.NoError(t, err)
 	assert.Nil(t, orderNumber)
 	// If you are viewing a commit it should return the previous activated version that is LIMIT versions ago.
-	orderNumber, err = GetPreviousPageCommitOrderNumber(p.Id, 7, 2, evergreen.SystemVersionRequesterTypes)
+	orderNumber, err = GetPreviousPageCommitOrderNumber(ctx, p.Id, 7, 2, evergreen.SystemVersionRequesterTypes)
 	assert.NoError(t, err)
 	assert.NotNil(t, orderNumber)
 	assert.Equal(t, 10, utility.FromIntPtr(orderNumber))
 	// If the previous pages activated version is the latest it should return 0.
-	orderNumber, err = GetPreviousPageCommitOrderNumber(p.Id, 9, 2, evergreen.SystemVersionRequesterTypes)
+	orderNumber, err = GetPreviousPageCommitOrderNumber(ctx, p.Id, 9, 2, evergreen.SystemVersionRequesterTypes)
 	assert.NoError(t, err)
 	assert.NotNil(t, orderNumber)
 	assert.Equal(t, 0, utility.FromIntPtr(orderNumber))


### PR DESCRIPTION

EVG-19270

### Description
Dove down a honeycomb rabbit hole and wanted to instrument the mainline commits query to get better performance insights. Passes context to the db calls so they can be tracked as part of the same span.


