### PR TITLE
EVG-20138: explicitly set logging output

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1006,8 +1006,7 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		fmt.Sprintf("--host_id=%s", h.Id),
 		fmt.Sprintf("--host_secret=%s", h.Secret),
 		fmt.Sprintf("--provider=%s", h.Distro.Provider),
-		// TODO (EVG-20138): explicitly pass file log output once agents have
-		// rolled over.
+		fmt.Sprintf("--log_output=file"),
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent")),
 		fmt.Sprintf("--working_directory=%s", h.Distro.WorkDir),
 		"--cleanup",
@@ -1028,8 +1027,7 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 		fmt.Sprintf("--shell_path=%s", shellPath),
 		fmt.Sprintf("--jasper_port=%d", settings.HostJasper.Port),
 		fmt.Sprintf("--credentials=%s", credsPath),
-		// TODO (EVG-20138): explicitly pass file log output once agent monitors
-		// have rolled over.
+		fmt.Sprintf("--log_output=file"),
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent.monitor")),
 	)
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1006,7 +1006,7 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		fmt.Sprintf("--host_id=%s", h.Id),
 		fmt.Sprintf("--host_secret=%s", h.Secret),
 		fmt.Sprintf("--provider=%s", h.Distro.Provider),
-		fmt.Sprintf("--log_output=file"),
+		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent")),
 		fmt.Sprintf("--working_directory=%s", h.Distro.WorkDir),
 		"--cleanup",
@@ -1027,7 +1027,7 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 		fmt.Sprintf("--shell_path=%s", shellPath),
 		fmt.Sprintf("--jasper_port=%d", settings.HostJasper.Port),
 		fmt.Sprintf("--credentials=%s", credsPath),
-		fmt.Sprintf("--log_output=file"),
+		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent.monitor")),
 	)
 


### PR DESCRIPTION
EVG-20138

### Description
#6664 left a small TODO for after agent versions had rolled over to actually use the newly-introduced CLI flag. Now that agents have rolled over to the newer version (i.e. the one that has the `--log_output` option), we can explicitly set the log output option.

### Testing
I verified with [the recent tasks endpoint](https://evergreen.mongodb.com/rest/v2/status/recent_tasks?minutes=1440&by_agent_version=true) that agents have rolled over to the newer version, so setting this flag is safe.

### Documentation
N/A