### PR TITLE
EVG-18971 fix retry logic for merging cq items

### DIFF
--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -34,7 +34,7 @@ func init() {
 		"generate.tasks":                        generateTaskFactory,
 		"git.apply_patch":                       gitApplyPatchFactory,
 		"git.get_project":                       gitFetchProjectFactory,
-		"git.merge_pr":                          gitMergePrFactory,
+		"git.merge_pr":                          gitMergePRFactory,
 		"git.push":                              gitPushFactory,
 		"gotest.parse_files":                    goTestFactory,
 		"gotest.parse_json":                     goTest2JSONFactory,

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-03-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-03-22"
+	AgentVersion = "2023-03-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -234,6 +234,8 @@ func getGithubClient(token, caller string) *http.Client {
 	return utility.GetOAuth2HTTPClient(token)
 }
 
+// getGithubClientRetry will retry github operations if the error is temporary, resp is nil,
+// or we hit a bad gateway error.
 func getGithubClientRetry(token, caller string) *http.Client {
 	grip.Info(message.Fields{
 		"ticket":  GithubInvestigation,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1149,7 +1149,7 @@ func GetExistingGithubHook(ctx context.Context, settings evergreen.Settings, own
 // MergePullRequest attempts to merge the given pull request. If commits are merged one after another, Github may
 // not have updated that this can be merged, so we allow retries.
 func MergePullRequest(ctx context.Context, token, owner, repo, commitMessage string, prNum int, mergeOpts *github.PullRequestOptions) error {
-	httpClient := getGithubClientRetry(token, "MergePullRequest")
+	httpClient := getGithubClient(token, "MergePullRequest")
 	defer utility.PutHTTPClient(httpClient)
 	githubClient := github.NewClient(httpClient)
 	res, _, err := githubClient.PullRequests.Merge(ctx, owner, repo,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -24,9 +24,9 @@ import (
 )
 
 const (
-	NumGithubAttempts   = 3
-	GithubRetryMinDelay = time.Second
-	GithubAccessURL     = "https://github.com/login/oauth/access_token"
+	numGithubAttempts   = 3
+	githubRetryMinDelay = time.Second
+	githubAccessURL     = "https://github.com/login/oauth/access_token"
 	githubHookURL       = "%s/rest/v2/hooks/github"
 
 	Github502Error   = "502 Server Error"
@@ -107,7 +107,7 @@ var (
 
 func githubShouldRetry(caller string) utility.HTTPRetryFunction {
 	return func(index int, req *http.Request, resp *http.Response, err error) bool {
-		if index >= NumGithubAttempts {
+		if index >= numGithubAttempts {
 			return false
 		}
 
@@ -173,7 +173,7 @@ func githubShouldRetry(caller string) utility.HTTPRetryFunction {
 // are returned.
 func githubShouldRetryWith404s(caller string) utility.HTTPRetryFunction {
 	return func(index int, req *http.Request, resp *http.Response, err error) bool {
-		if index >= NumGithubAttempts {
+		if index >= numGithubAttempts {
 			return false
 		}
 
@@ -218,8 +218,8 @@ func getGithubClientRetryWith404s(token, caller string) *http.Client {
 		token,
 		githubShouldRetryWith404s(caller),
 		utility.RetryHTTPDelay(utility.RetryOptions{
-			MaxAttempts: NumGithubAttempts,
-			MinDelay:    GithubRetryMinDelay,
+			MaxAttempts: numGithubAttempts,
+			MinDelay:    githubRetryMinDelay,
 		}),
 	)
 }
@@ -246,8 +246,8 @@ func getGithubClientRetry(token, caller string) *http.Client {
 		token,
 		githubShouldRetry(caller),
 		utility.RetryHTTPDelay(utility.RetryOptions{
-			MaxAttempts: NumGithubAttempts,
-			MinDelay:    GithubRetryMinDelay,
+			MaxAttempts: numGithubAttempts,
+			MinDelay:    githubRetryMinDelay,
 		}),
 	)
 }
@@ -576,8 +576,8 @@ func tryGithubPost(ctx context.Context, url string, oauthToken string, data inte
 
 		return false, nil
 	}, utility.RetryOptions{
-		MaxAttempts: NumGithubAttempts,
-		MinDelay:    GithubRetryMinDelay,
+		MaxAttempts: numGithubAttempts,
+		MinDelay:    githubRetryMinDelay,
 	})
 
 	if err != nil {
@@ -631,7 +631,7 @@ func GithubAuthenticate(ctx context.Context, code, clientId, clientSecret string
 		ClientSecret: clientSecret,
 		Code:         code,
 	}
-	resp, err := tryGithubPost(ctx, GithubAccessURL, "", authParameters)
+	resp, err := tryGithubPost(ctx, githubAccessURL, "", authParameters)
 	if resp != nil {
 		defer resp.Body.Close()
 	}


### PR DESCRIPTION
EVG-18971
### Description
Attempted to fix this already by using getGithubClientRetry but didn't realize this only retries in certain cases. Adding an explicit retry to the merge command will more reliably always retry on error. 

### Documentation
added some comments
