### PR TITLE
EVG-19284 Add ID query to MarkAsContainerDispatched

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -866,6 +866,7 @@ func (t *Task) cacheExpectedDuration() error {
 func (t *Task) MarkAsContainerDispatched(ctx context.Context, env evergreen.Environment, podID, agentVersion string) error {
 	dispatchedAt := time.Now()
 	query := IsContainerTaskScheduledQuery()
+	query[IdKey] = t.Id
 	query[StatusKey] = evergreen.TaskUndispatched
 	query[ContainerAllocatedKey] = true
 	update := bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2044,14 +2044,24 @@ func TestMarkAsContainerDispatched(t *testing.T) {
 		assert.NoError(t, db.Clear(Collection))
 	}()
 
-	getDispatchableContainerTask := func() Task {
-		return Task{
-			Id:                 utility.RandomString(),
-			Activated:          true,
-			ActivatedTime:      time.Now(),
-			Status:             evergreen.TaskUndispatched,
-			ContainerAllocated: true,
-			ExecutionPlatform:  ExecutionPlatformContainer,
+	getDispatchableContainerTasks := func() []Task {
+		return []Task{
+			{
+				Id:                 "should_not_be_dispatched",
+				Activated:          true,
+				ActivatedTime:      time.Now(),
+				Status:             evergreen.TaskUndispatched,
+				ContainerAllocated: true,
+				ExecutionPlatform:  ExecutionPlatformContainer,
+			},
+			{
+				Id:                 "should_be_dispatched",
+				Activated:          true,
+				ActivatedTime:      time.Now(),
+				Status:             evergreen.TaskUndispatched,
+				ContainerAllocated: true,
+				ExecutionPlatform:  ExecutionPlatformContainer,
+			},
 		}
 	}
 
@@ -2071,43 +2081,52 @@ func TestMarkAsContainerDispatched(t *testing.T) {
 		assert.Equal(t, evergreen.AgentVersion, dbTask.AgentVersion)
 	}
 
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task){
-		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			require.NoError(t, tsk.Insert())
-
-			require.NoError(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
-			checkTaskDispatched(t, tsk.Id)
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			for _, tsk := range tsks {
+				require.NoError(t, tsk.Insert())
+			}
+			require.NoError(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+			checkTaskDispatched(t, tsks[1].Id)
 		},
-		"FailsWithTaskWithoutContainerAllocated": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			tsk.ContainerAllocated = false
-			require.NoError(t, tsk.Insert())
+		"FailsWithTaskWithoutContainerAllocated": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			tsks[1].ContainerAllocated = false
+			for _, tsk := range tsks {
+				require.NoError(t, tsk.Insert())
+			}
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+			assert.Error(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
 		},
-		"FailsWithDeactivatedTasks": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			tsk.Activated = false
-			require.NoError(t, tsk.Insert())
+		"FailsWithDeactivatedTasks": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			tsks[1].Activated = false
+			for _, tsk := range tsks {
+				require.NoError(t, tsk.Insert())
+			}
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+			assert.Error(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
 		},
-		"FailsWithDisabledTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			tsk.Priority = evergreen.DisabledTaskPriority
-			require.NoError(t, tsk.Insert())
+		"FailsWithDisabledTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			tsks[1].Priority = evergreen.DisabledTaskPriority
+			for _, tsk := range tsks {
+				require.NoError(t, tsk.Insert())
+			}
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+			assert.Error(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
 		},
-		"FailsWithUnmetDependencies": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			tsk.DependsOn = []Dependency{
+		"FailsWithUnmetDependencies": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			tsks[1].DependsOn = []Dependency{
 				{TaskId: "task", Finished: true, Unattainable: true},
 			}
-			require.NoError(t, tsk.Insert())
+			for _, tsk := range tsks {
+				require.NoError(t, tsk.Insert())
+			}
 
-			assert.Error(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+			assert.Error(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
 		},
-		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk Task) {
-			require.Error(t, tsk.MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
+		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, env *mock.Environment, tsks []Task) {
+			require.Error(t, tsks[1].MarkAsContainerDispatched(ctx, env, podID, evergreen.AgentVersion))
 
-			dbTask, err := FindOneId(tsk.Id)
+			dbTask, err := FindOneId(tsks[1].Id)
 			assert.NoError(t, err)
 			assert.Zero(t, dbTask)
 		},
@@ -2118,7 +2137,7 @@ func TestMarkAsContainerDispatched(t *testing.T) {
 
 			require.NoError(t, db.Clear(Collection))
 
-			tCase(tctx, t, env, getDispatchableContainerTask())
+			tCase(tctx, t, env, getDispatchableContainerTasks())
 		})
 	}
 }

--- a/units/pod_health_check.go
+++ b/units/pod_health_check.go
@@ -119,13 +119,7 @@ func (j *podHealthCheckJob) Run(ctx context.Context) {
 
 	info, err := j.ecsPod.LatestStatusInfo(ctx)
 	if err != nil {
-		grip.Warning(message.WrapError(err, message.Fields{
-			"message":           "unable to get cloud pod's status info",
-			"pod":               j.PodID,
-			"status":            j.pod.Status,
-			"last_communicated": j.pod.TimeInfo.LastCommunicated,
-			"job":               j.ID(),
-		}))
+		j.AddError(errors.Wrap(err, "getting cloud pod's status info"))
 		return
 	}
 


### PR DESCRIPTION
EVG-19284

### Description
I'd been extremely confused tracing the logs of container task dispatching, as it seemed that what was actually happening was the opposite of what the logs were telling.

For instance, two container tasks that were reset at the same time both said they were allocated to different pods in Splunk. However, when the tasks hit `MarkEnd`, it appeared that the pod ID associated with each task had changed mid-flight, which shouldn't be possible. The first task now had the pod ID of the second task, and the second task now had an empty pod ID.

After much searching on how this could've happened, I found that `MarkAsContainerDispatched`, the function that assigns a pod ID to a task, doesn't actually query for the specific task in question. Instead, it just uses a query to pick up the first task that fits the query of being allocated to a container and undispatched. If there are many such tasks (there often are when doing bulk operations like version/build restarts) there's no promise this will pick up the actual task of this function. This led to the task that was getting its pod ID updated [here](https://github.com/evergreen-ci/evergreen/pull/6426/files#diff-4b29d204064065e99ec7762e466f51f0ac8461fcc5f8fc2eeda53d87a5044060R877) vs. the task that got its pod ID value modified [later](https://github.com/evergreen-ci/evergreen/pull/6426/files#diff-4b29d204064065e99ec7762e466f51f0ac8461fcc5f8fc2eeda53d87a5044060R892) could be different tasks, causing great confusion in the pod lifecycle.  

This would ultimately leave pods in a bad state where they wouldn't get terminated despite being unhealthy, leading to the original error message part of this JIRA ticket that we temporarily downleveled to warning.

All that was needed is a change to include the task ID as part of the `MarkAsContainerDispatched` query.

### Testing
Changed the `MarkAsContainerDispatched` unit tests, confirmed they'd fail before the change and succeed afterwards.