### PR TITLE
EVG-13927 remove the spot provider

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -152,7 +152,6 @@ type CreateHost struct {
 	IPv6            bool        `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
 	Region          string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
 	SecurityGroups  []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
-	Spot            bool        `mapstructure:"spot" json:"spot" yaml:"spot"`
 	Subnet          string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
 	UserdataFile    string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
 	UserdataCommand string      `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -123,7 +123,7 @@ type ManagerOpts struct {
 // provider.
 func GetSettings(provider string) (ProviderSettings, error) {
 	switch provider {
-	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Fleet:
+	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Fleet:
 		return &EC2ProviderSettings{}, nil
 	case evergreen.ProviderNameStatic:
 		return &StaticSettings{}, nil
@@ -152,18 +152,6 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 			env: env,
 			EC2ManagerOptions: &EC2ManagerOptions{
 				client:         &awsClientImpl{},
-				provider:       onDemandProvider,
-				region:         mgrOpts.Region,
-				providerKey:    mgrOpts.ProviderKey,
-				providerSecret: mgrOpts.ProviderSecret,
-			},
-		}
-	case evergreen.ProviderNameEc2Spot:
-		provider = &ec2Manager{
-			env: env,
-			EC2ManagerOptions: &EC2ManagerOptions{
-				client:         &awsClientImpl{},
-				provider:       spotProvider,
 				region:         mgrOpts.Region,
 				providerKey:    mgrOpts.ProviderKey,
 				providerSecret: mgrOpts.ProviderSecret,

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -50,15 +50,6 @@ type Manager interface {
 	// StartInstance starts a stopped instance.
 	StartInstance(context.Context, *host.Host, string) error
 
-	// IsUp returns true if the underlying provider has not destroyed the
-	// host (in other words, if the host "should" be reachable. This does not
-	// necessarily mean that the host actually *is* reachable via SSH
-	IsUp(context.Context, *host.Host) (bool, error)
-
-	// Called by the hostinit process when the host is actually up. Used
-	// to set additional provider-specific metadata
-	OnUp(context.Context, *host.Host) error
-
 	// GetDNSName returns the DNS name of a host.
 	GetDNSName(context.Context, *host.Host) (string, error)
 

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -36,10 +36,6 @@ func GetCloudHost(ctx context.Context, host *host.Host, env evergreen.Environmen
 	return &CloudHost{host, keyPath, mgr}, nil
 }
 
-func (cloudHost *CloudHost) IsUp(ctx context.Context) (bool, error) {
-	return cloudHost.CloudMgr.IsUp(ctx, cloudHost.Host)
-}
-
 func (cloudHost *CloudHost) ModifyHost(ctx context.Context, opts host.HostModifyOptions) error {
 	return cloudHost.CloudMgr.ModifyHost(ctx, cloudHost.Host, opts)
 }

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -17,14 +17,6 @@ func TestGetManager(t *testing.T) {
 
 	Convey("GetManager() should return non-nil for all valid provider names", t, func() {
 
-		Convey("EC2Spot should be returned for ec2-spot provider name", func() {
-			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2Spot, ProviderKey: "key", ProviderSecret: "secret"}
-			cloudMgr, err := GetManager(ctx, env, mgrOpts)
-			So(cloudMgr, ShouldNotBeNil)
-			So(err, ShouldBeNil)
-			So(cloudMgr, ShouldHaveSameTypeAs, &ec2Manager{})
-		})
-
 		Convey("EC2OnDemand should be returned for ec2-ondemand provider name", func() {
 			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2OnDemand, ProviderKey: "key", ProviderSecret: "secret"}
 			cloudMgr, err := GetManager(ctx, env, mgrOpts)

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -195,21 +195,6 @@ func (m *dockerManager) Configure(ctx context.Context, s *evergreen.Settings) er
 	return nil
 }
 
-// IsUp checks the container's state by querying the Docker API and
-// returns true if the host should be available to connect with SSH.
-func (m *dockerManager) IsUp(ctx context.Context, h *host.Host) (bool, error) {
-	cloudStatus, err := m.GetInstanceStatus(ctx, h)
-	if err != nil {
-		return false, err
-	}
-	return cloudStatus == StatusRunning, nil
-}
-
-// OnUp does nothing.
-func (m *dockerManager) OnUp(context.Context, *host.Host) error {
-	return nil
-}
-
 // Cleanup is a noop for the docker provider.
 func (m *dockerManager) Cleanup(context.Context) error {
 	return nil

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -78,37 +78,6 @@ func (s *DockerSuite) TestConfigureAPICall() {
 	s.Error(s.manager.Configure(ctx, settings))
 }
 
-func (s *DockerSuite) TestIsUpFailAPICall() {
-	mock, ok := s.client.(*dockerClientMock)
-	s.True(ok)
-
-	host := &host.Host{}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mock.failGet = true
-	_, err := s.manager.GetInstanceStatus(ctx, host)
-	s.Error(err)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.Error(err)
-	s.False(active)
-}
-
-func (s *DockerSuite) TestIsUpStatuses() {
-	host := &host.Host{ParentID: "parent"}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	status, err := s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.Equal(StatusRunning, status)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.True(active)
-}
-
 func (s *DockerSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1357,43 +1357,6 @@ func (m *ec2Manager) cancelSpotRequest(ctx context.Context, h *host.Host) (strin
 	return instanceId, nil
 }
 
-// IsUp returns whether a host is up.
-func (m *ec2Manager) IsUp(ctx context.Context, h *host.Host) (bool, error) {
-	status, err := m.GetInstanceStatus(ctx, h)
-	if err != nil {
-		return false, errors.Wrap(err, "checking if instance is up")
-	}
-	if status == StatusRunning {
-		return true, nil
-	}
-	return false, nil
-}
-
-// OnUp is called when the host is up.
-func (m *ec2Manager) OnUp(ctx context.Context, h *host.Host) error {
-	if isHostOnDemand(h) {
-		// On-demand hosts and its volumes are already tagged in the request for
-		// the instance.
-		return nil
-	}
-
-	if err := m.client.Create(m.credentials, m.region); err != nil {
-		return errors.Wrap(err, "creating client")
-	}
-	defer m.client.Close()
-
-	resources, err := m.getResources(ctx, h)
-	if err != nil {
-		return errors.Wrap(err, "getting resources")
-	}
-
-	if err = m.client.SetTags(ctx, resources, h); err != nil {
-		return errors.Wrap(err, "setting tags")
-	}
-
-	return nil
-}
-
 func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment *host.VolumeAttachment) error {
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -342,22 +342,6 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 	return errors.New("can't start instances for EC2 fleet provider")
 }
 
-func (m *ec2FleetManager) IsUp(ctx context.Context, h *host.Host) (bool, error) {
-	status, err := m.GetInstanceStatus(ctx, h)
-	if err != nil {
-		return false, errors.Wrap(err, "checking if instance is up")
-	}
-	if status == StatusRunning {
-		return true, nil
-	}
-	return false, nil
-}
-
-// OnUp is a noop for Fleet
-func (m *ec2FleetManager) OnUp(ctx context.Context, h *host.Host) error {
-	return nil
-}
-
 func (m *ec2FleetManager) Cleanup(ctx context.Context) error {
 	if err := m.client.Create(m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -91,7 +91,6 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 	foundHosts, err := host.Find(host.IsUninitialized)
 	assert.NoError(err)
 	assert.Len(foundHosts, 1)
-	assert.NoError(m.OnUp(ctx, h))
 
 	assert.NoError(m.TerminateInstance(ctx, h, evergreen.User, ""))
 	foundHosts, err = host.Find(host.IsTerminated)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
@@ -35,8 +34,6 @@ type EC2Suite struct {
 	onDemandManager           Manager
 	onDemandWithRegionOpts    *EC2ManagerOptions
 	onDemandWithRegionManager Manager
-	spotOpts                  *EC2ManagerOptions
-	spotManager               Manager
 	impl                      *ec2Manager
 	mock                      *awsClientMock
 	h                         *host.Host
@@ -61,8 +58,7 @@ func TestEC2Suite(t *testing.T) {
 func (s *EC2Suite) SetupTest() {
 	s.Require().NoError(db.ClearCollections(host.Collection, host.VolumesCollection, task.Collection, model.ProjectVarsCollection))
 	s.onDemandOpts = &EC2ManagerOptions{
-		client:   &awsClientMock{},
-		provider: onDemandProvider,
+		client: &awsClientMock{},
 	}
 	s.onDemandManager = &ec2Manager{env: s.env, EC2ManagerOptions: s.onDemandOpts}
 	_ = s.onDemandManager.Configure(s.ctx, &evergreen.Settings{
@@ -74,20 +70,11 @@ func (s *EC2Suite) SetupTest() {
 		},
 	})
 	s.onDemandWithRegionOpts = &EC2ManagerOptions{
-		client:   &awsClientMock{},
-		provider: onDemandProvider,
-		region:   "test-region",
+		client: &awsClientMock{},
+		region: "test-region",
 	}
 	s.onDemandWithRegionManager = &ec2Manager{env: s.env, EC2ManagerOptions: s.onDemandWithRegionOpts}
 	_ = s.onDemandManager.Configure(s.ctx, &evergreen.Settings{
-		Expansions: map[string]string{"test": "expand"},
-	})
-	s.spotOpts = &EC2ManagerOptions{
-		client:   &awsClientMock{},
-		provider: spotProvider,
-	}
-	s.spotManager = &ec2Manager{env: s.env, EC2ManagerOptions: s.spotOpts}
-	_ = s.spotManager.Configure(s.ctx, &evergreen.Settings{
 		Expansions: map[string]string{"test": "expand"},
 	})
 	var ok bool
@@ -158,11 +145,6 @@ func (s *EC2Suite) TestValidateProviderSettings() {
 	p.SecurityGroupIDs = nil
 	s.Error(p.Validate())
 	p.SecurityGroupIDs = []string{"sg-123456"}
-
-	s.NoError(p.Validate())
-	p.BidPrice = -1
-	s.Error(p.Validate())
-	p.BidPrice = 1
 	s.NoError(p.Validate())
 
 	p.IsVpc = true
@@ -421,238 +403,6 @@ func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
 	s.Equal(base64OfSomeUserData, *runInput.UserData)
 }
 
-func (s *EC2Suite) TestSpawnHostClassicSpot() {
-	h := &host.Host{}
-	h.Distro.Id = "distro_id"
-	h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
-		birch.EC.String("ami", "ami"),
-		birch.EC.String("instance_type", "instanceType"),
-		birch.EC.String("iam_instance_profile_arn", "my_profile"),
-		birch.EC.String("key_name", "keyName"),
-		birch.EC.String("subnet_id", "subnet-123456"),
-		birch.EC.String("user_data", someUserData),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
-		birch.EC.Array("mount_points", birch.NewArray(
-			birch.VC.Document(birch.NewDocument(
-				birch.EC.String("device_name", "device"),
-				birch.EC.String("virtual_name", "virtual"),
-			)),
-		)),
-	)}
-	s.Require().NoError(h.Insert())
-
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	_, err := s.spotManager.SpawnHost(ctx, h)
-	s.NoError(err)
-
-	manager, ok := s.spotManager.(*ec2Manager)
-	s.True(ok)
-	mock, ok := manager.client.(*awsClientMock)
-	s.True(ok)
-
-	s.Require().NotNil(mock.RequestSpotInstancesInput)
-	requestInput := *mock.RequestSpotInstancesInput
-	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
-	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
-	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
-	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
-	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
-	s.Equal("sg-123456", *requestInput.LaunchSpecification.SecurityGroups[0])
-	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
-	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
-}
-
-func (s *EC2Suite) TestSpawnHostClassicSpotInsufficientCapacityFallback() {
-	h := &host.Host{}
-	h.Distro.Id = "distro_id"
-	h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
-		birch.EC.String("ami", "ami"),
-		birch.EC.String("instance_type", "instanceType"),
-		birch.EC.String("iam_instance_profile_arn", "my_profile"),
-		birch.EC.String("key_name", "keyName"),
-		birch.EC.String("subnet_id", "subnet-123456"),
-		birch.EC.String("user_data", someUserData),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
-		birch.EC.Array("mount_points", birch.NewArray(
-			birch.VC.Document(birch.NewDocument(
-				birch.EC.String("device_name", "device"),
-				birch.EC.String("virtual_name", "virtual"),
-			)),
-		)),
-		birch.EC.Boolean("fallback", true),
-	)}
-	s.Require().NoError(h.Insert())
-
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	manager, ok := s.spotManager.(*ec2Manager)
-	s.True(ok)
-	mock, ok := manager.client.(*awsClientMock)
-	s.True(ok)
-
-	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
-	mock.requestSpotInstancesError = awserr.New(EC2InsufficientCapacity, "Test error for Insufficient Capacity", nil)
-
-	returnedHost, err := s.spotManager.SpawnHost(ctx, h)
-	s.NoError(err)
-	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Provider, "Provider should have been changed to OnDemand on fallback")
-	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Distro.Provider, "Provider should have been changed to OnDemand on fallback")
-
-	// Check that we have made a request for a spot instance
-	s.Require().NotNil(mock.RequestSpotInstancesInput)
-	requestInput := *mock.RequestSpotInstancesInput
-	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
-	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
-	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
-	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
-	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
-	s.Equal("sg-123456", *requestInput.LaunchSpecification.SecurityGroups[0])
-	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
-	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
-
-	// Check that we have made a fallback request for an on demand instance
-	s.Require().NotNil(mock.RunInstancesInput, "On Demand Instance Fallback was not called")
-	runInput := *mock.RunInstancesInput
-	s.Equal("ami", *runInput.ImageId)
-	s.Equal("instanceType", *runInput.InstanceType)
-	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
-	s.Equal("keyName", *runInput.KeyName)
-	s.Require().Len(runInput.BlockDeviceMappings, 1)
-	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)
-	s.Equal("sg-123456", *runInput.SecurityGroups[0])
-	s.Nil(runInput.SecurityGroupIds)
-	s.Nil(runInput.SubnetId)
-	s.Equal(base64OfSomeUserData, *runInput.UserData)
-}
-
-func (s *EC2Suite) TestSpawnHostClassicSpotUnfulfillableCapacityFallback() {
-	h := &host.Host{}
-	h.Distro.Id = "distro_id"
-	h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
-		birch.EC.String("ami", "ami"),
-		birch.EC.String("instance_type", "instanceType"),
-		birch.EC.String("iam_instance_profile_arn", "my_profile"),
-		birch.EC.String("key_name", "keyName"),
-		birch.EC.String("subnet_id", "subnet-123456"),
-		birch.EC.String("user_data", someUserData),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
-		birch.EC.Array("mount_points", birch.NewArray(
-			birch.VC.Document(birch.NewDocument(
-				birch.EC.String("device_name", "device"),
-				birch.EC.String("virtual_name", "virtual"),
-			)),
-		)),
-		birch.EC.Boolean("fallback", true),
-	)}
-	s.Require().NoError(h.Insert())
-
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	manager, ok := s.spotManager.(*ec2Manager)
-	s.True(ok)
-	mock, ok := manager.client.(*awsClientMock)
-	s.True(ok)
-
-	// Ensure that the mock for requesting a spot instance returns an InsufficientCapacity error.
-	mock.requestSpotInstancesError = awserr.New(EC2UnfulfillableCapacity, "Test error for Unfulfillable Capacity", nil)
-
-	returnedHost, err := s.spotManager.SpawnHost(ctx, h)
-	s.NoError(err)
-	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Provider, "Provider should have been changed to OnDemand on fallback")
-	s.Equal(evergreen.ProviderNameEc2OnDemand, returnedHost.Distro.Provider, "Provider should have been changed to OnDemand on fallback")
-
-	// Check that we have made a request for a spot instance
-	s.Require().NotNil(mock.RequestSpotInstancesInput)
-	requestInput := *mock.RequestSpotInstancesInput
-	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
-	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
-	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
-	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
-	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
-	s.Equal("sg-123456", *requestInput.LaunchSpecification.SecurityGroups[0])
-	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
-	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
-
-	// Check that we have made a fallback request for an on demand instance
-	s.Require().NotNil(mock.RunInstancesInput, "On Demand Instance Fallback was not called")
-	runInput := *mock.RunInstancesInput
-	s.Equal("ami", *runInput.ImageId)
-	s.Equal("instanceType", *runInput.InstanceType)
-	s.Equal("my_profile", *runInput.IamInstanceProfile.Arn)
-	s.Equal("keyName", *runInput.KeyName)
-	s.Require().Len(runInput.BlockDeviceMappings, 1)
-	s.Equal("virtual", *runInput.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *runInput.BlockDeviceMappings[0].DeviceName)
-	s.Equal("sg-123456", *runInput.SecurityGroups[0])
-	s.Nil(runInput.SecurityGroupIds)
-	s.Nil(runInput.SubnetId)
-	s.Equal(base64OfSomeUserData, *runInput.UserData)
-}
-
-func (s *EC2Suite) TestSpawnHostVPCSpot() {
-	h := &host.Host{}
-	h.Distro.Id = "distro_id"
-	h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	h.Distro.ProviderSettingsList = []*birch.Document{birch.NewDocument(
-		birch.EC.String("ami", "ami"),
-		birch.EC.String("instance_type", "instanceType"),
-		birch.EC.String("iam_instance_profile_arn", "my_profile"),
-		birch.EC.String("key_name", "keyName"),
-		birch.EC.String("subnet_id", "subnet-123456"),
-		birch.EC.String("user_data", someUserData),
-		birch.EC.Boolean("is_vpc", true),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-		birch.EC.SliceString("security_group_ids", []string{"sg-123456"}),
-		birch.EC.Array("mount_points", birch.NewArray(
-			birch.VC.Document(birch.NewDocument(
-				birch.EC.String("device_name", "device"),
-				birch.EC.String("virtual_name", "virtual"),
-			)),
-		)),
-	)}
-	s.Require().NoError(h.Insert())
-
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-	_, err := s.spotManager.SpawnHost(ctx, h)
-	s.NoError(err)
-
-	manager, ok := s.spotManager.(*ec2Manager)
-	s.Require().True(ok)
-	mock, ok := manager.client.(*awsClientMock)
-	s.Require().True(ok)
-
-	s.Require().NotNil(mock.RequestSpotInstancesInput)
-	requestInput := *mock.RequestSpotInstancesInput
-	s.Equal("ami", *requestInput.LaunchSpecification.ImageId)
-	s.Equal("instanceType", *requestInput.LaunchSpecification.InstanceType)
-	s.Equal("my_profile", *requestInput.LaunchSpecification.IamInstanceProfile.Arn)
-	s.Equal("keyName", *requestInput.LaunchSpecification.KeyName)
-	s.Equal("virtual", *requestInput.LaunchSpecification.BlockDeviceMappings[0].VirtualName)
-	s.Equal("device", *requestInput.LaunchSpecification.BlockDeviceMappings[0].DeviceName)
-	s.Nil(requestInput.LaunchSpecification.SecurityGroupIds)
-	s.Nil(requestInput.LaunchSpecification.SecurityGroups)
-	s.Nil(requestInput.LaunchSpecification.SubnetId)
-	s.Equal(base64OfSomeUserData, *requestInput.LaunchSpecification.UserData)
-}
-
 func (s *EC2Suite) TestNoKeyAndNotSpawnHostForTaskShouldFail() {
 	h := &host.Host{}
 	h.Distro.Id = "distro_id"
@@ -841,14 +591,6 @@ func (s *EC2Suite) TestGetInstanceStatus() {
 	s.Equal("public_dns_name", s.h.Host)
 	s.Require().Len(s.h.Volumes, 1)
 	s.Equal("volume_id", s.h.Volumes[0].VolumeID)
-
-	s.h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	s.h.Id = "instance_id"
-	status, err = s.onDemandManager.GetInstanceStatus(ctx, s.h)
-	s.NoError(err)
-	s.Equal(StatusRunning, status)
-
-	s.Equal("instance_id", s.h.ExternalIdentifier)
 }
 
 func (s *EC2Suite) TestTerminateInstance() {
@@ -1004,48 +746,12 @@ func (s *EC2Suite) TestGetInstanceName() {
 	s.True(strings.HasPrefix(id, "evg-foo-"))
 }
 
-func (s *EC2Suite) TestGetProvider() {
-	s.h.Distro.Arch = "Linux/Unix"
-	ec2Settings := &EC2ProviderSettings{
-		InstanceType: "instance",
-		IsVpc:        true,
-		SubnetId:     "subnet-123456",
-		VpcName:      "vpc_name",
-	}
-
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	manager, ok := s.spotManager.(*ec2Manager)
-	s.True(ok)
-	provider, err := manager.getProvider(ctx, s.h, ec2Settings)
-	s.NoError(err)
-	s.Equal(spotProvider, provider)
-
-	s.h.UserHost = true
-	provider, err = manager.getProvider(ctx, s.h, ec2Settings)
-	s.NoError(err)
-	s.Equal(onDemandProvider, provider)
-}
-
-func (s *EC2Suite) TestPersistInstanceId() {
-	s.h.Id = "instance_id"
-	s.h.Distro.Provider = evergreen.ProviderNameEc2Spot
-	s.Require().NoError(s.h.Insert())
-	manager, ok := s.onDemandManager.(*ec2Manager)
-	s.True(ok)
-	instanceID, err := manager.client.GetSpotInstanceId(s.ctx, s.h)
-	s.Equal("instance_id", instanceID)
-	s.NoError(err)
-	s.Equal("instance_id", s.h.ExternalIdentifier)
-}
-
 func (s *EC2Suite) TestGetInstanceStatuses() {
 	hosts := []host.Host{
 		{
-			Id: "sir-1",
+			Id: "i-1",
 			Distro: distro.Distro{
-				Provider:             evergreen.ProviderNameEc2Spot,
+				Provider:             evergreen.ProviderNameEc2OnDemand,
 				ProviderSettingsList: s.distro.ProviderSettingsList,
 			},
 		},
@@ -1057,28 +763,14 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			},
 		},
 		{
-			Id: "sir-3",
+			Id: "i-3",
 			Distro: distro.Distro{
-				Provider:             evergreen.ProviderNameEc2Spot,
+				Provider:             evergreen.ProviderNameEc2OnDemand,
 				ProviderSettingsList: s.distro.ProviderSettingsList,
 			},
 		},
 		{
 			Id: "i-4",
-			Distro: distro.Distro{
-				Provider:             evergreen.ProviderNameEc2OnDemand,
-				ProviderSettingsList: s.distro.ProviderSettingsList,
-			},
-		},
-		{
-			Id: "i-5",
-			Distro: distro.Distro{
-				Provider:             evergreen.ProviderNameEc2OnDemand,
-				ProviderSettingsList: s.distro.ProviderSettingsList,
-			},
-		},
-		{
-			Id: "i-6",
 			Distro: distro.Distro{
 				Provider:             evergreen.ProviderNameEc2OnDemand,
 				ProviderSettingsList: s.distro.ProviderSettingsList,
@@ -1091,22 +783,12 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	s.True(ok)
 	mock, ok := manager.client.(*awsClientMock)
 
-	// spot IDs returned doesn't match spot IDs submitted
-	mock.DescribeSpotInstanceRequestsOutput = &ec2.DescribeSpotInstanceRequestsOutput{
-		SpotInstanceRequests: []*ec2.SpotInstanceRequest{
-			{
-				InstanceId:            aws.String("nonexistent"),
-				State:                 aws.String(SpotStatusActive),
-				SpotInstanceRequestId: aws.String("1"),
-			},
-		},
-	}
 	mock.DescribeInstancesOutput = &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-6"),
+						InstanceId: aws.String("i-4"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameShuttingDown),
 						},
@@ -1116,7 +798,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-4"),
+						InstanceId: aws.String("i-2"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
@@ -1139,7 +821,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-5"),
+						InstanceId: aws.String("i-3"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameTerminated),
 						},
@@ -1155,28 +837,12 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	statuses, err := batchManager.GetInstanceStatuses(ctx, hosts)
 	s.NoError(err, "does not error if some of the instances do not exist")
 	s.Equal(map[string]CloudStatus{
-		"i-2":   StatusNonExistent,
-		"i-4":   StatusRunning,
-		"i-5":   StatusTerminated,
-		"i-6":   StatusTerminated,
-		"sir-1": StatusNonExistent,
-		"sir-3": StatusNonExistent,
+		"i-1": StatusNonExistent,
+		"i-2": StatusRunning,
+		"i-3": StatusTerminated,
+		"i-4": StatusTerminated,
 	}, statuses)
 
-	mock.DescribeSpotInstanceRequestsOutput = &ec2.DescribeSpotInstanceRequestsOutput{
-		SpotInstanceRequests: []*ec2.SpotInstanceRequest{
-			// This host returns with no id
-			{
-				InstanceId:            aws.String("i-3"),
-				State:                 aws.String(SpotStatusActive),
-				SpotInstanceRequestId: aws.String("sir-3"),
-			},
-			{
-				SpotInstanceRequestId: aws.String("sir-1"),
-				State:                 aws.String(ec2.SpotInstanceStateFailed),
-			},
-		},
-	}
 	mock.DescribeInstancesOutput = &ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
 			{
@@ -1205,7 +871,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-2"),
+						InstanceId: aws.String("i-1"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
@@ -1228,7 +894,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-6"),
+						InstanceId: aws.String("i-4"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameShuttingDown),
 						},
@@ -1238,7 +904,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId: aws.String("i-4"),
+						InstanceId: aws.String("i-2"),
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
@@ -1258,35 +924,21 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 					},
 				},
 			},
-			{
-				Instances: []*ec2.Instance{
-					{
-						InstanceId: aws.String("i-5"),
-						State: &ec2.InstanceState{
-							Name: aws.String(ec2.InstanceStateNameTerminated),
-						},
-					},
-				},
-			},
 		},
 	}
 	statuses, err = batchManager.GetInstanceStatuses(ctx, hosts)
 	s.NoError(err)
-	s.Len(mock.DescribeSpotInstanceRequestsInput.SpotInstanceRequestIds, 2)
-	s.Len(mock.DescribeInstancesInput.InstanceIds, 5)
-	s.Equal("i-2", *mock.DescribeInstancesInput.InstanceIds[0])
-	s.Equal("i-4", *mock.DescribeInstancesInput.InstanceIds[1])
-	s.Equal("i-5", *mock.DescribeInstancesInput.InstanceIds[2])
-	s.Equal("i-6", *mock.DescribeInstancesInput.InstanceIds[3])
-	s.Equal("i-3", *mock.DescribeInstancesInput.InstanceIds[4])
-	s.Len(statuses, 6)
+	s.Len(mock.DescribeInstancesInput.InstanceIds, 4)
+	s.Equal("i-1", *mock.DescribeInstancesInput.InstanceIds[0])
+	s.Equal("i-2", *mock.DescribeInstancesInput.InstanceIds[1])
+	s.Equal("i-3", *mock.DescribeInstancesInput.InstanceIds[2])
+	s.Equal("i-4", *mock.DescribeInstancesInput.InstanceIds[3])
+	s.Len(statuses, 4)
 	s.Equal(map[string]CloudStatus{
-		"i-2":   StatusRunning,
-		"i-4":   StatusRunning,
-		"i-5":   StatusTerminated,
-		"i-6":   StatusTerminated,
-		"sir-1": StatusFailed,
-		"sir-3": StatusRunning,
+		"i-1": StatusRunning,
+		"i-2": StatusRunning,
+		"i-3": StatusTerminated,
+		"i-4": StatusTerminated,
 	}, statuses)
 
 	s.Equal("public_dns_name_1", hosts[1].Host)
@@ -1295,8 +947,6 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	s.Equal("2.2.2.2", hosts[2].IPv4)
 	s.Equal("public_dns_name_3", hosts[3].Host)
 	s.Equal("3.3.3.3", hosts[3].IPv4)
-
-	s.Equal("i-3", hosts[2].ExternalIdentifier)
 }
 
 func (s *EC2Suite) TestGetInstanceStatusesForNonexistentInstances() {
@@ -1456,7 +1106,6 @@ func (s *EC2Suite) TestFromDistroSettings() {
 			birch.EC.String("key_name", "key"),
 			birch.EC.String("aws_access_key_id", "key_id"),
 			birch.EC.String("subnet_id", "subnet-123456"),
-			birch.EC.Double("bid_price", 0.001),
 			birch.EC.String("region", evergreen.DefaultEC2Region),
 			birch.EC.String("iam_instance_profile_arn", "a_new_arn"),
 			birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
@@ -1470,7 +1119,6 @@ func (s *EC2Suite) TestFromDistroSettings() {
 	s.Equal("instance", ec2Settings.InstanceType)
 	s.Require().Len(ec2Settings.SecurityGroupIDs, 1)
 	s.Equal("abcdef", ec2Settings.SecurityGroupIDs[0])
-	s.Equal(float64(0.001), ec2Settings.BidPrice)
 	s.Equal(evergreen.DefaultEC2Region, ec2Settings.Region)
 	s.Equal("a_new_arn", ec2Settings.IAMInstanceProfileARN)
 
@@ -1481,7 +1129,6 @@ func (s *EC2Suite) TestFromDistroSettings() {
 		InstanceType:          "other_instance",
 		SecurityGroupIDs:      []string{"ghijkl"},
 		IAMInstanceProfileARN: "a_beautiful_profile",
-		BidPrice:              float64(0.002),
 		AWSKeyID:              "other_key_id",
 		KeyName:               "other_key",
 	}

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -852,8 +852,8 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName:    aws.String("public_dns_name_2"),
-						PrivateIpAddress: aws.String("2.2.2.2"),
+						PublicDnsName:    aws.String("public_dns_name_3"),
+						PrivateIpAddress: aws.String("3.3.3.3"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -908,8 +908,8 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						State: &ec2.InstanceState{
 							Name: aws.String(ec2.InstanceStateNameRunning),
 						},
-						PublicDnsName:    aws.String("public_dns_name_3"),
-						PrivateIpAddress: aws.String("3.3.3.3"),
+						PublicDnsName:    aws.String("public_dns_name_2"),
+						PrivateIpAddress: aws.String("2.2.2.2"),
 						Placement: &ec2.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
 						},
@@ -937,16 +937,16 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	s.Equal(map[string]CloudStatus{
 		"i-1": StatusRunning,
 		"i-2": StatusRunning,
-		"i-3": StatusTerminated,
+		"i-3": StatusRunning,
 		"i-4": StatusTerminated,
 	}, statuses)
 
-	s.Equal("public_dns_name_1", hosts[1].Host)
-	s.Equal("1.1.1.1", hosts[1].IPv4)
-	s.Equal("public_dns_name_2", hosts[2].Host)
-	s.Equal("2.2.2.2", hosts[2].IPv4)
-	s.Equal("public_dns_name_3", hosts[3].Host)
-	s.Equal("3.3.3.3", hosts[3].IPv4)
+	s.Equal("public_dns_name_1", hosts[0].Host)
+	s.Equal("1.1.1.1", hosts[0].IPv4)
+	s.Equal("public_dns_name_2", hosts[1].Host)
+	s.Equal("2.2.2.2", hosts[1].IPv4)
+	s.Equal("public_dns_name_3", hosts[2].Host)
+	s.Equal("3.3.3.3", hosts[2].IPv4)
 }
 
 func (s *EC2Suite) TestGetInstanceStatusesForNonexistentInstances() {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -26,14 +26,13 @@ import (
 )
 
 const (
-	EC2ErrorNotFound         = "InvalidInstanceID.NotFound"
-	EC2DuplicateKeyPair      = "InvalidKeyPair.Duplicate"
-	EC2InsufficientCapacity  = "InsufficientInstanceCapacity"
-	EC2UnfulfillableCapacity = "UnfulfillableCapacity"
-	EC2InvalidParam          = "InvalidParameterValue"
-	EC2VolumeNotFound        = "InvalidVolume.NotFound"
-	EC2VolumeResizeRate      = "VolumeModificationRateExceeded"
-	ec2TemplateNameExists    = "InvalidLaunchTemplateName.AlreadyExistsException"
+	EC2ErrorNotFound        = "InvalidInstanceID.NotFound"
+	EC2DuplicateKeyPair     = "InvalidKeyPair.Duplicate"
+	EC2InsufficientCapacity = "InsufficientInstanceCapacity"
+	EC2InvalidParam         = "InvalidParameterValue"
+	EC2VolumeNotFound       = "InvalidVolume.NotFound"
+	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
+	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
 )
 
 var (

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -69,11 +69,6 @@ var (
 )
 
 var (
-	// bson fields for the EC2SpotSettings struct
-	BidPriceKey = bsonutil.MustHaveTag(EC2ProviderSettings{}, "BidPrice")
-)
-
-var (
 	// bson fields for the MountPoint struct
 	VirtualNameKey = bsonutil.MustHaveTag(MountPoint{}, "VirtualName")
 	DeviceNameKey  = bsonutil.MustHaveTag(MountPoint{}, "DeviceName")
@@ -158,10 +153,6 @@ func makeTags(intentHost *host.Host) []host.Tag {
 
 	if intentHost.UserHost {
 		systemTags = append(systemTags, host.Tag{Key: "mode", Value: "testing", CanBeModified: false})
-	}
-
-	if isHostSpot(intentHost) {
-		systemTags = append(systemTags, host.Tag{Key: "spot", Value: "true", CanBeModified: false})
 	}
 
 	// Add Evergreen-generated tags to host object

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -212,21 +212,6 @@ func (m *gceManager) StartInstance(ctx context.Context, host *host.Host, user st
 	return errors.New("StartInstance is not supported for GCE provider")
 }
 
-// IsUp checks whether the provisioned host is running.
-func (m *gceManager) IsUp(ctx context.Context, host *host.Host) (bool, error) {
-	status, err := m.GetInstanceStatus(ctx, host)
-	if err != nil {
-		return false, err
-	}
-
-	return status == StatusRunning, nil
-}
-
-// OnUp does nothing since tags are attached in SpawnInstance.
-func (m *gceManager) OnUp(context.Context, *host.Host) error {
-	return nil
-}
-
 func (m *gceManager) AttachVolume(context.Context, *host.Host, *host.VolumeAttachment) error {
 	return errors.New("can't attach volume with GCE provider")
 }

--- a/cloud/gce_test.go
+++ b/cloud/gce_test.go
@@ -159,51 +159,6 @@ func (s *GCESuite) TestConfigureAPICall() {
 	s.Error(s.manager.Configure(ctx, settings))
 }
 
-func (s *GCESuite) TestIsUpFailAPICall() {
-	mock, ok := s.client.(*gceClientMock)
-	s.True(ok)
-
-	host := &host.Host{}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mock.failGet = true
-	_, err := s.manager.GetInstanceStatus(ctx, host)
-	s.Error(err)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.Error(err)
-	s.False(active)
-}
-
-func (s *GCESuite) TestIsUpStatuses() {
-	mock, ok := s.client.(*gceClientMock)
-	s.True(ok)
-	s.True(mock.isActive)
-
-	host := &host.Host{}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	status, err := s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.Equal(StatusRunning, status)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.True(active)
-
-	mock.isActive = false
-	status, err = s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.NotEqual(StatusRunning, status)
-
-	active, err = s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.False(active)
-}
-
 func (s *GCESuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -27,13 +27,11 @@ func init() {
 // fields that can be set to change the response the cloud manager returns
 // when this mock instance is queried for.
 type MockInstance struct {
-	IsUp               bool
 	IsSSHReachable     bool
 	Status             CloudStatus
 	SSHOptions         []string
 	TimeTilNextPayment time.Duration
 	DNSName            string
-	OnUpRan            bool
 	Tags               []host.Tag
 	Type               string
 	BlockDevices       []string
@@ -154,7 +152,6 @@ func (m *mockManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, 
 	l.Lock()
 	defer l.Unlock()
 	m.Instances[h.Id] = MockInstance{
-		IsUp:               false,
 		IsSSHReachable:     false,
 		Status:             StatusInitializing,
 		SSHOptions:         []string{},
@@ -306,31 +303,6 @@ func (m *mockManager) StartInstance(ctx context.Context, host *host.Host, user s
 
 func (m *mockManager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	//no-op. maybe will need to load something from settings in the future.
-	return nil
-}
-
-func (m *mockManager) IsUp(ctx context.Context, host *host.Host) (bool, error) {
-	l := m.mutex
-	l.RLock()
-	instance, ok := m.Instances[host.Id]
-	l.RUnlock()
-	if !ok {
-		return false, errors.Errorf("unable to fetch host '%s'", host.Id)
-	}
-	return instance.IsUp, nil
-}
-
-func (m *mockManager) OnUp(ctx context.Context, host *host.Host) error {
-	l := m.mutex
-	l.Lock()
-	defer l.Unlock()
-	instance, ok := m.Instances[host.Id]
-	if !ok {
-		return errors.Errorf("unable to fetch host '%s'", host.Id)
-	}
-	instance.OnUpRan = true
-	m.Instances[host.Id] = instance
-
 	return nil
 }
 

--- a/cloud/openstack.go
+++ b/cloud/openstack.go
@@ -180,21 +180,6 @@ func (m *openStackManager) StartInstance(ctx context.Context, host *host.Host, u
 	return errors.New("StartInstance is not supported for OpenStack provider")
 }
 
-// IsUp checks whether the provisioned host is running.
-func (m *openStackManager) IsUp(ctx context.Context, host *host.Host) (bool, error) {
-	status, err := m.GetInstanceStatus(ctx, host)
-	if err != nil {
-		return false, err
-	}
-
-	return status == StatusRunning, nil
-}
-
-// OnUp does nothing since tags are attached in SpawnInstance.
-func (m *openStackManager) OnUp(ctx context.Context, host *host.Host) error {
-	return nil
-}
-
 // GetDNSName returns the private IP address of the host.
 func (m *openStackManager) GetDNSName(ctx context.Context, host *host.Host) (string, error) {
 	server, err := m.client.GetInstance(host.Id)

--- a/cloud/openstack_test.go
+++ b/cloud/openstack_test.go
@@ -103,52 +103,6 @@ func (s *OpenStackSuite) TestConfigureAPICall() {
 	s.Error(s.manager.Configure(ctx, settings))
 }
 
-func (s *OpenStackSuite) TestIsUpFailAPICall() {
-	mock, ok := s.client.(*openStackClientMock)
-	s.True(ok)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	host := &host.Host{}
-
-	mock.failGet = true
-	_, err := s.manager.GetInstanceStatus(ctx, host)
-	s.Error(err)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.Error(err)
-	s.False(active)
-}
-
-func (s *OpenStackSuite) TestIsUpStatuses() {
-	mock, ok := s.client.(*openStackClientMock)
-	s.True(ok)
-	s.True(mock.isServerActive)
-
-	host := &host.Host{}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	status, err := s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.Equal(StatusRunning, status)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.True(active)
-
-	mock.isServerActive = false
-	status, err = s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.NotEqual(StatusRunning, status)
-
-	active, err = s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.False(active)
-}
-
 func (s *OpenStackSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -164,7 +164,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 	d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", so.PublicKey, d.GetAuthorizedKeysFile())
 
 	// fake out replacing spot instances with on-demand equivalents
-	if d.Provider == evergreen.ProviderNameEc2Spot || d.Provider == evergreen.ProviderNameEc2Fleet {
+	if d.Provider == evergreen.ProviderNameEc2Fleet {
 		d.Provider = evergreen.ProviderNameEc2OnDemand
 	}
 

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -122,14 +122,6 @@ func (staticMgr *staticManager) Configure(ctx context.Context, settings *evergre
 	return nil
 }
 
-func (staticMgr *staticManager) IsUp(context.Context, *host.Host) (bool, error) {
-	return true, nil
-}
-
-func (staticMgr *staticManager) OnUp(context.Context, *host.Host) error {
-	return nil
-}
-
 func (staticMgr *staticManager) AttachVolume(context.Context, *host.Host, *host.VolumeAttachment) error {
 	return errors.New("can't attach volume with static provider")
 }

--- a/cloud/vsphere.go
+++ b/cloud/vsphere.go
@@ -172,22 +172,6 @@ func (m *vsphereManager) StartInstance(ctx context.Context, host *host.Host, use
 	return errors.New("StartInstance is not supported for vsphere provider")
 }
 
-// IsUp checks whether the provisioned host is running.
-func (m *vsphereManager) IsUp(ctx context.Context, host *host.Host) (bool, error) {
-	status, err := m.GetInstanceStatus(ctx, host)
-	if err != nil {
-		return false, errors.Wrapf(err,
-			"manager failed to get instance status for host %s", host.Id)
-	}
-
-	return status == StatusRunning, nil
-}
-
-// OnUp does nothing since tags are attached in SpawnInstance.
-func (m *vsphereManager) OnUp(ctx context.Context, host *host.Host) error {
-	return nil //TODO
-}
-
 func (m *vsphereManager) AttachVolume(context.Context, *host.Host, *host.VolumeAttachment) error {
 	return errors.New("can't attach volume with vSphere provider")
 }

--- a/cloud/vsphere_test.go
+++ b/cloud/vsphere_test.go
@@ -86,52 +86,6 @@ func (s *VSphereSuite) TestConfigureAPICall() {
 	s.Error(s.manager.Configure(ctx, settings))
 }
 
-func (s *VSphereSuite) TestIsUpFailAPICall() {
-	mock, ok := s.client.(*vsphereClientMock)
-	s.True(ok)
-
-	host := &host.Host{}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	mock.failPowerState = true
-	_, err := s.manager.GetInstanceStatus(ctx, host)
-	s.Error(err)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.Error(err)
-	s.False(active)
-}
-
-func (s *VSphereSuite) TestIsUpStatuses() {
-	mock, ok := s.client.(*vsphereClientMock)
-	s.True(ok)
-	s.True(mock.isActive)
-
-	host := &host.Host{}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	status, err := s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.Equal(StatusRunning, status)
-
-	active, err := s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.True(active)
-
-	mock.isActive = false
-	status, err = s.manager.GetInstanceStatus(ctx, host)
-	s.NoError(err)
-	s.NotEqual(StatusRunning, status)
-
-	active, err = s.manager.IsUp(ctx, host)
-	s.NoError(err)
-	s.False(active)
-}
-
 func (s *VSphereSuite) TestTerminateInstanceAPICall() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/docs/Configure-a-Project/Project-Commands.md
+++ b/docs/Configure-a-Project/Project-Commands.md
@@ -463,7 +463,6 @@ EC2 Parameters:
 -   `security_group_ids` - List of security groups. Must set if `ami` is
     set. May set if `distro` is set, which will override the value from
     the distro configuration.
--   `spot` - Spawn a spot instance if `true.` Defaults to `false`.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the
@@ -512,7 +511,6 @@ permissions:
 -   `ec2:DescribeInstances`
 -   `ec2:RunInstances`
 -   `ec2:TerminateInstances`
--   `pricing:GetProducts`
 
 ### Checking SSH Availability for Spawn Hosts
 

--- a/docs/Configure-a-Project/Project-Commands.md
+++ b/docs/Configure-a-Project/Project-Commands.md
@@ -421,8 +421,7 @@ Agent Parameters:
 
 -   `num_hosts` - Number of hosts to start, 1 \<= `num_hosts` \<= 10.
     Defaults to 1 (must be 1 if provider is Docker).
--   `provider` - Cloud provider. Must set `ec2` or `docker`. We intend
-    to support other providers as future work.
+-   `provider` - Cloud provider. Must set `ec2` or `docker`.
 -   `retries` - How many times Evergreen should try to create this host
     in EC2 before giving up. Evergreen will wait 1 minute between
     retries.

--- a/globals.go
+++ b/globals.go
@@ -480,7 +480,6 @@ const (
 // Constants related to cloud providers and provider-specific settings.
 const (
 	ProviderNameEc2OnDemand = "ec2-ondemand"
-	ProviderNameEc2Spot     = "ec2-spot"
 	ProviderNameEc2Fleet    = "ec2-fleet"
 	ProviderNameDocker      = "docker"
 	ProviderNameDockerMock  = "docker-mock"
@@ -502,7 +501,6 @@ const (
 // IsEc2Provider returns true if the provider is ec2.
 func IsEc2Provider(provider string) bool {
 	return provider == ProviderNameEc2OnDemand ||
-		provider == ProviderNameEc2Spot ||
 		provider == ProviderNameEc2Fleet
 }
 
@@ -518,7 +516,6 @@ var (
 	// relation to spawn hosts.
 	ProviderSpawnable = []string{
 		ProviderNameEc2OnDemand,
-		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
 		ProviderNameGce,
 		ProviderNameOpenstack,
@@ -532,7 +529,6 @@ var (
 	// spawn hosts.
 	ProviderUserSpawnable = []string{
 		ProviderNameEc2OnDemand,
-		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
 		ProviderNameGce,
 		ProviderNameOpenstack,
@@ -546,14 +542,12 @@ var (
 	// ProviderSpotEc2Type includes all cloud provider types that manage EC2
 	// spot instances.
 	ProviderSpotEc2Type = []string{
-		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
 	}
 
 	// ProviderEc2Type includes all cloud provider types that manage EC2
 	// instances.
 	ProviderEc2Type = []string{
-		ProviderNameEc2Spot,
 		ProviderNameEc2Fleet,
 		ProviderNameEc2OnDemand,
 	}

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -493,7 +493,7 @@ func (d *Distro) GetImageID() (string, error) {
 	key := ""
 
 	switch d.Provider {
-	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot, evergreen.ProviderNameEc2Fleet:
+	case evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Fleet:
 		key = "ami"
 	case evergreen.ProviderNameDocker, evergreen.ProviderNameDockerMock:
 		key = "image_url"

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -240,13 +240,6 @@ func TestGetImageID(t *testing.T) {
 			expectedOutput: "imageID",
 		},
 		{
-			name:           "Ec2Spot",
-			provider:       evergreen.ProviderNameEc2Spot,
-			key:            "ami",
-			value:          "imageID",
-			expectedOutput: "imageID",
-		},
-		{
 			name:           "Ec2Fleet",
 			provider:       evergreen.ProviderNameEc2Fleet,
 			key:            "ami",

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -30,7 +30,6 @@ const (
 	EventHostStarted                     = "HOST_STARTED"
 	EventHostStopped                     = "HOST_STOPPED"
 	EventHostModified                    = "HOST_MODIFIED"
-	EventHostFallback                    = "HOST_FALLBACK"
 	EventHostAgentDeployed               = "HOST_AGENT_DEPLOYED"
 	EventHostAgentDeployFailed           = "HOST_AGENT_DEPLOY_FAILED"
 	EventHostAgentMonitorDeployed        = "HOST_AGENT_MONITOR_DEPLOYED"

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -146,12 +146,6 @@ func LogHostModifyError(hostID, logs string) {
 	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: false, Logs: logs})
 }
 
-// LogHostFallback logs an event indicating that the host is being created using
-// a backup cloud provider.
-func LogHostFallback(hostId string) {
-	LogHostEvent(hostId, EventHostFallback, HostEventData{})
-}
-
 func LogHostAgentDeployed(hostId string) {
 	LogHostEvent(hostId, EventHostAgentDeployed, HostEventData{
 		AgentRevision: evergreen.AgentVersion,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -454,15 +454,6 @@ func (h *Host) IsEphemeral() bool {
 	return utility.StringSliceContains(evergreen.ProviderSpawnable, h.Provider)
 }
 
-func (h *Host) ShouldFallbackToOnDemand() bool {
-	// this case shouldn't happen unless the host is somehow misconfigured
-	if len(h.Distro.ProviderSettingsList) != 1 {
-		return false
-	}
-	fallback, _ := h.Distro.ProviderSettingsList[0].Lookup("fallback").BooleanOK()
-	return fallback
-}
-
 func (h *Host) IsContainer() bool {
 	return utility.StringSliceContains(evergreen.ProviderContainer, h.Provider)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4571,6 +4571,11 @@ func TestFindHostWithVolume(t *testing.T) {
 func TestStartingHostsByClient(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
 	doc1 := birch.NewDocument(birch.EC.String(awsRegionKey, evergreen.DefaultEC2Region))
+	doc2 := birch.NewDocument(
+		birch.EC.String(awsRegionKey, "us-west-1"),
+		birch.EC.String(awsKeyKey, "key1"),
+		birch.EC.String(awsSecretKey, "secret1"),
+	)
 	startingHosts := []Host{
 		{
 			Id:     "h0",
@@ -4585,7 +4590,7 @@ func TestStartingHostsByClient(t *testing.T) {
 			Status: evergreen.HostStarting,
 			Distro: distro.Distro{
 				Provider:             evergreen.ProviderNameEc2OnDemand,
-				ProviderSettingsList: []*birch.Document{doc1},
+				ProviderSettingsList: []*birch.Document{doc2},
 			},
 		},
 		{
@@ -4618,9 +4623,16 @@ func TestStartingHostsByClient(t *testing.T) {
 			Provider: evergreen.ProviderNameEc2OnDemand,
 			Region:   evergreen.DefaultEC2Region,
 		}:
-			require.Len(t, hosts, 2)
+			require.Len(t, hosts, 1)
 			compareHosts(t, hosts[0], startingHosts[0])
-			compareHosts(t, hosts[1], startingHosts[1])
+		case ClientOptions{
+			Provider: evergreen.ProviderNameEc2OnDemand,
+			Region:   "us-west-1",
+			Key:      "key1",
+			Secret:   "secret1",
+		}:
+			require.Len(t, hosts, 1)
+			compareHosts(t, hosts[0], startingHosts[1])
 		case ClientOptions{
 			Provider: evergreen.ProviderNameDocker,
 		}:

--- a/model/host/static_hosts_test.go
+++ b/model/host/static_hosts_test.go
@@ -51,7 +51,7 @@ func TestDecommissionInactiveStaticHosts(t *testing.T) {
 			inactiveEC2One := &Host{
 				Id:       "inactiveEC2One",
 				Status:   evergreen.HostRunning,
-				Provider: "ec2-spot",
+				Provider: "ec2-ondemand",
 			}
 			So(inactiveEC2One.Insert(), ShouldBeNil)
 

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -44,15 +44,6 @@ func insertTestDocuments() error {
 		},
 		Host{
 			Id:     "four",
-			Status: evergreen.HostRunning,
-			Distro: distro.Distro{
-				Id:       "redhat",
-				Provider: evergreen.ProviderNameEc2Spot,
-			},
-			StartedBy: evergreen.User,
-		},
-		Host{
-			Id:     "five",
 			Status: evergreen.HostUninitialized,
 			Distro: distro.Distro{
 				Id:       "foo",
@@ -61,7 +52,7 @@ func insertTestDocuments() error {
 			StartedBy: evergreen.User,
 		},
 		Host{
-			Id:     "six",
+			Id:     "five",
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "bar",
@@ -70,7 +61,7 @@ func insertTestDocuments() error {
 			StartedBy: evergreen.User,
 		},
 		Host{
-			Id:     "seven",
+			Id:     "six",
 			Status: evergreen.HostRunning,
 			Distro: distro.Distro{
 				Id:       "debian",
@@ -94,10 +85,9 @@ func TestHostStatsByProvider(t *testing.T) {
 	result := ProviderStats{}
 
 	assert.NoError(db.Aggregate(Collection, statsByProviderPipeline(), &result))
-	assert.Len(result, 3, "%+v", result)
+	assert.Len(result, 2, "%+v", result)
 
 	rmap := result.Map()
-	assert.Equal(1, rmap[evergreen.ProviderNameEc2Spot])
 	assert.Equal(3, rmap[evergreen.ProviderNameEc2Fleet])
 
 	alt, err := GetProviderCounts()

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -112,7 +112,7 @@ func TestHostStatsByDistro(t *testing.T) {
 
 	rcmap := result.CountMap()
 	assert.Equal(2, rcmap["debian"])
-	assert.Equal(2, rcmap["redhat"])
+	assert.Equal(1, rcmap["redhat"])
 
 	rtmap := result.TasksMap()
 	assert.Equal(2, rtmap["debian"])

--- a/public/static/js/distros.js
+++ b/public/static/js/distros.js
@@ -49,9 +49,6 @@ mciModule.controller('DistrosCtrl', function ($scope, $window, $http, $location,
     'id': 'ec2-ondemand',
     'display': 'EC2 On-Demand'
   }, {
-    'id': 'ec2-spot',
-    'display': 'EC2 Spot'
-  }, {
     'id': 'ec2-fleet',
     'display': 'EC2 Fleet'
   }, {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -326,11 +326,6 @@ func makeDockerIntentHost(taskID, userID string, createHost apimodels.CreateHost
 }
 
 func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.CreateHost) (*host.Host, error) {
-	provider := evergreen.ProviderNameEc2OnDemand
-	if createHost.Spot {
-		provider = evergreen.ProviderNameEc2Spot
-	}
-
 	if createHost.Region == "" {
 		createHost.Region = evergreen.DefaultEC2Region
 	}
@@ -365,7 +360,7 @@ func makeEC2IntentHost(taskID, userID, publicKey string, createHost apimodels.Cr
 	d.BootstrapSettings.Method = distro.BootstrapMethodNone
 
 	// set provider
-	d.Provider = provider
+	d.Provider = evergreen.ProviderNameEc2OnDemand
 
 	if publicKey != "" {
 		d.Setup += fmt.Sprintf("\necho \"\n%s\" >> %s\n", publicKey, d.GetAuthorizedKeysFile())

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -147,44 +147,6 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
-	// spawn a spot evergreen distro
-	c = apimodels.CreateHost{
-		Distro:              "archlinux-test",
-		CloudProvider:       "ec2",
-		NumHosts:            "1",
-		Scope:               "task",
-		SetupTimeoutSecs:    600,
-		TeardownTimeoutSecs: 21600,
-		Spot:                true,
-		KeyName:             "mock_key",
-	}
-	handler.createHost = c
-	h, err = data.MakeIntentHost(handler.taskID, "", "", handler.createHost)
-	assert.NoError(err)
-	assert.NotNil(h)
-	assert.Equal("archlinux-test", h.Distro.Id)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Provider)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Distro.Provider)
-	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
-
-	ec2Settings = &cloud.EC2ProviderSettings{}
-	ec2Settings2 = &cloud.EC2ProviderSettings{}
-	require.Len(h.Distro.ProviderSettingsList, 1)
-	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
-	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Equal("mock_key", ec2Settings.KeyName)
-	assert.Equal(true, ec2Settings.IsVpc)
-
-	h, err = host.FindOneByIdOrTag(h.Id)
-	assert.NoError(err)
-	require.NotNil(h)
-	ec2Settings2 = &cloud.EC2ProviderSettings{}
-	require.Len(h.Distro.ProviderSettingsList, 1)
-	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
-	assert.Equal("ami-123456", ec2Settings2.AMI)
-	assert.Equal("mock_key", ec2Settings2.KeyName)
-	assert.Equal(true, ec2Settings2.IsVpc)
-
 	// override some evergreen distro settings
 	c = apimodels.CreateHost{
 		Distro:              "archlinux-test",
@@ -193,7 +155,6 @@ func TestMakeIntentHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
-		Spot:                true,
 		AWSKeyID:            "my_aws_key",
 		AWSSecret:           "my_secret_key",
 		Subnet:              "subnet-123456",
@@ -203,8 +164,6 @@ func TestMakeIntentHost(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Provider)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Distro.Provider)
 	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	ec2Settings = &cloud.EC2ProviderSettings{}
@@ -233,7 +192,6 @@ func TestMakeIntentHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
-		Spot:                true,
 		AWSKeyID:            "my_aws_key",
 		AWSSecret:           "my_secret_key",
 		InstanceType:        "t1.micro",
@@ -245,8 +203,6 @@ func TestMakeIntentHost(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(h)
 	assert.Equal("", h.Distro.Id)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Provider)
-	assert.Equal(evergreen.ProviderNameEc2Spot, h.Distro.Provider)
 	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
 	ec2Settings2 = &cloud.EC2ProviderSettings{}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -454,7 +454,6 @@ func (s *hostTerminateHostHandlerSuite) TestExecuteWithRunningHost() {
 
 	mock := cloud.GetMockProvider()
 	mock.Set(h.hostID, cloud.MockInstance{
-		IsUp:   true,
 		Status: cloud.StatusRunning,
 	})
 

--- a/service/templates/distros.html
+++ b/service/templates/distros.html
@@ -409,13 +409,6 @@ Evergreen - Distros
                 <div class="icon fa fa-warning distro-error" ng-show="form.instanceType.$dirty && form.instanceType.$error.required || form.instanceType.$invalid">Instance
                   type is required</div>
               </div>
-              <div ng-show="activeDistro.provider.startsWith('ec2-spot')">
-                <label class="distro-label">Bid Price:</label>
-                <input ng-readonly="readOnly" ng-required="isDefaultRegion() && activeDistro.provider.startsWith('ec2-spot')" name="bidPrice"
-                  type="number" class="form-control" ng-model="activeDistro.settings.bid_price" placeholder="Maximum amount you're willing to pay per hour (dollars)">
-                <div class="icon fa fa-warning distro-error" ng-show="form.bidPrice.$dirty && form.bidPrice.$error.required || form.bidPrice.$invalid">Numeric
-                  bid price is required</div>
-              </div>
               <div>
                 <label class="distro-label">Key Name:</label>
                 <input type="text" ng-readonly="readOnly" name="keyName"
@@ -423,10 +416,6 @@ Evergreen - Distros
                   ng-readonly="readOnly">
                 <div class="icon fa fa-warning distro-error" ng-show="form.keyName.$dirty && form.keyName.$error.required || form.keyName.$invalid">EC2
                   key name is required</div>
-              </div>
-              <div ng-show="activeDistro.provider === 'ec2-spot'">
-                <label><input style="margin-right:10px;" ng-disabled="readOnly" type="checkbox"
-                  name="fallback" ng-model="activeDistro.settings.fallback">Fallback to EC2 On-Demand in the case of insufficient capacity </label> <br>
               </div>
               <div ng-show="activeDistro.provider === 'ec2-fleet'">
                 <br>

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -43,7 +43,6 @@ func TestHostMonitoringCheckJob(t *testing.T) {
 	require.NoError(h.Insert())
 
 	mockInstance := cloud.MockInstance{
-		IsUp:           true,
 		IsSSHReachable: true,
 		Status:         cloud.StatusTerminated,
 	}

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -145,7 +145,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 		"RunningStatusPreparesLegacyHostForProvisioning": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			provider := cloud.GetMockProvider()
 			mockInstance := cloud.MockInstance{
-				IsUp:    true,
 				Status:  cloud.StatusRunning,
 				DNSName: "dns_name",
 			}
@@ -155,7 +154,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, h.Insert())
 
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, mockInstance.Status))
-			assert.True(t, provider.Get(h.Id).OnUpRan)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
@@ -167,7 +165,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 		"RunningStatusMarksUserDataProvisionedHostAsProvisioned": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			provider := cloud.GetMockProvider()
 			mockInstance := cloud.MockInstance{
-				IsUp:    true,
 				Status:  cloud.StatusRunning,
 				DNSName: "dns_name",
 			}
@@ -177,7 +174,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, h.Insert())
 
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, mockInstance.Status))
-			assert.True(t, provider.Get(h.Id).OnUpRan)
 
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -145,8 +145,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 		"RunningStatusPreparesLegacyHostForProvisioning": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			provider := cloud.GetMockProvider()
 			mockInstance := cloud.MockInstance{
-				Status:  cloud.StatusRunning,
-				DNSName: "dns_name",
+				Status: cloud.StatusRunning,
 			}
 			provider.Set(h.Id, mockInstance)
 
@@ -158,15 +157,13 @@ func TestSetCloudHostStatus(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbHost)
-			assert.Equal(t, mockInstance.DNSName, dbHost.Host)
 			assert.False(t, dbHost.Provisioned)
 			assert.Equal(t, evergreen.HostProvisioning, dbHost.Status)
 		},
 		"RunningStatusMarksUserDataProvisionedHostAsProvisioned": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			provider := cloud.GetMockProvider()
 			mockInstance := cloud.MockInstance{
-				Status:  cloud.StatusRunning,
-				DNSName: "dns_name",
+				Status: cloud.StatusRunning,
 			}
 			provider.Set(h.Id, mockInstance)
 
@@ -178,7 +175,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 			dbHost, err := host.FindOneId(h.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbHost)
-			assert.Equal(t, mockInstance.DNSName, dbHost.Host)
 			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
 			assert.True(t, dbHost.Provisioned)
 		},

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -42,7 +42,6 @@ func TestHostTerminationJob(t *testing.T) {
 		"TerminatesRunningHost": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			require.NoError(t, h.Insert())
 			mcp.Set(h.Id, cloud.MockInstance{
-				IsUp:   true,
 				Status: cloud.StatusRunning,
 			})
 
@@ -68,7 +67,6 @@ func TestHostTerminationJob(t *testing.T) {
 		"SkipsCloudHostTermination": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			require.NoError(t, h.Insert())
 			mcp.Set(h.Id, cloud.MockInstance{
-				IsUp:   true,
 				Status: cloud.StatusRunning,
 			})
 
@@ -125,7 +123,6 @@ func TestHostTerminationJob(t *testing.T) {
 			h.Status = evergreen.HostTerminated
 			require.NoError(t, h.Insert())
 			mcp.Set(h.Id, cloud.MockInstance{
-				IsUp:   true,
 				Status: cloud.StatusRunning,
 			})
 

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -26,7 +26,6 @@ func TestSpawnhostStartJob(t *testing.T) {
 		}
 		assert.NoError(t, h.Insert())
 		mock.Set(h.Id, cloud.MockInstance{
-			IsUp:   true,
 			Status: cloud.StatusRunning,
 		})
 
@@ -47,7 +46,6 @@ func TestSpawnhostStartJob(t *testing.T) {
 		}
 		assert.NoError(t, h.Insert())
 		mock.Set(h.Id, cloud.MockInstance{
-			IsUp:   true,
 			Status: cloud.StatusStopped,
 		})
 

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -26,7 +26,6 @@ func TestSpawnhostStopJob(t *testing.T) {
 		}
 		assert.NoError(t, h.Insert())
 		mock.Set(h.Id, cloud.MockInstance{
-			IsUp:   true,
 			Status: cloud.StatusStopped,
 		})
 
@@ -47,7 +46,6 @@ func TestSpawnhostStopJob(t *testing.T) {
 		}
 		assert.NoError(t, h.Insert())
 		mock.Set(h.Id, cloud.MockInstance{
-			IsUp:   true,
 			Status: cloud.StatusRunning,
 		})
 

--- a/units/ssh_keys_update_cloud.go
+++ b/units/ssh_keys_update_cloud.go
@@ -82,7 +82,7 @@ func (j *cloudUpdateSSHKeysJob) Run(ctx context.Context) {
 
 	for _, pair := range settings.SSHKeyPairs {
 		switch j.Provider {
-		case evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot:
+		case evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand:
 			// Ignore if region already contains the public key.
 			if utility.StringSliceContains(pair.EC2Regions, j.Region) {
 				continue
@@ -110,7 +110,7 @@ func (j *cloudUpdateSSHKeysJob) Run(ctx context.Context) {
 		}
 
 		switch j.Provider {
-		case evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand, evergreen.ProviderNameEc2Spot:
+		case evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand:
 			if err := pair.AddEC2Region(j.Region); err != nil {
 				grip.Error(message.WrapError(err, message.Fields{
 					"message":  "could not update EC2 regions for SSH key",


### PR DESCRIPTION
[EVG-13927](https://jira.mongodb.org/browse/EVG-13927)

### Description
I was looking to remove OnUp for something else and I realized that the only provider that was making any material use of it was spot. Since we had [EVG-13927](https://jira.mongodb.org/browse/EVG-13927) for removing spot it seemed like an opportune time.

To Brian's point in the ticket, none of the existing configs specify [spot](https://github.com/evergreen-ci/evergreen/blob/d8d411c4e38da221976dc996308fa6b7418fb767/apimodels/agent_models.go#L155) for `host.create`.

### Testing
If tests are still broken I'll fix them🙈 . I'll try spinning up an on-demand host on staging before merging.
