### PR TITLE
EVG-14117: do not make commit queue tasks essential

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -645,7 +645,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			// When a GitHub PR patch is finalized with the PR alias, all of the
 			// tasks selected by the alias must finish in order for the
 			// build/version to be finished.
-			ActivatedTasksAreEssentialToComplete: evergreen.IsGitHubPatchRequester(requester),
+			ActivatedTasksAreEssentialToComplete: requester == evergreen.GithubPRRequester,
 		}
 		var build *build.Build
 		var tasks task.Tasks


### PR DESCRIPTION
EVG-14117

### Description
I believe there's currently two bugs, one of which I addressed here, which is that commit queue merges aren't being marked finished because they're marked essential (`evergreen.IsGithubRequester` includes the merge requester). Unfortunately, the actual bug was re-opened before #6521 was committed/deployed, so this is not the primary cause of the issue. There will be a follow-up PR to fix the other bug (which is a race).

### Testing
It seemed like a small enough change to just do it by inspection.

### Documentation
N/A