### PR TITLE
EVG-19825: make project upsert safer

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -344,8 +344,9 @@ var (
 	containerSecretExternalIDKey   = bsonutil.MustHaveTag(ContainerSecret{}, "ExternalID")
 )
 
+// IsPrivate returns if this project requires the user to be authed to view it.
 func (p *ProjectRef) IsPrivate() bool {
-	return utility.FromBoolPtr(p.Private)
+	return utility.FromBoolTPtr(p.Private)
 }
 
 func (p *ProjectRef) IsRestricted() bool {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1530,7 +1530,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 
 	// doc doesn't default to repo
 	doc.CommitQueue.Enabled = utility.FalsePtr()
-	assert.NoError(doc.Update())
+	assert.NoError(doc.Upsert())
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch("mongodb", "mci", "not_main")
 	assert.NoError(err)
 	assert.Nil(projectRef)

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -103,7 +103,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 
 	// Testing ProjectRef.RepoRefId == ""
 	project0.RepoRefId = ""
-	require.NoError(t, project0.Update())
+	require.NoError(t, project0.Upsert())
 	mergedVars, err = FindMergedProjectVars(project0.Id)
 	assert.NoError(err)
 	assert.Equal(project0Vars, *mergedVars)

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -195,13 +195,6 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 				"unable to find a suggested merge base commit for revision '%s', must fix on projects settings page",
 				revision)
 			gRepoPoller.ProjectRef.SetRepotrackerError(revisionDetails)
-			// kim: TODO: remove
-			// gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
-			// // kim: TODO: try replacing this iwth just a thing to set the
-			// // repotracker error.
-			// if err = gRepoPoller.ProjectRef.Upsert(); err != nil {
-			//     return []model.Revision{}, errors.Wrap(err, "updating project ref revision details")
-			// }
 			return []model.Revision{}, revisionError
 		}
 

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -194,7 +194,9 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			revisionError := errors.Wrapf(err,
 				"unable to find a suggested merge base commit for revision '%s', must fix on projects settings page",
 				revision)
-			gRepoPoller.ProjectRef.SetRepotrackerError(revisionDetails)
+			if err := gRepoPoller.ProjectRef.SetRepotrackerError(revisionDetails); err != nil {
+				return []model.Revision{}, errors.Wrap(err, "setting repotracker error")
+			}
 			return []model.Revision{}, revisionError
 		}
 

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -194,10 +194,14 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			revisionError := errors.Wrapf(err,
 				"unable to find a suggested merge base commit for revision '%s', must fix on projects settings page",
 				revision)
-			gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
-			if err = gRepoPoller.ProjectRef.Upsert(); err != nil {
-				return []model.Revision{}, errors.Wrap(err, "updating project ref revision details")
-			}
+			gRepoPoller.ProjectRef.SetRepotrackerError(revisionDetails)
+			// kim: TODO: remove
+			// gRepoPoller.ProjectRef.RepotrackerError = revisionDetails
+			// // kim: TODO: try replacing this iwth just a thing to set the
+			// // repotracker error.
+			// if err = gRepoPoller.ProjectRef.Upsert(); err != nil {
+			//     return []model.Revision{}, errors.Wrap(err, "updating project ref revision details")
+			// }
 			return []model.Revision{}, revisionError
 		}
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -182,7 +182,9 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	if err != nil {
 		return errors.Wrapf(err, "copying existing container secrets")
 	}
-	pRef.SetContainerSecrets(secrets)
+	if err := pRef.SetContainerSecrets(secrets); err != nil {
+		return errors.Wrap(err, "setting container secrets")
+	}
 
 	// Under the hood, this is updating the container secrets in the DB project
 	// ref, but this function's copy of the in-memory project ref won't reflect

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -178,16 +178,16 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 		return errors.Wrap(err, "setting up Secrets Manager vault to store newly-created project's container secrets")
 	}
 
-	pRef.ContainerSecrets, err = getCopiedContainerSecrets(ctx, settings, vault, pRef.Id, existingSecrets)
+	secrets, err := getCopiedContainerSecrets(ctx, settings, vault, pRef.Id, existingSecrets)
 	if err != nil {
 		return errors.Wrapf(err, "copying existing container secrets")
 	}
