### PR TITLE
EVG-20135: skip Docker cleanup for agents running in containers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -874,14 +874,18 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 			logger.Infof("Cleaned up processes for task: '%s'.", tc.task.ID)
 		}
 
-		logger.Info("Cleaning up Docker artifacts.")
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, dockerTimeout)
-		defer cancel()
-		if err := docker.Cleanup(ctx, logger); err != nil {
-			logger.Critical(errors.Wrap(err, "cleaning up Docker artifacts"))
+		// Agents running in containers don't have Docker available, so skip
+		// Docker cleanup for them.
+		if a.opts.Mode != PodMode {
+			logger.Info("Cleaning up Docker artifacts.")
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, dockerTimeout)
+			defer cancel()
+			if err := docker.Cleanup(ctx, logger); err != nil {
+				logger.Critical(errors.Wrap(err, "cleaning up Docker artifacts"))
+			}
+			logger.Info("Cleaned up Docker artifacts.")
 		}
-		logger.Info("Cleaned up Docker artifacts.")
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-07a"
+	AgentVersion = "2023-06-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20135

### Description
For agents already running inside containers, the Docker daemon is not available because Docker is itself the process running the container. Therefore, the container agent can simply skip any Docker-related cleanup.

### Testing
This isn't an easily testable condition because the Docker daemon cannot be easily tested/mocked. The conditional seems simple and sound enough that it seems like testing it wouldn't be worth the effort.

### Documentation
N/A