### PR TITLE
EVG-19167: Add origin field to GraphQL Splunk logging

### DIFF
--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -53,6 +53,7 @@ func (SplunkTracing) InterceptResponse(ctx context.Context, next graphql.Respons
 			"start":       start,
 			"end":         end,
 			"user":        usr.Username(),
+			"origin":      rc.Headers.Get("Origin"),
 		})
 
 	}()


### PR DESCRIPTION
EVG-19167

### Description
- Add origin field to Splunk logs
- Also fix existing error thrown when running `make gqlgen`: `PodAPIEventLogEntry` was being referenced using the `restModel` package when it actually resides in `model`.

### Testing
Verified on staging:
<img width="549" alt="Screenshot 2023-03-29 at 3 04 15 PM" src="https://user-images.githubusercontent.com/9298431/228642484-96a834d6-767f-4db1-8f71-20aa0ed4a6c7.png">