### PR TITLE
EVG-20073 Create versions for GitHub merge queue

### DIFF
--- a/config_test/evg_settings.yml
+++ b/config_test/evg_settings.yml
@@ -35,6 +35,7 @@ providers:
     # connecting to AWS.
     pod:
       ecs:
+        allowed_images: ["hadjri/evg-container-self-tests"]
         client_type: "mock"
       secrets_manager:
         client_type: "mock"

--- a/docs/decisions/2023-06-05_github_merge_queue.md
+++ b/docs/decisions/2023-06-05_github_merge_queue.md
@@ -45,6 +45,11 @@ to make a new type. A disadvantage is that anyone downstream who has written
 queries that assumes the number of requesters is fixed will need to take into
 account the new requester.
 
+### Inter-Project Triggers
+
+The GitHub merge queue integration does not create inter-project triggers. This
+will be left to another project if there is interest from users.
+
 ### Post results
 
 Post a check to the checks API. Note that GitHub "status checks" are of two
@@ -59,7 +64,7 @@ the PR to the merge queue.
 
 * [x] There is a new patch intent type in
 [model/patch](https://github.com/evergreen-ci/evergreen/blob/main/model/patch/github_merge_intent.go)
-* [ ] The intent will be procssed by the amboy [patch-intent-processor
+* [x] The intent will be procssed by the amboy [patch-intent-processor
 job](https://github.com/evergreen-ci/evergreen/blob/main/units/patch_intent.go).
 * [ ] New clone logic in the agent will clone the merge group branch.
 * [ ] Evergreen will post the result to the GitHub checks API.

--- a/globals.go
+++ b/globals.go
@@ -13,6 +13,7 @@ import (
 const (
 	User            = "mci"
 	GithubPatchUser = "github_pull_request"
+	GithubMergeUser = "github_merge_queue"
 	ParentPatchUser = "parent_patch"
 
 	HostRunning       = "running"

--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -47,28 +48,42 @@ type githubMergeIntent struct {
 
 	// HeadHash is the SHA of the head of the merge group. Evergreen checks this out.
 	HeadSHA string `bson:"head_hash"`
+
+	// Owner is the GitHub repository organization name.
+	Org string `bson:"org"`
+
+	// Repo is the GitHub repository name
+	Repo string `bson:"repo"`
 }
 
 // NewGithubIntent creates an Intent from a google/go-github MergeGroup.
-func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeGroup) (Intent, error) {
+func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeGroupEvent) (Intent, error) {
 	if msgDeliveryID == "" {
 		return nil, errors.New("message ID cannot be empty")
 	}
 	if caller == "" {
 		return nil, errors.New("empty caller errors")
 	}
-	if mg.GetHeadRef() == "" {
+	if mg.GetOrg().GetName() == "" {
+		return nil, errors.New("merge group org name cannot be empty")
+	}
+	if mg.GetRepo().GetName() == "" {
+		return nil, errors.New("merge group repo name cannot be empty")
+	}
+	if headRef := mg.GetMergeGroup().GetHeadRef(); headRef == "" {
 		return nil, errors.New("merge group head ref cannot be empty")
 	}
-	if mg.GetHeadSHA() == "" {
+	if mg.GetMergeGroup().GetHeadSHA() == "" {
 		return nil, errors.New("head ref cannot be empty")
 	}
 	return &githubMergeIntent{
 		DocumentID: msgDeliveryID,
 		MsgID:      msgDeliveryID,
 		IntentType: GithubMergeIntentType,
-		HeadRef:    mg.GetHeadRef(),
-		HeadSHA:    mg.GetHeadSHA(),
+		Org:        mg.GetOrg().GetName(),
+		Repo:       mg.GetRepo().GetName(),
+		HeadRef:    mg.GetMergeGroup().GetHeadRef(),
+		HeadSHA:    mg.GetMergeGroup().GetHeadSHA(),
 		CalledBy:   caller,
 	}, nil
 }
@@ -140,13 +155,32 @@ func (g *githubMergeIntent) GetCalledBy() string {
 
 // NewPatch creates a patch document from a merge intent.
 func (g *githubMergeIntent) NewPatch() *Patch {
+	// merge_group.head_ref looks like this:
+	// refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056
+	split := strings.Split(g.HeadRef, "/")
+
+	// handle cases where base branch has a slash in it
+	baseBranchSlice := []string{}
+	for i := 3; i < len(split)-1; i++ {
+		baseBranchSlice = append(baseBranchSlice, split[i])
+	}
+	baseBranch := strings.Join(baseBranchSlice, "/")
+
+	// produce a branch name like gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056
+	headBranch := strings.Join([]string{split[2], baseBranch, split[len(split)-1]}, "/")
+
 	patchDoc := &Patch{
-		Id:     mgobson.NewObjectId(),
-		Alias:  g.GetAlias(),
-		Status: evergreen.PatchCreated,
+		Id:      mgobson.NewObjectId(),
+		Alias:   g.GetAlias(),
+		Status:  evergreen.PatchCreated,
+		Author:  evergreen.GithubMergeUser,
+		Githash: g.HeadSHA,
 		GithubMergeData: thirdparty.GithubMergeGroup{
-			HeadRef: g.HeadRef,
-			HeadSHA: g.HeadSHA,
+			Org:        g.Org,
+			Repo:       g.Repo,
+			BaseBranch: baseBranch,
+			HeadBranch: headBranch,
+			HeadSHA:    g.HeadSHA,
 		},
 	}
 	return patchDoc

--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -74,7 +74,7 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 		return nil, errors.New("merge group head ref cannot be empty")
 	}
 	if mg.GetMergeGroup().GetHeadSHA() == "" {
-		return nil, errors.New("head ref cannot be empty")
+		return nil, errors.New("head SHA cannot be empty")
 	}
 	return &githubMergeIntent{
 		DocumentID: msgDeliveryID,
@@ -167,7 +167,9 @@ func (g *githubMergeIntent) NewPatch() *Patch {
 	baseBranch := strings.Join(baseBranchSlice, "/")
 
 	// produce a branch name like gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056
-	headBranch := strings.Join([]string{split[2], baseBranch, split[len(split)-1]}, "/")
+	ghReadOnlyQueue := split[2]
+	lastElement := split[len(split)-1]
+	headBranch := strings.Join([]string{ghReadOnlyQueue, baseBranch, lastElement}, "/")
 
 	patchDoc := &Patch{
 		Id:      mgobson.NewObjectId(),

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -15,36 +15,48 @@ func TestGithubMergeIntent(t *testing.T) {
 	defer func() {
 		require.NoError(t, db.Clear(IntentCollection))
 	}()
-	for tName, tCase := range map[string]func(t *testing.T, mg *github.MergeGroup){
-		"EmptyMessageDeliveryIDErrors": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("", "auto", mg)
+	for tName, tCase := range map[string]func(t *testing.T, mge *github.MergeGroupEvent){
+		"EmptyMessageDeliveryIDErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("", "auto", mge)
 			assert.Nil(t, intent)
 			assert.Error(t, err)
 		},
-		"EmptyCallerErrors": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "", mg)
+		"EmptyCallerErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "", mge)
 			assert.Nil(t, intent)
 			assert.Error(t, err)
 		},
-		"MissingHeadRefErrors": func(t *testing.T, mg *github.MergeGroup) {
-			mg.HeadRef = nil
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"MissingHeadRefErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			mge.MergeGroup.HeadRef = nil
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.Nil(t, intent)
 			assert.Error(t, err)
 		},
-		"MissingHeadSHAErrors": func(t *testing.T, mg *github.MergeGroup) {
-			mg.HeadSHA = nil
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"MissingHeadSHAErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			mge.MergeGroup.HeadSHA = nil
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.Nil(t, intent)
 			assert.Error(t, err)
 		},
-		"CorrectArgsSucceed": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"MissingOrgErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			mge.Org.Name = nil
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
+			assert.Nil(t, intent)
+			assert.Error(t, err)
+		},
+		"MissingRepoErrors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			mge.Repo.Name = nil
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
+			assert.Nil(t, intent)
+			assert.Error(t, err)
+		},
+		"CorrectArgsSucceed": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.NotNil(t, intent)
 			assert.NoError(t, err)
 		},
-		"RoundTrip": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"RoundTrip": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.NotNil(t, intent)
 			assert.NoError(t, err)
 			assert.NoError(t, intent.Insert())
@@ -54,8 +66,8 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.Len(t, intents, 1)
 			assert.Equal(t, intent, &intents[0])
 		},
-		"SetProcessed": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"SetProcessed": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.False(t, intent.IsProcessed())
 			assert.NotNil(t, intent)
 			assert.NoError(t, err)
@@ -67,8 +79,8 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.Len(t, intents, 1)
 			assert.True(t, intents[0].IsProcessed())
 		},
-		"Accessors": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"Accessors": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.NotNil(t, intent)
 			assert.NoError(t, err)
 			assert.Equal(t, GithubMergeIntentType, intent.GetType())
@@ -84,26 +96,42 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.Equal(t, "auto", intent.GetCalledBy())
 			assert.Equal(t, evergreen.CommitQueueAlias, intent.GetAlias())
 		},
-		"NewPatch": func(t *testing.T, mg *github.MergeGroup) {
-			intent, err := NewGithubMergeIntent("abc123", "auto", mg)
+		"NewPatch": func(t *testing.T, mge *github.MergeGroupEvent) {
+			intent, err := NewGithubMergeIntent("abc123", "auto", mge)
 			assert.NotNil(t, intent)
 			assert.NoError(t, err)
 			assert.NoError(t, intent.Insert())
 			p := intent.NewPatch()
 			assert.Equal(t, evergreen.CommitQueueAlias, p.Alias)
-			assert.Equal(t, *mg.HeadSHA, p.GithubMergeData.HeadSHA)
-			assert.Equal(t, *mg.HeadRef, p.GithubMergeData.HeadRef)
+			assert.Equal(t, *mge.MergeGroup.HeadSHA, p.GithubMergeData.HeadSHA)
+			assert.Equal(t, *mge.Org.Name, p.GithubMergeData.Org)
+			assert.Equal(t, *mge.Repo.Name, p.GithubMergeData.Repo)
+			assert.Equal(t, "main", p.GithubMergeData.BaseBranch)
+			assert.Equal(t, "gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056", p.GithubMergeData.HeadBranch)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.Clear(IntentCollection))
 			HeadSHA := "a"
-			HeadRef := "b"
+			HeadRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+			OrgName := "my_org"
+			RepoName := "my_repo"
+			org := github.Organization{
+				Name: &OrgName,
+			}
+			repo := github.Repository{
+				Name: &RepoName,
+			}
 			mg := github.MergeGroup{
 				HeadSHA: &HeadSHA,
 				HeadRef: &HeadRef,
 			}
-			tCase(t, &mg)
+			mge := github.MergeGroupEvent{
+				MergeGroup: &mg,
+				Org:        &org,
+				Repo:       &repo,
+			}
+			tCase(t, &mge)
 		})
 	}
 }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -775,7 +775,7 @@ func (p *Patch) IsPRMergePatch() bool {
 // IsCommitQueuePatch returns true if the the patch is part of any commit queue:
 // either Evergreen's commit queue or GitHub's merge queue.
 func (p *Patch) IsCommitQueuePatch() bool {
-	return p.Alias == evergreen.CommitQueueAlias || p.IsPRMergePatch() || p.GithubMergeData.HeadSHA != ""
+	return p.Alias == evergreen.CommitQueueAlias || p.IsPRMergePatch() || p.IsGithubMergePatch()
 }
 
 // IsGithubMergePatch returns true if the patch is from the GitHub merge queue.

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -772,8 +772,15 @@ func (p *Patch) IsPRMergePatch() bool {
 	return p.GithubPatchData.MergeCommitSHA != ""
 }
 
+// IsCommitQueuePatch returns true if the the patch is part of any commit queue:
+// either Evergreen's commit queue or GitHub's merge queue.
 func (p *Patch) IsCommitQueuePatch() bool {
-	return p.Alias == evergreen.CommitQueueAlias || p.IsPRMergePatch()
+	return p.Alias == evergreen.CommitQueueAlias || p.IsPRMergePatch() || p.GithubMergeData.HeadSHA != ""
+}
+
+// IsGithubMergePatch returns true if the patch is from the GitHub merge queue.
+func (p *Patch) IsGithubMergePatch() bool {
+	return p.GithubMergeData.HeadSHA != ""
 }
 
 func (p *Patch) IsBackport() bool {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -216,6 +216,9 @@ func getPatchedProjectYAML(ctx context.Context, projectRef *ProjectRef, opts *Ge
 	if p.IsPRMergePatch() {
 		hash = p.GithubPatchData.MergeCommitSHA
 	}
+	if p.IsGithubMergePatch() {
+		hash = p.GithubMergeData.HeadSHA
+	}
 	opts.Revision = hash
 
 	path := projectRef.RemotePath
@@ -572,7 +575,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		AuthorEmail:         authorEmail,
 	}
 
-	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, settings)
+	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, settings, githubOauthToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing manifest")
 	}
@@ -806,6 +809,10 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 	if p.IsPRMergePatch() {
 		hash = p.GithubPatchData.MergeCommitSHA
 	}
+	if p.IsGithubMergePatch() {
+		hash = p.GithubMergeData.HeadSHA
+	}
+
 	opts := GetProjectOpts{
 		Ref:          projectRef,
 		Token:        githubOauthToken,
@@ -941,7 +948,7 @@ func AbortPatchesWithGithubPatchData(createdBefore time.Time, closed bool, newPa
 	return errors.Wrap(catcher.Resolve(), "aborting patches")
 }
 
-func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *ProjectRef, project *Project) string {
+func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *ProjectRef, project *Project, githubMergePatch bool) string {
 	commitFmtString := "'%s' into '%s/%s:%s'"
 	description := []string{}
 	for _, p := range patches {
@@ -968,7 +975,11 @@ func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *Project
 		description = []string{"No Commits Added"}
 	}
 
-	return "Commit Queue Merge: " + strings.Join(description, " || ")
+	if githubMergePatch {
+		return "GitHub Merge Queue: " + description[0]
+	} else {
+		return "Commit Queue Merge: " + strings.Join(description, " || ")
+	}
 }
 
 type EnqueuePatch struct {
@@ -1056,7 +1067,7 @@ func MakeMergePatchFromExisting(ctx context.Context, settings *evergreen.Setting
 	if patchDoc.Patches, err = patch.MakeMergePatchPatches(existingPatch, commitMessage); err != nil {
 		return nil, errors.Wrap(err, "making merge patches from existing patch")
 	}
-	patchDoc.Description = MakeCommitQueueDescription(patchDoc.Patches, projectRef, project)
+	patchDoc.Description = MakeCommitQueueDescription(patchDoc.Patches, projectRef, project, patchDoc.IsGithubMergePatch())
 
 	// verify the commit queue has tasks/variants enabled that match the project
 	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -825,7 +825,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 
 	// no commits
 	patches := []patch.ModulePatch{}
-	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project))
+	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project, false))
 
 	// main repo commit
 	patches = []patch.ModulePatch{
@@ -834,7 +834,9 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Commit"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project))
+	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false))
+
+	assert.Equal(t, "GitHub Merge Queue: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, true))
 
 	// main repo + module commits
 	patches = []patch.ModulePatch{
@@ -848,7 +850,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project))
+	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false))
 
 	// module only commits
 	patches = []patch.ModulePatch{
@@ -860,7 +862,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Module Commit 1", "Module Commit 2"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project))
+	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false))
 }
 
 func TestRetryCommitQueueItems(t *testing.T) {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -249,7 +249,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		if disableMergeGroup {
 			return gimlet.NewJSONResponse(struct{}{})
 		}
-		if err := gh.AddIntentForGithubMerge(event.GetMergeGroup()); err != nil {
+		if err := gh.AddIntentForGithubMerge(event); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"source":   "GitHub hook",
 				"msg_id":   gh.msgID,
@@ -268,12 +268,12 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 }
 
 // AddIntentForGithubMerge creates and inserts an intent document in response to a GitHub merge group event.
-func (gh *githubHookApi) AddIntentForGithubMerge(mg *github.MergeGroup) error {
+func (gh *githubHookApi) AddIntentForGithubMerge(mg *github.MergeGroupEvent) error {
 	intent, err := patch.NewGithubMergeIntent(gh.msgID, patch.AutomatedCaller, mg)
 	if err != nil {
 		return errors.Wrap(err, "creating GitHub merge intent")
 	}
-	if err := data.AddPatchIntent(intent, gh.queue); err != nil {
+	if err := data.AddGithubMergeIntent(intent, gh.queue); err != nil {
 		return errors.Wrap(err, "saving GitHub merge intent")
 	}
 	return nil

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -379,7 +379,7 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if p.IsCommitQueuePatch() {
-		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, project)); err != nil {
+		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, project, p.IsCommitQueuePatch())); err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}

--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -48,7 +48,14 @@ func ConfigureIntegrationTest(t *testing.T, testSettings *evergreen.Settings, te
 	integrationSettings, err := evergreen.NewSettings(*settingsOverride)
 	require.NoError(t, err, "Error opening settings override file '%s'", *settingsOverride)
 
+	// Don't clobber allowed images if it doesn't exist in the override
+	// A longer-term fix will be in EVG-20160
+	allowedImages := testSettings.Providers.AWS.Pod.ECS.AllowedImages
 	testSettings.Providers = integrationSettings.Providers
+	if len(integrationSettings.Providers.AWS.Pod.ECS.AllowedImages) == 0 {
+		testSettings.Providers.AWS.Pod.ECS.AllowedImages = allowedImages
+	}
+
 	testSettings.Credentials = integrationSettings.Credentials
 	testSettings.AuthConfig = integrationSettings.AuthConfig
 	testSettings.Plugins = integrationSettings.Plugins

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -100,8 +100,11 @@ type GithubPatch struct {
 
 // GithubMergeGroup stores patch data for patches created from GitHub merge groups
 type GithubMergeGroup struct {
-	HeadRef string `bson:"head_ref"`
-	HeadSHA string `bson:"head_sha"`
+	Org        string `bson:"org"`
+	Repo       string `bson:"repo"`
+	BaseBranch string `bson:"base_branch"` // BaseBranch is what GitHub merges to
+	HeadBranch string `bson:"head_branch"` // HeadBranch is the merge group's gh-readonly-queue branch
+	HeadSHA    string `bson:"head_sha"`
 }
 
 // SendGithubStatusInput is the input to the SendPendingStatusToGithub function and contains

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
+	"github.com/google/go-github/v52/github"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/suite"
@@ -92,6 +93,20 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 	}).Insert())
 
 	s.NoError((&model.ProjectRef{
+		Owner:            "evergreen-ci",
+		Repo:             "commit-queue-sandbox",
+		Id:               "commit-queue-sandbox",
+		Enabled:          true,
+		PatchingDisabled: utility.FalsePtr(),
+		Branch:           "main",
+		RemotePath:       "evergreen.yml",
+		PRTestingEnabled: utility.TruePtr(),
+		CommitQueue: model.CommitQueueParams{
+			Enabled: utility.TruePtr(),
+		},
+	}).Insert())
+
+	s.NoError((&model.ProjectRef{
 		Id:         "childProj",
 		Identifier: "childProj",
 		Owner:      "evergreen-ci",
@@ -126,6 +141,12 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		Alias:     "doesntexist",
 		Variant:   "fake",
 		Task:      "fake",
+	}).Upsert())
+	s.NoError((&model.ProjectAlias{
+		ProjectID: "commit-queue-sandbox",
+		Alias:     evergreen.CommitQueueAlias,
+		Variant:   "^ubuntu2004$",
+		Task:      "^bynntask$",
 	}).Upsert())
 
 	s.NoError((&distro.Distro{Id: "ubuntu1604-test"}).Insert())
