### PR TITLE
EVG-18405: support build variant patch_only

### DIFF
--- a/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
+++ b/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
@@ -251,7 +251,7 @@ Fields:
 -   `name`: an identification string for the variant
 -   `display_name`: how the variant is displayed in the Evergreen UI
 -   `run_on`: a list of acceptable distros to run tasks for that variant
-    a. The first distro in the list is the primary distro. The others
+    on. The first distro in the list is the primary distro. The others
     are secondary distros. Each distro has a primary queue, a queue of
     all tasks that have specified it as their primary distro; and a
     secondary queue, a queue of tasks that have specified it as a

--- a/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
+++ b/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
@@ -1,6 +1,4 @@
 # Set Up a Project Configuration File
-kim: TODO: add section about setting priority at different definition levels.
-
 Project configurations are how you tell Evergreen what to do. They
 contain a set of tasks and variants to run those tasks on, and are
 stored within the repository they test. Project files are written in a
@@ -538,7 +536,9 @@ task).
 
 To cause a task to only run in commit builds, set `patchable: false`.
 
-To cause a task to only run in patches, set `patch_only: true`.
+To cause a task to only run in patches, set `patch_only: true`. `patch_only: true` can also be set at the build variant
+level to apply this behavior to all tasks in the build variant. The build variant level setting can be overridden if
+it's been explicitly set in the task definition or in the task listed under the build variant.
 
 To cause a task to only run in versions NOT triggered from git tags, set
 `allow_for_git_tag: false`.

--- a/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
+++ b/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
@@ -207,6 +207,7 @@ buildvariants:
 - name: ubuntu
   display_name: Ubuntu
   batchtime: 60
+  patch_only: true
   run_on:
   - ubuntu1404-test
   expansions:
@@ -250,7 +251,7 @@ Fields:
 -   `name`: an identification string for the variant
 -   `display_name`: how the variant is displayed in the Evergreen UI
 -   `run_on`: a list of acceptable distros to run tasks for that variant
-    on. The first distro in the list is the primary distro. The others
+    a. The first distro in the list is the primary distro. The others
     are secondary distros. Each distro has a primary queue, a queue of
     all tasks that have specified it as their primary distro; and a
     secondary queue, a queue of tasks that have specified it as a
