### PR TITLE
EVG-19670 Remove need for setting DEBUG_ENABLED env var for remote debugging

### DIFF
--- a/makefile
+++ b/makefile
@@ -263,7 +263,7 @@ $(clientBuildDir)/%/.signed:$(buildDir)/sign-executable $(clientBuildDir)/%/$(un
 	touch $@
 
 dist-staging:
-	STAGING_ONLY=1 SIGN_MACOS= $(MAKE) dist
+	STAGING_ONLY=1 DEBUG_ENABLED=1 SIGN_MACOS= $(MAKE) dist
 dist-unsigned:
 	SIGN_MACOS= $(MAKE) dist
 dist:$(buildDir)/dist.tar.gz


### PR DESCRIPTION
EVG-19670

### Description
Currently, unless you have DEBUG_ENABLED set on your local environment variables, the staging dist will not compile with the right flags needed for Delve to attach.

Making a makefile change to make this step unnecessary, to make it more convenient to setup remote debugging.

### Testing
Manually tested to confirm.