### PR TITLE
EVG-19631: remove commit queue merge dependence on patched parser project

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1802,7 +1802,10 @@ func activateExistingInactiveTasks(creationInfo TaskCreationInfo, existingBuilds
 
 func getTaskIdTables(creationInfo TaskCreationInfo) (TaskIdConfig, error) {
 	// The table should include only new and existing tasks
-	taskIdTable := NewPatchTaskIdTable(creationInfo.Project, creationInfo.Version, creationInfo.Pairs, creationInfo.ProjectRef.Identifier)
+	taskIdTable, err := NewPatchTaskIdTable(creationInfo.Project, creationInfo.Version, creationInfo.Pairs, creationInfo.ProjectRef.Identifier)
+	if err != nil {
+		return TaskIdConfig{}, errors.Wrap(err, "creating patch's task ID table")
+	}
 	existingTasks, err := task.FindAll(db.Query(task.ByVersion(creationInfo.Version.Id)).WithFields(task.DisplayOnlyKey, task.DisplayNameKey, task.BuildVariantKey))
 	if err != nil {
 		return TaskIdConfig{}, errors.Wrap(err, "getting existing task IDs")

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -734,7 +734,6 @@ func (p *Patch) UpdateGithashProjectAndTasks() error {
 			GithashKey:              p.Githash,
 			PatchesKey:              p.Patches,
 			ProjectStorageMethodKey: p.ProjectStorageMethod,
-			PatchedParserProjectKey: p.PatchedParserProject,
 			PatchedProjectConfigKey: p.PatchedProjectConfig,
 			VariantsTasksKey:        p.VariantsTasks,
 			BuildVariantsKey:        p.BuildVariants,

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -185,7 +185,6 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 	patch.Patches = []ModulePatch{{Githash: "abcdef"}}
 	patch.Tasks = append(patch.Tasks, "task1")
 	patch.BuildVariants = append(patch.BuildVariants, "bv1")
-	patch.PatchedParserProject = "config"
 	patch.VariantsTasks = []VariantTasks{
 		{
 			Variant: "variant1",
@@ -198,7 +197,6 @@ func (s *patchSuite) TestUpdateGithashProjectAndTasks() {
 	s.NoError(err)
 
 	s.Equal("abcdef", dbPatch.Githash)
-	s.Equal("config", dbPatch.PatchedParserProject)
 
 	s.Require().Len(dbPatch.Patches, 1)
 	s.Equal("abcdef", dbPatch.Patches[0].Githash)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -618,7 +618,10 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if p.IsCommitQueuePatch() && len(p.VariantsTasks) == 0 {
 		return nil, errors.Errorf("no builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)
 	}
-	taskIds := NewPatchTaskIdTable(project, patchVersion, tasks, projectRef.Identifier)
+	taskIds, err := NewPatchTaskIdTable(project, patchVersion, tasks, projectRef.Identifier)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating patch's task ID table")
+	}
 	variantsProcessed := map[string]bool{}
 
 	creationInfo := TaskCreationInfo{

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1255,7 +1255,8 @@ func (s *projectSuite) TestNewPatchTaskIdTable() {
 		},
 	}
 
-	config := NewPatchTaskIdTable(p, v, pairs, "project_identifier")
+	config, err := NewPatchTaskIdTable(p, v, pairs, "project_identifier")
+	s.Require().NoError(err)
 	s.Len(config.DisplayTasks, 0)
 	s.Len(config.ExecutionTasks, 2)
 	s.Equal("project_identifier_test_task1_revision_01_01_01_00_00_00",

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -97,7 +97,8 @@ func (pc *DBCommitQueueConnector) AddPatchForPR(ctx context.Context, projectRef 
 	// populate tasks/variants matching the commitqueue alias
 	proj.BuildProjectTVPairs(patchDoc, patchDoc.Alias)
 
-	if err = units.AddMergeTaskAndVariant(patchDoc, proj, &projectRef, commitqueue.SourcePullRequest); err != nil {
+	pp, err = units.AddMergeTaskAndVariant(ctx, patchDoc, proj, &projectRef, commitqueue.SourcePullRequest)
+	if err != nil {
 		return nil, err
 	}
 

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -250,20 +250,22 @@ func (s *commitQueueSuite) TestAddMergeTaskAndVariant() {
 	patchDoc := &patch.Patch{}
 	ref := &model.ProjectRef{}
 
-	s.NoError(AddMergeTaskAndVariant(patchDoc, project, ref, commitqueue.SourceDiff))
+	pp, err := AddMergeTaskAndVariant(s.ctx, patchDoc, project, ref, commitqueue.SourceDiff)
+	s.NoError(err)
+	s.NotZero(pp)
 
 	s.Require().Len(patchDoc.BuildVariants, 1)
 	s.Equal(evergreen.MergeTaskVariant, patchDoc.BuildVariants[0])
 	s.Require().Len(patchDoc.Tasks, 1)
 	s.Equal(evergreen.MergeTaskName, patchDoc.Tasks[0])
 
-	s.Require().Len(project.BuildVariants, 1)
-	s.Equal(evergreen.MergeTaskVariant, project.BuildVariants[0].Name)
-	s.Require().Len(project.BuildVariants[0].Tasks, 1)
+	s.Require().Len(pp.BuildVariants, 1)
+	s.Equal(evergreen.MergeTaskVariant, pp.BuildVariants[0].Name)
+	s.Require().Len(pp.BuildVariants[0].Tasks, 1)
 	s.True(project.BuildVariants[0].Tasks[0].CommitQueueMerge)
-	s.Require().Len(project.Tasks, 1)
+	s.Require().Len(pp.Tasks, 1)
 	s.Equal(evergreen.MergeTaskName, project.Tasks[0].Name)
-	s.Require().Len(project.TaskGroups, 1)
+	s.Require().Len(pp.TaskGroups, 1)
 	s.Equal(evergreen.MergeTaskGroup, project.TaskGroups[0].Name)
 }
 


### PR DESCRIPTION
EVG-19631

### Description
There was apparently one remaining place that was dependent on setting the `PatchedParserProject` (which is deprecated) to add the merge task to the commit queue patch. I removed that dependency, so nowhere in the code base sets the `PatchedParserProject` on the patch doc anymore. After this is deployed, I'm going to re-apply #6409, which should be safe once the pre-deploy commit queue patches all finish running.

### Testing
Ran existing tests, and ran a commit queue merge in the sandbox.

### Documentation
N/A