@@ -286,6 +287,7 @@ Fields:
     defined in `task_groups` under the tasks of a given build variant.
 -   `tags`: optional list of tags to group the build variant for alias definitions (explained [here](#task-and-variant-tags))
 -   `disable`: determines whether or not a build variant will run or not. Set to false by default
+-   `patch_only`: if set, the tasks under the build variant can only run in patches.
 
 Additionally, an item in the `tasks` list can be of the form
 

--- a/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
+++ b/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
@@ -1,4 +1,5 @@
 # Set Up a Project Configuration File
+kim: TODO: add section about setting priority at different definition levels.
 
 Project configurations are how you tell Evergreen what to do. They
 contain a set of tasks and variants to run those tasks on, and are

--- a/model/generate.go
+++ b/model/generate.go
@@ -685,7 +685,7 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 func isNonZeroBV(bv parserBV) bool {
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
 		bv.Disable || len(bv.Tags) > 0 ||
-		bv.BatchTime != nil || bv.Activate != nil || bv.PatchOnly != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
+		bv.BatchTime != nil || bv.PatchOnly != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
 		return true
 	}
 	return false

--- a/model/generate.go
+++ b/model/generate.go
@@ -685,7 +685,7 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 func isNonZeroBV(bv parserBV) bool {
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
 		bv.Disable || len(bv.Tags) > 0 ||
-		bv.BatchTime != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
+		bv.BatchTime != nil || bv.Activate != nil || bv.PatchOnly != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
 		return true
 	}
 	return false

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1332,9 +1332,9 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 		project := &Project{
 			BuildVariants: []BuildVariant{
 				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
-					{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
-					{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
-					{Name: "generator"},
+					{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
+					{Name: "dependedOn", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generator", Variant: "bv0"},
 				}},
 			},
 			Tasks: []ProjectTask{
@@ -1362,8 +1362,8 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 		project := &Project{
 			BuildVariants: []BuildVariant{
 				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
-					{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
-					{Name: "generator"},
+					{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generator", Variant: "bv0"},
 				}},
 			},
 			Tasks: []ProjectTask{
@@ -1393,9 +1393,9 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				{
 					Name: "bv0",
 					Tasks: []BuildVariantTaskUnit{
-						{Name: "generated"},
-						{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
-						{Name: "generator"},
+						{Name: "generated", Variant: "bv0"},
+						{Name: "dependedOn", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+						{Name: "generator", Variant: "bv0"},
 					},
 				},
 			},
@@ -1426,8 +1426,8 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				{
 					Name: "bv0",
 					Tasks: []BuildVariantTaskUnit{
-						{Name: "generated", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
-						{Name: "dependedOn", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+						{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
+						{Name: "dependedOn", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
 						{Name: "generator"},
 					},
 				},

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -517,7 +517,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 	// Find the build variant for this project/build
 	creationInfo.BuildVariant = creationInfo.Project.FindBuildVariant(creationInfo.Build.BuildVariant)
 	if creationInfo.BuildVariant == nil {
-		return nil, nil, errors.Errorf("finding build '%s' in project file '%s'",
+		return nil, nil, errors.Errorf("could not find build '%s' in project file '%s'",
 			creationInfo.Build.BuildVariant, creationInfo.Project.Identifier)
 	}
 
@@ -685,6 +685,7 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 	return b, tasksForBuild, nil
 }
 
+// kim: TODO: validate that the BVTU passed in here always has variant set.
 func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester string) []BuildVariantTaskUnit {
 	var willRun []BuildVariantTaskUnit
 	for _, bvt := range proj.tasksFromGroup(in) {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -685,7 +685,6 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 	return b, tasksForBuild, nil
 }
 
-// kim: TODO: validate that the BVTU passed in here always has variant set.
 func CreateTasksFromGroup(in BuildVariantTaskUnit, proj *Project, requester string) []BuildVariantTaskUnit {
 	var willRun []BuildVariantTaskUnit
 	for _, bvt := range proj.tasksFromGroup(in) {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2395,16 +2395,24 @@ func resetTaskData() error {
 
 func TestCreateTasksFromGroup(t *testing.T) {
 	assert := assert.New(t)
+	const tgName = "name"
+	const bvName = "first_build_variant"
 	in := BuildVariantTaskUnit{
-		Name:            "name",
+		Name:            tgName,
 		IsGroup:         true,
-		GroupName:       "task_group",
+		Variant:         bvName,
 		Priority:        0,
 		DependsOn:       []TaskUnitDependency{{Name: "new_dependency"}},
 		RunOn:           []string{},
 		ExecTimeoutSecs: 0,
 	}
 	p := &Project{
+		BuildVariants: []BuildVariant{
+			{
+				Name:  "first_build_variant",
+				Tasks: []BuildVariantTaskUnit{in},
+			},
+		},
 		Tasks: []ProjectTask{
 			{
 				Name:      "first_task",
@@ -2420,13 +2428,13 @@ func TestCreateTasksFromGroup(t *testing.T) {
 		},
 		TaskGroups: []TaskGroup{
 			{
-				Name:  "name",
+				Name:  tgName,
 				Tasks: []string{"first_task", "second_task", "third_task"},
 			},
 		},
 	}
 	bvts := CreateTasksFromGroup(in, p, evergreen.PatchVersionRequester)
-	assert.Equal(2, len(bvts))
+	require.Equal(t, 2, len(bvts))
 	assert.Equal("new_dependency", bvts[0].DependsOn[0].Name)
 	assert.Equal("new_dependency", bvts[1].DependsOn[0].Name)
 }

--- a/model/project.go
+++ b/model/project.go
@@ -93,11 +93,16 @@ type BuildVariantTaskUnit struct {
 	// the project level, or an error will be thrown
 	Name string `yaml:"name,omitempty" bson:"name"`
 	// IsGroup indicates that it is a task group or a task within a task group.
+	// This is always populated after translating the parser project to the
+	// project.
 	IsGroup bool `yaml:"-" bson:"-"`
 	// GroupName is the task group name if this is a task in a task group. If
 	// it is the task group itself, it is not populated (Name is the task group
 	// name).
 	GroupName string `yaml:"-" bson:"-"`
+	// Variant is the build variant that the task unit is part of. This is
+	// always populated after translating the parser project to the project.
+	Variant string `yaml:"-" bson:"-"`
 
 	// fields to overwrite ProjectTask settings.
 	Patchable      *bool                `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
@@ -113,8 +118,6 @@ type BuildVariantTaskUnit struct {
 	// currently unsupported (TODO EVG-578)
 	ExecTimeoutSecs int   `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs"`
 	Stepback        *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-
-	Variant string `yaml:"-" bson:"-"`
 
 	CommitQueueMerge bool `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge"`
 
@@ -166,8 +169,14 @@ func (b BuildVariants) Get(name string) (BuildVariant, error) {
 }
 
 // Populate updates the base fields of the BuildVariantTaskUnit with
-// fields from the project task definition.
-func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask) {
+// fields from the project task definition and build variant definition. When
+// there are conflicting settings defined at different levels, the priority of
+// settings are (from highest to lowest):
+// * Task settings within a build variant's list of tasks
+// * Task settings within a task group's list of tasks
+// * Project task's settings
+// * Build variant's settings
+func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask, bv BuildVariant) {
 	// We never update "Name" or "Commands"
 	if len(bvt.DependsOn) == 0 {
 		bvt.DependsOn = pt.DependsOn
@@ -199,6 +208,12 @@ func (bvt *BuildVariantTaskUnit) Populate(pt ProjectTask) {
 	}
 	if bvt.Stepback == nil {
 		bvt.Stepback = pt.Stepback
+	}
+
+	// Build variant level settings are lower priority than project task level
+	// settings.
+	if bvt.PatchOnly == nil {
+		bvt.PatchOnly = bv.PatchOnly
 	}
 }
 
@@ -260,6 +275,8 @@ func (bvt *BuildVariantTaskUnit) SkipOnPatchBuild() bool {
 }
 
 func (bvt *BuildVariantTaskUnit) SkipOnNonPatchBuild() bool {
+	// kim: TODO: verify in staging that patch_only at build variant level is
+	// respected and set in the translated project.
 	return utility.FromBoolPtr(bvt.PatchOnly)
 }
 
@@ -294,8 +311,10 @@ type BuildVariant struct {
 	DisplayName string            `yaml:"display_name,omitempty" bson:"display_name"`
 	Expansions  map[string]string `yaml:"expansions,omitempty" bson:"expansions"`
 	Modules     []string          `yaml:"modules,omitempty" bson:"modules"`
-	Disable     bool              `yaml:"disable,omitempty" bson:"disable"`
-	Tags        []string          `yaml:"tags,omitempty" bson:"tags"`
+	// kim: NOTE: I think this field doesn't work. Get this field to actually
+	// work.
+	Disable bool     `yaml:"disable,omitempty" bson:"disable"`
+	Tags    []string `yaml:"tags,omitempty" bson:"tags"`
 
 	// Use a *int for 2 possible states
 	// nil - not overriding the project setting
@@ -306,7 +325,8 @@ type BuildVariant struct {
 	CronBatchTime string `yaml:"cron,omitempty" bson:"cron,omitempty"`
 
 	// If Activate is set to false, then we don't initially activate the build variant.
-	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
+	Activate  *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
+	PatchOnly *bool `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
 
 	// Use a *bool so that there are 3 possible states:
 	//   1. nil   = not overriding the project setting (default)
@@ -1330,6 +1350,12 @@ func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
 	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()
 }
 
+// FindTaskForVariant returns the build variant task unit for a matching task or
+// task within a task group. If searching for a task within the task group, the
+// build variant task unit returned will have its fields populated, respecting
+// precedence of settings (such as PatchOnly). Note that for tasks within a task
+// group, the returned result will have the name of the task group it's part of,
+// rather than the name of the task.
 func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit {
 	bv := p.FindBuildVariant(variant)
 	if bv == nil {
@@ -1348,7 +1374,6 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 
 	for _, bvt := range bv.Tasks {
 		if bvt.Name == task {
-			bvt.Variant = variant
 			if projectTask := p.FindProjectTask(task); projectTask != nil {
 				return &bvt
 			} else if _, exists := tgMap[task]; exists {
@@ -1358,9 +1383,10 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 		if tg, ok := tgMap[bvt.Name]; ok {
 			for _, t := range tg.Tasks {
 				if t == task {
-					bvt.Variant = variant
 					// task group tasks need to be repopulated from the task list
-					bvt.Populate(*p.FindProjectTask(task))
+					// Note that the build variant task unit retains the task
+					// group's name.
+					bvt.Populate(*p.FindProjectTask(task), *bv)
 					return &bvt
 				}
 			}
@@ -1503,11 +1529,10 @@ func (p *Project) FindAllBuildVariantTasks() []BuildVariantTaskUnit {
 	allBVTs := []BuildVariantTaskUnit{}
 	for _, b := range p.BuildVariants {
 		for _, t := range b.Tasks {
-			t.Variant = b.Name
 			if t.IsGroup {
 				allBVTs = append(allBVTs, p.tasksFromGroup(t)...)
 			} else {
-				t.Populate(tasksByName[t.Name])
+				t.Populate(tasksByName[t.Name], b)
 				allBVTs = append(allBVTs, t)
 			}
 		}
@@ -1525,6 +1550,13 @@ func (p *Project) tasksFromGroup(bvTaskGroup BuildVariantTaskUnit) []BuildVarian
 	if tg == nil {
 		return nil
 	}
+	// kim: TODO: should do some double-checking in staging to verify that this
+	// is always set in all places that rely on it (e.g. generate.tasks, manual
+	// patch, project validation).
+	bv := p.FindBuildVariant(bvTaskGroup.Variant)
+	if bv == nil {
+		return nil
+	}
 
 	tasks := []BuildVariantTaskUnit{}
 	taskMap := map[string]ProjectTask{}
@@ -1539,8 +1571,8 @@ func (p *Project) tasksFromGroup(bvTaskGroup BuildVariantTaskUnit) []BuildVarian
 			// task is a member of a task group.
 			IsGroup:          true,
 			TaskGroup:        bvTaskGroup.TaskGroup,
-			Variant:          bvTaskGroup.Variant,
 			GroupName:        bvTaskGroup.Name,
+			Variant:          bvTaskGroup.Variant,
 			Patchable:        bvTaskGroup.Patchable,
 			PatchOnly:        bvTaskGroup.PatchOnly,
 			Disable:          bvTaskGroup.Disable,
@@ -1555,7 +1587,7 @@ func (p *Project) tasksFromGroup(bvTaskGroup BuildVariantTaskUnit) []BuildVarian
 			CommitQueueMerge: bvTaskGroup.CommitQueueMerge,
 		}
 		// Default to project task settings when unspecified
-		bvt.Populate(taskMap[t])
+		bvt.Populate(taskMap[t], *bv)
 		tasks = append(tasks, bvt)
 	}
 	return tasks

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -314,13 +314,11 @@ func (ts *taskSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // parserBV is a helper type storing intermediary variant definitions.
 type parserBV struct {
-	Name        string            `yaml:"name,omitempty" bson:"name,omitempty"`
-	DisplayName string            `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
-	Expansions  util.Expansions   `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
-	Tags        parserStringSlice `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
-	Modules     parserStringSlice `yaml:"modules,omitempty" bson:"modules,omitempty"`
-	// kim: TODO: verify if this Disable field works. If so, EVG-18405 only
-	// needs to address PatchOnly. (note to self: it doesn't work)
+	Name          string             `yaml:"name,omitempty" bson:"name,omitempty"`
+	DisplayName   string             `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+	Expansions    util.Expansions    `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
+	Tags          parserStringSlice  `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
+	Modules       parserStringSlice  `yaml:"modules,omitempty" bson:"modules,omitempty"`
 	Disable       bool               `yaml:"disable,omitempty" bson:"disable,omitempty"`
 	BatchTime     *int               `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
 	CronBatchTime string             `yaml:"cron,omitempty" bson:"cron,omitempty"`
@@ -511,13 +509,6 @@ func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
 
 // HasSpecificActivation returns if the build variant specifies an activation condition that
 // overrides the default, such as cron/batchtime, disabling the task, or explicitly deactivating it.
-// kim: NOTE: to deal with BV-level activation/disablement, this added special
-// logic to incorporate it with the existing BVTU/PT logic. It seems like this
-// could just be set on the the parserBVTaskUnit though, rather than duplicate
-// functionality to double-check BV level logic.
-// kim: NOTE: activation only needs to be considered for generated tasks
-// because users manually select which tasks are activated for non-generated
-// ones. Activate only affects default activation setting.
 func (bv *parserBV) hasSpecificActivation() bool {
 	return bv.BatchTime != nil || bv.CronBatchTime != "" ||
 		!utility.FromBoolTPtr(bv.Activate) || bv.Disable
@@ -893,8 +884,7 @@ func createIntermediateProject(yml []byte, unmarshalStrict bool) (*ParserProject
 }
 
 // TranslateProject converts our intermediate project representation into
-// the Project type that Evergreen actually uses. Errors are added to
-// pp.errors and pp.warnings and must be checked separately.
+// the Project type that Evergreen actually uses.
 func TranslateProject(pp *ParserProject) (*Project, error) {
 	// Transfer top level fields
 	proj := &Project{

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -205,7 +205,7 @@ func TestPopulateBVT(t *testing.T) {
 			bvt := project.BuildVariants[0].Tasks[0]
 			spec := project.GetSpecForTask("task1")
 			So(spec.Name, ShouldEqual, "task1")
-			bvt.Populate(spec)
+			bvt.Populate(spec, project.BuildVariants[0])
 
 			Convey("should inherit the unset fields from the Project", func() {
 				So(bvt.Name, ShouldEqual, "task1")
@@ -227,7 +227,7 @@ func TestPopulateBVT(t *testing.T) {
 			}
 			spec := project.GetSpecForTask("task1")
 			So(spec.Name, ShouldEqual, "task1")
-			bvt.Populate(spec)
+			bvt.Populate(spec, project.BuildVariants[0])
 
 			Convey("should not inherit set fields from the Project", func() {
 				So(bvt.Name, ShouldEqual, "task1")
@@ -2194,15 +2194,15 @@ func TestDependencyGraph(t *testing.T) {
 			{
 				Name: "ubuntu",
 				Tasks: []BuildVariantTaskUnit{
-					{Name: "compile", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
-					{Name: "setup"},
+					{Name: "compile", Variant: "ubuntu", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
+					{Name: "setup", Variant: "ubuntu"},
 				},
 			},
 			{
 				Name: "rhel",
 				Tasks: []BuildVariantTaskUnit{
-					{Name: "compile", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
-					{Name: "setup"},
+					{Name: "compile", Variant: "rhel", DependsOn: []TaskUnitDependency{{Name: "setup"}}},
+					{Name: "setup", Variant: "rhel"},
 				},
 			},
 		},
@@ -2218,11 +2218,12 @@ func TestFindAllBuildVariantTasks(t *testing.T) {
 			{Name: "in_group_0"},
 			{Name: "in_group_1"},
 		}
-		bvTasks := []BuildVariantTaskUnit{{Name: "task_group", IsGroup: true}}
+		const bvName = "bv"
+		bvTasks := []BuildVariantTaskUnit{{Name: "task_group", IsGroup: true, Variant: bvName}}
 		groups := []TaskGroup{{Name: bvTasks[0].Name, Tasks: []string{tasks[0].Name, tasks[1].Name}}}
 		p := Project{
 			Tasks:         tasks,
-			BuildVariants: []BuildVariant{{Name: "bv", Tasks: bvTasks}},
+			BuildVariants: []BuildVariant{{Name: bvName, Tasks: bvTasks}},
 			TaskGroups:    groups,
 		}
 

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -935,7 +935,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				bvt.Variant = buildvariant.Name
 				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt)
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3632,12 +3632,16 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B"},
 							},
 						},
-						{Name: "B"},
+						{
+							Name:    "B",
+							Variant: "ubuntu",
+						},
 					},
 				},
 			},
@@ -3650,8 +3654,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
-						{Name: "B"},
+						{
+							Name:      "A",
+							Variant:   "ubuntu",
+							DependsOn: []model.TaskUnitDependency{{Name: "B"}},
+						},
+						{
+							Name:    "B",
+							Variant: "ubuntu",
+						},
 					},
 				},
 			},
@@ -3664,14 +3675,34 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
-						{Name: "B", DependsOn: []model.TaskUnitDependency{{Name: "C", Variant: "rhel"}}},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name: "B",
+								},
+							},
+						},
+						{
+							Name:    "B",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name:    "C",
+									Variant: "rhel",
+								},
+							},
+						},
 					},
 				},
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3684,7 +3715,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A"},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+						},
 					},
 				},
 			},
@@ -3697,8 +3731,21 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B", Variant: "ubuntu"}}},
-						{Name: "B", Patchable: utility.FalsePtr()},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name:    "B",
+									Variant: "ubuntu",
+								},
+							},
+						},
+						{
+							Name:      "B",
+							Variant:   "ubuntu",
+							Patchable: utility.FalsePtr(),
+						},
 					},
 				},
 			},
@@ -3711,7 +3758,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name: "B",
+								},
+							},
+						},
 						{
 							Name:      "B",
 							Variant:   "ubuntu",
@@ -3725,7 +3780,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{Name: "C", Variant: "rhel"},
 					},
 				},
 			},
@@ -3738,8 +3793,21 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B", Variant: "ubuntu"}}},
-						{Name: "B", Patchable: utility.FalsePtr()},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name:    "B",
+									Variant: "ubuntu",
+								},
+							},
+						},
+						{
+							Name:      "B",
+							Variant:   "ubuntu",
+							Patchable: utility.FalsePtr(),
+						},
 					},
 				},
 			},
