### PR TITLE
EVG-20168 Update dependent build and version after restarting a task

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -827,7 +827,7 @@ func UpdateUnblockedDependencies(t *task.Task) error {
 		buildIds = append(buildIds, buildId)
 	}
 	if err := UpdateVersionAndPatchStatusForBuilds(buildIds); err != nil {
-		return errors.Wrapf(err, "updating version and patch status for builds")
+		return errors.Wrapf(err, "updating build, version, and patch statuses")
 	}
 
 	return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -817,6 +817,11 @@ func UpdateUnblockedDependencies(t *task.Task) error {
 		if err := UpdateUnblockedDependencies(&blockedTask); err != nil {
 			return errors.WithStack(err)
 		}
+
+		if err := UpdateBuildAndVersionStatusForTask(&blockedTask); err != nil {
+			return errors.Wrapf(err, "updating build and version status for task '%s'", blockedTask.Id)
+		}
+
 	}
 
 	return nil

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -822,11 +822,11 @@ func UpdateUnblockedDependencies(t *task.Task) error {
 		buildsToUpdate[blockedTask.BuildId] = true
 	}
 
-	var buildIds []string
-	for buildId := range buildsToUpdate {
-		buildIds = append(buildIds, buildId)
+	var buildIDs []string
+	for buildID := range buildsToUpdate {
+		buildIDs = append(buildIDs, buildID)
 	}
-	if err := UpdateVersionAndPatchStatusForBuilds(buildIds); err != nil {
+	if err := UpdateVersionAndPatchStatusForBuilds(buildIDs); err != nil {
 		return errors.Wrapf(err, "updating build, version, and patch statuses")
 	}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6344,7 +6344,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	assert.NoError(err)
 	assert.True(dbTask5.DependsOn[0].Unattainable)
 
-	// Restarting a dependent task should unblock builds
+	// Unblocking a dependent task should unblock its build
 	dbTask6, err := task.FindOneId(tasks[6].Id)
 	assert.NoError(err)
 	assert.False(dbTask6.DependsOn[0].Unattainable)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6238,8 +6238,8 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection))
 	v := Version{Id: "v"}
-	b := build.Build{Id: "build0"}
-	b2 := build.Build{Id: "build2", AllTasksBlocked: true}
+	b := build.Build{Id: "build0", Version: v.Id}
+	b2 := build.Build{Id: "build2", Version: v.Id, AllTasksBlocked: true}
 	tasks := []task.Task{
 		{Id: "t0", BuildId: b.Id, Version: v.Id},
 		{Id: "t1", BuildId: b.Id, Version: v.Id, Status: evergreen.TaskFailed},

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6344,6 +6344,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	assert.NoError(err)
 	assert.True(dbTask5.DependsOn[0].Unattainable)
 
+	// Restarting a dependent task should unblock builds
 	dbTask6, err := task.FindOneId(tasks[6].Id)
 	assert.NoError(err)
 	assert.False(dbTask6.DependsOn[0].Unattainable)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6236,13 +6236,16 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 
 func TestUpdateUnblockedDependencies(t *testing.T) {
 	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(task.Collection, build.Collection))
+	assert.NoError(db.ClearCollections(task.Collection, build.Collection, VersionCollection))
+	v := Version{Id: "v"}
 	b := build.Build{Id: "build0"}
+	b2 := build.Build{Id: "build2", AllTasksBlocked: true}
 	tasks := []task.Task{
-		{Id: "t0", BuildId: b.Id},
-		{Id: "t1", BuildId: b.Id, Status: evergreen.TaskFailed},
+		{Id: "t0", BuildId: b.Id, Version: v.Id},
+		{Id: "t1", BuildId: b.Id, Version: v.Id, Status: evergreen.TaskFailed},
 		{
 			Id:      "t2",
+			Version: v.Id,
 			BuildId: b.Id,
 			DependsOn: []task.Dependency{
 				{
@@ -6258,6 +6261,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 		},
 		{
 			Id:      "t3",
+			Version: v.Id,
 			BuildId: b.Id,
 			DependsOn: []task.Dependency{
 				{
@@ -6269,6 +6273,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 		},
 		{
 			Id:      "t4",
+			Version: v.Id,
 			BuildId: b.Id,
 			DependsOn: []task.Dependency{
 				{
@@ -6280,6 +6285,7 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 		},
 		{
 			Id:      "t5",
+			Version: v.Id,
 			BuildId: b.Id,
 			DependsOn: []task.Dependency{
 				{
@@ -6289,12 +6295,33 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 			},
 			Status: evergreen.TaskUndispatched,
 		},
+		{
+			Id:      "t6",
+			Version: v.Id,
+			BuildId: b2.Id,
+			DependsOn: []task.Dependency{
+				{
+					TaskId:       "t0",
+					Unattainable: true,
+				},
+			},
+			Status: evergreen.TaskUndispatched,
+		},
+		{
+			Id:      "t7",
+			Version: v.Id,
+			BuildId: b2.Id,
+			Status:  evergreen.TaskDispatched,
+		},
 	}
 
 	for _, t := range tasks {
 		assert.NoError(t.Insert())
 	}
+
+	assert.NoError(v.Insert())
 	assert.NoError(b.Insert())
+	assert.NoError(b2.Insert())
 
 	assert.NoError(UpdateUnblockedDependencies(&tasks[0]))
 
@@ -6316,6 +6343,13 @@ func TestUpdateUnblockedDependencies(t *testing.T) {
 	dbTask5, err := task.FindOneId(tasks[5].Id)
 	assert.NoError(err)
 	assert.True(dbTask5.DependsOn[0].Unattainable)
+
+	dbTask6, err := task.FindOneId(tasks[6].Id)
+	assert.NoError(err)
+	assert.False(dbTask6.DependsOn[0].Unattainable)
+	dbBuild2, err := build.FindOneId(b2.Id)
+	assert.NoError(err)
+	assert.False(dbBuild2.AllTasksBlocked)
 }
 
 type TaskConnectorAbortTaskSuite struct {

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -294,16 +294,17 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 				Status: cloud.StatusRunning,
 			})
 
-			b := build.Build{
-				Id:     "build",
-				Status: evergreen.BuildStarted,
-			}
-			require.NoError(t, b.Insert())
-
 			v := model.Version{
 				Id:     "version",
 				Status: evergreen.VersionStarted,
 			}
+
+			b := build.Build{
+				Id:      "build",
+				Version: v.Id,
+				Status:  evergreen.BuildStarted,
+			}
+			require.NoError(t, b.Insert())
 
 			pRef := model.ProjectRef{
 				Id:      "project_id",


### PR DESCRIPTION
EVG-20168

### Description
Build was setting all_tasks_blocked but never unsetting it when the dependent tasks were restarted 
That was causing patches to mistakenly believe they were complete and unschedule tasks 

### Testing
created a patch on staging and saw that the build now updates when you restart tasks that are dependent 
even if they were previously blocked 

https://spruce-staging.corp.mongodb.com/version/648cae22b2373620e2ba9d00/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC