### PR TITLE
EVG-20010: remove agent self-termination route

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-05-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-30"
+	AgentVersion = "2023-05-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20010

### Description
Remove the route that terminates the agent within the host. From the original context, it seems like it was introduced in EVG-1888 so that there would be a way to mass terminate agents across hosts. I don't really see a good reason why we would need to do this as opposed to just terminate hosts (and I believe nobody's ever needed such functionality in all the years of firefighting/outages), so it seems best to just remove.

I also don't think users would ever have a good reason to intentionally terminate the agent, so it seems safe to remove if we're not using it.

### Testing
N/A

### Documentation
N/A