@@ -3752,12 +3820,24 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "A", DependsOn: []model.TaskUnitDependency{{Name: "B"}}},
+						{
+							Name:    "A",
+							Variant: "ubuntu",
+							DependsOn: []model.TaskUnitDependency{
+								{
+									Name: "B",
+								},
+							},
+						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 							DependsOn: []model.TaskUnitDependency{
-								{Name: "C", Variant: "rhel"},
+								{
+									Name:    "C",
+									Variant: "rhel",
+								},
 							},
 						},
 					},
@@ -3765,7 +3845,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3779,7 +3862,8 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{
 									Name:          "B",
@@ -3788,7 +3872,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 								},
 							},
 						},
-						{Name: "B"},
+						{
+							Name:    "B",
+							Variant: "ubuntu",
+						},
 					},
 				},
 			},
@@ -3802,13 +3889,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
 							},
 						},
 						{
-							Name: "B",
+							Name:    "B",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "C", Variant: "rhel", PatchOptional: true},
 							},
@@ -3818,7 +3907,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3836,13 +3928,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Status: evergreen.TaskFailed},
 							},
 						},
 						{
-							Name: "B",
+							Name:    "B",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "C", Variant: "rhel"},
 							},
@@ -3852,7 +3946,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3870,7 +3967,8 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{
 									Name:    "B",
@@ -3879,7 +3977,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 								},
 							},
 						},
