### PR TITLE
EVG-18898 move lint to ubuntu22.04

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -678,8 +678,8 @@ buildvariants:
   - name: lint
     display_name: Lint
     run_on:
-      - ubuntu2004-small
-      - ubuntu2004-large
+      - ubuntu2204-small
+      - ubuntu2204-large
     expansions:
       GOROOT: /opt/golang/go1.20
     tasks:


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description
In https://github.com/evergreen-ci/evergreen/pull/6542 we missed moving lint to ubuntu2204.

### Testing
Hopefully it'll pass in this PR's patch.
