### PR TITLE
EVG-20202 Rename pod provisioning script output flag name

### DIFF
--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -116,7 +116,7 @@ func (h *podProvisioningScript) agentCommand(p *pod.Pod) []string {
 		"agent",
 		fmt.Sprintf("--api_server=%s", h.settings.ApiUrl),
 		"--mode=pod",
-		"--output=file",
+		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", strings.Join([]string{p.TaskContainerCreationOpts.WorkingDir, "agent"}, "/")),
 		fmt.Sprintf("--working_directory=%s", p.TaskContainerCreationOpts.WorkingDir),
 	}

--- a/rest/route/pod_agent_test.go
+++ b/rest/route/pod_agent_test.go
@@ -79,7 +79,7 @@ func TestPodProvisioningScript(t *testing.T) {
 
 				expected := "curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100 && " +
 					"chmod +x evergreen && " +
-					"./evergreen agent --api_server=www.test.com --mode=pod --output=file --log_prefix=/working/dir/agent --working_directory=/working/dir"
+					"./evergreen agent --api_server=www.test.com --mode=pod --log_output=file --log_prefix=/working/dir/agent --working_directory=/working/dir"
 				assert.Equal(t, expected, script)
 			},
 			"EvergreenClientDownloadsWithWindowsPod": func(t *testing.T, settings *evergreen.Settings, p *pod.Pod) {
@@ -93,7 +93,7 @@ func TestPodProvisioningScript(t *testing.T) {
 				require.True(t, ok, "route should return plaintext response")
 
 				expected := "curl.exe -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100; " +
-					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --output=file --log_prefix=/working/dir/agent --working_directory=/working/dir"
+					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_output=file --log_prefix=/working/dir/agent --working_directory=/working/dir"
 				assert.Equal(t, expected, script)
 			},
 			"S3ClientDownloadsWithLinuxPod": func(t *testing.T, settings *evergreen.Settings, p *pod.Pod) {
@@ -109,7 +109,7 @@ func TestPodProvisioningScript(t *testing.T) {
 
 				expected := fmt.Sprintf("(curl -fLO https://foo.com/%s/linux_amd64/evergreen --retry 10 --retry-max-time 100 || curl -fLO www.test.com/clients/linux_amd64/evergreen --retry 10 --retry-max-time 100) && "+
 					"chmod +x evergreen && "+
-					"./evergreen agent --api_server=www.test.com --mode=pod --output=file --log_prefix=/working/dir/agent --working_directory=/working/dir", evergreen.BuildRevision)
+					"./evergreen agent --api_server=www.test.com --mode=pod --log_output=file --log_prefix=/working/dir/agent --working_directory=/working/dir", evergreen.BuildRevision)
 				assert.Equal(t, expected, script)
 			},
 			"S3ClientDownloadsWithWindowsPod": func(t *testing.T, settings *evergreen.Settings, p *pod.Pod) {
@@ -125,7 +125,7 @@ func TestPodProvisioningScript(t *testing.T) {
 				require.True(t, ok, "route should return plaintext response")
 
 				expected := fmt.Sprintf("if (curl.exe -fLO https://foo.com/%s/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100) {} else { curl.exe -fLO www.test.com/clients/windows_amd64/evergreen.exe --retry 10 --retry-max-time 100 }; "+
-					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --output=file --log_prefix=/working/dir/agent --working_directory=/working/dir", evergreen.BuildRevision)
+					".\\evergreen.exe agent --api_server=www.test.com --mode=pod --log_output=file --log_prefix=/working/dir/agent --working_directory=/working/dir", evergreen.BuildRevision)
 				assert.Equal(t, expected, script)
 			},
 		} {


### PR DESCRIPTION
EVG-20202

### Description
Container tasks are exiting with the error `Incorrect Usage. flag provided but not defined: -output`, the flag needs to be renamed.
### Testing
Downloaded the CLI locally and tested with the new command that `provisioning_script` and error was gone.
