### PR TITLE
EVG-17141: Expose project alias description field

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -732,6 +732,7 @@ type ComplexityRoot struct {
 
 	ProjectAlias struct {
 		Alias       func(childComplexity int) int
+		Description func(childComplexity int) int
 		GitTag      func(childComplexity int) int
 		ID          func(childComplexity int) int
 		RemotePath  func(childComplexity int) int
@@ -4962,6 +4963,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProjectAlias.Alias(childComplexity), true
+
+	case "ProjectAlias.description":
+		if e.complexity.ProjectAlias.Description == nil {
+			break
+		}
+
+		return e.complexity.ProjectAlias.Description(childComplexity), true
 
 	case "ProjectAlias.gitTag":
 		if e.complexity.ProjectAlias.GitTag == nil {
@@ -34292,6 +34300,47 @@ func (ec *executionContext) fieldContext_ProjectAlias_alias(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _ProjectAlias_description(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectAlias) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProjectAlias_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProjectAlias_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectAlias",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProjectAlias_gitTag(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectAlias) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ProjectAlias_gitTag(ctx, field)
 	if err != nil {
@@ -35010,6 +35059,8 @@ func (ec *executionContext) fieldContext_ProjectEventSettings_aliases(ctx contex
 				return ec.fieldContext_ProjectAlias_id(ctx, field)
 			case "alias":
 				return ec.fieldContext_ProjectAlias_alias(ctx, field)
+			case "description":
+				return ec.fieldContext_ProjectAlias_description(ctx, field)
 			case "gitTag":
 				return ec.fieldContext_ProjectAlias_gitTag(ctx, field)
 			case "remotePath":
@@ -35456,6 +35507,8 @@ func (ec *executionContext) fieldContext_ProjectSettings_aliases(ctx context.Con
 				return ec.fieldContext_ProjectAlias_id(ctx, field)
 			case "alias":
 				return ec.fieldContext_ProjectAlias_alias(ctx, field)
+			case "description":
+				return ec.fieldContext_ProjectAlias_description(ctx, field)
 			case "gitTag":
 				return ec.fieldContext_ProjectAlias_gitTag(ctx, field)
 			case "remotePath":
@@ -41526,6 +41579,8 @@ func (ec *executionContext) fieldContext_RepoSettings_aliases(ctx context.Contex
 				return ec.fieldContext_ProjectAlias_id(ctx, field)
 			case "alias":
 				return ec.fieldContext_ProjectAlias_alias(ctx, field)
+			case "description":
+				return ec.fieldContext_ProjectAlias_description(ctx, field)
 			case "gitTag":
 				return ec.fieldContext_ProjectAlias_gitTag(ctx, field)
 			case "remotePath":
@@ -60329,7 +60384,7 @@ func (ec *executionContext) unmarshalInputProjectAliasInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "alias", "gitTag", "remotePath", "task", "taskTags", "variant", "variantTags"}
+	fieldsInOrder := [...]string{"id", "alias", "description", "gitTag", "remotePath", "task", "taskTags", "variant", "variantTags"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -60354,6 +60409,15 @@ func (ec *executionContext) unmarshalInputProjectAliasInput(ctx context.Context,
 				return it, err
 			}
 			it.Alias = data
+		case "description":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Description = data
 		case "gitTag":
 			var err error
 
@@ -67566,6 +67630,10 @@ func (ec *executionContext) _ProjectAlias(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "description":
+
+			out.Values[i] = ec._ProjectAlias_description(ctx, field, obj)
+
 		case "gitTag":
 
 			out.Values[i] = ec._ProjectAlias_gitTag(ctx, field, obj)

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -34,6 +34,7 @@ input MoveProjectInput {
 input ProjectAliasInput {
   id: String!
   alias: String!
+  description: String
   gitTag: String!
   remotePath: String!
   task: String!

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -181,6 +181,7 @@ type ProjectEventSettings {
 type ProjectAlias {
   id: String!
   alias: String!
+  description: String
   gitTag: String!
   remotePath: String!
   task: String!


### PR DESCRIPTION
EVG-17141

### Description
- Expose fields via GraphQL. These fields will be made required (`!`) after the front end is updated to fetch/save `description`.