### PR TITLE
EVG-20076 Clone for GitHub merge queue

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -76,18 +76,17 @@ type gitFetchProject struct {
 }
 
 type cloneOpts struct {
-	method             string
-	location           string
-	owner              string
-	repo               string
-	branch             string
-	dir                string
-	token              string
-	cloneParams        string
-	recurseSubmodules  bool
-	mergeTestRequester bool
-	useVerbose         bool
-	cloneDepth         int
+	method            string
+	location          string
+	owner             string
+	repo              string
+	branch            string
+	dir               string
+	token             string
+	cloneParams       string
+	recurseSubmodules bool
+	useVerbose        bool
+	cloneDepth        int
 }
 
 func (opts cloneOpts) validate() error {
@@ -301,7 +300,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, comm client.Com
 
 	// if there's a PR checkout the ref containing the changes
 	if isGitHub(conf) {
-		var ref, branchName, commitToTest string
+		var ref, localBranchName, remoteBranchName, commitToTest string
 		if conf.Task.Requester == evergreen.MergeTestRequester {
 			// Proceed if github has confirmed this pr is mergeable. If it hasn't checked, this request
 			// will make it check.
@@ -312,18 +311,26 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, comm client.Com
 				logger.Task().Warningf("Because errors were encountered trying to retrieve the pull request, we will use the last recorded hash to test (%s).", commitToTest)
 			}
 			ref = "merge"
-			branchName = fmt.Sprintf("evg-merge-test-%s", utility.RandomString())
-		} else {
+			localBranchName = fmt.Sprintf("evg-merge-test-%s", utility.RandomString())
+			remoteBranchName = fmt.Sprintf("pull/%d", conf.GithubPatchData.PRNumber)
+		} else if conf.Task.Requester == evergreen.GithubPRRequester {
 			// Github creates a ref called refs/pull/[pr number]/head
 			// that provides the entire tree of changes, including merges
 			ref = "head"
 			commitToTest = conf.GithubPatchData.HeadHash
-			branchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
+			localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
+			remoteBranchName = fmt.Sprintf("pull/%d", conf.GithubPatchData.PRNumber)
+		} else if conf.Task.Requester == evergreen.GithubMergeRequester {
+			ref = "head"
+			commitToTest = conf.GithubMergeData.HeadSHA
+			localBranchName = fmt.Sprintf("evg-mg-test-%s", utility.RandomString())
+			// HeadRef looks like "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+			remoteBranchName = strings.TrimPrefix(conf.GithubMergeData.HeadRef, "refs/heads/")
 		}
 		if commitToTest != "" {
 			gitCommands = append(gitCommands, []string{
-				fmt.Sprintf(`git fetch origin "pull/%d/%s:%s"`, conf.GithubPatchData.PRNumber, ref, branchName),
-				fmt.Sprintf(`git checkout "%s"`, branchName),
+				fmt.Sprintf(`git fetch origin "%s/%s:%s"`, remoteBranchName, ref, localBranchName),
+				fmt.Sprintf(`git checkout "%s"`, localBranchName),
 				fmt.Sprintf("git reset --hard %s", commitToTest),
 			}...)
 		}
@@ -333,7 +340,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, comm client.Com
 			// If this git log fails, then we know the clone is too shallow so we unshallow before reset.
 			gitCommands = append(gitCommands, fmt.Sprintf("git log HEAD..%s || git fetch --unshallow", conf.Task.Revision))
 		}
-		if !opts.mergeTestRequester {
+		if conf.Task.Requester != evergreen.MergeTestRequester {
 			gitCommands = append(gitCommands, fmt.Sprintf("git reset --hard %s", conf.Task.Revision))
 		}
 	}
@@ -428,15 +435,14 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 func (c *gitFetchProject) opts(projectMethod, projectToken string, logger client.LoggerProducer, conf *internal.TaskConfig) (cloneOpts, error) {
 	shallowCloneEnabled := conf.Distro == nil || !conf.Distro.DisableShallowClone
 	opts := cloneOpts{
-		method:             projectMethod,
-		owner:              conf.ProjectRef.Owner,
-		repo:               conf.ProjectRef.Repo,
-		branch:             conf.ProjectRef.Branch,
-		dir:                c.Directory,
-		token:              projectToken,
-		cloneParams:        c.CloneParams,
-		recurseSubmodules:  c.RecurseSubmodules,
-		mergeTestRequester: conf.Task.Requester == evergreen.MergeTestRequester,
+		method:            projectMethod,
+		owner:             conf.ProjectRef.Owner,
+		repo:              conf.ProjectRef.Repo,
+		branch:            conf.ProjectRef.Branch,
+		dir:               c.Directory,
+		token:             projectToken,
+		cloneParams:       c.CloneParams,
+		recurseSubmodules: c.RecurseSubmodules,
 	}
 	cloneDepth := c.CloneDepth
 	if cloneDepth == 0 && c.ShallowClone {
@@ -1029,7 +1035,7 @@ func isGitHubPRModulePatch(conf *internal.TaskConfig, modulePatch *patch.ModuleP
 }
 
 func isGitHub(conf *internal.TaskConfig) bool {
-	return conf.GithubPatchData.PRNumber != 0
+	return conf.GithubPatchData.PRNumber != 0 || conf.GithubMergeData.HeadSHA != ""
 }
 
 type noopWriteCloser struct {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -52,7 +52,9 @@ type GitGetProjectSuite struct {
 	modelData5  *modelutil.TestModelData
 	taskConfig5 *internal.TaskConfig
 	modelData6  *modelutil.TestModelData
-	taskConfig6 *internal.TaskConfig // used for TestMergeMultiplePatches
+	taskConfig6 *internal.TaskConfig     // used for TestMergeMultiplePatches
+	modelData7  *modelutil.TestModelData // GitHub merge queue
+	taskConfig7 *internal.TaskConfig     // GitHub merge queue
 
 	comm   *client.Mock
 	jasper jasper.Manager
@@ -130,6 +132,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 		HeadHash:   "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
 		Author:     "octocat",
 	}
+	s.taskConfig3.Task.Requester = evergreen.GithubPRRequester
 
 	s.modelData4, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath2, modelutil.MergePatch)
 	s.Require().NoError(err)
@@ -153,6 +156,18 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.taskConfig6.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
 	s.taskConfig6.BuildVariant.Modules = []string{"evergreen"}
+
+	s.modelData7, err = modelutil.SetupAPITestData(s.settings, "testtask1", "linux-64", configPath3, modelutil.InlinePatch)
+	s.Require().NoError(err)
+	s.taskConfig7, err = agentutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData7)
+	s.Require().NoError(err)
+	s.taskConfig7.Expansions = util.NewExpansions(map[string]string{evergreen.GlobalGitHubTokenExpansion: fmt.Sprintf("token " + globalGitHubToken)})
+	s.taskConfig7.BuildVariant.Modules = []string{"evergreen"}
+	s.taskConfig7.GithubMergeData = thirdparty.GithubMergeGroup{
+		HeadRef: "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056",
+		HeadSHA: "d2a90288ad96adca4a7d0122d8d4fd1deb24db11",
+	}
+	s.taskConfig7.Task.Requester = evergreen.GithubMergeRequester
 }
 
 func (s *GitGetProjectSuite) TestBuildCloneCommandUsesHTTPS() {
@@ -585,6 +600,32 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 	s.Equal("git reset --hard 55ca6286e3e4f4fba5d0448333fa99fc5a404a73", cmds[7])
 	s.Equal("git log --oneline -n 10", cmds[8])
 }
