### PR TITLE
EVG-19356 return if there's no connection

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -103,6 +103,10 @@ func (a *Agent) initOtel(ctx context.Context) error {
 }
 
 func (a *Agent) startMetrics(ctx context.Context, tc *internal.TaskConfig) (func(context.Context), error) {
+	if a.otelGrpcConn == nil {
+		return nil, nil
+	}
+
 	metricsExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(a.otelGrpcConn))
 	if err != nil {
 		return nil, errors.Wrap(err, "making otel metrics exporter")

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-05-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-19"
+	AgentVersion = "2023-05-19a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-19356](https://jira.mongodb.org/browse/EVG-19356)

### Description
If we returned [here](https://github.com/evergreen-ci/evergreen/blob/7b9bc9ae82961b033d1de8422abac9b896b673ec/agent/otel.go#L55-L58) because the endpoint wasn't set (such is the case in the smoke tests because they use [this config](https://github.com/evergreen-ci/evergreen/blob/f81ded5bceb8bf71c37b026aa259ba7417b6fd27/testdata/smoke_config.yml)) we should also skip setting up metrics. It seems like a good idea to make sure the connection is set up anyways.

### Testing
It will be telling if we see [this line](https://evergreen.mongodb.com/task_log_raw/evergreen_ubuntu2004_smoke_test_host_task_2f5ac478fb793fdd72a90174ecab8f56cbcdaf58_23_05_18_20_18_00/0?type=T#L1911) in the smoke logs.
> doing meter provider: failed to upload metrics: context deadline exceeded: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:4317: connect: connection refused"
