### PR TITLE
EVG-19965 Thread context to user patches page queries

### DIFF
--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -39,7 +39,7 @@ func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProject
 		IncludeHidden:   false,
 	}
 
-	patches, count, err := patch.ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err := patch.ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error while fetching patches for this project : %s", err.Error()))
 	}

--- a/graphql/user_resolver.go
+++ b/graphql/user_resolver.go
@@ -25,7 +25,7 @@ func (r *userResolver) Patches(ctx context.Context, obj *restModel.APIDBUser, pa
 		IncludeCommitQueue: patchesInput.IncludeCommitQueue,
 		IncludeHidden:      false,
 	}
-	patches, count, err := patch.ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err := patch.ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error getting patches for user %s: %s", utility.FromStringPtr(obj.UserID), err.Error()))
 	}

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -144,7 +145,7 @@ type ByPatchNameStatusesCommitQueuePaginatedOptions struct {
 	IncludeHidden      bool
 }
 
-func ByPatchNameStatusesCommitQueuePaginated(opts ByPatchNameStatusesCommitQueuePaginatedOptions) ([]Patch, int, error) {
+func ByPatchNameStatusesCommitQueuePaginated(ctx context.Context, opts ByPatchNameStatusesCommitQueuePaginatedOptions) ([]Patch, int, error) {
 	if opts.OnlyCommitQueue != nil && opts.IncludeCommitQueue != nil {
 		return nil, 0, errors.New("can't both include commit queue patches and also set only including commit queue patches")
 	}
@@ -205,8 +206,6 @@ func ByPatchNameStatusesCommitQueuePaginated(opts ByPatchNameStatusesCommitQueue
 
 	results := []Patch{}
 	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
 	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, paginatePipeline)
 	if err != nil {
 		return nil, 0, err

--- a/model/patch/db_test.go
+++ b/model/patch/db_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -97,7 +98,8 @@ func TestByPatchNameStatusesCommitQueuePaginated(t *testing.T) {
 		Project:            utility.ToStringPtr("evergreen"),
 		IncludeCommitQueue: utility.TruePtr(),
 	}
-	patches, count, err := ByPatchNameStatusesCommitQueuePaginated(opts)
+	ctx := context.TODO()
+	patches, count, err := ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Equal(t, 10, len(patches))
@@ -109,7 +111,7 @@ func TestByPatchNameStatusesCommitQueuePaginated(t *testing.T) {
 		Limit:              5,
 		Page:               0,
 	}
-	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Equal(t, 5, len(patches))
@@ -121,7 +123,7 @@ func TestByPatchNameStatusesCommitQueuePaginated(t *testing.T) {
 		Limit:              5,
 		Page:               1,
 	}
-	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Equal(t, 5, len(patches))
@@ -132,7 +134,7 @@ func TestByPatchNameStatusesCommitQueuePaginated(t *testing.T) {
 		Project:            utility.ToStringPtr("evergreen"),
 		IncludeCommitQueue: utility.FalsePtr(),
 	}
-	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, count)
 	assert.Equal(t, 5, len(patches))
@@ -143,7 +145,7 @@ func TestByPatchNameStatusesCommitQueuePaginated(t *testing.T) {
 		Project:         utility.ToStringPtr("evergreen"),
 		OnlyCommitQueue: utility.TruePtr(),
 	}
-	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(opts)
+	patches, count, err = ByPatchNameStatusesCommitQueuePaginated(ctx, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, 5, count)
 	assert.Equal(t, 5, len(patches))


### PR DESCRIPTION
EVG-19965

### Description
In order to aid in investigating the performance of the getTasksByVersion query I am threading context to the user patches page queries which fail on large patches in order to get traces on honeycomb. 



