### PR TITLE
EVG-19630 Update correct child patch status to github

### DIFF
--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -191,7 +191,9 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		projectName = utility.FromStringPtr(api.ProjectIdentifier)
 	}
 
-	collectiveStatus := t.patch.Status
+	// For parent patches, we want to look at the collective status of the child patches.
+	// For child patches, we only want to look at its own status.
+	collectiveStatus := t.data.Status
 	if t.patch.IsParent() {
 		var err error
 		collectiveStatus, err = t.patch.CollectiveStatus()

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -191,8 +191,8 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		projectName = utility.FromStringPtr(api.ProjectIdentifier)
 	}
 
-	// For parent patches, we want to look at the collective status of the child patches.
-	// For child patches, we only want to look at its own status.
+	// For child patches, we only want to look at its own status because the collective status will be affected
+	// by other child patches' and the parent's status
 	collectiveStatus := t.data.Status
 	if t.patch.IsParent() {
 		var err error

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -190,10 +190,16 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 	if api.ProjectIdentifier != nil {
 		projectName = utility.FromStringPtr(api.ProjectIdentifier)
 	}
-	collectiveStatus, err := patch.CollectiveStatus(t.patch.Id.Hex())
-	if err != nil {
-		return nil, errors.Wrap(err, "getting collective status for patch")
+
+	collectiveStatus := t.patch.Status
+	if t.patch.IsParent() {
+		var err error
+		collectiveStatus, err = t.patch.CollectiveStatus()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting collective patch status for patch '%s'", t.patch.Id)
+		}
 	}
+
 	grip.NoticeWhen(collectiveStatus != t.data.Status, message.Fields{
 		"message":                 "patch's current collective status does not match the patch event data's status",
 		"patch_collective_status": collectiveStatus,

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -111,6 +111,7 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 	status := t.data.Status
 	if evergreen.IsPatchRequester(t.version.Requester) {
 		var err error
+		// Look at collective status because we don't know whether the last patch to finish in the version was a child or a parent.
 		status, err = patch.CollectiveStatus(t.version.Id)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting collective status for patch")


### PR DESCRIPTION
EVG-19630

### Description
child patch statuses were not updating correctly on gituhb because we were passing in a collective status instead 
updated to pass in the correct status

### Testing
staging sandbox pr updates statuses correctly 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/467

![image](https://user-images.githubusercontent.com/26491602/232827444-a446d643-603b-47a7-a85e-64d809ba8755.png)

