### PR TITLE
EVG-20079 Support GitHub merge queue in scheduler

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -914,6 +914,10 @@ func IsCommitQueueRequester(requester string) bool {
 	return requester == MergeTestRequester
 }
 
+func IsGithubMergeQueueRequester(requester string) bool {
+	return requester == GithubMergeRequester
+}
+
 func ShouldConsiderBatchtime(requester string) bool {
 	return !IsPatchRequester(requester) && requester != AdHocRequester && requester != GitTagRequester
 }

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -275,7 +275,7 @@ func (unit *Unit) info() unitInfo {
 	}
 
 	for _, t := range unit.tasks {
-		if evergreen.IsCommitQueueRequester(t.Requester) {
+		if evergreen.IsCommitQueueRequester(t.Requester) || evergreen.IsGithubMergeQueueRequester(t.Requester) {
 			info.ContainsInCommitQueue = true
 		} else if evergreen.IsPatchRequester(t.Requester) {
 			info.ContainsInPatch = true

--- a/scheduler/planner_test.go
+++ b/scheduler/planner_test.go
@@ -210,6 +210,11 @@ func TestPlanner(t *testing.T) {
 					unit.SetDistro(&distro.Distro{})
 					assert.EqualValues(t, 2413, unit.RankValue())
 				})
+				t.Run("MergeQueue", func(t *testing.T) {
+					unit := NewUnit(task.Task{Id: "foo", Requester: evergreen.GithubMergeRequester})
+					unit.SetDistro(&distro.Distro{})
+					assert.EqualValues(t, 2413, unit.RankValue())
+				})
 				t.Run("Patches", func(t *testing.T) {
 					t.Run("CLI", func(t *testing.T) {
 						unit := NewUnit(task.Task{Id: "foo", Requester: evergreen.PatchVersionRequester})


### PR DESCRIPTION
EVG-20079

### Description
This takes advantage of existing code to give commit queue tasks higher
priority. It treats Evergreen commit queue tasks and GitHub merge queue tasks identically.

### Testing
I added a unit test to ensure that adding a GitHub merge queue task yielded the
same priority as adding an Evergreen commit queue task.
