### PR TITLE
EVG-20370: Require auth for Lobster

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -296,7 +296,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	}
 
 	// Lobster
-	app.AddPrefixRoute("/lobster").Handler(uis.lobsterPage).Get()
+	app.AddPrefixRoute("/lobster").Wrap(needsLogin).Handler(uis.lobsterPage).Get()
 
 	// GraphQL
 	app.AddRoute("/graphql").Wrap(allowsCORS, needsLogin).Handler(playground.ApolloSandboxHandler("GraphQL playground", "/graphql/query")).Get()


### PR DESCRIPTION
EVG-20370

### Description
This PR wraps the `/lobster` route with `needsLogin`. I used `needsLogin` as that's what both the `/task_log_raw` and `/test_logs` routes use so I figured it would make sense to be the same.

### Testing
* Tested on staging in an incognito window that I get redirected to login
* Tested on staging in a regular window that I can access Lobster
