### PR TITLE
EVG-19793 Update middleware for rotate route

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -207,7 +207,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}/task_executions").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetProjectTaskExecutionsHandler())
 	app.AddRoute("/projects/{project_id}/patch_trigger_aliases").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchPatchTriggerAliases())
 	app.AddRoute("/projects/{project_id}/parameters").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeFetchParameters())
-	app.AddRoute("/projects/variables/rotate").Version(2).Put().Wrap(requireUser, requireProjectAdmin).RouteHandler(makeProjectVarsPut())
+	app.AddRoute("/projects/variables/rotate").Version(2).Put().Wrap(requireUser, adminSettings).RouteHandler(makeProjectVarsPut())
 	app.AddRoute("/permissions").Version(2).Get().Wrap(requireUserToggleable).RouteHandler(&permissionsGetHandler{})
 	app.AddRoute("/repos/{repo_id}").Version(2).Get().Wrap(requireUser, viewProjectSettings).RouteHandler(makeGetRepoByID())
 	app.AddRoute("/repos/{repo_id}").Version(2).Patch().Wrap(requireUser, requireRepoAdmin, editProjectSettings).RouteHandler(makePatchRepoByID(settings))


### PR DESCRIPTION
EVG-19793

### Description
checking for project permissions was panicking because rotate route doesnt have to be attached to a project
switched to super user settings

### Testing
staging
