### PR TITLE
EVG-20168 use merge task to determine if patch is stuck

### DIFF
--- a/units/commit_queue.go
+++ b/units/commit_queue.go
@@ -352,20 +352,18 @@ func (j *commitQueueJob) TryUnstick(ctx context.Context, cq *commitqueue.CommitQ
 				return
 			}
 		}
-	}
-
-	// patch is done
-	if !utility.IsZeroTime(patchDoc.FinishTime) {
-		grip.Info(message.Fields{
-			"message":               "patch is already done, dequeueing",
-			"source":                "commit queue",
-			"job_id":                j.ID(),
-			"item":                  nextItem,
-			"project_id":            cq.ProjectID,
-			"time_since_enqueue":    time.Since(nextItem.EnqueueTime).Seconds(),
-			"time_since_patch_done": time.Since(patchDoc.FinishTime).Seconds(),
-		})
-		j.dequeue(cq, nextItem, "patch is already finished but still in the commit queue")
+		if mergeTask.IsFinished() {
+			grip.Info(message.Fields{
+				"message":               "patch is already done, dequeueing",
+				"source":                "commit queue",
+				"job_id":                j.ID(),
+				"item":                  nextItem,
+				"project_id":            cq.ProjectID,
+				"time_since_enqueue":    time.Since(nextItem.EnqueueTime).Seconds(),
+				"time_since_patch_done": time.Since(patchDoc.FinishTime).Seconds(),
+			})
+			j.dequeue(cq, nextItem, "patch is already finished but still in the commit queue")
+		}
 	}
 }
 


### PR DESCRIPTION
EVG-20168
### Description
Bynn and I have discussed this ticket a ton; overall we think that patches are being marked as "finished" too early because we aren't properly handling AllTasksBlocked for merge tasks. For now, adjusting how the unstick job behaves here should alleviate this.

