### PR TITLE
EVG-19716 Add log stream prefix to ECS options to fix OTEL error

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -226,6 +226,8 @@ const (
 	awsLogsGroup = "awslogs-group"
 	// awsLogsGroup is the log configuration option name for specifying the AWS region.
 	awsLogsRegion = "awslogs-region"
+	// awsLogsStreamPrefix is the log configuration option name for specifying the log stream prefix.
+	awsLogsStreamPrefix = "awslogs-stream-prefix"
 )
 
 // ExportECSPodDefinitionOptions exports the ECS pod creation options into
@@ -273,10 +275,11 @@ func exportECSPodContainerDef(settings *evergreen.Settings, opts pod.TaskContain
 	if opts.RepoCredsExternalID != "" {
 		def.SetRepositoryCredentials(*cocoa.NewRepositoryCredentials().SetID(opts.RepoCredsExternalID))
 	}
-	if ecsConf.LogRegion != "" && ecsConf.LogGroup != "" {
+	if ecsConf.LogRegion != "" && ecsConf.LogGroup != "" && ecsConf.LogStreamPrefix != "" {
 		def.SetLogConfiguration(*cocoa.NewLogConfiguration().SetLogDriver(awsECS.LogDriverAwslogs).SetOptions(map[string]string{
-			awsLogsGroup:  ecsConf.LogGroup,
-			awsLogsRegion: ecsConf.LogRegion,
+			awsLogsGroup:        ecsConf.LogGroup,
+			awsLogsRegion:       ecsConf.LogRegion,
+			awsLogsStreamPrefix: ecsConf.LogStreamPrefix,
 		}))
 	}
 

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -365,8 +365,9 @@ func TestExportECSPodDefinitionOptions(t *testing.T) {
 								Subnets:        []string{"subnet-12345"},
 								SecurityGroups: []string{"sg-12345"},
 							},
-							LogRegion: "us-east-1",
-							LogGroup:  "log_group",
+							LogRegion:       "us-east-1",
+							LogGroup:        "log_group",
+							LogStreamPrefix: "log_stream_prefix",
 						},
 						SecretsManager: evergreen.SecretsManagerConfig{
 							SecretPrefix: "secret_prefix",

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -172,8 +172,10 @@ type ECSConfig struct {
 	ExecutionRole string `bson:"execution_role" json:"execution_role" yaml:"execution_role"`
 	// LogRegion is the region used by the task definition's log configuration.
 	LogRegion string `bson:"log_region" json:"log_region" yaml:"log_region"`
-	// LogRegion is the log group name used by the task definition's log configuration.
+	// LogGroup is the log group name used by the task definition's log configuration.
 	LogGroup string `bson:"log_group" json:"log_group" yaml:"log_group"`
+	// LogStreamPrefix is the prefix used to determine log group stream names.
+	LogStreamPrefix string `bson:"log_stream_prefix" json:"log_stream_prefix" yaml:"log_stream_prefix"`
 	// AWSVPC specifies configuration when ECS tasks use AWSVPC networking.
 	AWSVPC AWSVPCConfig `bson:"awsvpc" json:"awsvpc" yaml:"awsvpc"`
 	// Clusters specify the configuration of each particular ECS cluster.

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1836,6 +1836,7 @@ type APIECSConfig struct {
 	ExecutionRole        *string                  `json:"execution_role"`
 	LogRegion            *string                  `json:"log_region"`
 	LogGroup             *string                  `json:"log_group"`
+	LogStreamPrefix      *string                  `json:"log_stream_prefix"`
 	AWSVPC               *APIAWSVPCConfig         `json:"awsvpc"`
 	Clusters             []APIECSClusterConfig    `json:"clusters"`
 	CapacityProviders    []APIECSCapacityProvider `json:"capacity_providers"`
@@ -1848,6 +1849,7 @@ func (a *APIECSConfig) BuildFromService(conf evergreen.ECSConfig) {
 	a.TaskRole = utility.ToStringPtr(conf.TaskRole)
 	a.ExecutionRole = utility.ToStringPtr(conf.ExecutionRole)
 	a.LogRegion = utility.ToStringPtr(conf.LogRegion)
+	a.LogStreamPrefix = utility.ToStringPtr(conf.LogStreamPrefix)
 	a.LogGroup = utility.ToStringPtr(conf.LogGroup)
 	var apiAWSVPC APIAWSVPCConfig
 	apiAWSVPC.BuildFromService(conf.AWSVPC)
@@ -1893,6 +1895,7 @@ func (a *APIECSConfig) ToService() (*evergreen.ECSConfig, error) {
 		TaskRole:             utility.FromStringPtr(a.TaskRole),
 		ExecutionRole:        utility.FromStringPtr(a.ExecutionRole),
 		LogRegion:            utility.FromStringPtr(a.LogRegion),
+		LogStreamPrefix:      utility.FromStringPtr(a.LogStreamPrefix),
 		LogGroup:             utility.FromStringPtr(a.LogGroup),
 		AWSVPC:               a.AWSVPC.ToService(),
 		Clusters:             clusters,

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1949,6 +1949,10 @@ Admin Settings
 										<label>Pod ECS Log Group Name</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_group">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Pod ECS Log Stream Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_stream_prefix">
+									</md-input-container>
 									<md-card-title>
 										<md-card-title-text>
 											<span>Pod ECS AWSVPC Subnets</span>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -326,6 +326,7 @@ func MockConfig() *evergreen.Settings {
 						TaskRole:             "task_role",
 						ExecutionRole:        "execution_role",
 						LogRegion:            "log_region",
+						LogStreamPrefix:      "log_stream_prefix",
 						LogGroup:             "log_group",
 						AWSVPC: evergreen.AWSVPCConfig{
 							Subnets:        []string{"subnet-12345"},


### PR DESCRIPTION
EVG-19716

### Description
Saw that container tasks were suddenly unable to start at all since OTEL changes have been added to the agent. 

Turns out it's because [Opentelemetry's](https://gist.github.com/hadjri/11fca9d9e9629347a2257706709b6e5c#file-ecs-go-L153) implementation that parses ECS task definitions sends an error if the log stream is not specified in the ECS log options, causing our agents to fail and exit without running tasks with the following error: `[p=emergency]: constructing agent: initializing tracer provider: making otel resource: detecting resources: [the ECS Metadata v4 did not return a AwsLogStream name]`

Added "awslogs-stream-prefix" as a mandatory option to our ECS log configuration since OTEL requires it. It also makes the stream names more readable in ECS so that is a plus too. Currently all stream names appear to be some random hash but this will make them be structured in the following format: `ecs/evg-agent/<id>`
### Testing
Confirmed in staging that this fixes the failing agents.