### PR TITLE
EVG-19305 Upgrade containerized variant to Ubuntu 20.04 and Mongo v5

### DIFF
--- a/self-tests-staging.yml
+++ b/self-tests-staging.yml
@@ -22,7 +22,7 @@ buildvariants:
       goarch: amd64
       IS_DOCKER: true
       GOROOT: /usr/local/go
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.2.18.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.4.18.tgz
       decompress: tar zxvf
     tasks:
       - name: "dist-unsigned"

--- a/self-tests-staging.yml
+++ b/self-tests-staging.yml
@@ -4,7 +4,7 @@ include:
 containers:
   - name: evg-container
     working_dir: /
-    image: "hadjri/evg-e2e-test-ubuntu"
+    image: "hadjri/evg-container-self-tests"
     resources:
       cpu: 4096
       memory_mb: 8192
@@ -13,8 +13,8 @@ containers:
       operating_system: linux
 
 buildvariants:
-  - name: ubuntu1604-container
-    display_name: Ubuntu 16.04 (Container)
+  - name: ubuntu2004-container
+    display_name: Ubuntu 20.04 (Container)
     run_on:
       - evg-container
     expansions:
@@ -22,7 +22,7 @@ buildvariants:
       goarch: amd64
       IS_DOCKER: true
       GOROOT: /usr/local/go
-      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.4.18.tgz
+      mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.14.tgz
       decompress: tar zxvf
     tasks:
       - name: "dist-unsigned"


### PR DESCRIPTION
EVG-19305

### Description
GraphQL tests are currently failing with a ["cannot create namespace"](https://evergreen-staging.corp.mongodb.com/task_log_raw/evg_ubuntu1604_container_test_graphql_0e89303b82adbfb5351dd3e36c56ba5dc91a74a1_23_04_11_13_17_36/2?type=T#L453) error, which is a byproduct of using MongoDB 4.2, which will not automatically create namespaces if they do not exist.

Furthermore, our container variant is still on Ubuntu 16.04, preventing it from running mongoDB versions 5 (and 6 in the future), which is what we're currently using for our tests in production.  Rather than bumping the container version of MongoDB from 4.2 to 4.4, I've bumped it up to 5.0 and created a [new Docker image](https://hub.docker.com/r/hadjri/evg-container-self-tests) running on Ubuntu 20.04 along with necessary Dockerfile changes needed to make the building and pushing work.
### Testing
Confirmed tests now pass.
