### PR TITLE
EVG-19296 skip notifications only for unfinished system unresponsive tasks

### DIFF
--- a/docs/Event-Driven-Notifications.md
+++ b/docs/Event-Driven-Notifications.md
@@ -14,6 +14,9 @@ Evergreen can notify you based on the outcome of your patches. To enable these, 
 ### Patch Finish
 For all new patches you create in the future (including Github Pull Requests), you'll receive an email or slack message when the patch has completed.
 
+### Tasks
+For new tasks that fit the desired requester and finish type, you'll receive a notification. Note that for system unresponsive tasks, we only send a notification on the last execution, since we auto-retry these.
+
 ### Spawn Host Outcome
 For your spawn hosts, you will receive notifications when a host is started, stopped, modified, or terminated.
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -512,7 +512,14 @@ func (t *Task) IsPatchRequest() bool {
 	return utility.StringSliceContains(evergreen.PatchRequesters, t.Requester)
 }
 
-func (t *Task) IsSystemUnresponsive() bool {
+// going to check
+// if isSystemUnresponsive && t.Execution == evergreen.MaxTaskExecution { still return notification }
+
+// IsFinishedSystemUnresponsive returns true if the task is on its final execution, i.e. it won't auto-retry anymore.
+func (t *Task) IsFinishedSystemUnresponsive() bool {
+	if t.Execution < evergreen.MaxTaskExecution {
+		return false
+	}
 	// this is a legacy case
 	if t.Status == evergreen.TaskSystemUnresponse {
 		return true

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1010,18 +1010,36 @@ func TestTaskResultOutcome(t *testing.T) {
 func TestIsSystemUnresponsive(t *testing.T) {
 	var task Task
 
-	task = Task{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem, TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat}}
-	assert.True(t, task.IsSystemUnresponsive(), "current definition")
+	task = Task{
+		Status:    evergreen.TaskFailed,
+		Execution: evergreen.MaxTaskExecution,
+		Details:   apimodels.TaskEndDetail{Type: evergreen.CommandTypeSystem, TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat},
+	}
+	assert.True(t, task.IsFinishedSystemUnresponsive(), "current definition")
 
-	task = Task{Status: evergreen.TaskSystemUnresponse}
-	assert.True(t, task.IsSystemUnresponsive(), "legacy definition")
+	task = Task{
+		Status:    evergreen.TaskSystemUnresponse,
+		Execution: evergreen.MaxTaskExecution,
+	}
+	assert.True(t, task.IsFinishedSystemUnresponsive(), "legacy definition")
 
-	task = Task{Status: evergreen.TaskFailed, Details: apimodels.TaskEndDetail{TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat}}
-	assert.False(t, task.IsSystemUnresponsive(), "normal timeout")
+	task = Task{
+		Status:    evergreen.TaskFailed,
+		Execution: evergreen.MaxTaskExecution,
+		Details:   apimodels.TaskEndDetail{TimedOut: true, Description: evergreen.TaskDescriptionHeartbeat}}
+	assert.False(t, task.IsFinishedSystemUnresponsive(), "normal timeout")
 
-	task = Task{Status: evergreen.TaskSucceeded}
-	assert.False(t, task.IsSystemUnresponsive(), "success")
+	task = Task{
+		Status:    evergreen.TaskSucceeded,
+		Execution: evergreen.MaxTaskExecution,
+	}
+	assert.False(t, task.IsFinishedSystemUnresponsive(), "success")
 
+	task = Task{
+		Status:    evergreen.TaskSystemUnresponse,
+		Execution: 0,
+	}
+	assert.False(t, task.IsFinishedSystemUnresponsive(), "still restarting")
 }
 
 func TestTaskStatusCount(t *testing.T) {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -425,7 +425,7 @@ func (t *taskTriggers) taskFailure(sub *event.Subscription) (*notification.Notif
 		return nil, nil
 	}
 
-	if t.task.IsSystemUnresponsive() {
+	if !t.task.IsFinishedSystemUnresponsive() {
 		return nil, nil
 	}
 
@@ -479,7 +479,7 @@ func (t *taskTriggers) taskFirstFailureInBuild(sub *event.Subscription) (*notifi
 	if t.task.DisplayOnly {
 		return nil, nil
 	}
-	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
+	if t.data.Status != evergreen.TaskFailed || !t.task.IsFinishedSystemUnresponsive() {
 		return nil, nil
 	}
 	rec, err := GetRecordByTriggerType(sub.ID, triggerTaskFirstFailureInBuild, t.task)
@@ -497,7 +497,7 @@ func (t *taskTriggers) taskFirstFailureInVersion(sub *event.Subscription) (*noti
 	if t.task.DisplayOnly {
 		return nil, nil
 	}
-	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
+	if t.data.Status != evergreen.TaskFailed || !t.task.IsFinishedSystemUnresponsive() {
 		return nil, nil
 	}
 	rec, err := GetRecordByTriggerType(sub.ID, event.TriggerTaskFirstFailureInVersion, t.task)
@@ -512,7 +512,7 @@ func (t *taskTriggers) taskFirstFailureInVersion(sub *event.Subscription) (*noti
 }
 
 func (t *taskTriggers) taskFirstFailureInVersionWithName(sub *event.Subscription) (*notification.Notification, error) {
-	if t.data.Status != evergreen.TaskFailed || t.task.IsSystemUnresponsive() {
+	if t.data.Status != evergreen.TaskFailed || !t.task.IsFinishedSystemUnresponsive() {
 		return nil, nil
 	}
 	rec, err := GetRecordByTriggerType(sub.ID, triggerTaskFirstFailureInVersionWithName, t.task)
@@ -547,12 +547,7 @@ func (t *taskTriggers) taskRegression(sub *event.Subscription) (*notification.No
 
 func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord.AlertRecord, error) {
 	if t.Status != evergreen.TaskFailed || !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.Requester) ||
-		t.IsSystemUnresponsive() {
-		return false, nil, nil
-	}
-
-	// Regressions are not actionable if they're caused by a host that was terminated or an agent that died
-	if t.Details.Description == evergreen.TaskDescriptionStranded || t.Details.Description == evergreen.TaskDescriptionHeartbeat {
+		!t.IsFinishedSystemUnresponsive() {
 		return false, nil, nil
 	}
 


### PR DESCRIPTION
EVG-19296

### Description
This unblocks some critical server work.

Right now we skip notifications for all system unresponsive tasks with the idea that they could succeed on future retries, and that this can't be a user's fault. However if a task does fail all 10 runs it is likely that it's user error and it seems like at that time we should send a notification, since we won't be retrying anymore. 

### Testing
Modified unit test

### Documentation
Couldn't find something existing so added a line
