### PR TITLE
EVG-19188 instrument amboy jobs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -571,7 +571,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 	defer a.killProcs(ctx, tc, false)
 	defer tskCancel()
 
-	tskCtx = contextWithTaskAttributes(tskCtx, tc.taskConfig.TaskAttributes())
+	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
 	tskCtx, span := a.tracer.Start(tskCtx, fmt.Sprintf("task: '%s'", tc.taskConfig.Task.DisplayName))
 	defer span.End()
 

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/contrib/detectors/aws/ec2"
 	"go.opentelemetry.io/contrib/detectors/aws/ecs"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -36,10 +35,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/encoding/protojson"
 )
-
-type taskAttributeKey int
-
-const taskAttributeContextKey taskAttributeKey = iota
 
 const (
 	exportInterval = 15 * time.Second
@@ -516,31 +511,4 @@ func getTraceFiles(taskDir string) ([]string, error) {
 	}
 
 	return fileNames, nil
-}
-
-type taskSpanProcessor struct{}
-
-func NewTaskSpanProcessor() sdktrace.SpanProcessor {
-	return &taskSpanProcessor{}
-}
-
-func (processor *taskSpanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpan) {
-	span.SetAttributes(taskAttributesFromContext(ctx)...)
-}
-
-func (processor *taskSpanProcessor) OnEnd(s sdktrace.ReadOnlySpan)    {}
-func (processor *taskSpanProcessor) Shutdown(context.Context) error   { return nil }
-func (processor *taskSpanProcessor) ForceFlush(context.Context) error { return nil }
-
-func contextWithTaskAttributes(ctx context.Context, attributes []attribute.KeyValue) context.Context {
-	return context.WithValue(ctx, taskAttributeContextKey, attributes)
-}
-
-func taskAttributesFromContext(ctx context.Context) []attribute.KeyValue {
-	attributesIface := ctx.Value(taskAttributeContextKey)
-	attributes, ok := attributesIface.([]attribute.KeyValue)
-	if !ok {
-		return nil
-	}
-	return attributes
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/v3/cpu"
@@ -88,7 +89,7 @@ func (a *Agent) initOtel(ctx context.Context) error {
 		sdktrace.WithBatcher(traceExporter),
 		sdktrace.WithResource(r),
 	)
-	tp.RegisterSpanProcessor(NewTaskSpanProcessor())
+	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
 		grip.Error(errors.Wrap(err, "encountered otel error"))

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-05-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-24"
+	AgentVersion = "2023-05-24a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/environment.go
+++ b/environment.go
@@ -882,6 +882,7 @@ func (e *envState) initTracer(ctx context.Context) error {
 		trace.WithBatcher(exp),
 		trace.WithResource(resource),
 	)
+	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)
 
 	e.RegisterCloser("otel-tracer-provider", false, func(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715
 	github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78
-	github.com/evergreen-ci/utility v0.0.0-20230508194838-873894227dc9
+	github.com/evergreen-ci/utility v0.0.0-20230519193518-4d91d64f59fb
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gophercloud/gophercloud v0.1.0
@@ -30,7 +30,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mongodb/amboy v0.0.0-20221207220239-4ab00e3ea9da
+	github.com/mongodb/amboy v0.0.0-20230524145255-082f8fd5857e
 	github.com/mongodb/anser v0.0.0-20230501213745-c62f11870fd4
 	github.com/mongodb/grip v0.0.0-20230503175150-8b2e395f3111
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -412,8 +412,8 @@ github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSu
 github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20230216205613-b8156d58f1e5/go.mod h1:JOJFPxtV7r9EEPqdcgkhgMvUMFGNTkUuYp0u2d8zcQI=
-github.com/evergreen-ci/utility v0.0.0-20230508194838-873894227dc9 h1:FEYS+Jjz+CSKTWnZgsvmHY7LlNMVfIxnp8rI7zYE5Es=
-github.com/evergreen-ci/utility v0.0.0-20230508194838-873894227dc9/go.mod h1:JOJFPxtV7r9EEPqdcgkhgMvUMFGNTkUuYp0u2d8zcQI=
+github.com/evergreen-ci/utility v0.0.0-20230519193518-4d91d64f59fb h1:4dg9C4w+nWiwzPgL9TClUZi1B5UedDVrffPZ2SoaaIg=
+github.com/evergreen-ci/utility v0.0.0-20230519193518-4d91d64f59fb/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -801,8 +801,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mongodb/amboy v0.0.0-20200527191935-07fdffff5b8c/go.mod h1:SfpzZNF2KZUT5zO0/q4eUqW+EQe64MiY8xXmkBHZDqk=
 github.com/mongodb/amboy v0.0.0-20211101161704-2b42087d24e6/go.mod h1:aYcnjrBUtbgB+naQ6FlVltCdprHv9Td2GOkQkZUqPvY=
 github.com/mongodb/amboy v0.0.0-20220408143015-94858bb64f00/go.mod h1:pyAwlkip3M7Hw91UqQpTo9Oo7clNgGFdOqa9EvgvhbM=
-github.com/mongodb/amboy v0.0.0-20221207220239-4ab00e3ea9da h1:1sLg2d9tVr6UDunkbYKh1pvSgxKQIYiTvOS0u8UPaV8=
-github.com/mongodb/amboy v0.0.0-20221207220239-4ab00e3ea9da/go.mod h1:a8nLsoZ7xIXS0S6WgZTgILrIU/YAHG/hex1OzcpLk2A=
+github.com/mongodb/amboy v0.0.0-20230524145255-082f8fd5857e h1:ZuKyZD+ZENSw7yG3JFDfV//XO0zUcX19vUFeNqbKTqg=
+github.com/mongodb/amboy v0.0.0-20230524145255-082f8fd5857e/go.mod h1:G20baATH9lHkoYG4HslUZz986ESan44YA5hy9my3xfg=
 github.com/mongodb/anser v0.0.0-20190422213746-1fb43a6d9968/go.mod h1:ESqf0zBEuYrqL0xADbIAFgdEOaBFpwZ4tkzY84ge+QA=
 github.com/mongodb/anser v0.0.0-20211116195831-fdc43007b59f/go.mod h1:jDikxuo5FKbiTMAb8B5AMT3QqFSNrim2+GiRTSCdazU=
 github.com/mongodb/anser v0.0.0-20230501213745-c62f11870fd4 h1:0/XR1OmWPRXADG+fSBQ/JO6TMcrpDLabuG6baNhpWt0=
@@ -1136,7 +1136,6 @@ go.mongodb.org/mongo-driver v1.8.2/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCu
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.8.4/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.10.1/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
-go.mongodb.org/mongo-driver v1.11.0/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/mongo-driver v1.11.1/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
 go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=


### PR DESCRIPTION
[EVG-19188](https://jira.mongodb.org/browse/EVG-19188)

### Description
https://github.com/mongodb/amboy/commit/082f8fd5857e799b8f4665c389c009965f71c68b creates a trace for each amboy job. Update amboy to use it in evergreen. Also update utility to get the `attributeSpanProcessor` from https://github.com/evergreen-ci/utility/commit/4d91d64f59fb653893f0f0b0f301971ce050b389, and use it for the app and agent's `TracerProvider`s.

The spans won't be too interesting yet unless we have a job that happens to pass its context to its db calls. But it'll let us do stuff like [EVG-19918](https://jira.mongodb.org/browse/EVG-19918).

### Testing
On staging this created traces like [this one](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/trace/fC9Kgznzk3Y) for the `patch-intent-processor` job.