### PR TITLE
EVG-19176  Add “verbose mode” to git clone retries

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -185,7 +185,7 @@ func (opts cloneOpts) buildHTTPCloneCommand() ([]string, error) {
 		clone = fmt.Sprintf("%s --recurse-submodules", clone)
 	}
 	if opts.useVerbose {
-		clone = fmt.Sprintf(" GIT_TRACE=1 GIT_CURL_VERBOSE=1 %s", clone)
+		clone = fmt.Sprintf("GIT_TRACE=1 GIT_CURL_VERBOSE=1 %s", clone)
 	}
 	if opts.cloneDepth > 0 {
 		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)
@@ -213,7 +213,7 @@ func (opts cloneOpts) buildSSHCloneCommand() ([]string, error) {
 		cloneCmd = fmt.Sprintf("%s --recurse-submodules", cloneCmd)
 	}
 	if opts.useVerbose {
-		cloneCmd = fmt.Sprintf(" GIT_TRACE=1 GIT_CURL_VERBOSE=1 %s", cloneCmd)
+		cloneCmd = fmt.Sprintf("GIT_TRACE=1 GIT_CURL_VERBOSE=1 %s", cloneCmd)
 	}
 	if opts.cloneDepth > 0 {
 		cloneCmd = fmt.Sprintf("%s --depth %d", cloneCmd, opts.cloneDepth)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-03-30"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-03-30"
+	AgentVersion = "2023-04-02"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-19176

### Description
This runs git clone in verbose mode on the last two retries. I only added it on the last two because if it only retries 2 or 3 times and passes, then I'm guess that the verbose logs are not necessary. And if it does retry the full five times and then fails, it's probably nice to have two iterations of verbose logs to look at in case there's any variation between them. I'm open to feedback on when we should start using verbose mode. 

### Testing
Tested on staging 

### Documentation
NA