### PR TITLE
EVG-18670 Standardize time taken formatting between patch finish notification and Spruce UI

### DIFF
--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -7,7 +7,6 @@ package graphql
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
@@ -74,26 +73,9 @@ func (r *patchResolver) Duration(ctx context.Context, obj *restModel.APIPatch) (
 	if tasks == nil {
 		return nil, ResourceNotFound.Send(ctx, "Could not find any tasks for patch")
 	}
-	timeTaken, makespan := task.GetTimeSpent(tasks)
+	timeTaken, makespan := task.GetFormattedTimeSpent(tasks)
 
-	// return nil if rounded timeTaken/makespan == 0s
-	t := timeTaken.Round(time.Second).String()
-	var tPointer *string
-	if t != "0s" {
-		tFormated := formatDuration(t)
-		tPointer = &tFormated
-	}
-	m := makespan.Round(time.Second).String()
-	var mPointer *string
-	if m != "0s" {
-		mFormated := formatDuration(m)
-		mPointer = &mFormated
-	}
-
-	return &PatchDuration{
-		Makespan:  mPointer,
-		TimeTaken: tPointer,
-	}, nil
+	return makePatchDuration(timeTaken, makespan), nil
 }
 
 // PatchTriggerAliases is the resolver for the patchTriggerAliases field.

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -496,13 +494,6 @@ func getAllTaskStatuses(tasks []task.Task) []string {
 	return statusesArr
 }
 
