### PR TITLE
EVG-19743 capture trace ID for a task

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -66,6 +66,7 @@ type TaskEndDetail struct {
 	TimeoutDuration time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty"`
 	OOMTracker      *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
 	Modules         ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
+	TraceID         string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
 }
 
 type OOMTrackerInfo struct {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-06-24"
+	AgentVersion = "2023-06-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1058,6 +1058,7 @@ type ComplexityRoot struct {
 		Status      func(childComplexity int) int
 		TimedOut    func(childComplexity int) int
 		TimeoutType func(childComplexity int) int
+		TraceID     func(childComplexity int) int
 		Type        func(childComplexity int) int
 	}
 
@@ -6793,6 +6794,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TaskEndDetail.TimeoutType(childComplexity), true
+
+	case "TaskEndDetail.traceID":
+		if e.complexity.TaskEndDetail.TraceID == nil {
+			break
+		}
+
+		return e.complexity.TaskEndDetail.TraceID(childComplexity), true
 
 	case "TaskEndDetail.type":
 		if e.complexity.TaskEndDetail.Type == nil {
@@ -44994,6 +45002,8 @@ func (ec *executionContext) fieldContext_Task_details(ctx context.Context, field
 				return ec.fieldContext_TaskEndDetail_timeoutType(ctx, field)
 			case "type":
 				return ec.fieldContext_TaskEndDetail_type(ctx, field)
+			case "traceID":
+				return ec.fieldContext_TaskEndDetail_traceID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TaskEndDetail", field.Name)
 		},
@@ -48062,6 +48072,47 @@ func (ec *executionContext) _TaskEndDetail_type(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext_TaskEndDetail_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskEndDetail",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskEndDetail_traceID(ctx context.Context, field graphql.CollectedField, obj *model.ApiTaskEndDetail) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TaskEndDetail_traceID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TraceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TaskEndDetail_traceID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TaskEndDetail",
 		Field:      field,
@@ -71101,6 +71152,10 @@ func (ec *executionContext) _TaskEndDetail(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "traceID":
+
+			out.Values[i] = ec._TaskEndDetail_traceID(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -156,6 +156,7 @@ type TaskEndDetail {
   timedOut: Boolean
   timeoutType: String
   type: String!
+  traceID: String
 }
 
 type OomTrackerInfo {

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -114,6 +114,7 @@ type ApiTaskEndDetail struct {
 	TimedOut    bool              `json:"timed_out"`
 	TimeoutType *string           `json:"timeout_type"`
 	OOMTracker  APIOomTrackerInfo `json:"oom_tracker_info"`
+	TraceID     *string           `json:"trace_id"`
 }
 
 func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
@@ -126,6 +127,7 @@ func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
 	apiOomTracker := APIOomTrackerInfo{}
 	apiOomTracker.BuildFromService(t.OOMTracker)
 	at.OOMTracker = apiOomTracker
+	at.TraceID = utility.ToStringPtr(t.TraceID)
 
 	return nil
 }
@@ -138,6 +140,7 @@ func (ad *ApiTaskEndDetail) ToService() apimodels.TaskEndDetail {
 		TimedOut:    ad.TimedOut,
 		TimeoutType: utility.FromStringPtr(ad.TimeoutType),
 		OOMTracker:  ad.OOMTracker.ToService(),
+		TraceID:     utility.FromStringPtr(ad.TraceID),
 	}
 }
 


### PR DESCRIPTION
[EVG-19743](https://jira.mongodb.org/browse/EVG-19743)

### Description
We'd like to display a link to a task's trace on the task page. This PR captures the trace ID when it's generated and sends it back to the app in `TaskEndDetails`.

### Testing
Ran a task on staging and [its trace id](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/trace/oYyGctRbicg?fields[]=c_name&span=44e2f925a4f73544) was persisted to the task document.
