### PR TITLE
EVG-19891: Update project health view string value

### DIFF
--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -174,8 +174,8 @@ type GithubProjectConflicts {
 }
 
 enum ProjectHealthView {
-  PROJECT_HEALTH_VIEW_ALL
-  PROJECT_HEALTH_VIEW_FAILED
+  ALL
+  FAILED
 }
 
 """

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/views_and_filters_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/views_and_filters_section.graphql
@@ -15,7 +15,7 @@ mutation {
             exactMatch: false
           }
         ]
-        projectHealthView: PROJECT_HEALTH_VIEW_FAILED
+        projectHealthView: FAILED
       }
     }
     section: VIEWS_AND_FILTERS

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -111,7 +111,7 @@
                   "exactMatch": false
                 }
               ],
-              "projectHealthView": "PROJECT_HEALTH_VIEW_FAILED"
+              "projectHealthView": "FAILED"
             }
           }
         }

--- a/graphql/tests/projectSettings/results.json
+++ b/graphql/tests/projectSettings/results.json
@@ -20,7 +20,7 @@
               "prTestingEnabled": true,
               "stepbackDisabled": false,
               "batchTime": 2,
-              "projectHealthView": "failed",
+              "projectHealthView": "FAILED",
               "parsleyFilters": [
                 {
                   "expression": "filter1",

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -138,8 +138,8 @@ type ParsleyFilter struct {
 type ProjectHealthView string
 
 const (
-	ProjectHealthViewFailed ProjectHealthView = "failed"
-	ProjectHealthViewAll    ProjectHealthView = "all"
+	ProjectHealthViewAll    ProjectHealthView = "ALL"
+	ProjectHealthViewFailed ProjectHealthView = "FAILED"
 )
 
 type ProjectBanner struct {


### PR DESCRIPTION
EVG-19891

### Description
- I introduced a mismatch in string values in https://github.com/evergreen-ci/evergreen/pull/6540: the GraphQL enum uses an uppercase string and the golang const uses lowercase. We should use uppercase strings in the database to align with GraphQL enum conventions and [gqlgen patterns](https://gqlgen.com/reference/name-collision/). I spoke with @khelif96 and we think it makes most sense to stick with enums here rather than reverting to a string (and going forward, we can adopt this pattern in other places where we've previously returned `String!` and added enums on the front end).
- Once this ticket is deployed, 6 project_ref documents in the database will need to be updated to convert `failed` to `FAILED`:
  ```
  db.project_ref.updateMany({project_health_view: "failed"}, {$set: {project_health_view: "FAILED"}})
  ```

### Testing
- Updated unit tests, which now actually return the values we want to see.

### Documentation
N/A