### PR TITLE
EVG-17174: fix team reviewer for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
     commit-message:
       prefix: "CHORE: "
     reviewers:
-      - evg-app
+      - evergreen-ci/evg-app


### PR DESCRIPTION
EVG-17174

### Description
I forgot that Dependabot has specific syntax if you request a team vs. request a specific user, so I fixed it to include the org name.

### Testing
I don't have a way to test this in advance of merging, so I'm just gonna believe the Dependabot docs that this is the right syntax.
