### PR TITLE
EVG-20072 Unify merge queue expansions

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1175,7 +1175,7 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken, appToken string)
 		}
 
 		if v.Requester == evergreen.GithubMergeRequester {
-			expansions.Put("is_github_merge_queue", "true")
+			expansions.Put("is_commit_queue", "true")
 		}
 
 		if p.IsPRMergePatch() || v.Requester == evergreen.GithubPRRequester {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -440,8 +440,7 @@ func TestPopulateExpansions(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 25)
 	assert.Equal("true", expansions.Get("is_patch"))
-	assert.Equal("true", expansions.Get("is_github_merge_queue"))
-	assert.False(expansions.Exists("is_commit_queue"))
+	assert.Equal("true", expansions.Get("is_commit_queue"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
 	assert.NoError(VersionUpdateOne(bson.M{VersionIdKey: v.Id}, bson.M{


### PR DESCRIPTION
EVG-20072

### Description
Stakeholders explained that it would be more useful to have a unified expansion,
since they plan to have the same behavior regardless of which commit queue the
version runs from, since from a stakeholder perspective the commit queues are
equivalent. Having an additional expansion for the GitHub merge queue is not useful.

### Testing
This is unit tested in the same way as the additional expansion, but now it
tests for only a single expansion.