### PR TITLE
EVG-20204 Temporarily remove token error to support multiple repos

### DIFF
--- a/config.go
+++ b/config.go
@@ -595,7 +595,8 @@ func (s *Settings) CreateInstallationToken(ctx context.Context, owner, repo stri
 	client := github.NewClient(httpClient)
 	installationId, _, err := client.Apps.FindRepositoryInstallation(ctx, owner, repo)
 	if err != nil {
-		return "", errors.Wrapf(err, "finding installation token for '%s/%s'", owner, repo)
+		// TODO EVG-19966: Return error here
+		return "", nil
 	}
 	if installationId == nil {
 		return "", errors.New(fmt.Sprintf("Installation id for '%s/%s' not found", owner, repo))

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -103,6 +103,12 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
+	grip.Info(message.Fields{
+		"source":   "GitHub hook",
+		"msg_id":   gh.msgID,
+		"event":    gh.eventType,
+		"bynnbynn": gh,
+	})
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		if event.HookID == nil {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -103,12 +103,6 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
-	grip.Info(message.Fields{
-		"source":   "GitHub hook",
-		"msg_id":   gh.msgID,
-		"event":    gh.eventType,
-		"bynnbynn": gh,
-	})
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		if event.HookID == nil {


### PR DESCRIPTION
EVG-20204

### Description
got webhooks to work through github app and not the one on the repo 
had to remove an error from install tokens because it's only installed on commit queue and not evergreen repo but this is temporary 
using the same github webhook secret as the one we were already using for the current webhook

### Testing
staging
1. comment on pr, triggered new patch, retry etc 
2. pushing commit triggers repo tracker 
3. statuses are updated correctly 

