### PR TITLE
EVG-14306, EVG-19287: Apply mutli sort logic to test resolvers and set HasCedarResults field in the API task model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20211025143051-a8d91b2e29fd
-	github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5
+	github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78
 	github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5
 	github.com/google/go-github/v34 v34.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826/go.mod h1:SnQ9F63VSR6kHbC4aFE+f7+iL3yANhjaN9TT9T4skao=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5 h1:yutavb2qdofFkOGefKjj8dKX0W9SuOKoY5wuzQRYPXg=
 github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
+github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78 h1:Q1HuesKSJFqxNVZoIzQRRc/yha8cYVt2W7ke62hvt9I=
+github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220302150552-3f7a1a268ea7/go.mod h1:EXIwZ5mlP/g0UrWPWX7oRTKQ8nD/ghE3lPCKQ8JMjbk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,6 @@ github.com/evergreen-ci/shrub v0.0.0-20211025143051-a8d91b2e29fd h1:ZTiko2itvbnM
 github.com/evergreen-ci/shrub v0.0.0-20211025143051-a8d91b2e29fd/go.mod h1:UTWsClgKujHCHUovGzTTRW5i5HPWo5Ie/PTeODAkcjo=
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1k9SExkF87VTess4JVR7Uvwr8AAKzJ864=
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826/go.mod h1:SnQ9F63VSR6kHbC4aFE+f7+iL3yANhjaN9TT9T4skao=
-github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5 h1:yutavb2qdofFkOGefKjj8dKX0W9SuOKoY5wuzQRYPXg=
-github.com/evergreen-ci/timber v0.0.0-20230210160503-ba8cf383fac5/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
 github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78 h1:Q1HuesKSJFqxNVZoIzQRRc/yha8cYVt2W7ke62hvt9I=
 github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -597,35 +597,38 @@ func (r *queryResolver) TaskTests(ctx context.Context, taskID string, execution 
 	if sortCategory != nil {
 		switch *sortCategory {
 		case TestSortCategoryStatus:
-			sortBy = testresult.SortByStatus
+			sortBy = testresult.SortByStatusKey
 		case TestSortCategoryDuration:
-			sortBy = testresult.SortByDuration
+			sortBy = testresult.SortByDurationKey
 		case TestSortCategoryTestName:
-			sortBy = testresult.SortByTestName
+			sortBy = testresult.SortByTestNameKey
 		case TestSortCategoryStartTime:
-			sortBy = testresult.SortByStart
+			sortBy = testresult.SortByStartKey
 		case TestSortCategoryBaseStatus:
 			if len(baseTaskOpts) > 0 {
 				// Only sort by base status if we know there
 				// are base task options we can send to the
 				// results service.
-				sortBy = testresult.SortByBaseStatus
+				sortBy = testresult.SortByBaseStatusKey
 			}
 		}
+	}
+	var sort []testresult.SortBy
+	if sortBy != "" {
+		sort = []testresult.SortBy{{Key: sortBy, OrderDSC: sortDirection != nil && *sortDirection == SortDirectionDesc}}
 	}
 
 	taskResults, err := dbTask.GetTestResults(
 		ctx,
 		evergreen.GetEnvironment(),
 		&testresult.FilterOptions{
-			TestName:     utility.FromStringPtr(testName),
-			Statuses:     statuses,
-			GroupID:      utility.FromStringPtr(groupID),
-			SortBy:       sortBy,
-			SortOrderDSC: sortDirection != nil && *sortDirection == SortDirectionDesc,
-			Limit:        utility.FromIntPtr(limit),
-			Page:         utility.FromIntPtr(page),
-			BaseTasks:    baseTaskOpts,
+			TestName:  utility.FromStringPtr(testName),
+			Statuses:  statuses,
+			GroupID:   utility.FromStringPtr(groupID),
+			Sort:      sort,
+			Limit:     utility.FromIntPtr(limit),
+			Page:      utility.FromIntPtr(page),
+			BaseTasks: baseTaskOpts,
 		},
 	)
 	if err != nil {

--- a/model/testresult/cedar_service.go
+++ b/model/testresult/cedar_service.go
@@ -121,6 +121,13 @@ func (s *cedarService) convertOpts(taskOpts []TaskOptions, filterOpts *FilterOpt
 
 	var cedarFilterOpts *testresults.FilterOptions
 	if filterOpts != nil {
+		var sort []testresults.SortBy
+		for _, sortBy := range filterOpts.Sort {
+			sort = append(sort, testresults.SortBy{
+				Key:      sortBy.Key,
+				OrderDSC: sortBy.OrderDSC,
+			})
+		}
 		var baseTasks []testresults.TaskOptions
 		for _, task := range filterOpts.BaseTasks {
 			baseTasks = append(baseTasks, testresults.TaskOptions{
@@ -128,16 +135,14 @@ func (s *cedarService) convertOpts(taskOpts []TaskOptions, filterOpts *FilterOpt
 				Execution: task.Execution,
 			})
 		}
-
 		cedarFilterOpts = &testresults.FilterOptions{
-			TestName:     filterOpts.TestName,
-			Statuses:     filterOpts.Statuses,
-			GroupID:      filterOpts.GroupID,
-			SortBy:       filterOpts.SortBy,
-			SortOrderDSC: filterOpts.SortOrderDSC,
-			Limit:        filterOpts.Limit,
-			Page:         filterOpts.Page,
-			BaseTasks:    baseTasks,
+			TestName:  filterOpts.TestName,
+			Statuses:  filterOpts.Statuses,
+			GroupID:   filterOpts.GroupID,
+			Sort:      sort,
+			Limit:     filterOpts.Limit,
+			Page:      filterOpts.Page,
+			BaseTasks: baseTasks,
 		}
 	}
 

--- a/model/testresult/local_service.go
+++ b/model/testresult/local_service.go
@@ -221,7 +221,7 @@ func (s *localService) filterAndSortTestResults(ctx context.Context, results []T
 func (s *localService) validateFilterOptions(opts *FilterOptions) error {
 	catcher := grip.NewBasicCatcher()
 
-	seenSortByKeys := map[string]int{}
+	seenSortByKeys := map[string]bool{}
 	for _, sortBy := range opts.Sort {
 		switch sortBy.Key {
 		case SortByStartKey, SortByDurationKey, SortByTestNameKey, SortByStatusKey, SortByBaseStatusKey, "":
@@ -230,13 +230,13 @@ func (s *localService) validateFilterOptions(opts *FilterOptions) error {
 			continue
 		}
 
-		if seenSortByKeys[sortBy.Key] == 1 {
+		if seenSortByKeys[sortBy.Key] {
 			catcher.Errorf("duplicate sort by key '%s'", sortBy.Key)
 		} else {
 			catcher.NewWhen(sortBy.Key == SortByBaseStatusKey && len(opts.BaseTasks) == 0, "must specify base task ID when sorting by base status")
 		}
 
-		seenSortByKeys[sortBy.Key] += 1
+		seenSortByKeys[sortBy.Key] = true
 	}
 
 	catcher.NewWhen(opts.Limit < 0, "limit cannot be negative")

--- a/model/testresult/local_service.go
+++ b/model/testresult/local_service.go
@@ -221,11 +221,24 @@ func (s *localService) filterAndSortTestResults(ctx context.Context, results []T
 func (s *localService) validateFilterOptions(opts *FilterOptions) error {
 	catcher := grip.NewBasicCatcher()
 
-	switch opts.SortBy {
-	case SortByStart, SortByDuration, SortByTestName, SortByStatus, SortByBaseStatus, "":
-	default:
-		catcher.Errorf("unrecognized sort by criteria '%s'", opts.SortBy)
+	seenSortByKeys := map[string]int{}
+	for _, sortBy := range opts.Sort {
+		switch sortBy.Key {
+		case SortByStartKey, SortByDurationKey, SortByTestNameKey, SortByStatusKey, SortByBaseStatusKey, "":
+		default:
+			catcher.Errorf("unrecognized sort by key '%s'", sortBy.Key)
+			continue
+		}
+
+		if seenSortByKeys[sortBy.Key] == 1 {
+			catcher.Errorf("duplicate sort by key '%s'", sortBy.Key)
+		} else {
+			catcher.NewWhen(sortBy.Key == SortByBaseStatusKey && len(opts.BaseTasks) == 0, "must specify base task ID when sorting by base status")
+		}
+
+		seenSortByKeys[sortBy.Key] += 1
 	}
+
 	catcher.NewWhen(opts.Limit < 0, "limit cannot be negative")
 	catcher.NewWhen(opts.Page < 0, "page cannot be negative")
 	catcher.NewWhen(opts.Limit == 0 && opts.Page > 0, "cannot specify a page without a limit")
@@ -266,44 +279,52 @@ func (s *localService) filterTestResults(results []TestResult, opts *FilterOptio
 }
 
 func (s *localService) sortTestResults(results []TestResult, opts *FilterOptions, baseStatusMap map[string]string) {
-	switch opts.SortBy {
-	case SortByStart:
-		sort.SliceStable(results, func(i, j int) bool {
-			if opts.SortOrderDSC {
-				return results[i].TestStartTime.After(results[j].TestStartTime)
+	sort.SliceStable(results, func(i, j int) bool {
+		for _, sortBy := range opts.Sort {
+			switch sortBy.Key {
+			case SortByStartKey:
+				if results[i].TestStartTime == results[j].TestStartTime {
+					continue
+				}
+				if sortBy.OrderDSC {
+					return results[i].TestStartTime.After(results[j].TestStartTime)
+				}
+				return results[i].TestStartTime.Before(results[j].TestStartTime)
+			case SortByDurationKey:
+				if results[i].Duration() == results[j].Duration() {
+					continue
+				}
+				if sortBy.OrderDSC {
+					return results[i].Duration() > results[j].Duration()
+				}
+				return results[i].Duration() < results[j].Duration()
+			case SortByTestNameKey:
+				if results[i].GetDisplayTestName() == results[j].GetDisplayTestName() {
+					continue
+				}
+				if sortBy.OrderDSC {
+					return results[i].GetDisplayTestName() > results[j].GetDisplayTestName()
+				}
+				return results[i].GetDisplayTestName() < results[j].GetDisplayTestName()
+			case SortByStatusKey:
+				if results[i].Status == results[j].Status {
+					continue
+				}
+				if sortBy.OrderDSC {
+					return results[i].Status > results[j].Status
+				}
+				return results[i].Status < results[j].Status
+			case SortByBaseStatusKey:
+				if baseStatusMap[results[i].GetDisplayTestName()] == baseStatusMap[results[j].GetDisplayTestName()] {
+					continue
+				}
+				if sortBy.OrderDSC {
+					return baseStatusMap[results[i].GetDisplayTestName()] > baseStatusMap[results[j].GetDisplayTestName()]
+				}
+				return baseStatusMap[results[i].GetDisplayTestName()] < baseStatusMap[results[j].GetDisplayTestName()]
 			}
-			return results[i].TestStartTime.Before(results[j].TestStartTime)
-		})
-	case SortByDuration:
-		sort.SliceStable(results, func(i, j int) bool {
-			if opts.SortOrderDSC {
-				return results[i].Duration() > results[j].Duration()
-			}
-			return results[i].Duration() < results[j].Duration()
-		})
-	case SortByTestName:
-		sort.SliceStable(results, func(i, j int) bool {
-			if opts.SortOrderDSC {
-				return results[i].GetDisplayTestName() > results[j].GetDisplayTestName()
-			}
-			return results[i].GetDisplayTestName() < results[j].GetDisplayTestName()
-		})
-	case SortByStatus:
-		sort.SliceStable(results, func(i, j int) bool {
-			if opts.SortOrderDSC {
-				return results[i].Status > results[j].Status
-			}
-			return results[i].Status < results[j].Status
-		})
-	case SortByBaseStatus:
-		if len(baseStatusMap) == 0 {
-			break
 		}
-		sort.SliceStable(results, func(i, j int) bool {
-			if opts.SortOrderDSC {
-				return baseStatusMap[results[i].GetDisplayTestName()] > baseStatusMap[results[j].GetDisplayTestName()]
-			}
-			return baseStatusMap[results[i].GetDisplayTestName()] < baseStatusMap[results[j].GetDisplayTestName()]
-		})
-	}
+
+		return false
+	})
 }

--- a/model/testresult/local_service_test.go
+++ b/model/testresult/local_service_test.go
@@ -301,8 +301,31 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		hasErr          bool
 	}{
 		{
-			name:   "InvalidSortBy",
-			opts:   &FilterOptions{SortBy: "invalid"},
+			name: "InvalidSortByKey",
+			opts: &FilterOptions{
+				Sort: []SortBy{
+					{Key: SortByTestNameKey},
+					{Key: "invalid"},
+				},
+			},
+			hasErr: true,
+		},
+		{
+			name: "DuplicateSortByKey",
+			opts: &FilterOptions{
+				Sort: []SortBy{
+					{Key: SortByTestNameKey},
+					{Key: SortByStatusKey},
+					{Key: SortByTestNameKey},
+				},
+			},
+			hasErr: true,
+		},
+		{
+			name: "SortByBaseStatusWithoutBaseTasksFindOptions",
+			opts: &FilterOptions{
+				Sort: []SortBy{{Key: SortByBaseStatusKey}},
+			},
 			hasErr: true,
 		},
 		{
@@ -369,7 +392,9 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByDurationASC",
-			opts: &FilterOptions{SortBy: SortByDuration},
+			opts: &FilterOptions{
+				Sort: []SortBy{{Key: SortByDurationKey}},
+			},
 			expectedResults: []TestResult{
 				results[3],
 				results[0],
@@ -381,8 +406,12 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByDurationDSC",
 			opts: &FilterOptions{
-				SortBy:       SortByDuration,
-				SortOrderDSC: true,
+				Sort: []SortBy{
+					{
+						Key:      SortByDurationKey,
+						OrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[1],
@@ -394,7 +423,9 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByTestNameASC",
-			opts: &FilterOptions{SortBy: SortByTestName},
+			opts: &FilterOptions{
+				Sort: []SortBy{{Key: SortByTestNameKey}},
+			},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -406,8 +437,12 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByTestNameDCS",
 			opts: &FilterOptions{
-				SortBy:       SortByTestName,
-				SortOrderDSC: true,
+				Sort: []SortBy{
+					{
+						Key:      SortByTestNameKey,
+						OrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[1],
@@ -419,7 +454,9 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByStatusASC",
-			opts: &FilterOptions{SortBy: SortByStatus},
+			opts: &FilterOptions{
+				Sort: []SortBy{{Key: SortByStatusKey}},
+			},
 			expectedResults: []TestResult{
 				results[1],
 				results[2],
@@ -431,8 +468,12 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByStatusDSC",
 			opts: &FilterOptions{
-				SortBy:       SortByStatus,
-				SortOrderDSC: true,
+				Sort: []SortBy{
+					{
+						Key:      SortByStatusKey,
+						OrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[0],
@@ -444,7 +485,9 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "SortByStartTimeASC",
-			opts: &FilterOptions{SortBy: SortByStart},
+			opts: &FilterOptions{
+				Sort: []SortBy{{Key: SortByStartKey}},
+			},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -454,10 +497,14 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 			expectedCount: 4,
 		},
 		{
-			name: "SortByStartTimeDCS",
+			name: "SortByStartTimeDSC",
 			opts: &FilterOptions{
-				SortBy:       SortByStart,
-				SortOrderDSC: true,
+				Sort: []SortBy{
+					{
+						Key:      SortByStartKey,
+						OrderDSC: true,
+					},
+				},
 			},
 			expectedResults: []TestResult{
 				results[3],
@@ -470,7 +517,7 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByBaseStatusASC",
 			opts: &FilterOptions{
-				SortBy:    SortByBaseStatus,
+				Sort:      []SortBy{{Key: SortByBaseStatusKey}},
 				BaseTasks: []TaskOptions{{TaskID: baseTaskID}},
 			},
 			expectedResults: []TestResult{
@@ -484,15 +531,40 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "SortByBaseStatusDSC",
 			opts: &FilterOptions{
-				SortBy:       SortByBaseStatus,
-				SortOrderDSC: true,
-				BaseTasks:    []TaskOptions{{TaskID: baseTaskID}},
+				Sort: []SortBy{
+					{
+						Key:      SortByBaseStatusKey,
+						OrderDSC: true,
+					},
+				},
+				BaseTasks: []TaskOptions{{TaskID: baseTaskID}},
 			},
 			expectedResults: []TestResult{
 				resultsWithBaseStatus[0],
 				resultsWithBaseStatus[2],
 				resultsWithBaseStatus[1],
 				resultsWithBaseStatus[3],
+			},
+			expectedCount: 4,
+		},
+		{
+			name: "MultiSort",
+			opts: &FilterOptions{
+				Sort: []SortBy{
+					{
+						Key: SortByStatusKey,
+					},
+					{
+						Key:      SortByTestNameKey,
+						OrderDSC: true,
+					},
+				},
+			},
+			expectedResults: []TestResult{
+				results[1],
+				results[2],
+				results[3],
+				results[0],
 			},
 			expectedCount: 4,
 		},

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -283,23 +283,28 @@ type TaskOptions struct {
 	ResultsService string
 }
 
-// FilterOptions represents the filtering arguments for fetching test results.
-type FilterOptions struct {
-	TestName     string
-	Statuses     []string
-	GroupID      string
-	SortBy       string
-	SortOrderDSC bool
-	Limit        int
-	Page         int
-	BaseTasks    []TaskOptions
+// SortBy describes the properties by which to sort a set of test results.
+type SortBy struct {
+	Key      string
+	OrderDSC bool
 }
 
 // Valid sort by keys.
 const (
-	SortByStart      = "start"
-	SortByDuration   = "duration"
-	SortByTestName   = "test_name"
-	SortByStatus     = "status"
-	SortByBaseStatus = "base_status"
+	SortByStartKey      = "start"
+	SortByDurationKey   = "duration"
+	SortByTestNameKey   = "test_name"
+	SortByStatusKey     = "status"
+	SortByBaseStatusKey = "base_status"
 )
+
+// FilterOptions represents the filtering arguments for fetching test results.
+type FilterOptions struct {
+	TestName  string
+	Statuses  []string
+	GroupID   string
+	Sort      []SortBy
+	Limit     int
+	Page      int
+	BaseTasks []TaskOptions
+}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -87,8 +87,9 @@ type APITask struct {
 	// via Evergreen's user-facing API.
 	OverrideDependencies bool   `json:"-"`
 	Archived             bool   `json:"archived"`
-	ResultsFailed        bool   `json:"-"`
 	ResultsService       string `json:"-"`
+	HasCedarResults      bool   `json"-"`
+	ResultsFailed        bool   `json:"-"`
 }
 
 type APIAbortInfo struct {
@@ -232,8 +233,9 @@ func (at *APITask) buildTask(t *task.Task) error {
 		Requester:                   utility.ToStringPtr(t.Requester),
 		Aborted:                     t.Aborted,
 		CanSync:                     t.CanSync,
-		ResultsFailed:               t.ResultsFailed,
 		ResultsService:              t.ResultsService,
+		HasCedarResults:             t.HasCedarResults,
+		ResultsFailed:               t.ResultsFailed,
 		MustHaveResults:             t.MustHaveResults,
 		ResetWhenFinished:           t.ResetWhenFinished,
 		ParentTaskId:                utility.FromStringPtr(t.DisplayTaskId),
@@ -419,8 +421,9 @@ func (at *APITask) ToService() (*task.Task, error) {
 		DisplayOnly:                 at.DisplayOnly,
 		Requester:                   utility.FromStringPtr(at.Requester),
 		CanSync:                     at.CanSync,
-		ResultsFailed:               at.ResultsFailed,
 		ResultsService:              at.ResultsService,
+		HasCedarResults:             at.HasCedarResults,
+		ResultsFailed:               at.ResultsFailed,
 		MustHaveResults:             at.MustHaveResults,
 		SyncAtEndOpts: task.SyncAtEndOptions{
 			Enabled:  at.SyncAtEndOpts.Enabled,

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -88,7 +88,7 @@ type APITask struct {
 	OverrideDependencies bool   `json:"-"`
 	Archived             bool   `json:"archived"`
 	ResultsService       string `json:"-"`
-	HasCedarResults      bool   `json"-"`
+	HasCedarResults      bool   `json:"-"`
 	ResultsFailed        bool   `json:"-"`
 }
 


### PR DESCRIPTION
EVG-14306, EVG-19287

### Description
- Update timber and the test results interface to enable multi sort logic
- Apply multi sort logic to the Task.tests resolver
- Add the legacy `HasCedarResults` field to the API task model to fix the bug in the Task.tests resolver where older tasks using said field would not return tasks. 

### Testing
Added unit tests and tested that single sort logic works in staging. I confirmed using the graphql playground that the Task.tests resolver returns tests for older tasks using the `HasCedarResults` field.

### Documentation
N/A
