### PR TITLE
docs: add that expansions are case-sensitive

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -584,7 +584,7 @@ Expansions are variables within your config file. They take the form
 `${key_name}` within your project, and are defined on a project-wide
 level on the project configuration page or on a build variant level
 within the project. They can be used **as inputs to commands**,
-including shell scripts.
+including shell scripts. 
 
 ``` yaml
 command: s3.get
@@ -621,6 +621,18 @@ replaced with its default value. If there is no default value, the empty
 string will be used. If the default value is prepended with an asterisk
 and that expansion also does not exist, the empty string will also be
 used.
+
+
+Expansions are also case-sensitive.
+
+``` yaml
+command: shell.exec
+   params:
+      working_dir: src
+     script: |
+       echo ${HelloWorld}
+```
+
 
 #### Usage
 


### PR DESCRIPTION
<img width="326" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26798134/eaf56abc-322a-437e-97cc-e84882fffcc5">

https://mongodb.slack.com/archives/G64DEE8DA/p1685027879808909
Validated: https://spruce.mongodb.com/task/evergreen_ubuntu2004_container_test_expansions_patch_d713dadd127865fa88193c33eed21b16f8b2eae3_646f808c0305b9ddaa5d8fb5_23_05_25_15_36_47/logs?execution=0
Chose HelloWorld over helloworld