### PR TITLE
EVG-18346 Point to different links for multi-commit merge patch diff links

### DIFF
--- a/graphql/tests/patch/results.json
+++ b/graphql/tests/patch/results.json
@@ -188,7 +188,7 @@
                 "fileDiffs": [
                   {
                     "fileName": "service/api_task.go",
-                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=service%2Fapi_task.go\u0026patch_number=0",
+                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=service%2Fapi_task.go\u0026patch_number=0\u0026commit_number=0",
                     "deletions": 4,
                     "additions": 5,
                     "description": ""
@@ -202,21 +202,21 @@
                 "fileDiffs": [
                   {
                     "fileName": "src/page/Task.tsx",
-                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2Fpage%2FTask.tsx&patch_number=1",
+                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2Fpage%2FTask.tsx&patch_number=1&commit_number=0",
                     "deletions": 4,
                     "additions": 11,
                     "description": ""
                   },
                   {
                     "fileName": "src/App.tsx",
-                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2FApp.tsx&patch_number=1",
+                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2FApp.tsx&patch_number=1&commit_number=1",
                     "deletions": 4,
                     "additions": 22,
                     "description": ""
                   },
                   {
                     "fileName": "src/page/Patch.tsx",
-                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2Fpage%2FPatch.tsx&patch_number=1",
+                    "diffLink": "https://localhost:8443/filediff/5e4ff3abe3c3317e352062e4?file_name=src%2Fpage%2FPatch.tsx&patch_number=1&commit_number=2",
                     "deletions": 4,
                     "additions": 33,
                     "description": ""

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -314,13 +314,8 @@ func (apiPatch *APIPatch) buildModuleChanges(p patch.Patch, identifier string) {
 		htmlLink := fmt.Sprintf("%s/filediff/%s?patch_number=%d", apiURL, *apiPatch.Id, patchNumber)
 		rawLink := fmt.Sprintf("%s/rawdiff/%s?patch_number=%d", apiURL, *apiPatch.Id, patchNumber)
 		fileDiffs := []FileDiff{}
-		commitNumber := 0
-		prevCommitMsg := ""
 		for i, file := range modPatch.PatchSet.Summary {
-			if i > 0 && file.Description != prevCommitMsg {
-				commitNumber++
-			}
-			diffLink := fmt.Sprintf("%s/filediff/%s?file_name=%s&patch_number=%d&commit_number=%d", apiURL, *apiPatch.Id, url.QueryEscape(file.Name), patchNumber, commitNumber)
+			diffLink := fmt.Sprintf("%s/filediff/%s?file_name=%s&patch_number=%d&commit_number=%d", apiURL, *apiPatch.Id, url.QueryEscape(file.Name), patchNumber, i)
 			fileName := file.Name
 			fileDiff := FileDiff{
 				FileName:    &fileName,
@@ -330,7 +325,6 @@ func (apiPatch *APIPatch) buildModuleChanges(p patch.Patch, identifier string) {
 				Description: file.Description,
 			}
 			fileDiffs = append(fileDiffs, fileDiff)
-			prevCommitMsg = file.Description
 		}
 		apiModPatch := APIModulePatch{
 			BranchName:     &branchName,

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -314,8 +314,13 @@ func (apiPatch *APIPatch) buildModuleChanges(p patch.Patch, identifier string) {
 		htmlLink := fmt.Sprintf("%s/filediff/%s?patch_number=%d", apiURL, *apiPatch.Id, patchNumber)
 		rawLink := fmt.Sprintf("%s/rawdiff/%s?patch_number=%d", apiURL, *apiPatch.Id, patchNumber)
 		fileDiffs := []FileDiff{}
-		for _, file := range modPatch.PatchSet.Summary {
-			diffLink := fmt.Sprintf("%s/filediff/%s?file_name=%s&patch_number=%d", apiURL, *apiPatch.Id, url.QueryEscape(file.Name), patchNumber)
+		commitNumber := 0
+		prevCommitMsg := ""
+		for i, file := range modPatch.PatchSet.Summary {
+			if i > 0 && file.Description != prevCommitMsg {
+				commitNumber++
+			}
+			diffLink := fmt.Sprintf("%s/filediff/%s?file_name=%s&patch_number=%d&commit_number=%d", apiURL, *apiPatch.Id, url.QueryEscape(file.Name), patchNumber, commitNumber)
 			fileName := file.Name
 			fileDiff := FileDiff{
 				FileName:    &fileName,
@@ -325,6 +330,7 @@ func (apiPatch *APIPatch) buildModuleChanges(p patch.Patch, identifier string) {
 				Description: file.Description,
 			}
 			fileDiffs = append(fileDiffs, fileDiff)
+			prevCommitMsg = file.Description
 		}
 		apiModPatch := APIModulePatch{
 			BranchName:     &branchName,

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -147,7 +147,7 @@ func TestAPIPatchBuildModuleChanges(t *testing.T) {
 	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[0].DiffLink), "commit_number=0"), -1)
 	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[1].DiffLink), "commit_number=1"), -1)
 	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[2].DiffLink), "commit_number=2"), -1)
-	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[3].DiffLink), "commit_number=2"), -1)
+	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[3].DiffLink), "commit_number=3"), -1)
 
 }
 

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -1,16 +1,18 @@
 package model
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
-
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/commitqueue"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -109,6 +111,44 @@ func TestAPIPatch(t *testing.T) {
 	assert.NotZero(a.GithubPatchData)
 	assert.NotEqual(a.VariantsTasks[0].Tasks, a.VariantsTasks[1].Tasks)
 	assert.Len(a.VariantsTasks[0].Tasks, 1)