-						{Name: "B"},
+						{Name: "B", Variant: "ubuntu"},
 					},
 				},
 			},
@@ -3897,15 +3995,23 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
-								{Name: "B"},
+								{
+									Name: "B",
+								},
 							},
 						},
 						{
-							Name: "B",
+							Name:    "B",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
-								{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
+								{
+									Name:    "C",
+									Variant: "rhel",
+									Status:  evergreen.TaskFailed,
+								},
 							},
 						},
 					},
@@ -3913,7 +4019,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3928,6 +4037,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
@@ -3935,6 +4045,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 						},
 					},
@@ -3951,6 +4062,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B"},
@@ -3958,6 +4070,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "C", Variant: "rhel", Status: evergreen.TaskFailed},
@@ -3968,7 +4081,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -3983,6 +4099,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
@@ -3990,6 +4107,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 						},
 					},
@@ -4006,6 +4124,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B"},
@@ -4013,6 +4132,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "C", Variant: "rhel"},
@@ -4023,7 +4143,10 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 				{
 					Name: "rhel",
 					Tasks: []model.BuildVariantTaskUnit{
-						{Name: "C"},
+						{
+							Name:    "C",
+							Variant: "rhel",
+						},
 					},
 				},
 			},
@@ -4038,6 +4161,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
@@ -4045,6 +4169,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:       "B",
+							Variant:    "ubuntu",
 							GitTagOnly: utility.TruePtr(),
 						},
 					},
