### PR TITLE
EVG-20374 Error when patches finalize with no tasks

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -591,6 +591,10 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		}).TVPairsToVariantTasks()
 	}
 
+	if len(p.VariantsTasks) == 0 {
+		return nil, errors.New("cannot finalize patch with no tasks")
+	}
+
 	// if variant tasks is still empty, then the patch is empty and we shouldn't add to commit queue
 	if p.IsCommitQueuePatch() && len(p.VariantsTasks) == 0 {
 		return nil, errors.Errorf("no builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -591,7 +591,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		}).TVPairsToVariantTasks()
 	}
 
-	// if variant tasks is still empty, then the patch is empty and we shouldn't add to commit queue
+	// if variant tasks is still empty, then the patch is empty and we shouldn't finalize
 	if len(p.VariantsTasks) == 0 {
 		if p.IsCommitQueuePatch() {
 			return nil, errors.Errorf("no builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -591,13 +591,12 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		}).TVPairsToVariantTasks()
 	}
 
-	if len(p.VariantsTasks) == 0 {
-		return nil, errors.New("cannot finalize patch with no tasks")
-	}
-
 	// if variant tasks is still empty, then the patch is empty and we shouldn't add to commit queue
-	if p.IsCommitQueuePatch() && len(p.VariantsTasks) == 0 {
-		return nil, errors.Errorf("no builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)
+	if len(p.VariantsTasks) == 0 {
+		if p.IsCommitQueuePatch() {
+			return nil, errors.Errorf("no builds or tasks for commit queue version in projects '%s', githash '%s'", p.Project, p.Githash)
+		}
+		return nil, errors.New("cannot finalize patch with no tasks")
 	}
 	taskIds, err := NewPatchTaskIdTable(project, patchVersion, tasks, projectRef.Identifier)
 	if err != nil {

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -432,18 +432,17 @@ modules:
 			ppStorageMethod := evergreen.ProjectStorageMethodDB
 			p.ProjectStorageMethod = ppStorageMethod
 
-			//normal patch works
+			//normal patch should error
 			p.Tasks = []string{}
 			p.BuildVariants = []string{}
 			p.VariantsTasks = []patch.VariantTasks{}
 			require.NoError(t, p.Insert())
 
-			v, err := FinalizePatch(ctx, p, evergreen.MergeTestRequester, token)
-			require.NoError(t, err)
-			assert.NotNil(t, v)
-			assert.Empty(t, v.BuildIds)
+			_, err := FinalizePatch(ctx, p, evergreen.MergeTestRequester, token)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "cannot finalize patch with no tasks")
 
-			// commit queue patch should not
+			// commit queue patch should fail with different error
 			p.Alias = evergreen.CommitQueueAlias
 			_, err = FinalizePatch(ctx, p, evergreen.MergeTestRequester, token)
 			require.Error(t, err)


### PR DESCRIPTION
EVG-20374

### Description
users were able to create an empty patch by passing in a task that didnt exist 
this forbids that 
