### PR TITLE
EVG-20157: Avoid potentially blocking startTask and improve command panic handler

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -232,7 +232,7 @@ func (s *AgentSuite) TestFinishTaskEndTaskError() {
 	s.Error(err)
 }
 
-func (s *AgentSuite) TestCancelStartTask() {
+func (s *AgentSuite) TestCancelledStartTaskIsNonBlocking() {
 	complete := make(chan string)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -241,7 +241,7 @@ func (s *AgentSuite) TestCancelStartTask() {
 	s.Zero(len(msgs))
 }
 
-func (s *AgentSuite) TestCancelRunCommands() {
+func (s *AgentSuite) TestCancelledRunningCommandsIsNonBlocking() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	cmd := model.PluginCommandConf{

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -41,6 +41,7 @@ type Mock struct {
 	loggingShouldFail           bool
 	NextTaskResponse            *apimodels.NextTaskResponse
 	NextTaskIsNil               bool
+	StartTaskShouldFail         bool
 	EndTaskResponse             *apimodels.EndTaskResponse
 	EndTaskShouldFail           bool
 	EndTaskResult               endTaskResult
@@ -116,7 +117,12 @@ func (c *Mock) GetAgentSetupData(ctx context.Context) (*apimodels.AgentSetupData
 	return &apimodels.AgentSetupData{}, nil
 }
 
-func (c *Mock) StartTask(ctx context.Context, td TaskData) error { return nil }
+func (c *Mock) StartTask(ctx context.Context, td TaskData) error {
+	if c.StartTaskShouldFail {
+		return errors.New("start task mock failure")
+	}
+	return nil
+}
 
 // EndTask returns a mock EndTaskResponse.
 func (c *Mock) EndTask(ctx context.Context, detail *apimodels.TaskEndDetail, td TaskData) (*apimodels.EndTaskResponse, error) {

--- a/agent/task.go
+++ b/agent/task.go
@@ -20,13 +20,13 @@ import (
 func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- string) {
 	defer func() {
 		if pErr := recovery.HandlePanicWithError(recover(), nil, "running commands"); pErr != nil {
-			m := message.Fields{
+			msg := message.Fields{
 				"message":   "programmatic error: task panicked while running task",
 				"operation": "running task",
-				"stack":     message.NewStack(1, "").Raw(),
+				"stack":     message.NewStack(2, "").Raw(),
 			}
-			grip.Alert(message.WrapError(pErr, m))
-			tc.logger.Execution().Error("Evergreen agent hit a runtime panic, marking task system-failed.")
+			grip.Alert(message.WrapError(pErr, msg))
+			tc.logger.Execution().Error("programmatic error: Evergreen agent hit a runtime panic while running task, marking task system-failed.")
 			trySendTaskComplete(tc.logger.Execution(), complete, evergreen.TaskSystemFailed)
 		}
 	}()


### PR DESCRIPTION
EVG-20157

### Description
This fixes a couple issues in `startTask` around its handling of sending complete channel messages, as well as some bugs with the way the panic handlers are written.

* Buffer the complete channel in case it's already full or there is no consumer (for example, if `wait` has moved on due to the heartbeat requesting an abort, `startTask` can block forever). This avoids goroutine leaks in the agent.
* Fix the panic handler for running individual commands and for doing task setup.
    * Log panic cases where possible both to the execution logs and to Splunk. The agent is not supposed to panic unless there's a bug, so we need a way to be alerted to it.
* Spruce up the agent test suite. Unfortunately, it seems like it's really out of date, has accumulated a lot of copy-pasting, and itself is buggy because it's not correctly testing the conditions described in the test case. I tried getting it to test what the test cases state they're supposed to test, but didn't fix every single issue because some of them will be reworked in the agent refactor anyways.
* Slightly improve documentation on the special `evergreen.TaskSystemFailed` status, which has a special meaning in the agent indicating that it failed to perform setup for the task it's trying to run.

### Testing
This condition is somewhat difficult to simulate, but I wrote a unit test for it.

### Documentation
N/A