### PR TITLE
EVG-19780 fix callback closure

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-05-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-18"
+	AgentVersion = "2023-05-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-19780](https://jira.mongodb.org/browse/EVG-19780)

### Description
https://github.com/evergreen-ci/evergreen/pull/6522 added a loop where we go over all the disk instruments and register callbacks for capturing metrics. I noticed this error output over and over again in the smoke test (e.g. [this one](https://evergreen.mongodb.com/task_log_raw/evergreen_ubuntu2004_smoke_test_host_task_cfa46091f860b5de9026272edc5e28bb3da23fcd_23_05_19_14_44_44/0?type=T#L2455)), for different device names:
```
 [2023/05/19 14:32:08.026] [agent] 2023/05/19 14:32:08 [p=trace]: 2023/05/19 14:32:08 internal_logging.go:58: "msg"="failed to record" "error"="observable instrument not registered for callback" "name"="system.disk.io.loop1.read" "description"="" "unit"="By" "number"="int64"
 [2023/05/19 14:32:08.026] [agent] 2023/05/19 14:32:08 [p=trace]: 2023/05/19 14:32:08 internal_logging.go:58: "msg"="failed to record" "error"="observable instrument not registered for callback" "name"="system.disk.io.loop1.write" "description"="" "unit"="By" "number"="int64"
 [2023/05/19 14:32:08.026] [agent] 2023/05/19 14:32:08 [p=trace]: 2023/05/19 14:32:08 internal_logging.go:58: "msg"="failed to record" "error"="observable instrument not registered for callback" "name"="system.disk.operations.loop1.read" "description"="" "unit"="{operation}" "number"="int64"
 [2023/05/19 14:32:08.026] [agent] 2023/05/19 14:32:08 [p=trace]: 2023/05/19 14:32:08 internal_logging.go:58: "msg"="failed to record" "error"="observable instrument not registered for callback" "name"="system.disk.operations.loop1.write" "description"="" "unit"="{operation}" "number"="int64"
 [2023/05/19 14:32:08.026] [agent] 2023/05/19 14:32:08 [p=trace]: 2023/05/19 14:32:08 internal_logging.go:58: "msg"="failed to record" "error"="observable instrument not registered for callback" "name"="system.disk.io_time.loop1" "description"="Time disk spent activated" "unit"="s" "number"="float64"
```

The issue is that the callback function is a [closure](https://go.dev/tour/moretypes/25)  where it binds the individual instrument fields, which are interfaces (which act as pointers because they contain a reference to their underlying value). So as we iterate the loop we're changing the underlying instruments those instruments contain and all the closures point to the last value in the dictionary. This is a variant of [the common loop variable bug](https://github.com/golang/go/discussions/56010). 
On the other hand, the instruments that are registered with the callback are the correct ones. So we end up with all the callbacks besides the last one erroring out since a callback is only allowed to touch the instruments that have been registered with it.

The solution here is to iterate over the dictionary within the callback. This has an additional advantage that we don't have to call `disk.IOCountersWithContext` with each iteration, which is wasteful since, at least on [linux](https://github.com/shirou/gopsutil/blob/cf428f8c7251cccd3f918ac920946325630f5ff5/disk/disk_linux.go#L411-L413) and [mac](https://github.com/shirou/gopsutil/blob/e563e6394edf0c5e770acca16ac7b8ffae1bb12e/disk/disk_darwin_cgo.go#L38-L40), we need to iterate over all the devices for every call anyways.

### Testing
I'll make sure the error is no longer getting logged before I merge this.
