### PR TITLE
EVG-20314: revert smoke test for container back to its original configuration

### DIFF
--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -362,6 +362,11 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 		}
 	} else if mode == agent.PodMode {
 		// TODO (PM-2617) Add task groups to the container task smoke test once they are supported
+		// TODO (EVG-17658): this test is highly fragile and has a chance of
+		// breaking if you change any of the container task YAML setup (e.g.
+		// change any container-related configuration in agent.yml).
+		// testdata/smoke/parser_projects.json. EVG-17658 should address the
+		// issues with the smoke test.
 		const containerTaskLog = "smoke test is running the container task"
 		if !strings.Contains(page, containerTaskLog) {
 			return errors.Errorf("did not find expected container task log: '%s'", containerTaskLog)

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -364,10 +364,11 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 		// TODO (PM-2617) Add task groups to the container task smoke test once they are supported
 		// TODO (EVG-17658): this test is highly fragile and has a chance of
 		// breaking if you change any of the container task YAML setup (e.g.
-		// change any container-related configuration in agent.yml).
-		// testdata/smoke/parser_projects.json. EVG-17658 should address the
-		// issues with the smoke test.
-		const containerTaskLog = "smoke test is running the container task"
+		// change any container-related configuration in agent.yml). If you
+		// change the container task setup, you will likely also have to change
+		// the smoke testdata. EVG-17658 should address the issues with the
+		// smoke test.
+		const containerTaskLog = "container task"
 		if !strings.Contains(page, containerTaskLog) {
 			return errors.Errorf("did not find expected container task log: '%s'", containerTaskLog)
 		}

--- a/operations/service_deploy_smoke_utils.go
+++ b/operations/service_deploy_smoke_utils.go
@@ -326,7 +326,7 @@ func checkTaskLogContent(body []byte, mode agent.Mode) error {
 			return nil
 		}
 		// Validate that setup_group only runs in first task
-		const firstTaskGroupTaskLog = "smoke test is running first task in the task group"
+		const firstTaskGroupTaskLog = "smoke test is running the first task in the task group"
 		const setupGroupLog = "smoke test is running the setup group"
 		if strings.Contains(page, firstTaskGroupTaskLog) {
 			if !strings.Contains(page, setupGroupLog) {

--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -74,14 +74,16 @@ tasks:
             set -o verbose
             set -o errexit
             echo "smoke test is running the fourth task in the task group"
-  - name: smoke_test_container_task
+  # TODO (EVG-17658): changing the smoke container task will cause the smoke test to break unless you very carefully and
+  # manually modify the smoke test's testdata. EVG-17658 is intended to address this issue.
+  - name: container_task
     commands:
       - command: shell.exec
         params:
           script: |
             set -o verbose
             set -o errexit
-            echo "smoke test is running the container task"
+            echo "container task"
   - name: smoke_test_generate_task
     commands:
       - command: git.get_project
@@ -235,12 +237,14 @@ buildvariants:
     tasks:
       - name: my_group
       - name: smoke_test_generate_task
+  # TODO (EVG-17658): changing the smoke container task will cause the smoke test to break unless you very carefully and
+  # manually modify the smoke test's testdata. EVG-17658 is intended to address this issue.
   - name: pod_bv
     display_name: pod_bv
     run_on:
       - container
     tasks:
-      - name: smoke_test_container_task
+      - name: container-task
 
 # TODO (EVG-17658): Refactor smoke tests to allow for faking agent creation
 # The following configuration is currently unused since the container task


### PR DESCRIPTION
EVG-20314

### Description
Revert the smoke test configuration and smoke test for the container task back to what it was before. The reason it doesn't work with the change in #6697 is because if you change the container task configuration in `agent.yml`, you must also manually change `testdata/smoke/parser_projects.json` to reflect the modified YAML. I didn't think it was worth it to try fixing the container task's smoke test data, so I'm just gonna revert it back to how it was before and leave it to EVG-17658 to improve it.

I also fixed an issue in the `smoke-test-host-task` where the expected string is missing "the".

### Testing
I read the smoke test logs for `smoke-test-container-task` and reasoned about how it's supposed to work.

### Documentation
N/A