### PR TITLE
EVG-19597 always validate github org when attaching to repo / saving page

### DIFF
--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
@@ -3,6 +3,8 @@ mutation {
         repoSettings: {
             projectRef: {
                 id: "repo_id"
+                owner: "hello",
+                repo: "world",
                 enabled: true,
                 remotePath: "my_path_is_new"
             }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2330,8 +2330,6 @@ func (p *ProjectRef) ValidateOwnerAndRepo(validOrgs []string) error {
 
 func validateOwner(owner string, validOrgs []string) error {
 	if len(validOrgs) > 0 && !utility.StringSliceContains(validOrgs, owner) {
-		fmt.Println("valid orgs: ", validOrgs)
-		fmt.Println(owner)
 		return errors.New("owner not authorized")
 	}
 	return nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -692,8 +692,11 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 // a GitHub project conflict. If no repo ref currently exists, the user attaching it will be added as the repo ref admin.
 func (p *ProjectRef) AttachToRepo(u *user.DBUser) error {
 	// Before allowing a project to attach to a repo, verify that this is a valid GitHub organization.
-	allowedOrgs := evergreen.GetEnvironment().Settings().GithubOrgs
-	if err := p.ValidateOwnerAndRepo(allowedOrgs); err != nil {
+	config, err := evergreen.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "getting config")
+	}
+	if err := p.ValidateOwnerAndRepo(config.GithubOrgs); err != nil {
 		return errors.Wrap(err, "validating new owner/repo")
 	}
 	before, err := GetProjectSettingsById(p.Id, false)
@@ -2327,6 +2330,8 @@ func (p *ProjectRef) ValidateOwnerAndRepo(validOrgs []string) error {
 
 func validateOwner(owner string, validOrgs []string) error {
 	if len(validOrgs) > 0 && !utility.StringSliceContains(validOrgs, owner) {
+		fmt.Println("valid orgs: ", validOrgs)
+		fmt.Println(owner)
 		return errors.New("owner not authorized")
 	}
 	return nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -723,10 +723,8 @@ func (p *ProjectRef) AttachToNewRepo(u *user.DBUser) error {
 	}
 
 	allowedOrgs := evergreen.GetEnvironment().Settings().GithubOrgs
-	if p.Enabled {
-		if err := p.ValidateOwnerAndRepo(allowedOrgs); err != nil {
-			return errors.Wrap(err, "validating new owner/repo")
-		}
+	if err := p.ValidateOwnerAndRepo(allowedOrgs); err != nil {
+		return errors.Wrap(err, "validating new owner/repo")
 	}
 
 	if p.UseRepoSettings() {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2811,25 +2811,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	update := &ProjectRef{
 		Id:      "iden_",
 		Enabled: true,
-		Owner:   "invalid",
-		Repo:    "nonexistent",
-	}
-
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
-	assert.Error(err)
-
-	update = &ProjectRef{
-		Id:      "iden_",
-		Enabled: true,
-		Owner:   "",
-		Repo:    "",
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
-	assert.Error(err)
-
-	update = &ProjectRef{
-		Id:      "iden_",
-		Enabled: true,
 		Owner:   "evergreen-ci",
 		Repo:    "test",
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -458,6 +458,10 @@ func TestAttachToNewRepo(t *testing.T) {
 		evergreen.RoleCollection, user.Collection, evergreen.ConfigCollection, GithubHooksCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
+	settings := evergreen.Settings{
+		GithubOrgs: []string{"newOwner", "evergreen-ci"},
+	}
+	assert.NoError(t, settings.Set())
 	pRef := ProjectRef{
 		Id:        "myProject",
 		Owner:     "evergreen-ci",
@@ -481,6 +485,11 @@ func TestAttachToNewRepo(t *testing.T) {
 		SystemRoles: []string{GetViewRepoRole("myRepo")},
 	}
 	assert.NoError(t, u.Insert())
+
+	// Can't attach to repo with an invalid owner
+	pRef.Owner = "invalid"
+	assert.Error(t, pRef.AttachToNewRepo(u))
+
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
 	hook := GithubHook{
@@ -550,9 +559,12 @@ func TestAttachToNewRepo(t *testing.T) {
 
 func TestAttachToRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
-		evergreen.RoleCollection, user.Collection, GithubHooksCollection))
+		evergreen.RoleCollection, user.Collection, GithubHooksCollection, evergreen.ConfigCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
-
+	settings := evergreen.Settings{
+		GithubOrgs: []string{"newOwner", "evergreen-ci"},
+	}
+	assert.NoError(t, settings.Set())
 	pRef := ProjectRef{
 		Id:     "myProject",
 		Owner:  "evergreen-ci",
@@ -629,6 +641,16 @@ func TestAttachToRepo(t *testing.T) {
 	assert.False(t, pRefFromDB.CommitQueue.IsEnabled())
 	assert.False(t, pRefFromDB.IsGithubChecksEnabled())
 	assert.True(t, pRefFromDB.IsPRTestingEnabled())
+
+	// Try attaching with a disallowed owner.
+	pRef = ProjectRef{
+		Id:     "myBadProject",
+		Owner:  "nonexistent",
+		Repo:   "evergreen",
+		Branch: "main",
+	}
+	assert.NoError(t, pRef.Insert())
+	assert.Error(t, pRef.AttachToRepo(u))
 }
 
 func TestDetachFromRepo(t *testing.T) {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -237,6 +237,17 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			}
 		}
 
+		if mergedSection.Owner != "" && mergedSection.Repo != "" {
+			// Validating owner/repo is cheap, and regardless of whether or not the project
+			// is enabled or we're using a repo, it makes sense to be strict about this.
+			config, err := evergreen.GetConfig()
+			if err != nil {
+				return nil, errors.Wrap(err, "getting evergreen config")
+			}
+			if err = mergedSection.ValidateOwnerAndRepo(config.GithubOrgs); err != nil {
+				return nil, errors.Wrap(err, "validating new owner/repo")
+			}
+		}
 		// Only need to check Github conflicts once so we use else if statements to handle this.
 		// Handle conflicts using the ref from the DB, since only general section settings are passed in from the UI.
 		if mergedSection.Owner != mergedBeforeRef.Owner || mergedSection.Repo != mergedBeforeRef.Repo {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -237,9 +237,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			}
 		}
 
-		if mergedSection.Owner != "" && mergedSection.Repo != "" {
-			// Validating owner/repo is cheap, and regardless of whether or not the project
-			// is enabled or we're using a repo, it makes sense to be strict about this.
+		// Validate owner/repo if the project is enabled or owner/repo is populated.
+		// This validation is cheap so it makes sense to be strict about this.
+		if mergedSection.Enabled || (mergedSection.Owner != "" && mergedSection.Repo != "") {
 			config, err := evergreen.GetConfig()
 			if err != nil {
 				return nil, errors.Wrap(err, "getting evergreen config")

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -275,6 +275,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			// Shouldn't succeed if the new owner isn't in the config.
 			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			assert.Error(t, err)
+			assert.Nil(t, settings)
 
 			config.GithubOrgs = append(config.GithubOrgs, ref.Owner) // Add the new owner
 			assert.NoError(t, config.Set())

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -49,6 +49,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			// Shouldn't succeed if the new owner isn't in the config.
 			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, true, "me")
 			assert.Error(t, err)
+			assert.Nil(t, settings)
 
 			config.GithubOrgs = append(config.GithubOrgs, ref.Owner) // Add the new owner
 			assert.NoError(t, config.Set())

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -32,8 +32,12 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 
 	for name, test := range map[string]func(t *testing.T, ref model.RepoRef){
 		model.ProjectPageGeneralSection: func(t *testing.T, ref model.RepoRef) {
-			assert.Empty(t, ref.SpawnHostScriptPath)
+			config, err := evergreen.GetConfig()
+			assert.NoError(t, err)
+			config.GithubOrgs = []string{ref.Owner}
+			assert.NoError(t, config.Set())
 
+			assert.Empty(t, ref.SpawnHostScriptPath)
 			ref.SpawnHostScriptPath = "my script path"
 			ref.Owner = "something different"
 			apiProjectRef := restModel.APIProjectRef{}
@@ -41,8 +45,16 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			// ensure that we're saving settings without a special case
+
+			// Shouldn't succeed if the new owner isn't in the config.
 			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, true, "me")
+			assert.Error(t, err)
+
+			config.GithubOrgs = append(config.GithubOrgs, ref.Owner) // Add the new owner
+			assert.NoError(t, config.Set())
+			
+			// ensure that we're saving settings without a special case
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, true, "me")
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 			repoRefFromDB, err := model.FindOneRepoRef(ref.Id)
@@ -248,7 +260,10 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		model.ProjectPageGeneralSection: func(t *testing.T, ref model.ProjectRef) {
 			assert.Empty(t, ref.SpawnHostScriptPath)
-
+			config, err := evergreen.GetConfig()
+			assert.NoError(t, err)
+			config.GithubOrgs = []string{ref.Owner}
+			assert.NoError(t, config.Set())
 			ref.SpawnHostScriptPath = "my script path"
 			ref.Owner = "something different"
 			apiProjectRef := restModel.APIProjectRef{}
@@ -256,8 +271,15 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			// ensure that we're saving settings without a special case
+			// Shouldn't succeed if the new owner isn't in the config.
 			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
+			assert.Error(t, err)
+
+			config.GithubOrgs = append(config.GithubOrgs, ref.Owner) // Add the new owner
+			assert.NoError(t, config.Set())
+
+			// Ensure that we're saving settings without a special case
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 			assert.Equal(t, "myRepoId", utility.FromStringPtr(settings.ProjectRef.RepoRefId))
@@ -512,7 +534,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 	} {
 		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
 			event.SubscriptionsCollection, event.EventCollection, evergreen.ScopeCollection, user.Collection,
-			model.GithubHooksCollection))
+			model.GithubHooksCollection, evergreen.ConfigCollection))
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		pRef := model.ProjectRef{

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -52,8 +52,8 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 
 			config.GithubOrgs = append(config.GithubOrgs, ref.Owner) // Add the new owner
 			assert.NoError(t, config.Set())
-			
-			// ensure that we're saving settings without a special case
+
+			// Ensure that we're saving settings without a special case
 			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, true, "me")
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1056,7 +1056,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	defer cancel()
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
-		evergreen.ScopeCollection, evergreen.RoleCollection))
+		evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection))
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
 	u := &user.DBUser{Id: "me"}
 	assert.NoError(t, u.Insert())

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -245,7 +245,7 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	env := testutil.NewEnvironment(ctx, t)
 	require.NoError(t, db.ClearCollections(dbModel.RepoRefCollection, dbModel.ProjectVarsCollection,
 		dbModel.ProjectAliasCollection, dbModel.GithubHooksCollection, commitqueue.Collection, user.Collection,
-		dbModel.ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
+		dbModel.ProjectRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection))
 
 	independentProject := &dbModel.ProjectRef{
 		Id:         "branch1",
@@ -312,6 +312,7 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	settings, err := evergreen.GetConfig()
 	assert.NoError(t, err)
 	settings.GithubOrgs = []string{branchProject.Owner}
+	assert.NoError(t, settings.Set())
 	attachProjectHandler := attachProjectToRepoHandler{}
 	// Test that turning on repo settings doesn't impact existing restricted values
 	req, _ := http.NewRequest(http.MethodPost, "rest/v2/projects/branch2/attach_to_repo", nil)
@@ -321,7 +322,7 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	resp := attachProjectHandler.Run(ctx)
 	assert.NotNil(t, resp)
 	assert.Equal(t, resp.Status(), http.StatusOK)
-
+	fmt.Println(resp.Data())
 	pRefs, err := dbModel.FindMergedEnabledProjectRefsByRepoAndBranch("owner", "repo", "main")
 	assert.NoError(t, err)
 	require.Len(t, pRefs, 2)

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -322,7 +322,6 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	resp := attachProjectHandler.Run(ctx)
 	assert.NotNil(t, resp)
 	assert.Equal(t, resp.Status(), http.StatusOK)
-	fmt.Println(resp.Data())
 	pRefs, err := dbModel.FindMergedEnabledProjectRefsByRepoAndBranch("owner", "repo", "main")
 	assert.NoError(t, err)
 	require.Len(t, pRefs, 2)


### PR DESCRIPTION
[EVG-19597](https://jira.mongodb.org/browse/EVG-19597) 

### Description
Realized from Bynn's scope that Lisbeth was able to track a personal Github org. After some investigation, it looks like the workflow "change owner -> enable repo -> enable project" is a loophole, since we don't validate this for projects attached to repo, since we assumed that the repo had to be valid. This would also be true for attach to new repo. 

Fixed both of these functions to validate, and updated the save page to validate strictly.

### Testing
Added some unit tests; tested in staging

