### PR TITLE
EVG-19998 cache unattainable task status

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -60,6 +60,7 @@ var (
 	SecondaryDistrosKey            = bsonutil.MustHaveTag(Task{}, "SecondaryDistros")
 	BuildVariantKey                = bsonutil.MustHaveTag(Task{}, "BuildVariant")
 	DependsOnKey                   = bsonutil.MustHaveTag(Task{}, "DependsOn")
+	UnattainableDependencyKey      = bsonutil.MustHaveTag(Task{}, "UnattainableDependency")
 	OverrideDependenciesKey        = bsonutil.MustHaveTag(Task{}, "OverrideDependencies")
 	NumDepsKey                     = bsonutil.MustHaveTag(Task{}, "NumDependents")
 	DisplayNameKey                 = bsonutil.MustHaveTag(Task{}, "DisplayName")
@@ -1838,6 +1839,13 @@ func updateAllMatchingDependenciesForTask(taskId, dependencyId string, unattaina
 		}}),
 	)
 	return res.Err()
+}
+
+func updateUnattainableDependency(taskID string, unattainableDependency bool) error {
+	return UpdateOne(
+		bson.M{IdKey: taskID},
+		bson.M{"$set": bson.M{UnattainableDependencyKey: unattainableDependency}},
+	)
 }
 
 // AbortAndMarkResetTasksForBuild aborts and marks tasks for a build to reset when finished.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2195,7 +2195,7 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 	}
 
 	if err := updateAllMatchingDependenciesForTask(t.Id, dependencyId, unattainable); err != nil {
-		return errors.Wrapf(err, "updating mathing dependencies for task '%s'", t.Id)
+		return errors.Wrapf(err, "updating matching dependencies for task '%s'", t.Id)
 	}
 
 	if err := t.RefreshUnattainableDependency(); err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -123,7 +123,9 @@ type Task struct {
 	BuildVariant            string           `bson:"build_variant" json:"build_variant"`
 	BuildVariantDisplayName string           `bson:"build_variant_display_name" json:"-"`
 	DependsOn               []Dependency     `bson:"depends_on" json:"depends_on"`
-	NumDependents           int              `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
+	// UnattainableDependency caches the contents of DependsOn for more efficient querying.
+	UnattainableDependency bool `bson:"unattainable_dependency" json:"unattainable_dependency"`
+	NumDependents          int  `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
 	// OverrideDependencies indicates whether a task should override its dependencies. If set, it will not
 	// wait for its dependencies to finish before running.
 	OverrideDependencies bool `bson:"override_dependencies,omitempty" json:"override_dependencies,omitempty"`
@@ -2193,7 +2195,12 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 	}
 
 	if err := updateAllMatchingDependenciesForTask(t.Id, dependencyId, unattainable); err != nil {
-		return err
+		return errors.Wrapf(err, "updating mathing dependencies for task '%s'", t.Id)
+	}
+
+	t.UnattainableDependency = t.hasUnattainableDependency()
+	if err := updateUnattainableDependency(t.Id, t.UnattainableDependency); err != nil {
+		return errors.Wrapf(err, "caching unattainable dependency for task '%s'", t.Id)
 	}
 
 	// Only want to log the task as blocked if it wasn't already blocked, and if we're not overriding dependencies.
@@ -2201,6 +2208,15 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 		event.LogTaskBlocked(t.Id, t.Execution)
 	}
 	return nil
+}
+
+func (t *Task) hasUnattainableDependency() bool {
+	for _, dependency := range t.DependsOn {
+		if dependency.Unattainable {
+			return true
+		}
+	}
+	return false
 }
 
 // AbortBuild sets the abort flag on all tasks associated with the build which are in an abortable
@@ -2950,13 +2966,7 @@ func (t *Task) Blocked() bool {
 	if t.OverrideDependencies {
 		return false
 	}
-	for _, dependency := range t.DependsOn {
-		if dependency.Unattainable {
-			return true
-		}
-	}
-
-	return false
+	return t.hasUnattainableDependency()
 }
 
 // WillRun returns true if the task will run eventually, but has not started

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2198,8 +2198,7 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 		return errors.Wrapf(err, "updating mathing dependencies for task '%s'", t.Id)
 	}
 
