### PR TITLE
EVG-19189 use tracer client for external API calls

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -116,7 +116,8 @@ var (
 	spawnhostsPerUserKey         = bsonutil.MustHaveTag(SpawnHostConfig{}, "SpawnHostsPerUser")
 
 	tracerEnabledKey        = bsonutil.MustHaveTag(TracerConfig{}, "Enabled")
-	tracerCollectorEndpoint = bsonutil.MustHaveTag(TracerConfig{}, "CollectorEndpoint")
+	collectorEndpointKey    = bsonutil.MustHaveTag(TracerConfig{}, "CollectorEndpoint")
+	externalHostsToTraceKey = bsonutil.MustHaveTag(TracerConfig{}, "ExternalHostsToTrace")
 )
 
 func byId(id string) bson.M {

--- a/config_test.go
+++ b/config_test.go
@@ -924,8 +924,9 @@ func (s *AdminSuite) TestCedarConfig() {
 
 func (s *AdminSuite) TestTracerConfig() {
 	config := TracerConfig{
-		Enabled:           true,
-		CollectorEndpoint: "localhost:4316",
+		Enabled:              true,
+		CollectorEndpoint:    "localhost:4316",
+		ExternalHostsToTrace: []string{"www.github.com"},
 	}
 
 	err := config.Set()

--- a/config_tracer.go
+++ b/config_tracer.go
@@ -50,7 +50,8 @@ func (c *TracerConfig) Set() error {
 	_, err := coll.UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
 			tracerEnabledKey:        c.Enabled,
-			tracerCollectorEndpoint: c.CollectorEndpoint,
+			collectorEndpointKey:    c.CollectorEndpoint,
+			externalHostsToTraceKey: c.ExternalHostsToTrace,
 		},
 	}, options.Update().SetUpsert(true))
 	return errors.Wrapf(err, "updating config section '%s'", c.SectionId())

--- a/config_tracer.go
+++ b/config_tracer.go
@@ -9,8 +9,9 @@ import (
 
 // TracerConfig configures the OpenTelemetry tracer provider. If not enabled traces will not be sent.
 type TracerConfig struct {
-	Enabled           bool   `yaml:"enabled" bson:"enabled" json:"enabled"`
-	CollectorEndpoint string `yaml:"collector_endpoint" bson:"collector_endpoint" json:"collector_endpoint"`
+	Enabled              bool     `yaml:"enabled" bson:"enabled" json:"enabled"`
+	CollectorEndpoint    string   `yaml:"collector_endpoint" bson:"collector_endpoint" json:"collector_endpoint"`
+	ExternalHostsToTrace []string `yaml:"external_hosts_to_trace" bson:"external_hosts_to_trace" json:"external_hosts_to_trace"`
 }
 
 // SectionId returns the ID of this config section.

--- a/environment.go
+++ b/environment.go
@@ -869,7 +869,11 @@ func (e *envState) initTracer(ctx context.Context) error {
 func (e *envState) initHTTPClientPool() {
 	clientFactory := func() *http.Client {
 		client := utility.NewBaseConfiguredHttpClient()
-		client.Transport = otelhttp.NewTransport(client.Transport)
+		client.Transport = otelhttp.NewTransport(client.Transport, otelhttp.WithFilter(
+			func(r *http.Request) bool {
+				return utility.StringSliceContains(e.settings.Tracer.ExternalHostsToTrace, r.URL.Host)
+			},
+		))
 		return client
 	}
 	utility.InitHTTPPool(clientFactory)

--- a/environment.go
+++ b/environment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -35,6 +36,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -217,6 +219,7 @@ func NewEnvironment(ctx context.Context, confPath string, db *DBSettings) (Envir
 	catcher.Add(e.createNotificationQueue(ctx))
 	catcher.Add(e.setupRoleManager())
 	catcher.Add(e.initTracer(ctx))
+	e.initHTTPClientPool()
 	catcher.Extend(e.initQueues(ctx))
 
 	if catcher.HasErrors() {
@@ -861,6 +864,15 @@ func (e *envState) initTracer(ctx context.Context) error {
 	})
 
 	return nil
+}
+
+func (e *envState) initHTTPClientPool() {
+	clientFactory := func() *http.Client {
+		client := utility.NewBaseConfiguredHttpClient()
+		client.Transport = otelhttp.NewTransport(client.Transport)
+		return client
+	}
+	utility.InitHTTPPool(clientFactory)
 }
 
 func (e *envState) setupRoleManager() error {

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	go.mongodb.org/mongo-driver v1.11.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.40.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0
@@ -163,7 +164,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib v1.10.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 // indirect
 	go.opentelemetry.io/otel/metric v0.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/evergreen-ci/evergreen
 
 go 1.19
 
+replace github.com/evergreen-ci/utility => /Users/jonathan.brill/repos/utility
+
 require (
 	github.com/99designs/gqlgen v0.17.20
 	github.com/PuerkitoBio/rehttp v1.1.0
@@ -161,7 +163,9 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib v1.10.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 // indirect
+	go.opentelemetry.io/otel/metric v0.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/evergreen-ci/evergreen
 
 go 1.19
 
-replace github.com/evergreen-ci/utility => /Users/jonathan.brill/repos/utility
-
 require (
 	github.com/99designs/gqlgen v0.17.20
 	github.com/PuerkitoBio/rehttp v1.1.0
@@ -21,7 +19,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20211025143051-a8d91b2e29fd
 	github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5
-	github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5
+	github.com/evergreen-ci/utility v0.0.0-20230329160933-c10e893cefce
 	github.com/google/go-github/v34 v34.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gophercloud/gophercloud v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1118,6 +1118,8 @@ go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40
 go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.40.0/go.mod h1:RK3vgddjxVcF1q7IBVppzG6k2cW/NBnZHQ3X4g+EYBQ=
 go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.40.0 h1:hATJDiGtTPWglqQRlWUiT5df32bOu9AJV41djhfF4Ig=
 go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.40.0/go.mod h1:nkEFz9FW/KZC65rsd8yrHm4aBKa5STMpe4/Xb5+LG64=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 h1:lE9EJyw3/JhrjWH/hEy9FptnalDQgj7vpbgC2KCCCxE=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0/go.mod h1:pcQ3MM3SWvrA71U4GDqv9UFDJ3HQsW7y5ZO3tDTlUdI=
 go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
 go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 h1:/fXHZHGvro6MVqV34fJzDhi7sHGpX3Ej/Qjmfn003ho=
@@ -1126,6 +1128,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0 h1:TKf2uAs2ueguzLaxOCB
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0/go.mod h1:HrbCVv40OOLTABmOn1ZWty6CHXkU8DK/Urc43tHug70=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0 h1:ap+y8RXX3Mu9apKVtOkM6WSFESLM8K3wNQyOU8sWHcc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0/go.mod h1:5w41DY6S9gZrbjuq6Y+753e96WfPha5IcsOSZTtullM=
+go.opentelemetry.io/otel/metric v0.37.0 h1:pHDQuLQOZwYD+Km0eb657A25NaRzy0a+eLyKfDXedEs=
+go.opentelemetry.io/otel/metric v0.37.0/go.mod h1:DmdaHfGt54iV6UKxsV9slj2bBRJcKC1B1uvDLIioc1s=
 go.opentelemetry.io/otel/sdk v1.14.0 h1:PDCppFRDq8A1jL9v6KMI6dYesaq+DFcDZvjsoGvxGzY=
 go.opentelemetry.io/otel/sdk v1.14.0/go.mod h1:bwIC5TjrNG6QDCHNWvW4HLHtUQ4I+VQDsnjhvyZCALM=
 go.opentelemetry.io/otel/trace v1.14.0 h1:wp2Mmvj41tDsyAJXiWDWpfNsOiIyd38fy85pyKcFq/M=

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,7 @@ github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YW
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=
 github.com/evergreen-ci/gimlet v0.0.0-20211029160936-5b64c7b33753/go.mod h1:57Sr3kCsdBlf9ii/ZYyuNDTzcDLDN7laOyJeIXYPGGs=
+github.com/evergreen-ci/gimlet v0.0.0-20220401150826-5898de01dbd8/go.mod h1:LfnJ3oYEVFUHwIPoAotvn9bbtAT+lAaCpH5YYnyxluk=
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee/go.mod h1:NqXYQ2lPMU7dY33a4ZrqXJKQ3ZY8IZru8H/rpY0hrxs=
 github.com/evergreen-ci/gimlet v0.0.0-20230317174941-7e759337ad2c h1:CFI5vY95JHQmHWKk4BcbENBG3XXnj+D+9gUfYfsTQzQ=
 github.com/evergreen-ci/gimlet v0.0.0-20230317174941-7e759337ad2c/go.mod h1:DfTQmg7Yf8DXDeeJxweZ2/o3AMS3D9wErxrlPcpXc7g=
@@ -390,6 +391,14 @@ github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826/go.mod h1:SnQ9F63VSR6kHbC4aFE+f7+iL3yANhjaN9TT9T4skao=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5 h1:yutavb2qdofFkOGefKjj8dKX0W9SuOKoY5wuzQRYPXg=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
+github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
+github.com/evergreen-ci/utility v0.0.0-20220302150552-3f7a1a268ea7/go.mod h1:EXIwZ5mlP/g0UrWPWX7oRTKQ8nD/ghE3lPCKQ8JMjbk=
+github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
+github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
+github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
+github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5/go.mod h1:JOJFPxtV7r9EEPqdcgkhgMvUMFGNTkUuYp0u2d8zcQI=
+github.com/evergreen-ci/utility v0.0.0-20230329160933-c10e893cefce h1:k8BC97hA5mztqXvL3ZfzWIO0w01uY1DT0Y4PTdO0O+Q=
+github.com/evergreen-ci/utility v0.0.0-20230329160933-c10e893cefce/go.mod h1:JOJFPxtV7r9EEPqdcgkhgMvUMFGNTkUuYp0u2d8zcQI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -663,6 +672,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
@@ -726,9 +737,11 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/VUBk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -800,6 +813,7 @@ github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/okta/okta-jwt-verifier-golang v1.1.1/go.mod h1:Nw85EhrNXkWgfkhE9lggRoRVZLVm7zf/ZtglDUzkKU8=
+github.com/okta/okta-jwt-verifier-golang v1.2.1/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=
 github.com/okta/okta-jwt-verifier-golang v1.3.0/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=
 github.com/okta/okta-jwt-verifier-golang v1.3.1 h1:V+9W5KD3nG7xN0UYtnzXtkurGcs71bLwzPFuUGNMwdE=
 github.com/okta/okta-jwt-verifier-golang v1.3.1/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=

--- a/go.sum
+++ b/go.sum
@@ -358,7 +358,6 @@ github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YW
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=
 github.com/evergreen-ci/gimlet v0.0.0-20211029160936-5b64c7b33753/go.mod h1:57Sr3kCsdBlf9ii/ZYyuNDTzcDLDN7laOyJeIXYPGGs=
-github.com/evergreen-ci/gimlet v0.0.0-20220401150826-5898de01dbd8/go.mod h1:LfnJ3oYEVFUHwIPoAotvn9bbtAT+lAaCpH5YYnyxluk=
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee/go.mod h1:NqXYQ2lPMU7dY33a4ZrqXJKQ3ZY8IZru8H/rpY0hrxs=
 github.com/evergreen-ci/gimlet v0.0.0-20230317174941-7e759337ad2c h1:CFI5vY95JHQmHWKk4BcbENBG3XXnj+D+9gUfYfsTQzQ=
 github.com/evergreen-ci/gimlet v0.0.0-20230317174941-7e759337ad2c/go.mod h1:DfTQmg7Yf8DXDeeJxweZ2/o3AMS3D9wErxrlPcpXc7g=
@@ -391,13 +390,6 @@ github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826/go.mod h1:SnQ9F63VSR6kHbC4aFE+f7+iL3yANhjaN9TT9T4skao=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5 h1:yutavb2qdofFkOGefKjj8dKX0W9SuOKoY5wuzQRYPXg=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
-github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
-github.com/evergreen-ci/utility v0.0.0-20220302150552-3f7a1a268ea7/go.mod h1:EXIwZ5mlP/g0UrWPWX7oRTKQ8nD/ghE3lPCKQ8JMjbk=
-github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
-github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
-github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5 h1:wtPk7ZyGpGZ8bBrdaBgZ8sf7CYlkIrNMa2/erdilPUY=
-github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5/go.mod h1:JOJFPxtV7r9EEPqdcgkhgMvUMFGNTkUuYp0u2d8zcQI=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -671,8 +663,6 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
-github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
@@ -736,11 +726,9 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/VUBk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
-github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -812,7 +800,6 @@ github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWk
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/okta/okta-jwt-verifier-golang v1.1.1/go.mod h1:Nw85EhrNXkWgfkhE9lggRoRVZLVm7zf/ZtglDUzkKU8=
-github.com/okta/okta-jwt-verifier-golang v1.2.1/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=
 github.com/okta/okta-jwt-verifier-golang v1.3.0/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=
 github.com/okta/okta-jwt-verifier-golang v1.3.1 h1:V+9W5KD3nG7xN0UYtnzXtkurGcs71bLwzPFuUGNMwdE=
 github.com/okta/okta-jwt-verifier-golang v1.3.1/go.mod h1:cHffA777f7Yi4K+yDzUp89sGD5v8sk04Pc3CiT1OMR8=

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -562,6 +562,25 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     });
   }
 
+  $scope.addExternalHostToTrace = function () {
+    if ($scope.Settings.tracer.external_hosts_to_trace === null) {
+      $scope.Settings.tracer.external_hosts_to_trace = [];
+    }
+
+    if ($scope.newExternalHostToTrace.length === 0) {
+      $scope.invalidExternalHostToTrace = "Host must have a non-zero length";
+      return
+    }
+
+    $scope.Settings.tracer.external_hosts_to_trace.push($scope.newExternalHostToTrace);
+    $scope.newExternalHostToTrace = "";
+    $scope.invalidExternalHostToTrace = "";
+  }
+
+  $scope.deleteExternalHostToTrace = function (index) {
+    $scope.Settings.tracer.external_hosts_to_trace.splice(index, 1);
+  }
+
   timestamp = function (ts) {
     return "[" + moment(ts, "YYYY-MM-DDTHH:mm:ss").format("lll") + "] ";
   }

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -170,6 +170,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.EqualValues(testSettings.Ui.HttpListenAddr, settingsFromConnector.Ui.HttpListenAddr)
 	s.EqualValues(testSettings.Tracer.Enabled, settingsFromConnector.Tracer.Enabled)
 	s.EqualValues(testSettings.Tracer.CollectorEndpoint, settingsFromConnector.Tracer.CollectorEndpoint)
+	s.EqualValues(testSettings.Tracer.ExternalHostsToTrace, settingsFromConnector.Tracer.ExternalHostsToTrace)
 
 	// spot check events in the event log
 	events, err := event.FindAdmin(event.RecentAdminEvents(1000))
@@ -301,6 +302,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.EqualValues(testSettings.Ui.HttpListenAddr, settingsFromConnector.Ui.HttpListenAddr)
 	s.EqualValues(testSettings.Tracer.Enabled, settingsFromConnector.Tracer.Enabled)
 	s.EqualValues(testSettings.Tracer.CollectorEndpoint, settingsFromConnector.Tracer.CollectorEndpoint)
+	s.EqualValues(testSettings.Tracer.ExternalHostsToTrace, settingsFromConnector.Tracer.ExternalHostsToTrace)
 }
 
 func (s *AdminDataSuite) TestRestart() {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2810,8 +2810,9 @@ func (c *APISpawnHostConfig) ToService() (interface{}, error) {
 }
 
 type APITracerSettings struct {
-	Enabled           *bool   `json:"enabled"`
-	CollectorEndpoint *string `json:"collector_endpoint"`
+	Enabled              *bool     `json:"enabled"`
+	CollectorEndpoint    *string   `json:"collector_endpoint"`
+	ExternalHostsToTrace []*string `json:"external_hosts_to_trace"`
 }
 
 func (c *APITracerSettings) BuildFromService(h interface{}) error {
@@ -2819,6 +2820,7 @@ func (c *APITracerSettings) BuildFromService(h interface{}) error {
 	case evergreen.TracerConfig:
 		c.Enabled = &v.Enabled
 		c.CollectorEndpoint = &v.CollectorEndpoint
+		c.ExternalHostsToTrace = utility.ToStringPtrSlice(v.ExternalHostsToTrace)
 	default:
 		return errors.Errorf("programmatic error: expected tracer config but got type %T", h)
 	}
@@ -2827,8 +2829,9 @@ func (c *APITracerSettings) BuildFromService(h interface{}) error {
 
 func (c *APITracerSettings) ToService() (interface{}, error) {
 	config := evergreen.TracerConfig{
-		Enabled:           utility.FromBoolPtr(c.Enabled),
-		CollectorEndpoint: utility.FromStringPtr(c.CollectorEndpoint),
+		Enabled:              utility.FromBoolPtr(c.Enabled),
+		CollectorEndpoint:    utility.FromStringPtr(c.CollectorEndpoint),
+		ExternalHostsToTrace: utility.FromStringPtrSlice(c.ExternalHostsToTrace),
 	}
 
 	return config, nil

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -228,6 +228,7 @@ func TestModelConversion(t *testing.T) {
 	assert.Equal(testSettings.Spawnhost.UnexpirableVolumesPerUser, *apiSettings.Spawnhost.UnexpirableVolumesPerUser)
 	assert.Equal(testSettings.Tracer.Enabled, *apiSettings.Tracer.Enabled)
 	assert.Equal(testSettings.Tracer.CollectorEndpoint, *apiSettings.Tracer.CollectorEndpoint)
+	assert.Equal(testSettings.Tracer.ExternalHostsToTrace, utility.FromStringPtrSlice(apiSettings.Tracer.ExternalHostsToTrace))
 
 	// test converting from the API model back to a DB model
 	dbInterface, err := apiSettings.ToService()
@@ -331,7 +332,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Spawnhost.UnexpirableHostsPerUser, dbSettings.Spawnhost.UnexpirableHostsPerUser)
 	assert.EqualValues(testSettings.Spawnhost.UnexpirableVolumesPerUser, dbSettings.Spawnhost.UnexpirableVolumesPerUser)
 	assert.EqualValues(testSettings.Tracer.Enabled, dbSettings.Tracer.Enabled)
-	assert.EqualValues(testSettings.Tracer.CollectorEndpoint, dbSettings.Tracer.CollectorEndpoint)
+	assert.Equal(testSettings.Tracer.CollectorEndpoint, dbSettings.Tracer.CollectorEndpoint)
+	assert.Equal(testSettings.Tracer.ExternalHostsToTrace, dbSettings.Tracer.ExternalHostsToTrace)
 }
 
 func TestRestart(t *testing.T) {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2586,6 +2586,44 @@ Admin Settings
 										<label>Collector Endpoint</label>
 										<input type="string" ng-model="Settings.tracer.collector_endpoint">
 									</md-input-container>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Traced External Hosts</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="ec2-list" class="form-group"
+												ng-repeat="(index, host) in Settings.tracer.external_hosts_to_trace">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=25>
+														<input class="control" type="text" ng-model="host"
+															placeholder="Host">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteExternalHostToTrace(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="newExternalHostToTrace"
+														placeholder="Host">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="new_subnet.length === 0" type="button"
+														style="float: left" ng-click="addExternalHostToTrace()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidExternalHostToTrace ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -462,8 +462,9 @@ func MockConfig() *evergreen.Settings {
 			UnexpirableVolumesPerUser: 2,
 		},
 		Tracer: evergreen.TracerConfig{
-			Enabled:           true,
-			CollectorEndpoint: "localhost:4317",
+			Enabled:              true,
+			CollectorEndpoint:    "localhost:4317",
+			ExternalHostsToTrace: []string{"www.github.com"},
 		},
 		ShutdownWaitSeconds: 15,
 	}


### PR DESCRIPTION
[EVG-19189](https://jira.mongodb.org/browse/EVG-19189)

### Description
Send spans for calls to external services, such as GitHub. 
Add a list of hosts we're interested in tracking to admin settings. This is because 
1. it was looking really excessive to send spans for every single log message we send to Splunk.
2. in some cases this library's spans might not add much since other instrumentation will have us better covered. E.g calls to the AWS API might be superfluous once we do [EVG-19211](https://jira.mongodb.org/browse/EVG-19211).

An alternative could be to make it a list of excluded hosts, but being explicit about what we wanted to track made sense to me. We could always go the other way later.

### Testing
Works in staging:
![Screenshot 2023-03-29 at 12 24 42 PM](https://user-images.githubusercontent.com/17027265/228604629-ac0fae47-0033-47f3-acc6-cc131b49fe40.png)
Yielded a trace that included two calls to the GitHub API.

#### Does this need documentation?
N/A
