### PR TITLE
EVG-20112 build the host index in tests

### DIFF
--- a/cmd/load-smoke-data/load-smoke-data.go
+++ b/cmd/load-smoke-data/load-smoke-data.go
@@ -75,8 +75,9 @@ func insertFileDocsToDB(ctx context.Context, fn string, db *mongo.Database, logs
 			return errors.Wrap(err, "creating task indexes")
 		}
 	case host.Collection:
-		if _, err = collection.Indexes().CreateOne(ctx, mongo.IndexModel{
-			Keys: host.StatusIndex,
+		if _, err = collection.Indexes().CreateMany(ctx, []mongo.IndexModel{
+			{Keys: host.StatusIndex},
+			{Keys: host.StartedByStatusIndex},
 		}); err != nil {
 			return errors.Wrap(err, "creating host index")
 		}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -205,7 +205,7 @@ func IdleEphemeralGroupedByDistroID() ([]IdleHostsByDistroID, error) {
 		},
 	}
 
-	if err := db.AggregateWithHint(Collection, pipeline, startedByStatusIndex, &idlehostsByDistroID); err != nil {
+	if err := db.AggregateWithHint(Collection, pipeline, StartedByStatusIndex, &idlehostsByDistroID); err != nil {
 		return nil, errors.Wrap(err, "grouping idle hosts by distro ID")
 	}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1965,8 +1965,8 @@ var StatusIndex = bson.D{
 	},
 }
 
-// startedByStatusIndex is the started_by_1_status_1 index.
-var startedByStatusIndex = bson.D{
+// StartedByStatusIndex is the started_by_1_status_1 index.
+var StartedByStatusIndex = bson.D{
 	{
 		Key:   StartedByKey,
 		Value: 1,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1922,7 +1922,7 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 
 func setupIdleHostQueryIndex(t *testing.T) {
 	require.NoError(t, db.EnsureIndex(Collection, mongo.IndexModel{
-		Keys: startedByStatusIndex,
+		Keys: StartedByStatusIndex,
 	}))
 }
 

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -463,8 +463,7 @@ func TestFlaggingIdleHostsWhenNonZeroMinimumHosts(t *testing.T) {
 
 func TestPopulateIdleHostJobsCalculations(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.DropCollections(host.Collection))
-	assert.NoError(db.DropCollections(distro.Collection))
+	assert.NoError(db.DropCollections(host.Collection, distro.Collection))
 	defer func() {
 		assert.NoError(db.DropCollections(host.Collection, distro.Collection))
 	}()


### PR DESCRIPTION
[EVG-20112](https://jira.mongodb.org/browse/EVG-20112)

### Description
#6637 added a hint for the `IdleEphemeralGroupedByDistroID` query but missed a test and the smoke tests. This PR adds the index for that test and for the smoke test.

### Testing
Ostensibly test-units will pass now.
