### PR TITLE
EVG-20304 Don't include titles in GitHub merge queue description

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -971,7 +971,7 @@ func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *Project
 	}
 
 	if githubMergePatch {
-		return "GitHub Merge Queue: " + description[0]
+		return "GitHub Merge Queue"
 	} else {
 		return "Commit Queue Merge: " + strings.Join(description, " || ")
 	}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -846,7 +846,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 	}
 	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false))
 
-	assert.Equal(t, "GitHub Merge Queue: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, true))
+	assert.Equal(t, "GitHub Merge Queue", MakeCommitQueueDescription(patches, projectRef, project, true))
 
 	// main repo + module commits
 	patches = []patch.ModulePatch{


### PR DESCRIPTION
EVG-20304

### Description
The event doesn't provide a list of commits from the virtual branch, so there isn't something to put in this field.

### Testing
Edited test.
