### PR TITLE
EVG-19648 avoid deactivating previous tasks if they're depended on

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1890,7 +1890,7 @@ func AbortAndMarkResetTasksForVersion(versionId string, taskIds []string, caller
 	return err
 }
 
-// HasUnfinishedTaskForVersion returns true if there are any scheduled but
+// HasUnfinishedTaskForVersions returns true if there are any scheduled but
 // unfinished tasks matching the given conditions.
 func HasUnfinishedTaskForVersions(versionIds []string, taskName, variantName string) (bool, error) {
 	count, err := Count(

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1574,6 +1574,18 @@ func CountActivatedTasksForVersion(versionId string) (int, error) {
 	}))
 }
 
+// HasActivatedDependentTasks returns true if there are active tasks waiting on the given task.
+func HasActivatedDependentTasks(taskId string) (bool, error) {
+	numDependentTasks, err := Count(db.Query(bson.M{
+		bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): taskId,
+		ActivatedKey: true,
+	}))
+	if err != nil {
+		return false, err
+	}
+	return numDependentTasks > 0, nil
+}
+
 func FindTaskGroupFromBuild(buildId, taskGroup string) ([]Task, error) {
 	tasks, err := FindWithSort(bson.M{
 		BuildIdKey:   buildId,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1578,12 +1578,11 @@ func CountActivatedTasksForVersion(versionId string) (int, error) {
 func HasActivatedDependentTasks(taskId string) (bool, error) {
 	numDependentTasks, err := Count(db.Query(bson.M{
 		bsonutil.GetDottedKeyName(DependsOnKey, DependencyTaskIdKey): taskId,
-		ActivatedKey: true,
+		ActivatedKey:            true,
+		OverrideDependenciesKey: bson.M{"$ne": true},
 	}))
-	if err != nil {
-		return false, err
-	}
-	return numDependentTasks > 0, nil
+
+	return numDependentTasks > 0, err
 }
 
 func FindTaskGroupFromBuild(buildId, taskGroup string) ([]Task, error) {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1767,3 +1767,40 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 		t.Run(testName, test)
 	}
 }
+
+func TestHasActivatedDependentTasks(t *testing.T) {
+	t1 := Task{
+		Id:        "activeDependent",
+		Activated: true,
+		DependsOn: []Dependency{
+			{TaskId: "current"},
+		},
+	}
+	t2 := Task{
+		Id: "inactiveDependent",
+		DependsOn: []Dependency{
+			{TaskId: "inactive"},
+		},
+	}
+	t3 := Task{
+		Id:        "manyDependencies",
+		Activated: true,
+		DependsOn: []Dependency{
+			{TaskId: "current"},
+			{TaskId: "secondTask"},
+		},
+	}
+	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3))
+
+	hasDependentTasks, err := HasActivatedDependentTasks("current")
+	assert.NoError(t, err)
+	assert.True(t, hasDependentTasks)
+
+	hasDependentTasks, err = HasActivatedDependentTasks("secondTask")
+	assert.NoError(t, err)
+	assert.True(t, hasDependentTasks)
+
+	hasDependentTasks, err = HasActivatedDependentTasks("inactive")
+	assert.NoError(t, err)
+	assert.False(t, hasDependentTasks)
+}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1769,6 +1769,7 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 }
 
 func TestHasActivatedDependentTasks(t *testing.T) {
+	assert.NoError(t, db.Clear(Collection))
 	t1 := Task{
 		Id:        "activeDependent",
 		Activated: true,
@@ -1800,7 +1801,14 @@ func TestHasActivatedDependentTasks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, hasDependentTasks)
 
+	// Tasks overriding dependencies don't count as dependent.
+	assert.NoError(t, t3.SetOverrideDependencies("me"))
+	hasDependentTasks, err = HasActivatedDependentTasks("secondTask")
+	assert.NoError(t, err)
+	assert.False(t, hasDependentTasks)
+
 	hasDependentTasks, err = HasActivatedDependentTasks("inactive")
 	assert.NoError(t, err)
 	assert.False(t, hasDependentTasks)
+
 }


### PR DESCRIPTION
EVG-19648

### Description
[This ticket](https://spruce.mongodb.com/task/mms_v20230412_deploy_gate_PACKAGE_CLOUD_DEPLOY_GATE_8d625c0f9fdc195431b5824995467764d6149181_23_04_17_17_30_16/logs?execution=0&logtype=event&sortBy=STATUS&sortDir=ASC) was unscheduled because a dependent task was deactivated because of [a previous success](https://spruce.mongodb.com/task/mms_v20230412_code_health_CHECK_PROM_ALERT_fe010402187c7649a2bfc7e7c2c11080854229ab_23_04_17_18_18_19/logs?execution=0). 

This PR (1) checks dependencies, and (2) removes legacy logic to include display task execution tasks (SetActiveState handles that). 

### Testing
Verified existing tests pass, and added a test to verify that a task with an active dependent task wouldn't be deactivated. 

