### PR TITLE
EVG-19262 Add system logging to testCase

### DIFF
--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -27,6 +27,11 @@ type xunitResults struct {
 	base
 }
 
+const (
+	systemOut = "system-out:"
+	systemErr = "system-err:"
+)
+
 func xunitResultsFactory() Command   { return &xunitResults{} }
 func (c *xunitResults) Name() string { return evergreen.AttachXUnitResultsCommandName }
 
@@ -223,11 +228,8 @@ func addTestCasesForSuite(suite testSuite, idx int, conf *internal.TaskConfig, c
 		// logs are only created when a test case does not succeed
 		test, log := tc.toModelTestResultAndLog(conf)
 		if log != nil {
-			if suite.SysOut != "" {
-				log.Lines = append(log.Lines, "system-out:", suite.SysOut)
-			}
-			if suite.SysErr != "" {
-				log.Lines = append(log.Lines, "system-err:", suite.SysErr)
+			if systemLogs := constructSystemLogs(tc.SysOut, tc.SysErr); len(systemLogs) > 0 {
+				log.Lines = append(log.Lines, systemLogs...)
 			}
 			cumulative.logs = append(cumulative.logs, log)
 			cumulative.logIdxToTestIdx = append(cumulative.logIdxToTestIdx, len(cumulative.tests))
@@ -238,4 +240,15 @@ func addTestCasesForSuite(suite testSuite, idx int, conf *internal.TaskConfig, c
 		cumulative = addTestCasesForSuite(*suite.NestedSuites, idx, conf, cumulative)
 	}
 	return cumulative
+}
+
+func constructSystemLogs(sysOut, sysErr string) []string {
+	var lines []string
+	if sysOut != "" {
+		lines = append(lines, systemOut, sysOut)
+	}
+	if sysErr != "" {
+		lines = append(lines, systemErr, sysErr)
+	}
+	return lines
 }

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -228,7 +228,7 @@ func addTestCasesForSuite(suite testSuite, idx int, conf *internal.TaskConfig, c
 		// logs are only created when a test case does not succeed
 		test, log := tc.toModelTestResultAndLog(conf)
 		if log != nil {
-			if systemLogs := constructSystemLogs(tc.SysOut, tc.SysErr); len(systemLogs) > 0 {
+			if systemLogs := constructSystemLogs(suite.SysOut, suite.SysErr); len(systemLogs) > 0 {
 				log.Lines = append(log.Lines, systemLogs...)
 			}
 			cumulative.logs = append(cumulative.logs, log)

--- a/agent/command/results_xunit_parser.go
+++ b/agent/command/results_xunit_parser.go
@@ -59,6 +59,8 @@ type testCase struct {
 	ClassName string          `xml:"classname,attr"`
 	Failure   *failureDetails `xml:"failure"`
 	Error     *failureDetails `xml:"error"`
+	SysOut    string          `xml:"system-out"`
+	SysErr    string          `xml:"system-err"`
 	Skipped   *failureDetails `xml:"skipped"`
 }
 
@@ -122,6 +124,13 @@ func (tc testCase) toModelTestResultAndLog(conf *internal.TaskConfig) (testresul
 		res.Status = evergreen.TestSkippedStatus
 	default:
 		res.Status = evergreen.TestSucceededStatus
+	}
+
+	if systemLogs := constructSystemLogs(tc.SysOut, tc.SysErr); len(systemLogs) > 0 {
+		if log == nil {
+			log = &model.TestLog{}
+		}
+		log.Lines = append(log.Lines, systemLogs...)
 	}
 
 	if log != nil {

--- a/agent/command/results_xunit_parser_test.go
+++ b/agent/command/results_xunit_parser_test.go
@@ -33,10 +33,14 @@ func TestXMLParsing(t *testing.T) {
 					So(res[0].Errors, ShouldEqual, 1)
 					So(res[0].Failures, ShouldEqual, 5)
 					So(res[0].Name, ShouldEqual, "nose2-junit")
+					So(res[0].SysOut, ShouldEqual, "sysout-suite")
+					So(res[0].SysErr, ShouldEqual, "syserr-suite")
 					So(res[0].TestCases[11].Name, ShouldEqual, "test_params_func:2")
 					So(res[0].TestCases[11].Time, ShouldEqual, 0.000098)
 					So(res[0].TestCases[11].Failure, ShouldNotBeNil)
 					So(res[0].TestCases[11].Failure.Message, ShouldEqual, "test failure")
+					So(res[0].TestCases[11].SysOut, ShouldEqual, "sysout-testcase")
+					So(res[0].TestCases[11].SysErr, ShouldEqual, "syserr-testcase")
 				})
 			})
 		})
@@ -253,6 +257,18 @@ func TestXMLToModelConversion(t *testing.T) {
 				Convey("and logs should be of the proper form", func() {
 					So(logs[0].Name, ShouldNotEqual, "")
 					So(len(logs[0].Lines), ShouldNotEqual, 0)
+					hasSystemErrTc := false
+					hasSystemOutTc := false
+					for _, line := range logs[0].Lines {
+						if line == "sysout-testcase" {
+							hasSystemOutTc = true
+						}
+						if line == "syserr-testcase" {
+							hasSystemErrTc = true
+						}
+					}
+					So(hasSystemErrTc, ShouldBeTrue)
+					So(hasSystemOutTc, ShouldBeTrue)
 				})
 			})
 		})

--- a/agent/command/testdata/xunit/junit_1.xml
+++ b/agent/command/testdata/xunit/junit_1.xml
@@ -18,6 +18,8 @@
             assert a == 1
             AssertionError
         </failure>
+        <system-out>sysout-testcase</system-out>
+        <system-err>syserr-testcase</system-err>
     </testcase>
     <testcase classname="pkg1.test.test_things" name="test_params_func_multi_arg:1" time="0.000094" />
     <testcase classname="pkg1.test.test_things" name="test_params_func_multi_arg:2" time="0.000089">
@@ -70,4 +72,6 @@
             AssertionError
         </failure>
     </testcase>
+    <system-out>sysout-suite</system-out>
+    <system-err>syserr-suite</system-err>
 </testsuite>

