### PR TITLE
EVG-19091 include starting hosts in idle hosts

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -181,7 +181,6 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 					{
 						StatusKey:    evergreen.HostStarting,
 						bootstrapKey: distro.BootstrapMethodUserData,
-
 						// Idle time starts from when a host is first able
 						// to run a task. For user data hosts this is the time
 						// when they first made contact with the app instead

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -181,10 +181,17 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 					{
 						StatusKey:    evergreen.HostStarting,
 						bootstrapKey: distro.BootstrapMethodUserData,
-						// User data hosts have a grace period between creation
-						// and provisioning during which they are not considered
-						// for idle termination to give agents time to start.
-						CreateTimeKey: bson.M{"$lte": time.Now().Add(-provisioningCutoff)},
+						"$or": []bson.M{
+							// Idle time starts from when a host is first able
+							// to run a task. For user data hosts this is the time
+							// when they first made contact with the app instead
+							// of when they're marked running.
+							{AgentStartTimeKey: bson.M{"$gt": utility.ZeroTime}},
+							// User data hosts have a grace period between creation
+							// and provisioning during which they are not considered
+							// for idle termination to give agents time to start.
+							{CreateTimeKey: bson.M{"$lte": time.Now().Add(-provisioningCutoff)}},
+						},
 					},
 				},
 			},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -181,17 +181,12 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 					{
 						StatusKey:    evergreen.HostStarting,
 						bootstrapKey: distro.BootstrapMethodUserData,
-						"$or": []bson.M{
-							// Idle time starts from when a host is first able
-							// to run a task. For user data hosts this is the time
-							// when they first made contact with the app instead
-							// of when they're marked running.
-							{AgentStartTimeKey: bson.M{"$gt": utility.ZeroTime}},
-							// User data hosts have a grace period between creation
-							// and provisioning during which they are not considered
-							// for idle termination to give agents time to start.
-							{CreateTimeKey: bson.M{"$lte": time.Now().Add(-provisioningCutoff)}},
-						},
+
+						// Idle time starts from when a host is first able
+						// to run a task. For user data hosts this is the time
+						// when they first made contact with the app instead
+						// of when they're marked running.
+						AgentStartTimeKey: bson.M{"$gt": utility.ZeroTime},
 					},
 				},
 			},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -389,7 +389,7 @@ func (h *Host) GetTaskGroupString() string {
 // IdleTime returns how long has this host has been sitting idle. In this context
 // idle time means the duration the host has not been running a task even though it
 // could have been. The time before the host was ready to run a task does not count
-// as idle time.
+// as idle time because the host needs time to come up.
 func (h *Host) IdleTime() time.Duration {
 	// If the host is currently running a task, it is not idle.
 	if h.RunningTask != "" {
@@ -419,7 +419,8 @@ func (h *Host) IdleTime() time.Duration {
 	return 0
 }
 
-// WastedComputeTime returns the duration since the last task to run on the host
+// WastedComputeTime returns the duration of compute we've paid for that
+// wasn't used to run a task. This is the duration since the last task to run on the host
 // completed or, if no task has run, the host's uptime. The time the host is alive
 // before it's able to run a task also counts as wasted compute.
 func (h *Host) WastedComputeTime() time.Duration {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -386,7 +386,10 @@ func (h *Host) GetTaskGroupString() string {
 	return fmt.Sprintf("%s_%s_%s_%s", h.RunningTaskGroup, h.RunningTaskBuildVariant, h.RunningTaskProject, h.RunningTaskVersion)
 }
 
-// IdleTime returns how long has this host has been sitting idle.
+// IdleTime returns how long has this host has been sitting idle. In this context
+// idle time means the duration the host has not been running a task even though it
+// could have been. The time before the host was ready to run a task does not count
+// as idle time.
 func (h *Host) IdleTime() time.Duration {
 	// If the host is currently running a task, it is not idle.
 	if h.RunningTask != "" {
@@ -417,7 +420,8 @@ func (h *Host) IdleTime() time.Duration {
 }
 
 // WastedComputeTime returns the duration since the last task to run on the host
-// completed or, if no task has run, the host's uptime.
+// completed or, if no task has run, the host's uptime. The time the host is alive
+// before it's able to run a task also counts as wasted compute.
 func (h *Host) WastedComputeTime() time.Duration {
 	// If the host has run a task, return the time the last task finished running.
 	if h.LastTask != "" {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2039,7 +2039,7 @@ func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 		AgentStartTime:        time.Now(),
 	}
 	// User data host that is not running task but has not had its
-	//  AgentStartTime set is not idle.
+	// AgentStartTime set is not idle.
 	host10 := &Host{
 		Id: "host10",
 		Distro: distro.Distro{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2529,31 +2529,31 @@ func TestIsIdleParent(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
-	billingTimeRecent := time.Now().Add(-5 * time.Minute)
-	billingTimeOld := time.Now().Add(-1 * time.Hour)
+	provisionTimeRecent := time.Now().Add(-5 * time.Minute)
+	provisionTimeOld := time.Now().Add(-1 * time.Hour)
 
 	host1 := &Host{
-		Id:               "host1",
-		Status:           evergreen.HostRunning,
-		BillingStartTime: billingTimeOld,
+		Id:            "host1",
+		Status:        evergreen.HostRunning,
+		ProvisionTime: provisionTimeOld,
 	}
 	host2 := &Host{
-		Id:               "host2",
-		Status:           evergreen.HostRunning,
-		HasContainers:    true,
-		BillingStartTime: billingTimeRecent,
+		Id:            "host2",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+		ProvisionTime: provisionTimeRecent,
 	}
 	host3 := &Host{
-		Id:               "host3",
-		Status:           evergreen.HostRunning,
-		HasContainers:    true,
-		BillingStartTime: billingTimeOld,
+		Id:            "host3",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+		ProvisionTime: provisionTimeOld,
 	}
 	host4 := &Host{
-		Id:               "host4",
-		Status:           evergreen.HostRunning,
-		HasContainers:    true,
-		BillingStartTime: billingTimeOld,
+		Id:            "host4",
+		Status:        evergreen.HostRunning,
+		HasContainers: true,
+		ProvisionTime: provisionTimeOld,
 	}
 	host5 := &Host{
 		Id:       "host5",

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -932,7 +932,7 @@ func (h *startTaskHandler) Run(ctx context.Context) gimlet.Responder {
 			if err = host.IncTaskCount(); err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "incrementing task count for task '%s' on host '%s'", t.Id, host.Id))
 			}
-			if err = host.IncIdleTime(host.SinceLastTaskCompletion()); err != nil {
+			if err = host.IncIdleTime(host.WastedComputeTime()); err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "incrementing total idle time on host '%s'", host.Id))
 			}
 			grip.Info(host.TaskStartMessage())

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -322,7 +322,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 }
 
 func (j *hostTerminationJob) incrementIdleTime(ctx context.Context) error {
-	idleTime := j.host.SinceLastTaskCompletion()
+	idleTime := j.host.WastedComputeTime()
 
 	cloudHost, err := cloud.GetCloudHost(ctx, j.host, j.env)
 	if err != nil {


### PR DESCRIPTION
[EVG-19091](https://jira.mongodb.org/browse/EVG-19091)

### Description
The same motivation as #6501. The solution proposed here is to expand the `IdleEphemeralGroupedByDistroID` query to include user data hosts that have contacted the app to ask for a task. This is also idle in the sense that these hosts are cleared to run tasks from this time. Also adjust `h.IdleTime()` accordingly.

Another adjustment to `h.IdleTime()` is to not count the time before the host is provisioned as idle time for the purposes of idle termination. That time still counts as `WastedComputeTime` so that logic was left as its own function. This is necessary since if we count the time since the host came online the host will have that much less time before it's considered idle. And especially now that user data hosts won't have the preceding few minutes to grab a task before they're considered for idle termination.

### Testing
I'll make sure an idle user data host gets killed in staging at around the idle time from when it first called `nextTask`.
