### PR TITLE
EVG-19994: fix broken links for project commands

### DIFF
--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -6,7 +6,7 @@ Evergreen creates a temporary task directory for each task. Commands by default 
 
 ## subprocess.exec
 
-In general, use [subprocess.exec](Project-Commands.md#subprocess-exec) instead of shell.exec.
+In general, use [subprocess.exec](Project-Commands.md#subprocessexec) instead of shell.exec.
 
 The reasons to prefer subprocess.exec include:
 1. Evergreen uses expansions with the same syntax as shell expansions.

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -897,7 +897,7 @@ This is set to true at the top level if you'd like to enable the OOM Tracker for
 ### Matrix Variant Definition
 
 The matrix syntax is deprecated in favor of the
-[generate.tasks](Project-Commands.md#generate-tasks)
+[generate.tasks](Project-Commands.md#generatetasks)
 command. **Evergreen is unlikely to do further development on matrix
 variant definitions.** The documentation is here for completeness, but
 please do not add new matrix variant definitions. It is typically
@@ -1363,7 +1363,7 @@ parameters are available:
     not be automatically pulled in to the version.
 -   `omit_generated_tasks` - boolean (default: false). If true and the
     dependency is a generator task (i.e. it generates tasks via the
-    [`generate.tasks`](Project-Commands.md#generate-tasks) command), then generated tasks will not be included
+    [`generate.tasks`](Project-Commands.md#generatetasks) command), then generated tasks will not be included
     as dependencies.
 
 So, for example:

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -307,7 +307,7 @@ use performance tooling.
 Enabling this feature allows users to push and pull their task working
 directory to and from a remote store (S3). This can be done either using
 the
-[s3.push](Project-Commands.md#s3-push)
+[s3.push](Project-Commands.md#s3push)
 or
 [s3.pull](Project-Commands.md#s3pull)
 project commands, or using it from [the CLI](../CLI.md#task-sync).


### PR DESCRIPTION
EVG-19994

### Documentation
Apparently, links in Pine to headers that contain a period need to omit the period. I only confirmed this by clicking a bunch of links in the docs.

There's also a bug where the timeout.update link is not being generated properly by Docusaurus despite being written the same way as all the other (working) links, which is being investigated in [RDPL-352](https://jira.mongodb.org/browse/RDPL-352).