### PR TITLE
docs: add metadata links

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -360,6 +360,18 @@ Options:
 -   JIRA custom fields: Custom field and display test allowing for the
     creation of a specific field when displaying jira links.
 
+
+## Metadata Links
+
+Customize additional links to specify for your project under the Plugins section
+of the project page, by specifying a link and title. 
+Right now this is restricted to patches, but work is planned in
+EVG-16363 to extend this to other requesters.
+
+This may also be added to individual tasks using `metadata_links` 
+for [task annotations](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage#task-annotations). 
+
+
 ## Distro Settings
 
 The Distros page allows all users to see all available distros a project

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -364,10 +364,13 @@ Options:
 ## Metadata Links
 
 Customize additional links to specify for your project under the Plugins section
-of the project page, by specifying a link and title (if this link includes `{version_id}` 
-we will sub in the version ID when rendering the link). 
+of the project page, by specifying a link and title. 
+
 Right now this is restricted to patches, but work is planned in
 EVG-16363 to extend this to other requesters.
+
+Special Fields:
+* `{version_id}` -- if this is included in the metadata link, we will sub in the ID when rendering the link
 
 This may also be added to individual tasks using `metadata_links` 
 for [task annotations](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage#task-annotations). 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -364,7 +364,8 @@ Options:
 ## Metadata Links
 
 Customize additional links to specify for your project under the Plugins section
-of the project page, by specifying a link and title. 
+of the project page, by specifying a link and title (if this link includes `{version_id}` 
+we will sub in the version ID when rendering the link). 
 Right now this is restricted to patches, but work is planned in
 EVG-16363 to extend this to other requesters.
 


### PR DESCRIPTION
### Description
Making a doc to link to for the newsletter.

Not adding a screenshot bc this should change in EVG-16363 but will make a note in that ticket to add it.

preview:
![image](https://github.com/evergreen-ci/evergreen/assets/26798134/a28a09c2-d501-4140-a82f-6d1141170c6e)



