### PR TITLE
EVG-19029 improve when/how we provide auth advice via CLI

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-03-30"
+	ClientVersion = "2023-04-10"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-04-02"

--- a/operations/http.go
+++ b/operations/http.go
@@ -56,7 +56,7 @@ func NewAPIError(resp *http.Response) APIError {
 
 func NewAuthError(resp *http.Response) APIError {
 	apiError := NewAPIError(resp)
-	apiError.body = strings.Join([]string{apiError.body, client.AuthError}, "")
+	apiError.body = fmt.Sprintf("%s (%s)", apiError.body, client.AuthError)
 	return apiError
 }
 

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -162,12 +162,12 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if pref.IsPatchingDisabled() || !pref.Enabled {
-		as.LoggedError(w, r, http.StatusUnauthorized, errors.New("patching is disabled"))
+		as.LoggedError(w, r, http.StatusBadRequest, errors.New("patching is disabled"))
 		return
 	}
 
 	if !pref.TaskSync.IsPatchEnabled() && (len(data.SyncTasks) != 0 || len(data.SyncBuildVariants) != 0) {
-		as.LoggedError(w, r, http.StatusUnauthorized, errors.New("task sync at the end of a patched task is disabled by project settings"))
+		as.LoggedError(w, r, http.StatusBadRequest, errors.New("task sync at the end of a patched task is disabled by project settings"))
 		return
 	}
 


### PR DESCRIPTION
EVG-19029

### Description
When we return an "unauthorized" label we wrap advice on re-logging in via the UI. We return unauthorized for a few situations where that's not actually the case, it's just the project isn't configured for it, so modified this. Also improved how the message itself looks (right now the sentences run right into each other).

### Testing
Original: 
```Unexpected reply from server (401 Unauthorized): 400 (Bad Request): patching is disabledPossibly user credentials are expired, try logging in again via the Evergreen web UI.```

New: 
```Unexpected reply from server (400 Bad Request): 400 (Bad Request): patching is disabled```

