### PR TITLE
EVG-19851: Clear running task of pods upon task timeout cleanup

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -679,7 +679,7 @@ func (p *Pod) SetRunningTask(ctx context.Context, env evergreen.Environment, tas
 	return nil
 }
 
-// ClearRunningTask clears the current task dispatched to the pod.
+// ClearRunningTask clears the current task dispatched to the pod, if one is set.
 func (p *Pod) ClearRunningTask() error {
 	if p.TaskRuntimeInfo.RunningTaskID == "" {
 		return nil


### PR DESCRIPTION
EVG-19851

### Description
When a task fails due to heartbeat, the agent is no longer in healthy communication with the app server and the end_task endpoint (which typically clears a pod's running task) does not therefore run. This causes these pods to retain their task runtime information even after the task they were running was cleaned up due to timeout.

Added change to clear pod's running task in this case so that the pod can be picked up by the termination job.
### Testing
Updated unit test.