### PR TITLE
EVG-20161 Try patch doc's cached merge commit SHA upon the first fetch attempt

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -76,17 +76,18 @@ type gitFetchProject struct {
 }
 
 type cloneOpts struct {
-	method            string
-	location          string
-	owner             string
-	repo              string
-	branch            string
-	dir               string
-	token             string
-	cloneParams       string
-	recurseSubmodules bool
-	useVerbose        bool
-	cloneDepth        int
+	method                 string
+	location               string
+	owner                  string
+	repo                   string
+	branch                 string
+	dir                    string
+	token                  string
+	cloneParams            string
+	recurseSubmodules      bool
+	useVerbose             bool
+	usePatchMergeCommitSha bool
+	cloneDepth             int
 }
 
 func (opts cloneOpts) validate() error {
@@ -302,13 +303,19 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, comm client.Com
 	if isGitHub(conf) {
 		var ref, localBranchName, remoteBranchName, commitToTest string
 		if conf.Task.Requester == evergreen.MergeTestRequester {
-			// Proceed if github has confirmed this pr is mergeable. If it hasn't checked, this request
-			// will make it check.
-			commitToTest, err = c.waitForMergeableCheck(ctx, comm, logger, conf, opts)
-			if err != nil {
-				commitToTest = conf.GithubPatchData.HeadHash
-				logger.Task().Errorf("Error checking if pull request is mergeable: %s", err)
-				logger.Task().Warningf("Because errors were encountered trying to retrieve the pull request, we will use the last recorded hash to test (%s).", commitToTest)
+			// If opts indicates this is the first attempt (of five), start by trying the patch's
+			// cached MergeCommitSHA from when it was created and skip the agent route.
+			if opts.usePatchMergeCommitSha {
+				commitToTest = conf.GithubPatchData.MergeCommitSHA
+			}
+			if commitToTest == "" {
+				// Proceed if github has confirmed this pr is mergeable.
+				commitToTest, err = c.waitForMergeableCheck(ctx, comm, logger, conf, opts)
+				if err != nil {
+					commitToTest = conf.GithubPatchData.HeadHash
+					logger.Task().Errorf("Error checking if pull request is mergeable: %s", err)
+					logger.Task().Warningf("Because errors were encountered trying to retrieve the pull request, we will use the last recorded hash to test (%s).", commitToTest)
+				}
 			}
 			ref = "merge"
 			localBranchName = fmt.Sprintf("evg-merge-test-%s", utility.RandomString())
@@ -435,14 +442,15 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 func (c *gitFetchProject) opts(projectMethod, projectToken string, logger client.LoggerProducer, conf *internal.TaskConfig) (cloneOpts, error) {
 	shallowCloneEnabled := conf.Distro == nil || !conf.Distro.DisableShallowClone
 	opts := cloneOpts{
-		method:            projectMethod,
-		owner:             conf.ProjectRef.Owner,
-		repo:              conf.ProjectRef.Repo,
-		branch:            conf.ProjectRef.Branch,
-		dir:               c.Directory,
-		token:             projectToken,
-		cloneParams:       c.CloneParams,
-		recurseSubmodules: c.RecurseSubmodules,
+		method:                 projectMethod,
+		owner:                  conf.ProjectRef.Owner,
+		repo:                   conf.ProjectRef.Repo,
+		branch:                 conf.ProjectRef.Branch,
+		dir:                    c.Directory,
+		token:                  projectToken,
+		cloneParams:            c.CloneParams,
+		recurseSubmodules:      c.RecurseSubmodules,
+		usePatchMergeCommitSha: true,
 	}
 	cloneDepth := c.CloneDepth
 	if cloneDepth == 0 && c.ShallowClone {
@@ -499,6 +507,11 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			if attemptNum > 0 {
+				// If clone failed once with the cached merge SHA, do not use it again
+				opts.usePatchMergeCommitSha = false
+				logger.Task().Warning("git clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
+			}
 			if attemptNum > 2 {
 				opts.useVerbose = true // use verbose for the last 2 attempts
 				logger.Task().Error(message.Fields{

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-21"
+	AgentVersion = "2023-06-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -531,18 +531,18 @@ func (p *Patch) AddSyncVariantsTasks(vts []VariantTasks) error {
 
 // UpdateMergeCommitSHA updates the merge commit SHA for the patch.
 func (p *Patch) UpdateMergeCommitSHA(sha string) error {
+	if p.GithubPatchData.MergeCommitSHA == sha {
+		return nil
+	}
 	shaKey := bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchMergeCommitSHAKey)
-	if err := UpdateOne(
+	return UpdateOne(
 		bson.M{IdKey: p.Id},
 		bson.M{
 			"$set": bson.M{
 				shaKey: sha,
 			},
 		},
-	); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
+	)
 }
 
 func (p *Patch) FindModule(moduleName string) *ModulePatch {

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -529,6 +529,22 @@ func (p *Patch) AddSyncVariantsTasks(vts []VariantTasks) error {
 	return nil
 }
 
+// UpdateMergeCommitSHA updates the merge commit SHA for the patch.
+func (p *Patch) UpdateMergeCommitSHA(sha string) error {
+	shaKey := bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchMergeCommitSHAKey)
+	if err := UpdateOne(
+		bson.M{IdKey: p.Id},
+		bson.M{
+			"$set": bson.M{
+				shaKey: sha,
+			},
+		},
+	); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
 func (p *Patch) FindModule(moduleName string) *ModulePatch {
 	for _, module := range p.Patches {
 		if module.ModuleName == moduleName {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -152,6 +152,26 @@ func (h *agentCheckGetPullRequestHandler) Parse(ctx context.Context, r *http.Req
 }
 
 func (h *agentCheckGetPullRequestHandler) Run(ctx context.Context) gimlet.Responder {
+	t, err := task.FindOneId(h.taskID)
+	if err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting task '%s'", h.taskID))
+	}
+	if t == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
+		})
+	}
+	p, err := patch.FindOne(patch.ByVersion(t.Version))
+	if err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting patch for task '%s'", h.taskID))
+	}
+	if p == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("patch for task '%s' not found", h.taskID),
+		})
+	}
 	token, err := h.settings.GetGithubOauthToken()
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting token"))
@@ -163,6 +183,9 @@ func (h *agentCheckGetPullRequestHandler) Run(ctx context.Context) gimlet.Respon
 	resp := apimodels.PullRequestInfo{
 		Mergeable:      pr.Mergeable,
 		MergeCommitSHA: pr.GetMergeCommitSHA(),
+	}
+	if err = p.UpdateMergeCommitSHA(pr.GetMergeCommitSHA()); err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "updating merge commit SHA for patch '%s'", p.Id.Hex()))
 	}
 	if h.req.LastRetry && (!utility.FromBoolPtr(resp.Mergeable) || resp.MergeCommitSHA == "") {
 		grip.Debug(message.Fields{

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/amboy/queue"
 	"github.com/mongodb/grip/send"
@@ -335,6 +337,59 @@ func TestAgentSetup(t *testing.T) {
 			require.True(t, ok)
 
 			tCase(ctx, t, r, s)
+		})
+	}
+}
+
+func TestAgentCheckGetPullRequestHandler(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *agentCheckGetPullRequestHandler, s *evergreen.Settings){
+		"FactorySucceeds": func(ctx context.Context, t *testing.T, rh *agentCheckGetPullRequestHandler, s *evergreen.Settings) {
+			copied := rh.Factory()
+			assert.NotZero(t, copied)
+			_, ok := copied.(*agentCheckGetPullRequestHandler)
+			assert.True(t, ok)
+		},
+		"ParseSucceeds": func(ctx context.Context, t *testing.T, rh *agentCheckGetPullRequestHandler, s *evergreen.Settings) {
+			json := []byte(`{
+                "owner": "evergreen",
+                "repo": "sandbox"
+            }`)
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/task/t1/pull_request", bytes.NewBuffer(json))
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": "t1"})
+			require.NoError(t, err)
+			assert.NoError(t, rh.Parse(ctx, req))
+			assert.Equal(t, "t1", rh.taskID)
+			assert.Equal(t, "evergreen", rh.req.Owner)
+			assert.Equal(t, "sandbox", rh.req.Repo)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(patch.Collection, task.Collection))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			env := &mock.Environment{}
+			assert.NoError(t, env.Configure(ctx))
+			env.EvergreenSettings.Credentials = map[string]string{"github": "token globalGitHubOauthToken"}
+
+			tsk := &task.Task{
+				Id:      "t1",
+				Version: "aaaaaaaaaaff001122334456",
+			}
+			patch := &patch.Patch{
+				Id:      patch.NewId("aaaaaaaaaaff001122334456"),
+				Version: "aaaaaaaaaaff001122334456",
+				GithubPatchData: thirdparty.GithubPatch{
+					MergeCommitSHA: "abc",
+				},
+			}
+			require.NoError(t, tsk.Insert())
+			require.NoError(t, patch.Insert())
+
+			r, ok := makeAgentGetPullRequest(env.Settings()).(*agentCheckGetPullRequestHandler)
+			require.True(t, ok)
+
+			tCase(ctx, t, r, env.Settings())
 		})
 	}
 }

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -125,9 +125,10 @@ type SendGithubStatusInput struct {
 
 var (
 	// BSON fields for GithubPatch
-	GithubPatchPRNumberKey  = bsonutil.MustHaveTag(GithubPatch{}, "PRNumber")
-	GithubPatchBaseOwnerKey = bsonutil.MustHaveTag(GithubPatch{}, "BaseOwner")
-	GithubPatchBaseRepoKey  = bsonutil.MustHaveTag(GithubPatch{}, "BaseRepo")
+	GithubPatchPRNumberKey       = bsonutil.MustHaveTag(GithubPatch{}, "PRNumber")
+	GithubPatchBaseOwnerKey      = bsonutil.MustHaveTag(GithubPatch{}, "BaseOwner")
+	GithubPatchBaseRepoKey       = bsonutil.MustHaveTag(GithubPatch{}, "BaseRepo")
+	GithubPatchMergeCommitSHAKey = bsonutil.MustHaveTag(GithubPatch{}, "MergeCommitSHA")
 )
 
 type retryConfig struct {


### PR DESCRIPTION
EVG-20161

### Description
This is a rework of the idea from #6672 

When the base branch has new commits that are not in the PR branch, Github can create a new merge commit for the merging of the PR. This means that the `merge_commit_sha` would be different from the last commit in the PR branch.

This is relevant for long commit queues where items get their `merge_commit_sha` cached on their patch doc upon queueing, but tasks won't get started until changes from the batch of size N ahead of them get merged into the base branch, at which point `merge_commit_sha` will have changed. This means that the [field](https://gist.github.com/hadjri/f3b3da7de0431c03b71a66abf378ac08#file-github-go-L100) we store on the patch to save the commit sha is subject to become invalid, and since it's a static & unchanging field we can't strictly rely on it at all times.

Change here is to do the same operation as the previous PR, but instead just check on the first git fetch attempt if the cached merge commit SHA is valid, and if not, retry the original way. Also introduced a change to keept the `MergeCommitSHA` field on the patch in the pull request route updated.
### Testing
Tested in staging, by committing something to main after a commit queue item had already been queued (but not started), and confirmed that it [failed on the first try, and succeeded](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu2004_bynntask_patch_ed8e6708b5e7aceaf81620df54d85df28ef69132_64933698b23736cc672082ee_23_06_21_17_43_06/0?type=ALL#L361) on retry after pinging the agent route.

Tested another item without committing anything to main in between to make sure the cached merge commit SHA still works in the happy case [on the first try](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu2004_bynntask_patch_ed8e6708b5e7aceaf81620df54d85df28ef69132_6493384e9dbe321cdf7025bb_23_06_21_17_50_12/0?type=ALL#L360) and the `/pull_request` endpoint doesn't get hit.