### PR TITLE
EVG-18405: support disabling build variants

### DIFF
--- a/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
+++ b/docs/02-Configure-a-Project/01-Project-Configuration-Files.md
@@ -532,15 +532,13 @@ early_termination:
 
 ### Limiting When a Task Will Run
 
-The following can be added to a task definition OR to a task listed
-under a build variant (so that it will only effect that variant's
-task).
+To limit the conditions when a task will run, the following settings can be
+added to a task definition, to a build variant definition, or to a specific task
+listed under a build variant (so that it will only affect that variant's task).
 
 To cause a task to only run in commit builds, set `patchable: false`.
 
-To cause a task to only run in patches, set `patch_only: true`. `patch_only: true` can also be set at the build variant
-level to apply this behavior to all tasks in the build variant. The build variant level setting can be overridden if
-it's been explicitly set in the task definition or in the task listed under the build variant.
+To cause a task to only run in patches, set `patch_only: true`.
 
 To cause a task to only run in versions NOT triggered from git tags, set
 `allow_for_git_tag: false`.
@@ -548,15 +546,36 @@ To cause a task to only run in versions NOT triggered from git tags, set
 To cause a task to only run in versions triggered from git tags, set
 `git_tag_only: true`.
 
-To cause a task to not run at all, set `disable: true`. Setting `disable: true` at the build variant level 
-will apply this behavior to all tasks in the build variant.
+To cause a task to not run at all, set `disable: true`.
 
 -   This behaves similarly to commenting out the task but will not
     trigger any validation errors.
--   Disabling its dependencies will still allow the task to run
+-   If a disable is disabled and is depended on by another task, the
+    dependent task will simply exclude the disabled task from its
+    dependencies.
 
 Can also set batchtime or cron on tasks or build variants, detailed
 [here](#build-variants).
+
+If there are conflicting settings defined at different levels, the order of
+priority (from highest to lowest) is:
+
+- Tasks listed under a build variant.
+- The task definition.
+- The build variant definition.
+
+For example, if we have this configuration:
+```yaml
+buildvariants:
+- name: some-build-variant
+  patchable: false
+  tasks:
+    - name: unpatchable-task
+    - name: patchable-task
+      patchable: true
+```
+In this case, `unpatchable-task` cannot run in patches, but `patchable-task`
+can.
 
 ### Expansions
 
@@ -664,8 +683,8 @@ Every task has some expansions available by default:
     queue task
 -   `${commit_message}` is the commit message if this is a commit queue
     task
--   `${requester}` is what triggered the task: patch, github_pr,
-    github_tag, commit, trigger, commit_queue, or ad_hoc
+-   `${requester}` is what triggered the task: patch, `github_pr`,
+    `github_tag`, `commit`, `trigger`, `commit_queue`, or `ad_hoc`
 
 The following expansions are available if a task was triggered by an
 inter-project dependency:
@@ -1309,10 +1328,10 @@ tasks to the task's depends_on field. The following additional
 parameters are available:
 
 -   `status` - string (default: "success"). One of ["success",
-    "failed", or "*"]. "*" includes any finished status as well
+    "failed", or "`*`"]. "`*`" includes any finished status as well
     as when the task is blocked.
 -   `variant` - string (by default, uses existing variant). Can specify a 
-     variant for the dependency to exist in, or "*" will depend on the task
+     variant for the dependency to exist in, or "`*`" will depend on the task
      for all matching variants.
 -   `patch_optional` - boolean (default: false). If true the dependency
     will only exist when the depended on task is present in the version

--- a/model/generate.go
+++ b/model/generate.go
@@ -683,6 +683,8 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 }
 
 func isNonZeroBV(bv parserBV) bool {
+	// Note: this omits activate from consideration, but it's unclear if it's
+	// intentional or not.
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
 		bv.Disable != nil || len(bv.Tags) > 0 ||
 		bv.BatchTime != nil || bv.PatchOnly != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {

--- a/model/generate.go
+++ b/model/generate.go
@@ -219,7 +219,7 @@ func cacheProjectData(p *Project) projectMaps {
 
 // saveNewBuildsAndTasks saves new builds and tasks to the db.
 func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version, p *Project) error {
-	// inherit priority from the parent task
+	// Inherit priority from the parent generator task.
 	for i, projBv := range p.BuildVariants {
 		for j := range projBv.Tasks {
 			p.BuildVariants[i].Tasks[j].Priority = g.Task.Priority
@@ -684,7 +684,7 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 
 func isNonZeroBV(bv parserBV) bool {
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
-		bv.Disable || len(bv.Tags) > 0 ||
+		bv.Disable != nil || len(bv.Tags) > 0 ||
 		bv.BatchTime != nil || bv.PatchOnly != nil || bv.Stepback != nil || len(bv.RunOn) > 0 {
 		return true
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -731,7 +731,8 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 		if task.Name != "" && !task.IsGroup {
 			// kim: NOTE: seems like this, which is always used to create task
 			// documents, will always skip disabled tasks until explicitly
-			// enabled.
+			// enabled. This is intentional because `disable: true` tasks should
+			// never run.
 			if task.IsDisabled() || task.SkipOnRequester(creationInfo.Build.Requester) {
 				continue
 			}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -729,6 +729,9 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 	for _, task := range creationInfo.BuildVariant.Tasks {
 		// Verify that the config isn't malformed.
 		if task.Name != "" && !task.IsGroup {
+			// kim: NOTE: seems like this, which is always used to create task
+			// documents, will always skip disabled tasks until explicitly
+			// enabled.
 			if task.IsDisabled() || task.SkipOnRequester(creationInfo.Build.Requester) {
 				continue
 			}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -729,10 +729,6 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 	for _, task := range creationInfo.BuildVariant.Tasks {
 		// Verify that the config isn't malformed.
 		if task.Name != "" && !task.IsGroup {
-			// kim: NOTE: seems like this, which is always used to create task
-			// documents, will always skip disabled tasks until explicitly
-			// enabled. This is intentional because `disable: true` tasks should
-			// never run.
 			if task.IsDisabled() || task.SkipOnRequester(creationInfo.Build.Requester) {
 				continue
 			}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -378,7 +378,8 @@ func (p *Patch) SetDownstreamParameters(parameters []Parameter) error {
 }
 
 // ResolveVariantTasks returns a set of all build variants and a set of all
-// tasks that will run based on the given VariantTasks.
+// tasks that will run based on the given VariantTasks, filtering out any
+// duplicates.
 func ResolveVariantTasks(vts []VariantTasks) (bvs []string, tasks []string) {
 	taskSet := map[string]bool{}
 	bvSet := map[string]bool{}

--- a/model/project.go
+++ b/model/project.go
@@ -286,6 +286,8 @@ func (bvt *BuildVariantTaskUnit) SkipOnNonGitTagBuild() bool {
 	return utility.FromBoolPtr(bvt.GitTagOnly)
 }
 
+// kim: TODO: check usages of this to see if there are conflicts or missing
+// cases compared to where the build variant disable field is referenced.
 func (bvt *BuildVariantTaskUnit) IsDisabled() bool {
 	return utility.FromBoolPtr(bvt.Disable)
 }
@@ -309,7 +311,6 @@ type BuildVariant struct {
 	DisplayName string            `yaml:"display_name,omitempty" bson:"display_name"`
 	Expansions  map[string]string `yaml:"expansions,omitempty" bson:"expansions"`
 	Modules     []string          `yaml:"modules,omitempty" bson:"modules"`
-	Disable     bool              `yaml:"disable,omitempty" bson:"disable"`
 	Tags        []string          `yaml:"tags,omitempty" bson:"tags"`
 
 	// Use a *int for 2 possible states
@@ -329,6 +330,10 @@ type BuildVariant struct {
 	//   2. true  = overriding the project setting with true
 	//   3. false = overriding the project setting with false
 	Stepback *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+
+	// kim: NOTE: this is currently unused, so it should be safe to change the
+	// existing usages of it.
+	Disable *bool `yaml:"disable,omitempty" bson:"disable"`
 
 	// the default distros.  will be used to run a task if no distro field is
 	// provided for the task
@@ -1667,7 +1672,10 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 	if len(bvs) == 1 && bvs[0] == "all" {
 		bvs = []string{}
 		for _, bv := range p.BuildVariants {
-			if bv.Disable {
+			// kim: QUESTION: does this conflict with precedence rules, which
+			// allow disable to be defined at build variant task unit level? It
+			// seems like it would, so probably has to be fixed.
+			if utility.FromBoolPtr(bv.Disable) {
 				continue
 			}
 			bvs = append(bvs, bv.Name)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1340,7 +1340,7 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.PatchOnly = bv.PatchOnly
 	}
 
-	// kim: TODO: test
+	// kim: TODO: test project translation
 	if res.Disable == nil {
 		res.Disable = bv.Disable
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -319,7 +319,7 @@ type parserBV struct {
 	Expansions    util.Expansions    `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
 	Tags          parserStringSlice  `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
 	Modules       parserStringSlice  `yaml:"modules,omitempty" bson:"modules,omitempty"`
-	Disable       bool               `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	Disable       *bool              `yaml:"disable,omitempty" bson:"disable,omitempty"`
 	BatchTime     *int               `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
 	CronBatchTime string             `yaml:"cron,omitempty" bson:"cron,omitempty"`
 	Stepback      *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
@@ -386,7 +386,7 @@ func (pbv *parserBV) canMerge() bool {
 		pbv.Expansions == nil &&
 		pbv.Tags == nil &&
 		pbv.Modules == nil &&
-		!pbv.Disable &&
+		pbv.Disable == nil &&
 		pbv.BatchTime == nil &&
 		pbv.CronBatchTime == "" &&
 		pbv.Stepback == nil &&
@@ -511,7 +511,7 @@ func (bvt *parserBVTaskUnit) hasSpecificActivation() bool {
 // overrides the default, such as cron/batchtime, disabling the task, or explicitly deactivating it.
 func (bv *parserBV) hasSpecificActivation() bool {
 	return bv.BatchTime != nil || bv.CronBatchTime != "" ||
-		!utility.FromBoolTPtr(bv.Activate) || bv.Disable
+		!utility.FromBoolTPtr(bv.Activate) || utility.FromBoolPtr(bv.Disable)
 }
 
 // FindAndTranslateProjectForPatch translates a parser project for a patch into
@@ -1334,10 +1334,16 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.RunOn = pt.RunOn
 	}
 
+	// Build variant level settings are lower priority than project task level
+	// settings.
 	if res.PatchOnly == nil {
 		res.PatchOnly = bv.PatchOnly
 	}
 
+	// kim: TODO: test
+	if res.Disable == nil {
+		res.Disable = bv.Disable
+	}
 	return res
 }
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1340,7 +1340,6 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.PatchOnly = bv.PatchOnly
 	}
 
-	// kim: TODO: test project translation
 	if res.Disable == nil {
 		res.Disable = bv.Disable
 	}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -312,7 +312,7 @@ func TestTranslateTasks(t *testing.T) {
 				},
 			},
 			{
-				Name:      "bv1",
+				Name:      "patch_only_bv",
 				PatchOnly: utility.FalsePtr(),
 				Tasks: parserBVTaskUnits{
 					{
@@ -323,6 +323,19 @@ func TestTranslateTasks(t *testing.T) {
 					},
 					{
 						Name: "a_task_with_no_special_configuration",
+					},
+				},
+			},
+			{
+				Name:    "disabled_bv",
+				Disable: utility.TruePtr(),
+				Tasks: parserBVTaskUnits{
+					{
+						Name: "your_task",
+					},
+					{
+						Name:    "my_task",
+						Disable: utility.FalsePtr(),
 					},
 				},
 			},
@@ -342,7 +355,7 @@ func TestTranslateTasks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, out)
 	require.Len(t, out.Tasks, 4)
-	require.Len(t, out.BuildVariants, 2)
+	require.Len(t, out.BuildVariants, 3)
 
 	for _, bv := range out.BuildVariants {
 		for _, bvtu := range bv.Tasks {
@@ -350,6 +363,7 @@ func TestTranslateTasks(t *testing.T) {
 		}
 	}
 
+	assert.Equal(t, "bv0", out.BuildVariants[0].Name)
 	require.Len(t, out.BuildVariants[0].Tasks, 3)
 	assert.Equal(t, "my_task", out.BuildVariants[0].Tasks[0].Name)
 	assert.Equal(t, 30, out.BuildVariants[0].Tasks[0].ExecTimeoutSecs)
@@ -376,6 +390,7 @@ func TestTranslateTasks(t *testing.T) {
 	assert.Contains(t, bvt.RunOn, "my_distro")
 	assert.True(t, bvt.IsGroup)
 
+	assert.Equal(t, "patch_only_bv", out.BuildVariants[1].Name)
 	require.Len(t, out.BuildVariants[1].Tasks, 3)
 	assert.Equal(t, "your_task", out.BuildVariants[1].Tasks[0].Name)
 	assert.True(t, utility.FromBoolPtr(out.BuildVariants[1].Tasks[0].Stepback))
@@ -385,6 +400,16 @@ func TestTranslateTasks(t *testing.T) {
 	assert.True(t, utility.FromBoolPtr(out.BuildVariants[1].Tasks[1].PatchOnly))
 	assert.Equal(t, "a_task_with_no_special_configuration", out.BuildVariants[1].Tasks[2].Name)
 	assert.False(t, utility.FromBoolPtr(out.BuildVariants[1].Tasks[2].PatchOnly))
+
+	assert.Equal(t, "disabled_bv", out.BuildVariants[2].Name)
+	require.Len(t, out.BuildVariants[2].Tasks, 2)
+	assert.Equal(t, "your_task", out.BuildVariants[2].Tasks[0].Name)
+	assert.False(t, utility.FromBoolPtr(out.BuildVariants[2].Tasks[0].GitTagOnly))
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[2].Tasks[0].Stepback))
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[2].Tasks[0].Disable))
+	assert.Equal(t, "my_task", out.BuildVariants[2].Tasks[1].Name)
+	assert.True(t, utility.FromBoolPtr(out.BuildVariants[2].Tasks[1].PatchOnly))
+	assert.False(t, utility.FromBoolPtr(out.BuildVariants[2].Tasks[1].Disable))
 }
 
 func TestTranslateDependsOn(t *testing.T) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2162,9 +2162,7 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the build, set batchtime to the zero time
-	// kim: NOTE: removed because disable is propagated down to the build
-	// variant task unit level with precedence observed.
-	if !utility.FromBoolTPtr(variant.Activate) { // || utility.FromBoolPtr(variant.Disable) {
+	if !utility.FromBoolTPtr(variant.Activate) {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2162,7 +2162,9 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the build, set batchtime to the zero time
-	if !utility.FromBoolTPtr(variant.Activate) || variant.Disable {
+	// kim: TODO: verify that this activation time logic doesn't conflict with
+	// build variant task level disable setting
+	if !utility.FromBoolTPtr(variant.Activate) || utility.FromBoolPtr(variant.Disable) {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2162,9 +2162,9 @@ func GetActivationTimeWithCron(curTime time.Time, cronBatchTime string) (time.Ti
 func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the build, set batchtime to the zero time
-	// kim: TODO: verify that this activation time logic doesn't conflict with
-	// build variant task level disable setting
-	if !utility.FromBoolTPtr(variant.Activate) || utility.FromBoolPtr(variant.Disable) {
+	// kim: NOTE: removed because disable is propagated down to the build
+	// variant task unit level with precedence observed.
+	if !utility.FromBoolTPtr(variant.Activate) { // || utility.FromBoolPtr(variant.Disable) {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -794,8 +794,6 @@ func (s *projectSuite) TestAliasResolution() {
 	s.Empty(displayTaskPairs)
 }
 
-// kim: TODO: fix this test. May have to check IsDisabled to get it to work
-// properly.
 func (s *projectSuite) TestBuildProjectTVPairs() {
 	// test all expansions
 	patchDoc := patch.Patch{
@@ -828,8 +826,6 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	s.Len(patchDoc.Tasks, 6)
 }
 
-// kim: TODO: fix this test. May have to check IsDisabled to get it to work
-// properly.
 func (s *projectSuite) TestResolvePatchVTs() {
 	// Specifying all.
 	patchDoc := patch.Patch{

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -640,7 +640,7 @@ func (s *projectSuite) SetupTest() {
 			},
 			{
 				Name:    "bv_3",
-				Disable: true,
+				Disable: utility.TruePtr(),
 				Tasks: []BuildVariantTaskUnit{
 					{
 						Name: "disabled_task",

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -573,7 +573,6 @@ func (s *projectSuite) SetupTest() {
 	for _, alias := range s.aliases {
 		s.NoError(alias.Upsert())
 	}
-
 	s.project = &Project{
 		Identifier: "project",
 		BuildVariants: []BuildVariant{
@@ -639,11 +638,11 @@ func (s *projectSuite) SetupTest() {
 				},
 			},
 			{
-				Name:    "bv_3",
-				Disable: utility.TruePtr(),
+				Name: "bv_3",
 				Tasks: []BuildVariantTaskUnit{
 					{
-						Name: "disabled_task",
+						Name:    "disabled_task",
+						Disable: utility.TruePtr(),
 					},
 				},
 			},
@@ -795,6 +794,8 @@ func (s *projectSuite) TestAliasResolution() {
 	s.Empty(displayTaskPairs)
 }
 
+// kim: TODO: fix this test. May have to check IsDisabled to get it to work
+// properly.
 func (s *projectSuite) TestBuildProjectTVPairs() {
 	// test all expansions
 	patchDoc := patch.Patch{
@@ -827,6 +828,8 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	s.Len(patchDoc.Tasks, 6)
 }
 
+// kim: TODO: fix this test. May have to check IsDisabled to get it to work
+// properly.
 func (s *projectSuite) TestResolvePatchVTs() {
 	// Specifying all.
 	patchDoc := patch.Patch{
@@ -1121,12 +1124,9 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	patchDoc := patch.Patch{}
 
 	s.project.BuildProjectTVPairs(&patchDoc, "disabled_stuff")
-	s.Equal([]string{"bv_3"}, patchDoc.BuildVariants)
-	s.Equal([]string{"disabled_task"}, patchDoc.Tasks)
-	s.Require().Len(patchDoc.VariantsTasks, 1)
-	s.Equal("bv_3", patchDoc.VariantsTasks[0].Variant)
-	s.Equal([]string{"disabled_task"}, patchDoc.VariantsTasks[0].Tasks)
-	s.Empty(patchDoc.VariantsTasks[0].DisplayTasks)
+	s.Empty(patchDoc.BuildVariants)
+	s.Empty(patchDoc.Tasks)
+	s.Empty(patchDoc.VariantsTasks)
 
 	patchDoc = patch.Patch{
 		BuildVariants: []string{"bv_3"},
@@ -1134,12 +1134,9 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	}
 
 	s.project.BuildProjectTVPairs(&patchDoc, "")
-	s.Equal([]string{"bv_3"}, patchDoc.BuildVariants)
-	s.Equal([]string{"disabled_task"}, patchDoc.Tasks)
-	s.Require().Len(patchDoc.VariantsTasks, 1)
-	s.Equal("bv_3", patchDoc.VariantsTasks[0].Variant)
-	s.Equal([]string{"disabled_task"}, patchDoc.VariantsTasks[0].Tasks)
-	s.Empty(patchDoc.VariantsTasks[0].DisplayTasks)
+	s.Empty(patchDoc.BuildVariants)
+	s.Empty(patchDoc.Tasks)
+	s.Empty(patchDoc.VariantsTasks)
 }
 
 func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -811,13 +811,14 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 	// build all pairsToCreate before creating builds, to handle dependencies (if applicable)
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		if ctx.Err() != nil {
-			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
+			return errors.Wrapf(ctx.Err(), "aborting version creation for version '%s'", v.Id)
 		}
-		// kim: TODO: check if this is correct with precedence rules. It may
-		// conflict with build variant task unit disable setting.
-		if utility.FromBoolPtr(buildvariant.Disable) {
-			continue
-		}
+		// kim: TODO: CreateBuildFromVersionNoInsert below already checks
+		// IsDisabled.
+		// kim: NOTE: removed because this violates precedence rules.
+		// if utility.FromBoolPtr(buildvariant.Disable) {
+		//     continue
+		// }
 		if len(aliases) > 0 {
 			var aliasesMatchingVariant model.ProjectAliases
 			aliasesMatchingVariant, err = aliases.AliasesMatchingVariant(buildvariant.Name, buildvariant.Tags)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -813,7 +813,9 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		if ctx.Err() != nil {
 			return errors.Wrapf(err, "aborting version creation for version %s", v.Id)
 		}
-		if buildvariant.Disable {
+		// kim: TODO: check if this is correct with precedence rules. It may
+		// conflict with build variant task unit disable setting.
+		if utility.FromBoolPtr(buildvariant.Disable) {
 			continue
 		}
 		if len(aliases) > 0 {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -813,12 +813,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		if ctx.Err() != nil {
 			return errors.Wrapf(ctx.Err(), "aborting version creation for version '%s'", v.Id)
 		}
-		// kim: TODO: CreateBuildFromVersionNoInsert below already checks
-		// IsDisabled.
-		// kim: NOTE: removed because this violates precedence rules.
-		// if utility.FromBoolPtr(buildvariant.Disable) {
-		//     continue
-		// }
 		if len(aliases) > 0 {
 			var aliasesMatchingVariant model.ProjectAliases
 			aliasesMatchingVariant, err = aliases.AliasesMatchingVariant(buildvariant.Name, buildvariant.Tags)


### PR DESCRIPTION
EVG-18405

### Description
Add support for `disable` at the build variant level. While this field already exists at the build variant level, I didn't find any project YAMLs using it, and I believe the existing usage was buggy, so I rewrote it.

* Allow `disable` to be specified at build variant level. It has lower precedence than disable settings specified at the task or build variant task levels.
* Update a few doc/code comments for clarity.
* Drive-by fix a couple markdown errors in the docs.

### Testing
Added unit tests and tested in staging patches that `disable: true` at the build variant level works as I described.

### Documentation
Updated docs and described precedence of conflicting settings.
