### PR TITLE
EVG-19867 Allow host.create to use function vars

### DIFF
--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -105,25 +105,25 @@ func CreateHostsFromTask(ctx context.Context, settings *evergreen.Settings, t *t
 	createHostCmds := []apimodels.CreateHost{}
 	catcher := grip.NewBasicCatcher()
 	for _, commandConf := range projectTask.Commands {
-		var createHost *apimodels.CreateHost
+		var cmds []model.PluginCommandConf
 		if commandConf.Function != "" {
-			cmds := proj.Functions[commandConf.Function]
-			for _, cmd := range cmds.List() {
-				createHost, err = createHostFromCommand(cmd)
-				if err != nil {
-					return err
-				}
-				if createHost == nil {
-					continue
-				}
-				createHostCmds = append(createHostCmds, *createHost)
-			}
+			cmds = proj.Functions[commandConf.Function].List()
 		} else {
-			createHost, err = createHostFromCommand(commandConf)
+			cmds = []model.PluginCommandConf{commandConf}
+		}
+		for _, cmd := range cmds {
+			createHost, err := createHostFromCommand(cmd)
 			if err != nil {
 				return err
 			}
 			if createHost == nil {
+				continue
+			}
+			cmdExpansions := util.NewExpansions(commandConf.Vars)
+			cmdExpansions.Update(expansions.Map())
+			err = createHost.Expand(cmdExpansions)
+			if err != nil {
+				catcher.Wrap(err, "handling expansions")
 				continue
 			}
 			createHostCmds = append(createHostCmds, *createHost)
@@ -135,11 +135,6 @@ func CreateHostsFromTask(ctx context.Context, settings *evergreen.Settings, t *t
 
 	hosts := []host.Host{}
 	for _, createHost := range createHostCmds {
-		err = createHost.Expand(expansions)
-		if err != nil {
-			catcher.Wrap(err, "handling expansions")
-			continue
-		}
 		err = createHost.Validate()
 		if err != nil {
 			catcher.Add(err)

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -184,6 +184,7 @@ buildvariants:
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
 			assert.Equal(t, "sg-provided", ec2Settings.SecurityGroupIDs[0])
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
+			assert.Equal(t, h.Distro.Id, "distro")
 		}
 	})
 
@@ -257,20 +258,27 @@ buildvariants:
 			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
 			assert.Equal(t, "sg-provided", ec2Settings.SecurityGroupIDs[0])
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
+			assert.Equal(t, h.Distro.Id, "distro")
 		}
 	})
 
