### PR TITLE
EVG-19753: check project ref for commit queue disablement before other checks

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -358,11 +358,6 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 		return nil, pr, errors.Errorf("user '%s' is not authorized to merge", info.Username)
 	}
 
-	pr, err = checkPRIsMergeable(ctx, env, sc, pr, info)
-	if err != nil {
-		return nil, pr, err
-	}
-
 	cqInfo := restModel.ParseGitHubComment(info.CommitMessage)
 	baseBranch := *pr.Base.Ref
 	projectRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(info.Owner, info.Repo, baseBranch)
@@ -371,6 +366,11 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 	}
 	if projectRef == nil {
 		return nil, pr, errors.Wrapf(errNoCommitQueueForBranch, "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
+	}
+
+	pr, err = checkPRIsMergeable(ctx, env, sc, pr, info)
+	if err != nil {
+		return nil, pr, err
 	}
 
 	patchDoc, err := tryEnqueueItemForPR(ctx, sc, projectRef, info.PR, cqInfo)


### PR DESCRIPTION
EVG-19753

### Description
Move the PR mergeability check so that it happens before checking actual commit queue enqueueing validation (i.e. user authorization and GitHub mergeable state). I don't think the project ref lookup needs the refreshed `github.PullRequest` info from `checkPRIsMergeable` since the base branch should remain the same.

### Testing
Existing unit tests pass.

### Documentation
N/A
