### PR TITLE
EVG-18278 Fix slack target for build break notifications for admins 

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -580,7 +580,7 @@ func makeBuildBreakSubscriber(userID string) (*event.Subscriber, error) {
 		if preference == user.PreferenceEmail {
 			subscriber.Target = u.Email()
 		} else if preference == user.PreferenceSlack {
-			slackTarget := fmt.Sprintf("@%s", u.Settings.SlackUsername)
+			slackTarget := fmt.Sprintf("@%s", strings.TrimPrefix(u.Settings.SlackUsername, "@"))
 			if u.Settings.SlackMemberId != "" {
 				slackTarget = u.Settings.SlackMemberId
 			}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -580,7 +580,7 @@ func makeBuildBreakSubscriber(userID string) (*event.Subscriber, error) {
 		if preference == user.PreferenceEmail {
 			subscriber.Target = u.Email()
 		} else if preference == user.PreferenceSlack {
-			slackTarget := u.Settings.SlackUsername
+			slackTarget := fmt.Sprintf("@%s", u.Settings.SlackUsername)
 			if u.Settings.SlackMemberId != "" {
 				slackTarget = u.Settings.SlackMemberId
 			}

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -772,13 +772,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	}
 	assert.NoError(AddBuildBreakSubscriptions(&v3, &proj2))
 	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
-	assert.Equal(subs[0].Subscriber.Target, "HELL0173")
-	if _, ok := event.(*rawAdminEventData); !ok {
-		s.NotEmpty(jsonTag, "struct %s: field '%s' must have json tag", t.Name(), f.Name)
-
-		s.NotEqual("resource_type", jsonTag, `'%s' has a json:"resource_type" tag, but should not`, t.String())
-		s.NotEqual("resource_type,omitempty", jsonTag, `'%s' has a json:"resource_type,omitempty" tag, but should not`, t.String())
-	}
+	assert.EqualValues(utility.ToStringPtr("HELL0173"), subs[0].Subscriber.Target)
 	assert.Len(subs, 2)
 }
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -731,7 +731,6 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		EmailAddress: "shaw@blizzard.com",
 		Settings: user.UserSettings{
 			SlackUsername: "hello.itsme",
-			SlackMemberId: "HELL0173",
 			Notifications: user.NotificationPreferences{
 				BuildBreak: user.PreferenceSlack,
 			},
@@ -772,7 +771,9 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	}
 	assert.NoError(AddBuildBreakSubscriptions(&v3, &proj2))
 	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
-	assert.EqualValues(utility.ToStringPtr("HELL0173"), subs[0].Subscriber.Target)
+	targetString, ok := subs[0].Subscriber.Target.(*string)
+	assert.True(ok)
+	assert.EqualValues("@hello.itsme", utility.FromStringPtr(targetString))
 	assert.Len(subs, 2)
 }
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -724,14 +724,16 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	proj2 := model.ProjectRef{
 		Id:                   "proj2",
 		NotifyOnBuildFailure: utility.TruePtr(),
-		Admins:               []string{"u2", "u3"},
+		Admins:               []string{"u2", "u3", "u4"},
 	}
 	u2 := user.DBUser{
 		Id:           "u2",
 		EmailAddress: "shaw@blizzard.com",
 		Settings: user.UserSettings{
+			SlackUsername: "hello.itsme",
+			SlackMemberId: "HELL0173",
 			Notifications: user.NotificationPreferences{
-				BuildBreak: user.PreferenceEmail,
+				BuildBreak: user.PreferenceSlack,
 			},
 		},
 	}
@@ -746,13 +748,6 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		},
 	}
 	assert.NoError(u3.Insert())
-	assert.NoError(AddBuildBreakSubscriptions(&v1, &proj2))
-	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
-	assert.Len(subs, 2)
-
-	// project has it enabled, but user doesn't want notifications
-	subs = []event.Subscription{}
-	assert.NoError(db.Clear(event.SubscriptionsCollection))
 	u4 := user.DBUser{
 		Id:           "u4",
 		EmailAddress: "rehgar@blizzard.com",
@@ -761,9 +756,16 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		},
 	}
 	assert.NoError(u4.Insert())
+	assert.NoError(AddBuildBreakSubscriptions(&v1, &proj2))
+	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.Len(subs, 2)
+
+	// project has it enabled, but user doesn't want notifications
+	subs = []event.Subscription{}
+	assert.NoError(db.Clear(event.SubscriptionsCollection))
 	v3 := model.Version{
 		Id:         "v3",
-		Identifier: proj1.Id,
+		Identifier: proj2.Id,
 		Requester:  evergreen.RepotrackerVersionRequester,
 		Branch:     "branch",
 		AuthorID:   u4.Id,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -772,6 +772,13 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	}
 	assert.NoError(AddBuildBreakSubscriptions(&v3, &proj2))
 	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.Equal(subs[0].Subscriber.Target, "HELL0173")
+	if _, ok := event.(*rawAdminEventData); !ok {
+		s.NotEmpty(jsonTag, "struct %s: field '%s' must have json tag", t.Name(), f.Name)
+
+		s.NotEqual("resource_type", jsonTag, `'%s' has a json:"resource_type" tag, but should not`, t.String())
+		s.NotEqual("resource_type,omitempty", jsonTag, `'%s' has a json:"resource_type,omitempty" tag, but should not`, t.String())
+	}
 	assert.Len(subs, 2)
 }
 


### PR DESCRIPTION
EVG-18278

### Description
The slack target for build break notifications didn't include the "@" like it should have. I opted to fix this instead of removing it because it's used by a lot of projects and only the slack (and not email) target was broken. Additionally, this was already fixed for most slack users when we switched to using memberIds for slack. 

### Testing
Expanded existing tests. 


