### PR TITLE
EVG-20139, EVG-20141: standardize command display names and rename some functions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -658,7 +658,7 @@ func (a *Agent) runTaskTimeoutCommands(ctx context.Context, tc *taskContext) {
 		return
 	}
 	if taskGroup.Timeout != nil {
-		err := a.runCommands(ctx, tc, taskGroup.Timeout.List(), runCommandsOptions{}, taskTimeoutBlock)
+		err := a.runCommandsInBlock(ctx, tc, taskGroup.Timeout.List(), runCommandsOptions{}, taskTimeoutBlock)
 		tc.logger.Execution().Error(errors.Wrap(err, "running timeout commands"))
 		tc.logger.Task().Infof("Finished running timeout commands in %s.", time.Since(start))
 	}
@@ -793,7 +793,7 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 	}
 	if taskGroup.TeardownTask != nil {
 		opts.failPreAndPost = taskGroup.TeardownTaskCanFailTask
-		err = a.runCommands(postCtx, tc, taskGroup.TeardownTask.List(), opts, postBlock)
+		err = a.runCommandsInBlock(postCtx, tc, taskGroup.TeardownTask.List(), opts, postBlock)
 		if err != nil {
 			tc.logger.Task().Error(errors.Wrap(err, "running post-task commands"))
 			if taskGroup.TeardownTaskCanFailTask {
@@ -832,7 +832,7 @@ func (a *Agent) runPostGroupCommands(ctx context.Context, tc *taskContext) {
 		var cancel context.CancelFunc
 		ctx, cancel = a.withCallbackTimeout(ctx, tc)
 		defer cancel()
-		err := a.runCommands(ctx, tc, taskGroup.TeardownGroup.List(), runCommandsOptions{}, postBlock)
+		err := a.runCommandsInBlock(ctx, tc, taskGroup.TeardownGroup.List(), runCommandsOptions{}, postBlock)
 		grip.Error(errors.Wrap(err, "running post-group commands"))
 		grip.Info("Finished running post-group commands.")
 	}
@@ -861,7 +861,7 @@ func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *api
 	}
 	defer cancel()
 
-	if err := a.runCommands(syncCtx, tc, taskSyncCmds.List(), runCommandsOptions{}, endTaskBlock); err != nil {
+	if err := a.runCommandsInBlock(syncCtx, tc, taskSyncCmds.List(), runCommandsOptions{}, endTaskBlock); err != nil {
 		tc.logger.Task().Error(message.WrapError(err, message.Fields{
 			"message":    "error running task sync",
 			"total_time": time.Since(start).String(),

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/mock"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 )
@@ -331,9 +332,10 @@ pre:
 	s.NoError(s.tc.logger.Close())
 
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec'",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running pre-task commands",
 	)
 }
@@ -391,10 +393,10 @@ post:
 	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running post-task commands",
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running post-task commands",
 	)
 }
@@ -416,7 +418,7 @@ post:
 	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running post-task commands",
 		"Running command 'shell.exec' (step 1 of 2)",
 		"Running command 'shell.exec' (step 2 of 2)",
@@ -469,7 +471,7 @@ func (s *AgentSuite) TestAbort() {
 
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(originalTaskID,
+	checkMockLogs(s.T(), s.mockCommunicator, originalTaskID,
 		"Heartbeat received signal to abort task",
 		"Task completed - FAILURE",
 		"Sending final task status: 'failed'",
@@ -660,10 +662,10 @@ task_groups:
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running pre-task commands",
 	)
 }
@@ -714,7 +716,7 @@ task_groups:
 	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id, "running task setup group")
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, "running task setup group")
 }
 
 func (s *AgentSuite) TestTeardownTaskFails() {
@@ -738,7 +740,7 @@ task_groups:
 	s.Error(s.a.runPostTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id, "running post-task commands")
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, "running post-task commands")
 }
 
 func (s *AgentSuite) TestSetupTask() {
@@ -760,10 +762,10 @@ task_groups:
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running pre-task commands",
 	)
 }
@@ -786,9 +788,9 @@ task_groups:
 	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running post-task commands",
 	)
 }
@@ -811,9 +813,9 @@ task_groups:
 	s.tc.taskConfig.Task.TaskGroup = s.tc.taskGroup
 	s.a.runPostGroupCommands(s.ctx, s.tc)
 	s.NoError(s.tc.logger.Close())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 	)
 }
 
@@ -840,10 +842,10 @@ task_groups:
 	s.a.runTaskTimeoutCommands(s.ctx, s.tc)
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
-	s.checkLogs(s.tc.taskConfig.Task.Id,
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running task-timeout commands",
-		"Running command 'shell.exec'",
-		"Finished command 'shell.exec'",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
 		"Finished running timeout commands",
 	)
 }
@@ -907,13 +909,13 @@ func (s *AgentSuite) getPanicLogs() []string {
 	return panicLogs
 }
 
-func (s *AgentSuite) checkLogs(taskID string, logsToFind ...string) {
+func checkMockLogs(t *testing.T, mc *client.Mock, taskID string, logsToFind ...string) {
 	logFound := make(map[string]bool)
 	for _, log := range logsToFind {
 		logFound[log] = false
 	}
 	var allLogs []string
-	for _, msg := range s.mockCommunicator.GetMockMessages()[taskID] {
+	for _, msg := range mc.GetMockMessages()[taskID] {
 		for log := range logFound {
 			if strings.Contains(msg.Message, log) {
 				logFound[log] = true
@@ -923,7 +925,7 @@ func (s *AgentSuite) checkLogs(taskID string, logsToFind ...string) {
 	}
 	var displayLogs bool
 	for log, found := range logFound {
-		if !s.True(found, "expected log not found: %s", log) {
+		if !assert.True(t, found, "expected log not found: %s", log) {
 			displayLogs = true
 		}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -306,7 +306,7 @@ func (s *AgentSuite) TestCancelledRunningCommandsIsNonBlocking() {
 		},
 	}
 	cmds := []model.PluginCommandConf{cmd}
-	err := s.a.runCommands(ctx, s.tc, cmds, runCommandsOptions{}, "post")
+	err := s.a.runCommandsInBlock(ctx, s.tc, cmds, runCommandsOptions{}, postBlock)
 	s.Require().Error(err)
 	s.True(utility.IsContextError(errors.Cause(err)))
 	s.Empty(s.getPanicLogs())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -334,8 +334,8 @@ pre:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'pre'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'pre'",
 		"Finished running pre-task commands",
 	)
 }
@@ -395,8 +395,8 @@ post:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running post-task commands",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
 		"Finished running post-task commands",
 	)
 }
@@ -420,8 +420,8 @@ post:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running post-task commands",
-		"Running command 'shell.exec' (step 1 of 2)",
-		"Running command 'shell.exec' (step 2 of 2)",
+		"Running command 'shell.exec' (step 1 of 2) in block 'post'",
+		"Running command 'shell.exec' (step 2 of 2) in block 'post'",
 		"Finished running post-task commands",
 	)
 }
@@ -664,8 +664,8 @@ task_groups:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'setup_group'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'setup_group'",
 		"Finished running pre-task commands",
 	)
 }
