### PR TITLE
EVG-18598 reset disabled priorities when restarting version

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -784,14 +785,14 @@ func TestCreateBuildFromVersion(t *testing.T) {
 				{Name: "taskA"}, {Name: "taskB"}, {Name: "taskC"}, {Name: "taskD"},
 			},
 			DisplayTasks: []displayTask{
-				displayTask{
+				{
 					Name: "bv1DisplayTask1",
 					ExecutionTasks: []string{
 						"taskA",
 						"taskB",
 					},
 				},
-				displayTask{
+				{
 					Name: "bv1DisplayTask2",
 					ExecutionTasks: []string{
 						"taskC",
@@ -2100,11 +2101,12 @@ func TestVersionRestart(t *testing.T) {
 	for _, t := range tasks {
 		assert.Equal(evergreen.TaskUndispatched, t.Status)
 		assert.True(t.Activated)
-
+		assert.True(t.Priority >= 0, fmt.Sprintf("task '%s' is priority '%d'", t.Id, t.Priority))
 		if t.Id == "task3" {
 			require.Len(t.DependsOn, 1)
 			assert.Equal("task1", t.DependsOn[0].TaskId)
 			assert.False(t.DependsOn[0].Finished, "restarting task1 should have marked dependency as unfinished")
+			assert.Equal(t.Priority, int64(100))
 		}
 	}
 	for _, b := range builds {
@@ -2306,6 +2308,7 @@ func resetTaskData() error {
 		BuildId:     build1.Id,
 		Version:     v.Id,
 		Status:      evergreen.TaskSucceeded,
+		Priority:    -1,
 	}
 	if err := task1.Insert(); err != nil {
 		return err
@@ -2326,6 +2329,7 @@ func resetTaskData() error {
 		BuildId:     build2.Id,
 		Version:     v.Id,
 		Status:      evergreen.TaskSucceeded,
+		Priority:    100,
 		DependsOn: []task.Dependency{
 			{
 				TaskId:   task1.Id,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1919,7 +1919,7 @@ func (t *Task) Reset() error {
 }
 
 // ResetTasks performs the same DB updates as (*Task).Reset, but resets many
-// tasks instead of a single one.
+// tasks instead of a single one, and verifies that priority isn't disabled.
 func ResetTasks(tasks []Task) error {
 	if len(tasks) == 0 {
 		return nil
@@ -1938,6 +1938,9 @@ func ResetTasks(tasks []Task) error {
 		resetTaskUpdate(nil),
 	); err != nil {
 		return err
+	}
+	if err := enableDisabledTasks(taskIDs); err != nil {
+		return errors.Wrap(err, "enabling disabled tasks")
 	}
 
 	return nil


### PR DESCRIPTION
EVG-18598

### Description
Verified through testing that restarting an individual task already sets disabled task priorities to 0 when they're restarted, so this only affects version restarts.

### Testing
Added to a unit test.

