### PR TITLE
EVG-17174: use Dependabot for automated dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 99
+    commit-message:
+      prefix: "CHORE: "
+    reviewers:
+      - evg-app


### PR DESCRIPTION
EVG-17174

### Description
This is pretty much the same configuration as https://github.com/mongodb/jasper/pull/260, but for Evergreen.

This enables Dependabot automatic upgrades for Go modules. Dependabot will periodically check all dependencies in `go.mod` for newer stable versions (it doesn't upgrade unversioned repos like our evergreen-ci ones) and open a PR to bump them. This initial merge will also trigger Dependabot to do an immediate check for new dependency versions and I suspect many of our dependencies are out of date, so merging this may trigger a lot of Dependabot PRs to be opened.

My proposed workflow is that once every quarter or so, someone is assigned to review the open Dependabot PRs; if they pass, they can just be merged. If not, we'll have to open tickets and triage when to fix them to get them in a mergeable state.

* Check for updates monthly to make it minimally annoying. It doesn't let you set it any less frequent than this.
* Increase the open PR limit from the default of 5. It's preferable to get all the available upgrades ASAP so we know about them rather than have Dependabot incrementally give us a subset of all the available updates. At worst, we can just leave the PRs open and ignore them until we're ready to actually bump.
* I set evg-app as the reviewer on all the Dependabot PRs. For the GitHub reminder in Slack, I'm pretty sure it can be configured to ignore Dependabot PRs if we want to avoid the alerts getting too noisy for the PRs we don't immediately merge (I'm prtty sure @ablack12 is the only one with permission to modify the reminder though).