### PR TITLE
EVG-19091 skip provisioned not running step

### DIFF
--- a/mock/environment.go
+++ b/mock/environment.go
@@ -57,6 +57,9 @@ func (e *Environment) Configure(ctx context.Context) error {
 	e.EnvContext = ctx
 
 	e.EvergreenSettings = testutil.TestConfig()
+	if err := evergreen.UpdateConfig(e.EvergreenSettings); err != nil {
+		return errors.WithStack(err)
+	}
 
 	e.Remote = queue.NewLocalLimitedSize(2, 1048)
 	if err := e.Remote.Start(ctx); err != nil {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1073,38 +1073,6 @@ func (h *Host) SetProvisionedNotRunning() error {
 	return nil
 }
 
-// UpdateStartingToRunning changes the host status from provisioning to
-// running, as well as logging that the host has finished provisioning.
-func (h *Host) UpdateStartingToRunning() error {
-	if h.Status != evergreen.HostStarting {
-		return nil
-	}
-
-	if err := UpdateOne(
-		bson.M{
-			IdKey:          h.Id,
-			StatusKey:      evergreen.HostStarting,
-			ProvisionedKey: true,
-		},
-		bson.M{"$set": bson.M{StatusKey: evergreen.HostRunning}},
-	); err != nil {
-		return errors.Wrap(err, "changing host status from starting to running")
-	}
-
-	h.Status = evergreen.HostRunning
-
-	event.LogHostProvisioned(h.Id)
-	grip.Info(message.Fields{
-		"message":   "host marked provisioned",
-		"host_id":   h.Id,
-		"host_tag":  h.Tag,
-		"distro":    h.Distro.Id,
-		"operation": "UpdateStartingToRunning",
-	})
-
-	return nil
-}
-
 // SetNeedsToRestartJasper sets this host as needing to have its Jasper service
 // restarted as long as the host does not already need a different
 // reprovisioning change. If the host is ready to reprovision now (i.e. no agent

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1191,11 +1191,7 @@ func (h *Host) SetUserDataHostProvisioned() error {
 		return nil
 	}
 
-	if !h.Provisioned {
-		return nil
-	}
-
-	if err := h.UpdateStartingToRunning(); err != nil {
+	if err := h.MarkAsProvisioned(); err != nil {
 		return errors.Wrap(err, "marking host as done provisioning itself and now running")
 	}
 

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -239,10 +239,8 @@ func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Mana
 func (j *cloudHostReadyJob) setNextState(ctx context.Context, h *host.Host) error {
 	switch h.Distro.BootstrapSettings.Method {
 	case distro.BootstrapMethodUserData:
-		// From the app server's perspective, it is done provisioning a user
-		// data host once the instance is running. The user data script will
-		// handle the rest of host provisioning.
-		return errors.Wrap(h.SetProvisionedNotRunning(), "marking host as provisioned but not yet running")
+		// The user data script will handle the rest of host provisioning.
+		return nil
 	case distro.BootstrapMethodNone:
 		// A host created by a task goes through no further provisioning, so we
 		// can just set it as running.

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -114,7 +114,6 @@ func TestCloudStatusJob(t *testing.T) {
 		}
 		if h.Id == "host-6" {
 			assert.Equal(evergreen.HostStarting, h.Status)
-			assert.True(h.Provisioned)
 		}
 	}
 }
@@ -164,7 +163,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			assert.False(t, dbHost.Provisioned)
 			assert.Equal(t, evergreen.HostProvisioning, dbHost.Status)
 		},
-		"RunningStatusMarksUserDataProvisionedHostAsProvisioned": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
+		"RunningStatusNoopsUserDataHost": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			provider := cloud.GetMockProvider()
 			mockInstance := cloud.MockInstance{
 				IsUp:    true,
@@ -184,7 +183,6 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, mockInstance.DNSName, dbHost.Host)
 			assert.Equal(t, evergreen.HostStarting, dbHost.Status)
-			assert.True(t, dbHost.Provisioned)
 		},
 		"NonExistentStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			require.NoError(t, h.Insert())


### PR DESCRIPTION
[EVG-19091](https://jira.mongodb.org/browse/EVG-19091)

### Description
It looks like the reason we have this intermediate `provisioned-not-running` state is [so we can do whatever setup on the host first](https://github.com/evergreen-ci/evergreen/pull/2723). Post https://github.com/evergreen-ci/evergreen/pull/6500 `OnUp` is no longer a thing so we should be good to skip it, I think?

In the case where a host comes online and there are no dispatchable tasks for it we should terminate it after the idle termination threshold is passed. An issue I observed is that the idle termination job only looks for hosts that are [running](https://github.com/evergreen-ci/evergreen/blob/6dace20f6ad21225fe63f04046f7d047d085ea48/model/host/db.go#L179), so a user data host that hasn't yet transitioned to running and that hasn't passed the `provisioningCutoff` isn't eligible for termination. Because nextTask doesn't set the host to `running` unless it's been already been marked provisioned by the set-cloud-hosts-ready job it won't get terminated by the idle termination job until set-cloud-hosts-ready has found the host running, which is often on the order of minutes after the host has requested its first task.

### Testing
I'll make sure a user data host still provisions as expected before I merge this.