@@ -764,8 +764,8 @@ task_groups:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running pre-task commands",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'setup_task'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'setup_task'",
 		"Finished running pre-task commands",
 	)
 }
@@ -789,8 +789,8 @@ task_groups:
 	s.NoError(s.tc.logger.Close())
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'teardown_task'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'teardown_task'",
 		"Finished running post-task commands",
 	)
 }
@@ -814,8 +814,8 @@ task_groups:
 	s.a.runPostGroupCommands(s.ctx, s.tc)
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'teardown_group'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'teardown_group'",
 	)
 }
 
@@ -844,8 +844,8 @@ task_groups:
 	s.Empty(s.getPanicLogs())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id,
 		"Running task-timeout commands",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
+		"Running command 'shell.exec' (step 1 of 1) in block 'timeout'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'timeout'",
 		"Finished running timeout commands",
 	)
 }

--- a/agent/command.go
+++ b/agent/command.go
@@ -99,10 +99,6 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 		}()
 	}
 
-	// Omit the block name from the display name, or else the display name
-	// becomes too verbose.
-	blockInfo.Block = ""
-
 	if commandInfo.Function != "" {
 		var commandSetSpan trace.Span
 		ctx, commandSetSpan = a.tracer.Start(ctx, fmt.Sprintf("function: '%s'", commandInfo.Function), trace.WithAttributes(
@@ -121,8 +117,10 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 			SubCmdNum:    idx + 1,
 			TotalSubCmds: len(cmds),
 		}
-		// Avoid using the command's display name here because it can include
-		// the block name, which makes it very verbose.
+		// Avoid using the command's display name here if the user has
+		// explicitly configured it, because the user-defined display name may
+		// be ambiguous (e.g. if the command runs in multiple different blocks
+		// or functions).
 		displayName := command.GetDefaultDisplayName(cmd.Name(), blockInfo, funcInfo)
 
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {

--- a/agent/command.go
+++ b/agent/command.go
@@ -38,7 +38,8 @@ type runCommandsOptions struct {
 	failPreAndPost bool
 }
 
-func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []model.PluginCommandConf,
+// runCommandsInBlock runs all the commands listed in a block (e.g. pre, post).
+func (a *Agent) runCommandsInBlock(ctx context.Context, tc *taskContext, commands []model.PluginCommandConf,
 	options runCommandsOptions, block string) (err error) {
 	var cmds []command.Command
 	defer func() {
@@ -62,11 +63,15 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "canceled while running commands")
 		}
-		cmds, err = command.Render(commandInfo, tc.taskConfig.Project, block)
+		blockInfo := command.BlockInfo{
+			CmdNum:    i + 1,
+			TotalCmds: len(commands),
+		}
+		cmds, err = command.Render(commandInfo, tc.taskConfig.Project, blockInfo)
 		if err != nil {
 			return errors.Wrapf(err, "rendering command '%s'", commandInfo.Command)
 		}
-		if err = a.runCommandSet(ctx, tc, commandInfo, cmds, options, i+1, len(commands)); err != nil {
+		if err = a.runCommandOrFunc(ctx, tc, commandInfo, cmds, options, blockInfo); err != nil {
 			return errors.WithStack(err)
 		}
 	}
@@ -74,8 +79,10 @@ func (a *Agent) runCommands(ctx context.Context, tc *taskContext, commands []mod
 	return errors.WithStack(err)
 }
 
-func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo model.PluginCommandConf,
-	cmds []command.Command, options runCommandsOptions, index, total int) error {
+// runCommandOrFunc runs a list of commands, which can either be single
+// standalone command or a list of sub-commands in a function.
+func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandInfo model.PluginCommandConf,
+	cmds []command.Command, options runCommandsOptions, blockInfo command.BlockInfo) error {
 
 	var err error
 	var logger client.LoggerProducer
@@ -83,7 +90,7 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 	if commandInfo.Loggers == nil {
 		logger = tc.logger
 	} else {
-		logger, err = a.makeLoggerProducer(ctx, tc, commandInfo.Loggers, getFunctionName(commandInfo))
+		logger, err = a.makeLoggerProducer(ctx, tc, commandInfo.Loggers, getCommandNameForFileLogger(commandInfo))
 		if err != nil {
 			return errors.Wrap(err, "making command logger")
 		}
@@ -91,6 +98,10 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 			grip.Error(errors.Wrap(logger.Close(), "closing command logger"))
 		}()
 	}
+
+	// Omit the block name from the display name, or else the display name
+	// becomes too verbose.
+	blockInfo.Block = ""
 
 	if commandInfo.Function != "" {
 		var commandSetSpan trace.Span
@@ -104,20 +115,28 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "canceled while running command list")
 		}
-		cmd.SetJasperManager(a.jasper)
 
-		fullCommandName := getCommandName(commandInfo, cmd)
+		// kim: TODO: test that command name still displays the same as before.
+		funcInfo := command.FunctionInfo{
+			Function: commandInfo.Function,
+		}
+		if len(cmds) > 1 {
+			// Include the function sub-command number only if it runs more than
+			// one command.
+			funcInfo.SubCmdNum = idx + 1
+		}
+		// kim: TODO: determine if logging the block name is too noisy, in which
+		// case it can be omitted.
+		// Don't use the command's display name here because it can include the
+		// block name, which makes it very verbose.
+		displayName := command.GetDefaultDisplayName(commandInfo.Command, blockInfo, funcInfo)
+
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {
-			tc.logger.Task().Infof("Skipping command %s on variant %s (step %d of %d).",
-				fullCommandName, tc.taskConfig.BuildVariant.Name, index, total)
+			tc.logger.Task().Infof("Skipping command %s on variant %s.", displayName, tc.taskConfig.BuildVariant.Name)
 			continue
 		}
-		if len(cmds) == 1 {
-			tc.logger.Task().Infof("Running command %s (step %d of %d).", fullCommandName, index, total)
-		} else {
-			// for functions with more than one command
-			tc.logger.Task().Infof("Running command %s (step %d.%d of %d).", fullCommandName, index, idx+1, total)
-		}
+
+		tc.logger.Task().Infof("Running command %s.", displayName)
 
 		ctx, commandSpan := a.tracer.Start(ctx, cmd.Name(), trace.WithAttributes(
 			attribute.String(commandNameAttribute, cmd.Name()),
@@ -126,7 +145,9 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 		tc.taskConfig.Expansions.Put(otelParentIDExpansion, commandSpan.SpanContext().SpanID().String())
 		tc.taskConfig.Expansions.Put(otelCollectorEndpointExpansion, a.opts.TraceCollectorEndpoint)
 
-		if err := a.runCommand(ctx, tc, logger, commandInfo, cmd, fullCommandName, options); err != nil {
+		cmd.SetJasperManager(a.jasper)
+
+		if err := a.runCommand(ctx, tc, logger, commandInfo, cmd, displayName, options); err != nil {
 			commandSpan.SetStatus(codes.Error, "running command")
 			commandSpan.RecordError(err, trace.WithAttributes(tc.taskConfig.TaskAttributes()...))
 			commandSpan.End()
@@ -137,8 +158,10 @@ func (a *Agent) runCommandSet(ctx context.Context, tc *taskContext, commandInfo 
 	return nil
 }
 
+// runCommand runs a single command, which is either a standalone command or a
+// single sub-command within a function.
 func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.LoggerProducer, commandInfo model.PluginCommandConf,
-	cmd command.Command, fullCommandName string, options runCommandsOptions) error {
+	cmd command.Command, displayName string, options runCommandsOptions) error {
 
 	for key, val := range commandInfo.Vars {
 		var newVal string
@@ -167,14 +190,14 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		defer func() {
 			// this channel will get read from twice even though we only send once, hence why it's buffered
 			cmdChan <- recovery.HandlePanicWithError(recover(), nil,
-				fmt.Sprintf("running command %s", fullCommandName))
+				fmt.Sprintf("running command %s", displayName))
 		}()
 		cmdChan <- cmd.Execute(ctx, a.comm, logger, tc.taskConfig)
 	}()
 	select {
 	case err := <-cmdChan:
 		if err != nil {
-			tc.logger.Task().Errorf("Command %s failed: %s.", fullCommandName, err)
+			tc.logger.Task().Errorf("Command %s failed: %s.", displayName, err)
 			if options.isTaskCommands || options.failPreAndPost ||
 				(cmd.Name() == "git.get_project" && tc.taskModel.Requester == evergreen.MergeTestRequester) {
 				// any git.get_project in the commit queue should fail
@@ -183,13 +206,13 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		}
 	case <-ctx.Done():
 		if ctx.Err() == context.DeadlineExceeded {
-			tc.logger.Task().Errorf("Command %s stopped early because idle timeout duration of %d seconds has been reached.", fullCommandName, int(tc.timeout.idleTimeoutDuration.Seconds()))
+			tc.logger.Task().Errorf("Command %s stopped early because idle timeout duration of %d seconds has been reached.", displayName, int(tc.timeout.idleTimeoutDuration.Seconds()))
 		} else {
-			tc.logger.Task().Errorf("Command %s stopped early: %s.", fullCommandName, ctx.Err())
+			tc.logger.Task().Errorf("Command %s stopped early: %s.", displayName, ctx.Err())
 		}
 		return errors.Wrap(ctx.Err(), "agent stopped early")
 	}
-	tc.logger.Task().Infof("Finished command %s in %s.", fullCommandName, time.Since(start).String())
+	tc.logger.Task().Infof("Finished command %s in %s.", displayName, time.Since(start).String())
 	if (options.isTaskCommands || options.failPreAndPost) && a.endTaskResp != nil && !a.endTaskResp.ShouldContinue {
 		// only error if we're running a command that should fail, and we don't want to continue to run other tasks
 		return errors.Errorf("task status has been set to '%s'; triggering end task", a.endTaskResp.Status)
@@ -216,7 +239,7 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	tc.logger.Execution().Info("Running task commands.")
 	start := time.Now()
 	opts := runCommandsOptions{isTaskCommands: true}
-	err := a.runCommands(ctx, tc, task.Commands, opts, "")
+	err := a.runCommandsInBlock(ctx, tc, task.Commands, opts, "")
 	tc.logger.Execution().Infof("Finished running task commands in %s.", time.Since(start).String())
 	if err != nil {
 		return err
@@ -224,19 +247,28 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	return nil
 }
 
-func getCommandName(commandInfo model.PluginCommandConf, cmd command.Command) string {
-	commandName := fmt.Sprintf(`'%s'`, cmd.Name())
-	if commandInfo.DisplayName != "" {
-		commandName = fmt.Sprintf(`'%s' (%s)`, commandInfo.DisplayName, commandName)
-	}
-	if commandInfo.Function != "" {
-		commandName = fmt.Sprintf(`%s in function '%s'`, commandName, commandInfo.Function)
-	}
+// kim: TODO: delete
+// getCommandAndFunctionName gets a display name for a command. If the command
+// is run within a function, it includes the function context
+//
+//	func getCommandAndFunctionName(commandInfo model.PluginCommandConf, cmd command.Command) string {
+//	    // kim: TODO: determine if this can use cmd.DisplayName, may need to
+//	    // guarantee cmd.DisplayName gets set.
+//	    commandName := fmt.Sprintf(`'%s'`, cmd.Name())
+//	    if commandInfo.DisplayName != "" {
+//	        commandName = fmt.Sprintf(`'%s' (%s)`, commandInfo.DisplayName, commandName)
+//	    }
+//	    if commandInfo.Function != "" {
+//	        commandName = fmt.Sprintf(`%s in function '%s'`, commandName, commandInfo.Function)
+//	    }
+//
+//	    return commandName
+//	}
+//
 
-	return commandName
-}
-
-func getFunctionName(commandInfo model.PluginCommandConf) string {
+// getCommandNameForFileLogger gets the name of the command that should be used
+// when the file logger is being used.
+func getCommandNameForFileLogger(commandInfo model.PluginCommandConf) string {
 	if commandInfo.DisplayName != "" {
 		return commandInfo.DisplayName
 	}

--- a/agent/command.go
+++ b/agent/command.go
@@ -64,6 +64,7 @@ func (a *Agent) runCommandsInBlock(ctx context.Context, tc *taskContext, command
 			return errors.Wrap(err, "canceled while running commands")
 		}
 		blockInfo := command.BlockInfo{
+			Block:     block,
 			CmdNum:    i + 1,
 			TotalCmds: len(commands),
 		}

--- a/agent/command.go
+++ b/agent/command.go
@@ -116,16 +116,13 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 			return errors.Wrap(err, "canceled while running command list")
 		}
 
-		// kim: TODO: test that command name still displays the same as before.
 		funcInfo := command.FunctionInfo{
 			Function:     commandInfo.Function,
 			SubCmdNum:    idx + 1,
 			TotalSubCmds: len(cmds),
 		}
-		// kim: TODO: determine if logging the block name is too noisy, in which
-		// case it can be omitted.
-		// Don't use the command's display name here because it can include the
-		// block name, which makes it very verbose.
+		// Avoid using the command's display name here because it can include
+		// the block name, which makes it very verbose.
 		displayName := command.GetDefaultDisplayName(cmd.Name(), blockInfo, funcInfo)
 
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {
@@ -243,25 +240,6 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	}
 	return nil
 }
-
-// kim: TODO: delete
-// getCommandAndFunctionName gets a display name for a command. If the command
-// is run within a function, it includes the function context
-//
-//	func getCommandAndFunctionName(commandInfo model.PluginCommandConf, cmd command.Command) string {
-//	    // kim: TODO: determine if this can use cmd.DisplayName, may need to
-//	    // guarantee cmd.DisplayName gets set.
-//	    commandName := fmt.Sprintf(`'%s'`, cmd.Name())
-//	    if commandInfo.DisplayName != "" {
-//	        commandName = fmt.Sprintf(`'%s' (%s)`, commandInfo.DisplayName, commandName)
-//	    }
-//	    if commandInfo.Function != "" {
-//	        commandName = fmt.Sprintf(`%s in function '%s'`, commandName, commandInfo.Function)
-//	    }
-//
-//	    return commandName
-//	}
-//
 
 // getCommandNameForFileLogger gets the name of the command that should be used
 // when the file logger is being used.

--- a/agent/command.go
+++ b/agent/command.go
@@ -118,18 +118,15 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 
 		// kim: TODO: test that command name still displays the same as before.
 		funcInfo := command.FunctionInfo{
-			Function: commandInfo.Function,
-		}
-		if len(cmds) > 1 {
-			// Include the function sub-command number only if it runs more than
-			// one command.
-			funcInfo.SubCmdNum = idx + 1
+			Function:     commandInfo.Function,
+			SubCmdNum:    idx + 1,
+			TotalSubCmds: len(cmds),
 		}
 		// kim: TODO: determine if logging the block name is too noisy, in which
 		// case it can be omitted.
 		// Don't use the command's display name here because it can include the
 		// block name, which makes it very verbose.
-		displayName := command.GetDefaultDisplayName(commandInfo.Command, blockInfo, funcInfo)
+		displayName := command.GetDefaultDisplayName(cmd.Name(), blockInfo, funcInfo)
 
 		if !commandInfo.RunOnVariant(tc.taskConfig.BuildVariant.Name) {
 			tc.logger.Task().Infof("Skipping command %s on variant %s.", displayName, tc.taskConfig.BuildVariant.Name)

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	GitFetchProjectRetries = 5
+	gitFetchProjectRetries = 5
 	defaultCommitterName   = "Evergreen Agent"
 	defaultCommitterEmail  = "no-reply@evergreen.mongodb.com"
 	shallowCloneDepth      = 100
@@ -503,7 +503,7 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 				opts.useVerbose = true // use verbose for the last 2 attempts
 				logger.Task().Error(message.Fields{
 					"message":      "running git clone with verbose output",
-					"num_attempts": GitFetchProjectRetries,
+					"num_attempts": gitFetchProjectRetries,
 					"attempt":      attemptNum,
 				})
 			}
@@ -514,7 +514,7 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 			}
 			return false, nil
 		}, utility.RetryOptions{
-			MaxAttempts: GitFetchProjectRetries,
+			MaxAttempts: gitFetchProjectRetries,
 			MinDelay:    fetchRetryMinDelay,
 			MaxDelay:    fetchRetryMaxDelay,
 		})
@@ -523,7 +523,7 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 			"operation":            "git.get_project",
 			"message":              "cloning failed",
 			"num_attempts":         attemptNum,
-			"num_attempts_allowed": GitFetchProjectRetries,
+			"num_attempts_allowed": gitFetchProjectRetries,
 			"owner":                conf.ProjectRef.Owner,
 			"repo":                 conf.ProjectRef.Repo,
 			"branch":               conf.ProjectRef.Branch,

--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -133,7 +133,7 @@ func TestPatchPlugin(t *testing.T) {
 			for _, task := range taskConfig.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, taskConfig.Project, "")
+					pluginCmds, err := Render(command, taskConfig.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -290,7 +290,7 @@ func (s *GitGetProjectSuite) TestGitPlugin() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project, "")
+			pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -331,7 +331,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project, "")
+			pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -374,7 +374,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project, "")
+			pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -420,7 +420,7 @@ func (s *GitGetProjectSuite) TestValidateGitCommands() {
 
 	for _, task := range conf.Project.Tasks {
 		for _, command := range task.Commands {
-			pluginCmds, err = Render(command, conf.Project, "")
+			pluginCmds, err = Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -773,7 +773,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
 			var pluginCmds []Command
-			pluginCmds, err = Render(command, conf.Project, "")
+			pluginCmds, err = Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -815,7 +815,7 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
 			var pluginCmds []Command
-			pluginCmds, err = Render(command, conf.Project, "")
+			pluginCmds, err = Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)
@@ -1023,7 +1023,7 @@ index edc0c34..8e82862 100644
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
-			pluginCmds, err := Render(command, conf.Project, "")
+			pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 			s.NoError(err)
 			s.NotNil(pluginCmds)
 			pluginCmds[0].SetJasperManager(s.jasper)

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -32,7 +32,7 @@ type Command interface {
 	// SetType sets the command's type (e.g. system or test).
 	SetType(string)
 
-	// DisplayName is the user-configured display name for the command. It can
+	// DisplayName is the user-configurable display name for the command. It can
 	// be set by the user; otherwise, it defaults to displaying information
 	// about the command and other relevant context like the function and block
 	// it runs in.

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -24,7 +24,7 @@ type Command interface {
 	// Execute is called after ParseParams.
 	Execute(context.Context, client.Communicator, client.LoggerProducer, *internal.TaskConfig) error
 
-	// A string name for the command
+	// Name is the name of the command.
 	Name() string
 
 	// Type returns the command's type (e.g. system or test).
@@ -32,6 +32,10 @@ type Command interface {
 	// SetType sets the command's type (e.g. system or test).
 	SetType(string)
 
+	// DisplayName is the user-configured display name for the command. It can
+	// be set by the user; otherwise, it defaults to displaying information
+	// about the command and other relevant context like the function and block
+	// it runs in.
 	DisplayName() string
 	SetDisplayName(string)
 

--- a/agent/command/keyval_test.go
+++ b/agent/command/keyval_test.go
@@ -40,7 +40,7 @@ func TestIncKey(t *testing.T) {
 			for _, task := range conf.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {
-					pluginCmds, err := Render(command, &model.Project{}, "")
+					pluginCmds, err := Render(command, &model.Project{}, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -65,8 +65,13 @@ func GetCommandFactory(name string) (CommandFactory, bool) {
 	return evgRegistry.getCommandFactory(name)
 }
 
-func Render(c model.PluginCommandConf, project *model.Project, block string) ([]Command, error) {
-	return evgRegistry.renderCommands(c, project, block)
+// Render takes a command specification and returns the commands to actually
+// run. It resolves the command specification into either a single command (in
+// the case of standalone command) or a list of commands (in the case of a
+// function).
+// kim: TODO: test display name defaulting.
+func Render(c model.PluginCommandConf, project *model.Project, blockInfo BlockInfo) ([]Command, error) {
+	return evgRegistry.renderCommands(c, project, blockInfo)
 }
 
 func RegisteredCommandNames() []string { return evgRegistry.registeredCommandNames() }
@@ -127,7 +132,7 @@ func (r *commandRegistry) getCommandFactory(name string) (CommandFactory, bool) 
 }
 
 func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
-	project *model.Project, block string) ([]Command, error) {
+	project *model.Project, blockInfo BlockInfo) ([]Command, error) {
 
 	var (
 		parsed []model.PluginCommandConf
@@ -135,18 +140,14 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 	)
 	catcher := grip.NewBasicCatcher()
 
-	if block != "" {
-		block = fmt.Sprintf(`in "%v"`, block)
-	}
-
-	if name := commandInfo.Function; name != "" {
-		cmds, ok := project.Functions[name]
+	if funcName := commandInfo.Function; funcName != "" {
+		cmds, ok := project.Functions[funcName]
 		if !ok {
-			catcher.Errorf("function '%s' not found in project functions", name)
+			catcher.Errorf("function '%s' not found in project functions", funcName)
 		} else if cmds != nil {
 			for i, c := range cmds.List() {
 				if c.Function != "" {
-					catcher.Errorf("cannot reference a function ('%s') within another function ('%s')", c.Function, name)
+					catcher.Errorf("cannot reference a function ('%s') within another function ('%s')", c.Function, funcName)
 					continue
 				}
 
@@ -156,7 +157,17 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 				}
 
 				if c.DisplayName == "" {
-					c.DisplayName = fmt.Sprintf(`'%v' in "%v" %s (#%d)`, c.Command, name, block, i+1)
+					// kim: TODO: test that UI display name displays the name
+					// more like how it's displayed in the logs.
+					// kim: TODO: may be better to instead display
+					// (#STEP_NUMBER) as "step FUNC.SUBCOMMAND of
+					// TOTAL_IN_BLOCK" format, would have to pass in total
+					// number of commands in the block.
+					funcInfo := FunctionInfo{
+						Function:  c.Function,
+						SubCmdNum: i + 1,
+					}
+					c.DisplayName = GetDefaultDisplayName(c.Command, blockInfo, funcInfo)
 				}
 
 				if c.TimeoutSecs == 0 {
@@ -168,7 +179,9 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		}
 	} else {
 		if commandInfo.DisplayName == "" {
-			commandInfo.DisplayName = fmt.Sprintf(`'%v' %s `, commandInfo.Command, block)
+			// kim: TODO: standardize this display name against function.
+			// kim: TODO: test
+			commandInfo.DisplayName = GetDefaultDisplayName(commandInfo.Command, blockInfo, FunctionInfo{})
 		}
 		parsed = append(parsed, commandInfo)
 	}
@@ -199,4 +212,55 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 	}
 
 	return out, nil
+}
+
+// BlockInfo contains information about the enclosing block in which a function
+// or standalone command runs. For example, this would contain information about
+// the pre block that contains a particular shell.exec command.
+type BlockInfo struct {
+	// Block is the name of the block that the command is part of.
+	Block string
+	// CmdNum is the ordinal of a command in the block.
+	CmdNum int
+	// TotalCmds is the total number of commands in the block.
+	TotalCmds int
+}
+
+// FunctionInfo contains information about the enclosing block in which a
+// command listed within a function runs. For example, this would contain
+// information about the second shell.exec that runs in a function.
+type FunctionInfo struct {
+	// Function is the name of the function that the command is part of.
+	Function string
+	// SubCmdNum is the ordinal of the command within the function.
+	SubCmdNum int
+}
+
+// GetDefaultDisplayName returns the default display name for a command.
+// cmdNum is command/function number, subCmdNum only applies for subcmds in
+// functions
+// kim: TODO: add unit tests
+// kim: TODO: potentially pass in BlockInfo and FuncInfo structs for
+// cleanliness.
+func GetDefaultDisplayName(commandName string, blockInfo BlockInfo, funcInfo FunctionInfo) string {
+	displayName := fmt.Sprintf("'%s'", commandName)
+	if funcInfo.Function != "" {
+		displayName = fmt.Sprintf("%s in function '%s'", displayName, funcInfo.Function)
+	}
+	if blockInfo.CmdNum > 0 && blockInfo.TotalCmds > 0 {
+		if funcInfo.SubCmdNum > 0 {
+			displayName = fmt.Sprintf("%s (step %d.%d of %d)", displayName, blockInfo.CmdNum, funcInfo.SubCmdNum, blockInfo.TotalCmds)
+		} else {
+			displayName = fmt.Sprintf("%s (step %d of %d)", displayName, blockInfo.CmdNum, blockInfo.TotalCmds)
+		}
+	}
+	// kim: TODO: decide if having the block is worth it or not. It makes the
+	// name pretty long, and is omitted when it's running the main task block,
+	// so it's already a little wonky.
+	// Alternatively, maybe pass a showBlock option to DisplayName to choose
+	// when/where to show the block name.
+	if blockInfo.Block != "" {
+		displayName = fmt.Sprintf("%s in block '%s'", displayName, blockInfo.Block)
+	}
+	return displayName
 }

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -248,12 +248,6 @@ func GetDefaultDisplayName(commandName string, blockInfo BlockInfo, funcInfo Fun
 			displayName = fmt.Sprintf("%s (step %d of %d)", displayName, blockInfo.CmdNum, blockInfo.TotalCmds)
 		}
 	}
-	// kim: TODO: decide if having the block is worth it or not. It makes the
-	// name pretty long, and is omitted when it's running the main task block,
-	// so it's already a little wonky.
-	// Alternatively, maybe pass a showBlock option to DisplayName to choose
-	// when/where to show the block name. Or even more alternatively, only set
-	// the block name when passing the end task details back to the app server.
 	if blockInfo.Block != "" {
 		displayName = fmt.Sprintf("%s in block '%s'", displayName, blockInfo.Block)
 	}

--- a/agent/command/registry_test.go
+++ b/agent/command/registry_test.go
@@ -135,4 +135,114 @@ func TestRenderCommands(t *testing.T) {
 		require.Len(t, cmds, 1)
 		assert.Equal(t, "'command.mock'", cmds[0].DisplayName())
 	})
+	t.Run("CommandsInFuncHaveExplicitOrDefaultDisplayNames", func(t *testing.T) {
+		info := model.PluginCommandConf{
+			Function: "my-func",
+		}
+		p := &model.Project{
+			Functions: map[string]*model.YAMLCommandSet{
+				"my-func": {
+					MultiCommand: []model.PluginCommandConf{
+						{
+							Command: "command.mock",
+						},
+						{
+							Command: "command.mock",
+						},
+						{
+							Command:     "command.mock",
+							DisplayName: "run-a-shell-thing",
+						},
+					},
+				},
+			},
+		}
+		cmds, err := registry.renderCommands(info, p, BlockInfo{
+			Block:     "pre",
+			CmdNum:    1,
+			TotalCmds: 1,
+		})
+		require.NoError(t, err)
+		require.Len(t, cmds, 3)
+		assert.Equal(t, "'command.mock' in function 'my-func' (step 1.1 of 1) in block 'pre'", cmds[0].DisplayName())
+		assert.Equal(t, "'command.mock' in function 'my-func' (step 1.2 of 1) in block 'pre'", cmds[1].DisplayName())
+		assert.Equal(t, "run-a-shell-thing", cmds[2].DisplayName())
+	})
+}
+
+func TestGetDefaultDisplayName(t *testing.T) {
+	t.Run("NoCommandInfoProducesNoDisplayName", func(t *testing.T) {
+		assert.Equal(t, "''", GetDefaultDisplayName("", BlockInfo{}, FunctionInfo{}))
+	})
+	t.Run("JustCommandName", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec'", GetDefaultDisplayName("shell.exec", BlockInfo{}, FunctionInfo{}))
+	})
+	t.Run("CommandNameAndBlockName", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in block 'pre'", GetDefaultDisplayName("shell.exec", BlockInfo{
+			Block: "pre",
+		}, FunctionInfo{}))
+	})
+	t.Run("CommandNameAndBlockCommandNumber", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' (step 3 of 5)", GetDefaultDisplayName("shell.exec", BlockInfo{
+			CmdNum:    3,
+			TotalCmds: 5,
+		}, FunctionInfo{}))
+	})
+	t.Run("CommandNameAndBlockNameAndBlockCommandNumber", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' (step 3 of 5) in block 'post'", GetDefaultDisplayName("shell.exec", BlockInfo{
+			Block:     "post",
+			CmdNum:    3,
+			TotalCmds: 5,
+		}, FunctionInfo{}))
+	})
+	t.Run("CommandNameAndBlockNameAndBlockCommandNumberWithOnlyOneCommandInBlock", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' (step 1 of 1) in block 'post'", GetDefaultDisplayName("shell.exec", BlockInfo{
+			Block:     "post",
+			CmdNum:    1,
+			TotalCmds: 1,
+		}, FunctionInfo{}))
+	})
+	t.Run("CommandNameAndFunc", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in function 'my-func'", GetDefaultDisplayName("shell.exec", BlockInfo{}, FunctionInfo{
+			Function: "my-func",
+		}))
+	})
+	t.Run("CommandNameAndBlockCommandNumberAndFuncSubcommandNumber", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in function 'my-func' (step 5.4 of 12)", GetDefaultDisplayName("shell.exec", BlockInfo{
+			CmdNum:    5,
+			TotalCmds: 12,
+		}, FunctionInfo{
+			Function:     "my-func",
+			SubCmdNum:    4,
+			TotalSubCmds: 10,
+		}))
+	})
+	t.Run("CommandNameAndBlockCommandNumberAndFuncSubcommandNumberWithOnlyOneSubcommand", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in function 'my-func' (step 5 of 12)", GetDefaultDisplayName("shell.exec", BlockInfo{
+			CmdNum:    5,
+			TotalCmds: 12,
+		}, FunctionInfo{
+			Function:     "my-func",
+			SubCmdNum:    1,
+			TotalSubCmds: 1,
+		}))
+	})
+	t.Run("CommandNameAndFuncAndFuncSubcommandNumberButNoBlock", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in function 'my-func'", GetDefaultDisplayName("shell.exec", BlockInfo{}, FunctionInfo{
+			Function:     "my-func",
+			SubCmdNum:    4,
+			TotalSubCmds: 10,
+		}))
+	})
+	t.Run("CommandNameAndAllBlockInfoAndAllFuncInfo", func(t *testing.T) {
+		assert.Equal(t, "'shell.exec' in function 'my-func' (step 5.4 of 12) in block 'pre'", GetDefaultDisplayName("shell.exec", BlockInfo{
+			Block:     "pre",
+			CmdNum:    5,
+			TotalCmds: 12,
+		}, FunctionInfo{
+			Function:     "my-func",
+			SubCmdNum:    4,
+			TotalSubCmds: 10,
+		}))
+	})
 }