@@ -4061,6 +4186,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
@@ -4068,6 +4194,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:       "B",
+							Variant:    "ubuntu",
 							GitTagOnly: utility.TruePtr(),
 						},
 					},
@@ -4084,6 +4211,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Tasks: []model.BuildVariantTaskUnit{
 						{
 							Name:      "A",
+							Variant:   "ubuntu",
 							Patchable: utility.FalsePtr(),
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
@@ -4091,6 +4219,7 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 						},
 						{
 							Name:           "B",
+							Variant:        "ubuntu",
 							AllowForGitTag: utility.FalsePtr(),
 						},
 					},
@@ -4106,13 +4235,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
 							},
 						},
 						{
 							Name:           "B",
+							Variant:        "ubuntu",
 							AllowForGitTag: utility.TruePtr(),
 						},
 					},
@@ -4128,13 +4259,15 @@ func TestValidateTVDependsOnTV(t *testing.T) {
 					Name: "ubuntu",
 					Tasks: []model.BuildVariantTaskUnit{
 						{
-							Name: "A",
+							Name:    "A",
+							Variant: "ubuntu",
 							DependsOn: []model.TaskUnitDependency{
 								{Name: "B", Variant: "ubuntu"},
 							},
 						},
 						{
 							Name:      "B",
+							Variant:   "ubuntu",
 							PatchOnly: utility.TruePtr(),
 						},
 					},

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -241,10 +241,12 @@ func TestValidateDependencyGraph(t *testing.T) {
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
 							{
-								Name: "compile",
+								Name:    "compile",
+								Variant: "bv1",
 							},
 							{
-								Name: "testOne",
+								Name:    "testOne",
+								Variant: "bv1",
 								DependsOn: []model.TaskUnitDependency{
 									{Name: "compile"},
 									{Name: "testSpecial", Variant: "bv2"},
@@ -254,7 +256,7 @@ func TestValidateDependencyGraph(t *testing.T) {
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: "bv1"}}}},
+							{Name: "testSpecial", Variant: "bv2", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: "bv1"}}}},
 					},
 				},
 			}