@@ -907,6 +928,61 @@ func (s *PatchIntentUnitsSuite) TestBuildTasksAndVariantsWithReusePatchId() {
 	s.Equal([]string{"t1", "t2", "t3", "t4"}, currentPatchDoc.Tasks)
 }
 
+func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
+	headRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+	orgName := "evergreen-ci"
+	repoName := "commit-queue-sandbox"
+	headSHA := "d2a90288ad96adca4a7d0122d8d4fd1deb24db11"
+	org := github.Organization{
+		Name: &orgName,
+	}
+	repo := github.Repository{
+		Name: &repoName,
+	}
+	mg := github.MergeGroup{
+		HeadSHA: &headSHA,
+		HeadRef: &headRef,
+	}
+	mge := github.MergeGroupEvent{
+		MergeGroup: &mg,
+		Org:        &org,
+		Repo:       &repo,
+	}
+	intent, err := patch.NewGithubMergeIntent("id", "auto", &mge)
+
+	s.NoError(err)
+	s.Require().NotNil(intent)
+	s.NoError(intent.Insert())
+
+	j := NewPatchIntentProcessor(s.env, mgobson.NewObjectId(), intent).(*patchIntentProcessor)
+	j.env = s.env
+
+	patchDoc := intent.NewPatch()
+	s.NoError(j.finishPatch(s.ctx, patchDoc))
+
+	s.NoError(j.Error())
+	s.False(j.HasErrors())
+
+	dbPatch, err := patch.FindOne(patch.ById(j.PatchID))
+	s.NoError(err)
+	s.Require().NotNil(dbPatch)
+	s.True(patchDoc.Activated, "patch should be finalized")
+
+	variants := []string{"ubuntu2004"}
+	tasks := []string{"bynntask"}
+	s.verifyPatchDoc(dbPatch, j.PatchID, headSHA, false, variants, tasks)
+	s.projectExists(j.PatchID.Hex())
+
+	s.Zero(dbPatch.ProjectStorageMethod, "patch's project storage method should be unset after patch is finalized")
+	s.verifyParserProjectDoc(dbPatch, 4)
+
+	s.verifyVersionDoc(dbPatch, evergreen.GithubMergeRequester, evergreen.GithubMergeUser, headSHA, 1)
+
+	out := []event.Subscription{}
+	s.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.Require().Empty(out)
+}
+
 func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
 	s.Require().NoError(err)
