### PR TITLE
EVG-19698: Improve branch project settings validation

### DIFF
--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/general_section.graphql
@@ -8,6 +8,7 @@ mutation {
                 remotePath: "my_path_is_new"
                 owner: "evergreen-ci"
                 repo: "commit-queue-sandbox"
+                branch: "main"
             }
         },
         section: GENERAL

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
@@ -7,6 +7,7 @@ mutation {
                 repo: "world",
                 enabled: true,
                 remotePath: "my_path_is_new"
+                branch: "main"
             }
         },
         section: GENERAL

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -39,8 +39,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-const defaultBranch = "main"
-
 // The ProjectRef struct contains general information, independent of any revision control system, needed to track a given project.
 // Booleans that can be defined from both the repo and branch must be pointers, so that branch configurations can specify when to default to the repo.
 type ProjectRef struct {
@@ -498,11 +496,6 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 			}
 			return nil
 		}
-	}
-
-	// TODO EVG-17412: Remove the following code that defaults the branch to main.
-	if p.Branch == "" {
-		p.Branch = defaultBranch
 	}
 
 	err := db.Insert(ProjectRefCollection, p)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1284,7 +1284,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 
 	assert.Equal(t, "mongodb", repoRef.Owner)
 	assert.Equal(t, "mongo", repoRef.Repo)
-	assert.Equal(t, "main", repoRef.Branch)
+	assert.Empty(t, repoRef.Branch)
 	assert.True(t, repoRef.DoesTrackPushEvents())
 	assert.Contains(t, repoRef.Admins, "bob")
 	assert.Contains(t, repoRef.Admins, "other bob")
@@ -2174,8 +2174,7 @@ func TestAddEmptyBranch(t *testing.T) {
 	}
 	assert.NoError(t, p.Add(&u))
 	assert.NotEmpty(t, p.Id)
-	assert.NotEmpty(t, p.Branch)
-	assert.Equal(t, "", p.Branch)
+	assert.Empty(t, p.Branch)
 
 	cq, err := commitqueue.FindOneId(p.Id)
 	assert.NoError(t, err)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2175,7 +2175,7 @@ func TestAddEmptyBranch(t *testing.T) {
 	assert.NoError(t, p.Add(&u))
 	assert.NotEmpty(t, p.Id)
 	assert.NotEmpty(t, p.Branch)
-	assert.Equal(t, "main", p.Branch)
+	assert.Equal(t, "", p.Branch)
 
 	cq, err := commitqueue.FindOneId(p.Id)
 	assert.NoError(t, err)

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -52,6 +52,7 @@ func (r *RepoRef) Insert() error {
 // Ensures that fields that aren't relevant to repos aren't set.
 func (r *RepoRef) Upsert() error {
 	r.RepoRefId = ""
+	r.Branch = ""
 	_, err := db.Upsert(
 		RepoRefCollection,
 		bson.M{

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -52,7 +52,6 @@ func (r *RepoRef) Insert() error {
 // Ensures that fields that aren't relevant to repos aren't set.
 func (r *RepoRef) Upsert() error {
 	r.RepoRefId = ""
-	r.Branch = defaultBranch
 	_, err := db.Upsert(
 		RepoRefCollection,
 		bson.M{

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -247,6 +247,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err = mergedSection.ValidateOwnerAndRepo(config.GithubOrgs); err != nil {
 				return nil, errors.Wrap(err, "validating new owner/repo")
 			}
+			if mergedSection.Branch == "" {
+				return nil, errors.New("branch not set on enabled repo")
+			}
 		}
 		// Only need to check Github conflicts once so we use else if statements to handle this.
 		// Handle conflicts using the ref from the DB, since only general section settings are passed in from the UI.

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -247,9 +247,6 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err = mergedSection.ValidateOwnerAndRepo(config.GithubOrgs); err != nil {
 				return nil, errors.Wrap(err, "validating new owner/repo")
 			}
-			if mergedSection.Branch == "" {
-				return nil, errors.New("branch not set on enabled repo")
-			}
 		}
 		// Only need to check Github conflicts once so we use else if statements to handle this.
 		// Handle conflicts using the ref from the DB, since only general section settings are passed in from the UI.
@@ -275,6 +272,10 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 
 		if mergedSection.Enabled {
+			if mergedSection.Branch == "" {
+				return nil, errors.New("branch not set on enabled repo")
+			}
+
 			config, err := evergreen.GetConfig()
 			if err != nil {
 				return nil, errors.Wrap(err, "getting evergreen config")

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -458,6 +458,18 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotNil(t, oldAdminFromDB)
 			assert.NotContains(t, oldAdminFromDB.Roles(), model.GetRepoAdminRole(ref.Id))
 		},
+		"errors saving enabled project with no branch": func(t *testing.T, ref model.ProjectRef) {
+			ref.Branch = ""
+			apiProjectRef := restModel.APIProjectRef{}
+			assert.NoError(t, apiProjectRef.BuildFromService(ref))
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "branch not set on enabled repo")
+			assert.Nil(t, settings)
+		},
 		model.ProjectPageVariablesSection: func(t *testing.T, ref model.ProjectRef) {
 			// remove a variable, modify a variable, delete/add a private variable, add a variable, leave a private variable unchanged
 			apiProjectVars := restModel.APIProjectVars{

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -459,6 +459,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotContains(t, oldAdminFromDB.Roles(), model.GetRepoAdminRole(ref.Id))
 		},
 		"errors saving enabled project with no branch": func(t *testing.T, ref model.ProjectRef) {
+			ref.Enabled = true
 			ref.Branch = ""
 			apiProjectRef := restModel.APIProjectRef{}
 			assert.NoError(t, apiProjectRef.BuildFromService(ref))


### PR DESCRIPTION
EVG-19698

### Description
- Prevent users from saving an enabled project with no branch (front end validation is also being added in https://github.com/evergreen-ci/spruce/pull/1802)
- New projects no longer default to `main` branch (empty string instead)

### Testing
- Added unit test and tested on the UI

### Documentation
N/A