### PR TITLE
EVG-19334: delete host ID field from volume attachment

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -78,7 +78,7 @@ type Manager interface {
 	ModifyVolume(context.Context, *host.Volume, *model.VolumeModifyOptions) error
 
 	// GetVolumeAttachment gets a volume's attachment
-	GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error)
+	GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error)
 
 	// CheckInstanceType determines if the given instance type is available in the current region.
 	CheckInstanceType(context.Context, string) error
@@ -252,4 +252,11 @@ func ConvertContainerManager(m Manager) (ContainerManager, error) {
 		return cm, nil
 	}
 	return nil, errors.Errorf("programmer error: cannot convert manager %T to container manager", m)
+}
+
+// VolumeAttachment contains information about a volume attached to a host.
+type VolumeAttachment struct {
+	VolumeID   string
+	HostID     string
+	DeviceName string
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -235,7 +235,7 @@ func (m *dockerManager) ModifyVolume(context.Context, *host.Volume, *model.Volum
 	return errors.New("can't modify volume with Docker provider")
 }
 
-func (m *dockerManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *dockerManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with Docker provider")
 }
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1539,7 +1539,7 @@ func (m *ec2Manager) DeleteVolume(ctx context.Context, volume *host.Volume) erro
 	return errors.Wrapf(volume.Remove(), "deleting volume '%s' in DB", volume.ID)
 }
 
-func (m *ec2Manager) GetVolumeAttachment(ctx context.Context, volumeID string) (*host.VolumeAttachment, error) {
+func (m *ec2Manager) GetVolumeAttachment(ctx context.Context, volumeID string) (*VolumeAttachment, error) {
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
@@ -1569,7 +1569,7 @@ func (m *ec2Manager) GetVolumeAttachment(ctx context.Context, volumeID string) (
 		return nil, errors.Errorf("AWS returned an invalid volume attachment %+v", ec2Attachment)
 	}
 
-	attachment := &host.VolumeAttachment{
+	attachment := &VolumeAttachment{
 		VolumeID:   *ec2Attachment.VolumeId,
 		DeviceName: *ec2Attachment.Device,
 		HostID:     *ec2Attachment.InstanceId,

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -416,7 +416,7 @@ func (m *ec2FleetManager) ModifyVolume(context.Context, *host.Volume, *model.Vol
 	return errors.New("can't modify volume with EC2 fleet provider")
 }
 
-func (m *ec2FleetManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *ec2FleetManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with EC2 fleet provider")
 }
 

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -247,7 +247,7 @@ func (m *gceManager) ModifyVolume(context.Context, *host.Volume, *model.VolumeMo
 	return errors.New("can't modify volume with GCE provider")
 }
 
-func (m *gceManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *gceManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with GCE provider")
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -439,7 +439,7 @@ func (m *mockManager) ModifyVolume(ctx context.Context, volume *host.Volume, opt
 	return nil
 }
 
-func (m *mockManager) GetVolumeAttachment(ctx context.Context, volumeID string) (*host.VolumeAttachment, error) {
+func (m *mockManager) GetVolumeAttachment(ctx context.Context, volumeID string) (*VolumeAttachment, error) {
 	l := m.mutex
 	l.Lock()
 	defer l.Unlock()
@@ -447,7 +447,7 @@ func (m *mockManager) GetVolumeAttachment(ctx context.Context, volumeID string) 
 	for id, instance := range m.Instances {
 		for _, device := range instance.BlockDevices {
 			if device == volumeID {
-				return &host.VolumeAttachment{HostID: id, VolumeID: volumeID}, nil
+				return &VolumeAttachment{HostID: id, VolumeID: volumeID}, nil
 			}
 		}
 	}

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -247,7 +247,7 @@ func (m *openStackManager) ModifyVolume(context.Context, *host.Volume, *model.Vo
 	return errors.New("can't modify volume with OpenStack provider")
 }
 
-func (m *openStackManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *openStackManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with OpenStack provider")
 }
 

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -150,7 +150,7 @@ func (m *staticManager) ModifyVolume(context.Context, *host.Volume, *model.Volum
 	return errors.New("can't modify volume with static provider")
 }
 
-func (m *staticManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *staticManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with static provider")
 }
 

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -208,7 +208,7 @@ func (m *vsphereManager) ModifyVolume(context.Context, *host.Volume, *model.Volu
 	return errors.New("can't modify volume with vSphere provider")
 }
 
-func (m *vsphereManager) GetVolumeAttachment(context.Context, string) (*host.VolumeAttachment, error) {
+func (m *vsphereManager) GetVolumeAttachment(context.Context, string) (*VolumeAttachment, error) {
 	return nil, errors.New("can't get volume attachment with vSphere provider")
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -197,7 +197,6 @@ type VolumeAttachment struct {
 	VolumeID   string `bson:"volume_id" json:"volume_id"`
 	DeviceName string `bson:"device_name" json:"device_name"`
 	IsHome     bool   `bson:"is_home" json:"is_home"`
-	HostID     string `bson:"host_id" json:"host_id"`
 }
 
 // PortMap maps container port to the parent host ports (container port is formatted as <port>/<protocol>)


### PR DESCRIPTION
EVG-19334

### Description
Delete the host ID field from the host's volume attachment. The host ID is only used in a single error check and is never persisted in the DB, so it seems like it should just be removed.

* Delete host ID from volume attachment model.
* Change return type in cloud provider so it can still return the host ID for the one error check.

### Testing
It's not used except in one error case, so it only has to compile and pass existing tests.

### Documentation
N/A
