### PR TITLE
EVG-18898 js-test to ubuntu-2204

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -636,6 +636,7 @@ buildvariants:
       - name: "docker-cleanup"
       - name: test-db-auth
       - name: test-cloud
+      - name: "js-test"
 
   - name: race-detector
     display_name: Race Detector
@@ -730,16 +731,6 @@ buildvariants:
     tasks:
       - name: ".agent .test"
       - name: ".cli .test"
-
-  - name: ubuntu2004
-    display_name: Ubuntu 20.04
-    batchtime: 2880
-    run_on:
-      - ubuntu2004-small
-    expansions:
-      GOROOT: /opt/golang/go1.20
-    tasks:
-      - name: "js-test"
 
 # TODO: EVG-19745 Use a security-vetted image once one is available
 containers:


### PR DESCRIPTION
[EVG-18898](https://jira.mongodb.org/browse/EVG-18898)

### Description
Given the issues with js-test aren't related to the upgrade to ubuntu22.04 it shouldn't need to be a variant unto itself.
