### PR TITLE
EVG-19306 Do not look for decommissioned pods in the terminated job

### DIFF
--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -121,9 +121,6 @@ func FindByNeedsTermination() ([]Pod, error) {
 				StatusKey: StatusStarting,
 				bsonutil.GetDottedKeyName(TimeInfoKey, TimeInfoStartingKey): bson.M{"$lte": staleCutoff},
 			},
-			{
-				StatusKey: StatusDecommissioned,
-			},
 		},
 	}))
 }

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -49,7 +49,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 			require.Len(t, pods, 1)
 			assert.Equal(t, stalePod.ID, pods[0].ID)
 		},
-		"ReturnsMatchingDecommissionedPod": func(t *testing.T) {
+		"SkipsDecommissionedPod": func(t *testing.T) {
 			decommissionedPod := Pod{
 				ID:     "pod_id",
 				Status: StatusDecommissioned,
@@ -58,8 +58,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 
 			pods, err := FindByNeedsTermination()
 			require.NoError(t, err)
-			require.Len(t, pods, 1)
-			assert.Equal(t, decommissionedPod.ID, pods[0].ID)
+			require.Len(t, pods, 0)
 		},
 		"ReturnsMatchingStaleInitializingPod": func(t *testing.T) {
 			stalePod := Pod{


### PR DESCRIPTION
EVG-19306

### Description
We introduced a [safety measure](https://github.com/evergreen-ci/evergreen/pull/5908) to ensure that a pod can only run one single task in its lifecycle, whereby we mark the pod as decommissioned immediately upon setting its running task.  However, our cron job that looks for pods to terminate looks for decommissioned pods, meaning that pods marked as decommissioned that were actively running tasks would match the termination filter, resulting in pods prematurely getting terminated with running tasks.

Removed this from the filter, since it appears that a decommissioned pod will still properly get terminated once it [asks for another task](https://gist.github.com/hadjri/174b7f5a5b34a2781a73ed0cc63199a4#file-pod_agent-go-L242)
### Testing
Ran a container patch with this change and saw tasks finally completing successfully
### Documentation
n/a