--- a/agent/command/testdata/xunit/junit_3.xml
+++ b/agent/command/testdata/xunit/junit_3.xml
@@ -1,10 +1,49 @@
-<?xml version="1.0" encoding="UTF-8"?><testsuite name="nosetests" tests="648" errors="0" failures="1" skip="188"><testcase classname="test.test_auth.TestAuthURIOptions" name="test_uri_options" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_auth.TestDelegatedAuth" name="test_delegated_auth" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_auth.TestGSSAPI" name="test_gssapi_simple" time="0.000"><skipped type="unittest.case.SkipTest" message="Kerberos module not available."><![CDATA[SkipTest: Kerberos module not available.
-]]></skipped></testcase><testcase classname="test.test_auth.TestGSSAPI" name="test_gssapi_threaded" time="0.000"><skipped type="unittest.case.SkipTest" message="Kerberos module not available."><![CDATA[SkipTest: Kerberos module not available.
-]]></skipped></testcase><testcase classname="test.test_auth.TestSASL" name="test_sasl_plain" time="0.000"><skipped type="unittest.case.SkipTest" message="Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL"><![CDATA[SkipTest: Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL
-]]></skipped></testcase><testcase classname="test.test_auth.TestSASL" name="test_sasl_plain_bad_credentials" time="0.000"><skipped type="unittest.case.SkipTest" message="Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL"><![CDATA[SkipTest: Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL
-]]></skipped></testcase><testcase classname="test.test_binary.TestBinary" name="test_binary" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_equality" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_exceptions" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_legacy_csharp_uuid" time="0.143"></testcase><testcase classname="test.test_binary.TestBinary" name="test_legacy_java_uuid" time="0.009"></testcase><testcase classname="test.test_binary.TestBinary" name="test_pickle" time="0.002"></testcase><testcase classname="test.test_binary.TestBinary" name="test_repr" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_subtype" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_uri_to_uuid" time="0.000"></testcase><testcase classname="test.test_binary.TestBinary" name="test_uuid_queries" time="0.010"></testcase><testcase classname="test.test_bson.TestBSON" name="test_aware_datetime" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bad_dbref" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bad_encode" time="0.016"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bad_id_keys" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bad_string_lengths" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_basic_decode" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_basic_encode" time="0.000"><failure type="exceptions.AssertionError" message="'\x05\x00\x00\x00\x00' != '\x00\x00'"><![CDATA[Traceback (most recent call last):
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="nosetests" tests="648" errors="0" failures="1" skip="188">
+    <testcase classname="test.test_auth.TestAuthURIOptions" name="test_uri_options" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_auth.TestDelegatedAuth" name="test_delegated_auth" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_auth.TestGSSAPI" name="test_gssapi_simple" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Kerberos module not available."><![CDATA[SkipTest: Kerberos module not available.
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_auth.TestGSSAPI" name="test_gssapi_threaded" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Kerberos module not available."><![CDATA[SkipTest: Kerberos module not available.
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_auth.TestSASL" name="test_sasl_plain" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL">
+            <![CDATA[SkipTest: Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_auth.TestSASL" name="test_sasl_plain_bad_credentials" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL">
+            <![CDATA[SkipTest: Must set SASL_HOST, SASL_USER, and SASL_PASS to test SASL
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_binary" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_exceptions" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_legacy_csharp_uuid" time="0.143"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_legacy_java_uuid" time="0.009"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_pickle" time="0.002"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_repr" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_subtype" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_uri_to_uuid" time="0.000"></testcase>
+    <testcase classname="test.test_binary.TestBinary" name="test_uuid_queries" time="0.010"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_aware_datetime" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bad_dbref" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bad_encode" time="0.016"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bad_id_keys" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bad_string_lengths" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_basic_decode" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_basic_encode" time="0.000">
+        <failure type="exceptions.AssertionError" message="'\x05\x00\x00\x00\x00' != '\x00\x00'"><![CDATA[Traceback (most recent call last):
   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 331, in run
     testMethod()
   File "/Users/kyle/Projects/mongo-python-driver/test/test_bson.py", line 171, in test_basic_encode
@@ -14,190 +53,1328 @@
   File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 508, in _baseAssertEqual
     raise self.failureException(msg)
 AssertionError: '\x05\x00\x00\x00\x00' != '\x00\x00'
-]]></failure></testcase><testcase classname="test.test_bson.TestBSON" name="test_basic_validation" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bson_regex" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_bytes_as_keys" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_custom_class" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_data_timestamp" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_dates" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_datetime_encode_decode" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_dbpointer" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_dst" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_encode_then_decode" time="0.180"></testcase><testcase classname="test.test_bson.TestBSON" name="test_exception_wrapping" time="0.001"></testcase><testcase classname="test.test_bson.TestBSON" name="test_minkey_maxkey_comparison" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_move_id" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_naive_decode" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_non_string_keys" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_null_character" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_ordered_dict" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_overflow" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_random_data_is_not_bson" time="0.004"></testcase><testcase classname="test.test_bson.TestBSON" name="test_regex_from_native" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_small_long_encode_decode" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_subclasses" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_timestamp_comparison" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_tuple" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_unicode_regex" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_utf8" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_uuid" time="0.000"></testcase><testcase classname="test.test_bson.TestBSON" name="test_uuid_legacy" time="0.000"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_empty" time="0.002"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_find" time="0.002"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_insert" time="0.005"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_insert_check_keys" time="0.002"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_large_inserts_ordered" time="0.348"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_large_inserts_unordered" time="0.286"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_multiple_error_ordered_batch" time="0.006"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_multiple_error_unordered_batch" time="0.007"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_multiple_execution" time="0.003"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_numerous_inserts" time="1.216"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_remove" time="0.019"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_remove_one" time="0.005"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_replace_one" time="0.004"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_single_error_ordered_batch" time="0.004"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_single_error_unordered_batch" time="0.005"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_single_ordered_batch" time="0.004"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_single_unordered_batch" time="0.004"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_update" time="0.007"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_update_one" time="0.006"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_upsert" time="0.005"></testcase><testcase classname="test.test_bulk.TestBulk" name="test_upsert_large" time="0.124"></testcase><testcase classname="test.test_bulk.TestBulkAuthorization" name="test_no_remove" time="0.003"><skipped type="unittest.case.SkipTest" message="Need at least MongoDB 2.5.3 with auth"><![CDATA[SkipTest: Need at least MongoDB 2.5.3 with auth
-]]></skipped></testcase><testcase classname="test.test_bulk.TestBulkAuthorization" name="test_readonly" time="0.003"><skipped type="unittest.case.SkipTest" message="Need at least MongoDB 2.5.3 with auth"><![CDATA[SkipTest: Need at least MongoDB 2.5.3 with auth
-]]></skipped></testcase><testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_ordered_failure" time="0.022"></testcase><testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_ordered_success" time="0.003"></testcase><testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_unordered_failure" time="0.003"></testcase><testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_unordered_success" time="0.008"></testcase><testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_fsync_and_j" time="0.018"></testcase><testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_j_without_journal" time="0.004"><skipped type="unittest.case.SkipTest" message="Need mongod started with --nojournal"><![CDATA[SkipTest: Need mongod started with --nojournal
-]]></skipped></testcase><testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_write_concern_failure_ordered" time="0.003"></testcase><testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_write_concern_failure_unordered" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_alive" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_auth_from_uri" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_client.TestClient" name="test_auto_start_request" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_connect" time="0.016"></testcase><testcase classname="test.test_client.TestClient" name="test_constants" time="0.017"></testcase><testcase classname="test.test_client.TestClient" name="test_contextlib" time="0.006"></testcase><testcase classname="test.test_client.TestClient" name="test_copy_db" time="0.748"></testcase><testcase classname="test.test_client.TestClient" name="test_database_names" time="0.330"></testcase><testcase classname="test.test_client.TestClient" name="test_disconnect" time="0.005"></testcase><testcase classname="test.test_client.TestClient" name="test_document_class" time="0.006"></testcase><testcase classname="test.test_client.TestClient" name="test_drop_database" time="0.001"><skipped type="unittest.case.SkipTest" message="This test often fails due to SERVER-2329"><![CDATA[SkipTest: This test often fails due to SERVER-2329
-]]></skipped></testcase><testcase classname="test.test_client.TestClient" name="test_equality" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_fork" time="2.010"></testcase><testcase classname="test.test_client.TestClient" name="test_from_uri" time="0.004"><system-err><![CDATA[/Users/kyle/Projects/mongo-python-driver/test/test_client.py:320: DeprecationWarning: slave_okay is deprecated. Please use read_preference instead.
+]]></failure>
+        <system-out>sysout-testcase</system-out>
+        <system-err>syserr-testcase</system-err>
+    </testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_basic_validation" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bson_regex" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_bytes_as_keys" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_custom_class" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_data_timestamp" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_dates" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_datetime_encode_decode" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_dbpointer" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_dst" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_encode_then_decode" time="0.180"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_exception_wrapping" time="0.001"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_minkey_maxkey_comparison" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_move_id" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_naive_decode" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_non_string_keys" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_null_character" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_ordered_dict" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_overflow" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_random_data_is_not_bson" time="0.004"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_regex_from_native" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_small_long_encode_decode" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_subclasses" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_timestamp_comparison" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_tuple" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_unicode_regex" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_utf8" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_uuid" time="0.000"></testcase>
+    <testcase classname="test.test_bson.TestBSON" name="test_uuid_legacy" time="0.000"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_empty" time="0.002"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_find" time="0.002"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_insert" time="0.005"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_insert_check_keys" time="0.002"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_large_inserts_ordered" time="0.348"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_large_inserts_unordered" time="0.286"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_multiple_error_ordered_batch" time="0.006"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_multiple_error_unordered_batch" time="0.007"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_multiple_execution" time="0.003"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_numerous_inserts" time="1.216"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_remove" time="0.019"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_remove_one" time="0.005"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_replace_one" time="0.004"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_single_error_ordered_batch" time="0.004"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_single_error_unordered_batch" time="0.005"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_single_ordered_batch" time="0.004"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_single_unordered_batch" time="0.004"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_update" time="0.007"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_update_one" time="0.006"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_upsert" time="0.005"></testcase>
+    <testcase classname="test.test_bulk.TestBulk" name="test_upsert_large" time="0.124"></testcase>
+    <testcase classname="test.test_bulk.TestBulkAuthorization" name="test_no_remove" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Need at least MongoDB 2.5.3 with auth"><![CDATA[SkipTest: Need at least MongoDB 2.5.3 with auth
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_bulk.TestBulkAuthorization" name="test_readonly" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Need at least MongoDB 2.5.3 with auth"><![CDATA[SkipTest: Need at least MongoDB 2.5.3 with auth
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_ordered_failure"
+              time="0.022"></testcase>
+    <testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_ordered_success"
+              time="0.003"></testcase>
+    <testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_unordered_failure"
+              time="0.003"></testcase>
+    <testcase classname="test.test_bulk.TestBulkNoResults" name="test_no_results_unordered_success"
+              time="0.008"></testcase>
+    <testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_fsync_and_j" time="0.018"></testcase>
+    <testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_j_without_journal" time="0.004">
+        <skipped type="unittest.case.SkipTest" message="Need mongod started with --nojournal"><![CDATA[SkipTest: Need mongod started with --nojournal
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_write_concern_failure_ordered"
+              time="0.003"></testcase>
+    <testcase classname="test.test_bulk.TestBulkWriteConcern" name="test_write_concern_failure_unordered"
+              time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_alive" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_auth_from_uri" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_auto_start_request" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_connect" time="0.016"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_constants" time="0.017"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_contextlib" time="0.006"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_copy_db" time="0.748"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_database_names" time="0.330"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_disconnect" time="0.005"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_document_class" time="0.006"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_drop_database" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="This test often fails due to SERVER-2329"><![CDATA[SkipTest: This test often fails due to SERVER-2329
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_equality" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_fork" time="2.010"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_from_uri" time="0.004">
+        <system-err><![CDATA[/Users/kyle/Projects/mongo-python-driver/test/test_client.py:320: DeprecationWarning: slave_okay is deprecated. Please use read_preference instead.
   "mongodb://%s:%d" % (host, port), slave_okay=True).slave_okay)
 /Users/kyle/Projects/mongo-python-driver/test/test_client.py:322: DeprecationWarning: slave_okay is deprecated. Please use read_preference instead.
   "mongodb://%s:%d/?slaveok=true;w=2" % (host, port)).slave_okay)
-]]></system-err></testcase><testcase classname="test.test_client.TestClient" name="test_fsync_lock_unlock" time="0.367"></testcase><testcase classname="test.test_client.TestClient" name="test_get_db" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_get_default_database" time="0.000"></testcase><testcase classname="test.test_client.TestClient" name="test_get_default_database_error" time="0.000"></testcase><testcase classname="test.test_client.TestClient" name="test_get_default_database_with_authsource" time="0.000"></testcase><testcase classname="test.test_client.TestClient" name="test_getters" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_host_w_port" time="0.015"></testcase><testcase classname="test.test_client.TestClient" name="test_init_disconnected" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_init_disconnected_with_auth" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_interrupt_signal" time="1.510"></testcase><testcase classname="test.test_client.TestClient" name="test_ipv6" time="0.001"><skipped type="unittest.case.SkipTest" message="No IPv6"><![CDATA[SkipTest: No IPv6
-]]></skipped></testcase><testcase classname="test.test_client.TestClient" name="test_iteration" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_lazy_auth_raises_operation_failure" time="0.001"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_client.TestClient" name="test_lazy_connect_w0" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_max_wire_version" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_nested_request" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_network_timeout" time="5.142"></testcase><testcase classname="test.test_client.TestClient" name="test_network_timeout_validation" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_operation_failure_with_request" time="1.900"></testcase><testcase classname="test.test_client.TestClient" name="test_operation_failure_without_request" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_replica_set" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_client.TestClient" name="test_repr" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_request_threads" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_timeouts" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_types" time="0.000"></testcase><testcase classname="test.test_client.TestClient" name="test_tz_aware" time="0.004"></testcase><testcase classname="test.test_client.TestClient" name="test_unix_socket" time="0.005"></testcase><testcase classname="test.test_client.TestClient" name="test_use_greenlets" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_waitQueueMultiple" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_waitQueueTimeoutMS" time="0.001"></testcase><testcase classname="test.test_client.TestClient" name="test_wire_version" time="0.002"></testcase><testcase classname="test.test_client.TestClient" name="test_wire_version_mongos_ha" time="0.003"></testcase><testcase classname="test.test_client.TestClient" name="test_with_start_request" time="0.001"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_find_one" time="0.247"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_insert" time="0.320"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_max_bson_size" time="0.002"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_remove" time="0.188"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_save" time="0.210"></testcase><testcase classname="test.test_client.TestClientLazyConnect" name="test_update" time="0.254"></testcase><testcase classname="test.test_client.TestClientLazyConnectBadSeeds" name="test_connect" time="1.335"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_find_one" time="0.215"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_insert" time="0.329"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_max_bson_size" time="0.002"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_remove" time="0.251"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_save" time="0.355"></testcase><testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_update" time="0.283"></testcase><testcase classname="test.test_client.TestMongoClientFailover" name="test_discover_primary" time="0.002"></testcase><testcase classname="test.test_client.TestMongoClientFailover" name="test_reconnect" time="0.002"></testcase><testcase classname="test.test_code.TestCode" name="test_code" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_equality" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_read_only" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_repr" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_scope_kwargs" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_scope_preserved" time="0.000"></testcase><testcase classname="test.test_code.TestCode" name="test_types" time="0.000"></testcase><testcase classname="test.test_collection.TestCollection" name="test_aggregate" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_aggregate_with_compile_re" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_aggregation_cursor" time="0.002"><skipped type="unittest.case.SkipTest" message="Aggregation cursor requires MongoDB &gt;= 2.5.1"><![CDATA[SkipTest: Aggregation cursor requires MongoDB >= 2.5.1
-]]></skipped></testcase><testcase classname="test.test_collection.TestCollection" name="test_aggregation_cursor_validation" time="0.002"><skipped type="unittest.case.SkipTest" message="Aggregation cursor requires MongoDB &gt;= 2.5.1"><![CDATA[SkipTest: Aggregation cursor requires MongoDB >= 2.5.1
-]]></skipped></testcase><testcase classname="test.test_collection.TestCollection" name="test_as_class" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_bad_dbref" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_bad_encode" time="0.002"></testcase><testcase classname="test.test_collection.TestCollection" name="test_collection" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_compile_re" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_continue_on_error" time="0.010"></testcase><testcase classname="test.test_collection.TestCollection" name="test_count" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_create_index" time="0.022"></testcase><testcase classname="test.test_collection.TestCollection" name="test_cursor_timeout" time="0.002"></testcase><testcase classname="test.test_collection.TestCollection" name="test_deprecated_ttl_index_kwarg" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_disabling_manipulators" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_distinct" time="0.009"></testcase><testcase classname="test.test_collection.TestCollection" name="test_drop_index" time="0.013"></testcase><testcase classname="test.test_collection.TestCollection" name="test_drop_indexes_non_existant" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_duplicate_key_error" time="0.012"></testcase><testcase classname="test.test_collection.TestCollection" name="test_ensure_index" time="2.439"></testcase><testcase classname="test.test_collection.TestCollection" name="test_ensure_unique_index_threaded" time="0.358"></testcase><testcase classname="test.test_collection.TestCollection" name="test_error_code" time="0.003"></testcase><testcase classname="test.test_collection.TestCollection" name="test_exhaust" time="0.016"></testcase><testcase classname="test.test_collection.TestCollection" name="test_field_selection" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_fields_specifier_as_dict" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_and_modify" time="0.014"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_and_modify_with_sort" time="0.010"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_kwargs" time="0.010"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_one" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_one_non_objectid" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_one_with_find_args" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_w_fields" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_w_regex" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_with_nested" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_find_with_sort" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_generator_insert" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_group" time="0.055"></testcase><testcase classname="test.test_collection.TestCollection" name="test_group_with_scope" time="0.042"></testcase><testcase classname="test.test_collection.TestCollection" name="test_id_can_be_anything" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_2dsphere" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_background" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_dont_drop_dups" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_drop_dups" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_geo2d" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_hashed" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_haystack" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_info" time="0.011"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_on_binary" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_on_subfield" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_sparse" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_index_text" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_adds_id" time="0.003"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_find_one" time="0.309"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_iterables" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_large_batch" time="3.137"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_large_document" time="0.552"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_manipulate_false" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_message_creation" time="0.033"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_multiple" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_insert_multiple_with_duplicate" time="0.026"></testcase><testcase classname="test.test_collection.TestCollection" name="test_invalid_key_names" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_iteration" time="0.002"></testcase><testcase classname="test.test_collection.TestCollection" name="test_large_limit" time="1.136"></testcase><testcase classname="test.test_collection.TestCollection" name="test_last_error_options" time="0.036"></testcase><testcase classname="test.test_collection.TestCollection" name="test_manual_last_error" time="0.002"></testcase><testcase classname="test.test_collection.TestCollection" name="test_map_reduce" time="0.665"></testcase><testcase classname="test.test_collection.TestCollection" name="test_messages_with_unicode_collection_names" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_min_query" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_multi_update" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_numerous_inserts" time="0.075"></testcase><testcase classname="test.test_collection.TestCollection" name="test_options" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_parallel_scan" time="0.002"><skipped type="unittest.case.SkipTest" message="Requires MongoDB &gt;= 2.5.5"><![CDATA[SkipTest: Requires MongoDB >= 2.5.5
-]]></skipped></testcase><testcase classname="test.test_collection.TestCollection" name="test_query_on_query_field" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_reindex" time="0.011"></testcase><testcase classname="test.test_collection.TestCollection" name="test_remove_all" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_remove_non_objectid" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_remove_one" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_rename" time="0.013"></testcase><testcase classname="test.test_collection.TestCollection" name="test_safe_insert" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_safe_remove" time="0.008"></testcase><testcase classname="test.test_collection.TestCollection" name="test_safe_save" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_safe_update" time="0.007"></testcase><testcase classname="test.test_collection.TestCollection" name="test_save" time="0.009"></testcase><testcase classname="test.test_collection.TestCollection" name="test_save_adds_id" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_save_with_invalid_key" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_snapshot" time="0.003"></testcase><testcase classname="test.test_collection.TestCollection" name="test_unique_index" time="0.009"></testcase><testcase classname="test.test_collection.TestCollection" name="test_update" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_update_manipulate" time="0.005"></testcase><testcase classname="test.test_collection.TestCollection" name="test_update_nmodified" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_update_with_invalid_keys" time="0.006"></testcase><testcase classname="test.test_collection.TestCollection" name="test_upsert" time="0.004"></testcase><testcase classname="test.test_collection.TestCollection" name="test_wtimeout" time="0.003"></testcase><testcase classname="test.test_common.TestCommon" name="test_baseobject" time="0.061"></testcase><testcase classname="test.test_common.TestCommon" name="test_mongo_client" time="0.009"></testcase><testcase classname="test.test_common.TestCommon" name="test_mongo_replica_set_client" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set."><![CDATA[SkipTest: Not connected to a replica set.
-]]></skipped></testcase><testcase classname="test.test_common.TestCommon" name="test_uuid_subtype" time="0.036"></testcase><testcase classname="test.test_common.TestCommon" name="test_write_concern" time="0.002"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_add_remove_option" time="0.002"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_bad_getitem" time="0.001"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_batch_size" time="0.129"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_clone" time="0.009"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_comment" time="0.015"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_count" time="0.010"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_count_with_fields" time="0.004"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_count_with_limit_and_skip" time="0.052"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_cursor_transfer" time="0.008"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_deepcopy_cursor_littered_with_regexes" time="0.002"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_distinct" time="0.008"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_explain" time="0.002"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_get_more" time="0.004"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_getitem_numeric_index" time="0.041"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_getitem_slice_index" time="0.060"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_hint" time="0.046"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_len" time="0.001"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_limit" time="0.045"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_limit_and_batch_size" time="0.335"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_max" time="0.011"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_max_scan" time="0.043"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_max_time_ms" time="0.001"><skipped type="unittest.case.SkipTest" message="MaxTimeMS requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: MaxTimeMS requires MongoDB >= 2.5.3
-]]></skipped></testcase><testcase classname="test.test_cursor.TestCursor" name="test_max_time_ms_getmore" time="0.001"><skipped type="unittest.case.SkipTest" message="Need test commands enabled"><![CDATA[SkipTest: Need test commands enabled
-]]></skipped></testcase><testcase classname="test.test_cursor.TestCursor" name="test_min" time="0.011"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_properties" time="0.001"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_rewind" time="0.004"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_skip" time="0.049"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_sort" time="0.014"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_tailable" time="0.007"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_where" time="0.014"></testcase><testcase classname="test.test_cursor.TestCursor" name="test_with_statement" time="0.039"></testcase><testcase classname="test.test_database.TestDatabase" name="test_authenticate_add_remove_user" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_authenticate_and_request" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_authenticate_and_safe" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_authenticate_multiple" time="0.003"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_auto_ref_and_deref" time="0.010"></testcase><testcase classname="test.test_database.TestDatabase" name="test_collection_names" time="0.004"></testcase><testcase classname="test.test_database.TestDatabase" name="test_command" time="0.002"></testcase><testcase classname="test.test_database.TestDatabase" name="test_command_ignores_network_timeout" time="0.205"></testcase><testcase classname="test.test_database.TestDatabase" name="test_command_max_time_ms" time="0.002"><skipped type="unittest.case.SkipTest" message="MaxTimeMS requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: MaxTimeMS requires MongoDB >= 2.5.3
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_command_read_pref_warning" time="0.002"></testcase><testcase classname="test.test_database.TestDatabase" name="test_command_response_without_ok" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_command_with_compile_re" time="0.006"></testcase><testcase classname="test.test_database.TestDatabase" name="test_create_collection" time="0.024"></testcase><testcase classname="test.test_database.TestDatabase" name="test_default_roles" time="0.004"><skipped type="unittest.case.SkipTest" message="Default roles only exist in MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: Default roles only exist in MongoDB >= 2.5.3
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_deref" time="0.008"></testcase><testcase classname="test.test_database.TestDatabase" name="test_drop_collection" time="0.025"></testcase><testcase classname="test.test_database.TestDatabase" name="test_equality" time="0.003"></testcase><testcase classname="test.test_database.TestDatabase" name="test_errors" time="0.022"></testcase><testcase classname="test.test_database.TestDatabase" name="test_eval" time="0.068"></testcase><testcase classname="test.test_database.TestDatabase" name="test_get_coll" time="0.002"></testcase><testcase classname="test.test_database.TestDatabase" name="test_id_ordering" time="0.002"></testcase><testcase classname="test.test_database.TestDatabase" name="test_iteration" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_last_status" time="0.003"></testcase><testcase classname="test.test_database.TestDatabase" name="test_long" time="0.002"></testcase><testcase classname="test.test_database.TestDatabase" name="test_make_user_readonly" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_manipulator_properties" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_marc" time="0.007"></testcase><testcase classname="test.test_database.TestDatabase" name="test_name" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_new_user_cmds" time="0.001"><skipped type="unittest.case.SkipTest" message="User manipulation through commands requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: User manipulation through commands requires MongoDB >= 2.5.3
-]]></skipped></testcase><testcase classname="test.test_database.TestDatabase" name="test_password_digest" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_profiling_info" time="0.004"></testcase><testcase classname="test.test_database.TestDatabase" name="test_profiling_levels" time="0.006"></testcase><testcase classname="test.test_database.TestDatabase" name="test_remove" time="0.009"></testcase><testcase classname="test.test_database.TestDatabase" name="test_repr" time="0.001"></testcase><testcase classname="test.test_database.TestDatabase" name="test_save_a_bunch" time="0.482"></testcase><testcase classname="test.test_database.TestDatabase" name="test_save_find_one" time="0.038"></testcase><testcase classname="test.test_database.TestDatabase" name="test_system_js" time="0.051"></testcase><testcase classname="test.test_database.TestDatabase" name="test_system_js_list" time="0.004"></testcase><testcase classname="test.test_database.TestDatabase" name="test_validate_collection" time="0.007"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_creation" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_dbref_hash" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_deepcopy" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_equality" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_kwargs" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_pickling" time="0.001"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_read_only" time="0.000"></testcase><testcase classname="test.test_dbref.TestDBRef" name="test_repr" time="0.000"></testcase><testcase classname="test.test_errors.TestErrors" name="test_base_exception" time="0.001"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_alternate_collection" time="0.011"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_basic" time="0.011"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_close" time="0.006"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_context_manager" time="0.005"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_file" time="0.002"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_custom_opts" time="0.002"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_default_opts" time="0.009"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_lazy_connect" time="0.003"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_cursor_options" time="0.003"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_custom_opts" time="0.007"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_default_opts" time="0.005"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_file_document" time="0.007"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_lazy_connect" time="0.005"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_iterator" time="0.013"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_md5" time="0.005"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_multi_chunk_file" time="0.011"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_multiple_reads" time="0.007"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_prechunked_string" time="0.050"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_read_unaligned_buffer_size" time="0.008"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_readchunk" time="0.007"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_readline" time="0.016"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_seek" time="0.012"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_set_after_close" time="0.005"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_small_chunks" time="1.645"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_tell" time="0.032"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_write_file_like" time="0.142"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_write_lines" time="0.019"></testcase><testcase classname="test.test_grid_file.TestGridFile" name="test_write_unicode" time="0.028"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_alt_collection" time="0.065"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_basic" time="0.016"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_empty_file" time="0.010"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_exists" time="0.020"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_file_exists" time="0.014"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_get_last_version" time="0.044"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_get_last_version_with_metadata" time="0.045"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_get_version" time="0.070"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_get_version_with_metadata" time="0.088"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs" time="0.022"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_find" time="0.084"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_lazy_connect" time="0.018"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_request" time="0.012"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_list" time="0.028"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_missing_length_iter" time="0.015"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_put_filelike" time="0.018"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_put_unicode" time="0.014"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_request" time="0.023"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_threaded_reads" time="0.089"></testcase><testcase classname="test.test_gridfs.TestGridfs" name="test_threaded_writes" time="0.193"></testcase><testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_replica_set" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_secondary" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_secondary_lazy" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_basic" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_binary" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_code" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_cursor" time="0.004"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_datetime" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_dbref" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_maxkey" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_minkey" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_objectid" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_regex" time="0.002"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_regex_object_hook" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_timestamp" time="0.001"></testcase><testcase classname="test.test_json_util.TestJsonUtil" name="test_uuid" time="0.001"></testcase><testcase classname="test.test_legacy_connections.TestConnection" name="test_connection" time="0.004"></testcase><testcase classname="test.test_legacy_connections.TestConnection" name="test_connection_alias" time="0.000"></testcase><testcase classname="test.test_legacy_connections.TestReplicaSetConnection" name="test_replica_set_connection" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_legacy_connections.TestReplicaSetConnection" name="test_replica_set_connection_alias" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_base_object" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_continue_until_slave_works" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_create_collection" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_database_names" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_disconnect" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_document_class" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_drop_database" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_get_db" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_insert_find_one_in_request" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_insert_find_one_with_pause" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_insert_find_one_with_slaves" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_iteration" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_kill_cursor_explicit" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_nested_request" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_raise_autoreconnect_if_all_slaves_fail" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_repr" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_request_threads" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_types" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_tz_aware" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_unique_index" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_use_greenlets" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
-]]></skipped></testcase><testcase classname="test.test_mongos_ha.TestMongosHA" name="test_failover" time="0.068"></testcase><testcase classname="test.test_mongos_ha.TestMongosHA" name="test_lazy_connect" time="0.007"></testcase><testcase classname="test.test_mongos_ha.TestMongosHA" name="test_reconnect" time="0.007"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_binary_str_equivalence" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_creation" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_equality" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_from_datetime" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_from_hex" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_generation_time" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_is_valid" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_multiprocessing" time="0.109"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_pickle_backwards_compatability" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_pickling" time="0.001"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_repr_str" time="0.000"></testcase><testcase classname="test.test_objectid.TestObjectId" name="test_unicode" time="0.000"></testcase><testcase classname="test.test_pooling.TestMaxOpenSocketsThreads" name="test_blocking" time="1.250"></testcase><testcase classname="test.test_pooling.TestMaxOpenSocketsThreads" name="test_wait_queue_timeout" time="2.007"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size" time="1.119"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_none" time="1.122"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_connection_failure" time="0.005"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_end_request_only" time="1.120"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_leaked_request" time="1.124"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_leaked_request_no_rendezvous" time="0.114"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_multiple_request" time="1.146"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request" time="1.122"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request2" time="1.136"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request_no_rendezvous" time="0.120"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request_no_rendezvous2" time="0.119"></testcase><testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_request" time="1.119"></testcase><testcase classname="test.test_pooling.TestPoolSocketSharingThreads" name="test_pool" time="10.029"></testcase><testcase classname="test.test_pooling.TestPoolSocketSharingThreads" name="test_pool_request" time="10.010"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_dead_request_socket_with_max_size" time="0.010"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_dependent_pools" time="0.007"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_disconnect" time="0.152"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_independent_pools" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_max_pool_size_validation" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_multiple_connections" time="0.011"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_no_disconnect" time="0.314"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_request_socket" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_request_socket_after_check" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_socket" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_socket_after_request" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_reuses_open_socket" time="0.005"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_with_fork" time="0.020"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_primitive_thread" time="0.505"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_request" time="0.016"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_request_with_fork" time="0.031"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_reset_and_request" time="0.007"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_simple_disconnect" time="0.010"></testcase><testcase classname="test.test_pooling.TestPoolingThreads" name="test_socket_reclamation" time="1.006"></testcase><testcase classname="test.test_pooling.TestWaitQueueMultipleThreads" name="test_wait_queue_multiple" time="1.007"></testcase><testcase classname="test.test_pooling.TestWaitQueueMultipleThreads" name="test_wait_queue_multiple_unset" time="1.014"></testcase><testcase classname="test.test_pooling_gevent.TestMaxOpenSocketsGevent" name="test_blocking" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxOpenSocketsGevent" name="test_wait_queue_timeout" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_none" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_connection_failure" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_end_request_only" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_leaked_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_leaked_request_no_rendezvous" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_multiple_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_redundant_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_redundant_request2" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_redundant_request_no_rendezvous" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_redundant_request_no_rendezvous2" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolSocketSharingGevent" name="test_pool" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolSocketSharingGevent" name="test_pool_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_dead_request_socket_with_max_size" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_dependent_pools" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_disconnect" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_independent_pools" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_max_pool_size_validation" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_multiple_connections" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_no_disconnect" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_request_socket" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_request_socket_after_check" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_socket" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_socket_after_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_reuses_open_socket" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_reset_and_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_simple_disconnect" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_socket_reclamation" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGeventSpecial" name="test_greenlet_sockets" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestPoolingGeventSpecial" name="test_greenlet_sockets_with_request" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestUseGreenletsWithoutGevent" name="test_use_greenlets_without_gevent" time="0.000"></testcase><testcase classname="test.test_pooling_gevent.TestWaitQueueMultipleGevent" name="test_wait_queue_multiple" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pooling_gevent.TestWaitQueueMultipleGevent" name="test_wait_queue_multiple_unset" time="0.000"><skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
-]]></skipped></testcase><testcase classname="test.test_pymongo.TestPyMongo" name="test_mongo_client_alias" time="0.001"></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_aggregate" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_aggregate_command_with_out" time="0.005"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_command" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_count" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_create_collection" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_distinct" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_drop_collection" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_group" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_inline_map_reduce" time="0.004"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_map_reduce" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_map_reduce_command" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestMongosConnection" name="test_mongos_connection" time="0.047"></testcase><testcase classname="test.test_read_preferences.TestMongosConnection" name="test_only_secondary_ok_commands_have_read_prefs" time="0.002"><skipped type="unittest.case.SkipTest" message="Only mongos have read_prefs added to the spec"><![CDATA[SkipTest: Only mongos have read_prefs added to the spec
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestMovingAverage" name="test_empty_init" time="0.000"></testcase><testcase classname="test.test_read_preferences.TestMovingAverage" name="test_moving_average" time="0.000"></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_latency_validation" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_mode_validation" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_nearest" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary_preferred" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary_with_tags" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary_only" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary_preferred" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_read_preferences.TestReadPreferences" name="test_tag_sets_validation" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_alive" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_auto_reconnect_exception_when_read_preference_is_secondary" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_auto_start_request" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_close" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_connect" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_copy_db" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_database_names" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_disconnect" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_document_class" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_drop_database" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_fork" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_db" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_default_database" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_default_database_error" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_default_database_with_authsource" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_init_disconnected" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_init_disconnected_with_auth" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_init_disconnected_with_auth_failure" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_interrupt_signal" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_ipv6" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_iteration" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_kill_cursor_explicit_primary" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_kill_cursor_explicit_secondary" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_lazy_auth_raises_operation_failure" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_nested_request" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_network_timeout" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_network_timeout_validation" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_operation_failure_with_request" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_operation_failure_without_request" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_operations" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_pinned_member" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_properties" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_repr" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_request_threads" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_schedule_refresh" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_timeout_does_not_mark_member_down" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_tz_aware" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_use_greenlets" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_waitQueueMultiple" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_waitQueueTimeoutMS" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientAgainstStandalone" name="test_connect" time="0.002"></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientInternalIPs" name="test_connect_with_internal_ips" time="0.000"></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_find_one" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_insert" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_max_bson_size" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_read_mode_secondary" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_remove" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_save" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_update" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_find_one" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_insert" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_max_bson_size" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_remove" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_save" time="0.002"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_update" time="0.003"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_find_one" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_insert" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_max_bson_size" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_remove" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_save" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_update" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetClientMaxWriteBatchSize" name="test_max_write_batch_size" time="0.003"></testcase><testcase classname="test.test_replica_set_client.TestReplicaSetWireVersion" name="test_wire_version" time="0.011"></testcase><testcase classname="test.test_replica_set_reconfig.TestSecondaryAdded" name="test_client" time="0.002"></testcase><testcase classname="test.test_replica_set_reconfig.TestSecondaryAdded" name="test_replica_set_client" time="0.002"></testcase><testcase classname="test.test_replica_set_reconfig.TestSecondaryBecomesStandalone" name="test_client" time="0.001"></testcase><testcase classname="test.test_replica_set_reconfig.TestSecondaryBecomesStandalone" name="test_replica_set_client" time="0.002"></testcase><testcase classname="test.test_replica_set_reconfig.TestSecondaryRemoved" name="test_replica_set_client" time="0.002"></testcase><testcase classname="test.test_replica_set_reconfig.TestSocketError" name="test_socket_error_marks_member_down" time="0.001"></testcase><testcase classname="test.test_son.TestSON" name="test_copying" time="0.001"></testcase><testcase classname="test.test_son.TestSON" name="test_equality" time="0.000"></testcase><testcase classname="test.test_son.TestSON" name="test_ordered_dict" time="0.000"></testcase><testcase classname="test.test_son.TestSON" name="test_pickle" time="0.001"></testcase><testcase classname="test.test_son.TestSON" name="test_pickle_backwards_compatability" time="0.000"></testcase><testcase classname="test.test_son.TestSON" name="test_to_dict" time="0.000"></testcase><testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_basic" time="0.452"></testcase><testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_id_injection" time="0.381"></testcase><testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_id_shuffling" time="0.127"></testcase><testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_ns_injection" time="0.416"></testcase><testcase classname="test.test_ssl.TestClientSSL" name="test_config_ssl" time="0.001"></testcase><testcase classname="test.test_ssl.TestClientSSL" name="test_no_ssl_module" time="0.000"><skipped type="unittest.case.SkipTest" message="The ssl module is available, can't test what happens without it."><![CDATA[SkipTest: The ssl module is available, can't test what happens without it.
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_implicitly_set" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation_hostname_fail" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation_optional" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_mongodb_x509_auth" time="0.000"><skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
-]]></skipped></testcase><testcase classname="test.test_ssl.TestSSL" name="test_simple_ssl" time="0.000"><skipped type="unittest.case.SkipTest" message="No simple mongod available over SSL"><![CDATA[SkipTest: No simple mongod available over SSL
-]]></skipped></testcase><testcase classname="test.test_thread_util.TestCounter" name="test_greenlet_counter" time="0.000"><skipped type="unittest.case.SkipTest" message="greenlet not installed"><![CDATA[SkipTest: greenlet not installed
-]]></skipped></testcase><testcase classname="test.test_thread_util.TestCounter" name="test_thread_counter" time="0.003"></testcase><testcase classname="test.test_thread_util.TestGreenletIdent" name="test_unwatch_cleans_up" time="0.000"><skipped type="unittest.case.SkipTest" message="need Gevent"><![CDATA[SkipTest: need Gevent
-]]></skipped></testcase><testcase classname="test.test_thread_util.TestIdent" name="test_greenlet_ident" time="0.000"><skipped type="unittest.case.SkipTest" message="greenlet not installed"><![CDATA[SkipTest: greenlet not installed
-]]></skipped></testcase><testcase classname="test.test_thread_util.TestIdent" name="test_thread_ident" time="0.001"></testcase><testcase classname="test.test_threads.TestThreads" name="test_safe_insert" time="1.002"></testcase><testcase classname="test.test_threads.TestThreads" name="test_safe_update" time="1.032"></testcase><testcase classname="test.test_threads.TestThreads" name="test_server_disconnect" time="0.019"></testcase><testcase classname="test.test_threads.TestThreads" name="test_threading" time="0.529"></testcase><testcase classname="test.test_threads.TestThreadsAuth" name="test_auto_auth_login" time="0.002"><skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
-]]></skipped></testcase><testcase classname="test.test_threads_replica_set_client.TestThreadsAuthReplicaSet" name="test_auto_auth_login" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_safe_insert" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_safe_update" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_server_disconnect" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_threading" time="0.001"><skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
-]]></skipped></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_datetime" time="0.000"></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_datetime_copy_pickle" time="0.001"></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_equality" time="0.000"></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_exceptions" time="0.000"></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_repr" time="0.000"></testcase><testcase classname="test.test_timestamp.TestTimestamp" name="test_timestamp" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_parse_uri" time="0.001"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_parse_uri_unicode" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_partition" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_rpartition" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_split_hosts" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_split_options" time="0.000"></testcase><testcase classname="test.test_uri_parser.TestURI" name="test_validate_userinfo" time="0.000"></testcase></testsuite>
+]]></system-err>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_fsync_lock_unlock" time="0.367"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_get_db" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_get_default_database" time="0.000"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_get_default_database_error" time="0.000"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_get_default_database_with_authsource"
+              time="0.000"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_getters" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_host_w_port" time="0.015"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_init_disconnected" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_init_disconnected_with_auth" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_interrupt_signal" time="1.510"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_ipv6" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="No IPv6"><![CDATA[SkipTest: No IPv6
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_iteration" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_lazy_auth_raises_operation_failure" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_lazy_connect_w0" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_max_wire_version" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_nested_request" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_network_timeout" time="5.142"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_network_timeout_validation" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_operation_failure_with_request"
+              time="1.900"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_operation_failure_without_request"
+              time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_replica_set" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_client.TestClient" name="test_repr" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_request_threads" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_timeouts" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_types" time="0.000"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_tz_aware" time="0.004"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_unix_socket" time="0.005"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_use_greenlets" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_waitQueueMultiple" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_waitQueueTimeoutMS" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_wire_version" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_wire_version_mongos_ha" time="0.003"></testcase>
+    <testcase classname="test.test_client.TestClient" name="test_with_start_request" time="0.001"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_find_one" time="0.247"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_insert" time="0.320"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_max_bson_size" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_remove" time="0.188"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_save" time="0.210"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnect" name="test_update" time="0.254"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectBadSeeds" name="test_connect" time="1.335"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_find_one"
+              time="0.215"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_insert" time="0.329"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_max_bson_size"
+              time="0.002"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_remove" time="0.251"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_save" time="0.355"></testcase>
+    <testcase classname="test.test_client.TestClientLazyConnectOneGoodSeed" name="test_update" time="0.283"></testcase>
+    <testcase classname="test.test_client.TestMongoClientFailover" name="test_discover_primary" time="0.002"></testcase>
+    <testcase classname="test.test_client.TestMongoClientFailover" name="test_reconnect" time="0.002"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_code" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_read_only" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_repr" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_scope_kwargs" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_scope_preserved" time="0.000"></testcase>
+    <testcase classname="test.test_code.TestCode" name="test_types" time="0.000"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_aggregate" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_aggregate_with_compile_re"
+              time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_aggregation_cursor" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Aggregation cursor requires MongoDB &gt;= 2.5.1"><![CDATA[SkipTest: Aggregation cursor requires MongoDB >= 2.5.1
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_aggregation_cursor_validation" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Aggregation cursor requires MongoDB &gt;= 2.5.1"><![CDATA[SkipTest: Aggregation cursor requires MongoDB >= 2.5.1
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_as_class" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_bad_dbref" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_bad_encode" time="0.002"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_collection" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_compile_re" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_continue_on_error" time="0.010"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_count" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_create_index" time="0.022"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_cursor_timeout" time="0.002"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_deprecated_ttl_index_kwarg"
+              time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_disabling_manipulators"
+              time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_distinct" time="0.009"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_drop_index" time="0.013"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_drop_indexes_non_existant"
+              time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_duplicate_key_error" time="0.012"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_ensure_index" time="2.439"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_ensure_unique_index_threaded"
+              time="0.358"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_error_code" time="0.003"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_exhaust" time="0.016"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_field_selection" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_fields_specifier_as_dict"
+              time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_and_modify" time="0.014"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_and_modify_with_sort"
+              time="0.010"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_kwargs" time="0.010"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_one" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_one_non_objectid" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_one_with_find_args"
+              time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_w_fields" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_w_regex" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_with_nested" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_find_with_sort" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_generator_insert" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_group" time="0.055"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_group_with_scope" time="0.042"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_id_can_be_anything" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_2dsphere" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_background" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_dont_drop_dups" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_drop_dups" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_geo2d" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_hashed" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_haystack" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_info" time="0.011"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_on_binary" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_on_subfield" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_sparse" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_index_text" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_adds_id" time="0.003"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_find_one" time="0.309"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_iterables" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_large_batch" time="3.137"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_large_document" time="0.552"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_manipulate_false"
+              time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_message_creation"
+              time="0.033"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_multiple" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_insert_multiple_with_duplicate"
+              time="0.026"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_invalid_key_names" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_iteration" time="0.002"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_large_limit" time="1.136"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_last_error_options" time="0.036"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_manual_last_error" time="0.002"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_map_reduce" time="0.665"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_messages_with_unicode_collection_names"
+              time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_min_query" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_multi_update" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_numerous_inserts" time="0.075"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_options" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_parallel_scan" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Requires MongoDB &gt;= 2.5.5"><![CDATA[SkipTest: Requires MongoDB >= 2.5.5
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_query_on_query_field" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_reindex" time="0.011"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_remove_all" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_remove_non_objectid" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_remove_one" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_rename" time="0.013"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_safe_insert" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_safe_remove" time="0.008"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_safe_save" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_safe_update" time="0.007"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_save" time="0.009"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_save_adds_id" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_save_with_invalid_key" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_snapshot" time="0.003"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_unique_index" time="0.009"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_update" time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_update_manipulate" time="0.005"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_update_nmodified" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_update_with_invalid_keys"
+              time="0.006"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_upsert" time="0.004"></testcase>
+    <testcase classname="test.test_collection.TestCollection" name="test_wtimeout" time="0.003"></testcase>
+    <testcase classname="test.test_common.TestCommon" name="test_baseobject" time="0.061"></testcase>
+    <testcase classname="test.test_common.TestCommon" name="test_mongo_client" time="0.009"></testcase>
+    <testcase classname="test.test_common.TestCommon" name="test_mongo_replica_set_client" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set."><![CDATA[SkipTest: Not connected to a replica set.
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_common.TestCommon" name="test_uuid_subtype" time="0.036"></testcase>
+    <testcase classname="test.test_common.TestCommon" name="test_write_concern" time="0.002"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_add_remove_option" time="0.002"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_bad_getitem" time="0.001"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_batch_size" time="0.129"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_clone" time="0.009"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_comment" time="0.015"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_count" time="0.010"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_count_with_fields" time="0.004"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_count_with_limit_and_skip" time="0.052"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_cursor_transfer" time="0.008"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_deepcopy_cursor_littered_with_regexes"
+              time="0.002"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_distinct" time="0.008"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_explain" time="0.002"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_get_more" time="0.004"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_getitem_numeric_index" time="0.041"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_getitem_slice_index" time="0.060"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_hint" time="0.046"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_len" time="0.001"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_limit" time="0.045"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_limit_and_batch_size" time="0.335"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_max" time="0.011"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_max_scan" time="0.043"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_max_time_ms" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="MaxTimeMS requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: MaxTimeMS requires MongoDB >= 2.5.3
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_max_time_ms_getmore" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Need test commands enabled"><![CDATA[SkipTest: Need test commands enabled
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_min" time="0.011"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_properties" time="0.001"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_rewind" time="0.004"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_skip" time="0.049"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_sort" time="0.014"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_tailable" time="0.007"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_where" time="0.014"></testcase>
+    <testcase classname="test.test_cursor.TestCursor" name="test_with_statement" time="0.039"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_authenticate_add_remove_user" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_authenticate_and_request" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_authenticate_and_safe" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_authenticate_multiple" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_auto_ref_and_deref" time="0.010"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_collection_names" time="0.004"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command" time="0.002"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command_ignores_network_timeout"
+              time="0.205"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command_max_time_ms" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="MaxTimeMS requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: MaxTimeMS requires MongoDB >= 2.5.3
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command_read_pref_warning" time="0.002"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command_response_without_ok"
+              time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_command_with_compile_re" time="0.006"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_create_collection" time="0.024"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_default_roles" time="0.004">
+        <skipped type="unittest.case.SkipTest" message="Default roles only exist in MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: Default roles only exist in MongoDB >= 2.5.3
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_deref" time="0.008"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_drop_collection" time="0.025"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_equality" time="0.003"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_errors" time="0.022"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_eval" time="0.068"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_get_coll" time="0.002"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_id_ordering" time="0.002"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_iteration" time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_last_status" time="0.003"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_long" time="0.002"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_make_user_readonly" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_manipulator_properties" time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_marc" time="0.007"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_name" time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_new_user_cmds" time="0.001">
+        <skipped type="unittest.case.SkipTest"
+                 message="User manipulation through commands requires MongoDB &gt;= 2.5.3"><![CDATA[SkipTest: User manipulation through commands requires MongoDB >= 2.5.3
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_password_digest" time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_profiling_info" time="0.004"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_profiling_levels" time="0.006"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_remove" time="0.009"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_repr" time="0.001"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_save_a_bunch" time="0.482"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_save_find_one" time="0.038"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_system_js" time="0.051"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_system_js_list" time="0.004"></testcase>
+    <testcase classname="test.test_database.TestDatabase" name="test_validate_collection" time="0.007"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_creation" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_dbref_hash" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_deepcopy" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_kwargs" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_pickling" time="0.001"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_read_only" time="0.000"></testcase>
+    <testcase classname="test.test_dbref.TestDBRef" name="test_repr" time="0.000"></testcase>
+    <testcase classname="test.test_errors.TestErrors" name="test_base_exception" time="0.001"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_alternate_collection" time="0.011"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_basic" time="0.011"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_close" time="0.006"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_context_manager" time="0.005"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_file" time="0.002"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_custom_opts" time="0.002"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_default_opts" time="0.009"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_in_lazy_connect" time="0.003"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_cursor_options" time="0.003"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_custom_opts" time="0.007"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_default_opts" time="0.005"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_file_document" time="0.007"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_grid_out_lazy_connect" time="0.005"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_iterator" time="0.013"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_md5" time="0.005"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_multi_chunk_file" time="0.011"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_multiple_reads" time="0.007"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_prechunked_string" time="0.050"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_read_unaligned_buffer_size"
+              time="0.008"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_readchunk" time="0.007"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_readline" time="0.016"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_seek" time="0.012"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_set_after_close" time="0.005"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_small_chunks" time="1.645"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_tell" time="0.032"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_write_file_like" time="0.142"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_write_lines" time="0.019"></testcase>
+    <testcase classname="test.test_grid_file.TestGridFile" name="test_write_unicode" time="0.028"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_alt_collection" time="0.065"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_basic" time="0.016"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_empty_file" time="0.010"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_exists" time="0.020"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_file_exists" time="0.014"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_get_last_version" time="0.044"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_get_last_version_with_metadata"
+              time="0.045"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_get_version" time="0.070"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_get_version_with_metadata" time="0.088"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs" time="0.022"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_find" time="0.084"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_lazy_connect" time="0.018"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_gridfs_request" time="0.012"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_list" time="0.028"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_missing_length_iter" time="0.015"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_put_filelike" time="0.018"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_put_unicode" time="0.014"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_request" time="0.023"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_threaded_reads" time="0.089"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfs" name="test_threaded_writes" time="0.193"></testcase>
+    <testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_replica_set" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_secondary" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_gridfs.TestGridfsReplicaSet" name="test_gridfs_secondary_lazy" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_basic" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_binary" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_code" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_cursor" time="0.004"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_datetime" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_dbref" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_maxkey" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_minkey" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_objectid" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_regex" time="0.002"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_regex_object_hook" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_timestamp" time="0.001"></testcase>
+    <testcase classname="test.test_json_util.TestJsonUtil" name="test_uuid" time="0.001"></testcase>
+    <testcase classname="test.test_legacy_connections.TestConnection" name="test_connection" time="0.004"></testcase>
+    <testcase classname="test.test_legacy_connections.TestConnection" name="test_connection_alias"
+              time="0.000"></testcase>
+    <testcase classname="test.test_legacy_connections.TestReplicaSetConnection" name="test_replica_set_connection"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_legacy_connections.TestReplicaSetConnection" name="test_replica_set_connection_alias"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_base_object"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection"
+              name="test_continue_until_slave_works" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_create_collection"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_database_names"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_disconnect"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_document_class"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_drop_database"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_get_db" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection"
+              name="test_insert_find_one_in_request" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection"
+              name="test_insert_find_one_with_pause" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection"
+              name="test_insert_find_one_with_slaves" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_iteration"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_kill_cursor_explicit"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_nested_request"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection"
+              name="test_raise_autoreconnect_if_all_slaves_fail" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_repr" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_request_threads"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_types" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_tz_aware" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_unique_index"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_master_slave_connection.TestMasterSlaveConnection" name="test_use_greenlets"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to master-slave set"><![CDATA[SkipTest: Not connected to master-slave set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_mongos_ha.TestMongosHA" name="test_failover" time="0.068"></testcase>
+    <testcase classname="test.test_mongos_ha.TestMongosHA" name="test_lazy_connect" time="0.007"></testcase>
+    <testcase classname="test.test_mongos_ha.TestMongosHA" name="test_reconnect" time="0.007"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_binary_str_equivalence" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_creation" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_from_datetime" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_from_hex" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_generation_time" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_is_valid" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_multiprocessing" time="0.109"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_pickle_backwards_compatability"
+              time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_pickling" time="0.001"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_repr_str" time="0.000"></testcase>
+    <testcase classname="test.test_objectid.TestObjectId" name="test_unicode" time="0.000"></testcase>
+    <testcase classname="test.test_pooling.TestMaxOpenSocketsThreads" name="test_blocking" time="1.250"></testcase>
+    <testcase classname="test.test_pooling.TestMaxOpenSocketsThreads" name="test_wait_queue_timeout"
+              time="2.007"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size" time="1.119"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_none"
+              time="1.122"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_connection_failure"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_end_request_only"
+              time="1.120"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_leaked_request"
+              time="1.124"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads"
+              name="test_max_pool_size_with_leaked_request_no_rendezvous" time="0.114"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_multiple_request"
+              time="1.146"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request"
+              time="1.122"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_redundant_request2"
+              time="1.136"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads"
+              name="test_max_pool_size_with_redundant_request_no_rendezvous" time="0.120"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads"
+              name="test_max_pool_size_with_redundant_request_no_rendezvous2" time="0.119"></testcase>
+    <testcase classname="test.test_pooling.TestMaxPoolSizeThreads" name="test_max_pool_size_with_request"
+              time="1.119"></testcase>
+    <testcase classname="test.test_pooling.TestPoolSocketSharingThreads" name="test_pool" time="10.029"></testcase>
+    <testcase classname="test.test_pooling.TestPoolSocketSharingThreads" name="test_pool_request"
+              time="10.010"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_dead_request_socket_with_max_size"
+              time="0.010"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_dependent_pools" time="0.007"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_disconnect" time="0.152"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_independent_pools" time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_max_pool_size_validation"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_multiple_connections" time="0.011"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_no_disconnect" time="0.314"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_request_socket"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_request_socket_after_check"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_socket"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_removes_dead_socket_after_request"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_reuses_open_socket"
+              time="0.005"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_pool_with_fork" time="0.020"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_primitive_thread" time="0.505"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_request" time="0.016"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_request_with_fork" time="0.031"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_reset_and_request" time="0.007"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_simple_disconnect" time="0.010"></testcase>
+    <testcase classname="test.test_pooling.TestPoolingThreads" name="test_socket_reclamation" time="1.006"></testcase>
+    <testcase classname="test.test_pooling.TestWaitQueueMultipleThreads" name="test_wait_queue_multiple"
+              time="1.007"></testcase>
+    <testcase classname="test.test_pooling.TestWaitQueueMultipleThreads" name="test_wait_queue_multiple_unset"
+              time="1.014"></testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxOpenSocketsGevent" name="test_blocking" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxOpenSocketsGevent" name="test_wait_queue_timeout" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_none" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_connection_failure" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_end_request_only"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_leaked_request"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_leaked_request_no_rendezvous" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_multiple_request"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_redundant_request" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_redundant_request2" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_redundant_request_no_rendezvous" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent"
+              name="test_max_pool_size_with_redundant_request_no_rendezvous2" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestMaxPoolSizeGevent" name="test_max_pool_size_with_request"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolSocketSharingGevent" name="test_pool" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolSocketSharingGevent" name="test_pool_request" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_dead_request_socket_with_max_size"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_dependent_pools" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_disconnect" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_independent_pools" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_max_pool_size_validation" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_multiple_connections" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_no_disconnect" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_request_socket"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent"
+              name="test_pool_removes_dead_request_socket_after_check" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_socket" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_removes_dead_socket_after_request"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_pool_reuses_open_socket" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_request" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_reset_and_request" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_simple_disconnect" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGevent" name="test_socket_reclamation" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGeventSpecial" name="test_greenlet_sockets" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestPoolingGeventSpecial" name="test_greenlet_sockets_with_request"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestUseGreenletsWithoutGevent"
+              name="test_use_greenlets_without_gevent" time="0.000"></testcase>
+    <testcase classname="test.test_pooling_gevent.TestWaitQueueMultipleGevent" name="test_wait_queue_multiple"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pooling_gevent.TestWaitQueueMultipleGevent" name="test_wait_queue_multiple_unset"
+              time="0.000">
+        <skipped type="unittest.case.SkipTest" message="Gevent not installed"><![CDATA[SkipTest: Gevent not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_pymongo.TestPyMongo" name="test_mongo_client_alias" time="0.001"></testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_aggregate" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_aggregate_command_with_out"
+              time="0.005">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_command" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_count" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_create_collection"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_distinct" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_drop_collection"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_group" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_inline_map_reduce"
+              time="0.004">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_map_reduce" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestCommandAndReadPreference" name="test_map_reduce_command"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestMongosConnection" name="test_mongos_connection"
+              time="0.047"></testcase>
+    <testcase classname="test.test_read_preferences.TestMongosConnection"
+              name="test_only_secondary_ok_commands_have_read_prefs" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Only mongos have read_prefs added to the spec"><![CDATA[SkipTest: Only mongos have read_prefs added to the spec
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestMovingAverage" name="test_empty_init" time="0.000"></testcase>
+    <testcase classname="test.test_read_preferences.TestMovingAverage" name="test_moving_average"
+              time="0.000"></testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_latency_validation" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_mode_validation" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_nearest" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary_preferred" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_primary_with_tags" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary_only" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_secondary_preferred" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_read_preferences.TestReadPreferences" name="test_tag_sets_validation" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_alive" time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_auto_reconnect_exception_when_read_preference_is_secondary" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_auto_start_request" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_close" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_connect" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_copy_db" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_database_names" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_disconnect" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_document_class" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_drop_database" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_fork" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_db" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_default_database"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_get_default_database_error"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_get_default_database_with_authsource" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_init_disconnected" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_init_disconnected_with_auth"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_init_disconnected_with_auth_failure" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_interrupt_signal" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_ipv6" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_iteration" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_kill_cursor_explicit_primary"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_kill_cursor_explicit_secondary"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_lazy_auth_raises_operation_failure" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_nested_request" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_network_timeout" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_network_timeout_validation"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_operation_failure_with_request"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_operation_failure_without_request" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_operations" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_pinned_member" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_properties" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_repr" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_request_threads" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_schedule_refresh" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient"
+              name="test_timeout_does_not_mark_member_down" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_tz_aware" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_use_greenlets" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_waitQueueMultiple" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClient" name="test_waitQueueTimeoutMS" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientAgainstStandalone" name="test_connect"
+              time="0.002"></testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientInternalIPs"
+              name="test_connect_with_internal_ips" time="0.000"></testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_find_one"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_insert" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_max_bson_size"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_read_mode_secondary"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_remove" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_save" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnect" name="test_update" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_find_one"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_insert"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_max_bson_size"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_remove"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_save"
+              time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectBadSeeds" name="test_update"
+              time="0.003">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_find_one"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_insert"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_max_bson_size"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_remove"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_save"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientLazyConnectGevent" name="test_update"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetClientMaxWriteBatchSize"
+              name="test_max_write_batch_size" time="0.003"></testcase>
+    <testcase classname="test.test_replica_set_client.TestReplicaSetWireVersion" name="test_wire_version"
+              time="0.011"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSecondaryAdded" name="test_client" time="0.002"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSecondaryAdded" name="test_replica_set_client"
+              time="0.002"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSecondaryBecomesStandalone" name="test_client"
+              time="0.001"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSecondaryBecomesStandalone" name="test_replica_set_client"
+              time="0.002"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSecondaryRemoved" name="test_replica_set_client"
+              time="0.002"></testcase>
+    <testcase classname="test.test_replica_set_reconfig.TestSocketError" name="test_socket_error_marks_member_down"
+              time="0.001"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_copying" time="0.001"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_ordered_dict" time="0.000"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_pickle" time="0.001"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_pickle_backwards_compatability" time="0.000"></testcase>
+    <testcase classname="test.test_son.TestSON" name="test_to_dict" time="0.000"></testcase>
+    <testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_basic" time="0.452"></testcase>
+    <testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_id_injection" time="0.381"></testcase>
+    <testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_id_shuffling" time="0.127"></testcase>
+    <testcase classname="test.test_son_manipulator.TestSONManipulator" name="test_ns_injection" time="0.416"></testcase>
+    <testcase classname="test.test_ssl.TestClientSSL" name="test_config_ssl" time="0.001"></testcase>
+    <testcase classname="test.test_ssl.TestClientSSL" name="test_no_ssl_module" time="0.000">
+        <skipped type="unittest.case.SkipTest"
+                 message="The ssl module is available, can't test what happens without it."><![CDATA[SkipTest: The ssl module is available, can't test what happens without it.
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_implicitly_set" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation_hostname_fail" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_cert_ssl_validation_optional" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_mongodb_x509_auth" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No mongod available over SSL with certs"><![CDATA[SkipTest: No mongod available over SSL with certs
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_ssl.TestSSL" name="test_simple_ssl" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="No simple mongod available over SSL"><![CDATA[SkipTest: No simple mongod available over SSL
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_thread_util.TestCounter" name="test_greenlet_counter" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="greenlet not installed"><![CDATA[SkipTest: greenlet not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_thread_util.TestCounter" name="test_thread_counter" time="0.003"></testcase>
+    <testcase classname="test.test_thread_util.TestGreenletIdent" name="test_unwatch_cleans_up" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="need Gevent"><![CDATA[SkipTest: need Gevent
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_thread_util.TestIdent" name="test_greenlet_ident" time="0.000">
+        <skipped type="unittest.case.SkipTest" message="greenlet not installed"><![CDATA[SkipTest: greenlet not installed
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_thread_util.TestIdent" name="test_thread_ident" time="0.001"></testcase>
+    <testcase classname="test.test_threads.TestThreads" name="test_safe_insert" time="1.002"></testcase>
+    <testcase classname="test.test_threads.TestThreads" name="test_safe_update" time="1.032"></testcase>
+    <testcase classname="test.test_threads.TestThreads" name="test_server_disconnect" time="0.019"></testcase>
+    <testcase classname="test.test_threads.TestThreads" name="test_threading" time="0.529"></testcase>
+    <testcase classname="test.test_threads.TestThreadsAuth" name="test_auto_auth_login" time="0.002">
+        <skipped type="unittest.case.SkipTest" message="Authentication is not enabled on server"><![CDATA[SkipTest: Authentication is not enabled on server
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_threads_replica_set_client.TestThreadsAuthReplicaSet" name="test_auto_auth_login"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_safe_insert"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_safe_update"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_server_disconnect"
+              time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_threads_replica_set_client.TestThreadsReplicaSet" name="test_threading" time="0.001">
+        <skipped type="unittest.case.SkipTest" message="Not connected to a replica set"><![CDATA[SkipTest: Not connected to a replica set
+]]></skipped>
+    </testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_datetime" time="0.000"></testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_datetime_copy_pickle" time="0.001"></testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_equality" time="0.000"></testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_exceptions" time="0.000"></testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_repr" time="0.000"></testcase>
+    <testcase classname="test.test_timestamp.TestTimestamp" name="test_timestamp" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_parse_uri" time="0.001"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_parse_uri_unicode" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_partition" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_rpartition" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_split_hosts" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_split_options" time="0.000"></testcase>
+    <testcase classname="test.test_uri_parser.TestURI" name="test_validate_userinfo" time="0.000"></testcase>
+    <system-out>sysout-suite</system-out>
+    <system-err>syserr-suite</system-err>
+</testsuite>

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-04-10"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-04-07"
+	AgentVersion = "2023-04-12"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-19262

### Description
Added some `SysOut` and `SysErr` fields to test cases for `attach.xunit_results`, similarly to how we do it for test suites.

The large line change diff comes from me doing a (Cmd + L) file reformat in Goland IDE because the file was hard to read.
### Testing
Confirmed sysout and syserr are showing up in logs for test cases in staging now. Added unit tests
### Documentation
n/a