### PR TITLE
EVG-20009: close agent when signalled

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-05-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-05-30"
+	AgentVersion = "2023-05-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20009

### Description
The agent closer currently runs in a defer, but deferred functions do not run if the program exits (e.g. via `os.Exit`). I just manually called it when the goroutine exits the process.

### Testing
Not really a testable condition since it's a signal catcher, but I verified in a Go playground that it behaves as expected.

### Documentation
N/A
