### PR TITLE
docs: add some info about tags to dependencies

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1389,7 +1389,7 @@ supported as a space-separated list. For example,
     variant: "A B C D"
 ```
 
-[Task/variant tags](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#task-and-variant-tags) 
+[Task/variant tags](#task-and-variant-tags) 
 can also be used to define dependencies.
 
 ``` yaml

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1389,6 +1389,20 @@ supported as a space-separated list. For example,
     variant: "A B C D"
 ```
 
+[Task/variant tags](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#task-and-variant-tags) 
+can also be used to define dependencies.
+
+``` yaml
+- name: push
+  depends_on:
+  - name: test
+    variant: ".favorite"
+
+- name: push
+  depends_on:
+  - "!.favorite !.other" ## runs all tasks that don't match these tags
+```
+
 ### Ignoring Changes to Certain Files
 
 Some commits to your repository don't need to be tested. The obvious


### PR DESCRIPTION
### Description
Keeping this pretty light since the tags section also goes through examples, but want to make sure they're linked.