@@ -958,13 +1034,15 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	s.Require().NotNil(dbPatch)
 	s.True(patchDoc.Activated, "patch should be finalized")
 
-	s.verifyPatchDoc(dbPatch, j.PatchID)
+	variants := []string{"ubuntu1604", "ubuntu1604-arm64", "ubuntu1604-debug", "race-detector"}
+	tasks := []string{"dist", "dist-test"}
+	s.verifyPatchDoc(dbPatch, j.PatchID, s.hash, true, variants, tasks)
 	s.projectExists(j.PatchID.Hex())
 
 	s.Zero(dbPatch.ProjectStorageMethod, "patch's project storage method should be unset after patch is finalized")
-	s.verifyParserProjectDoc(dbPatch)
+	s.verifyParserProjectDoc(dbPatch, 8)
 
-	s.verifyVersionDoc(dbPatch, evergreen.PatchVersionRequester)
+	s.verifyVersionDoc(dbPatch, evergreen.PatchVersionRequester, s.user, s.hash, 4)
 
 	s.gridFSFileExists(dbPatch.Patches[0].PatchSet.PatchFileId)
 
@@ -1023,11 +1101,13 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntentWithoutFinalizing() {
 	s.Require().NotNil(dbPatch)
 	s.False(patchDoc.Activated, "patch should not be finalized")
 
-	s.verifyPatchDoc(dbPatch, j.PatchID)
+	variants := []string{"ubuntu1604", "ubuntu1604-arm64", "ubuntu1604-debug", "race-detector"}
+	tasks := []string{"dist", "dist-test"}
+	s.verifyPatchDoc(dbPatch, j.PatchID, s.hash, true, variants, tasks)
 	s.projectExists(j.PatchID.Hex())
 
 	s.Equal(evergreen.ProjectStorageMethodDB, dbPatch.ProjectStorageMethod, "unfinalized patch should have project storage method set")
-	s.verifyParserProjectDoc(dbPatch)
+	s.verifyParserProjectDoc(dbPatch, 8)
 
 	dbVersion, err := model.VersionFindOne(model.VersionById(patchDoc.Id.Hex()))
 	s.NoError(err)
@@ -1063,41 +1143,52 @@ func (s *PatchIntentUnitsSuite) TestFindEvergreenUserForPR() {
 	s.Equal(evergreen.GithubPatchUser, u.Id)
 }
 
-func (s *PatchIntentUnitsSuite) verifyPatchDoc(patchDoc *patch.Patch, expectedPatchID mgobson.ObjectId) {
+func (s *PatchIntentUnitsSuite) TestFindEvergreenUserForGithubMergeGroup() {
+	u, err := findEvergreenUserForGithubMergeGroup(123)
+	s.NoError(err)
+	s.Require().NotNil(u)
+	s.Equal(evergreen.GithubMergeUser, u.Id)
+}
+
+func (s *PatchIntentUnitsSuite) verifyPatchDoc(patchDoc *patch.Patch, expectedPatchID mgobson.ObjectId, hash string, verifyModules bool, variants []string, tasks []string) {
 	s.Equal(evergreen.PatchCreated, patchDoc.Status)
 	s.Equal(expectedPatchID, patchDoc.Id)
-	s.NotEmpty(patchDoc.Patches)
+	if verifyModules {
+		s.NotEmpty(patchDoc.Patches)
+	}
 	s.Empty(patchDoc.PatchedParserProject)
 	s.NotZero(patchDoc.CreateTime)
 	s.Zero(patchDoc.GithubPatchData)
 	s.Zero(patchDoc.StartTime)
 	s.Zero(patchDoc.FinishTime)
 	s.NotEqual(0, patchDoc.PatchNumber)
-	s.Equal(s.hash, patchDoc.Githash)
+	s.Equal(hash, patchDoc.Githash)
 
-	s.Len(patchDoc.Patches, 1)
-	s.Empty(patchDoc.Patches[0].ModuleName)
-	s.Equal(s.hash, patchDoc.Patches[0].Githash)
-	s.Empty(patchDoc.Patches[0].PatchSet.Patch)
-	s.NotEmpty(patchDoc.Patches[0].PatchSet.PatchFileId)
-	s.Len(patchDoc.Patches[0].PatchSet.Summary, 2)
+	if verifyModules {
+		s.Len(patchDoc.Patches, 1)
+		s.Empty(patchDoc.Patches[0].ModuleName)
+		s.Equal(hash, patchDoc.Patches[0].Githash)
+		s.Empty(patchDoc.Patches[0].PatchSet.Patch)
+		s.NotEmpty(patchDoc.Patches[0].PatchSet.PatchFileId)
+		s.Len(patchDoc.Patches[0].PatchSet.Summary, 2)
+	}
 
-	s.Len(patchDoc.BuildVariants, 4)
-	s.Contains(patchDoc.BuildVariants, "ubuntu1604")
-	s.Contains(patchDoc.BuildVariants, "ubuntu1604-arm64")
-	s.Contains(patchDoc.BuildVariants, "ubuntu1604-debug")
-	s.Contains(patchDoc.BuildVariants, "race-detector")
-	s.Len(patchDoc.Tasks, 2)
-	s.Contains(patchDoc.Tasks, "dist")
-	s.Contains(patchDoc.Tasks, "dist-test")
+	s.Len(patchDoc.BuildVariants, len(variants))
+	for _, v := range variants {
+		s.Contains(patchDoc.BuildVariants, v)
+	}
+	s.Len(patchDoc.Tasks, len(tasks))
+	for _, t := range tasks {
+		s.Contains(patchDoc.Tasks, t)
+	}
 	s.NotZero(patchDoc.CreateTime)
 }
 
-func (s *PatchIntentUnitsSuite) verifyParserProjectDoc(p *patch.Patch) {
+func (s *PatchIntentUnitsSuite) verifyParserProjectDoc(p *patch.Patch, variants int) {
 	_, dbParserProject, err := model.FindAndTranslateProjectForPatch(s.ctx, s.env.Settings(), p)
 	s.Require().NoError(err)
 	s.Require().NotZero(dbParserProject)
-	s.Len(dbParserProject.BuildVariants, 8)
+	s.Len(dbParserProject.BuildVariants, variants)
 }
 
 func (s *PatchIntentUnitsSuite) projectExists(projectId string) {
@@ -1106,7 +1197,7 @@ func (s *PatchIntentUnitsSuite) projectExists(projectId string) {
 	s.NotNil(pp)
 }
 
-func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expectedRequester string) {
+func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expectedRequester, expectedUser, hash string, builds int) {
 	versionDoc, err := model.VersionFindOne(model.VersionById(patchDoc.Id.Hex()))
 	s.NoError(err)
 	s.Require().NotNil(versionDoc)
@@ -1114,31 +1205,19 @@ func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expected
 	s.NotZero(versionDoc.CreateTime)
 	s.Zero(versionDoc.StartTime)
 	s.Zero(versionDoc.FinishTime)
-	s.Equal(s.hash, versionDoc.Revision)
+	s.Equal(hash, versionDoc.Revision)
 	s.Equal(patchDoc.Description, versionDoc.Message)
-	s.Equal(s.user, versionDoc.Author)
-	s.Len(versionDoc.BuildIds, 4)
+	s.Equal(expectedUser, versionDoc.Author)
+	s.Len(versionDoc.BuildIds, builds)
 
-	s.Require().Len(versionDoc.BuildVariants, 4)
-	s.True(versionDoc.BuildVariants[0].Activated)
-	s.Zero(versionDoc.BuildVariants[0].ActivateAt)
-	s.NotEmpty(versionDoc.BuildVariants[0].BuildId)
-	s.Contains(versionDoc.BuildIds, versionDoc.BuildVariants[0].BuildId)
+	s.Require().Len(versionDoc.BuildVariants, builds)
 
-	s.True(versionDoc.BuildVariants[1].Activated)
-	s.Zero(versionDoc.BuildVariants[1].ActivateAt)
-	s.NotEmpty(versionDoc.BuildVariants[1].BuildId)
-	s.Contains(versionDoc.BuildIds, versionDoc.BuildVariants[1].BuildId)
-
-	s.True(versionDoc.BuildVariants[2].Activated)
-	s.Zero(versionDoc.BuildVariants[2].ActivateAt)
-	s.NotEmpty(versionDoc.BuildVariants[2].BuildId)
-	s.Contains(versionDoc.BuildIds, versionDoc.BuildVariants[2].BuildId)
-
-	s.True(versionDoc.BuildVariants[3].Activated)
-	s.Zero(versionDoc.BuildVariants[3].ActivateAt)
-	s.NotEmpty(versionDoc.BuildVariants[3].BuildId)
-	s.Contains(versionDoc.BuildIds, versionDoc.BuildVariants[3].BuildId)
+	for i := 0; i < builds; i++ {
+		s.True(versionDoc.BuildVariants[i].Activated)
+		s.Zero(versionDoc.BuildVariants[i].ActivateAt)
+		s.NotEmpty(versionDoc.BuildVariants[i].BuildId)
+		s.Contains(versionDoc.BuildIds, versionDoc.BuildVariants[i].BuildId)
+	}
 
 	s.Equal(expectedRequester, versionDoc.Requester)
 	s.Empty(versionDoc.Errors)


### PR DESCRIPTION
EVG-20073

### Description

This adds support to the patch-intent-processor amboy job for GitHub merge queue
items.

### Testing

This tests the new requester type by running similar integration tests for the
patch-intent-processor job as currently exist for other requester types.

### Documentation

Light edits to the ADR. There are not user-facing changes yet, so I have not
added public docs.
