### PR TITLE
EVG-19104 add logging to merge commit fallback

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -350,9 +350,13 @@ func (c *gitFetchProject) waitForMergeableCheck(ctx context.Context, comm client
 		getPRRetryMaxDelay = 15 * time.Second
 	)
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-
+	attempt := 0
 	err := utility.Retry(ctx, func() (bool, error) {
-		info, err := comm.GetPullRequestInfo(ctx, td, conf.GithubPatchData.PRNumber, opts.owner, opts.repo)
+		var lastAttempt bool
+		if attempt == getPRAttempts-1 {
+			lastAttempt = true
+		}
+		info, err := comm.GetPullRequestInfo(ctx, td, conf.GithubPatchData.PRNumber, opts.owner, opts.repo, lastAttempt)
 		if err != nil {
 			return false, errors.Wrap(err, "getting pull request data from GitHub")
 		}

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -573,7 +573,7 @@ func (c *baseCommunicator) SendLogMessages(ctx context.Context, taskData TaskDat
 	return nil
 }
 
-func (c *baseCommunicator) GetPullRequestInfo(ctx context.Context, taskData TaskData, prNum int, owner, repo string) (*apimodels.PullRequestInfo, error) {
+func (c *baseCommunicator) GetPullRequestInfo(ctx context.Context, taskData TaskData, prNum int, owner, repo string, lastAttempt bool) (*apimodels.PullRequestInfo, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
@@ -581,9 +581,10 @@ func (c *baseCommunicator) GetPullRequestInfo(ctx context.Context, taskData Task
 	info.setTaskPathSuffix("pull_request")
 
 	body := apimodels.CheckMergeRequest{
-		PRNum: prNum,
-		Owner: owner,
-		Repo:  repo,
+		PRNum:     prNum,
+		Owner:     owner,
+		Repo:      repo,
+		LastRetry: lastAttempt,
 	}
 	resp, err := c.retryRequest(ctx, info, &body)
 	if err != nil {

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -79,7 +79,7 @@ type SharedCommunicator interface {
 	GetDataPipesConfig(context.Context) (*apimodels.DataPipesConfig, error)
 
 	// GetPullRequestInfo takes in a PR number, owner, and repo and returns information from the corresponding pull request.
-	GetPullRequestInfo(context.Context, TaskData, int, string, string) (*apimodels.PullRequestInfo, error)
+	GetPullRequestInfo(context.Context, TaskData, int, string, string, bool) (*apimodels.PullRequestInfo, error)
 
 	// DisableHost signals to the app server that the host should be disabled.
 	DisableHost(context.Context, string, apimodels.DisableInfo) error

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -507,7 +507,7 @@ func (c *Mock) GetAdditionalPatches(ctx context.Context, patchId string, td Task
 	return []string{"555555555555555555555555"}, nil
 }
 
-func (c *Mock) GetPullRequestInfo(ctx context.Context, taskData TaskData, prNum int, owner, repo string) (*apimodels.PullRequestInfo, error) {
+func (c *Mock) GetPullRequestInfo(ctx context.Context, taskData TaskData, prNum int, owner, repo string, lastAttempt bool) (*apimodels.PullRequestInfo, error) {
 	return &apimodels.PullRequestInfo{
 		Mergeable: utility.TruePtr(),
 	}, nil

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -36,9 +36,10 @@ type HeartbeatResponse struct {
 
 // CheckMergeRequest holds information sent by the agent to get a PR and check mergeability.
 type CheckMergeRequest struct {
-	PRNum int    `json:"pr_num"`
-	Owner string `json:"owner"`
-	Repo  string `json:"repo"`
+	PRNum     int    `json:"pr_num"`
+	Owner     string `json:"owner"`
+	Repo      string `json:"repo"`
+	LastRetry bool   `json:"last_retry"` // Temporary field to help us understand if we are testing with the wrong commit.
 }
 
 type PullRequestInfo struct {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -168,6 +168,15 @@ func (h *agentCheckGetPullRequestHandler) Run(ctx context.Context) gimlet.Respon
 		Mergeable:      pr.Mergeable,
 		MergeCommitSHA: pr.GetMergeCommitSHA(),
 	}
+	if h.req.LastRetry && (!utility.FromBoolPtr(resp.Mergeable) || resp.MergeCommitSHA == "") {
+		grip.Debug(message.Fields{
+			"message": "last attempt to retry getting pull request",
+			"route":   "/pull_request",
+			"ticket":  "EVG-19723",
+			"resp":    resp,
+			"request": h.req,
+		})
+	}
 	return gimlet.NewJSONResponse(resp)
 }
 


### PR DESCRIPTION
EVG-19104 

### Description
Adding some logging to see if we ever go through all of our retries and [fall back on an old commit](https://github.com/evergreen-ci/evergreen/blob/98e0fe9852cbf3c907dbc03893c3367590359cba/agent/command/git.go#L311) (and if so, is this ever a problem). Will set up a splunk alert for myself and will plan to look at EVG-19723 in about a month.
