### PR TITLE
EVG-17957 Check for multiple pod secrets across new and original lists

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1994,6 +1994,23 @@ func TestValidateContainerSecrets(t *testing.T) {
 		}
 		_, err := ValidateContainerSecrets(&settings, projectID, nil, toUpdate)
 		assert.Error(t, err)
+
+		toUpdate = []ContainerSecret{
+			{
+				Name:  "pear",
+				Type:  ContainerSecretPodSecret,
+				Value: "abcde",
+			},
+		}
+		original := []ContainerSecret{
+			{
+				Name:  "dragonfruit",
+				Type:  ContainerSecretPodSecret,
+				Value: "abcde",
+			},
+		}
+		_, err = ValidateContainerSecrets(&settings, projectID, original, toUpdate)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
EVG-17957

### Description
A pod is supposed to be able to have at most one pod secret, but I was able to set two pod secrets for the same project without an error because the validation we do for secrets to update only checks the new list of secrets and doesn't first check if there are existing pod secrets.

### Testing
Wrote initially failing test, and confirmed it now passes