-	t.UnattainableDependency = t.hasUnattainableDependency()
-	if err := updateUnattainableDependency(t.Id, t.UnattainableDependency); err != nil {
+	if err := t.RefreshUnattainableDependency(); err != nil {
 		return errors.Wrapf(err, "caching unattainable dependency for task '%s'", t.Id)
 	}
 
@@ -2208,6 +2207,13 @@ func (t *Task) MarkUnattainableDependency(dependencyId string, unattainable bool
 		event.LogTaskBlocked(t.Id, t.Execution)
 	}
 	return nil
+}
+
+// RefreshUnattainableDependency refreshes the contents of the task's UnattainableDependency field
+// by iterating through the task's DependsOn.
+func (t *Task) RefreshUnattainableDependency() error {
+	t.UnattainableDependency = t.hasUnattainableDependency()
+	return updateUnattainableDependency(t.Id, t.UnattainableDependency)
 }
 
 func (t *Task) hasUnattainableDependency() bool {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1764,7 +1764,11 @@ func MarkOneTaskReset(t *task.Task) error {
 	}
 
 	if err := UpdateUnblockedDependencies(t); err != nil {
-		return errors.Wrap(err, "clearing cached unattainable dependencies")
+		return errors.Wrap(err, "clearing unattainable dependencies")
+	}
+
+	if err := t.RefreshUnattainableDependency(); err != nil {
+		return errors.Wrap(err, "refreshing cached unattainable status")
 	}
 
 	if err := t.MarkDependenciesFinished(false); err != nil {
@@ -1792,7 +1796,8 @@ func MarkTasksReset(taskIds []string) error {
 
 	catcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		catcher.Wrapf(UpdateUnblockedDependencies(&t), "clearing cached unattainable dependencies for task '%s'", t.Id)
+		catcher.Wrapf(UpdateUnblockedDependencies(&t), "clearing unattainable dependencies for task '%s'", t.Id)
+		catcher.Wrapf(t.RefreshUnattainableDependency(), "refreshing cached unattainable status for task '%s'", t.Id)
 		catcher.Wrapf(t.MarkDependenciesFinished(false), "marking direct dependencies unfinished for task '%s'", t.Id)
 	}
 


### PR DESCRIPTION
[EVG-19998](https://jira.mongodb.org/browse/EVG-19998)

### Description
#### Problem Statement
The [schedulableHostTasksQuery](https://github.com/evergreen-ci/evergreen/blob/fbbbd42cd673b24b9e12e9eb810674a7c389c1b2/model/task/db.go#L708) is inefficient if there are many documents that have a mix of blocked and unblocked dependencies. The reason for this is that we filter out tasks with blocked dependencies [here](https://github.com/evergreen-ci/evergreen/blob/fbbbd42cd673b24b9e12e9eb810674a7c389c1b2/model/task/db.go#L720), but the index can only be used to filter out tasks that have **all** their dependencies blocked. For tasks that have some unblocked dependencies we need to fetch the actual documents and filter the array[^1]. Some distros have many (~200k) tasks like this, and potentially long dependency arrays to look through, and this throws off the query planner.

#### Proposed Solution
Add a new field to the task document that caches whether there are any unattainable dependencies. This will allow the query to use a new index that will be added to replace the current one. Once we can assume a task has this field (after old tasks have TTLed, once there's a TTL 😅) this might also make things like [this](https://github.com/evergreen-ci/evergreen/blob/fbbbd42cd673b24b9e12e9eb810674a7c389c1b2/model/task/db.go#L252-L262) more efficient too.

#### Migration plan
Once this new field is being set for some time (a week?) we can assume that any new task that would want to run will have the field set. Any reset task will also have the field set. We can then adjust the `schedulableHostTasksQuery` to match on `unattainable_dependency: false`.

### Testing
Added a test for `MarkUnattainableDependency`

[^1]: The index has a key for each of the dependency subdocuments. The best we can do is avoid the keys in the index where there is an unattainable dependency, which filters the tasks that don't have **any** unblocked dependencies.
If a task has any unblocked dependencies that task will have a key that's `depends_on.unattainable: false` so that task will still be selected and need to be filtered.