### PR TITLE
docs: Update doc for REST v2 API

### DIFF
--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -6,7 +6,7 @@
 
 Many of the these REST endpoints do not require authentication to
 access, but some do. These will return a 404 if no authentication
-headers are sent, if the username is invalid, or if the API key is
+headers are sent, if the username is invalid, or if the API key 
 incorrect. Use the `user` and `api_key` fields from the
 [settings](https://spruce.mongodb.com/preferences/cli) page to set two headers,
 `Api-User` and `Api-Key`.
@@ -746,7 +746,7 @@ Returns a paginated list of all patches associated with a specific user
 
 ##### Fetch Patch By Id
 
-    GET /projects/<project_id>/patches
+    GET /patches/<patch_id>
 
 Fetch a single patch using its ID
 

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -8,7 +8,7 @@ Base URL: `http://<EVERGREEN_HOST>/rest/v2/`
 
 Many of the these REST endpoints do not require authentication to
 access, but some do. These will return a 404 if no authentication
-headers are sent, if the username is invalid, or if the API key 
+headers are sent, if the username is invalid, or if the API key is
 incorrect. Use the `user` and `api_key` fields from the
 [settings](https://spruce.mongodb.com/preferences/cli) page to set two headers,
 `Api-User` and `Api-Key`.

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1,5 +1,7 @@
 # REST v2 API
 
+Base URL: `http://<EVERGREEN_HOST>/rest/v2/`
+
 ## General Functionality
 
 ### A note on authentication


### PR DESCRIPTION
Changes:
- Fix the endpoint for getting a patch by its patch_id.
- Document the base URL explicitly.