### PR TITLE
EVG-19702 Log event when repo is created, add events for repo attachments

### DIFF
--- a/model/event/project_event.go
+++ b/model/event/project_event.go
@@ -3,10 +3,14 @@ package event
 func init() {
 	registry.setUnexpirable(EventResourceTypeProject, EventTypeProjectModified)
 	registry.setUnexpirable(EventResourceTypeProject, EventTypeProjectAdded)
+	registry.setUnexpirable(EventResourceTypeProject, EventTypeProjectAttachedToRepo)
+	registry.setUnexpirable(EventResourceTypeProject, EventTypeProjectDetachedFromRepo)
 }
 
 const (
-	EventResourceTypeProject = "PROJECT"
-	EventTypeProjectModified = "PROJECT_MODIFIED"
-	EventTypeProjectAdded    = "PROJECT_ADDED"
+	EventResourceTypeProject         = "PROJECT"
+	EventTypeProjectModified         = "PROJECT_MODIFIED"
+	EventTypeProjectAdded            = "PROJECT_ADDED"
+	EventTypeProjectAttachedToRepo   = "PROJECT_ATTACHED_TO_REPO"
+	EventTypeProjectDetachedFromRepo = "PROJECT_DETACHED_FROM_REPO"
 )

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -224,16 +224,14 @@ func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSet
 	return errors.Wrap(LogProjectModified(id, userId, before, after), "logging project modified")
 }
 
-// GetAndLogProjectModifiedWithRepoAttachment retrieves the project settings before and after the change, and logs the modification
-// as an event, alongside a repo attachment/detachment event.
-func GetAndLogProjectModifiedWithRepoAttachment(id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
+// GetAndLogProjectRepoAttachment retrieves the project settings before and after the change, and logs the modification
+// as a repo attachment/detachment event.
+func GetAndLogProjectRepoAttachment(id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
 	after, err := GetProjectSettingsById(id, isRepo)
 	if err != nil {
 		return errors.Wrap(err, "getting after project settings event")
 	}
-	if err = LogProjectModified(id, userId, before, after); err != nil {
-		return errors.Wrap(err, "logging project modified")
-	}
+
 	return errors.Wrap(LogProjectRepoAttachment(id, userId, attachmentType, before, after), "logging project repo attachment")
 }
 

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -225,14 +225,16 @@ func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSet
 }
 
 // GetAndLogProjectModifiedWithRepoAttachment retrieves the project settings before and after the change, and logs the modification
-// as an event, alongside a repo attachment event.
+// as an event, alongside a repo attachment/detachment event.
 func GetAndLogProjectModifiedWithRepoAttachment(id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
 	after, err := GetProjectSettingsById(id, isRepo)
 	if err != nil {
 		return errors.Wrap(err, "getting after project settings event")
 	}
-
-	return errors.Wrap(LogProjectRepoAttachment(id, userId, attachmentType, before, after), "logging project modified")
+	if err = LogProjectModified(id, userId, before, after); err != nil {
+		return errors.Wrap(err, "logging project modified")
+	}
+	return errors.Wrap(LogProjectRepoAttachment(id, userId, attachmentType, before, after), "logging project repo attachment")
 }
 
 // resolveDefaults checks if certain project event fields are nil, and if so, sets the field's corresponding flag.

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -258,6 +258,9 @@ func (p *ProjectSettings) resolveDefaults() *ProjectSettingsEvent {
 
 func LogProjectModified(projectId, username string, before, after *ProjectSettings) error {
 	eventData := constructProjectChangeEvent(username, before, after)
+	if eventData == nil {
+		return nil
+	}
 	return LogProjectEvent(event.EventTypeProjectModified, projectId, *eventData)
 }
 

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -224,7 +224,7 @@ func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSet
 	return errors.Wrap(LogProjectModified(id, userId, before, after), "logging project modified")
 }
 
-// GetAndLogProjectModifiedWithRepoAttachment retrieves the project settings before and after the change, and logs the modification.
+// GetAndLogProjectModifiedWithRepoAttachment retrieves the project settings before and after the change, and logs the modification
 // as an event, alongside a repo attachment event.
 func GetAndLogProjectModifiedWithRepoAttachment(id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
 	after, err := GetProjectSettingsById(id, isRepo)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -711,7 +711,7 @@ func (p *ProjectRef) DetachFromRepo(u *user.DBUser) error {
 	}
 	catcher.Add(UpsertAliasesForProject(repoAliasesToCopy, p.Id))
 
-	catcher.Add(GetAndLogProjectModifiedWithRepoAttachment(p.Id, u.Id, event.EventTypeProjectDetachedFromRepo, false, before))
+	catcher.Add(GetAndLogProjectRepoAttachment(p.Id, u.Id, event.EventTypeProjectDetachedFromRepo, false, before))
 	return catcher.Resolve()
 }
 
@@ -746,7 +746,7 @@ func (p *ProjectRef) AttachToRepo(u *user.DBUser) error {
 		return errors.Wrap(err, "attaching repo to scope")
 	}
 
