### PR TITLE
EVG-17996 Add exec platform to system failed logs

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -295,6 +295,10 @@ const (
 	// Valid types of performing git clone
 	CloneMethodLegacySSH = "legacy-ssh"
 	CloneMethodOAuth     = "oauth"
+
+	// ContainerHealthDashboard is the name of the Splunk dashboard that displays
+	// charts relating to the health of container tasks.
+	ContainerHealthDashboard = "container task health dashboard"
 )
 
 var TaskStatuses = []string{

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -3,6 +3,7 @@ package model
 import (
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -64,11 +65,11 @@ func (q *ContainerTaskQueue) populate() error {
 	}
 
 	grip.Info(message.Fields{
-		"message":    "generated container task queue",
-		"usage":      "container task health dashboard",
-		"candidates": len(candidates),
-		"queue":      len(readyForAllocation),
-		"duration":   time.Since(startAt),
+		"message":     "generated container task queue",
+		"included_on": evergreen.ContainerHealthDashboard,
+		"candidates":  len(candidates),
+		"queue":       len(readyForAllocation),
+		"duration":    time.Since(startAt),
 	})
 
 	q.queue = readyForAllocation

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1335,13 +1335,14 @@ func (t *Task) MarkSystemFailed(description string) error {
 		event.LogTaskFinished(t.Id, t.Execution, evergreen.TaskSystemFailed)
 	}
 	grip.Info(message.Fields{
-		"message":     "marking task system failed",
-		"usage":       "container task health dashboard",
-		"task_id":     t.Id,
-		"execution":   t.Execution,
-		"status":      t.Status,
-		"host_id":     t.HostId,
-		"description": description,
+		"message":            "marking task system failed",
+		"usage":              "container task health dashboard",
+		"task_id":            t.Id,
+		"execution":          t.Execution,
+		"status":             t.Status,
+		"host_id":            t.HostId,
+		"description":        description,
+		"execution_platform": t.ExecutionPlatform,
 	})
 
 	t.ContainerAllocated = false

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1336,7 +1336,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 	}
 	grip.Info(message.Fields{
 		"message":            "marking task system failed",
-		"usage":              "container task health dashboard",
+		"included_on":        evergreen.ContainerHealthDashboard,
 		"task_id":            t.Id,
 		"execution":          t.Execution,
 		"status":             t.Status,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1341,6 +1341,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 		"execution":          t.Execution,
 		"status":             t.Status,
 		"host_id":            t.HostId,
+		"pod_id":             t.PodID,
 		"description":        description,
 		"execution_platform": t.ExecutionPlatform,
 	})

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -644,7 +644,7 @@ func MarkEnd(settings *evergreen.Settings, t *task.Task, caller string, finishTi
 
 	grip.Info(message.Fields{
 		"message":            "marking task finished",
-		"usage":              "container task health dashboard",
+		"included_on":        evergreen.ContainerHealthDashboard,
 		"task_id":            t.Id,
 		"execution":          t.Execution,
 		"status":             status,

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -331,7 +331,7 @@ func (h *podAgentNextTask) setAgentFirstContactTime(p *pod.Pod) {
 
 	grip.Info(message.Fields{
 		"message":                   "pod initiated first contact with application server",
-		"usage":                     "container task health dashboard",
+		"included_on":               evergreen.ContainerHealthDashboard,
 		"pod":                       p.ID,
 		"secs_since_pod_allocation": time.Since(p.TimeInfo.Initializing).Seconds(),
 		"secs_since_pod_creation":   time.Since(p.TimeInfo.Starting).Seconds(),

--- a/units/crons.go
+++ b/units/crons.go
@@ -1340,7 +1340,7 @@ func PopulatePodAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 
 		grip.InfoWhen(remaining <= 0 && ctq.Len() > 0, message.Fields{
 			"message":             "reached max parallel pod request limit, not allocating any more",
-			"usage":               "container task health dashboard",
+			"included_on":         evergreen.ContainerHealthDashboard,
 			"context":             "pod allocation",
 			"num_remaining_tasks": ctq.Len(),
 		})

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -159,7 +159,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	if utility.StringSliceContains(pd.PodIDs, intentPod.ID) {
 		grip.Info(message.Fields{
 			"message":                    "successfully allocated pod for container task",
-			"usage":                      "container task health dashboard",
+			"included_on":                evergreen.ContainerHealthDashboard,
 			"task":                       j.task.Id,
 			"pod":                        intentPod.ID,
 			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
@@ -167,7 +167,7 @@ func (j *podAllocatorJob) Run(ctx context.Context) {
 	} else {
 		grip.Info(message.Fields{
 			"message":                    "container task already has a pod allocated to run it",
-			"usage":                      "container task health dashboard",
+			"included_on":                evergreen.ContainerHealthDashboard,
 			"task":                       j.task.Id,
 			"secs_since_task_activation": time.Since(j.task.ActivatedTime).Seconds(),
 		})

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -234,7 +234,7 @@ func (j *podCreationJob) logTaskTimingStats() error {
 
 	msg := message.Fields{
 		"message":          "created pod to run container tasks",
-		"usage":            "container task health dashboard",
+		"included_on":      evergreen.ContainerHealthDashboard,
 		"pod":              j.pod.ID,
 		"dispatcher_group": disp.GroupID,
 	}

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -129,7 +129,7 @@ func (j *podTerminationJob) Run(ctx context.Context) {
 	grip.Info(message.Fields{
 		"message":            "successfully terminated pod",
 		"pod":                j.PodID,
-		"usage":              "container task health dashboard",
+		"included_on":        evergreen.ContainerHealthDashboard,
 		"termination_reason": j.Reason,
 		"job":                j.ID(),
 	})

--- a/units/stats_pod.go
+++ b/units/stats_pod.go
@@ -82,8 +82,8 @@ func (j *podStatsCollector) logStats() error {
 	}
 
 	msg := message.Fields{
-		"message": "pod stats",
-		"usage":   "container task health dashboard",
+		"message":     "pod stats",
+		"included_on": evergreen.ContainerHealthDashboard,
 	}
 	// Ensure that the statuses of interest are always set, even if the query
 	// returns no statistics for that status.


### PR DESCRIPTION
EVG-17996

### Description
`execution_platform` needs to be a part of this log for it to be reflected in the "Container Tasks Finished by Status" dashboard.