### PR TITLE
EVG-19998 use UnattainableDependency field for the schedulable tasks query

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -31,7 +31,7 @@ var (
 		{Key: ActivatedKey, Value: 1},
 		{Key: PriorityKey, Value: 1},
 		{Key: OverrideDependenciesKey, Value: 1},
-		{Key: bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey), Value: 1},
+		{Key: UnattainableDependencyKey, Value: 1},
 	}
 )
 
@@ -717,7 +717,7 @@ func schedulableHostTasksQuery() bson.M {
 		ByExecutionPlatform(ExecutionPlatformHost),
 		// Filter tasks containing unattainable dependencies
 		{"$or": []bson.M{
-			{bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true}},
+			{UnattainableDependencyKey: false},
 			{OverrideDependenciesKey: true},
 		}},
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1265,7 +1265,7 @@ func UnscheduleStaleUnderwaterHostTasks(distroID string) (int, error) {
 		},
 	}
 
-	// Force the query to use 'distro_1_status_1_activated_1_priority_1_override_dependencies_1_depends_on.unattainable_1'
+	// Force the query to use 'distro_1_status_1_activated_1_priority_1_override_dependencies_1_unattainable_dependency_1'
 	// instead of defaulting to 'status_1_depends_on.status_1_depends_on.unattainable_1'.
 	info, err := UpdateAllWithHint(query, update, ActivatedTasksByDistroIndex)
 	if err != nil {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1577,7 +1577,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: true,
 				},
 			},
-			Priority: 0,
+			UnattainableDependency: true,
+			Priority:               0,
 		},
 		{
 			Id:        "t1",
@@ -1593,7 +1594,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: false,
 				},
 			},
-			Priority: 0,
+			UnattainableDependency: false,
+			Priority:               0,
 		},
 		{
 			Id:        "t2",
@@ -1606,7 +1608,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: true,
 				},
 			},
-			OverrideDependencies: true,
+			UnattainableDependency: true,
+			OverrideDependencies:   true,
 		},
 	}
 	for _, task := range tasks {


### PR DESCRIPTION
[EVG-19998](https://jira.mongodb.org/browse/EVG-19998)

### Description
#6570 added the `UnattainableDependency` field to a task which caches whether the task is blocked on a dependency. The changes were deployed on 6/7. After a week any tasks that have not run will have been deactivated by the scheduler ([here](https://github.com/evergreen-ci/evergreen/blob/68ed1ad907490e58d66203bc619f19123dc50655/model/task/task.go#L1248-L1276)). So by Friday all schedulable tasks will have this field set and we're all clear to use the new field in the query.

I'll make sure this doesn't get deployed until Monday. We'll need to build the index on prod before it's deployed.

### Testing
I built the index in staging and the query used the index as expected. When the code was deployed to staging the scheduler picked up my task and scheduled it, fwiw.