### PR TITLE
EVG-19201 add more attributes

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -737,6 +737,10 @@ task_groups:
 		},
 		Project: p,
 		WorkDir: s.tc.taskDirectory,
+		ProjectRef: &model.ProjectRef{
+			Id:         "abcdef",
+			Identifier: "project_identifier",
+		},
 		Timeout: &internal.Timeout{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/agent/command.go
+++ b/agent/command.go
@@ -104,7 +104,7 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 		))
 		if err := a.runCommand(ctx, tc, logger, commandInfo, cmd, fullCommandName, options); err != nil {
 			commandSpan.SetStatus(codes.Error, "running command")
-			commandSpan.RecordError(err)
+			commandSpan.RecordError(err, trace.WithAttributes(tc.taskConfig.TaskAttributes()...))
 			commandSpan.End()
 			return errors.Wrap(err, "running command")
 		}

--- a/agent/command.go
+++ b/agent/command.go
@@ -20,12 +20,12 @@ import (
 )
 
 const (
-	commandsAttribute = "evergreen.commands"
+	commandsAttribute = "evergreen.command"
 )
 
 var (
-	commandNameAttribute  = fmt.Sprintf("%s.command", commandsAttribute)
-	functionNameAttribute = fmt.Sprintf("%s.function", commandsAttribute)
+	commandNameAttribute  = fmt.Sprintf("%s.command_name", commandsAttribute)
+	functionNameAttribute = fmt.Sprintf("%s.function_name", commandsAttribute)
 )
 
 type runCommandsOptions struct {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -36,14 +36,14 @@ const (
 	defaultCommitterEmail  = "no-reply@evergreen.mongodb.com"
 	shallowCloneDepth      = 100
 
-	gitGetProjectOtelAttribute = "evergreen.command.git_get_project"
+	gitGetProjectAttribute = "evergreen.command.git_get_project"
 )
 
 var (
-	cloneOwnerAttribure  = fmt.Sprintf("%s.clone_owner", gitGetProjectOtelAttribute)
-	cloneRepoAttribure   = fmt.Sprintf("%s.clone_repo", gitGetProjectOtelAttribute)
-	cloneBranchAttribure = fmt.Sprintf("%s.clone_branch", gitGetProjectOtelAttribute)
-	cloneModuleAttribure = fmt.Sprintf("%s.clone_module", gitGetProjectOtelAttribute)
+	cloneOwnerAttribute  = fmt.Sprintf("%s.clone_owner", gitGetProjectAttribute)
+	cloneRepoAttribute   = fmt.Sprintf("%s.clone_repo", gitGetProjectAttribute)
+	cloneBranchAttribute = fmt.Sprintf("%s.clone_branch", gitGetProjectAttribute)
+	cloneModuleAttribute = fmt.Sprintf("%s.clone_module", gitGetProjectAttribute)
 )
 
 // gitFetchProject is a command that fetches source code from git for the project
@@ -546,9 +546,9 @@ func (c *gitFetchProject) fetchSource(ctx context.Context,
 	logger.Execution().Debugf("Commands are: %s", redactedCmds)
 
 	ctx, span := getTracer().Start(ctx, "clone_source", trace.WithAttributes(
-		attribute.String(cloneOwnerAttribure, opts.owner),
-		attribute.String(cloneRepoAttribure, opts.repo),
-		attribute.String(cloneBranchAttribure, opts.branch),
+		attribute.String(cloneOwnerAttribute, opts.owner),
+		attribute.String(cloneRepoAttribute, opts.repo),
+		attribute.String(cloneBranchAttribute, opts.branch),
 	))
 	defer span.End()
 
@@ -673,7 +673,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	}
 
 	ctx, span := getTracer().Start(ctx, "clone_module", trace.WithAttributes(
-		attribute.String(cloneModuleAttribure, module.Name),
+		attribute.String(cloneModuleAttribute, module.Name),
 	))
 	defer span.End()
 

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -179,6 +179,7 @@ func (tc *TaskConfig) AddTaskBaggageToCtx(ctx context.Context) (context.Context,
 		evergreen.BuildNameOtelAttribute:         tc.Task.BuildVariant,
 		evergreen.ProjectIdentifierOtelAttribute: tc.ProjectRef.Identifier,
 		evergreen.ProjectIDOtelAttribute:         tc.ProjectRef.Id,
+		evergreen.DistroIDOtelAttribute:          tc.Task.DistroId,
 	} {
 		member, err := baggage.NewMember(key, val)
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-04-24"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-04-24"
+	AgentVersion = "2023-04-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -429,6 +429,7 @@ const (
 	BuildNameOtelAttribute         = "evergreen.build.name"
 	ProjectIdentifierOtelAttribute = "evergreen.project.identifier"
 	ProjectIDOtelAttribute         = "evergreen.project.id"
+	DistroIDOtelAttribute          = "evergreen.distro.id"
 )
 
 const (


### PR DESCRIPTION
[EVG-19201](https://jira.mongodb.org/browse/EVG-19201)

### Description
When the task traces went live we noticed additional attributes that would be helpful.

### Testing
[Works in staging](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/result/Hm6V92CB3qX/trace/ZCed9RtmQA?fields[]=c_name&fields[]=c_service.name&span=d6ba0a0d05188b2f). Adding the task attributes to the error lets us do stuff like [this](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/result/7LEM7qK3Tf2). They aren't added automatically since the HC span processor [only adds the attributes to the span itself](https://github.com/honeycombio/honeycomb-opentelemetry-go/blob/3c99d6a5ed156936da680c6e4051ce472cab89eb/baggage_span_processor.go#L37-L42).