### PR TITLE
EVG-18291: fix log message spelling

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1124,7 +1124,7 @@ func (h *Host) AddVolumeToHost(newVolume *VolumeAttachment) error {
 		message.Fields{
 			"host_id":   h.Id,
 			"volume_id": newVolume.VolumeID,
-			"op":        "host volume acocunting",
+			"op":        "host volume accounting",
 			"message":   "problem setting host info on volume records",
 		}))
 


### PR DESCRIPTION
EVG-18291

### Description
This doesn't fix anything to do with the actual ticket question, but I drive-by noticed a spelling mistake.

### Testing
N/A

### Documentation
N/A
