### PR TITLE
EVG-18002 Add a middleware for Github payload validation 

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -72,7 +72,7 @@ func (gh *githubHookApi) Factory() gimlet.RouteHandler {
 }
 
 func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
-	payload := getPayload(r.Context())
+	payload := getGitHubPayload(r.Context())
 	if payload == nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -177,6 +177,7 @@ func (s *GithubWebhookRouteSuite) TestParseAndValidate() {
 	ctx := context.Background()
 	secret := []byte(s.conf.Api.GithubWebhookSecret)
 	req, err := makeRequest("1", "pull_request", s.prBody, secret)
+	req = setGitHubPayload(req, s.prBody)
 	s.NoError(err)
 
 	err = s.h.Parse(ctx, req)
@@ -186,6 +187,7 @@ func (s *GithubWebhookRouteSuite) TestParseAndValidate() {
 	s.Equal("1", s.h.msgID)
 
 	req, err = makeRequest("2", "push", s.pushBody, secret)
+	req = setGitHubPayload(req, s.pushBody)
 	s.NoError(err)
 	s.NotNil(req)
 
@@ -196,6 +198,7 @@ func (s *GithubWebhookRouteSuite) TestParseAndValidate() {
 	s.Equal("2", s.h.msgID)
 
 	req, err = makeRequest("3", "issue_comment", s.commitQueueCommentBody, secret)
+	req = setGitHubPayload(req, s.commitQueueCommentBody)
 	s.NoError(err)
 	s.NotNil(req)
 

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -943,11 +943,11 @@ func (m *githubAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request
 }
 
 func setGitHubPayload(r *http.Request, payload []byte) *http.Request {
-	return r.WithContext(context.WithValue(r.Context(), payloadKey, payload))
+	return r.WithContext(context.WithValue(r.Context(), githubPayloadKey, payload))
 }
 
 func getGitHubPayload(ctx context.Context) []byte {
-	if rv := ctx.Value(payloadKey); rv != nil {
+	if rv := ctx.Value(githubPayloadKey); rv != nil {
 		if t, ok := rv.([]byte); ok {
 			return t
 		}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -34,8 +34,8 @@ type (
 
 const (
 	// These are private custom types to avoid key collisions.
-	RequestContext requestContextKey = 0
-	payloadKey     requestContextKey = 3
+	RequestContext   requestContextKey = 0
+	githubPayloadKey requestContextKey = 3
 )
 
 type projCtxMiddleware struct{}
@@ -938,15 +938,15 @@ func (m *githubAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	r = setPayload(r, payload)
+	r = setGitHubPayload(r, payload)
 	next(rw, r)
 }
 
-func setPayload(r *http.Request, payload []byte) *http.Request {
+func setGitHubPayload(r *http.Request, payload []byte) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), payloadKey, payload))
 }
 
-func getPayload(ctx context.Context) []byte {
+func getGitHubPayload(ctx context.Context) []byte {
 	if rv := ctx.Value(payloadKey); rv != nil {
 		if t, ok := rv.([]byte); ok {
 			return t

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -932,7 +932,6 @@ func (m *githubAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request
 	r.Body = io.NopCloser(bytes.NewBuffer(payload))
 
 	_, err = github.ValidatePayload(r, githubSecret)
-
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":  "GitHub hook",
@@ -940,7 +939,7 @@ func (m *githubAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request
 			"msg_id":  r.Header.Get("X-Github-Delivery"),
 			"event":   r.Header.Get("X-Github-Event"),
 		}))
-		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(errors.Wrap(err, "unable to validate github payload")))
+		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating github payload")))
 		return
 	}
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -137,6 +137,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}/client_urls").Version(2).Get().RouteHandler(makeGetDistroClientURLs(env))
 
 	app.AddRoute("/hooks/github").Version(2).Post().Wrap(requireValidGithubPayload).RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
+	// Middleware is omitted for hooks/aws routes because they cannot be called by users and validation occurs in Parse function.
 	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeEC2SNS(env, opts.APIQueue))
 	app.AddRoute("/hooks/aws/ecs").Version(2).Post().RouteHandler(makeECSSNS(env, opts.APIQueue))
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -34,6 +34,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 
 	// Middleware
 	requireUser := gimlet.NewRequireAuthHandler()
+	requireValidGithubPayload := NewGithubAuthMiddleware()
 	requireTask := NewTaskAuthMiddleware()
 	requireTaskHost := NewTaskHostAuthMiddleware()
 	requireHost := NewHostAuthMiddleware()
@@ -135,8 +136,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	// client_urls is used by the agent monitor deploy job which does not pass in user info
 	app.AddRoute("/distros/{distro_id}/client_urls").Version(2).Get().RouteHandler(makeGetDistroClientURLs(env))
 
-	// Middleware is omitted for webhook routes because they cannot be called by users and validation occurs in Parse function.
-	app.AddRoute("/hooks/github").Version(2).Post().RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
+	app.AddRoute("/hooks/github").Version(2).Post().Wrap(requireValidGithubPayload).RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
 	app.AddRoute("/hooks/aws").Version(2).Post().RouteHandler(makeEC2SNS(env, opts.APIQueue))
 	app.AddRoute("/hooks/aws/ecs").Version(2).Post().RouteHandler(makeECSSNS(env, opts.APIQueue))
 


### PR DESCRIPTION
EVG-18002

### Description
This adds a middleware that makes sure that the github payload is valid. While this adds some duplication, middleware is still the right place to handle auth, and parsing the body shouldn't be expensive. 

### Testing
Testing by creating a PR on staging and ensuring that we can still receive webhooks. 
