### PR TITLE
EVG-19708 Increase smoke test task check attempts

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-04-24"
+	ClientVersion = "2023-04-28"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-04-26b"

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -232,7 +232,7 @@ func getAndCheckBuilds(username, key string, client *http.Client) ([]apimodels.A
 // contents.
 func checkTaskStatusAndLogs(client *http.Client, mode agent.Mode, tasks []string, username, key string) error {
 	grip.Infof("Checking task status and task logs for tasks: %s", strings.Join(tasks, ", "))
-	const taskCheckAttempts = 30
+	const taskCheckAttempts = 40
 OUTER:
 	for i := 0; i < taskCheckAttempts; i++ {
 		// Poll the app server until the task is finished and check its task


### PR DESCRIPTION
EVG-19708

### Description
Since generate.tasks has been added to the smoke tests, they do more work and have occasionally been [timing out](https://spruce.mongodb.com/version/644833a661837db984a8c099/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) since they're not able to always verify the tasks have succeeded within 30 attempts. Increasing the task check attempts from 30 to 40 which should help alleviate this.
### Testing
Submitted a few smoke test patches and have not been able to reproduce the timeouts since
