### PR TITLE
EVG-19842: Remove branch for repos

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -840,7 +840,6 @@ type ComplexityRoot struct {
 	RepoRef struct {
 		Admins                   func(childComplexity int) int
 		BatchTime                func(childComplexity int) int
-		Branch                   func(childComplexity int) int
 		BuildBaronSettings       func(childComplexity int) int
 		CommitQueue              func(childComplexity int) int
 		ContainerSizeDefinitions func(childComplexity int) int
@@ -5610,13 +5609,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.RepoRef.BatchTime(childComplexity), true
-
-	case "RepoRef.branch":
-		if e.complexity.RepoRef.Branch == nil {
-			break
-		}
-
-		return e.complexity.RepoRef.Branch(childComplexity), true
 
 	case "RepoRef.buildBaronSettings":
 		if e.complexity.RepoRef.BuildBaronSettings == nil {
@@ -15913,8 +15905,6 @@ func (ec *executionContext) fieldContext_GroupedProjects_repo(ctx context.Contex
 				return ec.fieldContext_RepoRef_admins(ctx, field)
 			case "batchTime":
 				return ec.fieldContext_RepoRef_batchTime(ctx, field)
-			case "branch":
-				return ec.fieldContext_RepoRef_branch(ctx, field)
 			case "buildBaronSettings":
 				return ec.fieldContext_RepoRef_buildBaronSettings(ctx, field)
 			case "commitQueue":
@@ -39173,50 +39163,6 @@ func (ec *executionContext) fieldContext_RepoRef_batchTime(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _RepoRef_branch(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_RepoRef_branch(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Branch, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_RepoRef_branch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "RepoRef",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _RepoRef_buildBaronSettings(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RepoRef_buildBaronSettings(ctx, field)
 	if err != nil {
@@ -41545,8 +41491,6 @@ func (ec *executionContext) fieldContext_RepoSettings_projectRef(ctx context.Con
 				return ec.fieldContext_RepoRef_admins(ctx, field)
 			case "batchTime":
 				return ec.fieldContext_RepoRef_batchTime(ctx, field)
-			case "branch":
-				return ec.fieldContext_RepoRef_branch(ctx, field)
 			case "buildBaronSettings":
 				return ec.fieldContext_RepoRef_buildBaronSettings(ctx, field)
 			case "commitQueue":
@@ -60789,7 +60733,7 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "admins", "batchTime", "branch", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "owner", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig", "containerSizeDefinitions"}
+	fieldsInOrder := [...]string{"id", "admins", "batchTime", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "owner", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig", "containerSizeDefinitions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -60837,14 +60781,6 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("batchTime"))
 			it.BatchTime, err = ec.unmarshalOInt2int(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "branch":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("branch"))
-			it.Branch, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -68585,13 +68521,6 @@ func (ec *executionContext) _RepoRef(ctx context.Context, sel ast.SelectionSet, 
 		case "batchTime":
 
 			out.Values[i] = ec._RepoRef_batchTime(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "branch":
-
-			out.Values[i] = ec._RepoRef_branch(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/graphql/schema/types/repo_ref.graphql
+++ b/graphql/schema/types/repo_ref.graphql
@@ -3,7 +3,6 @@ input RepoRefInput {
   id: String! @requireProjectAccess(access: EDIT)
   admins: [String!]
   batchTime: Int
-  branch: String
   buildBaronSettings: BuildBaronSettingsInput
   commitQueue: CommitQueueParamsInput
   deactivatePrevious: Boolean
@@ -51,7 +50,6 @@ type RepoRef {
   id: String!
   admins: [String!]! @requireProjectFieldAccess
   batchTime: Int! @requireProjectFieldAccess
-  branch: String!
   buildBaronSettings: BuildBaronSettings! @requireProjectFieldAccess
   commitQueue: RepoCommitQueueParams! @requireProjectFieldAccess
   containerSizeDefinitions: [ContainerResources!] @requireProjectFieldAccess

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
@@ -7,7 +7,6 @@ mutation {
                 repo: "world",
                 enabled: true,
                 remotePath: "my_path_is_new"
-                branch: "main"
             }
         },
         section: GENERAL

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1949,6 +1949,7 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 		}
 		// some fields shouldn't be set to nil when defaulting to the repo
 		if !defaultToRepo {
+			setUpdate[ProjectRefBranchKey] = p.Branch
 			setUpdate[ProjectRefEnabledKey] = p.Enabled
 			setUpdate[ProjectRefDisplayNameKey] = p.DisplayName
 			setUpdate[ProjectRefIdentifierKey] = p.Identifier

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -275,7 +275,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 
 		if mergedSection.Enabled {
-			if mergedSection.Branch == "" {
+			if mergedSection.Branch == "" && !isRepo {
 				return nil, errors.New("branch not set on enabled repo")
 			}
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -275,8 +275,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 
 		if mergedSection.Enabled {
+			// Branches are not defined for repos, so only check that enabled projects have one specified.
 			if mergedSection.Branch == "" && !isRepo {
-				return nil, errors.New("branch not set on enabled repo")
+				return nil, errors.New("branch not set on enabled project")
 			}
 
 			config, err := evergreen.GetConfig()

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -472,7 +472,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			}
 			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "branch not set on enabled repo")
+			assert.Contains(t, err.Error(), "branch not set on enabled project")
 			assert.Nil(t, settings)
 		},
 		model.ProjectPageVariablesSection: func(t *testing.T, ref model.ProjectRef) {


### PR DESCRIPTION
EVG-19842

### Description
- Remove `branch` field from RepoRef and RepoRefInput. This field is removed from the front end in https://github.com/evergreen-ci/spruce/pull/1845.
- Don't set the repo's branch field when defaulting a page to the repo.

### Testing
- Update unit tests

### Documentation
N/A