@@ -270,7 +272,7 @@ func TestValidateDependencyGraph(t *testing.T) {
 					{
 						Name: "bv1",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
+							{Name: "compile", Variant: "bv1"},
 							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
 								{Name: "compile"},
 								{Name: "testSpecial", Variant: "bv2"},
@@ -279,14 +281,14 @@ func TestValidateDependencyGraph(t *testing.T) {
 					{
 						Name: "bv2",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "testSpecial", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: model.AllVariants}}},
+							{Name: "testSpecial", Variant: "bv2", DependsOn: []model.TaskUnitDependency{{Name: "testOne", Variant: model.AllVariants}}},
 						},
 					},
 					{
 						Name: "bv3",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+							{Name: "compile", Variant: "bv3"},
+							{Name: "testOne", Variant: "bv3", DependsOn: []model.TaskUnitDependency{
 								{Name: "compile"},
 								{Name: "testSpecial", Variant: "bv2"},
 							}}},
@@ -294,8 +296,8 @@ func TestValidateDependencyGraph(t *testing.T) {
 					{
 						Name: "bv4",
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile"},
-							{Name: "testOne", DependsOn: []model.TaskUnitDependency{
+							{Name: "compile", Variant: "bv4"},
+							{Name: "testOne", Variant: "bv4", DependsOn: []model.TaskUnitDependency{
 								{Name: "compile"},
 								{Name: "testSpecial", Variant: "bv2"},
 							}}},


### PR DESCRIPTION
EVG-18405

### Description
The original ticket asks for being able to specify `patch_only` and `disable` at the build variant level. This is half of the requested change and only includes `patch_only`. `disable` already exists but it appears to be non-functional (it also has some problems in that it's not a pointer, so there's no way to distinguish between it being unset and it being set to false). To reduce the riskiness of these changes, I'm going to include a follow-up PR to fix build variant level `disable`.

For completeness' sake, I will also have a follow-up PR to support other fields at the build variant level, such as `patchable`, `allow_for_git_tag` and `git_tag_only`.

* Refactor parser project translation to ensure that the build variant task unit's `Variant` is always set when it's translated to a project.
    * Add a debug log and graceful continue on error in a spot where I think `Variant` should be set but I can't confirm for certain. I'll remove the log in a follow-up PR once I'm sure it does not occur.
* Support `patch_only` at the build variant level.
* Improve some parser project doc comments where there's tricky logic and one case where I believe there's a bug but I can't tell.

### Testing
Added unit tests and tested in staging that `patch_only` worked. I also tested some extra patches to ensure that `Variant` really is being set and to spot check that it's not causing issues with configuring patches or generating tasks.

### Documentation
Added docs.
