### PR TITLE
EVG-19587: Omit logging "context canceled" errors from GQL

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"runtime/debug"
-	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -16,8 +15,6 @@ import (
 	"github.com/ravilushqa/otelgqlgen"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
-
-const ContextCanceledErrorMessage = "context canceled"
 
 // Handler returns a gimlet http handler func used as the gql route handler
 func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +57,7 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 			queryPath = fieldCtx.Path().String()
 			args = fieldCtx.Args
 		}
-		if err != nil && !strings.HasSuffix(err.Error(), ContextCanceledErrorMessage) {
+		if !errors.Is(err, context.Canceled) {
 			grip.Error(message.WrapError(err, message.Fields{
 				"path":    "/graphql/query",
 				"query":   queryPath,


### PR DESCRIPTION
[EVG-19587](jira.mongodb.com/browes/EVG-19587)

### Description
These code changes decrease the logging level for "context canceled" errors coming from GQL. Sometimes a single query will produce thousands of "context canceled" errors when a user closes their browser before a response is received. gqlgen middleware doesn't allow a way to reduce multiple errors into 1. The "context canceled" error from GQL seems to be expected behavior so far and isn't actionable but it could still be useful to continue logging in case it help in a future diagnostic. 

We originally thought that the main reason for the uptick in these errors was because we began threading the ctx to the db resolver in this [PR](https://github.com/evergreen-ci/evergreen/pull/6360) merged on March 29 but it's probably not true because the [mainline commits query context canceled error](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen%22%20path%3D%22%2Fgraphql%2Fquery%22%20AND%20error%3D%22*%3A%20context%20canceled%22%20AND%20query%3D%22mainlineCommits.versions%5B*%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1677646800&latest=1684382400&display.events.timelineEarliestTime=1679544000&display.events.timelineLatestTime=1679630400&sid=1684439091.1101263) is the most common single error and it began on March 23rd. 
### Testing
add a description of how you tested it

### Documentation
remember to add or edit docs in the docs/ directory if relevant
