### PR TITLE
EVG-18405: set variant in commit queue merge task group

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -582,6 +582,7 @@ func AddMergeTaskAndVariant(ctx context.Context, patchDoc *patch.Patch, project 
 		Tasks: []model.BuildVariantTaskUnit{
 			{
 				Name:             evergreen.MergeTaskGroup,
+				Variant:          evergreen.MergeTaskVariant,
 				IsGroup:          true,
 				CommitQueueMerge: true,
 			},

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -263,6 +263,8 @@ func (s *commitQueueSuite) TestAddMergeTaskAndVariant() {
 	s.Equal(evergreen.MergeTaskVariant, pp.BuildVariants[0].Name)
 	s.Require().Len(pp.BuildVariants[0].Tasks, 1)
 	s.True(project.BuildVariants[0].Tasks[0].CommitQueueMerge)
+	s.Equal(evergreen.MergeTaskGroup, project.BuildVariants[0].Tasks[0].Name)
+	s.Equal(evergreen.MergeTaskVariant, project.BuildVariants[0].Tasks[0].Variant)
 	s.Require().Len(pp.Tasks, 1)
 	s.Equal(evergreen.MergeTaskName, project.Tasks[0].Name)
 	s.Require().Len(pp.TaskGroups, 1)


### PR DESCRIPTION
EVG-18405

### Description
Based on [Splunk logs](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20EVG-18405&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1682959680&latest=1682961498&sid=1682961944.3287592), there's exactly one place that doesn't follow the "all build variant task units are created by project translation" rule, and it's because the commit queue job manually edits the project model to add in the merge task group. I don't believe that the missing `Variant` has any effect on the merge task's behavior, but I'd like to remove [this fallback behavior](https://github.com/evergreen-ci/evergreen/blob/762e83e5c8beb3990eb4965d3380cd8f9e6287dd/model/project.go#L1551-L1561).

### Testing
Added to commit queue unit tests.

### Documentation
N/A