### PR TITLE
EVG-18260 verify that hidden project can be accessed via rest API

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -509,6 +509,14 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 			"project_identifier": p.Identifier,
 		}))
 	}
+
+	newProjectVars := ProjectVars{
+		Id: p.Id,
+	}
+	err = newProjectVars.Insert()
+	if err != nil {
+		return errors.Wrapf(err, "adding project variables for project '%s'", p.Id)
+	}
 	return p.addPermissions(creator)
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -513,8 +513,7 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 	newProjectVars := ProjectVars{
 		Id: p.Id,
 	}
-	err = newProjectVars.Insert()
-	if err != nil {
+	if err = newProjectVars.Insert(); err != nil {
 		return errors.Wrapf(err, "adding project variables for project '%s'", p.Id)
 	}
 	return p.addPermissions(creator)

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -154,17 +154,6 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 		"project_identifier": projectRef.Identifier,
 	}))
 
-	newProjectVars := model.ProjectVars{
-		Id: projectRef.Id,
-	}
-
-	err = newProjectVars.Insert()
-	if err != nil {
-		return false, gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "initializing project variables for project '%s'", projectRef.Identifier).Error(),
-		}
-	}
 	err = model.LogProjectAdded(projectRef.Id, u.DisplayName())
 	grip.Error(message.WrapError(err, message.Fields{
 		"message":            "problem logging project added",

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -226,6 +226,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 	if err != nil {
 		return nil, errors.Wrap(err, "getting the original merged project ref")
 	}
+	if mergedSection.IsHidden() {
+		return nil, errors.Wrap(err, "can't update a hidden project")
+	}
 
 	catcher := grip.NewBasicCatcher()
 	modified := false

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -227,7 +227,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		return nil, errors.Wrap(err, "getting the original merged project ref")
 	}
 	if mergedSection.IsHidden() {
-		return nil, errors.Wrap(err, "can't update a hidden project")
+		return nil, errors.New("can't update a hidden project")
 	}
 
 	catcher := grip.NewBasicCatcher()

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -328,6 +328,9 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 
 // Run updates a project by name.
 func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
+	if h.newProjectRef.IsHidden() {
+		return gimlet.NewJSONErrorResponse("can't patch a hidden project")
+	}
 	if err := h.newProjectRef.ValidateOwnerAndRepo(h.settings.GithubOrgs); err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating owner and repo"))
 	}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -62,7 +62,8 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 	project2.Identifier = "project2"
 	s.NoError(project2.Add(&user))
 
-	s.NoError(getTestVar().Insert())
+	_, err := getTestVar().Upsert()
+	s.NoError(err)
 	aliases := getTestAliases()
 	for _, alias := range aliases {
 		s.NoError(alias.Upsert())


### PR DESCRIPTION
EVG-18260 

### Description
Moved project variable creation into Add() since we assume that both project ref and project var must exist for any project in lots of places.

In thinking through this, realized we should gate hidden projects from being modifiable via route or UI since they're meant to be backend only skeleton projects.

### Testing
Verified in staging that a hidden project could be accessed via rest API if the variables doc existed.
