### PR TITLE
EVG-19296 correctly consider system unresponsive tasks for notifications

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1351,6 +1351,14 @@ func (t *Task) MarkSystemFailed(description string) error {
 	t.FinishTime = time.Now()
 	t.Details = GetSystemFailureDetails(description)
 
+	switch t.ExecutionPlatform {
+	case ExecutionPlatformHost:
+		event.LogHostTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed)
+	case ExecutionPlatformContainer:
+		event.LogContainerTaskFinished(t.Id, t.Execution, t.PodID, evergreen.TaskSystemFailed)
+	default:
+		event.LogTaskFinished(t.Id, t.Execution, evergreen.TaskSystemFailed)
+	}
 	grip.Info(message.Fields{
 		"message":            "marking task system failed",
 		"included_on":        evergreen.ContainerHealthDashboard,
@@ -1366,7 +1374,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 	t.ContainerAllocated = false
 	t.ContainerAllocatedTime = time.Time{}
 
-	err := UpdateOne(
+	return UpdateOne(
 		bson.M{
 			IdKey: t.Id,
 		},
@@ -1382,18 +1390,6 @@ func (t *Task) MarkSystemFailed(description string) error {
 			},
 		},
 	)
-	if err != nil {
-		return err
-	}
-	switch t.ExecutionPlatform {
-	case ExecutionPlatformHost:
-		event.LogHostTaskFinished(t.Id, t.Execution, t.HostId, evergreen.TaskSystemFailed)
-	case ExecutionPlatformContainer:
-		event.LogContainerTaskFinished(t.Id, t.Execution, t.PodID, evergreen.TaskSystemFailed)
-	default:
-		event.LogTaskFinished(t.Id, t.Execution, evergreen.TaskSystemFailed)
-	}
-	return nil
 }
 
 // GetSystemFailureDetails returns a task's end details based on an input description.

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -712,7 +712,7 @@ func (t *taskTriggers) taskRuntimeChange(sub *event.Subscription) (*notification
 // For example, it excludes  setup failures.
 func isValidFailedTaskStatus(status string) bool {
 	return status == evergreen.TaskFailed || status == evergreen.TaskSystemFailed ||
-		status == evergreen.TaskTimedOut || status == evergreen.TaskTestTimedOut
+		status == evergreen.TaskSystemUnresponse || status == evergreen.TaskTimedOut || status == evergreen.TaskTestTimedOut
 }
 
 func isTestStatusRegression(oldStatus, newStatus string) bool {


### PR DESCRIPTION
EVG-19296 
### Description
In this ticket, Jeff mentioned that some system failures still aren't being logged. Looking for example at [this task](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_rhel_80_64_bit_dynamic_all_feature_flags_required_display_sharding_clustered_collections_e8b6fe12d6a962e537ef2503a22789936f507a3f_23_04_06_05_57_13/execution-tasks?execution=9&sorts=STATUS%3AASC), the [notification is nil for the subscription](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1680753600&latest=1680926400&q=search%20index%3Devergreen%20%22642f064a562343b05d90779d%22%7C%20spath%20subscription_id%20%7C%20search%20subscription_id%3D61bcf367c9ec443c5b7e9fd1&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&display.page.search.tab=events&display.general.type=events&sid=1686161603.5364544) even though it should correctly [hit this trigger](https://github.com/evergreen-ci/evergreen/blob/771dd58bb09defbbba0788186bba012ac198906b/trigger/task.go#L415).

"system-unresponsive" was not being considered a valid task status. 