-	if err := pRef.Update(); err != nil {
-		return errors.Wrapf(err, "updating project ref's container secrets")
-	}
-	// This updates the container secrets in the DB project ref only, not
-	// the in-memory copy.
-	if err := UpsertContainerSecrets(ctx, vault, pRef.ContainerSecrets); err != nil {
+	pRef.SetContainerSecrets(secrets)
+
+	// Under the hood, this is updating the container secrets in the DB project
+	// ref, but this function's copy of the in-memory project ref won't reflect
+	// those changes.
+	if err := UpsertContainerSecrets(ctx, vault, secrets); err != nil {
 		return errors.Wrapf(err, "upserting container secrets")
 	}
 
@@ -427,7 +427,7 @@ func HideBranch(projectID string) error {
 		Enabled:   false,
 		Hidden:    utility.TruePtr(),
 	}
-	if err := skeletonProj.Update(); err != nil {
+	if err := skeletonProj.Upsert(); err != nil {
 		return errors.Wrapf(err, "updating project '%s'", pRef.Id)
 	}
 	if err := model.UpdateAdminRoles(pRef, nil, pRef.Admins); err != nil {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -561,6 +561,7 @@ func TestHideBranch(t *testing.T) {
 		RepoRefId: repo.Id,
 		Enabled:   false,
 		Hidden:    utility.TruePtr(),
+		Private:   utility.TruePtr(),
 	}
 	assert.Equal(t, skeletonProj, *hiddenProj)
 

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -794,11 +794,11 @@ func TestProjectViewPermission(t *testing.T) {
 	}
 	assert.NoError(env.RoleManager().AddScope(scopeAll))
 	proj1 := model.ProjectRef{
-		Id:      "proj1",
-		Private: utility.TruePtr(),
+		Id: "proj1",
 	}
 	proj2 := model.ProjectRef{
-		Id: "proj2",
+		Id:      "proj2",
+		Private: utility.FalsePtr(),
 	}
 	assert.NoError(proj1.Insert())
 	assert.NoError(proj2.Insert())

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -536,12 +536,13 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// complete all updates
-	if err = h.newProjectRef.Update(); err != nil {
+	if err = h.newProjectRef.Upsert(); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating project '%s'", h.newProjectRef.Id))
 	}
 
-	// This updates the container secrets in the DB project ref only, not the
-	// in-memory copy.
+	// Under the hood, this is updating the container secrets in the DB project
+	// ref, but this function's copy of the in-memory project ref won't reflect
+	// those changes.
 	if err := data.UpsertContainerSecrets(ctx, h.vault, allContainerSecrets); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "upserting container secrets"))
 	}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1091,6 +1091,7 @@ func TestDeleteProject(t *testing.T) {
 			RepoRefId: repo.Id,
 			Enabled:   false,
 			Hidden:    utility.TruePtr(),
+			Private:   utility.TruePtr(),
 		}
 		assert.Equal(t, skeletonProj, *hiddenProj)
 
@@ -1161,7 +1162,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId is populated
 
 	pRef.RepoRefId = ""
-	assert.NoError(t, pRef.Update())
+	assert.NoError(t, pRef.Upsert())
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)
@@ -1235,7 +1236,7 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId isn't populated
 
 	pRef.RepoRefId = repoRef.Id
-	assert.NoError(t, pRef.Update())
+	assert.NoError(t, pRef.Upsert())
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)

--- a/service/project.go
+++ b/service/project.go
@@ -835,16 +835,6 @@ func (uis *UIServer) setRevision(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	// // update the projectRef too
-	// projectRef.RepotrackerError.Exists = false
-	// projectRef.RepotrackerError.InvalidRevision = ""
-	// projectRef.RepotrackerError.MergeBaseRevision = ""
-	// // kim: TODO: possibly change this to just $set the one field.
-	// err = projectRef.Upsert()
-	// if err != nil {
-	//     uis.LoggedError(w, r, http.StatusInternalServerError, err)
-	//     return
-	// }
 
 	// run the repotracker for the project
 	ts := utility.RoundPartOfHour(1).Format(units.TSFormat)

--- a/service/project.go
+++ b/service/project.go
@@ -831,15 +831,20 @@ func (uis *UIServer) setRevision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// update the projectRef too
-	projectRef.RepotrackerError.Exists = false
-	projectRef.RepotrackerError.InvalidRevision = ""
-	projectRef.RepotrackerError.MergeBaseRevision = ""
-	err = projectRef.Upsert()
-	if err != nil {
+	if err := projectRef.SetRepotrackerError(&model.RepositoryErrorDetails{}); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
+	// // update the projectRef too
+	// projectRef.RepotrackerError.Exists = false
+	// projectRef.RepotrackerError.InvalidRevision = ""
+	// projectRef.RepotrackerError.MergeBaseRevision = ""
+	// // kim: TODO: possibly change this to just $set the one field.
+	// err = projectRef.Upsert()
+	// if err != nil {
+	//     uis.LoggedError(w, r, http.StatusInternalServerError, err)
+	//     return
+	// }
 
 	// run the repotracker for the project
 	ts := utility.RoundPartOfHour(1).Format(units.TSFormat)


### PR DESCRIPTION
EVG-19825

### Description
* If a project is not already explicitly set to public/private, set it to private during all upserts.
* Consolidate `Update()` into `Upsert()` since they're pretty much the same thing.
* Reduce usage of upsert in places where the logic can do single field updates. I couldn't remove it from some places though (such as hiding a project), because they relied on doing whole-document updates.

### Testing
Added unit tests.

### Documentation
N/A