### PR TITLE
EVG-19620: fix archived task test result fetching

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2518,6 +2518,11 @@ func (t *Task) GetTestResults(ctx context.Context, env evergreen.Environment, fi
 	if err != nil {
 		return testresult.TaskTestResults{}, errors.Wrap(err, "creating test results task options")
 	}
+	grip.Info(message.Fields{
+		"name":        "julian:",
+		"has_results": t.HasResults(),
+		"task_opts":   taskOpts,
+	})
 	if len(taskOpts) == 0 {
 		return testresult.TaskTestResults{}, nil
 	}
@@ -2591,8 +2596,12 @@ func (t *Task) CreateTestResultsTaskOptions() ([]testresult.TaskOptions, error) 
 			})
 		}
 	} else if t.HasResults() {
+		taskID := t.Id
+		if t.Archived {
+			taskID = t.OldTaskId
+		}
 		taskOpts = append(taskOpts, testresult.TaskOptions{
-			TaskID:         t.Id,
+			TaskID:         taskID,
 			Execution:      t.Execution,
 			ResultsService: t.ResultsService,
 		})

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2518,11 +2518,6 @@ func (t *Task) GetTestResults(ctx context.Context, env evergreen.Environment, fi
 	if err != nil {
 		return testresult.TaskTestResults{}, errors.Wrap(err, "creating test results task options")
 	}
-	grip.Info(message.Fields{
-		"name":        "julian:",
-		"has_results": t.HasResults(),
-		"task_opts":   taskOpts,
-	})
 	if len(taskOpts) == 0 {
 		return testresult.TaskTestResults{}, nil
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3838,6 +3838,17 @@ func TestCreateTestResultsTaskOptions(t *testing.T) {
 			tsk:  &Task{Id: "task"},
 		},
 		{
+			name: "RegularTaskResultsLegacyCedarResultsFlag",
+			tsk: &Task{
+				Id:              "task",
+				Execution:       1,
+				HasCedarResults: true,
+			},
+			expectedOpts: []testresult.TaskOptions{
+				{TaskID: "task", Execution: 1},
+			},
+		},
+		{
 			name: "RegularTaskResults",
 			tsk: &Task{
 				Id:             "task",
@@ -3846,6 +3857,33 @@ func TestCreateTestResultsTaskOptions(t *testing.T) {
 			},
 			expectedOpts: []testresult.TaskOptions{
 				{TaskID: "task", Execution: 1, ResultsService: "some_service"},
+			},
+		},
+		{
+
+			name: "ArchivedRegularTaskResultsLegacyCedarResultsFlags",
+			tsk: &Task{
+				Id:              "task_0",
+				OldTaskId:       "task",
+				Execution:       0,
+				HasCedarResults: true,
+				Archived:        true,
+			},
+			expectedOpts: []testresult.TaskOptions{
+				{TaskID: "task", Execution: 0},
+			},
+		},
+		{
+			name: "ArchivedRegularTaskResults",
+			tsk: &Task{
+				Id:             "task_0",
+				OldTaskId:      "task",
+				Execution:      0,
+				ResultsService: "some_service",
+				Archived:       true,
+			},
+			expectedOpts: []testresult.TaskOptions{
+				{TaskID: "task", Execution: 0, ResultsService: "some_service"},
 			},
 		},
 		{


### PR DESCRIPTION
EVG-19620

### Description
When creating the `testresult.TaskOptions` make sure we are using the `OldTaskID` field for archived tasks.

### Testing
Added more unit tests and tested in staging. 

### Documentation
N/A
