### PR TITLE
EVG-17589 Add generator to smoke config

### DIFF
--- a/agent/command/testdata/generated.json
+++ b/agent/command/testdata/generated.json
@@ -1,71 +1,24 @@
 {
   "buildvariants": [
     {
-      "name": "testBV1",
+      "name": "ubuntu1604",
       "tasks": [
         {
-          "name": "shouldDependOnVersionGen",
-          "activate": false
-        }
-      ],
-      "activate": false
-    },
-    {
-      "name": "testBV2",
-      "tasks": [
-        {
-          "name": "shouldDependOnDependencyTask",
-          "activate": false
-        }
-      ],
-      "activate": false
-    },
-    {
-      "name": "testBV3",
-      "tasks": [
-        {
-          "name": "shouldDependOnDependencyTask",
-          "activate": false
-        }
-      ],
-      "activate": false
-    },
-    {
-      "name": "testBV5",
-      "tasks": [
-        {
-          "name": "shouldDependOnDependencyTask"
+          "name": "task_to_add_via_generator"
         }
       ]
     }
   ],
   "tasks": [
     {
-      "name": "shouldDependOnVersionGen",
+      "name": "task_to_add_via_generator",
       "commands": [
         {
           "command": "shell.exec",
           "params": {
             "working_dir": "src",
-            "script": "echo noop"
+            "script": "exit 1"
           }
-        }
-      ]
-    },
-    {
-      "name": "shouldDependOnDependencyTask",
-      "commands": [
-        {
-          "command": "shell.exec",
-          "params": {
-            "working_dir": "src",
-            "script": "echo noop"
-          }
-        }
-      ],
-      "depends_on": [
-        {
-          "name": "dependencyTask"
         }
       ]
     }

--- a/agent/command/testdata/generated.json
+++ b/agent/command/testdata/generated.json
@@ -1,0 +1,73 @@
+{
+  "buildvariants": [
+    {
+      "name": "testBV1",
+      "tasks": [
+        {
+          "name": "shouldDependOnVersionGen",
+          "activate": false
+        }
+      ],
+      "activate": false
+    },
+    {
+      "name": "testBV2",
+      "tasks": [
+        {
+          "name": "shouldDependOnDependencyTask",
+          "activate": false
+        }
+      ],
+      "activate": false
+    },
+    {
+      "name": "testBV3",
+      "tasks": [
+        {
+          "name": "shouldDependOnDependencyTask",
+          "activate": false
+        }
+      ],
+      "activate": false
+    },
+    {
+      "name": "testBV5",
+      "tasks": [
+        {
+          "name": "shouldDependOnDependencyTask"
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "name": "shouldDependOnVersionGen",
+      "commands": [
+        {
+          "command": "shell.exec",
+          "params": {
+            "working_dir": "src",
+            "script": "echo noop"
+          }
+        }
+      ]
+    },
+    {
+      "name": "shouldDependOnDependencyTask",
+      "commands": [
+        {
+          "command": "shell.exec",
+          "params": {
+            "working_dir": "src",
+            "script": "echo noop"
+          }
+        }
+      ],
+      "depends_on": [
+        {
+          "name": "dependencyTask"
+        }
+      ]
+    }
+  ]
+}

--- a/agent/command/testdata/generated.json
+++ b/agent/command/testdata/generated.json
@@ -16,7 +16,7 @@
         {
           "command": "shell.exec",
           "params": {
-            "script": "exit 0"
+            "script": "echo generated_task"
           }
         }
       ]

--- a/agent/command/testdata/generated.json
+++ b/agent/command/testdata/generated.json
@@ -1,7 +1,7 @@
 {
   "buildvariants": [
     {
-      "name": "ubuntu1604",
+      "name": "localhost",
       "tasks": [
         {
           "name": "task_to_add_via_generator"
@@ -17,7 +17,7 @@
           "command": "shell.exec",
           "params": {
             "working_dir": "src",
-            "script": "exit 1"
+            "script": "exit 0"
           }
         }
       ]

--- a/agent/command/testdata/generated.json
+++ b/agent/command/testdata/generated.json
@@ -16,7 +16,6 @@
         {
           "command": "shell.exec",
           "params": {
-            "working_dir": "src",
             "script": "exit 0"
           }
         }

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-04-20"
+	ClientVersion = "2023-04-24"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-04-19"

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -38,7 +38,6 @@ task_groups:
       - first_task_in_task_group
       - second_task_in_task_group
       - test
-      - generate_task
       - third_task_in_task_group
       - fourth_task_in_task_group
 
@@ -232,6 +231,7 @@ buildvariants:
       - localhost
     tasks:
       - name: my_group
+      - name: generate_task
   - name: pod_bv
     display_name: pod_bv
     run_on:

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -40,6 +40,7 @@ task_groups:
       - test
       - third_task_in_task_group
       - fourth_task_in_task_group
+      - generate_task
 
 tasks:
   - name: first_task_in_task_group
@@ -82,6 +83,12 @@ tasks:
             set -o verbose
             set -o errexit
             echo "container task"
+  - name: generate_task
+    commands:
+      - command: generate.tasks
+        params:
+          files:
+            - "agent/command/testdata/generated.json"
   - name: test
     commands:
       - command: git.get_project

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -87,7 +87,7 @@ tasks:
       - command: generate.tasks
         params:
           files:
-            - "agent/command/testdata/generated.json"
+            - "src/agent/command/testdata/generated.json"
   - name: test
     commands:
       - command: git.get_project

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -38,9 +38,9 @@ task_groups:
       - first_task_in_task_group
       - second_task_in_task_group
       - test
+      - generate_task
       - third_task_in_task_group
       - fourth_task_in_task_group
-      - generate_task
 
 tasks:
   - name: first_task_in_task_group

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -84,11 +84,12 @@ tasks:
             echo "container task"
   - name: generate_task
     commands:
-      - command: generate.tasks
+      - command: shell.exec
         params:
-          working_dir: src
-          files:
-            - "agent/command/testdata/generated.json"
+          script: |
+            pwd
+            ls
+            echo "MALIK"
   - name: test
     commands:
       - command: git.get_project

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -86,8 +86,9 @@ tasks:
     commands:
       - command: generate.tasks
         params:
+          working_dir: src
           files:
-            - "src/agent/command/testdata/generated.json"
+            - "agent/command/testdata/generated.json"
   - name: test
     commands:
       - command: git.get_project

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -84,12 +84,21 @@ tasks:
             echo "container task"
   - name: generate_task
     commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: "token foo"
+      #need to git get project first. Nobody ever just starts with the generate.tasks command
       - command: shell.exec
         params:
           script: |
             pwd
             ls
             echo "MALIK"
+      - command: generate.tasks
+        params:
+          files:
+            - agent/command/testdata/generated.json
   - name: test
     commands:
       - command: git.get_project

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -88,13 +88,6 @@ tasks:
         params:
           directory: src
           token: "token foo"
-      #need to git get project first. Nobody ever just starts with the generate.tasks command
-      - command: shell.exec
-        params:
-          script: |
-            pwd
-            ls
-            echo "MALIK"
       - command: generate.tasks
         params:
           files:


### PR DESCRIPTION
EVG-17589

### Description
Added a generate.tasks command to the `agent.yml` that the smoke tests use, and modified some logic in the smoke test itself to check that the generated tasks are created properly and succeed. I'd expect this patch to fail because the `agent.yml` changes are not yet in the main branch, but attached evidence of the task passing when I pointed it to my forked branch.
### Testing
Task [succeeded in staging](https://spruce.mongodb.com/task/evergreen_ubuntu2004_smoke_test_host_task_patch_b83cfc0b5578f8cfad5b8bfaf6c7db977caf1a23_64469437850e61d595b5aa1b_23_04_24_14_37_56/logs?execution=0&logtype=task)
