### PR TITLE
EVG-20097 Use non-cached admin settings for containers validation

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -80,7 +80,7 @@ func (o *TaskIntentPodOptions) Validate(ecsConf evergreen.ECSConfig) error {
 	if o.OS == OSWindows {
 		catcher.Wrap(o.WindowsVersion.Validate(), "must specify a valid Windows version")
 	}
-	catcher.ErrorfWhen(!utility.StringSliceContains(ecsConf.AllowedImages, o.Image), "image '%s' not allowed", o.Image)
+	catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !utility.StringSliceContains(ecsConf.AllowedImages, o.Image), "image '%s' not allowed", o.Image)
 	catcher.NewWhen(o.Image == "", "missing image")
 	catcher.NewWhen(o.WorkingDir == "", "missing working directory")
 	catcher.NewWhen(o.PodSecretExternalID == "", "missing pod secret external ID")

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -307,7 +307,9 @@ func TestNewTaskIntentPod(t *testing.T) {
 	})
 	t.Run("FailsWithNotAllowedImage", func(t *testing.T) {
 		opts := makeValidOpts()
-		ecsConf := evergreen.ECSConfig{}
+		ecsConf := evergreen.ECSConfig{
+			AllowedImages: []string{"allowedImage"},
+		}
 		opts.Image = "notAllowedImage"
 		p, err := NewTaskIntentPod(ecsConf, opts)
 		assert.Error(t, err)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2874,7 +2874,7 @@ func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, container
 		catcher.NewWhen(container.Size == "" && container.Resources == nil, "either size or resources must be defined")
 		catcher.NewWhen(container.Image == "", "image must be defined")
 		catcher.NewWhen(container.Name == "", "name must be defined")
-		catcher.ErrorfWhen(!utility.StringSliceContains(ecsConf.AllowedImages, container.Image), "image '%s' not allowed", container.Image)
+		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !utility.StringSliceContains(ecsConf.AllowedImages, container.Image), "image '%s' not allowed", container.Image)
 
 	}
 	return catcher.Resolve()

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -929,6 +929,7 @@ func (s *PatchIntentUnitsSuite) TestBuildTasksAndVariantsWithReusePatchId() {
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
+	s.NoError(evergreen.UpdateConfig(testutil.TestConfig()))
 	headRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
 	orgName := "evergreen-ci"
 	repoName := "commit-queue-sandbox"

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -202,13 +202,11 @@ func (j *podAllocatorJob) populate() error {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
-
-	// Use the latest service flags instead of those cached in the environment.
-	settings := *j.env.Settings()
-	if err := settings.ServiceFlags.Get(j.env); err != nil {
-		return errors.Wrap(err, "getting service flags")
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "getting admin settings")
 	}
-	j.settings = settings
+	j.settings = *settings
 
 	if j.task == nil {
 		t, err := task.FindOneId(j.TaskID)
@@ -233,7 +231,7 @@ func (j *podAllocatorJob) populate() error {
 	}
 
 	if j.smClient == nil {
-		client, err := cloud.MakeSecretsManagerClient(&settings)
+		client, err := cloud.MakeSecretsManagerClient(&j.settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing Secrets Manager client")
 		}

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -202,6 +202,7 @@ func (j *podAllocatorJob) populate() error {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
+	// Retrieve the latest settings rather than the cached ones.
 	settings, err := evergreen.GetConfig()
 	if err != nil {
 		return errors.Wrap(err, "getting admin settings")

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -343,9 +343,18 @@ func validateAllDependenciesSpec(project *model.Project) ValidationErrors {
 	return errs
 }
 
-func validateContainers(settings *evergreen.Settings, project *model.Project, ref *model.ProjectRef, _ bool) ValidationErrors {
+func validateContainers(_ *evergreen.Settings, project *model.Project, ref *model.ProjectRef, _ bool) ValidationErrors {
+	settings, err := evergreen.GetConfig()
+	if err != nil {
+		return ValidationErrors{
+			ValidationError{
+				Message: errors.Wrap(err, "getting evergreen settings").Error(),
+				Level:   Error,
+			},
+		}
+	}
 	errs := ValidationErrors{}
-	err := model.ValidateContainers(settings.Providers.AWS.Pod.ECS, ref, project.Containers)
+	err = model.ValidateContainers(settings.Providers.AWS.Pod.ECS, ref, project.Containers)
 	if err != nil {
 		errs = append(errs,
 			ValidationError{

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	_ "github.com/evergreen-ci/evergreen/plugin"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -3246,13 +3247,14 @@ func TestValidateContainers(t *testing.T) {
 				Pod: evergreen.AWSPodConfig{
 					ECS: evergreen.ECSConfig{
 						AllowedImages: []string{
-							"demo/image:latest",
+							"hadjri/evg-container-self-tests",
 						},
 					},
 				},
 			},
 		},
 	}
+	assert.NoError(t, evergreen.UpdateConfig(testutil.TestConfig()))
 	defer func() {
 		assert.NoError(t, db.Clear(model.ProjectRefCollection))
 	}()
@@ -3342,7 +3344,7 @@ func TestValidateContainers(t *testing.T) {
 				Containers: []model.Container{
 					{
 						Name:       "c1",
-						Image:      "demo/image:latest",
+						Image:      "hadjri/evg-container-self-tests",
 						WorkingDir: "/root",
 						Size:       "s1",
 						Credential: "c1",


### PR DESCRIPTION
EVG-20097

### Description
We have been modifying this field frequently and will probably continue to do so, changing so that we dynamically fetch the allowed images and don't require a prod bounce for the changes to take effect.

### Testing
Ran a container task in staging based off of a new image and the task went through and succeeded without error.
