### PR TITLE
EVG-20137: remove special smoke test handling for agent PID env var

### DIFF
--- a/agent/logging.go
+++ b/agent/logging.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
-	"github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/grip"
@@ -44,41 +43,33 @@ func getInc() int { return <-idSource }
 
 // GetSender configures the agent's local logging to a file.
 func (a *Agent) GetSender(ctx context.Context, prefix string) (send.Sender, error) {
-	var (
-		err     error
-		sender  send.Sender
-		senders []send.Sender
-	)
+	var senders []send.Sender
 
-	if os.Getenv(util.MarkerAgentPID) == "" { // this var is set if the agent is started via a command
-		if token := a.opts.SetupData.SplunkClientToken; token != "" {
-			info := send.SplunkConnectionInfo{
-				ServerURL: a.opts.SetupData.SplunkServerURL,
-				Token:     a.opts.SetupData.SplunkClientToken,
-				Channel:   a.opts.SetupData.SplunkChannel,
-			}
-			grip.Info("Configuring splunk sender.")
-			sender, err = send.NewSplunkLogger("evergreen.agent", info, send.LevelInfo{Default: level.Alert, Threshold: level.Alert})
-			if err != nil {
-				return nil, errors.Wrap(err, "creating Splunk logger")
-			}
-			senders = append(senders, sender)
+	if a.opts.SetupData.SplunkClientToken != "" && a.opts.SetupData.SplunkServerURL != "" && a.opts.SetupData.SplunkChannel != "" {
+		info := send.SplunkConnectionInfo{
+			ServerURL: a.opts.SetupData.SplunkServerURL,
+			Token:     a.opts.SetupData.SplunkClientToken,
+			Channel:   a.opts.SetupData.SplunkChannel,
 		}
-	} else {
-		grip.Notice("Agent started via command - not configuring external logger.")
+		grip.Info("Configuring splunk sender.")
+		sender, err := send.NewSplunkLogger("evergreen.agent", info, send.LevelInfo{Default: level.Alert, Threshold: level.Alert})
+		if err != nil {
+			return nil, errors.Wrap(err, "creating Splunk logger")
+		}
+		senders = append(senders, sender)
 	}
 
 	if prefix == "" {
 		// pass
 	} else if prefix == evergreen.LocalLoggingOverride || prefix == "--" || prefix == evergreen.StandardOutputLoggingOverride {
-		sender, err = send.NewNativeLogger("evergreen.agent", send.LevelInfo{Default: level.Info, Threshold: level.Debug})
+		sender, err := send.NewNativeLogger("evergreen.agent", send.LevelInfo{Default: level.Info, Threshold: level.Debug})
 		if err != nil {
 			return nil, errors.Wrap(err, "creating native console logger")
 		}
 
 		senders = append(senders, sender)
 	} else {
-		sender, err = send.NewFileLogger("evergreen.agent",
+		sender, err := send.NewFileLogger("evergreen.agent",
 			fmt.Sprintf("%s-%d-%d.log", prefix, os.Getpid(), getInc()), send.LevelInfo{Default: level.Info, Threshold: level.Debug})
 		if err != nil {
 			return nil, errors.Wrap(err, "creating file logger")

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-07a"
+	AgentVersion = "2023-06-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20137

### Description
Remove a special smoke-test-specific conditional from the agent logging setup code. The agent only logs alerts to Splunk if the Splunk information is populated anyways, and it doesn't populate this info for the smoke test, so we can just remove the marker PID check.

### Testing
Ran the smoke test and it still behaved the same. The only behavioral difference is that [this line](https://evergreen.mongodb.com/task_log_raw/evergreen_ubuntu2204_smoke_test_host_task_patch_f92db0c07e13176df03e22b1d22391722e1c954d_6489e9c43627e039c0bf9dc8_23_06_14_16_24_37/0?type=T#L693) no longer logs, but it seems trivial.

### Documentation
N/A
