### PR TITLE
EVG-19774 Add legacy project page redirect logic

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -95,6 +95,7 @@ var (
 	cloudCleanupDisabledKey            = bsonutil.MustHaveTag(ServiceFlags{}, "CloudCleanupDisabled")
 	containerConfigurationsDisabledKey = bsonutil.MustHaveTag(ServiceFlags{}, "ContainerConfigurationsDisabled")
 	legacyUIPublicAccessDisabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "LegacyUIPublicAccessDisabled")
+	legacyUIProjectPageDisabledKey     = bsonutil.MustHaveTag(ServiceFlags{}, "LegacyUIProjectPageDisabled")
 	unrecognizedPodCleanupDisabledKey  = bsonutil.MustHaveTag(ServiceFlags{}, "UnrecognizedPodCleanupDisabled")
 
 	// ContainerPoolsConfig keys

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -35,6 +35,7 @@ type ServiceFlags struct {
 	CloudCleanupDisabled            bool `bson:"cloud_cleanup_disabled" json:"cloud_cleanup_disabled"`
 	ContainerConfigurationsDisabled bool `bson:"container_configurations_disabled" json:"container_configurations_disabled"`
 	LegacyUIPublicAccessDisabled    bool `bson:"legacy_ui_public_access_disabled" json:"legacy_ui_public_access_disabled"`
+	LegacyUIProjectPageDisabled     bool `bson:"legacy_ui_project_page_disabled" json:"legacy_ui_project_page_disabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -106,6 +107,7 @@ func (c *ServiceFlags) Set() error {
 			cloudCleanupDisabledKey:            c.CloudCleanupDisabled,
 			containerConfigurationsDisabledKey: c.ContainerConfigurationsDisabled,
 			legacyUIPublicAccessDisabledKey:    c.LegacyUIPublicAccessDisabled,
+			legacyUIProjectPageDisabledKey:     c.LegacyUIProjectPageDisabled,
 			unrecognizedPodCleanupDisabledKey:  c.UnrecognizedPodCleanupDisabled,
 		},
 	}, options.Update().SetUpsert(true))

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2257,6 +2257,7 @@ type APIServiceFlags struct {
 	CloudCleanupDisabled            bool `json:"cloud_cleanup_disabled"`
 	ContainerConfigurationsDisabled bool `json:"container_configurations_disabled"`
 	LegacyUIPublicAccessDisabled    bool `json:"legacy_ui_public_access_disabled"`
+	LegacyUIProjectPageDisabled     bool `json:"legacy_ui_project_page_disabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2545,6 +2546,7 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 		as.CloudCleanupDisabled = v.CloudCleanupDisabled
 		as.ContainerConfigurationsDisabled = v.ContainerConfigurationsDisabled
 		as.LegacyUIPublicAccessDisabled = v.LegacyUIPublicAccessDisabled
+		as.LegacyUIProjectPageDisabled = v.LegacyUIProjectPageDisabled
 	default:
 		return errors.Errorf("programmatic error: expected service flags config but got type %T", h)
 	}
@@ -2586,6 +2588,7 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 		CloudCleanupDisabled:            as.CloudCleanupDisabled,
 		ContainerConfigurationsDisabled: as.ContainerConfigurationsDisabled,
 		LegacyUIPublicAccessDisabled:    as.LegacyUIPublicAccessDisabled,
+		LegacyUIProjectPageDisabled:     as.LegacyUIProjectPageDisabled,
 	}, nil
 }
 

--- a/service/project.go
+++ b/service/project.go
@@ -48,7 +48,7 @@ func (uis *UIServer) projectsPage(w http.ResponseWriter, r *http.Request) {
 	}
 	if flags.LegacyUIProjectPageDisabled {
 		newUIProjectsLink := fmt.Sprintf("%s/projects", uis.Settings.Ui.UIv2Url)
-		http.Redirect(w, r, newUIProjectsLink, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, newUIProjectsLink, http.StatusPermanentRedirect)
 	}
 
 	allProjects, err := uis.filterViewableProjects(dbUser)

--- a/service/project.go
+++ b/service/project.go
@@ -46,12 +46,9 @@ func (uis *UIServer) projectsPage(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "retrieving admin settings")))
 	}
-	if flags.LegacyUIProjectPageDisabled && dbUser != nil && dbUser.Settings.UseSpruceOptions.SpruceV1 {
-		newUILink := ""
-		if len(uis.Settings.Ui.UIv2Url) > 0 {
-			newUILink = fmt.Sprintf("%s/projects", uis.Settings.Ui.UIv2Url)
-		}
-		http.Redirect(w, r, newUILink, http.StatusTemporaryRedirect)
+	if flags.LegacyUIProjectPageDisabled {
+		newUIProjectsLink := fmt.Sprintf("%s/projects", uis.Settings.Ui.UIv2Url)
+		http.Redirect(w, r, newUIProjectsLink, http.StatusTemporaryRedirect)
 	}
 
 	allProjects, err := uis.filterViewableProjects(dbUser)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -411,6 +411,17 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
+												<td>Legacy UI Project Page</td>
+												<td colspan="2">
+													<md-radio-group
+															data-ng-model="Settings.service_flags.legacy_ui_project_page_disabled"
+															layout="row">
+														<md-radio-button data-ng-value="false"></md-radio-button>
+														<md-radio-button data-ng-value="true"></md-radio-button>
+													</md-radio-group>
+												</td>
+											</tr>
+											<tr>
 												<td>&nbsp;</td>
 											</tr>
 											<tr>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -418,6 +418,7 @@ func MockConfig() *evergreen.Settings {
 			CloudCleanupDisabled:            true,
 			ContainerConfigurationsDisabled: true,
 			LegacyUIPublicAccessDisabled:    true,
+			LegacyUIProjectPageDisabled:     true,
 		},
 		SSHKeyDirectory: "/ssh_key_directory",
 		SSHKeyPairs: []evergreen.SSHKeyPair{


### PR DESCRIPTION
EVG-19774

### Description
Added Spruce redirect functionality for the legacy project page, along with an admin flag to turn it on. The redirect will not be active until we toggle it.
### Testing
Tested locally.
### Documentation
Has been documented via email and banner that the legacy project page will be deprecated in 3 weeks (June 13).