-	t.Run("SecurityGroupNotProvided", func(t *testing.T) {
+	t.Run("WithCommandVars", func(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(host.Collection))
 		versionYaml := `
+functions:
+  make-host:
+    command: host.create
+    params:
+      distro: ${distro}
+      scope: task
+      num_hosts: 2
+      security_group_ids: [sg-provided]
 tasks:
 - name: t3
   commands:
-  - command: host.create
-    params:
+  - func: "make-host"
+    vars:
       distro: distro
-      scope: task
-      num_hosts: 3
 buildvariants:
 - name: "bv"
   tasks:
@@ -296,7 +304,6 @@ buildvariants:
 			RunningTask: t3.Id,
 		}
 		assert.NoError(t, h3.Insert())
-
 		pp := &model.ParserProject{}
 		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
 		assert.NoError(t, err)
@@ -308,10 +315,11 @@ buildvariants:
 		}
 		assert.NoError(t, evergreen.UpdateConfig(settings))
 
-		assert.NoError(t, CreateHostsFromTask(ctx, settings, &t3, user.DBUser{Id: "me"}, ""))
+		err = CreateHostsFromTask(ctx, settings, &t3, user.DBUser{Id: "me"}, "")
+		assert.NoError(t, err)
 		createdHosts, err := host.Find(host.IsUninitialized)
 		assert.NoError(t, err)
-		assert.Len(t, createdHosts, 3)
+		assert.Len(t, createdHosts, 2)
 		for _, h := range createdHosts {
 			assert.Equal(t, "me", h.StartedBy)
 			assert.True(t, h.UserHost)
@@ -321,9 +329,78 @@ buildvariants:
 			assert.NoError(t, ec2Settings.FromDistroSettings(h.Distro, ""))
 			assert.NotEmpty(t, ec2Settings.KeyName)
 			assert.InDelta(t, time.Now().Add(evergreen.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
+			require.Len(t, ec2Settings.SecurityGroupIDs, 1)
+			assert.Equal(t, "sg-provided", ec2Settings.SecurityGroupIDs[0])
+			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
+			assert.Equal(t, h.Distro.Id, "distro")
+		}
+	})
+
+	t.Run("SecurityGroupNotProvided", func(t *testing.T) {
+		assert.NoError(t, db.ClearCollections(host.Collection))
+		versionYaml := `
+tasks:
+- name: t4
+  commands:
+  - command: host.create
+    params:
+      distro: distro
+      scope: task
+      num_hosts: 3
+buildvariants:
+- name: "bv"
+  tasks:
+  - name: t4
+`
+		v4 := model.Version{
+			Id:         "v4",
+			Identifier: "p",
+		}
+		assert.NoError(t, v4.Insert())
+		t4 := task.Task{
+			Id:           "t4",
+			DisplayName:  "t4",
+			Version:      "v4",
+			DistroId:     "distro",
+			Project:      "p",
+			BuildVariant: "bv",
+			HostId:       "h4",
+		}
+		assert.NoError(t, t4.Insert())
+		h4 := host.Host{
+			Id:          "h4",
+			RunningTask: t4.Id,
+		}
+		assert.NoError(t, h4.Insert())
+
+		pp := &model.ParserProject{}
+		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
+		assert.NoError(t, err)
+		pp.Id = "v4"
+		assert.NoError(t, pp.Insert())
+
+		settings := &evergreen.Settings{
+			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
+		}
+		assert.NoError(t, evergreen.UpdateConfig(settings))
+
+		assert.NoError(t, CreateHostsFromTask(ctx, settings, &t4, user.DBUser{Id: "me"}, ""))
+		createdHosts, err := host.Find(host.IsUninitialized)
+		assert.NoError(t, err)
+		assert.Len(t, createdHosts, 3)
+		for _, h := range createdHosts {
+			assert.Equal(t, "me", h.StartedBy)
+			assert.True(t, h.UserHost)
+			assert.Equal(t, t4.Id, h.ProvisionOptions.TaskId)
+			assert.Len(t, h.Distro.ProviderSettingsList, 1)
+			ec2Settings := &cloud.EC2ProviderSettings{}
+			assert.NoError(t, ec2Settings.FromDistroSettings(h.Distro, ""))
+			assert.NotEmpty(t, ec2Settings.KeyName)
+			assert.InDelta(t, time.Now().Add(evergreen.DefaultSpawnHostExpiration).Unix(), h.ExpirationTime.Unix(), float64(1*time.Millisecond))
 			require.Len(t, ec2Settings.SecurityGroupIDs, 2)
 			assert.Equal(t, "sg-distro", ec2Settings.SecurityGroupIDs[0]) // if not overridden, stick with ec2 security group
 			assert.Equal(t, distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
+			assert.Equal(t, h.Distro.Id, "distro")
 		}
 	})
 }


### PR DESCRIPTION
EVG-19867

### Description
Functions that include `host.create` that pass in variables have those variables get ignored when `Also start any hosts this task started (if applicable)` is set in the UI and `CreateHostsFromTask` is run. If the distro value is set there, it will cause the spawn host command to fail, saying that no distro was specified.

The git diff is treating it weirdly but `WithCommandVars` is the new test case. I also refactored some of the looping logic at the beginning of the function to be more succinct.
### Testing
Test-driven approach, wrote initially failing tests and added change to fix them.
### Documentation
n/a