### PR TITLE
EVG-19752 Include OverrideDependencies when determining container dispatchable

### DIFF
--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2618,6 +2618,25 @@ func TestShouldAllocateContainer(t *testing.T) {
 			tsk.Activated = false
 			assert.False(t, tsk.ShouldAllocateContainer())
 		},
+		"ReturnsFalseForTaskWithIncompleteDependencies": func(t *testing.T, tsk Task) {
+			tsk.DependsOn = []Dependency{
+				{
+					TaskId:   "dependency0",
+					Finished: false,
+				},
+			}
+			assert.False(t, tsk.ShouldAllocateContainer())
+		},
+		"ReturnsTrueForTaskWithOverrideDependencies": func(t *testing.T, tsk Task) {
+			tsk.DependsOn = []Dependency{
+				{
+					TaskId:   "dependency0",
+					Finished: false,
+				},
+			}
+			tsk.OverrideDependencies = true
+			assert.True(t, tsk.ShouldAllocateContainer())
+		},
 		"ReturnsFalseForDisplayTask": func(t *testing.T, tsk Task) {
 			tsk.DisplayOnly = true
 			tsk.ExecutionPlatform = ""


### PR DESCRIPTION
EVG-19752

### Description
We observed `OverrideDependencies` wasn't being respected for container tasks. Turns out that the `ShouldAllocateContainer` function which determines whether a task should be allocated a container would always check the `DependsOn` field even if it's supposed to be skipped.
### Testing
Confirmed fix in staging, added some unit test cases.
