### PR TITLE
EVG-18219 Add logging for host statuses

### DIFF
--- a/units/host_status.go
+++ b/units/host_status.go
@@ -107,6 +107,10 @@ clientsLoop:
 					j.AddError(j.terminateUnknownHosts(ctx, err.Error()))
 					continue clientsLoop
 				}
+				grip.Error(message.WrapError(err, message.Fields{
+					"message": "getting instance statuses from AWS",
+					"job":     j.ID(),
+				}))
 				j.AddError(errors.Wrap(err, "getting host statuses for providers"))
 				continue clientsLoop
 			}


### PR DESCRIPTION
EVG-18219

### Description
Adding an explicit grip log with a custom message to filter for a splunk alert 

"Because people are less likely to modify grip logs when they're tied to alerts. Errors that we add using AddError we generally just have for debugging/tracking/error rate monitoring, not for specific alerts that need to look for specific conditions" - kim 
