### PR TITLE
EVG-19042: improve host creation traceability

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -25,9 +25,13 @@ const (
 	// HostBuildingFailed is a failure state indicating that an intent host was
 	// attempting to create a host but failed during creation. Hosts that fail
 	// to build will terminate shortly.
-	HostBuildingFailed  = "building-failed"
-	HostStarting        = "starting"
-	HostProvisioning    = "provisioning"
+	HostBuildingFailed = "building-failed"
+	HostStarting       = "starting"
+	HostProvisioning   = "provisioning"
+	// HostProvisionFailed is a failure state indicating that a host was
+	// successfully created (i.e. requested from the cloud provider) but failed
+	// while it was starting up. Hosts that fail to provisoin will terminate
+	// shortly.
 	HostProvisionFailed = "provision failed"
 	HostQuarantined     = "quarantined"
 	HostDecommissioned  = "decommissioned"

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -101,7 +101,13 @@ func LogHostEvent(hostId string, eventType string, eventData HostEventData) {
 }
 
 func LogHostCreated(hostId string) {
-	LogHostEvent(hostId, EventHostCreated, HostEventData{})
+	LogHostEvent(hostId, EventHostCreated, HostEventData{Successful: true})
+}
+
+// LogHostCreationFailed logs an event indicating that the host errored while it
+// was being created.
+func LogHostCreationFailed(hostID, logs string) {
+	LogHostEvent(hostID, EventHostCreated, HostEventData{Successful: false, Logs: logs})
 }
 
 // LogHostStartSucceeded logs an event indicating that the host was successfully

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4750,10 +4750,16 @@ func TestFindHostsInRange(t *testing.T) {
 }
 
 func TestRemoveAndReplace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
 	require.NoError(t, db.Clear(Collection))
 
 	// removing a nonexistent host errors
-	assert.Error(t, RemoveStrict("asdf"))
+	assert.Error(t, RemoveStrict(ctx, env, "asdf"))
 
 	// replacing an existing host works
 	h := Host{


### PR DESCRIPTION
EVG-19042

### Description
This PR provides some fixups and improvements to the host creation job so that it's more traceable.

* Add event logs when host creation fails.
* Remove some duplicate/unnecessary error logs from `SpawnHost`. These already get logged by the host creation job, so the cloud provider doesn't need to log them.
* When hosts get self-throttled (i.e. due to max host limitations), set them to a failed state rather than removing the document. This makes it easier to trace what happened to them via event logs.
* Actually pass the transaction context like you're supposed to for host creation. This isn't that related to the rest of the PR, but the host creation transaction is supposed to pass the context to the client function and it seemed like a convenient PR to just do it.

### Testing
Existing tests should pass. I also verified in staging that host creation still works.

### Documentation
N/A
