### PR TITLE
EVG-18657 query by version and parent version for certain operations

### DIFF
--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -65,7 +65,7 @@ func (r *patchResolver) CommitQueuePosition(ctx context.Context, obj *restModel.
 
 // Duration is the resolver for the duration field.
 func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (*PatchDuration, error) {
-	query := db.Query(task.ByVersion(*obj.Id)).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey)
+	query := db.Query(task.ByVersionWithChildTasks(*obj.Id)).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey)
 	tasks, err := task.FindAllFirstExecution(query)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -425,22 +425,6 @@ func modifyVersionHandler(ctx context.Context, patchID string, modification mode
 	if err != nil {
 		return mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}
-
-	// Restart is handled through graphql because we need the user to specify
-	// which downstream tasks they want to restart.
-	if evergreen.IsPatchRequester(v.Requester) && modification.Action != evergreen.RestartAction {
-		// Only modify the child patch if it is finalized.
-		childPatchIds, err := patch.GetFinalizedChildPatchIdsForPatch(patchID)
-		if err != nil {
-			return ResourceNotFound.Send(ctx, err.Error())
-		}
-		for _, childPatchId := range childPatchIds {
-			if err = modifyVersionHandler(ctx, childPatchId, modification); err != nil {
-				return errors.Wrap(mapHTTPStatusToGqlError(ctx, httpStatus, err), fmt.Sprintf("modifying child patch '%s'", childPatchId))
-			}
-		}
-	}
-
 	return nil
 }
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -187,7 +187,7 @@ func AbortBuild(buildId string, caller string) error {
 		return errors.Wrapf(err, "deactivating build '%s'", buildId)
 	}
 