-func formatDuration(duration string) string {
-	regex := regexp.MustCompile(`\d*[dhms]`)
-	return strings.TrimSpace(regex.ReplaceAllStringFunc(duration, func(m string) string {
-		return m + " "
-	}))
-}
-
 func removeGeneralSubscriptions(usr *user.DBUser, subscriptions []event.Subscription) []string {
 	filteredSubscriptions := make([]string, 0, len(subscriptions))
 	for _, subscription := range subscriptions {
@@ -512,6 +503,23 @@ func removeGeneralSubscriptions(usr *user.DBUser, subscriptions []event.Subscrip
 	}
 
 	return filteredSubscriptions
+}
+
+func makePatchDuration(t, m string) *PatchDuration {
+	var tPointer *string
+	if t != "0s" {
+		tPointer = &t
+	}
+
+	var mPointer *string
+	if m != "0s" {
+		mPointer = &m
+	}
+
+	return &PatchDuration{
+		Makespan:  mPointer,
+		TimeTaken: tPointer,
+	}
 }
 
 func getResourceTypeAndIdFromSubscriptionSelectors(ctx context.Context, selectors []restModel.APISelector) (string, string, error) {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -505,21 +505,18 @@ func removeGeneralSubscriptions(usr *user.DBUser, subscriptions []event.Subscrip
 	return filteredSubscriptions
 }
 
-func makePatchDuration(t, m string) *PatchDuration {
-	var tPointer *string
-	if t != "0s" {
-		tPointer = &t
+func makePatchDuration(timeTaken, makeSpan string) *PatchDuration {
+	res := &PatchDuration{}
+
+	if timeTaken != "0s" {
+		res.TimeTaken = &timeTaken
 	}
 
-	var mPointer *string
-	if m != "0s" {
-		mPointer = &m
+	if makeSpan != "0s" {
+		res.Makespan = &makeSpan
 	}
 
-	return &PatchDuration{
-		Makespan:  mPointer,
-		TimeTaken: tPointer,
-	}
+	return res
 }
 
 func getResourceTypeAndIdFromSubscriptionSelectors(ctx context.Context, selectors []restModel.APISelector) (string, string, error) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3097,6 +3097,22 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	return timeTaken, latestFinishTime.Sub(earliestStartTime)
 }
 
+func GetFormattedTimeSpent(tasks []Task) (string, string) {
+	timeTaken, makespan := GetTimeSpent(tasks)
+
+	t := timeTaken.Round(time.Second).String()
+	m := makespan.Round(time.Second).String()
+
+	return formatDuration(t), formatDuration(m)
+}
+
+func formatDuration(duration string) string {
+	regex := regexp.MustCompile(`\d*[dhms]`)
+	return strings.TrimSpace(regex.ReplaceAllStringFunc(duration, func(m string) string {
+		return m + " "
+	}))
+}
+
 type TasksSortOrder struct {
 	Key   string
 	Order int

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3097,7 +3097,7 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	return timeTaken, latestFinishTime.Sub(earliestStartTime)
 }
 
-// GetTimeSpent returns the total time_taken and makespan of tasks as a formatted string
+// GetFormattedTimeSpent returns the total time_taken and makespan of tasks as a formatted string
 func GetFormattedTimeSpent(tasks []Task) (string, string) {
 	timeTaken, makespan := GetTimeSpent(tasks)
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3097,6 +3097,7 @@ func GetTimeSpent(tasks []Task) (time.Duration, time.Duration) {
 	return timeTaken, latestFinishTime.Sub(earliestStartTime)
 }
 
+// GetTimeSpent returns the total time_taken and makespan of tasks as a formatted string
 func GetFormattedTimeSpent(tasks []Task) (string, string) {
 	timeTaken, makespan := GetTimeSpent(tasks)
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1659,6 +1659,46 @@ func TestGetTimeSpent(t *testing.T) {
 	assert.EqualValues(0, makespan)
 }
 
+func TestGetFormattedTimeSpent(t *testing.T) {
+	assert := assert.New(t)
+	referenceTime := time.Unix(1136239445, 0)
+	tasks := []Task{
+		{
+			StartTime:  referenceTime,
+			FinishTime: referenceTime.Add(time.Hour),
+			TimeTaken:  time.Hour,
+		},
+		{
+			StartTime:  referenceTime,
+			FinishTime: referenceTime.Add(2 * time.Hour),
+			TimeTaken:  2 * time.Hour,
+		},
+		{
+			DisplayOnly: true,
+			FinishTime:  referenceTime.Add(3 * time.Hour),
+			TimeTaken:   2 * time.Hour,
+		},
+		{
+			StartTime:  referenceTime,
+			FinishTime: utility.ZeroTime,
+			TimeTaken:  0,
+		},
+		{
+			StartTime:  utility.ZeroTime,
+			FinishTime: utility.ZeroTime,
+			TimeTaken:  0,
+		},
+	}
+
+	timeTaken, makespan := GetFormattedTimeSpent(tasks)
+	assert.Equal("2h 0m 0s", makespan)
+	assert.Equal("3h 0m 0s", timeTaken)
+
+	timeTaken, makespan = GetFormattedTimeSpent(tasks[2:])
+	assert.Equal("0s", makespan)
+	assert.Equal("0s", timeTaken)
+}
+
 func TestUpdateDependsOn(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
 	t1 := &Task{Id: "t1"}

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -279,7 +279,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		return nil, errors.Wrapf(err, "getting tasks for patch '%s'", t.patch.Id)
 	}
 	if tasks == nil {
-		return nil, errors.Wrapf(err, "no tasks found for patch '%s'", t.patch.Id)
+		return nil, errors.Errorf("no tasks found for patch '%s'", t.patch.Id)
 	}
 	_, makespan := task.GetFormattedTimeSpent(tasks)
 

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -273,15 +273,15 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 			Color:     slackColor,
 		})
 	}
-	var makespan time.Duration
-	if utility.IsZeroTime(t.patch.FinishTime) {
-		patchTasks, err := task.Find(task.ByVersion(t.patch.Id.Hex()))
-		if err == nil {
-			_, makespan = task.GetTimeSpent(patchTasks)
-		}
-	} else {
-		makespan = t.patch.FinishTime.Sub(t.patch.StartTime)
+
+	tasks, err := task.Find(task.ByVersion(t.patch.Id.Hex()))
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting tasks for patch '%s'", t.patch.Id)
 	}
+	if tasks == nil {
+		return nil, errors.Wrapf(err, "no tasks found for patch '%s'", t.patch.Id)
+	}
+	_, makespan := task.GetFormattedTimeSpent(tasks)
 
 	data.slack = append(data.slack, message.SlackAttachment{
 		Title:     "Evergreen Patch",
@@ -291,7 +291,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 		Fields: []*message.SlackAttachmentField{
 			{
 				Title: "Time Taken",
-				Value: makespan.String(),
+				Value: makespan,
 			},
 		},
 	})


### PR DESCRIPTION
EVG-18670

### Description
This standardizes how the time taken is formatted to avoid a very large integer in notifications for cases where there is no start time or an end time. 

### Testing 
Additional unit test plus existing tests 
