### PR TITLE
EVG-19631: remove fallback logic for inserting parser project during patch finalization

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -484,35 +484,17 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			return nil, err
 		}
 	}
-	// unmarshal the project YAML for storage
-	project := &Project{}
-	projectRef, opts, err := getLoadProjectOptsForPatch(p, githubOauthToken)
+	projectRef, err := FindMergedProjectRef(p.Project, p.Version, true)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching project options for patch")
+		return nil, errors.Wrapf(err, "finding project '%s'", p.Project)
+	}
+	if projectRef == nil {
+		return nil, errors.Errorf("project '%s' not found", p.Project)
 	}
 
-	// It used to be that the parser project was not stored until patches were
-	// finalized. Newer patches always store the parser project when the patch
-	// is created rather than when it's finalized. For backward compatibility
-	// with existing unfinalized patches, the parser project must be inserted
-	// now if an old patch is being finalized.
-	mustInsertParserProjectDuringFinalization := p.PatchedParserProject != ""
-	var intermediateProject *ParserProject
-	// TODO (EVG-18700): this if-else most likely is equivalent to just calling
-	// FindAndTranslateProjectForPatch. Try removing the if block in a follow-up
-	// commit.
-	if mustInsertParserProjectDuringFinalization {
-		intermediateProject, err = LoadProjectInto(ctx, []byte(p.PatchedParserProject), opts, p.Project, project)
-		if err != nil {
-			return nil, errors.Wrapf(err,
-				"marshalling patched parser project from repository revision '%s'",
-				p.Githash)
-		}
-	} else {
-		project, intermediateProject, err = FindAndTranslateProjectForPatch(ctx, settings, p)
-		if err != nil {
-			return nil, errors.Wrapf(err, "finding and translating project for patch '%s'", p.Id.Hex())
-		}
+	project, intermediateProject, err := FindAndTranslateProjectForPatch(ctx, settings, p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding and translating project for patch '%s'", p.Id.Hex())
 	}
 	var config *ProjectConfig
 	if projectRef.IsVersionControlEnabled() {
@@ -685,14 +667,18 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		)
 	}
 
+	// Newer patches always stored the parser project during patch creation.
+	// However, it used to be that the parser project was not stored until
+	// patches were finalized. For backward compatibility with the old
+	// unfinalized patches, try storing the parser project now that it's
+	// finalizing.
+
 	ppStorageMethod := p.ProjectStorageMethod
 	if ppStorageMethod == "" {
-		// It used to be that the parser project was not stored until patches
-		// were finalized, so for backward compatibility with existing
-		// unfinalized patches, try storing the parser project in in the DB.
 		ppStorageMethod = evergreen.ProjectStorageMethodDB
 	}
-	if mustInsertParserProjectDuringFinalization {
+
+	if p.PatchedParserProject != "" {
 		intermediateProject.Init(p.Id.Hex(), patchVersion.CreateTime)
 		ppStorageMethod, err = ParserProjectUpsertOneWithS3Fallback(ctx, settings, ppStorageMethod, intermediateProject)
 		if err != nil {


### PR DESCRIPTION
EVG-19631

### Description
I forgot to remove a piece of code as part of EVG-18700. It should be safe to remove, since the if block is redundant.

### Testing
Existing unit tests pass and submitted a patch in staging to double check that things are working.

### Documentation
N/A