### PR TITLE
docs: fix some markdown formatting errors

### DIFF
--- a/docs/02-Test with Evergreen/01-Configure a Project/01-Project-Configuration-Files.md
+++ b/docs/02-Test with Evergreen/01-Configure a Project/01-Project-Configuration-Files.md
@@ -52,8 +52,8 @@ Notice that tasks contain:
 1.  A name
 2.  A set of dependencies on other tasks
 3.  A distro or list of distros to run on (documented more under
-    [\"Build
-    Variants\"](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants)).
+    ["Build
+    Variants"](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants)).
     If run_on is set at the task level, it takes precedent over the
     default set for the buildvariant (unless run_on is explicitly
     defined for this task under a specific build variant).
@@ -269,10 +269,9 @@ allowing tasks within a build variant to be run on different distros.
 This is useful for optimizing tasks like compilations, that can benefit
 from larger, more powerful machines.
 
-Version Controlled Project Settings \-\-\-\-\-\-\-\-\-\-\-\-\--Project
-configurations can version control some select project settings (e.g.
-aliases, plugins) directly within the yaml rather than on the project
-page UI, for better accessibility and maintainability. Read more
+### Version Controlled Project Settings
+Project configurations can version control some select project settings (e.g. aliases, plugins) directly within the yaml
+rather than on the project page UI, for better accessibility and maintainability. Read more
 [here](https://github.com/evergreen-ci/evergreen/wiki/Project-and-Distro-Settings#version-control).
 
 ## Advanced Features
@@ -323,23 +322,23 @@ We will maintain the following merge rules:
 #### Validating changes to config files
 
 When editing yaml project files, you can verify that the file will work
-correctly after committing by checking it with the \"validate\" command.
+correctly after committing by checking it with the "validate" command.
 To validate local changes within modules, use the `local_modules` flag
 to list out module name and path pairs.
 
 Note: Must include a local path for includes that use a module.
 
-`` ` evergreen validate <path-to-yaml-project-file> -lm <module-name>=<path-to-yaml> ``\`
+``` evergreen validate <path-to-yaml-project-file> -lm <module-name>=<path-to-yaml> ```
 
-The validation step will check for
+The validation step will check for:
 
-:   -   valid yaml syntax
-    -   correct names for all commands used in the file
-    -   logical errors, like duplicated variant or task names
-    -   invalid sets of parameters to commands
-    -   warning conditions such as referencing a distro pool that does
-        not exist
-    -   merging errors from include files
+-   valid yaml syntax
+-   correct names for all commands used in the file
+-   logical errors, like duplicated variant or task names
+-   invalid sets of parameters to commands
+-   warning conditions such as referencing a distro pool that does
+    not exist
+-   merging errors from include files
 
 ### Modules
 
@@ -347,7 +346,7 @@ For patches that run tests based off of changes across multiple
 projects, the modules field may be defined to specify other git projects
 with configurations specifying the way that changes across them are
 applied within the patch at runtime. If configured correctly, the left
-hand side of the Spruce UI under \"Version Manifest\" will contain
+hand side of the Spruce UI under "Version Manifest" will contain
 details on how the modules were parsed from YAML and which git revisions
 are being used.
 
@@ -582,7 +581,7 @@ Every task has some expansions available by default:
 
 -   `${is_patch}` is "true" if the running task is in a patch build and
     undefined if it is not.
--   `${is_stepback}` is \"true\" if the running task was stepped back.
+-   `${is_stepback}` is "true" if the running task was stepped back.
 -   `${author}` is the patch author's username for patch tasks or the
     git commit author for git tasks
 -   `${author_email}` is the patch or the git commit authors email
@@ -624,7 +623,7 @@ Every task has some expansions available by default:
     or PR triggered commit queue item
 -   `${triggered_by_git_tag}` is the name of the tag that triggered this
     version, if applicable
--   `${is_commit_queue}` is the string \"true\" if this is a commit
+-   `${is_commit_queue}` is the string "true" if this is a commit
     queue task
 -   `${commit_message}` is the commit message if this is a commit queue
     task
@@ -636,7 +635,7 @@ inter-project dependency:
 
 -   `${trigger_event_identifier}` is the ID of the task or build that
     initiated this trigger
--   `${trigger_event_type}` will be \"task\" or \"build,\" identifying
+-   `${trigger_event_type}` will be "task" or "build," identifying
     what type of ID `${trigger_event_identifier}` is
 -   `${trigger_status}` is the task or build status of whatever
     initiated this trigger
@@ -771,8 +770,8 @@ For Example:
 -   `red` would return the item named "red"
 -   `.primary` would return all items with the tag "primary"
 -   `!.primary` would return all items that are NOT tagged "primary"
--   `.cool !blue` would return all items that are tagged \"cool\" and
-    NOT named \"blue\"
+-   `.cool !blue` would return all items that are tagged "cool" and
+    NOT named "blue"
 -   `.cool !.primary` would return all items that are tagged "cool" and
     NOT tagged "primary"
 -   `*` would return all items
@@ -1272,11 +1271,11 @@ A task can be made to depend on other tasks by adding the depended on
 tasks to the task's depends_on field. The following additional
 parameters are available:
 
--   `status` - string (default: \"success\"). One of \[\"success\",
-    \"failed\", or \"*\"\]. \"*\" includes any finished status as well
+-   `status` - string (default: "success"). One of ["success",
+    "failed", or "*"]. "*" includes any finished status as well
     as when the task is blocked.
 -   `variant` - string (by default, uses existing variant). Can specify a 
-     variant for the dependency to exist in, or \"*\" will depend on the task
+     variant for the dependency to exist in, or "*" will depend on the task
      for all matching variants.
 -   `patch_optional` - boolean (default: false). If true the dependency
     will only exist when the depended on task is present in the version
@@ -1458,12 +1457,12 @@ is complete (or when the task is complete, if `should_continue` is set).
 
     POST localhost:2285/task_status
 
-| Name            | Type    | Description                                                                                                                                                 |
-|--------------------|---------|-------------------------------------------|
-| status          | string  | Required. The overall task status. This can be \"success\" or \"failed\". If this is configured incorrectly, the task will system fail.                     |
-| type            | string  | The failure type. This can be \"setup\", \"system\", or \"test\" (see above section for corresponding colors). Will default to the command's failure type. |
-| desc            | string  | Provide details on the task failure. This is limited to 500 characters. Will default to the command's display name.                                        |
-| should_continue | boolean | Defaults to false. If set, will finish running the task before setting the status.                                                                          |
+| Name            | Type    | Description                                                                                                                                          |
+|-----------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| status          | string  | Required. The overall task status. This can be "success" or "failed". If this is configured incorrectly, the task will system fail.                  |
+| type            | string  | The failure type. This can be "setup", "system", or "test" (see above section for corresponding colors). Will default to the command's failure type. |
+| desc            | string  | Provide details on the task failure. This is limited to 500 characters. Will default to the command's display name.                                  |
+| should_continue | boolean | Defaults to false. If set, will finish running the task before setting the status.                                                                   |
 
 Example in a command:
 

--- a/docs/02-Test with Evergreen/01-Configure a Project/02-Project-Commands.md
+++ b/docs/02-Test with Evergreen/01-Configure a Project/02-Project-Commands.md
@@ -110,19 +110,19 @@ The format is as follows:
 }
 ```
 
-The available fields for each json object in the \"results\" array above
+The available fields for each json object in the "results" array above
 are the following. Note that all fields are optional and there is very
 little validation on the data, so the server may accept inputs that are
 logically nonsensical.
 
 | Name        | Type          | Description                                                                                                            |
 |--------------------|---------|-------------------------------------------|
-| `status`    | string (enum) | The final status of the test. Should be one of: \"fail\", \"pass\", \"silentfail\", \"skip\".                          |
+| `status`    | string (enum) | The final status of the test. Should be one of: "fail", "pass", "silentfail", "skip".                          |
 | `test_file` | string        | The name of the test. This is what will be displayed in the test results section of the UI as the test identifier.     |
 | `group_id`  | string        | The group ID if the test is associated with a group. This is mostly used for tests logging directly to cedar.          |
 | `url`       | string        | The URL containing the rich-text view of the test logs.                                                                |
 | `url_raw`   | string        | The URL containing the plain-text view of the test logs.                                                               |
-| `line_num`  | int           | The line number of the test within the \"url\" parameter, if the URL actually contains the logs for multiple tests.    |
+| `line_num`  | int           | The line number of the test within the "url" parameter, if the URL actually contains the logs for multiple tests.    |
 | `exit_code` | int           | The status with which the test command exited. For the most part this does nothing.                                    |
 | `task_id`   | string        | The ID of the task with which this test should be associated. The test will appear on the page for the specified task. |
 | `execution` | int           | The execution of the task above with which this test should be associated.                                             |
@@ -274,7 +274,7 @@ Parameters:
         "echo-hi": {
             "command": "shell.exec",
             "params": {
-                "script": "echo \"hi\"\n"
+                "script": "echo "hi"\n"
             }
         }
     },
@@ -347,12 +347,12 @@ Parameters:
     `<module_name> : ${<module_name>_rev}`. For patch builds, the hash
     must be passed directly as `<module_name> : <hash>`. Note that this
     means that for patch builds, editing the
-    [\"modules\"](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#modules)
+    ["modules"](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#modules)
     section of the project config will not change the checked out hash.
 -   `token`: Use a token to clone instead of the ssh key on the host.
     Since this is a secret, it should be provided as a project
     expansion. For example, you could provide an expansion called
-    \"github_token\" and then set this field to \${github_token}.
+    "github_token" and then set this field to \${github_token}.
     Evergreen will populate the expansion when it parses the project
     yaml.
 -   `clone_depth`: Clone with `git clone --depth <clone_depth>`. For
@@ -848,7 +848,7 @@ Parameters:
 -   `local_file`: the local file to post
 -   `remote_file`: the S3 path to post the file to
 -   `bucket`: the S3 bucket to use. Note: buckets created after Sept.
-    30, 2020 containing dots (\".\") are not supported.
+    30, 2020 containing dots (".") are not supported.
 -   `permissions`: the permissions string to upload with
 -   `content_type`: the MIME type of the file
 -   `optional`: boolean to indicate if failure to find or upload this
@@ -866,10 +866,10 @@ Parameters:
 -   `region`: AWS region for the bucket. We suggest us-east-1, since
     that is where ec2 hosts are located. If you would like to override,
     you can use this parameter.
--   `visibility`: one of \"private\", which allows logged-in users to
-    see the file; \"public\" (the default), which allows anyone to see
-    the file; \"none\", which hides the file from the UI for everybody;
-    or \"signed\", which creates a pre signed url, allowing logged-in
+-   `visibility`: one of "private", which allows logged-in users to
+    see the file; "public" (the default), which allows anyone to see
+    the file; "none", which hides the file from the UI for everybody;
+    or "signed", which creates a pre signed url, allowing logged-in
     users to see the file (even if it's private on s3). Visibility:
     signed should not be combined with permissions: public-read or
     permissions: public-read-write.
@@ -1005,7 +1005,7 @@ Parameters:
 -   `s3_copy_files`: a map of `source` (`bucket` and `path`),
     `destination`, `build_variants` (a list of strings), `display_name`,
     and `optional` (suppresses errors). Note: destination buckets
-    created after Sept. 30, 2020 containing dots (\".\") are not
+    created after Sept. 30, 2020 containing dots (".") are not
     supported.
 
 ## shell.exec
@@ -1029,10 +1029,10 @@ Parameters:
     conflicting environment variables defined by `add_expansions_to_env` or
     `include_expansions_in_env`, this has the lowest priority. Unless
     overridden, the following environment variables will be set by default:
-    - \"CI\" will be set to \"true\".
-    - \"GOCACHE\" will be set to `${workdir}/.gocache`.
-    - \"EVR_TASK_ID\" will be set to the running task's ID.
-    - \"TMP\", \"TMPDIR\", and \"TEMP\" will be set to `${workdir}/tmp`.
+    - "CI" will be set to "true".
+    - "GOCACHE" will be set to `${workdir}/.gocache`.
+    - "EVR_TASK_ID" will be set to the running task's ID.
+    - "TMP", "TMPDIR", and "TEMP" will be set to `${workdir}/tmp`.
 -   `add_expansions_to_env`: when true, add all expansions to the
     command's environment. In case of conflicting environment variables
     defined by `env` or `include_expansions_in_env`, this has higher
@@ -1064,8 +1064,8 @@ Parameters:
 -   `ignore_standard_error`: if true, discards output sent to stderr
 -   `redirect_standard_error_to_output`: if true, sends stderr to
     stdout. Can be used to synchronize these 2 streams
--   `exec_as_string`: if true, executes as \"sh -c \'your script
-    here\'\". By default, shell.exec runs sh then pipes your script to
+-   `exec_as_string`: if true, executes as "sh -c 'your script
+    here'". By default, shell.exec runs sh then pipes your script to
     its stdin. Use this parameter if your script will be doing something
     that may change stdin, such as sshing
 
@@ -1097,10 +1097,10 @@ Parameters:
     conflicting environment variables defined by `add_expansions_to_env` or
     `include_expansions_in_env`, this has the lowest priority. Unless
     overridden, the following environment variables will be set by default:
-    - \"CI\" will be set to \"true\".
-    - \"GOCACHE\" will be set to `${workdir}/.gocache`.
-    - \"EVR_TASK_ID\" will be set to the running task's ID.
-    - \"TMP\", \"TMPDIR\", and \"TEMP\" will be set to `${workdir}/tmp`.
+    - "CI" will be set to "true".
+    - "GOCACHE" will be set to `${workdir}/.gocache`.
+    - "EVR_TASK_ID" will be set to the running task's ID.
+    - "TMP", "TMPDIR", and "TEMP" will be set to `${workdir}/tmp`.
 -   `command`: a command string (cannot use with `binary` or `args`),
     split on spaces for use as arguments\--note that expansions will
     *not* be split on spaces; each expansion represents its own

--- a/docs/02-Test with Evergreen/01-Configure a Project/02-Project-Commands.md
+++ b/docs/02-Test with Evergreen/01-Configure a Project/02-Project-Commands.md
@@ -274,7 +274,7 @@ Parameters:
         "echo-hi": {
             "command": "shell.exec",
             "params": {
-                "script": "echo "hi"\n"
+                "script": "echo hi"
             }
         }
     },

--- a/docs/02-Test with Evergreen/01-Configure a Project/03-Project-and-Distro-Settings.md
+++ b/docs/02-Test with Evergreen/01-Configure a Project/03-Project-and-Distro-Settings.md
@@ -63,8 +63,8 @@ Evergreen.
 
 Admins can also set the branch project to inherit values from a
 repo-level project settings configuration. This can be learned about at
-[\'Using Repo Level
-Settings\'](https://github.com/evergreen-ci/evergreen/wiki/Using-Repo-Level-Settings).
+['Using Repo Level
+Settings'](https://github.com/evergreen-ci/evergreen/wiki/Using-Repo-Level-Settings).
 
 ### Access and Admin Settings
 
@@ -109,8 +109,8 @@ github checks, git tag triggers, project triggers, and patch triggers.
 For most aliases, you must define a variant regex or tags, and a task
 regex or tags. The matching variants/tasks will be included for the
 alias. Tags should be listed as they are defined under the task
-definition (i.e. without the \".\") and tag negation is also supported
-(by prefixing the tag name with \"!\"). Multiple tags should be
+definition (i.e. without the ".") and tag negation is also supported
+(by prefixing the tag name with "!"). Multiple tags should be
 comma-delimited.
 
 Aliases can also be defined locally as shown
@@ -118,22 +118,22 @@ Aliases can also be defined locally as shown
 
 ### GitHub Pull Request Testing
 
-Enabling \"Automated Testing\" will have Evergreen automatically create a patch for
+Enabling "Automated Testing" will have Evergreen automatically create a patch for
 each pull request opened in the repository as well as each subsequent
 push to each pull request. In order for this to work, you must fill out
-at least 1 row in the section titled \"GitHub Patch Definitions,\" as
+at least 1 row in the section titled "GitHub Patch Definitions," as
 those define what tasks will be run in this patch.
 
 If you'd like the option of creating patches but wouldn't like it to happen automatically,
-you can enable \"Manual Testing\".
+you can enable "Manual Testing".
 
 ![github_settings.png](../../images/github_settings.png)
 
 You can also have tasks run for a *different* project for
 each pull request opened in the repository as well as each subsequent
 push to each pull request. To do that, add a trigger aliases to the
-\"Github Trigger Alias\" section. Before an alias can be added, it needs
-to be defined in the \"Patch Trigger Aliases\" section.
+"Github Trigger Alias" section. Before an alias can be added, it needs
+to be defined in the "Patch Trigger Aliases" section.
 
 ![github_trigger_alias.png](../../images/github_trigger_alias.png)
 
@@ -160,8 +160,8 @@ This allows for versions to be created from pushed git tags.
 -   Versions are displayed on the waterfall page.
 -   The author of the version matches the author from the original
     waterfall version.
--   The version is titled \"Triggered From Git Tag \'\<git tag\>\':
-    \<commit message for this revision\>\"
+-   The version is titled "Triggered From Git Tag '\<git tag\>':
+    \<commit message for this revision\>"
 -   The expansion `${triggered_by_git_tag}` is set to the git tag that
     was pushed.
 -   If the revision exists for multiple projects, it will check if a
@@ -218,10 +218,10 @@ Ambiguous behavior is outlined here:
 
 ### Project Triggers
 
-Users can specify that commits to another project (the \"upstream\"
-project) will trigger builds in their project (the \"downstream\"
+Users can specify that commits to another project (the "upstream"
+project) will trigger builds in their project (the "downstream"
 project). Configure triggers in the downstream project from the project
-configuration page. Click \"NEW TRIGGER\".
+configuration page. Click "NEW TRIGGER".
 
 Options:
 
@@ -240,9 +240,9 @@ Options:
 ### Patch Trigger Aliases
 
 Users can create aliases that can be used in patch builds (in the
-\"upstream\" project) to kick off a child patch (in the \"downstream\"
+"upstream" project) to kick off a child patch (in the "downstream"
 project). Create aliases in the upstream project in the Patch Trigger
-Aliases section of the project configuration page. Click \"NEW ALIAS\".
+Aliases section of the project configuration page. Click "NEW ALIAS".
 
 Options:
 
@@ -293,8 +293,8 @@ Options:
 Periodic builds can be viewed on the project waterfall page, and can be
 filtered on on Spruce. You can also find out about the results of
 periodic builds by adding a notification subscription on the project
-settings page. In the notification popup, select \"when any version
-finishes\" with Build Initiator = Periodic Build.
+settings page. In the notification popup, select "when any version
+finishes" with Build Initiator = Periodic Build.
 
 Also note that periodic builds cannot currently be used to schedule
 tasks for which you hope to use performance tooling, like performance
@@ -327,8 +327,8 @@ virtual workstation.
 Options:
 
 -   Enable Git Clone: A git clone will automatically be run on the
-    defined project, i.e. \"git clone -b v20210623
-    <git@github.com>:10gen/mms.git\"
+    defined project, i.e. "git clone -b v20210623
+    <git@github.com>:10gen/mms.git"
 -   Commands: Specify commands to be run on the project in order using
     the setup CLI command from the workstation, allowing for an optional
     working subdirectory to be passed in.
@@ -378,18 +378,18 @@ The process of scheduling tasks contains a number of distinct phases
 that all execute independently:
 
 1.  *Task Finding* identifies all runable undispatched runnable tasks
-    for a disto. You can choose to include tasks which have unsatisfied
+    for a distro. You can choose to include tasks which have unsatisfied
     dependencies, if the task dispatcher supports having these tasks in
     the queue. There are multiple implementations of the task finder in
     evergreen, which use different approaches to returning these
-    queries. Evergreen typically uses the \"Legacy\" implementation in
+    queries. Evergreen typically uses the "Legacy" implementation in
     production because it is the most stable, but the other
     implementations are equivalent.
 
 2.  *Task Planning* manages how tasks are ordered in the queue. There
     are two implementations, Evergreen's Legacy implementation which
     orders tasks using a short circuiting list of comparison operation,
-    and the \"Tunable\" implementation which uses a point-based
+    and the "Tunable" implementation which uses a point-based
     algorithim that makes it possible to tune the factors that impact
     the ordering of a task. The tunable factors are:
 
@@ -440,9 +440,9 @@ that all execute independently:
 
 Enabling version control for configurations on the project page will
 allow a number of the settings detailed above to also be specified in
-the project yaml alongside the settings that are specified in [\'Project
+the project yaml alongside the settings that are specified in ['Project
 Configuration
-Files\'](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files).
+Files'](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files).
 Evergreen will merge the settings in the project page, repo page, then the yaml, in that order. In case of duplicates, like aliases with the same names, the ones defined on the project page will take precedence over those
 defined in the yaml. 
 

--- a/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
+++ b/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
@@ -64,46 +64,45 @@ comprise a suite of tests or generation of a set of artifacts.
 
 **Task**
 
-| Name                   | Type          | Description                                                                                                                                                                                                                                                          |
-|--------------------|---------|-------------------------------------------|
-| `task_id`              | string        | Unique identifier of this task                                                                                                                                                                                                                                       |
-| `create_time`          | time          | Time that this task was first created                                                                                                                                                                                                                                |
-| `dispatch_time`        | time          | Time that this time was dispatched                                                                                                                                                                                                                                   |
-| `scheduled_time`       | time          | Time that this task is scheduled to begin                                                                                                                                                                                                                            |
-| `start_time`           | time          | Time that this task began execution                                                                                                                                                                                                                                  |
-| `finish_time`          | time          | Time that this task finished execution                                                                                                                                                                                                                               |
-| `version_id`           | string        | An identifier of this task by its project and commit hash                                                                                                                                                                                                            |
-| `branch`               | string        | The version control branch that this task is associated with                                                                                                                                                                                                         |
-| `revision`             | string        | The version control identifier associated with this task                                                                                                                                                                                                             |
-| `requester`            | string        | Version created by one of \"patch_request\", \"github_pull_request\", \"gitter_request\" (caused by git commit, aka the repotracker requester), \"trigger_request\" (Project Trigger versions) , \"merge_test\" (commit queue patches), \"ad_hoc\" (periodic builds) |
-| `priority`             | int           | The priority of this task to be run                                                                                                                                                                                                                                  |
-| `activated`            | boolean       | Whether the task is currently active                                                                                                                                                                                                                                 |
-| `activated_by`         | string        | Identifier of the process or user that activated this task                                                                                                                                                                                                           |
-| `build_id`             | string        | Identifier of the build that this task is part of                                                                                                                                                                                                                    |
-| `distro_id`            | string        | Identifier of the distro that this task runs on                                                                                                                                                                                                                      |
-| `build_variant`        | string        | Name of the buildvariant that this task runs on                                                                                                                                                                                                                      |
-| `depends_on`           | array         | List of task_ids of task that this task depends on before beginning                                                                                                                                                                                                  |
-| `display_name`         | string        | Name of this task displayed in the UI                                                                                                                                                                                                                                |
-| `host_id`              | string        | The ID of the host this task ran or is running on                                                                                                                                                                                                                    |
-| `tags`                 | \[string\]    | List of tags defined for the task, if any                                                                                                                                                                                                                            |
-| `execution`            | int           | The number of the execution of this particular task                                                                                                                                                                                                                  |
-| `order`                | int           | For mainline commits, represents the position in the commit history of commit this task is associated with. For patches, this represents the number of total patches submitted by the user.                                                                          |
-| `status`               | string        | The current status of this task                                                                                                                                                                                                                                      |
-| `display_status`       | string        | The status of this task that is displayed in the UI                                                                                                                                                                                                                  |
-| `status_details`       | status_object | Object containing additional information about the status                                                                                                                                                                                                            |
-| `logs`                 | logs_object   | Object containing raw and event logs for this task                                                                                                                                                                                                |
-| `parsley_logs`         | logs_object   | Object containing parsley logs for this task 
-|
-| `time_taken_ms`        | int           | Number of milliseconds this task took during execution                                                                                                                                                                                                               |
-| `expected_duration_ms` | int           | Number of milliseconds expected for this task to execute                                                                                                                                                                                                             |
-| `previous_executions`  | \[Task\]      | Contains previous executions of the task if they were requested, and available. May be empty.                                                                                                                                                              |
-| `parent_task_id`       | string        | The ID of the task's parent display task, if requested and available                                                                                                                                                                                      |
-| ` artifacts`           | \[File\]      | The list of artifacts associated with the task.
+| Name                   | Type          | Description                                                                                                                                                                                                                                             |
+|------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `task_id`              | string        | Unique identifier of this task                                                                                                                                                                                                                          |
+| `create_time`          | time          | Time that this task was first created                                                                                                                                                                                                                   |
+| `dispatch_time`        | time          | Time that this time was dispatched                                                                                                                                                                                                                      |
+| `scheduled_time`       | time          | Time that this task is scheduled to begin                                                                                                                                                                                                               |
+| `start_time`           | time          | Time that this task began execution                                                                                                                                                                                                                     |
+| `finish_time`          | time          | Time that this task finished execution                                                                                                                                                                                                                  |
+| `version_id`           | string        | An identifier of this task by its project and commit hash                                                                                                                                                                                               |
+| `branch`               | string        | The version control branch that this task is associated with                                                                                                                                                                                            |
+| `revision`             | string        | The version control identifier associated with this task                                                                                                                                                                                                |
+| `requester`            | string        | Version created by one of patch_request", "github_pull_request", "gitter_request" (caused by git commit, aka the repotracker requester), "trigger_request" (Project Trigger versions) , "merge_test" (commit queue patches), "ad_hoc" (periodic builds) |
+| `priority`             | int           | The priority of this task to be run                                                                                                                                                                                                                     |
+| `activated`            | boolean       | Whether the task is currently active                                                                                                                                                                                                                    |
+| `activated_by`         | string        | Identifier of the process or user that activated this task                                                                                                                                                                                              |
+| `build_id`             | string        | Identifier of the build that this task is part of                                                                                                                                                                                                       |
+| `distro_id`            | string        | Identifier of the distro that this task runs on                                                                                                                                                                                                         |
+| `build_variant`        | string        | Name of the buildvariant that this task runs on                                                                                                                                                                                                         |
+| `depends_on`           | array         | List of task_ids of task that this task depends on before beginning                                                                                                                                                                                     |
+| `display_name`         | string        | Name of this task displayed in the UI                                                                                                                                                                                                                   |
+| `host_id`              | string        | The ID of the host this task ran or is running on                                                                                                                                                                                                       |
+| `tags`                 | []string      | List of tags defined for the task, if any                                                                                                                                                                                                               |
+| `execution`            | int           | The number of the execution of this particular task                                                                                                                                                                                                     |
+| `order`                | int           | For mainline commits, represents the position in the commit history of commit this task is associated with. For patches, this represents the number of total patches submitted by the user.                                                             |
+| `status`               | string        | The current status of this task                                                                                                                                                                                                                         |
+| `display_status`       | string        | The status of this task that is displayed in the UI                                                                                                                                                                                                     |
+| `status_details`       | status_object | Object containing additional information about the status                                                                                                                                                                                               |
+| `logs`                 | logs_object   | Object containing raw and event logs for this task                                                                                                                                                                                                      |
+| `parsley_logs`         | logs_object   | Object containing parsley logs for this task                                                                                                                                                                                                            |
+| `time_taken_ms`        | int           | Number of milliseconds this task took during execution                                                                                                                                                                                                  |
+| `expected_duration_ms` | int           | Number of milliseconds expected for this task to execute                                                                                                                                                                                                |
+| `previous_executions`  | []Task        | Contains previous executions of the task if they were requested, and available. May be empty.                                                                                                                                                           |
+| `parent_task_id`       | string        | The ID of the task's parent display task, if requested and available                                                                                                                                                                                    |
+| `artifacts`            | []File        | The list of artifacts associated with the task.
 
 **Logs**
 
 | Name       | Type   | Description                                           |
-|--------------------|---------|-------------------------------------------|
+|--------------------|---------|----------------------------------------------|
 | agent_log  | string | Link to logs created by the agent process             |
 | task_log   | string | Link to logs created by the task execution            |
 | system_log | string | Link to logs created by the machine running the task  |
@@ -135,7 +134,7 @@ comprise a suite of tests or generation of a set of artifacts.
 List all tasks within a specific build.
 
 | Name                 | Type    | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
+|----------------------|---------|--------------------------------------------------------------------------------------|
 | start_at             | string  | Optional. The identifier of the task to start at in the pagination                   |
 | limit                | int     | Optional. The number of tasks to be returned per page of pagination. Defaults to 100 |
 | fetch_all_executions | boolean | Optional. Fetches previous executions of tasks if they are available                 |
@@ -148,14 +147,14 @@ List all tasks within a specific build.
 List all tasks within a mainline commit of a given project (excludes
 patch tasks)
 
-| Name      | Type   | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
-| start_at  | string | Optional. The identifier of the task to start at in the pagination                   |
-| limit     | int    | Optional. The number of tasks to be returned per page of pagination. Defaults to 100 |
-| variant   | string | Optional. Only return tasks within this variant                                      |
-| variant_regex   | string | Optional. Only return tasks within variants that match this regex              |
-| task_name | string | Optional. Only return tasks with this display name                                   |
-| status    | string | Optional. Only return tasks with this status                                   |
+| Name          | Type   | Description                                                                          |
+|---------------|--------|--------------------------------------------------------------------------------------|
+| start_at      | string | Optional. The identifier of the task to start at in the pagination                   |
+| limit         | int    | Optional. The number of tasks to be returned per page of pagination. Defaults to 100 |
+| variant       | string | Optional. Only return tasks within this variant                                      |
+| variant_regex | string | Optional. Only return tasks within variants that match this regex                    |
+| task_name     | string | Optional. Only return tasks with this display name                                   |
+| status        | string | Optional. Only return tasks with this status                                         |
 
 ##### Get A Single Task
 
@@ -164,7 +163,7 @@ patch tasks)
 Fetch a single task using its ID
 
 | Name                 | Type | Description                                                             |
-|--------------------|---------|-------------------------------------------|
+|----------------------|------|-------------------------------------------------------------------------|
 | fetch_all_executions | any  | Optional. Fetches previous executions of the task if they are available |
 
 ##### Restart A Task
@@ -175,7 +174,7 @@ Restarts the task of the given ID. Can only be performed if the task is
 finished.
 
 | Name        | Type    | Description                                                                                                                          |
-|--------------------|---------|-------------------------------------------|
+|-------------|---------|--------------------------------------------------------------------------------------------------------------------------------------|
 | failed_only | boolean | Optional. For a display task, restarts only failed execution tasks. When used with a non-display task, this parameter has no effect. |
 
 ##### Abort A Task
@@ -193,9 +192,9 @@ progress.
 
 **Accepted Parameters**
 
-| Name      | Type    | Description                                                               |
-|--------------------|---------|-------------------------------------------|
-| activated | boolean | The activation status of the task to be set to                            |
+| Name      | Type    | Description                                                              |
+|-----------|---------|--------------------------------------------------------------------------|
+| activated | boolean | The activation status of the task to be set to                           |
 | priority  | int     | The priority of this task's execution. Limited to 100 for non-superusers |
 
 For example, to set activate the task and set its status priority to
@@ -214,14 +213,14 @@ Task Annotations give users more context about task failures.
 
 **Annotation**
 
-| Name             | Type                     | Description                                                                                                      |
-|--------------------|---------|-------------------------------------------|
-| task_id          | string                   | Identifier of the task that this annotation is for                                                               |
-| task_execution   | int                      | The number of the execution of the task that the annotation is for                                               |
-| metadata         | map\[string\]interface{} | Structured data about the task. Since this is user-given json data, the structure can differ between annotations |
-| note             | note_object              | Comment about the task failure                                                                                   |
-| issues           | \[\]issue_link           | Links to tickets definitely related                                                                              |
-| suspected_issues | \[\]issue_link           | Links to tickets possibly related                                                                                |
+| Name             | Type                   | Description                                                                                                      |
+|------------------|------------------------|------------------------------------------------------------------------------------------------------------------|
+| task_id          | string                 | Identifier of the task that this annotation is for                                                               |
+| task_execution   | int                    | The number of the execution of the task that the annotation is for                                               |
+| metadata         | map[string]interface{} | Structured data about the task. Since this is user-given json data, the structure can differ between annotations |
+| note             | note_object            | Comment about the task failure                                                                                   |
+| issues           | []issue_link           | Links to tickets definitely related                                                                              |
+| suspected_issues | []issue_link           | Links to tickets possibly related                                                                                |
 
 **Note**
 
@@ -254,10 +253,10 @@ Task Annotations give users more context about task failures.
 
     Returns a list containing the latest annotation for the given task, or null if there are no annotations.  
 
-|Name                          |Type                | Description    
-|------------------------------|--------------------|-----------------------------------------------------
-|fetch_all_executions          |boolean             | Optional. Fetches annotations for all executions of the task if they are available    
-|execution                     |int                 | Optional. The 0-based number corresponding to the execution of the task the annotation is associated with. Defaults to the latest execution.    
+| Name                 | Type    | Description                                                                                                                                  |
+|----------------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| fetch_all_executions | boolean | Optional. Fetches annotations for all executions of the task if they are available                                                           |
+| execution            | int     | Optional. The 0-based number corresponding to the execution of the task the annotation is associated with. Defaults to the latest execution. |
 
 Create or Update a New Task Annotation
 
@@ -277,7 +276,7 @@ body:
 **Parameters**
 
 | Name      | Type | Description                                                                    |
-|--------------------|---------|-------------------------------------------|
+|-----------|------|--------------------------------------------------------------------------------|
 | execution | int  | Optional. Can be set in lieu of specifying task_execution in the request body. |
 
     {
@@ -300,10 +299,10 @@ Create or Update a New Task Annotation By Appending
 
 Creates a task annotation, or updates an existing task annotation, appending issues and suspected issues that are included in the update. A new annotation is created based if the annotation exists and if upsert is true. Task execution must be provided for this endpoint, either in the request body or set as a url parameter.  If no task_execution is specified in the request body or in the url, a bad status error will be returned. Note that usage of this endpoint requires that the requesting user have security to modify task annotations. The user does not need to specify the source, it will be added automatically. Example request body:    
 
-|Name             |Type                |Description    
-|-----------------|--------------------|---------------------------------------------
-|execution        |int                 |Optional. Can be set in lieu of specifying task_execution in the request body.
-|upsert           |bool                |Optional. Will create a new annotation if task annotation isn't found and upsert is true. 
+| Name      | Type | Description                                                                               |
+|-----------|------|-------------------------------------------------------------------------------------------|
+| execution | int  | Optional. Can be set in lieu of specifying task_execution in the request body.            |
+| upsert    | bool | Optional. Will create a new annotation if task annotation isn't found and upsert is true. |
 
     {
       "task_id": "my_task_id",
@@ -372,7 +371,7 @@ Fetches the annotations for all the tasks in a build.
 **Parameters**
 
 | Name                 | Type    | Description                                                                        |
-|--------------------|---------|-------------------------------------------|
+|----------------------|---------|------------------------------------------------------------------------------------|
 | fetch_all_executions | boolean | Optional. Fetches annotations for all executions of the task if they are available |
 
 
@@ -385,7 +384,7 @@ Fetches the annotations for all the tasks in a version.
 **Parameters**
 
 | Name                 | Type    | Description                                                                        |
-|--------------------|---------|-------------------------------------------|
+|----------------------|---------|------------------------------------------------------------------------------------|
 | fetch_all_executions | boolean | Optional. Fetches annotations for all executions of the task if they are available |
 
 
@@ -417,7 +416,7 @@ A test is a sub-operation of a task performed by Evergreen.
 **Test**
 
 | Name       | Type     | Description                                                |
-|--------------------|---------|-------------------------------------------|
+|------------|----------|------------------------------------------------------------|
 | task_id    | string   | Identifier of the task this test is a part of              |
 | Status     | string   | Execution status of the test                               |
 | test_file  | string   | Name of the test file that this test was run in            |
@@ -429,7 +428,7 @@ A test is a sub-operation of a task performed by Evergreen.
 **Test Logs**
 
 | Name     | Type   | Description                                                              |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|--------------------------------------------------------------------------|
 | url      | string | URL where the log can be fetched                                         |
 | line_num | int    | Line number in the log file corresponding to information about this test |
 | url_raw  | string | URL of the unprocessed version of the logs file for this test            |
@@ -450,7 +449,7 @@ to see this format).
 **Parameters**
 
 | Name      | Type   | Description                                                                                                                      |
-|--------------------|---------|-------------------------------------------|
+|-----------|--------|----------------------------------------------------------------------------------------------------------------------------------|
 | start_at  | string | Optional. The identifier of the test to start at in the pagination                                                               |
 | limit     | int    | Optional. The number of tests to be returned per page of pagination. Defaults to 100                                             |
 | status    | string | Optional. A status of test to limit the results to.                                                                              |
@@ -469,7 +468,7 @@ the given task.
 **Parameters**
 
 | Name      | Type | Description                                                                                                                      |
-|--------------------|---------|-------------------------------------------|
+|-----------|------|----------------------------------------------------------------------------------------------------------------------------------|
 | execution | int  | Optional. The 0-based number corresponding to the execution of the task. Defaults to 0, meaning the first time the task was run. |
 
 
@@ -481,19 +480,19 @@ A manifest is a representation of the modules associated with a version.
 
 **Manifest**
 
-| Name     | Type                  | Description                                                       |
-|--------------------|---------|-------------------------------------------|
-| \_id     | string                | Identifier for the version.                                       |
-| revision | string                | The revision of the version.                                      |
-| project  | string                | The project identifier for the version.                           |
-| branch   | string                | The branch of the repository.                                     |
-| modules  | map\[string\]\*Module | Map from the Github repository name to the module's information. |
-| is_base  | bool                  | True if the version is a mainline build.                          |
+| Name     | Type                | Description                                                      |
+|----------|---------------------|------------------------------------------------------------------|
+| \_id     | string              | Identifier for the version.                                      |
+| revision | string              | The revision of the version.                                     |
+| project  | string              | The project identifier for the version.                          |
+| branch   | string              | The branch of the repository.                                    |
+| modules  | map[string]\*Module | Map from the Github repository name to the module's information. |
+| is_base  | bool                | True if the version is a mainline build.                         |
 
 **Module**
 
 | Name     | Type   | Description                                             |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|---------------------------------------------------------|
 | repo     | string | The name of the repository.                             |
 | branch   | string | The branch of the repository.                           |
 | revision | string | The revision of the head of the branch.                 |
@@ -518,7 +517,7 @@ The hosts resource defines a running machine instance in Evergreen.
 **Host**
 
 | Name         | Type        | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
+|--------------|-------------|--------------------------------------------------------------------------------------|
 | host_id      | string      | Unique identifier of a specific host                                                 |
 | distro       | distro_info | Object containing information about the distro type of this host                     |
 | started_by   | string      | Name of the process or user that started this host                                   |
@@ -530,14 +529,14 @@ The hosts resource defines a running machine instance in Evergreen.
 **Distro Info**
 
 | Name      | Type   | Description                                                                               |
-|--------------------|---------|-------------------------------------------|
+|-----------|--------|-------------------------------------------------------------------------------------------|
 | distro_id | string | Unique Identifier of this distro. Can be used to fetch more informaiton about this distro |
 | provider  | string | The service which provides this type of machine                                           |
 
 **Task Info**
 
 | Name          | Type   | Description                                                                           |
-|--------------------|---------|-------------------------------------------|
+|---------------|--------|---------------------------------------------------------------------------------------|
 | task_id       | string | Unique Identifier of this task. Can be used to fetch more informaiton about this task |
 | name          | string | The name of this task                                                                 |
 | dispatch_time | time   | Time that this task was dispatched to this host                                       |
@@ -556,7 +555,7 @@ Returns a paginated list of all hosts in Evergreen
 **Parameters**
 
 | Name     | Type   | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|--------------------------------------------------------------------------------------|
 | start_at | string | Optional. The identifier of the host to start at in the pagination                   |
 | limit    | int    | Optional. The number of hosts to be returned per page of pagination. Defaults to 100 |
 | status   | string | Optional. A status of host to limit the results to                                   |
@@ -571,7 +570,7 @@ Returns a list of hosts spawned by the given user.
 **Parameters**
 
 | Name     | Type   | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|--------------------------------------------------------------------------------------|
 | start_at | string | Optional. The identifier of the host to start at in the pagination                   |
 | limit    | int    | Optional. The number of hosts to be returned per page of pagination. Defaults to 100 |
 | status   | string | Optional. A status of host to limit the results to                                   |
@@ -640,7 +639,7 @@ parsed as a rest.APIError
 **Change Password**
 
 | Name    | Type   | Description                                                                                                                                                                                  |
-|--------------------|---------|-------------------------------------------|
+|---------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rdp_pwd | string | New RDP password; must meet RDP password criteria as provided by Microsoft at: <https://technet.microsoft.com/en-us/library/cc786468(v=ws.10>).aspx and be between 6 and 255 characters long |
 
 ##### Extend the Expiration of Host with Given Host ID
@@ -677,31 +676,31 @@ A patch is a manually initiated version submitted to test local changes.
 
 **Patch**
 
-| Name                  | Type             | Description                                                                                                                          |
-|--------------------|---------|-------------------------------------------|
-| patch_id              | string           | Unique identifier of a specific patch                                                                                                |
-| description           | string           | Description of the patch                                                                                                             |
-| project_id            | string           | Name of the project                                                                                                                  |
-| branch                | string           | The branch on which the patch was initiated                                                                                          |
-| git_hash              | string           | Hash of commit off which the patch was initiated                                                                                     |
-| patch_number          | int              | Incrementing counter of user's patches                                                                                              |
-| author                | string           | Author of the patch                                                                                                                  |
-| status                | string           | Status of patch                                                                                                                      |
-| commit_queue_position | int              | Only populated for commit queue patches: returns the 0-indexed position of the patch on the queue, or -1 if not on the queue anymore |
-| create_time           | time             | Time patch was created                                                                                                               |
-| start_time            | time             | Time patch started to run                                                                                                            |
-| finish_time           | time             | Time at patch completion                                                                                                             |
-| build_variants        | string\[\]       | List of identifiers of builds to run for this patch                                                                                  |
-| tasks                 | string\[\]       | List of identifiers of tasks used in this patch                                                                                      |
-| variants_tasks        | variant_task\[\] | List of documents of available tasks and associated build variant                                                                    |
-| activated             | bool             | Whether the patch has been finalized and activated                                                                                   |
+| Name                  | Type           | Description                                                                                                                          |
+|-----------------------|----------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| patch_id              | string         | Unique identifier of a specific patch                                                                                                |
+| description           | string         | Description of the patch                                                                                                             |
+| project_id            | string         | Name of the project                                                                                                                  |
+| branch                | string         | The branch on which the patch was initiated                                                                                          |
+| git_hash              | string         | Hash of commit off which the patch was initiated                                                                                     |
+| patch_number          | int            | Incrementing counter of user's patches                                                                                               |
+| author                | string         | Author of the patch                                                                                                                  |
+| status                | string         | Status of patch                                                                                                                      |
+| commit_queue_position | int            | Only populated for commit queue patches: returns the 0-indexed position of the patch on the queue, or -1 if not on the queue anymore |
+| create_time           | time           | Time patch was created                                                                                                               |
+| start_time            | time           | Time patch started to run                                                                                                            |
+| finish_time           | time           | Time at patch completion                                                                                                             |
+| build_variants        | string[]       | List of identifiers of builds to run for this patch                                                                                  |
+| tasks                 | string[]       | List of identifiers of tasks used in this patch                                                                                      |
+| variants_tasks        | variant_task[] | List of documents of available tasks and associated build variant                                                                    |
+| activated             | bool           | Whether the patch has been finalized and activated                                                                                   |
 
 **Variant Task**
 
 | Name  | Type       | Description                                      |
 |-------|------------|--------------------------------------------------|
 | name  | string     | Name of build variant                            |
-| tasks | string\[\] | All tasks available to run on this build variant |
+| tasks | string[] | All tasks available to run on this build variant |
 
 
 #### Endpoints
@@ -716,7 +715,7 @@ project
 **Parameters**
 
 | Name     | Type   | Description                                                                            |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|----------------------------------------------------------------------------------------|
 | start_at | string | Optional. The create_time of the patch to start at in the pagination. Defaults to now  |
 | limit    | int    | Optional. The number of patches to be returned per page of pagination. Defaults to 100 |
 
@@ -730,7 +729,7 @@ Returns a paginated list of all patches associated with a specific user
 **Parameters**
 
 | Name     | Type   | Description                                                                            |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|----------------------------------------------------------------------------------------|
 | start_at | string | Optional. The create_time of the patch to start at in the pagination. Defaults to now  |
 | limit    | int    | Optional. The number of patches to be returned per page of pagination. Defaults to 100 |
 
@@ -750,7 +749,7 @@ Fetch the raw diff for a patch
 **Parameters**
 
 | Name   | Type   | Description                                                                                           |
-|--------------------|---------|-------------------------------------------|
+|--------|--------|-------------------------------------------------------------------------------------------------------|
 | module | string | Optional. A module to get the diff for. Returns the empty string when no patch exists for the module. |
 
 ##### Abort a Patch
@@ -783,10 +782,10 @@ Update the list of tasks that the specified patch will run. This works both for 
           ]
     }
 
-|Name              |Type                           | Description|
-|------------------|-------------------------------|------------------------------------|
-|description       |string                         | Optional, if sent will update the patch's description|
-|variants          |array of variant objects       | Required, these are the variants and tasks that the patch should run.|
+| Name        | Type                     | Description                                                           |
+|-------------|--------------------------|-----------------------------------------------------------------------|
+| description | string                   | Optional, if sent will update the patch's description                 |
+| variants    | array of variant objects | Required, these are the variants and tasks that the patch should run. |
 
 Each variant object is of the format { "variant": "\<variant name\>", "tasks": ["task name"] }. This field is analogous in syntax and usage to the "buildvariants" field in the project's evergreen.yml file. Names of display tasks can be specified in the tasks array and will work as one would expect. For an already-scheduled patch, any new tasks in this array will be created, and any existing tasks not in this array will be unscheduled.  
 
@@ -820,38 +819,38 @@ buildvariant.
 
 **Build**
 
-| Name                    | Type       | Description                                                                                                                                                                                                                                                                      |
-|--------------------|---------|-------------------------------------------|
-| `project_id`            | string     | The identifier of the project this build represents                                                                                                                                                                                                                              |
-| `create_time`           | time       | Time at which build was created                                                                                                                                                                                                                                                  |
-| `start_time`            | time       | Time at which build started running tasks                                                                                                                                                                                                                                        |
-| `finish_time`           | time       | Time at which build finished running all tasks                                                                                                                                                                                                                                   |
-| `version`               | string     | The version this build is running tasks for                                                                                                                                                                                                                                      |
-| `branch`                | string     | The branch of project the build is running                                                                                                                                                                                                                                       |
-| `gitspec`               | string     | Hash of the revision on which this build is running                                                                                                                                                                                                                              |
-| `build_variant`         | string     | Build distro and architecture information                                                                                                                                                                                                                                        |
-| `status`                | string     | The status of the build                                                                                                                                                                                                                                                          |
-| `tags`                  | \[string\] | List of tags defined for the build variant, if any                                                                                                                                                                                                                               |
-| `activated`             | bool       | Whether this build was manually initiated                                                                                                                                                                                                                                        |
-| `activated_by`          | string     | Who initiated the build                                                                                                                                                                                                                                                          |
-| `activated_time`        | time       | When the build was initiated                                                                                                                                                                                                                                                     |
-| `order`                 | int        | Incrementing counter of project's builds                                                                                                                                                                                                                                        |
-| `tasks`                 | \[string\] | The tasks to be run on this build                                                                                                                                                                                                                                                |
-| `time_taken_ms`         | int        | How long the build took to complete all tasks                                                                                                                                                                                                                                    |
-| `display_name`          | string     | Displayed title of the build showing version and variant running                                                                                                                                                                                                                 |
-| `predicted_makespan_ms` | int        | Predicted makespan by the scheduler prior to execution                                                                                                                                                                                                                           |
-| `actual_makespan_ms`    | int        | Actual makespan measured during execution                                                                                                                                                                                                                                        |
-| `origin`                | string     | The source of the patch, a commit or a patch                                                                                                                                                                                                                                     |
-| `status_counts`         | Object     | Contains aggregated data about the statuses of tasks in this build. The keys of this object are statuses and the values are the number of tasks within this build in that status. Note that this field provides data that you can get yourself by querying tasks for this build. |
-| `task_cache`            | Object     | Contains a subset of information about tasks for the build; this is not provided/accurate for most routes ([get versions for project](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-versions-for-a-project) is an exception). |
-| `definition_info`       | Object     | Some routes will return information about the variant as defined in the project. Does not expand expansions; they will be returned as written in the project yaml (i.e. `${syntax}`) |
+| Name                    | Type     | Description                                                                                                                                                                                                                                                                      |
+|-------------------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `project_id`            | string   | The identifier of the project this build represents                                                                                                                                                                                                                              |
+| `create_time`           | time     | Time at which build was created                                                                                                                                                                                                                                                  |
+| `start_time`            | time     | Time at which build started running tasks                                                                                                                                                                                                                                        |
+| `finish_time`           | time     | Time at which build finished running all tasks                                                                                                                                                                                                                                   |
+| `version`               | string   | The version this build is running tasks for                                                                                                                                                                                                                                      |
+| `branch`                | string   | The branch of project the build is running                                                                                                                                                                                                                                       |
+| `gitspec`               | string   | Hash of the revision on which this build is running                                                                                                                                                                                                                              |
+| `build_variant`         | string   | Build distro and architecture information                                                                                                                                                                                                                                        |
+| `status`                | string   | The status of the build                                                                                                                                                                                                                                                          |
+| `tags`                  | []string | List of tags defined for the build variant, if any                                                                                                                                                                                                                               |
+| `activated`             | bool     | Whether this build was manually initiated                                                                                                                                                                                                                                        |
+| `activated_by`          | string   | Who initiated the build                                                                                                                                                                                                                                                          |
+| `activated_time`        | time     | When the build was initiated                                                                                                                                                                                                                                                     |
+| `order`                 | int      | Incrementing counter of project's builds                                                                                                                                                                                                                                         |
+| `tasks`                 | []string | The tasks to be run on this build                                                                                                                                                                                                                                                |
+| `time_taken_ms`         | int      | How long the build took to complete all tasks                                                                                                                                                                                                                                    |
+| `display_name`          | string   | Displayed title of the build showing version and variant running                                                                                                                                                                                                                 |
+| `predicted_makespan_ms` | int      | Predicted makespan by the scheduler prior to execution                                                                                                                                                                                                                           |
+| `actual_makespan_ms`    | int      | Actual makespan measured during execution                                                                                                                                                                                                                                        |
+| `origin`                | string   | The source of the patch, a commit or a patch                                                                                                                                                                                                                                     |
+| `status_counts`         | Object   | Contains aggregated data about the statuses of tasks in this build. The keys of this object are statuses and the values are the number of tasks within this build in that status. Note that this field provides data that you can get yourself by querying tasks for this build. |
+| `task_cache`            | Object   | Contains a subset of information about tasks for the build; this is not provided/accurate for most routes ([get versions for project](https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#get-versions-for-a-project) is an exception).                                 |
+| `definition_info`       | Object   | Some routes will return information about the variant as defined in the project. Does not expand expansions; they will be returned as written in the project yaml (i.e. `${syntax}`)                                                                                             |
 
 
 **Definition Info**
 
-| Name      | Type | Description                                           |
-|-----------|--------|-----------------------------------------------------|
-| cron      | string | The cron defined for the variant, if provided, as defined [here](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants)         |
+| Name      | Type   | Description                                                                                                                                                      |
+|-----------|--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| cron      | string | The cron defined for the variant, if provided, as defined [here](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants)      |
 | batchtime | int    | The batchtime defined for the variant, if provided, as defined [here](https://github.com/evergreen-ci/evergreen/wiki/Project-Configuration-Files#build-variants) |
 
 
@@ -885,7 +884,7 @@ values
 **Parameters**
 
 | Name      | Type | Description                                                           |
-|--------------------|---------|-------------------------------------------|
+|-----------|------|-----------------------------------------------------------------------|
 | priority  | int  | Optional. The priority to set the build to                            |
 | activated | bool | Optional. Set to true to activate, and false to deactivate the build. |
 
@@ -898,21 +897,21 @@ A version is a commit in a project.
 
 **Version**
 
-| Name                    | Type            | Description                                                                                                                                                                                                                                                          |
-|--------------------|---------|-------------------------------------------|
-| `create_time`           | time            | Time that the version was first created                                                                                                                                                                                                                              |
-| `start_time`            | time            | Time at which tasks associated with this version started running                                                                                                                                                                                                     |
-| `finish_time`           | time            | Time at which tasks associated with this version finished running                                                                                                                                                                                                    |
-| `revision`              | string          | The version control identifier                                                                                                                                                                                                                                       |
-| `author`                | string          | Author of the version                                                                                                                                                                                                                                                |
-| `author_email`          | string          | Email of the author of the version                                                                                                                                                                                                                                   |
-| `message`               | string          | Message left with the commit                                                                                                                                                                                                                                         |
-| `status`                | string          | The status of the version                                                                                                                                                                                                                                            |
-| `repo`                  | string          | The github repository where the commit was made                                                                                                                                                                                                                      |
-| `branch`                | string          | The version control branch where the commit was made                                                                                                                                                                                                                 |
-| `build_variants_status` | \[\]buildDetail | List of documents of the associated build variant and the build id                                                                                                                                                                                                   |
-| `requester`             | string          | Version created by one of \"patch_request\", \"github_pull_request\", \"gitter_request\" (caused by git commit, aka the repotracker requester), \"trigger_request\" (Project Trigger versions) , \"merge_test\" (commit queue patches), \"ad_hoc\" (periodic builds) |
-| `activated`             | boolean or null | Will be null for versions created before this field was added.                                                                                                                                                                                                       |
+| Name                    | Type            | Description                                                                                                                                                                                                                                              |
+|-------------------------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `create_time`           | time            | Time that the version was first created                                                                                                                                                                                                                  |
+| `start_time`            | time            | Time at which tasks associated with this version started running                                                                                                                                                                                         |
+| `finish_time`           | time            | Time at which tasks associated with this version finished running                                                                                                                                                                                        |
+| `revision`              | string          | The version control identifier                                                                                                                                                                                                                           |
+| `author`                | string          | Author of the version                                                                                                                                                                                                                                    |
+| `author_email`          | string          | Email of the author of the version                                                                                                                                                                                                                       |
+| `message`               | string          | Message left with the commit                                                                                                                                                                                                                             |
+| `status`                | string          | The status of the version                                                                                                                                                                                                                                |
+| `repo`                  | string          | The github repository where the commit was made                                                                                                                                                                                                          |
+| `branch`                | string          | The version control branch where the commit was made                                                                                                                                                                                                     |
+| `build_variants_status` | []buildDetail   | List of documents of the associated build variant and the build id                                                                                                                                                                                       |
+| `requester`             | string          | Version created by one of "patch_request", "github_pull_request", "gitter_request" (caused by git commit, aka the repotracker requester), "trigger_request" (Project Trigger versions) , "merge_test" (commit queue patches), "ad_hoc" (periodic builds) |
+| `activated`             | boolean or null | Will be null for versions created before this field was added.                                                                                                                                                                                           |
 
 
 #### Endpoints
@@ -957,7 +956,7 @@ Fetches a list of builds associated with a version
 **Parameters**
 
 | Name    | Type   | Description                                                                  |
-|--------------------|---------|-------------------------------------------|
+|---------|--------|------------------------------------------------------------------------------|
 | variant | string | Optional. Only return the build with this variant (using Distro identifier). |
 
 
@@ -975,8 +974,8 @@ the request, rather than retrieved from the repo.
 **Parameters**
 
 | Name       | Type         | Description                                                                                                                                                                         |
-|--------------------|---------|-------------------------------------------|
-| project_id | string       | Required. This is the project with which the version will be associated, and the code to test will be checked out from the project's branch.                                       |
+|------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| project_id | string       | Required. This is the project with which the version will be associated, and the code to test will be checked out from the project's branch.                                        |
 | message    | string       | Optional. A description of the version which will be displayed in the UI                                                                                                            |
 | activate   | boolean      | Optional. If true, the defined tasks will run immediately. Otherwise, the version will be created and can be activated in the UI                                                    |
 | is_adhoc   | boolean      | Optional. If true, the version will be indicated as coming from an ad hoc source and will not display as if it were a patch or commit. If false, it will be assumed to be a commit. |
@@ -995,31 +994,31 @@ exception of project variables, task annotation settings, workstation settings, 
 
 **Project**
 
-| Name                 | Type                  | Description                                                                                                        |
-|--------------------|---------|-------------------------------------------|
-| admins               | \[\]string or null    | Usernames of project admins. Can be null for some projects ([EVG-6598](https://jira.mongodb.org/browse/EVG-6598)). |
-| delete_admins        | \[\]string            | Usernames of project admins to remove                                                                              |
-| batch_time           | int                   | Unique identifier of a specific patch                                                                              |
-| branch_name          | string                | Name of branch                                                                                                     |
-| commit_queue         | CommitQueueParams     | Options for commit queue                                                                                           |
-| deactivate_previous  | bool                  | List of identifiers of tasks used in this patch                                                                    |
-| display_name         | string                | Project name displayed to users                                                                                    |
-| enabled              | bool                  | Whether evergreen is enabled for this project                                                                      |
-| identifier           | string                | Internal evergreen identifier for project                                                                          |
-| notify_on_failure    | bool                  | Notify original committer (or admins) when build fails                                                             |
-| owner_name           | string                | Owner of project repository                                                                                        |
-| patching_disabled    | bool                  | Disable patching                                                                                                   |
-| pr_testing_enabled   | bool                  | Enable github pull request testing                                                                                 |
-| private              | bool                  | A user must be logged in to view private projects                                                                  |
-| remote_path          | string                | Path to config file in repo                                                                                        |
-| repo_name            | string                | Repository name                                                                                                    |
-| tracks_push_events   | bool                  | If true, repotracker is run on github push events. If false, repotracker is run periodically every few minutes.    |
-| revision             | string                | Only used when modifying projects to change the base revision and run the repotracker.                             |
-| triggers             | \[\]TriggerDefinition | a list of triggers for the project                                                                                 |
-| aliases              | \[\]APIProjectAlias   | a list of aliases for the project                                                                                  |
-| variables            | ProjectVars           | project variables information                                                                                      |
-| subscriptions        | \[\]Subscription      | a list of subscriptions for the project                                                                            |
-| delete_subscriptions | \[\]string            | subscription IDs. Will delete these subscriptions when given.                                                      |
+| Name                 | Type                | Description                                                                                                        |
+|----------------------|---------------------|--------------------------------------------------------------------------------------------------------------------|
+| admins               | []string or null    | Usernames of project admins. Can be null for some projects ([EVG-6598](https://jira.mongodb.org/browse/EVG-6598)). |
+| delete_admins        | []string            | Usernames of project admins to remove                                                                              |
+| batch_time           | int                 | Unique identifier of a specific patch                                                                              |
+| branch_name          | string              | Name of branch                                                                                                     |
+| commit_queue         | CommitQueueParams   | Options for commit queue                                                                                           |
+| deactivate_previous  | bool                | List of identifiers of tasks used in this patch                                                                    |
+| display_name         | string              | Project name displayed to users                                                                                    |
+| enabled              | bool                | Whether evergreen is enabled for this project                                                                      |
+| identifier           | string              | Internal evergreen identifier for project                                                                          |
+| notify_on_failure    | bool                | Notify original committer (or admins) when build fails                                                             |
+| owner_name           | string              | Owner of project repository                                                                                        |
+| patching_disabled    | bool                | Disable patching                                                                                                   |
+| pr_testing_enabled   | bool                | Enable github pull request testing                                                                                 |
+| private              | bool                | A user must be logged in to view private projects                                                                  |
+| remote_path          | string              | Path to config file in repo                                                                                        |
+| repo_name            | string              | Repository name                                                                                                    |
+| tracks_push_events   | bool                | If true, repotracker is run on github push events. If false, repotracker is run periodically every few minutes.    |
+| revision             | string              | Only used when modifying projects to change the base revision and run the repotracker.                             |
+| triggers             | []TriggerDefinition | a list of triggers for the project                                                                                 |
+| aliases              | []APIProjectAlias   | a list of aliases for the project                                                                                  |
+| variables            | ProjectVars         | project variables information                                                                                      |
+| subscriptions        | []Subscription      | a list of subscriptions for the project                                                                            |
+| delete_subscriptions | []string            | subscription IDs. Will delete these subscriptions when given.                                                      |
 
 
 **CommitQueueParams**
@@ -1040,46 +1039,46 @@ exception of project variables, task annotation settings, workstation settings, 
 | level         | string | build or task                             |
 | variant_regex | string | matching variants will trigger a build    |
 | task_regex    | string | matching tasks will trigger a build       |
-| status        | string | status to trigger for (or \"\*\")         |
+| status        | string | status to trigger for (or "\*")           |
 | config_file   | string | definition file                           |
 | command       | string | shell command that creates task json file |
 
 
 **ProjectAlias**
 
-| Name    | Type       | Description                                                                              |
-|--------------------|---------|-------------------------------------------|
-| \_id    | string     | The id for the alias. If the alias should be deleted, this must be given.                |
-| alias   | string     | Required. Alias to use with the CLI. May be specified multiple times.                    |
-| variant | string     | Required. Variant regex for alias.                                                       |
-| task    | string     | Task regex for alias. Will use the union of task and tags. Either task or tags required. |
-| tags    | \[\]string | Tags for alias. Will use the union of task and tags. Either task or tags required.       |
-| delete  | bool       | If the given alias for the project should be deleted, set this to true.                  |
+| Name    | Type     | Description                                                                              |
+|---------|----------|------------------------------------------------------------------------------------------|
+| \_id    | string   | The id for the alias. If the alias should be deleted, this must be given.                |
+| alias   | string   | Required. Alias to use with the CLI. May be specified multiple times.                    |
+| variant | string   | Required. Variant regex for alias.                                                       |
+| task    | string   | Task regex for alias. Will use the union of task and tags. Either task or tags required. |
+| tags    | []string | Tags for alias. Will use the union of task and tags. Either task or tags required.       |
+| delete  | bool     | If the given alias for the project should be deleted, set this to true.                  |
 
 
 **ProjectVars**
 
-| Name            | Type                | Description                                                                                                                                               |
-|--------------------|---------|-------------------------------------------|
-| vars            | map\[string\]string | Map of the variable to its value (if private, value is not shown)                                                                                         |
-| private_vars    | map\[string\]bool   | Indicates whether that variable should be private, i.e. the value will not be shown (NOTE: once a variable has been set to private this cannot be undone) |
-| restricted_vars | map\[string\]bool   | Indicates whether that variable should be restricted, i.e. only used by commands that are guaranteed to not leak the values (currently s3.put and s3.get) |
-| vars_to_delete  | \[\]string          | Only used to remove existing variables.                                                                                                                   |
+| Name            | Type              | Description                                                                                                                                               |
+|-----------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| vars            | map[string]string | Map of the variable to its value (if private, value is not shown)                                                                                         |
+| private_vars    | map[string]bool   | Indicates whether that variable should be private, i.e. the value will not be shown (NOTE: once a variable has been set to private this cannot be undone) |
+| restricted_vars | map[string]bool   | Indicates whether that variable should be restricted, i.e. only used by commands that are guaranteed to not leak the values (currently s3.put and s3.get) |
+| vars_to_delete  | []string          | Only used to remove existing variables.                                                                                                                   |
 
 
 **Subscription**
 
-| Name           | Type                | Description                                   |
-|--------------------|---------|-------------------------------------------|
-| id             | string              |                                               |
-| resource_type  | string              |                                               |
-| trigger        | string              |                                               |
-| selectors      | \[\]Selector        |                                               |
-| regex_selector | \[\]Selector        |                                               |
-| subscriber     | Subscriber          |                                               |
-| owner_type     | string              | For projects, this will always be \"project\" |
-| owner          | string              | The project ID                                |
-| trigger_data   | map\[string\]string |                                               |
+| Name           | Type              | Description                                 |
+|----------------|-------------------|---------------------------------------------|
+| id             | string            |                                             |
+| resource_type  | string            |                                             |
+| trigger        | string            |                                             |
+| selectors      | []Selector        |                                             |
+| regex_selector | []Selector        |                                             |
+| subscriber     | Subscriber        |                                             |
+| owner_type     | string            | For projects, this will always be "project" |
+| owner          | string            | The project ID                              |
+| trigger_data   | map[string]string |                                             |
 
 
 **Selector**
@@ -1111,7 +1110,7 @@ annotation settings, workstation settings, and container secrets) is omitted.
 **Parameters**
 
 | Name     | Type   | Description                                                                             |
-|--------------------|---------|-------------------------------------------|
+|----------|--------|-----------------------------------------------------------------------------------------|
 | start_at | string | Optional. The id of the project to start at in the pagination. Defaults to empty string |
 | limit    | int    | Optional. The number of projects to be returned per page of pagination. Defaults to 100 |
 
@@ -1123,12 +1122,12 @@ annotation settings, workstation settings, and container secrets) is omitted.
 Returns the project (restricted to project admins). Includes public
 variables, aliases, and subscriptions. Note that private variables are
 *always redacted.* If you want to use this to copy project variables,
-see instead the \"Copy Project Variables\" route.
+see instead the "Copy Project Variables" route.
 
 **Parameters**
 
 | Name                 | Type | Description                                                                                                                                 |
-|--------------------|---------|-------------------------------------------|
+|----------------------|------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | includeRepo          | bool | Optional. Setting to true will return the merged result of project and repo level settings. Defaults to false                               |
 | includeProjectConfig | bool | Optional. Setting to true will return the merged result of the project and the config properties set in the project YAML. Defaults to false |
 
@@ -1141,8 +1140,8 @@ Modify an existing project (restricted to project admins). Will enable webhooks
 if an enabled project, and enable PR testing and the commit queue if specified. 
 
 For lists, if there is a complementary
-\"delete\" field, then the former field indicates items to be added,
-while the \"delete\" field indicates items to be deleted. Otherwise, the
+"delete" field, then the former field indicates items to be added,
+while the "delete" field indicates items to be deleted. Otherwise, the
 given list will overwrite the original list (the only exception is for project
 variables -- we will ignore any empty project variables to avoid accidentally 
 overwriting private variables).
@@ -1170,7 +1169,7 @@ project/repo. Copies variables from projectA to projectB.
 **CopyVariablesOptions**
 
 | Name            | Type   | Description                                                                                                                       |
-|--------------------|---------|-------------------------------------------|
+|-----------------|--------|-----------------------------------------------------------------------------------------------------------------------------------|
 | copy_to         | string | Required. ProjectID to copy `source_project` variables to.                                                                        |
 | include_private | bool   | If set to true, private variables will also be copied.                                                                            |
 | overwrite       | bool   | If set to true, will remove variables from the `copy_to` project that are not in `source_project`.                                |
@@ -1198,13 +1197,13 @@ start as query parameters to support legacy behavior).
 **Parameters**
 
 | Name             | Type   | Description                                                                                                                                                                                                                                                                                                  |
-|--------------------|---------|-------------------------------------------|
-| skip             | int    | Optional. Number of versions to skip.                                                                                                                                                                                                                                                                   |
-| limit            | int    | Optional. The number of versions to be returned per page of pagination. Defaults to 20.                                                                                                                                                                                                                                                                   |
-| revision_start   | int    | Optional. The version order number to start at, for pagination.                                                                                                                                                                                                                |
-| revision_end     | int    | Optional. The version order number to end at, for pagination.                                                                                                                                                                                                                                                                   |
-| start_time_str   | string | Optional. Timestamp to start looking for applicable versions.                                                                                                                                                                                                                                                                    |
-| end_time_str     | string | Optional. Timestamp to stop looking for applicable versions.                                                                                                                                                                                                                                                                   |
+|------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| skip             | int    | Optional. Number of versions to skip.                                                                                                                                                                                                                                                                        |
+| limit            | int    | Optional. The number of versions to be returned per page of pagination. Defaults to 20.                                                                                                                                                                                                                      |
+| revision_start   | int    | Optional. The version order number to start at, for pagination.                                                                                                                                                                                                                                              |
+| revision_end     | int    | Optional. The version order number to end at, for pagination.                                                                                                                                                                                                                                                |
+| start_time_str   | string | Optional. Timestamp to start looking for applicable versions.                                                                                                                                                                                                                                                |
+| end_time_str     | string | Optional. Timestamp to stop looking for applicable versions.                                                                                                                                                                                                                                                 |
 | requester        | string | Returns versions for this requester only. Defaults to `gitter_request` (caused by git commit, aka the repotracker requester). Can also be set to `patch_request`, `github_pull_request`, `trigger_request` (Project Trigger versions) , `merge_test` (commit queue patches), and `ad_hoc` (periodic builds). |
 | include_builds   | bool   | If set, will return some information for each build in the version.                                                                                                                                                                                                                                          |
 | by_build_variant | string | If set, will only include information for this build, and only return versions with this build activated. Must have `include_builds` set.                                                                                                                                                                    |
@@ -1214,18 +1213,18 @@ start as query parameters to support legacy behavior).
 
 **Response**
 
-| Name                    | Type            | Description                                                                                                                          |
-|--------------------|---------|-------------------------------------------|
-| `create_time`           | time            | Time that the version was first created                                                                                              |
-| `start_time`            | time            | Time at which tasks associated with this version started running                                                                     |
-| `finish_time`           | time            | Time at which tasks associated with this version finished running                                                                    |
-| `revision`              | string          | The version control identifier                                                                                                       |
-| `author`                | string          | Author of the version                                                                                                                |
-| `message`               | string          | Message left with the commit                                                                                                         |
-| `status`                | string          | The status of the version                                                                                                            |
-| `errors`                | \[\]string      | List of errors creating the version                                                                                                  |
-| `build_variants_status` | \[\]buildDetail | List of documents of the associated build variant and the build id (this won't be populated if include_builds is set)               |
-| `builds`                | \[\]APIBuild    | List of builds for the version (only populated if include_builds is set). If include_tasks is set, then the task_cache is populated. |
+| Name                    | Type          | Description                                                                                                                          |
+|-------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `create_time`           | time          | Time that the version was first created                                                                                              |
+| `start_time`            | time          | Time at which tasks associated with this version started running                                                                     |
+| `finish_time`           | time          | Time at which tasks associated with this version finished running                                                                    |
+| `revision`              | string        | The version control identifier                                                                                                       |
+| `author`                | string        | Author of the version                                                                                                                |
+| `message`               | string        | Message left with the commit                                                                                                         |
+| `status`                | string        | The status of the version                                                                                                            |
+| `errors`                | []string      | List of errors creating the version                                                                                                  |
+| `build_variants_status` | []buildDetail | List of documents of the associated build variant and the build id (this won't be populated if include_builds is set)                |
+| `builds`                | []APIBuild    | List of builds for the version (only populated if include_builds is set). If include_tasks is set, then the task_cache is populated. |
 
 
 ##### Modify Versions For A Project
@@ -1240,17 +1239,17 @@ This route is restricted to project admins.
 **Parameters**
 
 | Name             | Type   | Description                                                                                                                                                                                                                                                                                                  |
-|--------------------|---------|-------------------------------------------|
-| start_time_str   | string | Timestamp to start looking for applicable versions.                                                                                                                                                                                                                                                                   |
-| end_time_str     | string | Optional. Timestamp to stop looking for applicable versions.                                                                                                                                                                                                                                                                   |
-| revision_start   | int    | Optional. The version order number to start at.                                                                                                                                                                                                                                                                  |
-| revision_end     | int    | Optional. The version order number to end at.                                                                                                                                                                                                                                                                   |
-| priority         | int    | Priority to set for all tasks within applicable versions.                                                                                                                                                                                                                                                                   |
-| limit            | int    | Optional. The number of versions to be returned per page of pagination. Defaults to 20.                                                                                                                                                                                                                                                                   |
+|------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| start_time_str   | string | Timestamp to start looking for applicable versions.                                                                                                                                                                                                                                                          |
+| end_time_str     | string | Optional. Timestamp to stop looking for applicable versions.                                                                                                                                                                                                                                                 |
+| revision_start   | int    | Optional. The version order number to start at.                                                                                                                                                                                                                                                              |
+| revision_end     | int    | Optional. The version order number to end at.                                                                                                                                                                                                                                                                |
+| priority         | int    | Priority to set for all tasks within applicable versions.                                                                                                                                                                                                                                                    |
+| limit            | int    | Optional. The number of versions to be returned per page of pagination. Defaults to 20.                                                                                                                                                                                                                      |
 | requester        | string | Returns versions for this requester only. Defaults to `gitter_request` (caused by git commit, aka the repotracker requester). Can also be set to `patch_request`, `github_pull_request`, `trigger_request` (Project Trigger versions) , `merge_test` (commit queue patches), and `ad_hoc` (periodic builds). |
-| by_build_variant | string | If set, will only include information for this build, and only return versions with this build activated. Must have `include_builds` set.                                                                                                                                                                                                                                                                   |                                                                                                                                                                                                                                                                   
-| by_task          | string | If set, will only include information for this task, and will only return versions with this task activated. Must have `include_tasks` set.                                                                                                                                                                                                                                                                   |
-| skip             | int    | Optional. Number of versions to skip.                                                                                                                                                                                                                                                                   |
+| by_build_variant | string | If set, will only include information for this build, and only return versions with this build activated. Must have `include_builds` set.                                                                                                                                                                    |
+| by_task          | string | If set, will only include information for this task, and will only return versions with this task activated. Must have `include_tasks` set.                                                                                                                                                                  |
+| skip             | int    | Optional. Number of versions to skip.                                                                                                                                                                                                                                                                        |
 
 
 ##### Get Tasks For A Project
@@ -1264,7 +1263,7 @@ task name rather than a task ID is passed into the URL.
 **Parameters**
 
 | Name          | Type   | Description                                                             |
-|--------------------|---------|-------------------------------------------|
+|---------------|--------|-------------------------------------------------------------------------|
 | num_versions  | int    | Optional. The number of latest versions to be searched. Defaults to 20. |
 | start_at      | int    | Optional. The version order number to start returning results after.    |
 | build_variant | string | If set, will only include tasks that have run on this build variant.    |
@@ -1278,19 +1277,19 @@ Parameters should be passed into the JSON body.
 
 **Parameters**
 
-| Name          | Type     | Description                               |
-|---------------|----------|-------------------------------------------|
-| task_name     | string   | Required. The task to return execution info for. |
-| build_variant | string   | Required. The build variant to return task execution info for.  |
-| start_time    | Time     | Required. Will only return execution info after this time. Format should be 2022-12-01T12:30:00.000Z  |
-| end_time      | Time.    | Optional. If not provided, will default to the current time. |
+| Name          | Type     | Description                                                                                                                                                                                                                                        |
+|---------------|----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| task_name     | string   | Required. The task to return execution info for.                                                                                                                                                                                                   |
+| build_variant | string   | Required. The build variant to return task execution info for.                                                                                                                                                                                     |
+| start_time    | Time     | Required. Will only return execution info after this time. Format should be 2022-12-01T12:30:00.000Z                                                                                                                                               |
+| end_time      | Time.    | Optional. If not provided, will default to the current time.                                                                                                                                                                                       |
 | requesters    | []string | Optional. If not provided, will default to `gitter_request` (versions created by git commit). Can also be `github_pull_request`, `trigger_request` (Project Trigger versions) , `merge_test` (commit queue patches), or `ad_hoc` (periodic builds) |
 
 **Response**
 
-| Name           | Type                         | Description                                                                                                                                                                                                  |
-|----------------|-----|-------------------------------------------|
-| num_completed  | int | The number of completed executions for the task/variant pair within the given interval. |
+| Name          | Type | Description                                                                             |
+|---------------|------|-----------------------------------------------------------------------------------------|
+| num_completed | int  | The number of completed executions for the task/variant pair within the given interval. |
 
 
 ##### Rotate Variables
@@ -1302,10 +1301,10 @@ Restricted to superusers due to the fact it modifies ALL projects.
 **RotateVariablesOptions**
 
 | Name        | Type   | Description                                                       |
-|--------------------|---------|-------------------------------------------|
+|-------------|--------|-------------------------------------------------------------------|
 | to_replace  | string | Required. Variable value to search and replace.                   |
 | replacement | string | Required. Value to replace the variables that match `to_replace`. |
-| dry_run     | bool   | If set to true, we don't complete the update                     |
+| dry_run     | bool   | If set to true, we don't complete the update                      |
 
 
 If `dry_run` is set, the route doesn't update but returns a map of
@@ -1324,7 +1323,7 @@ this route is legacy, and is no longer supported.
 **Parameters**
 
 | Name   | Type | Description                                                                            |
-|--------------------|---------|-------------------------------------------|
+|--------|------|----------------------------------------------------------------------------------------|
 | offset | int  | Optional. Zero-based offset to return results from.                                    |
 | limit  | int  | Optional. The number of versions to be returned per page of pagination. Defaults to 10 |
 
@@ -1332,7 +1331,7 @@ this route is legacy, and is no longer supported.
 **Response**
 
 | Name           | Type                         | Description                                                                                                                                                                                                  |
-|--------------------|---------|-------------------------------------------|
+|----------------|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rows           | object                       | The keys of this object are build variant identifiers. The values are BuildList objects from below. These are the builds contained in the recent versions, but grouped by build variant rather than version. |
 | versions       | Array of APIVersions objects | This array contains the recent versions for the requested project, in reverse chronological order.                                                                                                           |
 | build_variants | Array of strings             | The deduplicated display names for all the build variants in the rows parameter                                                                                                                              |
@@ -1342,16 +1341,16 @@ this route is legacy, and is no longer supported.
 
 **BuildList**
 
-| Name            | Type   | Description                                                                                                                                       |
-|--------------------|---------|-------------------------------------------|
-| `build_variant` | string | the identifier of each of the build variant objects below (all are the same variant)                                                              |
-| `builds`        | object | The keys of this object are build IDs. The values are the full build objects: <https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#id12> |
+| Name                 | Type      | Description                                                                                                                                       |
+| -------------------- | --------- | -------------------------------------------                                                                                                       |
+| `build_variant`      | string    | the identifier of each of the build variant objects below (all are the same variant)                                                              |
+| `builds`             | object    | The keys of this object are build IDs. The values are the full build objects: <https://github.com/evergreen-ci/evergreen/wiki/REST-V2-Usage#id12> |
 
 
 **APIVersions**
 
 | Name        | Type                     | Description                                                                                                                                                                       |
-|--------------------|---------|-------------------------------------------|
+|-------------|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `rolled_up` | boolean                  | if true, these are inactive versions                                                                                                                                              |
 | `versions`  | Array of Version objects | If rolled_up is true, this will contain multiple version objects, none of which ran any tasks. Otherwise, this will contain a single version object, of which at least 1 task ran |
 
@@ -1385,11 +1384,11 @@ Checks a specified project alias in a specified project against an Evergreen con
 
 **Parameters**
 
-|Name             |Type     |Description    
-|-----------------|---------|-----------------------------
-|version          |string   |Required. The ID of the version (commit or patch) from which to retrieve the configuration as well as the project ID    
-|alias            |string   |Required. The name of the alias to test against the configuration. The special aliases \__commit_queue, \__github, and \__git_tag can be used here    
-|include_deps     |boolean  |Optional. If true, will also select the tasks that are dependencies of the selected tasks, even if they do not match the alias definition. Defaults to false.    
+| Name         | Type    | Description
+|--------------|---------|
+| version      | string  | Required. The ID of the version (commit or patch) from which to retrieve the configuration as well as the project ID
+| alias        | string  | Required. The name of the alias to test against the configuration. The special aliases \__commit_queue, \__github, and \__git_tag can be used here
+| include_deps | boolean | Optional. If true, will also select the tasks that are dependencies of the selected tasks, even if they do not match the alias definition. Defaults to false.
 
 
 #### Distro 
@@ -1411,7 +1410,7 @@ Fetches distros defined in the system.
 | Name | Type   | Description                             |
 |------|--------|-----------------------------------------|
 | name | string | The unique name of the public key       |
-| key  | string | The public key, (e.g: 'ssh-rsa ...') |
+| key  | string | The public key, (e.g: 'ssh-rsa ...')    |
 
 
 #### Endpoints
@@ -1423,7 +1422,7 @@ Fetches distros defined in the system.
 Fetch the SSH public keys of the current user (as determined by the
 Api-User and Api-Key headers) as an array of Key objects.
 
-If the user has no public keys, expect: \[\]
+If the user has no public keys, expect: []
 
 ##### Add a Public Key to the Current User
 
@@ -1448,13 +1447,13 @@ Any other status code indicates that the key was not successfully added.
 
     DELETE /keys/{key_name}
 
-Delete the SSH public key with name \'{key_name}\' from the current user
+Delete the SSH public key with name `{key_name}` from the current user
 (as determined by the Api-User and Api-Key headers).
 
-If a public key with name \'{key_name}\' was successfully deleted, HTTP
+If a public key with name `{key_name}` was successfully deleted, HTTP
 status code 200 OK will be returned.
 
-If a public key with name \'{key_name}\' does not exist, HTTP status
+If a public key with name `{key_name}` does not exist, HTTP status
 code 400 Bad Request will be returned.
 
 Any other code indicates that the public key was not deleted
@@ -1468,17 +1467,17 @@ Status
 **APICLIUpdate**
 
 | Name            | Type            | Description                                                                                            |
-|--------------------|---------|-------------------------------------------|
+|-----------------|-----------------|--------------------------------------------------------------------------------------------------------|
 | `client_config` | APIClientConfig | Client version/URLs                                                                                    |
 | `ignore_update` | bool            | If true, degraded mode for clients is enabled, and the client should treat their version as up-to date |
 
 
 **APIClientConfig**
 
-| Name            | Type                | Description                              |
-|--------------------|---------|-------------------------------------------|
-| latest_revision | string              | a string representing the client version |
-| client_binaries | \[APIClientBinary\] | Array of APIClientBinary objects         |
+| Name            | Type              | Description                              |
+|-----------------|-------------------|------------------------------------------|
+| latest_revision | string            | a string representing the client version |
+| client_binaries | []APIClientBinary | Array of APIClientBinary objects         |
 
 
 **APIClientBinary**
@@ -1522,11 +1521,11 @@ distro combinations.
 **TaskStats**
 
 | Name                   | Type   | Description                                                                                               |
-|--------------------|---------|-------------------------------------------|
+|------------------------|--------|-----------------------------------------------------------------------------------------------------------|
 | `task_name`            | string | Name of the task the test ran under.                                                                      |
 | `variant`              | string | Name of the build variant the task ran on. Omitted if the grouping does not include the build variant.    |
 | `distro`               | string | Identifier of the distro that the task ran on. Omitted if the grouping does not include the distro.       |
-| `date`                 | string | The start date (\"YYYY-MM-DD\" UTC day) of the period the statistics cover.                               |
+| `date`                 | string | The start date ("YYYY-MM-DD" UTC day) of the period the statistics cover.                                 |
 | `num_success`          | int    | The number of times the task was successful during the target period.                                     |
 | `num_failed`           | int    | The number of times the task failed during the target period.                                             |
 | `num_total`            | int    | The number of times the task ran during the target period.                                                |
@@ -1545,19 +1544,19 @@ distro combinations.
 
 Returns a paginated list of task stats associated with a specific project filtered and grouped according to the query parameters.  
 
-|Name            |Type                                  |Description    
-|----------------|--------------------------------------|------------------------------
-|after_date      |string                                |The start date (included) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC.
-|before_date     |string                                |The end date (excluded) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC.    
-|group_num_days  |int                                   |Optional. Indicates that the statistics should be aggregated by groups of`group_num_days`days. The first group will start on`after_date`, the last group will end on the day preceding`before_date`and may have less than`group_num_days`days. Defaults to 1.    
-|requesters      |[]string or comma separated strings   |Optional. The requesters that triggered the task execution. Accepted values are`mainline`,`patch`,`trigger`, and`adhoc`. Defaults to`mainline`.    
-|tasks           |[]string or comma separated strings   |The tasks to include in the statistics.    
-|variants        |[]string or comma separated strings   |Optional. The build variants to include in the statistics.    
-|distros         |[]string or comma separated strings   |Optional. The distros to include in the statistics.    
-|group_by        |string                                |Optional. How to group the results. Accepted values are`task_variant`,`task`. By default the results are not grouped, i.e. are returned by combination of task + variant + distro.    
-|sort            |string                                |Optional. The order in which the results are returned. Accepted values are`earliest`and`latest`. Defaults to`earliest`.    
-|start_at        |string                                |Optional. The identifier of the task stats to start at in the pagination    
-|limit           |int                                   |Optional. The number of task stats to be returned per page of pagination. Defaults to 1000.  
+| Name           | Type                                | Description                                                                                                                                                                                                                                                   |
+|----------------|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| after_date     | string                              | The start date (included) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC.                                                                                                                                                         |
+| before_date    | string                              | The end date (excluded) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC.                                                                                                                                                           |
+| group_num_days | int                                 | Optional. Indicates that the statistics should be aggregated by groups of`group_num_days`days. The first group will start on`after_date`, the last group will end on the day preceding`before_date`and may have less than`group_num_days`days. Defaults to 1. |
+| requesters     | []string or comma separated strings | Optional. The requesters that triggered the task execution. Accepted values are`mainline`,`patch`,`trigger`, and`adhoc`. Defaults to`mainline`.                                                                                                               |
+| tasks          | []string or comma separated strings | The tasks to include in the statistics.                                                                                                                                                                                                                       |
+| variants       | []string or comma separated strings | Optional. The build variants to include in the statistics.                                                                                                                                                                                                    |
+| distros        | []string or comma separated strings | Optional. The distros to include in the statistics.                                                                                                                                                                                                           |
+| group_by       | string                              | Optional. How to group the results. Accepted values are`task_variant`,`task`. By default the results are not grouped, i.e. are returned by combination of task + variant + distro.                                                                            |
+| sort           | string                              | Optional. The order in which the results are returned. Accepted values are`earliest`and`latest`. Defaults to`earliest`.                                                                                                                                       |
+| start_at       | string                              | Optional. The identifier of the task stats to start at in the pagination                                                                                                                                                                                      |
+| limit          | int                                 | Optional. The number of task stats to be returned per page of pagination. Defaults to 1000.                                                                                                                                                                   |
 
 #### TaskReliability 
 
@@ -1565,21 +1564,21 @@ Task Reliability success scores are aggregated task execution statistics for a g
 
 ##### Objects
 
-|Name                 |Type       |Description    
-|---------------------|-----------|-----------------------------------------------------
-|task_name            |string     |Name of the task the test ran under.    
-|variant              |string     |Name of the build variant the task ran on. Omitted if the grouping does not include the build variant.    
-|distro               |string     |Identifier of the distro that the task ran on. Omitted if the grouping does not include the distro.    
-|date                 |string     |The start date ("YYYY-MM-DD" UTC day) of the period the statistics cover.    
-|num_success          |int        |The number of times the task was successful during the target period.    
-|num_failed           |int        |The number of times the task failed during the target period.    
-|num_total            |int        |The number of times the task ran during the target period.    
-|num_timeout          |int        |The number of times the task ended on a timeout during the target period.    
-|num_test_failed      |int        |The number of times the task failed with a failure of type `test` during the target period.    
-|num_system_failed    |int        |The number of times the task failed with a failure of type `system` during the target period.    
-|num_setup_failed     |int        |The number of times the task failed with a failure of type `setup` during the target period.    
-|avg_duration_success |float      |The average duration, in seconds, of the tasks that passed during the target period.    
-|success_rate         |float      |The success rate score calculated over the time span, grouped by time period and distro, variant or task. The value ranges from 0.0 (total failure) to 1.0 (total success).  
+| Name                 | Type   | Description                                                                                                                                                                 |
+|----------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| task_name            | string | Name of the task the test ran under.                                                                                                                                        |
+| variant              | string | Name of the build variant the task ran on. Omitted if the grouping does not include the build variant.                                                                      |
+| distro               | string | Identifier of the distro that the task ran on. Omitted if the grouping does not include the distro.                                                                         |
+| date                 | string | The start date ("YYYY-MM-DD" UTC day) of the period the statistics cover.                                                                                                   |
+| num_success          | int    | The number of times the task was successful during the target period.                                                                                                       |
+| num_failed           | int    | The number of times the task failed during the target period.                                                                                                               |
+| num_total            | int    | The number of times the task ran during the target period.                                                                                                                  |
+| num_timeout          | int    | The number of times the task ended on a timeout during the target period.                                                                                                   |
+| num_test_failed      | int    | The number of times the task failed with a failure of type `test` during the target period.                                                                                 |
+| num_system_failed    | int    | The number of times the task failed with a failure of type `system` during the target period.                                                                               |
+| num_setup_failed     | int    | The number of times the task failed with a failure of type `setup` during the target period.                                                                                |
+| avg_duration_success | float  | The average duration, in seconds, of the tasks that passed during the target period.                                                                                        |
+| success_rate         | float  | The success rate score calculated over the time span, grouped by time period and distro, variant or task. The value ranges from 0.0 (total failure) to 1.0 (total success). |
 
 ##### Endpoints 
 
@@ -1592,19 +1591,19 @@ specific project filtered and grouped according to the query parameters.
 
 **Parameters**
 
-| Name             | Type                                  | Description                                                                                                                                                                                                                                                           |
-|-------------|-----------------|-------------------------------------------|
-| `before_date`    | string                                | The end date (included) of the targeted time interval. The format is \"YYYY-MM-DD\". The date is UTC. Defaults to today.                                                                                                                                              |
-| `after_date`     | string                                | The start date (included) of the targeted time interval. The format is \"YYYY-MM-DD\". The date is UTC. Defaults to `before_date`.                                                                                                                                    |
-| `group_num_days` | int                                   | Optional. Indicates that the statistics should be aggregated by groups of `group_num_days` days. The first group will start on the nearest first date greater than `after_date`, the last group will start on `before_date` - `group_num_days`\` days. Defaults to 1. |
-| `requesters`     | \[\]string or comma separated strings | Optional. The requesters that triggered the task execution. Accepted values are `mainline`, `patch`, `trigger`, and `adhoc`. Defaults to `mainline`.                                                                                                                  |
-| `tasks`          | \[\]string or comma separated strings | The tasks to include in the statistics.                                                                                                                                                                                                                               |
-| `variants`       | \[\]string or comma separated strings | Optional. The build variants to include in the statistics.                                                                                                                                                                                                            |
-| `distros`        | \[\]string or comma separated strings | Optional. The distros to include in the statistics.                                                                                                                                                                                                                   |
-| `group_by`       | string                                | Optional. How to group the results. Accepted values are `task`, `task_variant`, and `task_variant_distro`. By default the results are grouped by task.                                                                                                                |
-| `sort`           | string                                | Optional. The order in which the results are returned. Accepted values are `earliest` and `latest`. Defaults to `latest`.                                                                                                                                             |
-| `start_at`       | string                                | Optional. The identifier of the task stats to start at in the pagination                                                                                                                                                                                              |
-| `limit`          | int                                   | Optional. The number of task stats to be returned per page of pagination. Defaults to 1000.                                                                                                                                                                           |
+| Name             | Type                                | Description                                                                                                                                                                                                                                                           |
+|------------------|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `before_date`    | string                              | The end date (included) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC. Defaults to today.                                                                                                                                                |
+| `after_date`     | string                              | The start date (included) of the targeted time interval. The format is "YYYY-MM-DD". The date is UTC. Defaults to `before_date`.                                                                                                                                      |
+| `group_num_days` | int                                 | Optional. Indicates that the statistics should be aggregated by groups of `group_num_days` days. The first group will start on the nearest first date greater than `after_date`, the last group will start on `before_date` - `group_num_days`\` days. Defaults to 1. |
+| `requesters`     | []string or comma separated strings | Optional. The requesters that triggered the task execution. Accepted values are `mainline`, `patch`, `trigger`, and `adhoc`. Defaults to `mainline`.                                                                                                                  |
+| `tasks`          | []string or comma separated strings | The tasks to include in the statistics.                                                                                                                                                                                                                               |
+| `variants`       | []string or comma separated strings | Optional. The build variants to include in the statistics.                                                                                                                                                                                                            |
+| `distros`        | []string or comma separated strings | Optional. The distros to include in the statistics.                                                                                                                                                                                                                   |
+| `group_by`       | string                              | Optional. How to group the results. Accepted values are `task`, `task_variant`, and `task_variant_distro`. By default the results are grouped by task.                                                                                                                |
+| `sort`           | string                              | Optional. The order in which the results are returned. Accepted values are `earliest` and `latest`. Defaults to `latest`.                                                                                                                                             |
+| `start_at`       | string                              | Optional. The identifier of the task stats to start at in the pagination                                                                                                                                                                                              |
+| `limit`          | int                                 | Optional. The number of task stats to be returned per page of pagination. Defaults to 1000.                                                                                                                                                                           |
 
 
 ##### Examples
@@ -1648,14 +1647,14 @@ issues.
 
 **Email**
 
-| Name            | Type                    | Description                                                                                                           |
-|--------------------|---------|-------------------------------------------|
-| `from`          | string                  | Optional. The email sender.                                                                                           |
-| `recipients`    | \[\]string              | The email recipient.                                                                                                  |
-| `subject`       | string                  | Optional. The email subject.                                                                                          |
-| `body`          | string                  | Optional. The email body.                                                                                             |
-| `is_plain_text` | string                  | Optional. Specifies the Content-Type of the email. If true, it will be \"text/plain\"; otherwise it is \"text/html\". |
-| `headers`       | map\[string\]\[\]string | Optional. Email headers.                                                                                              |
+| Name            | Type                | Description                                                                                                       |
+|-----------------|---------------------|-------------------------------------------------------------------------------------------------------------------|
+| `from`          | string              | Optional. The email sender.                                                                                       |
+| `recipients`    | []string            | The email recipient.                                                                                              |
+| `subject`       | string              | Optional. The email subject.                                                                                      |
+| `body`          | string              | Optional. The email body.                                                                                         |
+| `is_plain_text` | string              | Optional. Specifies the Content-Type of the email. If true, it will be "text/plain"; otherwise it is "text/html". |
+| `headers`       | map[string][]string | Optional. Email headers.                                                                                          |
 
 
 **Slack**
@@ -1664,28 +1663,28 @@ issues.
 |--------------------|---------|-------------------------------------------|
 | `target`      | string              | Required. The name of the recipient.         |
 | `msg`         | string              | Required. The message for the notification.  |
-| `attachments` | \[\]SlackAttachment | Optional. Array of attachments to a message. |
+| `attachments` | []SlackAttachment | Optional. Array of attachments to a message. |
 
 
 **SlackAttachment**
 
-| Name          | Type                     | Description                                                                                                                                              |
-|--------------------|---------|-------------------------------------------|
-| `title`       | string                   | Optional. The attachment title.                                                                                                                          |
-| `title_link`  | string                   | Optional. A URL that turns the title into a link.                                                                                                        |
-| `text`        | string                   | If `fallback` is empty, this is required. The main body text of the attachment as plain text, or with markdown using `mrkdwn_in`.                        |
-| `fallback`    | string                   | If `text` is empty, this is required. A plain text summary of an attachment for clients that don't show formatted text (eg. IRC, mobile notifications). |
-| `mrkdwn_in`   | \[\]string               | Optional. An array of fields that should be formatted with markdown.                                                                                     |
-| `color`       | string                   | Optional. The message color. Can either be one of good (green), warning (yellow), danger (red), or any hex color code (eg. #439FE0).                     |
-| `author_name` | string                   | Optional. The display name of the author.                                                                                                                |
-| `author_icon` | string                   | Optional. A URL that displays the author icon. Will only work if `author_name` is present.                                                               |
-| `fields`      | \[\]SlackAttachmentField | Optional. Array of SlackAttachmentFields that get displayed in a table-like format.                                                                      |
+| Name          | Type                   | Description                                                                                                                                             |
+|---------------|------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `title`       | string                 | Optional. The attachment title.                                                                                                                         |
+| `title_link`  | string                 | Optional. A URL that turns the title into a link.                                                                                                       |
+| `text`        | string                 | If `fallback` is empty, this is required. The main body text of the attachment as plain text, or with markdown using `mrkdwn_in`.                       |
+| `fallback`    | string                 | If `text` is empty, this is required. A plain text summary of an attachment for clients that don't show formatted text (eg. IRC, mobile notifications). |
+| `mrkdwn_in`   | []string               | Optional. An array of fields that should be formatted with markdown.                                                                                    |
+| `color`       | string                 | Optional. The message color. Can either be one of good (green), warning (yellow), danger (red), or any hex color code (eg. #439FE0).                    |
+| `author_name` | string                 | Optional. The display name of the author.                                                                                                               |
+| `author_icon` | string                 | Optional. A URL that displays the author icon. Will only work if `author_name` is present.                                                              |
+| `fields`      | []SlackAttachmentField | Optional. Array of SlackAttachmentFields that get displayed in a table-like format.                                                                     |
 
 
 **SlackAttachmentField**
 
 | Name    | Type   | Description                                                                                                         |
-|--------------------|---------|-------------------------------------------|
+|---------|--------|---------------------------------------------------------------------------------------------------------------------|
 | `title` | string | Optional. The field title.                                                                                          |
 | `value` | string | Optional. The field text. It can be formatted as plain text or with markdown by using `mrkdwn_in`.                  |
 | `short` | string | Optional. Indicates whether the field object is short enough to be displayed side-by-side with other field objects. |
@@ -1696,18 +1695,18 @@ attachments](https://api.slack.com/reference/messaging/attachments).
 
 **JIRA Issue**
 
-| Name          | Type                     | Description                                     |
-|--------------------|---------|-------------------------------------------|
-| `issue_key`   | string                   | Optional.                                       |
-| `project`     | string                   | Optional. The project name.                     |
-| `summary`     | string                   | Optional. The summary text.                     |
-| `description` | string                   | Optional. The issue description.                |
-| `reporter`    | string                   | Optional. The issue reporter.                   |
-| `assignee`    | string                   | Optional. The issue assignee.                   |
-| `type`        | string                   | Optional. The issue type.                       |
-| `components`  | string                   | Optional. The project components.               |
-| `labels`      | string                   | Optional. The issue labels.                     |
-| `fields`      | map\[string\]interface{} | Optional. Arbitrary map of custom field values. |
+| Name          | Type                   | Description                                     |
+|---------------|------------------------|-------------------------------------------------|
+| `issue_key`   | string                 | Optional.                                       |
+| `project`     | string                 | Optional. The project name.                     |
+| `summary`     | string                 | Optional. The summary text.                     |
+| `description` | string                 | Optional. The issue description.                |
+| `reporter`    | string                 | Optional. The issue reporter.                   |
+| `assignee`    | string                 | Optional. The issue assignee.                   |
+| `type`        | string                 | Optional. The issue type.                       |
+| `components`  | string                 | Optional. The project components.               |
+| `labels`      | string                 | Optional. The issue labels.                     |
+| `fields`      | map[string]interface{} | Optional. Arbitrary map of custom field values. |
 
 
 This corresponds with the documentation in the [JIRA API for creating
@@ -1716,7 +1715,7 @@ issues](https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/issu
 **JIRA Comment**
 
 | Name       | Type   | Description                                                       |
-|--------------------|---------|-------------------------------------------|
+|------------|--------|-------------------------------------------------------------------|
 | `issue_id` | string | Optional. The ID of the issue where the comment should be posted. |
 | `body`     | string | Optional. The comment text.                                       |
 
@@ -1728,8 +1727,8 @@ comments](https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/is
 
     POST /notifications/<type>
 
-The type can be \"email\", \"slack\", \"jira_issue\", or
-\"jira_comment\".
+The type can be "email", "slack", "jira_issue", or
+"jira_comment".
 
 ### Permissions
 
@@ -1784,7 +1783,7 @@ Note that usage of this endpoint requires that the requesting user have security
       }
 }
 ```
-  
+
 * resource_type - the type of resources for which permission is granted. Must be one of "project", "distro", or "superuser" 
 * resources - an array of strings representing what resources the access is for. For a resource_type of project, this will be a list of projects. For a resource_type of distro, this will be a list of distros. 
 * permissions - an object whose keys are the permission keys returned by the /permissions endpoint above, and whose values are the levels of access to grant for that permission (also returned by the /permissions endpoint)  
@@ -1796,13 +1795,13 @@ Get User Permissions
 **Parameters**
 
 | Name | Type    | Description                                                      |
-|--------------------|---------|-------------------------------------------|
+|------|---------|------------------------------------------------------------------|
 | all  | Boolean | Optional. If included, we will not filter out basic permissions. |
 
 
 Retrieves all permissions for the user (ignoring basic permissions that
 are given to all users, unless all=true is included). The format of the
-response is :  
+response is :
 ```
 [ {
  "type": "project",
@@ -1817,7 +1816,7 @@ response is :
 ```
 
 -   type - the type of resources for which the listed permissions apply.
-    Will be \"project\", \"distro\", or \"superuser\"
+    Will be "project", "distro", or "superuser"
 -   permissions - an object whose keys are the resources for which the
     user has permissions. Note that these objects will often have many
     keys, since logged-in users have basic permissions to every project
@@ -1862,8 +1861,8 @@ security to modify roles. The format of the body is: :
     }
 
 -   resource_type - the type of resources for which to delete
-    permissions. Must be one of \"project\", \"distro\", \"superuser\",
-    or \"all\". \"all\" will revoke all permissions for the user.
+    permissions. Must be one of "project", "distro", "superuser",
+    or "all". "all" will revoke all permissions for the user.
 -   resource_id - the resource ID for which to delete permissions.
     Required unless deleting all permissions.
 
@@ -1872,7 +1871,10 @@ security to modify roles. The format of the body is: :
     GET /roles/<role_id>/users
 
 Gets a list of users for the specified role. The format of the response
-is: :: { \"users\": \[\"list\", \"of\", \"users\"\] } :
+is:
+```json
+{ "users": ["list", "of", "users"] }
+```
 
 ##### Give Roles to User
 
@@ -1922,7 +1924,7 @@ The format of the response is: :
 **Query Parameters**
 
 | Name    | Type | Description                                                                          |
-|--------------------|---------|-------------------------------------------|
+|---------|------|--------------------------------------------------------------------------------------|
 | dry_run | bool | If set to true, route returns the IDs of the hosts/volumes that *would* be modified. |
 
 ## REST V2 Use Case Guide
@@ -1974,7 +1976,7 @@ which returns a paginated list of hosts. Page through the results to
 inspect all hosts.
 
 By default, this endpoint will only return hosts that are considered
-\"up\" (status is equal to running, initializing, starting,
+"up" (status is equal to running, initializing, starting,
 provisioning, or provision failed).
 
 ### Restart all failures for a commit
@@ -2015,6 +2017,7 @@ For example, to enable the commit queue the body would be:
     }
 
 To add and delete admins:
+
     { "admins": ["annie.black", "brian.samek"], // does not overwrite existing admins    
       "delete_admins": ["john.liu"] // deletes existing admin }
 

--- a/docs/04-Modify Evergreen/01-Using-Degrade-Mode.md
+++ b/docs/04-Modify Evergreen/01-Using-Degrade-Mode.md
@@ -17,7 +17,7 @@ appropriate.
 
 The interface to enable/disable each Evergreen service is available in
 the Evergreen UI from the Admin Settings page of the dropdown in the top
-right, and is also available from the \"evergreen admin\" CLI commands.
+right, and is also available from the "evergreen admin" CLI commands.
 Any changes to the service flags should be communicated to other
 superusers. If making a change that will be noticed by end-users (such
 as disabling task dispatch), the banner message should be set as well.
@@ -38,7 +38,7 @@ quickly and safely fixed, consider instead deploying the fix and forcing
 agents to roll over to the new revision. One thing to keep in mind is
 that disabling task dispatch for over 15 minutes will cause the monitor
 to start terminating hosts for being idle, because idle is defined as
-\"not processing tasks for 15 minutes.\"
+"not processing tasks for 15 minutes."
 
 Enable task dispatch when the problem is fixed or will be fixed by
 getting a new agent revision.


### PR DESCRIPTION
Docs have a bunch of markdown formatting mistakes, I fixed some of them.

* Remove incorrect escapes of single/double quotes.
* Remove some leftover rst formatting.
* Fix markdown table formatting (I have a plugin to automatically do this, I didn't do it by hand).