### PR TITLE
EVG-20112 hint for IdleEphemeralGroupedByDistroID

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -205,7 +205,7 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 		},
 	}
 
-	if err := db.Aggregate(Collection, pipeline, &idlehostsByDistroID); err != nil {
+	if err := db.AggregateWithHint(Collection, pipeline, startedByStatusIndex, &idlehostsByDistroID); err != nil {
 		return nil, errors.Wrap(err, "grouping idle hosts by distro ID")
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1965,6 +1965,18 @@ var StatusIndex = bson.D{
 	},
 }
 
+// startedByStatusIndex is the started_by_1_status_1 index.
+var startedByStatusIndex = bson.D{
+	{
+		Key:   StartedByKey,
+		Value: 1,
+	},
+	{
+		Key:   StatusKey,
+		Value: 1,
+	},
+}
+
 func CountInactiveHostsByProvider() ([]InactiveHostCounts, error) {
 	var counts []InactiveHostCounts
 	err := db.Aggregate(Collection, inactiveHostCountPipeline(), &counts)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1920,10 +1920,21 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 	}
 }
 
+func setupIdleHostQueryIndex(t *testing.T) {
+	require.NoError(t, db.EnsureIndex(Collection, mongo.IndexModel{
+		Keys: startedByStatusIndex,
+	}))
+}
+
 func TestIdleEphemeralGroupedByDistroID(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	setupIdleHostQueryIndex(t)
+
+	defer func() {
+		assert.NoError(db.DropCollections(Collection))
+	}()
 
 	const (
 		d1 = "distro1"

--- a/units/crons.go
+++ b/units/crons.go
@@ -271,23 +271,21 @@ func PopulateHostTerminationJobs(env evergreen.Environment) amboy.QueueOperation
 
 func PopulateIdleHostJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		// Hot fix for DB upgrade issue
-		return nil
-		// flags, err := evergreen.GetServiceFlags()
-		// if err != nil {
-		//     return errors.Wrap(err, "getting service flags")
-		// }
-		//
-		// if flags.MonitorDisabled {
-		//     grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
-		//         "message": "monitor is disabled",
-		//         "impact":  "not submitting detecting idle hosts",
-		//         "mode":    "degraded",
-		//     })
-		//     return nil
-		// }
-		//
-		// return queue.Put(ctx, NewIdleHostTerminationJob(env, utility.RoundPartOfHour(1).Format(TSFormat)))
+		flags, err := evergreen.GetServiceFlags()
+		if err != nil {
+			return errors.Wrap(err, "getting service flags")
+		}
+
+		if flags.MonitorDisabled {
+			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
+				"message": "monitor is disabled",
+				"impact":  "not submitting detecting idle hosts",
+				"mode":    "degraded",
+			})
+			return nil
+		}
+
+		return queue.Put(ctx, NewIdleHostTerminationJob(env, utility.RoundPartOfHour(1).Format(TSFormat)))
 	}
 }
 

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -42,7 +42,8 @@ func numIdleHostsFound(ctx context.Context, env evergreen.Environment, t *testin
 // test.
 func testFlaggingIdleHostsSetupTest(t *testing.T) {
 	require.NoError(t, db.DropCollections(host.Collection, distro.Collection), "dropping collections")
-	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey), "adding host index")
+	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey), "adding running_task_1 index")
+	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, false, false, host.StartedByKey, host.StatusKey), "adding started_by_1_status_1 index")
 }
 
 // testFlaggingIdleHostsTeardownTest resets the relevant DB collections after a


### PR DESCRIPTION
[EVG-20112](https://jira.mongodb.org/browse/EVG-20112)

### Description
Upgrading the db to 6.0 caused this query to stop using the expected index and the query was getting stuck. It seems that the sort on `creation_time` was causing it to prefer the `creation_time_1` index instead of using the `started_by_1_status_1`.

### Testing
The explain plan is much better now. I'll take it for a spin in staging to make sure it works.
