### PR TITLE
EVG-19325: prevent ambiguous unfinished build state

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1216,10 +1216,10 @@ func getBuildStatus(buildTasks []task.Task) buildStatus {
 		}
 		if !t.Blocked() && !t.IsFinished() {
 			// A build is not finished until all of its tasks are either blocked
-			// or finished running, regardless of whether it's activated. This
-			// is because it's ambiguous if the build really succeeded/failed
-			// when some of its tasks are inactive. The one exception is
-			// disabled tasks, which can't run until the user enables it.
+			// or finished running, regardless of whether it's activated (due to
+			// reasons such as activate: false configuration or setting disabled
+			// priority). This is because it's ambiguous if the build really
+			// succeeded/failed when some of its tasks are inactive.
 			return buildStatus{status: evergreen.BuildStarted}
 		}
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1178,8 +1178,6 @@ type buildStatus struct {
 
 // getBuildStatus returns a string denoting the status of the build and
 // a boolean denoting if all tasks in the build are blocked.
-// kim: TODO: should probably encode the state where there's a mix of
-// unscheduled and finished tasks as started.
 func getBuildStatus(buildTasks []task.Task) buildStatus {
 	// Check if no tasks have started and if all tasks are blocked.
 	noStartedTasks := true
@@ -1216,9 +1214,6 @@ func getBuildStatus(buildTasks []task.Task) buildStatus {
 		if t.Status == evergreen.TaskStarted {
 			return buildStatus{status: evergreen.BuildStarted}
 		}
-		// if t.Activated && !t.Blocked() && !t.IsFinished() {
-		// kim: TODO: may have to see how this interacts with disable. Disable
-		// would have activate == false until explicitly enabled
 		if !t.Blocked() && !t.IsFinished() {
 			// A build is not finished until all of its tasks are either blocked
 			// or finished running, regardless of whether it's activated. This
@@ -1238,9 +1233,6 @@ func getBuildStatus(buildTasks []task.Task) buildStatus {
 	return buildStatus{status: evergreen.BuildSucceeded}
 }
 
-// kim: NOTE: will probably have to change this to ensure that even if the build
-// is finished, it gets a pending state if it has at least one unfinished but
-// scheduled task.
 // updateBuildGithubStatus updates the GitHub check status for a build. If the
 // build has no GitHub checks, then it is a no-op. Note that this is for GitHub
 // checks, which are *not* the same as GitHub PR statuses.
@@ -1300,7 +1292,6 @@ func checkUpdateBuildPRStatusPending(b *build.Build) error {
 
 // updateBuildStatus updates the status of the build based on its tasks' statuses
 // Returns true if the build's status has changed or if all of the build's tasks become blocked.
-// kim: TODO: likely need to put fix somewhere in here.
 func updateBuildStatus(b *build.Build) (bool, error) {
 	buildTasks, err := task.FindWithFields(task.ByBuildId(b.Id), task.StatusKey, task.ActivatedKey, task.DependsOnKey, task.IsGithubCheckKey, task.AbortedKey)
 	if err != nil {
@@ -1308,7 +1299,6 @@ func updateBuildStatus(b *build.Build) (bool, error) {
 	}
 
 	buildStatus := getBuildStatus(buildTasks)
-	// pp.Println("build status:", b.Id, buildStatus)
 	// If all the tasks are unscheduled, set active to false
 	if buildStatus.allTasksUnscheduled {
 		if err = b.SetActivated(false); err != nil {
@@ -1375,7 +1365,6 @@ func updateBuildStatus(b *build.Build) (bool, error) {
 	return true, nil
 }
 
-// kim: NOTE: may have to change this logic to deal with highly ambiguous state.
 func getVersionStatus(builds []build.Build) string {
 	// Check if no builds have started in the version.
 	noStartedBuilds := true
@@ -1391,8 +1380,6 @@ func getVersionStatus(builds []build.Build) string {
 
 	// Check if builds are started but not finished.
 	for _, b := range builds {
-		// kim: TODO: may have to remove build activated state here. Not sure
-		// what this even does??? What the point...
 		if b.Activated && !evergreen.IsFinishedBuildStatus(b.Status) && !b.AllTasksBlocked {
 			return evergreen.VersionStarted
 		}
@@ -1408,9 +1395,6 @@ func getVersionStatus(builds []build.Build) string {
 	return evergreen.VersionSucceeded
 }
 
-// kim: TODO: possibly refuse to send status update (or update it to pending)
-// when the build status is finished but ambiguous (i.e. not all scheduled tasks
-// finished).
 // updateVersionGithubStatus updates the GitHub check status for a version. If
 // the version has no GitHub checks, then it is a no-op. Note that this is for
 // GitHub check statuses, which are *not* the same as GitHub PR statuses.
@@ -1486,7 +1470,6 @@ func updateVersionStatus(v *Version) (string, error) {
 }
 
 // UpdatePatchStatus updates the status of a patch.
-// kim: NOTE: seems like the patch inherits its status from the version status.
 func UpdatePatchStatus(p *patch.Patch, versionStatus string) error {
 	patchStatus, err := evergreen.VersionStatusToPatchStatus(versionStatus)
 	if err != nil {
@@ -1529,7 +1512,6 @@ func UpdatePatchStatus(p *patch.Patch, versionStatus string) error {
 // UpdateBuildAndVersionStatusForTask updates the status of the task's build based on all the tasks in the build
 // and the task's version based on all the builds in the version.
 // Also update build and version Github statuses based on the subset of tasks and builds included in github checks
-// kim: TODO: likely need to put fix somewhere in here.
 func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	taskBuild, err := build.FindOneId(t.BuildId)
 	if err != nil {
@@ -1542,7 +1524,6 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 	if err != nil {
 		return errors.Wrapf(err, "updating build '%s' status", taskBuild.Id)
 	}
-	// pp.Println("build status changed?", buildStatusChanged)
 	// If the build status has not changed, then the version and patch statuses must have also not changed.
 	if !buildStatusChanged {
 		return nil
@@ -1607,7 +1588,6 @@ func UpdateBuildAndVersionStatusForTask(t *task.Task) error {
 
 // UpdateVersionAndPatchStatusForBuilds updates the status of all versions, patches and
 // builds associated with the given input list of build IDs.
-// kim: TODO: likely need to put fix somewhere in here.
 func UpdateVersionAndPatchStatusForBuilds(buildIds []string) error {
 	if len(buildIds) == 0 {
 		return nil


### PR DESCRIPTION
EVG-19325

### Description
This fixes a loophole where a task may not have run because it's inactive, but nonetheless the build is considered finished, which then shows in the GitHub status as finished. In this case, the build logically should remain in a started state because it's not actually finished running all of its tasks. In other words, an absence of failures is not the same as successful completion - a successful build means everything's run, and it's all green.

Unfortunately, one weakness is that it can't distinguish between tasks that initially start out deactivated because of YAML configuration (e.g. `activate: false`) vs. those that are activated and then later deactivated by manual user intervention (by REST routes/pressing buttons in Spruce). The argument I would make for not splitting those cases is that users probably won't be able to spot a difference between "version not done because of `activate: false`" (i.e. the build is done because of automatic rules) vs. "version not done because a user manually unscheduled a task" (i.e. the build is not done because manual user intervention), since they look the same in the UI (unless you dig into the task event logs). But, if we really think that manual modification of task state is that different from YAML-configured task state and we think users would prefer the inconsistent behavior, I'm open to having it only affect manual user button presses, but it will be much more complicated than just this (and would additionally have to consider desired mainline vs. patch behavior).

* Leave the build status pending as long as there are deactivated tasks that can run (e.g. due to restarting and then unscheduling a task).
* Add a couple doc comments.

### Testing
Updated unit tests and tested in staging with the commit queue sandbox (https://github.com/evergreen-ci/commit-queue-sandbox/pull/486) that the build status was still pending after restarting/unscheduling. It still updates the GitHub status to a finished status if I reschedule the descheduled task. Notifications worked as expected and were only sent when things were done, not when they were ambiguous.

### Documentation
N/A