+func (s *GitGetProjectSuite) TestBuildCommandForGitHubMergeQueue() {
+	conf := s.taskConfig7
+	logger, err := s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	s.NoError(err)
+
+	c := gitFetchProject{
+		Directory: "dir",
+	}
+
+	opts := cloneOpts{
+		method: evergreen.CloneMethodLegacySSH,
+		branch: conf.ProjectRef.Branch,
+		owner:  conf.ProjectRef.Owner,
+		repo:   conf.ProjectRef.Repo,
+		dir:    c.Directory,
+	}
+	s.Require().NoError(opts.setLocation())
+
+	cmds, err := c.buildCloneCommand(s.ctx, s.comm, logger, conf, opts)
+	s.NoError(err)
+	s.Len(cmds, 9)
+	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056/head:evg-mg-test-"))
+	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-mg-test-"))
+	s.Equal("git reset --hard d2a90288ad96adca4a7d0122d8d4fd1deb24db11", cmds[7])
+	s.Equal("git log --oneline -n 10", cmds[8])
+}
 
 func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	conf := s.taskConfig2
@@ -597,13 +638,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
 	}
 
 	opts := cloneOpts{
-		method:             evergreen.CloneMethodOAuth,
-		branch:             conf.ProjectRef.Branch,
-		owner:              conf.ProjectRef.Owner,
-		repo:               conf.ProjectRef.Repo,
-		dir:                c.Directory,
-		token:              c.Token,
-		mergeTestRequester: true,
+		method: evergreen.CloneMethodOAuth,
+		branch: conf.ProjectRef.Branch,
+		owner:  conf.ProjectRef.Owner,
+		repo:   conf.ProjectRef.Repo,
+		dir:    c.Directory,
+		token:  c.Token,
 	}
 	s.Require().NoError(opts.setLocation())
 

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -31,6 +31,7 @@ type TaskConfig struct {
 	Redacted           map[string]bool
 	WorkDir            string
 	GithubPatchData    thirdparty.GithubPatch
+	GithubMergeData    thirdparty.GithubMergeGroup
 	Timeout            *Timeout
 	TaskSync           evergreen.S3Credentials
 	EC2Keys            []evergreen.EC2Key
@@ -96,6 +97,7 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	}
 	if patchDoc != nil {
 		taskConfig.GithubPatchData = patchDoc.GithubPatchData
+		taskConfig.GithubMergeData = patchDoc.GithubMergeData
 	}
 
 	taskConfig.Timeout = &Timeout{}

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-07a"
+	AgentVersion = "2023-06-15"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/decisions/2023-06-05_github_merge_queue.md
+++ b/docs/decisions/2023-06-05_github_merge_queue.md
@@ -61,6 +61,6 @@ the PR to the merge queue.
 [model/patch](https://github.com/evergreen-ci/evergreen/blob/main/model/patch/github_merge_intent.go)
 * [ ] The intent will be procssed by the amboy [patch-intent-processor
 job](https://github.com/evergreen-ci/evergreen/blob/main/units/patch_intent.go).
-* [ ] New clone logic in the agent will clone the merge group branch.
+* [x] New clone logic in the agent will clone the merge group branch.
 * [ ] Evergreen will post the result to the GitHub checks API.
 * [ ] A new UI element will allow users to opt into the GitHub merge queue.


### PR DESCRIPTION
EVG-20076

### Description
This adds clone logic for the GitHub merge queue. The GitHub merge queue exposes a special branch, similar to the branch it exposes for PRs.

Note that this is rebased on an existing PR.

Manual PR because lint doesn't work correctly https://spruce.mongodb.com/version/648b2c5be3c331b9c399f271/tasks.

### Testing
I added a test, similar to the PR clone test, to validate that the clone commands are correct.

### Documentation
None needed.
