### PR TITLE
Add to task annotations docs

### DIFF
--- a/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
+++ b/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
@@ -221,7 +221,7 @@ Task Annotations give users more context about task failures.
 | note             | note_object            | Comment about the task failure                                                                                   |
 | issues           | []issue_link           | Links to tickets definitely related                                                                              |
 | suspected_issues | []issue_link           | Links to tickets possibly related                                                                                |
-| metadata_links   | []metadata_link        | List of arbitrary links associated with a task, meant to be displayed in the task metadata sidebar               |
+| metadata_links   | []metadata_link        | List of links associated with a task, to be displayed in the task metadata sidebar, currently limited to 1       |
 
 
 **Note**

--- a/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
+++ b/docs/02-Test with Evergreen/05-Use the API/01-REST-V2-Usage.md
@@ -97,7 +97,7 @@ comprise a suite of tests or generation of a set of artifacts.
 | `expected_duration_ms` | int           | Number of milliseconds expected for this task to execute                                                                                                                                                                                                |
 | `previous_executions`  | []Task        | Contains previous executions of the task if they were requested, and available. May be empty.                                                                                                                                                           |
 | `parent_task_id`       | string        | The ID of the task's parent display task, if requested and available                                                                                                                                                                                    |
-| `artifacts`            | []File        | The list of artifacts associated with the task.
+| `artifacts`            | []File        | The list of artifacts associated with the task.                                                                                                                                                                                                         |
 
 **Logs**
 
@@ -221,6 +221,8 @@ Task Annotations give users more context about task failures.
 | note             | note_object            | Comment about the task failure                                                                                   |
 | issues           | []issue_link           | Links to tickets definitely related                                                                              |
 | suspected_issues | []issue_link           | Links to tickets possibly related                                                                                |
+| metadata_links   | []metadata_link        | List of arbitrary links associated with a task, meant to be displayed in the task metadata sidebar               |
+
 
 **Note**
 
@@ -245,6 +247,14 @@ Task Annotations give users more context about task failures.
 | issue_key        | string        | Text to be displayed              |
 | source           | source_object | The source of the edit            |
 | confidence_score | float32       | The confidence score of the issue |
+
+**Metadata Link**
+
+| Name             | Type          | Description            |
+|------------------|---------------|------------------------|
+| url              | string        | The url of the link    |
+| text             | string        | Text to be displayed   |
+| source           | source_object | The source of the edit |
 
 #### Endpoints
 


### PR DESCRIPTION
EVG-18934

### Documentation
Documenting the [implementation](https://github.com/evergreen-ci/evergreen/commit/f509cb0771728f5cfbfa1448f469f8adce5ecaad) of this PR (will include `.md` file changes of PRs from now on - was used to the pattern of updating docs manually in the wiki post merge)