### PR TITLE
EVG-19293 remove logging average historic runtime from end stats

### DIFF
--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -11,9 +11,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// this is about a month.
-const oneMonthIsh = 30 * 24 * time.Hour
-
 var DurationIndex = bson.D{
 	{Key: ProjectKey, Value: 1},
 	{Key: BuildVariantKey, Value: 1},

--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -29,7 +29,7 @@ type expectedDurationResults struct {
 	StdDev           float64 `bson:"std_dev"`
 }
 
-func getExpectedDurationsForWindow(name, project, buildVariant string, start, end time.Time, withStdDev bool) ([]expectedDurationResults, error) {
+func getExpectedDurationsForWindow(name, project, buildVariant string, start, end time.Time) ([]expectedDurationResults, error) {
 	match := bson.M{
 		BuildVariantKey: buildVariant,
 		ProjectKey:      project,
@@ -51,17 +51,6 @@ func getExpectedDurationsForWindow(name, project, buildVariant string, start, en
 		match[DisplayNameKey] = name
 	}
 
-	group := bson.M{
-		"_id": fmt.Sprintf("$%s", DisplayNameKey),
-		"exp_dur": bson.M{
-			"$avg": fmt.Sprintf("$%s", TimeTakenKey),
-		},
-	}
-	if withStdDev {
-		group["std_dev"] = bson.M{
-			"$stdDevPop": fmt.Sprintf("$%s", TimeTakenKey),
-		}
-	}
 	pipeline := []bson.M{
 		{
 			"$match": match,
@@ -74,7 +63,15 @@ func getExpectedDurationsForWindow(name, project, buildVariant string, start, en
 			},
 		},
 		{
-			"$group": group,
+			"$group": bson.M{
+				"_id": fmt.Sprintf("$%s", DisplayNameKey),
+				"exp_dur": bson.M{
+					"$avg": fmt.Sprintf("$%s", TimeTakenKey),
+				},
+				"std_dev": bson.M{
+					"$stdDevPop": fmt.Sprintf("$%s", TimeTakenKey),
+				},
+			},
 		},
 	}
 

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -62,7 +62,7 @@ func TestExpectedDuration(t *testing.T) {
 	}
 	assert.NoError(t4.Insert())
 
-	results, err := getExpectedDurationsForWindow("", project, bv, now.Add(-1*time.Hour), now, true)
+	results, err := getExpectedDurationsForWindow("", project, bv, now.Add(-1*time.Hour), now)
 	assert.NoError(err)
 	assert.EqualValues(25*time.Minute, results[0].ExpectedDuration)
 	assert.InDelta(9.35*float64(time.Minute), results[0].StdDev, 0.01*float64(time.Minute))

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2806,20 +2806,6 @@ func GetAllDependencies(taskIDs []string, taskMap map[string]*Task) ([]Dependenc
 	return deps, nil
 }
 
-func (t *Task) GetHistoricRuntime() (time.Duration, error) {
-	runtimes, err := getExpectedDurationsForWindow(t.DisplayName, t.Project, t.BuildVariant,
-		t.FinishTime.Add(-oneMonthIsh), t.FinishTime.Add(-time.Second), false)
-	if err != nil {
-		return 0, errors.WithStack(err)
-	}
-
-	if len(runtimes) != 1 {
-		return 0, errors.Errorf("expected exactly one task runtime data point, but actually got %d", len(runtimes))
-	}
-
-	return time.Duration(runtimes[0].ExpectedDuration), nil
-}
-
 func (t *Task) FetchExpectedDuration() util.DurationStats {
 	if t.DurationPrediction.TTL == 0 {
 		t.DurationPrediction.TTL = utility.JitterInterval(predictionTTL)
@@ -2845,7 +2831,7 @@ func (t *Task) FetchExpectedDuration() util.DurationStats {
 	refresher := func(previous util.DurationStats) (util.DurationStats, bool) {
 		defaultVal := util.DurationStats{Average: defaultTaskDuration, StdDev: 0}
 		vals, err := getExpectedDurationsForWindow(t.DisplayName, t.Project, t.BuildVariant,
-			time.Now().Add(-taskCompletionEstimateWindow), time.Now(), true)
+			time.Now().Add(-taskCompletionEstimateWindow), time.Now())
 		grip.Notice(message.WrapError(err, message.Fields{
 			"name":      t.DisplayName,
 			"id":        t.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -786,21 +786,12 @@ func logTaskEndStats(t *task.Task) error {
 		msg["container_allocated_time"] = t.ContainerAllocatedTime
 	}
 
-	timeForHistoricRuntime := time.Now()
-	historicRuntime, err := t.GetHistoricRuntime()
-	if err != nil {
-		msg[message.FieldsMsgName] = "problem computing historic runtime"
-		grip.Warning(message.WrapError(err, msg))
-	} else {
-		msg["average_runtime_secs"] = historicRuntime.Seconds()
-		grip.Info(msg)
-	}
+	grip.Info(msg)
 	grip.Debug(message.Fields{
-		"ticket":                         "EVG-19293",
-		"message":                        "ran task-end-stats",
-		"time_taken_ms":                  time.Since(now).Milliseconds(),
-		"time_taken_historic_runtime_ms": time.Since(timeForHistoricRuntime).Milliseconds(),
-		"task":                           t.Id,
+		"ticket":        "EVG-19293",
+		"message":       "ran task-end-stats",
+		"time_taken_ms": time.Since(now).Milliseconds(),
+		"task":          t.Id,
 	})
 	return nil
 }


### PR DESCRIPTION
EVG-19293 
### Description
Removing standard deviation didn't make this computation more expensive. I don't see that dashboards are using it or see an argument that it's worth logging so I think we should drop this to keep EndTask efficient.