-	return errors.Wrapf(task.AbortBuild(buildId, task.AbortInfo{User: caller}), "aborting tasks for build '%s'", buildId)
+	return errors.Wrapf(task.AbortBuildTasks(buildId, task.AbortInfo{User: caller}), "aborting tasks for build '%s'", buildId)
 }
 
 func TryMarkVersionStarted(versionId string, startTime time.Time) error {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -55,10 +55,9 @@ type VersionToRestart struct {
 // SetVersionActivation updates the "active" state of all builds and tasks associated with a
 // version to the given setting. It also updates the task cache for all builds affected.
 func SetVersionActivation(versionId string, active bool, caller string) error {
-	q := bson.M{
-		task.VersionKey: versionId,
-		task.StatusKey:  evergreen.TaskUndispatched,
-	}
+	q := task.ByVersionWithChildTasks(versionId)
+	q[task.StatusKey] = evergreen.TaskUndispatched
+
 	var tasksToModify []task.Task
 	var err error
 	// If activating a task, set the ActivatedBy field to be the caller.

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -877,7 +877,7 @@ func CancelPatch(p *patch.Patch, reason task.AbortInfo) error {
 		if err := SetVersionActivation(p.Version, false, reason.User); err != nil {
 			return errors.WithStack(err)
 		}
-		return errors.WithStack(task.AbortVersion(p.Version, reason))
+		return errors.WithStack(task.AbortVersionTasks(p.Version, reason))
 	}
 
 	return errors.WithStack(patch.Remove(patch.ById(p.Id)))

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -168,13 +168,23 @@ func TestSetPriority(t *testing.T) {
 		Id:      "t1",
 		Version: "aabbccddeeff001122334455",
 	}
+	t2 := task.Task{
+		Id:            "t2",
+		Version:       "something_else",
+		ParentPatchID: t1.Version,
+	}
 	assert.NoError(t, t1.Insert())
+	assert.NoError(t, t2.Insert())
 	for _, p := range patches {
 		assert.NoError(t, p.Insert())
 	}
 	err := SetVersionsPriority([]string{"aabbccddeeff001122334455"}, 7, "")
 	assert.NoError(t, err)
 	foundTask, err := task.FindOneId("t1")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(7), foundTask.Priority)
+
+	foundTask, err = task.FindOneId("t2")
 	assert.NoError(t, err)
 	assert.Equal(t, int64(7), foundTask.Priority)
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1491,6 +1491,7 @@ func FindOneIdWithFields(id string, projected ...string) (*Task, error) {
 	return task, nil
 }
 
+// findAllTaskIDs returns a list of task IDs associated with the given query.
 func findAllTaskIDs(q db.Q) ([]string, error) {
 	tasks := []Task{}
 	err := db.FindAllQ(Collection, q, &tasks)

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -228,6 +228,7 @@ func TestFailedTasksByVersion(t *testing.T) {
 }
 
 func TestFindTasksByVersionWithChildTasks(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
 	mainVersion := "main_version"
 	mainVersionTaskIds := []string{"t1", "t3"}
 	tasks := []Task{
@@ -262,6 +263,7 @@ func TestFindTasksByVersionWithChildTasks(t *testing.T) {
 	}
 }
 func TestFindTasksByBuildIdAndGithubChecks(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(Collection))
 	tasks := []Task{
 		{
 			Id:            "t1",

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -227,6 +227,40 @@ func TestFailedTasksByVersion(t *testing.T) {
 	})
 }
 
+func TestFindTasksByVersionWithChildTasks(t *testing.T) {
+	mainVersion := "main_version"
+	mainVersionTaskIds := []string{"t1", "t3"}
+	tasks := []Task{
+		{
+			Id:      "t1",
+			Version: mainVersion,
+		},
+		{
+			Id:      "t2",
+			Version: "different_version",
+		},
+		{
+			Id:            "t3",
+			Version:       "different_version",
+			ParentPatchID: mainVersion,
+		},
+		{
+			Id:            "t4",
+			Version:       "different_version",
+			ParentPatchID: "different_parent",
+		},
+	}
+	for _, task := range tasks {
+		assert.NoError(t, task.Insert())
+	}
+
+	dbTasks, err := Find(ByVersionWithChildTasks(mainVersion))
+	assert.NoError(t, err)
+	assert.Len(t, dbTasks, 2)
+	for _, dbTask := range dbTasks {
+		assert.Contains(t, mainVersionTaskIds, dbTask.Id)
+	}
+}
 func TestFindTasksByBuildIdAndGithubChecks(t *testing.T) {
 	tasks := []Task{
 		{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2199,10 +2199,9 @@ func AbortBuildTasks(buildId string, reason AbortInfo) error {
 // AbortVersionTasks sets the abort flag on all tasks associated with the version which are in an
 // abortable state
 func AbortVersionTasks(versionId string, reason AbortInfo) error {
-	q := bson.M{
-		VersionKey: versionId,
-		StatusKey:  bson.M{"$in": evergreen.TaskAbortableStatuses},
-	}
+	q := ByVersionWithChildTasks(versionId)
+	q[StatusKey] = bson.M{"$in": evergreen.TaskAbortableStatuses}
+
 	if reason.TaskID != "" {
 		q[IdKey] = bson.M{"$ne": reason.TaskID}
 		// if the aborting task is part of a display task, we also don't want to mark it as aborted

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3030,7 +3030,7 @@ func TestAddExecTasksToDisplayTask(t *testing.T) {
 	assert.False(t, utility.IsZeroTime(dtFromDB.ActivatedTime))
 }
 
-func TestAbortVersion(t *testing.T) {
+func TestAbortVersionTasks(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	finishedExecTask := &Task{
 		Id:      "et1",
@@ -3055,7 +3055,7 @@ func TestAbortVersion(t *testing.T) {
 	}
 	assert.NoError(t, db.InsertMany(Collection, finishedExecTask, failingExecTask, otherExecTask, dt))
 
-	assert.NoError(t, AbortVersion("v1", AbortInfo{TaskID: "et2"}))
+	assert.NoError(t, AbortVersionTasks("v1", AbortInfo{TaskID: "et2"}))
 
 	var err error
 	dt, err = FindOneId("dt")

--- a/model/version.go
+++ b/model/version.go
@@ -213,7 +213,8 @@ func setVersionStatus(versionId, newStatus string) error {
 // GetTimeSpent returns the total time_taken and makespan of a version for
 // each task that has finished running
 func (v *Version) GetTimeSpent() (time.Duration, time.Duration, error) {
-	query := db.Query(task.ByVersion(v.Id)).WithFields(task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey)
+	query := db.Query(task.ByVersionWithChildTasks(v.Id)).WithFields(
+		task.TimeTakenKey, task.StartTimeKey, task.FinishTimeKey, task.DisplayOnlyKey, task.ExecutionKey)
 	tasks, err := task.FindAllFirstExecution(query)
 	if err != nil {
 		return 0, 0, errors.Wrapf(err, "getting tasks for version '%s'", v.Id)

--- a/model/version_modification.go
+++ b/model/version_modification.go
@@ -42,7 +42,7 @@ func ModifyVersion(version Version, user user.DBUser, modifications VersionModif
 		// abort after deactivating the version so we aren't bombarded with failing tasks while
 		// the deactivation is in progress
 		if modifications.Abort {
-			if err := task.AbortVersion(version.Id, task.AbortInfo{User: user.DisplayName()}); err != nil {
+			if err := task.AbortVersionTasks(version.Id, task.AbortInfo{User: user.DisplayName()}); err != nil {
 				return http.StatusInternalServerError, errors.Wrap(err, "aborting patch")
 			}
 		}

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -211,9 +211,9 @@ func (h *versionAbortHandler) Parse(ctx context.Context, r *http.Request) error 
 	return nil
 }
 
-// Execute calls the data AbortVersion function to abort all tasks of a version.
+// Execute calls the data AbortVersionTasks function to abort all tasks of a version.
 func (h *versionAbortHandler) Run(ctx context.Context) gimlet.Responder {
-	if err := task.AbortVersion(h.versionId, task.AbortInfo{User: h.userId}); err != nil {
+	if err := task.AbortVersionTasks(h.versionId, task.AbortInfo{User: h.userId}); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "aborting version '%s'", h.versionId))
 	}
 

--- a/service/build.go
+++ b/service/build.go
@@ -235,7 +235,7 @@ func (uis *UIServer) modifyBuild(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !putParams.Active && putParams.Abort {
-			if err = task.AbortBuild(projCtx.Build.Id, task.AbortInfo{User: user.Id}); err != nil {
+			if err = task.AbortBuildTasks(projCtx.Build.Id, task.AbortInfo{User: user.Id}); err != nil {
 				http.Error(w, "Error unscheduling tasks", http.StatusInternalServerError)
 				return
 			}

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -275,7 +275,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 	}
 	var makespan time.Duration
 	if utility.IsZeroTime(t.patch.FinishTime) {
-		patchTasks, err := task.Find(task.ByVersion(t.patch.Id.Hex()))
+		patchTasks, err := task.Find(task.ByVersionWithChildTasks(t.patch.Id.Hex()))
 		if err == nil {
 			_, makespan = task.GetTimeSpent(patchTasks)
 		}


### PR DESCRIPTION
EVG-18657

### Description
A number of things don't behave quite right for child patch tasks (or require looping through and querying patches).
Specifically:
1) Did a bit of refactoring of functions for clarity, and removed some unused things I found
2) Query with child tasks for activation/deactivation, makespan, priority, and aborts.
3) Removed special graphql handling of child patches, since we now handle it in the operations listed in (2) directly.

We'd also want to add an index here on versionID and parent patch ID because [all of the clauses need to be supported](https://www.mongodb.com/docs/manual/reference/operator/query/or/#-or-clauses-and-indexes).

### Testing
Augmented existing unit testing, will test on staging.