### PR TITLE
EVG-19906 Remove debug logging for commit queue refresh

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -433,14 +433,6 @@ func checkPRIsMergeable(ctx context.Context, sc Connector, pr *github.PullReques
 				return pr, err
 			}
 			pr = refreshedPR
-			grip.Debug(message.Fields{
-				"message":            "calling refresh from commit queue",
-				"ticket":             "EVG-19827",
-				"owner":              info.Owner,
-				"repo":               info.Repo,
-				"pr":                 pr,
-				"new_mergeble_state": pr.GetMergeableState(),
-			})
 		}
 	}
 


### PR DESCRIPTION
EVG-19906

### Description
removing logs because there was never an instance where the automatic refresh trigger from the commit queue changed the status of a pr from block to unblocked