+}
+
+func TestAPIPatchBuildModuleChanges(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	evergreen.SetEnvironment(env)
+	p := patch.Patch{
+		Patches: []patch.ModulePatch{
+			{
+				PatchSet: patch.PatchSet{
+					Summary: []thirdparty.Summary{
+						{
+							Description: "test",
+						},
+						{
+							Description: "test2",
+						},
+						{
+							Description: "test3",
+						},
+						{
+							Description: "test3",
+						},
+					},
+				},
+			},
+		},
+	}
+	a := APIPatch{Id: utility.ToStringPtr("patch_id")}
+	a.buildModuleChanges(p, "")
+	require.Len(t, a.ModuleCodeChanges, 1)
+	assert.Len(t, a.ModuleCodeChanges[0].FileDiffs, 4)
+	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[0].DiffLink), "commit_number=0"), -1)
+	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[1].DiffLink), "commit_number=1"), -1)
+	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[2].DiffLink), "commit_number=2"), -1)
+	assert.NotEqual(t, strings.Index(utility.FromStringPtr(a.ModuleCodeChanges[0].FileDiffs[3].DiffLink), "commit_number=2"), -1)
+
 }
 
 func TestGithubPatch(t *testing.T) {

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -116,8 +116,12 @@ func TestAPIPatch(t *testing.T) {
 func TestAPIPatchBuildModuleChanges(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	originalEnv := evergreen.GetEnvironment()
 	env := testutil.NewEnvironment(ctx, t)
 	evergreen.SetEnvironment(env)
+	defer func() {
+		evergreen.SetEnvironment(originalEnv)
+	}()
 	p := patch.Patch{
 		Patches: []patch.ModulePatch{
 			{

--- a/service/patch.go
+++ b/service/patch.go
@@ -149,10 +149,11 @@ func (uis *UIServer) fileDiffPage(w http.ResponseWriter, r *http.Request) {
 			http.StatusInternalServerError)
 	}
 	uis.render.WriteResponse(w, http.StatusOK, struct {
-		Data        patch.Patch
-		FileName    string
-		PatchNumber string
-	}{*fullPatch, r.FormValue("file_name"), r.FormValue("patch_number")},
+		Data         patch.Patch
+		FileName     string
+		PatchNumber  string
+		CommitNumber string
+	}{*fullPatch, r.FormValue("file_name"), r.FormValue("patch_number"), r.FormValue("commit_number")},
 		"base", "file_diff.html")
 }
 

--- a/service/templates/file_diff.html
+++ b/service/templates/file_diff.html
@@ -11,6 +11,7 @@
 var patches = {{.Data.Patches}};
 var filename = {{.FileName}};
 var patchNumber = {{.PatchNumber}};
+var commitNumber = {{.CommitNumber}};
 
 var handlePatchNumber = function(i) {
   var outputBlock = $('<code></code>');
@@ -24,14 +25,16 @@ var handlePatchNumber = function(i) {
   for (var j = 0; j < lines.length; ++j) {
     var line = lines[j];
 
-    var isNewFile = (line.indexOf('diff --git') === 0);
+    var isNewFile = (line.indexOf('diff --git') === 0) || line === '---';
 
     if (isNewFile && found) {
       break;
     }
 
-    if (filename && isNewFile && line.indexOf(filename) != -1) {
+    if (filename && isNewFile && line.indexOf(filename) != -1 && commitNumber == 0) {
       found = true;
+    } else if (filename && isNewFile && line.indexOf(filename) != -1) {
+      commitNumber--;
     }
 
     if (line.substring(0, 3) == "+++") {

--- a/service/templates/file_diff.html
+++ b/service/templates/file_diff.html
@@ -25,15 +25,16 @@ var handlePatchNumber = function(i) {
   for (var j = 0; j < lines.length; ++j) {
     var line = lines[j];
 
-    var isNewFile = (line.indexOf('diff --git') === 0) || line === '---';
+    var isNewFile = (line.indexOf('diff --git') === 0);
+    var isNextCommit = line === '---'
 
-    if (isNewFile && found) {
+    if ((isNewFile || isNextCommit) && found) {
       break;
     }
 
     if (filename && isNewFile && line.indexOf(filename) != -1 && commitNumber == 0) {
       found = true;
-    } else if (filename && isNewFile && line.indexOf(filename) != -1) {
+    } else if (filename && isNewFile) {
       commitNumber--;
     }
 


### PR DESCRIPTION
EVG-18346

### Description
Currently, HTML diff links only accept a filename parameter when templating the data. This means for commit queue merge patches that have multiple commits as part of their changes panel such as [this one](https://spruce.mongodb.com/version/637ba3350305b9100cee7294/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), if the same file is changed between both commits, they will point to the same diff, i.e. the first one matching the filename in the full diff file.

Introduced a change to track which commit we are on in the templating logic and serve the data accordingly. Also did a drive-by change fixing a bug I noticed where for multi-commit diffs the beginning of the next commit bleeds into the top of the preceding commit's changes ([example](https://evergreen.mongodb.com/filediff/637ba3350305b9100cee7294/?file_name=evergreen%2Flint_fuzzer_sanity_all.sh&patch_number=0))

### Testing
Unit testing, tested in staging and locally.