### PR TITLE
EVG-19932: Add distro permissions directive

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1142,6 +1142,7 @@ func GetPermissionLevelsForPermissionKey(permissionKey string) []PermissionLevel
 		}
 	case PermissionDistroSettings:
 		return []PermissionLevel{
+			DistroSettingsAdmin,
 			DistroSettingsEdit,
 			DistroSettingsView,
 			DistroSettingsNone,

--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -45,7 +45,7 @@ func setupPermissions(t *testing.T) {
 		ID:        "superuser_scope",
 		Name:      "superuser scope",
 		Type:      evergreen.SuperUserResourceType,
-		Resources: []string{"super_user", "distro-id"},
+		Resources: []string{"super_user"},
 	}
 	err = roleManager.AddScope(superUserScope)
 	require.NoError(t, err)
@@ -164,10 +164,9 @@ func TestRequireDistroAccess(t *testing.T) {
 	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
 	require.EqualError(t, err, "input: distro not specified")
 
-	// superuser should be successful for create
+	// superuser should be successful for create with no distro ID specified
 	require.NoError(t, usr.AddRole("superuser"))
 
-	obj = interface{}(map[string]interface{}{"distroId": "distro-id"})
 	res, err := config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessCreate)
 	require.NoError(t, err)
 	require.Nil(t, res)

--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -45,10 +45,29 @@ func setupPermissions(t *testing.T) {
 		ID:        "superuser_scope",
 		Name:      "superuser scope",
 		Type:      evergreen.SuperUserResourceType,
-		Resources: []string{"super_user"},
+		Resources: []string{"super_user", "distro-id"},
 	}
 	err = roleManager.AddScope(superUserScope)
 	require.NoError(t, err)
+
+	superUserDistroRole := gimlet.Role{
+		ID:    "superuser_distro_access",
+		Name:  "admin access",
+		Scope: evergreen.AllDistrosScope,
+		Permissions: map[string]int{
+			"distro_settings": 30,
+			"distro_hosts":    20,
+		},
+	}
+	require.NoError(t, roleManager.UpdateRole(superUserDistroRole))
+
+	superUserDistroScope := gimlet.Scope{
+		ID:        "all_distros",
+		Name:      "all distros",
+		Type:      evergreen.DistroResourceType,
+		Resources: []string{"distro-id"},
+	}
+	require.NoError(t, roleManager.AddScope(superUserDistroScope))
 
 	projectAdminRole := gimlet.Role{
 		ID:          "admin_project",
@@ -74,6 +93,179 @@ func setupPermissions(t *testing.T) {
 	}
 	err = roleManager.AddScope(projectScope)
 	require.NoError(t, err)
+
+	distroAdminRole := gimlet.Role{
+		ID:          "admin_distro-id",
+		Scope:       "distro_distro-id",
+		Permissions: map[string]int{"distro_settings": evergreen.DistroSettingsAdmin.Value},
+	}
+	require.NoError(t, roleManager.UpdateRole(distroAdminRole))
+
+	distroEditRole := gimlet.Role{
+		ID:          "edit_distro-id",
+		Scope:       "distro_distro-id",
+		Permissions: map[string]int{"distro_settings": evergreen.DistroSettingsEdit.Value},
+	}
+	require.NoError(t, roleManager.UpdateRole(distroEditRole))
+
+	distroViewRole := gimlet.Role{
+		ID:          "view_distro-id",
+		Scope:       "distro_distro-id",
+		Permissions: map[string]int{"distro_settings": evergreen.DistroSettingsView.Value},
+	}
+	require.NoError(t, roleManager.UpdateRole(distroViewRole))
+
+	distroScope := gimlet.Scope{
+		ID:        "distro_distro-id",
+		Name:      "distro-id",
+		Type:      evergreen.DistroResourceType,
+		Resources: []string{"distro-id"},
+	}
+	require.NoError(t, roleManager.AddScope(distroScope))
+}
+
+func TestRequireDistroAccess(t *testing.T) {
+	setupPermissions(t)
+	require.NoError(t, db.Clear(user.Collection),
+		"unable to clear user collection")
+	dbUser := &user.DBUser{
+		Id: apiUser,
+		Settings: user.UserSettings{
+			SlackUsername: "testuser",
+			SlackMemberId: "testuser",
+		},
+	}
+	require.NoError(t, dbUser.Insert())
+
+	const email = "testuser@mongodb.com"
+	const accessToken = "access_token"
+	const refreshToken = "refresh_token"
+	config := New("/graphql")
+	require.NotNil(t, config)
+	ctx := context.Background()
+	obj := interface{}(nil)
+
+	// callCount keeps track of how many times the function is called
+	callCount := 0
+	next := func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		callCount++
+		return nil, nil
+	}
+
+	usr, err := user.GetOrCreateUser(apiUser, "User Name", email, accessToken, refreshToken, []string{})
+	require.NoError(t, err)
+	require.NotNil(t, usr)
+
+	ctx = gimlet.AttachUser(ctx, usr)
+	require.NotNil(t, ctx)
+
+	// Fails when distro is not specified
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.EqualError(t, err, "input: distro not specified")
+
+	// superuser should be successful for create
+	require.NoError(t, usr.AddRole("superuser"))
+
+	obj = interface{}(map[string]interface{}{"distroId": "distro-id"})
+	res, err := config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessCreate)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 1, callCount)
+
+	require.NoError(t, usr.RemoveRole("superuser"))
+
+	// superuser_distro_access is successful for admin, edit, view
+	require.NoError(t, usr.AddRole("superuser_distro_access"))
+
+	obj = interface{}(map[string]interface{}{"distroId": "distro-id"})
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 2, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessEdit)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 3, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessView)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 4, callCount)
+
+	require.NoError(t, usr.RemoveRole("superuser_distro_access"))
+
+	// admin access is successful for admin, edit, view
+	require.NoError(t, usr.AddRole("admin_distro-id"))
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 5, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessEdit)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 6, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessView)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 7, callCount)
+
+	require.NoError(t, usr.RemoveRole("admin_distro-id"))
+
+	// edit access fails for admin, is successful for edit & view
+	require.NoError(t, usr.AddRole("edit_distro-id"))
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.Nil(t, res)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
+	require.Equal(t, 7, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessEdit)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 8, callCount)
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessView)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 9, callCount)
+
+	require.NoError(t, usr.RemoveRole("edit_distro-id"))
+
+	// view access fails for admin & edit, is successful for view
+	require.NoError(t, usr.AddRole("view_distro-id"))
+
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.Equal(t, 9, callCount)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
+
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessEdit)
+	require.Equal(t, 9, callCount)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
+
+	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessView)
+	require.NoError(t, err)
+	require.Nil(t, res)
+	require.Equal(t, 10, callCount)
+
+	require.NoError(t, usr.RemoveRole("view_distro-id"))
+
+	// no access fails all query attempts
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
+	require.Equal(t, 10, callCount)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
+
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessEdit)
+	require.Equal(t, 10, callCount)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
+
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessView)
+	require.Equal(t, 10, callCount)
+	require.EqualError(t, err, "input: user 'testuser' does not have permission to access settings for the distro 'distro-id'")
 }
 
 func TestRequireProjectAdmin(t *testing.T) {

--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -164,6 +164,9 @@ func TestRequireDistroAccess(t *testing.T) {
 	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
 	require.EqualError(t, err, "input: distro not specified")
 
+	_, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessCreate)
+	require.EqualError(t, err, "input: user 'testuser' does not have create distro permissions")
+
 	// superuser should be successful for create with no distro ID specified
 	require.NoError(t, usr.AddRole("superuser"))
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -73,6 +73,7 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
+	RequireDistroAccess       func(ctx context.Context, obj interface{}, next graphql.Resolver, access DistroSettingsAccess) (res interface{}, err error)
 	RequireProjectAccess      func(ctx context.Context, obj interface{}, next graphql.Resolver, access ProjectSettingsAccess) (res interface{}, err error)
 	RequireProjectAdmin       func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
 	RequireProjectFieldAccess func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
@@ -8265,7 +8266,7 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 	return introspection.WrapTypeFromDef(parsedSchema, parsedSchema.Types[name]), nil
 }
 