--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -49,7 +49,7 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
-					pluginCmds, err := Render(command, conf.Project, "")
+					pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
@@ -111,7 +111,7 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 			for _, testTask := range conf.Project.Tasks {
 				So(len(testTask.Commands), ShouldNotEqual, 0)
 				for _, command := range testTask.Commands {
-					pluginCmds, err := Render(command, conf.Project, "")
+					pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -54,7 +54,7 @@ func TestAttachResults(t *testing.T) {
 			for _, projTask := range conf.Project.Tasks {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
-					pluginCmds, err := Render(command, conf.Project, "")
+					pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)
@@ -108,7 +108,7 @@ func TestAttachRawResults(t *testing.T) {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
 
-					pluginCmds, err := Render(command, conf.Project, "")
+					pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -52,7 +52,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 			for _, projTask := range conf.Project.Tasks {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
 				for _, command := range projTask.Commands {
-					pluginCmds, err := Render(command, conf.Project, "")
+					pluginCmds, err := Render(command, conf.Project, BlockInfo{})
 					require.NoError(t, err)
 					So(pluginCmds, ShouldNotBeNil)
 					So(err, ShouldBeNil)

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -103,20 +103,11 @@ func (s *CommandSuite) TestShellExec() {
 	s.NoError(err)
 
 	s.Require().NoError(s.tc.logger.Close())
-	messages := s.mockCommunicator.GetMockMessages()
-	s.Len(messages, 1)
-	foundSuccessLogMessage := false
-	foundShellLogMessage := false
-	for _, msg := range messages[taskID] {
-		if msg.Message == "Task completed - SUCCESS." {
-			foundSuccessLogMessage = true
-		}
-		if strings.HasPrefix(msg.Message, "Finished command 'shell.exec'") {
-			foundShellLogMessage = true
-		}
-	}
-	s.True(foundSuccessLogMessage)
-	s.True(foundShellLogMessage)
+
+	checkMockLogs(s.T(), s.mockCommunicator, taskID,
+		"Task completed - SUCCESS",
+		"Finished command 'shell.exec' in function 'foo' (step 1 of 1)",
+	)
 
 	detail := s.mockCommunicator.GetEndTaskDetail()
 	s.Equal("success", detail.Status)

--- a/agent/task.go
+++ b/agent/task.go
@@ -153,7 +153,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 				ctx2, cancel = a.withCallbackTimeout(ctx, tc)
 			}
 			defer cancel()
-			err = a.runCommands(ctx2, tc, taskGroup.SetupGroup.List(), opts, preBlock)
+			err = a.runCommandsInBlock(ctx2, tc, taskGroup.SetupGroup.List(), opts, preBlock)
 			if err != nil {
 				tc.logger.Execution().Error(errors.Wrap(err, "running task setup group"))
 				if taskGroup.SetupGroupFailTask {
@@ -174,7 +174,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 	if taskGroup.SetupTask != nil {
 		tc.logger.Task().Infof("Running setup task for task group '%s'.", taskGroup.Name)
 		opts.failPreAndPost = taskGroup.SetupGroupFailTask
-		err = a.runCommands(ctx, tc, taskGroup.SetupTask.List(), opts, preBlock)
+		err = a.runCommandsInBlock(ctx, tc, taskGroup.SetupTask.List(), opts, preBlock)
 	}
 	if err != nil {
 		err = errors.Wrap(err, "Running pre-task commands failed")
@@ -193,7 +193,7 @@ func (tc *taskContext) setCurrentCommand(command command.Command) {
 	tc.currentCommand = command
 
 	if tc.logger != nil {
-		tc.logger.Execution().Infof("Current command set to '%s' (%s).", tc.currentCommand.DisplayName(), tc.currentCommand.Type())
+		tc.logger.Execution().Infof("Current command set to %s (%s).", tc.currentCommand.DisplayName(), tc.currentCommand.Type())
 	}
 }
 
@@ -220,7 +220,7 @@ func (tc *taskContext) setCurrentIdleTimeout(cmd command.Command) {
 
 	tc.setIdleTimeout(timeout)
 	if tc.currentCommand != nil {
-		tc.logger.Execution().Debugf("Set idle timeout for '%s' (%s) to %s.",
+		tc.logger.Execution().Debugf("Set idle timeout for %s (%s) to %s.",
 			tc.currentCommand.DisplayName(), tc.currentCommand.Type(), tc.getIdleTimeout())
 	} else {
 		tc.logger.Execution().Debugf("Set current idle timeout to %s.", tc.getIdleTimeout())

--- a/agent/task.go
+++ b/agent/task.go
@@ -153,7 +153,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 				ctx2, cancel = a.withCallbackTimeout(ctx, tc)
 			}
 			defer cancel()
-			err = a.runCommandsInBlock(ctx2, tc, taskGroup.SetupGroup.List(), opts, preBlock)
+			err = a.runCommandsInBlock(ctx2, tc, taskGroup.SetupGroup.List(), opts, setupGroupBlock)
 			if err != nil {
 				tc.logger.Execution().Error(errors.Wrap(err, "running task setup group"))
 				if taskGroup.SetupGroupFailTask {
@@ -174,7 +174,11 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 	if taskGroup.SetupTask != nil {
 		tc.logger.Task().Infof("Running setup task for task group '%s'.", taskGroup.Name)
 		opts.failPreAndPost = taskGroup.SetupGroupFailTask
-		err = a.runCommandsInBlock(ctx, tc, taskGroup.SetupTask.List(), opts, preBlock)
+		block := preBlock
+		if tc.taskGroup != "" {
+			block = setupTaskBlock
+		}
+		err = a.runCommandsInBlock(ctx, tc, taskGroup.SetupTask.List(), opts, block)
 	}
 	if err != nil {
 		err = errors.Wrap(err, "Running pre-task commands failed")

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-21"
+	AgentVersion = "2023-06-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-20a"
+	AgentVersion = "2023-06-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1202,9 +1202,15 @@ func validateCommands(section string, project *model.Project,
 	commands []model.PluginCommandConf) ValidationErrors {
 	errs := ValidationErrors{}
 
-	for _, cmd := range commands {
+	for i, cmd := range commands {
 		commandName := fmt.Sprintf("'%s' command", cmd.Command)
-		_, err := command.Render(cmd, project, "")
+		// kim: TODO: test that validation display name looks generally alright.
+		blockInfo := command.BlockInfo{
+			Block:     "",
+			CmdNum:    i + 1,
+			TotalCmds: len(commands),
+		}
+		_, err := command.Render(cmd, project, blockInfo)
 		if err != nil {
 			if cmd.Function != "" {
 				commandName = fmt.Sprintf("'%s' function", cmd.Function)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1204,7 +1204,9 @@ func validateCommands(section string, project *model.Project,
 
 	for i, cmd := range commands {
 		commandName := fmt.Sprintf("'%s' command", cmd.Command)
-		// kim: TODO: test that validation display name looks generally alright.
+		if cmd.Function != "" {
+			commandName = fmt.Sprintf("'%s' function", cmd.Function)
+		}
 		blockInfo := command.BlockInfo{
 			Block:     "",
 			CmdNum:    i + 1,
@@ -1212,14 +1214,11 @@ func validateCommands(section string, project *model.Project,
 		}
 		_, err := command.Render(cmd, project, blockInfo)
 		if err != nil {
-			if cmd.Function != "" {
-				commandName = fmt.Sprintf("'%s' function", cmd.Function)
-			}
 			errs = append(errs, ValidationError{Message: fmt.Sprintf("%s section in %s: %s", section, commandName, err)})
 		}
 		if cmd.Type != "" {
 			if !utility.StringSliceContains(evergreen.ValidCommandTypes, cmd.Type) {
-				msg := fmt.Sprintf("%s section in '%s': invalid command type: '%s'", section, commandName, cmd.Type)
+				msg := fmt.Sprintf("%s section in %s: invalid command type: '%s'", section, commandName, cmd.Type)
 				errs = append(errs, ValidationError{Message: msg})
 			}
 		}


### PR DESCRIPTION
EVG-20139
EVG-20141

### Description
#### Current Command Format
In the UI: `'shell.exec' in "my-func-name" (#5) in "pre"`
Which has the format: `'COMMAND_NAME' in "FUNC_NAME" (#COMMAND_NUMBER) in "BLOCK_NAME"`

In the task logs: `'shell.exec' in function 'my-func-name' (step 5.12 of 8)`
Which has the format: `'COMMAND_NAME' in function 'FUNC_NAME' (step COMMAND_NUMBER.FUNC_SUBCOMMAND_NUM of TOTAL_COMMANDS_IN_BLOCK)`

Some problems with the current command format:
* The "failing command" and the task logs represent the failing command in different formats, making it difficult to deduce which task log lines correspond to the actual failing command.
* The UI display name doesn't mention what the context of the failing command is, so it's unclear if the func name is a function or if it's the command block section in which it failed.
* The UI display name doesn't include the function sub-command number that failed, but the task logs do.

#### Proposed Command Format
If a command doesn't already have an explicit display name configured by the user, the command format is as follows for both the UI and the task logs:
`'COMMAND_NAME' in function 'FUNC_NAME' (step COMMAND_NUMBER.FUNC_SUBCOMMAND_NUM of TOTAL_COMMANDS_IN_BLOCK) in block 'BLOCK_NAME'`

For example:
`'shell.exec' in function 'my-func-name' (step 5.12 of 8) in block 'pre'`

The biggest difference is that commands in the task logs now include the `in block 'BLOCK_NAME'` at the end, like the UI currently shows. I thought it might be kind of excessively verbose, but it is more explicit in the case where you're lost in the task logs on which specific block you're looking at. It also has the side benefit of you being able to search for the "failing command" exactly as-is in the task logs.

**I'm also open to alternative display formats if you think this one can be improved.**

#### Changes
* Make the default command display name consistent between the task logs and the UI.
* Rename a couple functions to better reflect what they actually do.

### Testing
Added unit tests for task log command name, existing tests should also pass.

Tested in staging that the commands displayed as expected in the task logs, and also appeared as expected in Spruce:
[Example of succeeding task](https://spruce-staging.corp.mongodb.com/task/evg_race_detector_test_util_fbcd2ecadeaf57797fb385a49740d32814b1989e_23_06_16_02_34_46/logs?execution=2)
[Example of failed task](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_js_test_fbcd2ecadeaf57797fb385a49740d32814b1989e_23_06_16_02_34_46/logs?execution=1)

### Documentation
N/A