### PR TITLE
EVG-20314: improve smoke test string checks

### DIFF
--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -344,7 +344,7 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 			return errors.New("did not find setup_task in task logs")
 		}
 		const teardownTaskLog = "smoke test is running the teardown task"
-		if !strings.Contains(page, "teardown_task") {
+		if !strings.Contains(page, teardownTaskLog) {
 			return errors.New("did not find teardown_task in task logs")
 		}
 

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -312,7 +312,8 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 	// Note that these checks have a direct dependency on the task configuration
 	// in the smoke test's project YAML (agent.yml).
 	if mode == agent.HostMode {
-		if strings.Contains(page, "generate_task") {
+		const generatorTaskName = "smoke_test_generate_task"
+		if strings.Contains(page, generatorTaskName) {
 			if !strings.Contains(page, "Finished command 'generate.tasks'") {
 				return errors.New("did not find expected log in generate.tasks command")
 			}
@@ -325,38 +326,45 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 			return nil
 		}
 		// Validate that setup_group only runs in first task
-		if strings.Contains(page, "first") {
-			if !strings.Contains(page, "setup_group") {
+		const firstTaskGroupTaskLog = "smoke test is running first task in the task group"
+		const setupGroupLog = "smoke test is running the setup group"
+		if strings.Contains(page, firstTaskGroupTaskLog) {
+			if !strings.Contains(page, setupGroupLog) {
 				return errors.New("did not find setup_group in task logs for first task")
 			}
 		} else {
-			if strings.Contains(page, "setup_group") {
+			if strings.Contains(page, setupGroupLog) {
 				return errors.New("setup_group should only run in first task")
 			}
 		}
 
 		// Validate that setup_task and teardown_task run for all tasks
-		if !strings.Contains(page, "setup_task") {
+		const setupTaskLog = "smoke test is running the setup task"
+		if !strings.Contains(page, setupTaskLog) {
 			return errors.New("did not find setup_task in task logs")
 		}
+		const teardownTaskLog = "smoke test is running the teardown task"
 		if !strings.Contains(page, "teardown_task") {
 			return errors.New("did not find teardown_task in task logs")
 		}
 
 		// Validate that teardown_group only runs in last task
-		if strings.Contains(page, "fourth") {
-			if !strings.Contains(page, "teardown_group") {
-				return errors.New("did not find teardown_group in task logs for last (fourth) task")
+		const lastTaskGroupTaskLog = "smoke test is running the fourth task in the task group"
+		const teardownGroupLog = "smoke test is running the teardown group"
+		if strings.Contains(page, lastTaskGroupTaskLog) {
+			if !strings.Contains(page, teardownGroupLog) {
+				return errors.New("did not find teardown_group in task logs for last task in the task group")
 			}
 		} else {
-			if strings.Contains(page, "teardown_group") {
-				return errors.New("teardown_group should only run in last (fourth) task")
+			if strings.Contains(page, teardownGroupLog) {
+				return errors.New("teardown_group should only run in last task in the task group")
 			}
 		}
 	} else if mode == agent.PodMode {
 		// TODO (PM-2617) Add task groups to the container task smoke test once they are supported
-		if !strings.Contains(page, "container task") {
-			return errors.New("did not find container task in logs")
+		const containerTaskLog = "smoke test is running the container task"
+		if !strings.Contains(page, containerTaskLog) {
+			return errors.Errorf("did not find expected container task log: '%s'", containerTaskLog)
 		}
 	}
 

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -12,28 +12,28 @@ task_groups:
           script: |
             set -o verbose
             set -o errexit
-            echo "setup_group"
+            echo "smoke test is running the setup group"
     teardown_group:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "teardown_group"
+            echo "smoke test is running the teardown group"
     setup_task:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "setup_task"
+            echo "smoke test is running the setup task"
     teardown_task:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "teardown_task"
+            echo "smoke test is running the teardown task"
     tasks:
       - first_task_in_task_group
       - second_task_in_task_group
@@ -42,47 +42,47 @@ task_groups:
       - fourth_task_in_task_group
 
 tasks:
-  - name: first_task_in_task_group
+  - name: smoke_test_first_task_in_task_group
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "first"
-  - name: second_task_in_task_group
+            echo "smoke test is running the first task in the task group"
+  - name: smoke_test_second_task_in_task_group
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "second"
-  - name: third_task_in_task_group
+            echo "smoke test is running the second task in the task group"
+  - name: smoke_test_third_task_in_task_group
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "third"
-  - name: fourth_task_in_task_group
+            echo "smoke test is running the third task in the task group"
+  - name: smoke_test_fourth_task_in_task_group
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "fourth"
-  - name: container_task
+            echo "smoke test is running the fourth task in the task group"
+  - name: smoke_test_container_task
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "container task"
-  - name: generate_task
+            echo "smoke test is running the container task"
+  - name: smoke_test_generate_task
     commands:
       - command: git.get_project
         params:


### PR DESCRIPTION
EVG-20314

### Description
The smoke test is failing spuriously because it's checking for string output that is too ambiguous/short (i.e. someone made a commit that coincidentally included the word "first" in it, and the smoke test is wrongly thinking that's the relevant output of the smoke test). I made the strings much more unique so there's a much lower chance that the test coincidentally fails because it happened to output a conflicting string.

### Testing
I just changed some strings, and the smoke test can't pass because it's using the `agent.yml` committed to main. This will be substantially reworked in EVG-19590, but for now, there's no way to easily get it to pass. It seems easier to just commit this and check the (currently red) smoke test turns green.

### Documentation
N/A