-//go:embed "schema/directives.graphql" "schema/mutation.graphql" "schema/query.graphql" "schema/scalars.graphql" "schema/types/annotation.graphql" "schema/types/commit_queue.graphql" "schema/types/config.graphql" "schema/types/host.graphql" "schema/types/issue_link.graphql" "schema/types/logkeeper.graphql" "schema/types/mainline_commits.graphql" "schema/types/patch.graphql" "schema/types/permissions.graphql" "schema/types/pod.graphql" "schema/types/project.graphql" "schema/types/project_settings.graphql" "schema/types/project_subscriber.graphql" "schema/types/project_vars.graphql" "schema/types/repo_ref.graphql" "schema/types/repo_settings.graphql" "schema/types/spawn.graphql" "schema/types/subscriptions.graphql" "schema/types/task.graphql" "schema/types/task_logs.graphql" "schema/types/task_queue_item.graphql" "schema/types/ticket_fields.graphql" "schema/types/user.graphql" "schema/types/version.graphql" "schema/types/volume.graphql"
+//go:embed "schema/directives.graphql" "schema/mutation.graphql" "schema/query.graphql" "schema/scalars.graphql" "schema/types/annotation.graphql" "schema/types/commit_queue.graphql" "schema/types/config.graphql" "schema/types/distro.graphql" "schema/types/host.graphql" "schema/types/issue_link.graphql" "schema/types/logkeeper.graphql" "schema/types/mainline_commits.graphql" "schema/types/patch.graphql" "schema/types/permissions.graphql" "schema/types/pod.graphql" "schema/types/project.graphql" "schema/types/project_settings.graphql" "schema/types/project_subscriber.graphql" "schema/types/project_vars.graphql" "schema/types/repo_ref.graphql" "schema/types/repo_settings.graphql" "schema/types/spawn.graphql" "schema/types/subscriptions.graphql" "schema/types/task.graphql" "schema/types/task_logs.graphql" "schema/types/task_queue_item.graphql" "schema/types/ticket_fields.graphql" "schema/types/user.graphql" "schema/types/version.graphql" "schema/types/volume.graphql"
 var sourcesFS embed.FS
 
 func sourceData(filename string) string {
@@ -8284,6 +8285,7 @@ var sources = []*ast.Source{
 	{Name: "schema/types/annotation.graphql", Input: sourceData("schema/types/annotation.graphql"), BuiltIn: false},
 	{Name: "schema/types/commit_queue.graphql", Input: sourceData("schema/types/commit_queue.graphql"), BuiltIn: false},
 	{Name: "schema/types/config.graphql", Input: sourceData("schema/types/config.graphql"), BuiltIn: false},
+	{Name: "schema/types/distro.graphql", Input: sourceData("schema/types/distro.graphql"), BuiltIn: false},
 	{Name: "schema/types/host.graphql", Input: sourceData("schema/types/host.graphql"), BuiltIn: false},
 	{Name: "schema/types/issue_link.graphql", Input: sourceData("schema/types/issue_link.graphql"), BuiltIn: false},
 	{Name: "schema/types/logkeeper.graphql", Input: sourceData("schema/types/logkeeper.graphql"), BuiltIn: false},
@@ -8312,6 +8314,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) dir_requireDistroAccess_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 DistroSettingsAccess
+	if tmp, ok := rawArgs["access"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("access"))
+		arg0, err = ec.unmarshalNDistroSettingsAccess2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDistroSettingsAccess(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["access"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) dir_requireProjectAccess_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -73659,6 +73676,16 @@ func (ec *executionContext) marshalNDistro2ᚕᚖgithubᚗcomᚋevergreenᚑci�
 	wg.Wait()
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalNDistroSettingsAccess2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDistroSettingsAccess(ctx context.Context, v interface{}) (DistroSettingsAccess, error) {
+	var res DistroSettingsAccess
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDistroSettingsAccess2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDistroSettingsAccess(ctx context.Context, sel ast.SelectionSet, v DistroSettingsAccess) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNDuration2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIDuration(ctx context.Context, v interface{}) (model.APIDuration, error) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -412,6 +412,51 @@ type VolumeHost struct {
 	HostID   string `json:"hostId"`
 }
 
+type DistroSettingsAccess string
+
+const (
+	DistroSettingsAccessAdmin  DistroSettingsAccess = "ADMIN"
+	DistroSettingsAccessCreate DistroSettingsAccess = "CREATE"
+	DistroSettingsAccessEdit   DistroSettingsAccess = "EDIT"
+	DistroSettingsAccessView   DistroSettingsAccess = "VIEW"
+)
+
+var AllDistroSettingsAccess = []DistroSettingsAccess{
+	DistroSettingsAccessAdmin,
+	DistroSettingsAccessCreate,
+	DistroSettingsAccessEdit,
+	DistroSettingsAccessView,
+}
+
+func (e DistroSettingsAccess) IsValid() bool {
+	switch e {
+	case DistroSettingsAccessAdmin, DistroSettingsAccessCreate, DistroSettingsAccessEdit, DistroSettingsAccessView:
+		return true
+	}
+	return false
+}
+
+func (e DistroSettingsAccess) String() string {
+	return string(e)
+}
+
+func (e *DistroSettingsAccess) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = DistroSettingsAccess(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid DistroSettingsAccess", str)
+	}
+	return nil
+}
+
+func (e DistroSettingsAccess) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type HostSortBy string
 
 const (

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -69,31 +69,6 @@ func New(apiURL string) Config {
 		}
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have permission to access settings for the distro '%s'", user.Username(), distroId))
 	}
-	c.Directives.RequireProjectFieldAccess = func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
-		user := mustHaveUser(ctx)
-
-		projectRef, isProjectRef := obj.(*restModel.APIProjectRef)
-		if !isProjectRef {
-			return nil, InternalServerError.Send(ctx, "project not valid")
-		}
-
-		projectId := utility.FromStringPtr(projectRef.Id)
-		if projectId == "" {
-			return nil, ResourceNotFound.Send(ctx, "project not specified")
-		}
-
-		opts := gimlet.PermissionOpts{
-			Resource:      projectId,
-			ResourceType:  evergreen.ProjectResourceType,
-			Permission:    evergreen.PermissionProjectSettings,
-			RequiredLevel: evergreen.ProjectSettingsView.Value,
-		}
-		if user.HasPermission(opts) {
-			return next(ctx)
-		}
-		return nil, Forbidden.Send(ctx, fmt.Sprintf("user does not have permission to access the field '%s' for project with ID '%s'", graphql.GetFieldContext(ctx).Path(), projectId))
-
-	}
 	c.Directives.RequireProjectAdmin = func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
 		// Allow if user is superuser.
 		user := mustHaveUser(ctx)

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -12,3 +12,8 @@ directive @requireProjectAccess(access: ProjectSettingsAccess!) on ARGUMENT_DEFI
 requireProjectFieldAccess is used to restrict view access for certain project fields.
 """
 directive @requireProjectFieldAccess on FIELD_DEFINITION
+
+"""
+requireDistroACcess is used to restrict view, edit, admin, and create access for distros.
+"""
+directive @requireDistroAccess(access: DistroSettingsAccess!) on ARGUMENT_DEFINITION

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -14,6 +14,6 @@ requireProjectFieldAccess is used to restrict view access for certain project fi
 directive @requireProjectFieldAccess on FIELD_DEFINITION
 
 """
-requireDistroACcess is used to restrict view, edit, admin, and create access for distros.
+requireDistroAccess is used to restrict view, edit, admin, and create access for distros.
 """
 directive @requireDistroAccess(access: DistroSettingsAccess!) on ARGUMENT_DEFINITION

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -1,0 +1,6 @@
+enum DistroSettingsAccess {
+  ADMIN
+  CREATE
+  EDIT
+  VIEW
+}


### PR DESCRIPTION
EVG-19932

### Description
- Add `@requireDistroAccess(DistroSettingsAccess)` directive to gate future distro resolvers.
- The technical design identified multiple directives that would be added for various permissions, but I remembered that we can use an argument to specify the permission level and use just one directive.
- I also noticed that we distinguish between create and admin permissions for distros, so I added a fourth permission level. I'll update the project tickets to reflect these changes.

### Testing
- Add unit tests for various permission levels with the directive

### Documentation
N/A