### PR TITLE
EVG-18916: fix flaky shell.exec test

### DIFF
--- a/scripts/verify-agent-version-update.sh
+++ b/scripts/verify-agent-version-update.sh
@@ -9,7 +9,7 @@ fi
 # Find the common ancestor between the current set of changes and the upstream branch, then see if any source code files
 # have changed in the agent or its subpackages.
 common_ancestor=$(git merge-base ${BRANCH_NAME}@{upstream} HEAD);
-files_changed="$(git diff --name-only "${common_ancestor}" -- 'agent/**.go' ':!agent/**_test.go', 'operations/agent.go')"
+files_changed="$(git diff --name-only "${common_ancestor}" -- 'operations/agent.go' 'agent/**.go' ':!agent/**_test.go')"
 if [[ "${files_changed}" == "" ]]; then
     exit 0;
 fi


### PR DESCRIPTION
EVG-18916

### Description
This was flaking out because the `shell.exec` command didn't have an explicit shell defined, and the shell is only defaulted if you call `ParseParams` (which this test didn't). The test would occasionally flake out due to a race between the command running (with invalid input due to the lack of shell) and the context timing out (which is detected in a separate goroutine).

### Testing
Ran the test in a patch 100 times before and after my fix. Before the fix, it's flaky. After the fix, no flakiness.

### Documentation
N/A
