### PR TITLE
EVG-16283 Add evergreen keep-definitions and evergreen reset-definitions

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -250,6 +250,13 @@ func MostRecentPatchByUserAndProject(user, project string) db.Q {
 	}).Sort([]string{"-" + CreateTimeKey}).Limit(1)
 }
 
+// MostRecentPatchByPR returns the latest patch for a pr number
+func MostRecentPatchByPR(prNumber int) db.Q {
+	return db.Query(bson.M{
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchPRNumberKey): prNumber,
+	}).Sort([]string{"-" + CreateTimeKey}).Limit(1)
+}
+
 // ByVersion produces a query that returns the patch for a given version.
 func ByVersion(version string) db.Q {
 	return db.Query(bson.M{VersionKey: version})

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -545,6 +545,19 @@ func (p *Patch) UpdateMergeCommitSHA(sha string) error {
 	)
 }
 
+// UpdateRepeatPatchId updates the repeat patch Id value to be used for subsequent pr patches
+func (p *Patch) UpdateRepeatPatchId(patchId string) error {
+	repeatKey := bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.RepeatPatchIdNextPatchKey)
+	return UpdateOne(
+		bson.M{IdKey: p.Id},
+		bson.M{
+			"$set": bson.M{
+				repeatKey: patchId,
+			},
+		},
+	)
+}
+
 func (p *Patch) FindModule(moduleName string) *ModulePatch {
 	for _, module := range p.Patches {
 		if module.ModuleName == moduleName {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -35,6 +35,8 @@ const (
 	patchComment            = "evergreen patch"
 	commitQueueMergeComment = "evergreen merge"
 	evergreenHelpComment    = "evergreen help"
+	keepDefinitionsComment  = "evergreen keep-definitions"
+	resetDefinitionsComment = "evergreen reset-definitions"
 
 	refTags = "refs/tags/"
 
@@ -328,6 +330,30 @@ func (gh *githubHookApi) handleComment(ctx context.Context, event *github.IssueC
 		return errors.Wrap(err, "sending help comment")
 	}
 
+	if isKeepDefinitionsComment(commentBody) {
+		grip.Info(gh.getCommentLogWithMessage(event, fmt.Sprintf("'%s' triggered", commentBody)))
+
+		err := keepPRPatchDefinition(event.Issue.GetNumber())
+
+		grip.Error(message.WrapError(err, gh.getCommentLogWithMessage(event,
+			"problem keeping pr patch definitions")))
+
+		return errors.Wrap(err, "keeping pr patch definition")
+
+	}
+
+	if isResetDefinitionsComment(commentBody) {
+		grip.Info(gh.getCommentLogWithMessage(event, fmt.Sprintf("'%s' triggered", commentBody)))
+
+		err := resetPRPatchDefinition(event.Issue.GetNumber())
+
+		grip.Error(message.WrapError(err, gh.getCommentLogWithMessage(event,
+			"problem resetting pr patch definitions")))
+
+		return errors.Wrap(err, "resetting pr patch definition")
+
+	}
+
 	return nil
 }
 
@@ -413,6 +439,8 @@ func getHelpTextFromProjects(repoRef *model.RepoRef, projectRefs []model.Project
 			"this is required to create a PR patch when only manual PR testing is enabled")
 	}
 	if autoPRProjectEnabled || manualPRProjectEnabled {
+		res += fmt.Sprintf(formatStr, keepDefinitionsComment, "reuse the tasks from the previous patch in subsequent patches")
+		res += fmt.Sprintf(formatStr, resetDefinitionsComment, "reset the patch tasks to the original definition")
 		res += fmt.Sprintf(formatStr, refreshStatusComment, "resyncs PR GitHub checks")
 	}
 	if cqProjectEnabled {
@@ -444,6 +472,22 @@ func (gh *githubHookApi) createPRPatch(ctx context.Context, owner, repo, calledB
 	}
 
 	return gh.AddIntentForPR(pr, pr.User.GetLogin(), calledBy)
+}
+
+func resetPRPatchDefinition(prNumber int) error {
+	p, err := patch.FindOne(patch.MostRecentPatchByPR(prNumber))
+	if err != nil {
+		return errors.Wrap(err, "getting most recent patch for pr")
+	}
+	return p.UpdateRepeatPatchId("")
+}
+
+func keepPRPatchDefinition(prNumber int) error {
+	p, err := patch.FindOne(patch.MostRecentPatchByPR(prNumber))
+	if err != nil || p == nil {
+		return errors.Wrap(err, "getting most recent patch for pr")
+	}
+	return p.UpdateRepeatPatchId(p.Id.Hex())
 }
 
 func (gh *githubHookApi) refreshPatchStatus(ctx context.Context, owner, repo string, prNumber int) error {
@@ -769,6 +813,14 @@ func isPatchComment(comment string) bool {
 // it may be followed by a newline and a message.
 func triggersCommitQueue(comment string) bool {
 	return strings.HasPrefix(trimComment(comment), commitQueueMergeComment)
+}
+
+func isKeepDefinitionsComment(comment string) bool {
+	return trimComment(comment) == keepDefinitionsComment
+}
+
+func isResetDefinitionsComment(comment string) bool {
+	return trimComment(comment) == resetDefinitionsComment
 }
 
 // The bool value returns whether the patch should be created or not.

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -146,6 +146,8 @@ type GithubPatch struct {
 	MergeCommitSHA string `bson:"merge_commit_sha"`
 	CommitTitle    string `bson:"commit_title"`
 	CommitMessage  string `bson:"commit_message"`
+	// the patchId to copy the definitions for for the next patch the pr creates
+	RepeatPatchIdNextPatch string `bson:"repeat_patch_id_next_patch"`
 }
 
 // GithubMergeGroup stores patch data for patches created from GitHub merge groups
@@ -175,6 +177,7 @@ var (
 	GithubPatchBaseOwnerKey      = bsonutil.MustHaveTag(GithubPatch{}, "BaseOwner")
 	GithubPatchBaseRepoKey       = bsonutil.MustHaveTag(GithubPatch{}, "BaseRepo")
 	GithubPatchMergeCommitSHAKey = bsonutil.MustHaveTag(GithubPatch{}, "MergeCommitSHA")
+	RepeatPatchIdNextPatchKey    = bsonutil.MustHaveTag(GithubPatch{}, "RepeatPatchIdNextPatch")
 )
 
 type retryConfig struct {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -533,6 +533,9 @@ func (j *patchIntentProcessor) buildTasksAndVariants(patchDoc *patch.Patch, proj
 		if err != nil {
 			return err
 		}
+		if j.IntentType == patch.GithubIntentType {
+			patchDoc.GithubPatchData.RepeatPatchIdNextPatch = reusePatchId
+		}
 	}
 
 	// Verify that all variants exists

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -615,6 +615,8 @@ func (j *patchIntentProcessor) setToPreviousPatchDefinition(patchDoc *patch.Patc
 		if err = setTasksToPreviousFailed(patchDoc, reusePatch, project); err != nil {
 			return "", errors.Wrap(err, "settings tasks to previous failed")
 		}
+	} else if j.IntentType == patch.GithubIntentType {
+		patchDoc.Tasks = reusePatch.Tasks
 	} else {
 		// Only add activated tasks from previous patch
 		query := db.Query(bson.M{


### PR DESCRIPTION
[EVG-16283](https://jira.mongodb.org/browse/EVG-16283)

### Description
This adds a PR-level option where users comment on the PR with evergreen keep-definitions to reuse the definitions in the most recent patch that ran on subsequent pushes. It also adds an option to reset to default with evergreen reset-definitions. 

### Testing
Added unit tests and [tested on staging](https://github.com/evergreen-ci/commit-queue-sandbox/pull/545). 
<img width="688" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/13104717/34442ef3-87b3-4489-8929-417d85313afd">