-	return GetAndLogProjectModifiedWithRepoAttachment(p.Id, u.Id, event.EventTypeProjectAttachedToRepo, false, before)
+	return GetAndLogProjectRepoAttachment(p.Id, u.Id, event.EventTypeProjectAttachedToRepo, false, before)
 }
 
 // AttachToNewRepo modifies the project's owner/repo, updates the old and new repo scopes (if relevant), and
@@ -787,7 +787,7 @@ func (p *ProjectRef) AttachToNewRepo(u *user.DBUser) error {
 		return errors.Wrap(err, "updating owner/repo in the DB")
 	}
 
-	return GetAndLogProjectModifiedWithRepoAttachment(p.Id, u.Id, event.EventTypeProjectAttachedToRepo, false, before)
+	return GetAndLogProjectRepoAttachment(p.Id, u.Id, event.EventTypeProjectAttachedToRepo, false, before)
 }
 
 // addGithubConflictsToUpdate turns off any settings that may introduce conflicts by

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -560,7 +560,7 @@ func TestAttachToNewRepo(t *testing.T) {
 func checkRepoAttachmentEventLog(t *testing.T, project ProjectRef, attachmentType string) {
 	events, err := MostRecentProjectEvents(project.Id, 10)
 	require.NoError(t, err)
-	require.Len(t, events, 2)
+	require.Len(t, events, 1)
 	assert.Equal(t, project.Id, events[0].ResourceId)
 	assert.Equal(t, event.EventResourceTypeProject, events[0].ResourceType)
 	assert.Equal(t, attachmentType, events[0].EventType)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -557,9 +557,18 @@ func TestAttachToNewRepo(t *testing.T) {
 
 }
 
+func checkRepoAttachmentEventLog(t *testing.T, project ProjectRef, attachmentType string) {
+	events, err := MostRecentProjectEvents(project.Id, 10)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	assert.Equal(t, project.Id, events[0].ResourceId)
+	assert.Equal(t, event.EventResourceTypeProject, events[0].ResourceType)
+	assert.Equal(t, attachmentType, events[0].EventType)
+}
+
 func TestAttachToRepo(t *testing.T) {
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
-		evergreen.RoleCollection, user.Collection, GithubHooksCollection, evergreen.ConfigCollection))
+		evergreen.RoleCollection, user.Collection, GithubHooksCollection, event.EventCollection, evergreen.ConfigCollection))
 	require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 	settings := evergreen.Settings{
 		GithubOrgs: []string{"newOwner", "evergreen-ci"},
@@ -592,6 +601,7 @@ func TestAttachToRepo(t *testing.T) {
 	assert.NoError(t, pRef.AttachToRepo(u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
+	checkRepoAttachmentEventLog(t, pRef, event.EventTypeProjectAttachedToRepo)
 
 	pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 	assert.NoError(t, err)
@@ -631,6 +641,7 @@ func TestAttachToRepo(t *testing.T) {
 	assert.NoError(t, pRef.AttachToRepo(u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
+	checkRepoAttachmentEventLog(t, pRef, event.EventTypeProjectAttachedToRepo)
 
 	pRefFromDB, err = FindBranchProjectRef(pRef.Id)
 	assert.NoError(t, err)
@@ -657,7 +668,7 @@ func TestDetachFromRepo(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser){
 		"project ref is updated correctly": func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser) {
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
-
+			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDB)
@@ -678,7 +689,7 @@ func TestDetachFromRepo(t *testing.T) {
 		},
 		"project variables are updated": func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser) {
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
-
+			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			vars, err := FindOneProjectVars(pRef.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, vars)
@@ -698,6 +709,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, repoAlias.Upsert())
 
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
@@ -729,6 +741,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(repoAliases, pRef.RepoRefId))
 
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 3)
@@ -781,6 +794,7 @@ func TestDetachFromRepo(t *testing.T) {
 			}
 			assert.NoError(t, repoSubscription.Upsert())
 			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 
 			subs, err := event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)
 			assert.NoError(t, err)
@@ -802,7 +816,7 @@ func TestDetachFromRepo(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection,
-				evergreen.RoleCollection, user.Collection, event.SubscriptionsCollection, ProjectAliasCollection))
+				evergreen.RoleCollection, user.Collection, event.SubscriptionsCollection, event.EventCollection, ProjectAliasCollection))
 			require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 			pRef := &ProjectRef{


### PR DESCRIPTION
EVG-19702

### Description
The [repo](https://spruce.mongodb.com/project/634d56d3850e610cacfe7e0b/settings/event-log) in question from the ticket has no event logs because it was created by "attach to repo" being clicked for an existing project, copying over all settings and variables to the repo. By the time the button was clicked, the project had undergone changes and had event logs, but the repo was initialized with no event logs.

This is a bit confusing, because in the DB there is nothing acknowledging the existence of the created repo at all, so I added two changes to allow us to keep a better paper trail of what's happening:

- Logging a `PROJECT_ADDED` event when a repo is newly created from the "attach to repo" command
- Created two new events to log for a project, for when it attaches to / detaches from a repo, respectively.

### Testing
Tested with repo attachment / detachment in staging, and confirmed that newly attached repos get `PROJECT_ADDED` events.