### PR TITLE
EVG-19889: document spawn host expiration

### DIFF
--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -656,9 +656,11 @@ parsed as a rest.APIError
 
 Extend the expiration time of a host with a given ID. Users may only
 extend expirations for hosts which were created by them, unless the user
-is a super-user
+is a super-user.
 
 The expiration date of a host may not be more than 1 week in the future.
+Furthermore, the lifetime of an expirable host can be extended at most 30 days
+past host creation.
 
 A response code of 200 OK indicates that the host's expiration was
 successfully extended.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -279,7 +279,7 @@ evergreen --delete-tag KEY
 ```
 Note these tags cannot overwrite Evergreen tags. 
 
-Hosts can be set to never expire using the `--no-expire` tag (although each user has a limit for these kinds of hosts). Hosts can be set to expire again using the `--expire` tag, which will set the host to expire in 24 hours (this can be extended using `--extend <hours>`. 
+Hosts can be set to never expire using the `--no-expire` tag (although each user has a limit for these kinds of hosts). Hosts can be set to expire again using the `--expire` tag, which will set the host to expire in 24 hours. This expiration can be extended using `--extend <hours>`, and you can extend its lifetime up to a max of 30 days past host creation.
 
 
 ### Stop/Start Host to Change Instance Type

--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -32,9 +32,9 @@ EC2 spawn hosts can be stopped/started and modified from the Spawn Host page, or
 
 ## Spawn Host Expiration
 
-By default, spawn hosts expire after one week. This expiration can be configured when spawning the host or can be set
-later by pressing the "edit" button for the host. You can extend an expirable host's lifetime up to 30 days past host
-creation.
+By default, spawn hosts expire after one week. This expiration can be set (or the host can be made unexpirable) when
+spawning the host or can be set later by pressing the "edit" button for the host. You can extend an expirable host's
+lifetime up to 30 days past host creation.
 
 If you'd like to get a notification before a host expires, you can [set up a
 notification](../Project-Configuration/Notifications.md#spawn-host-expiration) for it.

--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -26,8 +26,15 @@ Fetching artifacts can also be performed manually; see [fetch](../CLI.md#fetch) 
 
 Artifacts are placed in /data/mci. Note that you will likely be able to ssh into the host before the artifacts are finished fetching. 
 
-
 If your project has a project setup script defined at the admin level, you can also check "Use project-specific setup script defined at ..." before creating the spawn host. You can check if there are errors fetching artifacts or running this script on the host page: ``https://spruce.mongodb.com/host/<host_id>``.
 
-
 EC2 spawn hosts can be stopped/started and modified from the Spawn Host page, or via the command line, which is documented in [Basic Host Usage](../CLI.md#basic-host-usage) in the Evergreen command line tool documentation.
+
+## Spawn Host Expiration
+
+By default, spawn hosts expire after one week. This expiration can be configured when spawning the host or can be set
+later by pressing the "edit" button for the host. You can extend an expirable host's lifetime up to 30 days past host
+creation.
+
+If you'd like to get a notification before a host expires, you can [set up a
+notification](../Project-Configuration/Notifications.md#spawn-host-expiration) for it.


### PR DESCRIPTION
Document the maximum amount of time you can extend an expirable spawn host's duration and mention that you can get notifications for expiring spawn hosts.