### PR TITLE
EVG-19269 Reroute version page to spruce before checking for project

### DIFF
--- a/service/version.go
+++ b/service/version.go
@@ -21,11 +21,23 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
 
-	if err != nil || project == nil || projCtx.Version == nil {
-		http.Error(w, "not found", http.StatusNotFound)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id)) {
+		return
+	}
+
+	if project == nil || projCtx.Version == nil {
+		grip.Debug(message.Fields{
+			"message": "project or version not found",
+			"project": project,
+			"projCtx": projCtx,
+			"version": projCtx.Version,
+		})
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 

--- a/service/version.go
+++ b/service/version.go
@@ -21,12 +21,18 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
 
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	grip.DebugWhen(err != nil, message.Fields{
+		"message": "error getting project for version page",
+		"project": project,
+		"projCtx": projCtx,
+	})
+
+	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id)) {
 		return
 	}
 
-	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id)) {
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/service/version.go
+++ b/service/version.go
@@ -21,7 +21,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
 
-	grip.DebugWhen(err != nil, message.Fields{
+	grip.DebugWhen(err != nil || project == nil || projCtx.Version == nil, message.Fields{
 		"message": "error getting project for version page",
 		"project": project,
 		"projCtx": projCtx,


### PR DESCRIPTION
EVG-19269

### Description

The legacy version page was failing but Spruce wasn't so I updated it so that we redirect to Spruce early and this should hopefully unblock cloud.

I also added some logging so we could figure out why this is happening. 
There is also a chance that this change will not fix the issue but that will also be made clearer by the logging.
