### PR TITLE
hotfix: Comment out idle termination job populator

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -271,21 +271,23 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 
 func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
-		if err != nil {
-			return errors.Wrap(err, "getting service flags")
-		}
-
-		if flags.MonitorDisabled {
-			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-				"message": "monitor is disabled",
-				"impact":  "not submitting detecting idle hosts",
-				"mode":    "degraded",
-			})
-			return nil
-		}
-
-		return queue.Put(ctx, NewIdleHostTerminationJob(env, utility.RoundPartOfHour(1).Format(TSFormat)))
+		// Hot fix for DB upgrade issue
+		return nil
+		// flags, err := evergreen.GetServiceFlags()
+		// if err != nil {
+		//     return errors.Wrap(err, "getting service flags")
+		// }
+		//
+		// if flags.MonitorDisabled {
+		//     grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
+		//         "message": "monitor is disabled",
+		//         "impact":  "not submitting detecting idle hosts",
+		//         "mode":    "degraded",
+		//     })
+		//     return nil
+		// }
+		//
+		// return queue.Put(ctx, NewIdleHostTerminationJob(env, utility.RoundPartOfHour(1).Format(TSFormat)))
 	}
 }
 


### PR DESCRIPTION
The server upgrade is causing the idle host query within the job to stall. For now, we don't have a fine-grained way to stop the job without just commenting it out.