### PR TITLE
EVG-19059 Route child patch links correctly

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -277,7 +277,7 @@ func (p *Patch) GetURL(uiHost string) string {
 	if p.Activated {
 		url = uiHost + "/version/" + p.Id.Hex()
 		if p.IsChild() {
-			url += "/downstream-tasks"
+			url += "/downstream-projects"
 		}
 	} else {
 		url = uiHost + "/patch/" + p.Id.Hex()

--- a/model/project.go
+++ b/model/project.go
@@ -1441,6 +1441,11 @@ func (p *Project) findProjectTasksWithTag(tags []string) []string {
 
 func (p *Project) GetModuleByName(name string) (*Module, error) {
 	for _, v := range p.Modules {
+		grip.Info(message.Fields{
+			"bynnbynn": "checking module",
+			"name":     v.Name,
+			"module":   v,
+		})
 		if v.Name == name {
 			return &v, nil
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -1441,11 +1441,6 @@ func (p *Project) findProjectTasksWithTag(tags []string) []string {
 
 func (p *Project) GetModuleByName(name string) (*Module, error) {
 	for _, v := range p.Modules {
-		grip.Info(message.Fields{
-			"bynnbynn": "checking module",
-			"name":     v.Name,
-			"module":   v,
-		})
 		if v.Name == name {
 			return &v, nil
 		}

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -482,7 +482,7 @@ type versionLinkInput struct {
 func versionLink(i versionLinkInput) string {
 	url := fmt.Sprintf("%s/version/%s", i.uiBase, url.PathEscape(i.versionID))
 	if i.isChild {
-		url += "/downstream-tasks"
+		url += "/downstream-projects"
 	}
 	url += "?redirect_spruce_users=true"
 	return url

--- a/units/github_status_refresh_test.go
+++ b/units/github_status_refresh_test.go
@@ -157,7 +157,7 @@ func (s *githubStatusRefreshSuite) TestStatusPending() {
 
 	// Child patch status
 	status = s.getAndValidateStatus(s.env.InternalSender)
-	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-projects?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
 	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
 	s.Equal(message.GithubStatePending, status.State)
 	s.Equal("tasks are running", status.Description)
@@ -225,7 +225,7 @@ func (s *githubStatusRefreshSuite) TestStatusSucceeded() {
 
 	// Child patch status
 	status = s.getAndValidateStatus(s.env.InternalSender)
-	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-projects?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
 	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
 	s.Equal(message.GithubStateSuccess, status.State)
 	s.Equal("child patch finished in 12m0s", status.Description)
@@ -292,7 +292,7 @@ func (s *githubStatusRefreshSuite) TestStatusFailed() {
 
 	// Child patch status
 	status = s.getAndValidateStatus(s.env.InternalSender)
-	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-tasks?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
+	s.Equal(fmt.Sprintf("https://example.com/version/%s/downstream-projects?redirect_spruce_users=true", childPatch.Id.Hex()), status.URL)
 	s.Equal("evergreen/myChildProjectIdentifier", status.Context)
 	s.Equal(message.GithubStateFailure, status.State)
 	s.Equal("child patch finished in 12m0s", status.Description)


### PR DESCRIPTION
EVG-19059

### Description
child patch links were not correctly redirecting users 

### Testing

the link in this pr correctly links child patches
https://github.com/evergreen-ci/commit-queue-sandbox/pull/464

