### PR TITLE
EVG-18876 include commit messages for PR items

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -150,7 +150,7 @@ func writePatchInfo(patchDoc *patch.Patch, patchSummaries []thirdparty.Summary, 
 		PatchSet: patch.PatchSet{
 			PatchFileId:    patchFileID,
 			Summary:        patchSummaries,
-			CommitMessages: []string{patchDoc.GithubPatchData.CommitMessage},
+			CommitMessages: []string{patchDoc.GithubPatchData.CommitTitle},
 		},
 	})
 

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -137,6 +137,7 @@ func getPatchInfo(ctx context.Context, settings *evergreen.Settings, githubToken
 	return patchContent, summaries, config, patchConfig.PatchedParserProject, nil
 }
 
+// writePatchInfo writes a PR patch's contents to gridFS and stores this info with the patch.
 func writePatchInfo(patchDoc *patch.Patch, patchSummaries []thirdparty.Summary, patchContent string) error {
 	patchFileID := fmt.Sprintf("%s_%s", patchDoc.Id.Hex(), patchDoc.Githash)
 	if err := db.WriteGridFile(patch.GridFSPrefix, patchFileID, strings.NewReader(patchContent)); err != nil {
@@ -147,8 +148,9 @@ func writePatchInfo(patchDoc *patch.Patch, patchSummaries []thirdparty.Summary, 
 	patchDoc.Patches = append(patchDoc.Patches, patch.ModulePatch{
 		Githash: patchDoc.Githash,
 		PatchSet: patch.PatchSet{
-			PatchFileId: patchFileID,
-			Summary:     patchSummaries,
+			PatchFileId:    patchFileID,
+			Summary:        patchSummaries,
+			CommitMessages: []string{patchDoc.GithubPatchData.CommitMessage},
 		},
 	})
 

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -334,7 +334,7 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 			Name:      "myfile.go",
 			Additions: 1,
 			Deletions: 0,
-				},
+		},
 	}
 
 	patchContents := `diff --git a/myfile.go b/myfile.go

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -323,15 +323,18 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 	patchDoc := &patch.Patch{
 		Id:      mgobson.ObjectIdHex("aabbccddeeff112233445566"),
 		Githash: "abcdef",
-		GithubPatchData:
+		GithubPatchData: thirdparty.GithubPatch{
+			CommitTitle:   "my title",
+			CommitMessage: "more info",
+		},
 	}
 
 	patchSummaries := []thirdparty.Summary{
-		thirdparty.Summary{
+		{
 			Name:      "myfile.go",
 			Additions: 1,
 			Deletions: 0,
-		},
+				},
 	}
 
 	patchContents := `diff --git a/myfile.go b/myfile.go
@@ -344,8 +347,10 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 	`
 
 	s.NoError(writePatchInfo(patchDoc, patchSummaries, patchContents))
-	s.Len(patchDoc.Patches, 1)
+	s.Require().Len(patchDoc.Patches, 1)
 	s.Equal(patchSummaries, patchDoc.Patches[0].PatchSet.Summary)
+	s.Require().Len(patchDoc.Patches[0].PatchSet.CommitMessages, 1)
+	s.Equal(patchDoc.Patches[0].PatchSet.CommitMessages[0], patchDoc.GithubPatchData.CommitTitle)
 	storedPatchContents, err := patch.FetchPatchContents(patchDoc.Patches[0].PatchSet.PatchFileId)
 	s.NoError(err)
 	s.Equal(patchContents, storedPatchContents)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -323,6 +323,7 @@ func (s *CommitQueueSuite) TestWritePatchInfo() {
 	patchDoc := &patch.Patch{
 		Id:      mgobson.ObjectIdHex("aabbccddeeff112233445566"),
 		Githash: "abcdef",
+		GithubPatchData:
 	}
 
 	patchSummaries := []thirdparty.Summary{


### PR DESCRIPTION
EVG-18876
### Description
For PR CQ items, we create the patch slightly differently such that commit_messages isn't populated. 

### Testing
[tested on staging](https://evergreen-staging.corp.mongodb.com/rest/v2/patches/6440287cb23736ed76eda692) / added to unit test
