### PR TITLE
EVG-20140: remove duplicate deferred context cancellation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -558,7 +558,6 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (bool, error) {
 	})
 
 	defer a.killProcs(ctx, tc, false)
-	defer tskCancel()
 
 	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
 	tskCtx, span := a.tracer.Start(tskCtx, fmt.Sprintf("task: '%s'", tc.taskConfig.Task.DisplayName))

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-14"
+	AgentVersion = "2023-06-15"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20140

### Description
This deferred context cancellation is not needed because there's already a deferred cancel [above it](https://github.com/evergreen-ci/evergreen/blob/59d70cb3f4bfa05574ebbe50246fcf9e6fd51bf4/agent/agent.go#L518).

### Testing
N/A

### Documentation
N/A