### PR TITLE
EVG-19281: fix broken log links for archived task executions

### DIFF
--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -321,22 +321,26 @@ func (at *APITask) BuildFromService(t *task.Task, args *APITaskArgs) error {
 	if args == nil {
 		return nil
 	}
+	baseTaskID := t.Id
+	if t.OldTaskId != "" {
+		baseTaskID = t.OldTaskId
+	}
 	if args.LogURL != "" {
 		ll := LogLinks{
-			AllLogLink:    utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, t.Id, t.Execution, "ALL")),
-			TaskLogLink:   utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, t.Id, t.Execution, "T")),
-			AgentLogLink:  utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, t.Id, t.Execution, "E")),
-			SystemLogLink: utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, t.Id, t.Execution, "S")),
-			EventLogLink:  utility.ToStringPtr(fmt.Sprintf(EventLogLinkFormat, args.LogURL, t.Id)),
+			AllLogLink:    utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, baseTaskID, t.Execution, "ALL")),
+			TaskLogLink:   utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, baseTaskID, t.Execution, "T")),
+			AgentLogLink:  utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, baseTaskID, t.Execution, "E")),
+			SystemLogLink: utility.ToStringPtr(fmt.Sprintf(TaskLogLinkFormat, args.LogURL, baseTaskID, t.Execution, "S")),
+			EventLogLink:  utility.ToStringPtr(fmt.Sprintf(EventLogLinkFormat, args.LogURL, baseTaskID)),
 		}
 		at.Logs = ll
 	}
 	if args.ParsleyLogURL != "" {
 		ll := LogLinks{
-			AllLogLink:    utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, t.Id, t.Execution, "all")),
-			TaskLogLink:   utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, t.Id, t.Execution, "task")),
-			AgentLogLink:  utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, t.Id, t.Execution, "agent")),
-			SystemLogLink: utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, t.Id, t.Execution, "system")),
+			AllLogLink:    utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, baseTaskID, t.Execution, "all")),
+			TaskLogLink:   utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, baseTaskID, t.Execution, "task")),
+			AgentLogLink:  utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, baseTaskID, t.Execution, "agent")),
+			SystemLogLink: utility.ToStringPtr(fmt.Sprintf(ParsleyTaskLogLinkFormat, args.ParsleyLogURL, baseTaskID, t.Execution, "system")),
 		}
 		at.ParsleyLogs = ll
 	}

--- a/rest/model/task_test.go
+++ b/rest/model/task_test.go
@@ -147,6 +147,36 @@ func TestTaskBuildFromService(t *testing.T) {
 					Requester: evergreen.RepotrackerVersionRequester,
 				},
 			},
+			{
+				at: APITask{
+					Id: utility.ToStringPtr("old_task_id"),
+					Logs: LogLinks{
+						AllLogLink:    utility.ToStringPtr("url/task_log_raw/old_task_id/0?type=ALL"),
+						TaskLogLink:   utility.ToStringPtr("url/task_log_raw/old_task_id/0?type=T"),
+						SystemLogLink: utility.ToStringPtr("url/task_log_raw/old_task_id/0?type=S"),
+						AgentLogLink:  utility.ToStringPtr("url/task_log_raw/old_task_id/0?type=E"),
+						EventLogLink:  utility.ToStringPtr("url/event_log/task/old_task_id"),
+					},
+					ParsleyLogs: LogLinks{
+						AllLogLink:    utility.ToStringPtr("parsley/evergreen/old_task_id/0/all"),
+						TaskLogLink:   utility.ToStringPtr("parsley/evergreen/old_task_id/0/task"),
+						SystemLogLink: utility.ToStringPtr("parsley/evergreen/old_task_id/0/system"),
+						AgentLogLink:  utility.ToStringPtr("parsley/evergreen/old_task_id/0/agent"),
+					},
+					CreateTime:             &time.Time{},
+					DispatchTime:           &time.Time{},
+					ScheduledTime:          &time.Time{},
+					ContainerAllocatedTime: &time.Time{},
+					StartTime:              &time.Time{},
+					FinishTime:             &time.Time{},
+					IngestTime:             &time.Time{},
+				},
+				st: task.Task{
+					Id:        "task_id",
+					OldTaskId: "old_task_id",
+					Requester: evergreen.RepotrackerVersionRequester,
+				},
+			},
 		}
 		Convey("running BuildFromService(), should populate mainline and blocked dependencies", func() {
 			for _, tc := range modelPairs {


### PR DESCRIPTION
EVG-19281

### Description
Fix an issue where the log links were using the archived task ID (i.e. with the `_<execution_num>` appended) instead of the original task ID.

### Testing
Added unit test and checked in staging that the log URLs worked for an old task execution.

### Documentation
N/A