### PR TITLE
EVG-20146 Point container configuration to ECR image

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -736,7 +736,7 @@ buildvariants:
 containers:
   - name: evg-container
     working_dir: /
-    image: "hadjri/evg-container-self-testing"
+    image: "557821124784.dkr.ecr.us-east-1.amazonaws.com/evergreen/production-ecs:latest"
     resources:
       cpu: 4096
       memory_mb: 8192


### PR DESCRIPTION
EVG-20146

### Description
Dockerhub has been rate limiting our image pulls in prod, causing tasks to sometimes system-fail. Migration to ECR will circumvent this issue. Created a new ECR repo: https://us-east-1.console.aws.amazon.com/ecr/repositories/private/557821124784/evergreen/production-ecs?region=us-east-1 and pushed the same Dockerfile as we have in version control to it.
### Testing
Ran a [task](https://spruce.mongodb.com/task/evergreen_ubuntu2004_container_test_model_build_patch_e877efc1e8e3c8f0d31f32cff00fac3097ce68ef_648756a161837d46a5630ff7_23_06_12_17_32_29/tests?execution=0&sortBy=STATUS&sortDir=ASC) using this new image to confirm that we had the correct permissions in place for the ECS instances.
