### PR TITLE
EVG-17680 remove redundant stale query

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -137,10 +137,6 @@ var BaseTaskStatusKey = bsonutil.GetDottedKeyName(BaseTaskKey, StatusKey)
 var All = db.Query(nil)
 
 var (
-	SelectorTaskInProgress = bson.M{
-		"$in": []string{evergreen.TaskStarted, evergreen.TaskDispatched},
-	}
-
 	FinishedOpts = []bson.M{{
 		StatusKey: bson.M{
 			"$in": []string{
@@ -504,33 +500,20 @@ func ByIdsAndStatus(taskIds []string, statuses []string) bson.M {
 	}
 }
 
-type StaleReason int
-
-const (
-	HeartbeatPastCutoff StaleReason = iota
-	NoHeartbeatSinceDispatch
-)
-
 // ByStaleRunningTask creates a query that finds any running tasks
-// whose last heartbeat was at least the specified threshold ago, or
-// that has been dispatched but hasn't started in twice that long.
-func ByStaleRunningTask(staleness time.Duration, reason StaleReason) bson.M {
-	var reasonQuery bson.M
-	switch reason {
-	case HeartbeatPastCutoff:
-		reasonQuery = bson.M{
-			StatusKey:        SelectorTaskInProgress,
-			DisplayOnlyKey:   bson.M{"$ne": true},
-			LastHeartbeatKey: bson.M{"$lte": time.Now().Add(-staleness)},
-		}
-	case NoHeartbeatSinceDispatch:
-		reasonQuery = bson.M{
-			StatusKey:       evergreen.TaskDispatched,
-			DisplayOnlyKey:  bson.M{"$ne": true},
-			DispatchTimeKey: bson.M{"$lte": time.Now().Add(-2 * staleness)},
-		}
+// whose last heartbeat was at least the specified threshold ago.
+func ByStaleRunningTask(staleness time.Duration) bson.M {
+	return bson.M{
+		StatusKey: bson.M{
+			"$in": []string{evergreen.TaskStarted, evergreen.TaskDispatched},
+		},
+		DisplayOnlyKey: bson.M{
+			"$ne": true,
+		},
+		LastHeartbeatKey: bson.M{
+			"$lte": time.Now().Add(-staleness),
+		},
 	}
-	return reasonQuery
 }
 
 // ByCommit creates a query on Evergreen as the requester on a revision, buildVariant, displayName and project.

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -802,7 +802,7 @@ func TestFindByStaleRunningTask(t *testing.T) {
 			}
 			require.NoError(t, tsk.Insert())
 
-			found, err := Find(ByStaleRunningTask(30*time.Minute, HeartbeatPastCutoff))
+			found, err := Find(ByStaleRunningTask(30 * time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.Equal(t, tsk.Id, found[0].Id)
@@ -815,7 +815,7 @@ func TestFindByStaleRunningTask(t *testing.T) {
 			}
 			require.NoError(t, tsk.Insert())
 
-			found, err := Find(ByStaleRunningTask(30*time.Minute, HeartbeatPastCutoff))
+			found, err := Find(ByStaleRunningTask(30 * time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.Equal(t, tsk.Id, found[0].Id)
@@ -842,7 +842,7 @@ func TestFindByStaleRunningTask(t *testing.T) {
 				require.NoError(t, tsk.Insert())
 			}
 
-			found, err := Find(ByStaleRunningTask(30*time.Minute, HeartbeatPastCutoff))
+			found, err := Find(ByStaleRunningTask(30 * time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 2)
 			for _, tsk := range found {
@@ -857,7 +857,7 @@ func TestFindByStaleRunningTask(t *testing.T) {
 			}
 			require.NoError(t, tsk.Insert())
 
-			found, err := Find(ByStaleRunningTask(30*time.Minute, HeartbeatPastCutoff))
+			found, err := Find(ByStaleRunningTask(30 * time.Minute))
 			require.NoError(t, err)
 			assert.Empty(t, found)
 		},
@@ -869,7 +869,7 @@ func TestFindByStaleRunningTask(t *testing.T) {
 			}
 			require.NoError(t, tsk.Insert())
 
-			found, err := Find(ByStaleRunningTask(0, HeartbeatPastCutoff))
+			found, err := Find(ByStaleRunningTask(0))
 			require.NoError(t, err)
 			assert.Empty(t, found)
 		},


### PR DESCRIPTION
EVG-17680
### Description
Any task that isn't dispatched by 2 x time also would've not had a heartbeat for 1 x time, so would've been caught already. 

Verified that we never find tasks with this query [in Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%22message%22%3D%22found%20stale%20tasks%22%20%22reason%22%3D%22no%20heartbeat%20since%20dispatch%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-30d%40d&latest=now&workload_pool=standard_perf&sid=1684353107.894773).

(Alternatively we could change this behavior to not consider dispatched in the first query, but I don't know that we've had trouble with how this has been working already.)

### Testing
Modified existing test.
