### PR TITLE
EVG-19813 log agent otel errors

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -81,6 +81,10 @@ func (a *Agent) initOtel(ctx context.Context) error {
 	)
 	tp.RegisterSpanProcessor(NewTaskSpanProcessor())
 	otel.SetTracerProvider(tp)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		grip.Error(errors.Wrap(err, "encountered otel error"))
+	}))
+
 	a.tracer = tp.Tracer(packageName)
 
 	a.metricsExporter, err = otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(grpcConn))

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-05-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-05"
+	AgentVersion = "2023-05-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-19813](https://jira.mongodb.org/browse/EVG-19813)

### Description
When the traces weren't making it to the collector I didn't see any errors in the agent logs. I think the reason is that by default the errors go to stdout and we don't capture that in the agent logs. I probably could have found them in the systemd logs, but I hadn't looked there. In any case, it makes sense to add these errors to the agent logs so they'll be together with all the rest of the agent's logging.

We could have the errors go to Splunk if we set the level to `Alert`, but I think we've usually tried to keep those messages to a minimum.

### Testing
I mangled the collector endpoint in admin settings and when it tried to send traces/metrics I saw this in the admin logs
```
[evergreen.agent] 2023/05/08 16:53:47 [p=error]: encountered otel error: traces export: rpc error: code = Unknown desc = unexpected HTTP status code received from server: 302 (Found); transport: received unexpected content-type "text/html; charset=utf-8"
[evergreen.agent] 2023/05/08 16:53:57 [p=error]: encountered otel error: traces export: rpc error: code = Unknown desc = unexpected HTTP status code received from server: 302 (Found); transport: received unexpected content-type "text/html; charset=utf-8"
[evergreen.agent] 2023/05/08 16:53:57 [p=error]: encountered otel error: failed to upload metrics: rpc error: code = Unknown desc = unexpected HTTP status code received from server: 302 (Found); transport: received unexpected content-type "text/html; charset=utf-8"
```
