### PR TITLE
EVG-20279: log why killProcs runs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -574,7 +574,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (shouldExit bool, 
 		"task_secret": tc.task.Secret,
 	})
 
-	defer a.killProcs(ctx, tc, false, "preparing to run new task")
+	defer a.killProcs(ctx, tc, false, "finished task")
 
 	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
 	tskCtx, span := a.tracer.Start(tskCtx, fmt.Sprintf("task: '%s'", tc.taskConfig.Task.DisplayName))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -574,7 +574,7 @@ func (a *Agent) runTask(ctx context.Context, tc *taskContext) (shouldExit bool, 
 		"task_secret": tc.task.Secret,
 	})
 
-	defer a.killProcs(ctx, tc, false)
+	defer a.killProcs(ctx, tc, false, "preparing to run new task")
 
 	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
 	tskCtx, span := a.tracer.Start(tskCtx, fmt.Sprintf("task: '%s'", tc.taskConfig.Task.DisplayName))
@@ -707,7 +707,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		tc.logger.Task().Errorf("Programmer error: invalid task status '%s'.", detail.Status)
 	}
 
-	a.killProcs(ctx, tc, false)
+	a.killProcs(ctx, tc, false, "ending task")
 
 	if tc.logger != nil {
 		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
@@ -786,8 +786,8 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 	defer span.End()
 
 	start := time.Now()
-	a.killProcs(ctx, tc, false)
-	defer a.killProcs(ctx, tc, false)
+	a.killProcs(ctx, tc, false, "starting post task commands")
+	defer a.killProcs(ctx, tc, false, "finished post task commands")
 	tc.logger.Task().Info("Running post-task commands.")
 	opts := runCommandsOptions{}
 	postCtx, cancel := a.withCallbackTimeout(ctx, tc)
@@ -824,7 +824,7 @@ func (a *Agent) runPostGroupCommands(ctx context.Context, tc *taskContext) {
 	// Only killProcs if tc.taskConfig is not nil. This avoids passing an
 	// empty working directory to killProcs, and is okay because this
 	// killProcs is only for the processes run in runPostGroupCommands.
-	defer a.killProcs(ctx, tc, true)
+	defer a.killProcs(ctx, tc, true, "finished teardown group commands")
 	defer func() {
 		if tc.logger != nil {
 			grip.Error(tc.logger.Close())
@@ -839,7 +839,7 @@ func (a *Agent) runPostGroupCommands(ctx context.Context, tc *taskContext) {
 	}
 	if taskGroup.TeardownGroup != nil {
 		grip.Info("Running post-group commands.")
-		a.killProcs(ctx, tc, true)
+		a.killProcs(ctx, tc, true, "starting teardown group commands")
 		var cancel context.CancelFunc
 		ctx, cancel = a.withCallbackTimeout(ctx, tc)
 		defer cancel()
@@ -882,38 +882,49 @@ func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *api
 	tc.logger.Task().Infof("Finished running task sync in %s.", time.Since(start))
 }
 
-func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool) {
+func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string) {
 	logger := grip.NewJournaler("killProcs")
 	if tc.logger != nil && !tc.logger.Closed() {
 		logger = tc.logger.Execution()
 	}
 
-	if a.shouldKill(tc, ignoreTaskGroupCheck) {
-		if tc.task.ID != "" && tc.taskConfig != nil {
-			logger.Infof("Cleaning up processes for task: '%s'.", tc.task.ID)
-			if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, logger); err != nil {
-				// If the host is in a state where ps is timing out we need human intervention.
-				if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
-					disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})
-					logger.CriticalWhen(disableErr != nil, errors.Wrap(err, "disabling host due to ps timeout"))
-				}
-				logger.Critical(errors.Wrap(err, "cleaning up spawned processes"))
-			}
-			logger.Infof("Cleaned up processes for task: '%s'.", tc.task.ID)
-		}
+	if !a.shouldKill(tc, ignoreTaskGroupCheck) {
+		return
+	}
 
-		// Agents running in containers don't have Docker available, so skip
-		// Docker cleanup for them.
-		if a.opts.Mode != PodMode {
-			logger.Info("Cleaning up Docker artifacts.")
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, dockerTimeout)
-			defer cancel()
-			if err := docker.Cleanup(ctx, logger); err != nil {
-				logger.Critical(errors.Wrap(err, "cleaning up Docker artifacts"))
+	cleanupMsg := message.Fields{
+		"message": "cleaning up task",
+		"reason":  reason,
+	}
+	if tc.task.ID != "" {
+		cleanupMsg["task"] = tc.task.ID
+	}
+	logger.Info(cleanupMsg)
+
+	if tc.task.ID != "" && tc.taskConfig != nil {
+		logger.Infof("Cleaning up processes for task: '%s'.", tc.task.ID)
+		if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, logger); err != nil {
+			// If the host is in a state where ps is timing out we need human intervention.
+			if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
+				disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})
+				logger.CriticalWhen(disableErr != nil, errors.Wrap(err, "disabling host due to ps timeout"))
 			}
-			logger.Info("Cleaned up Docker artifacts.")
+			logger.Critical(errors.Wrap(err, "cleaning up spawned processes"))
 		}
+		logger.Infof("Cleaned up processes for task: '%s'.", tc.task.ID)
+	}
+
+	// Agents running in containers don't have Docker available, so skip
+	// Docker cleanup for them.
+	if a.opts.Mode != PodMode {
+		logger.Info("Cleaning up Docker artifacts.")
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, dockerTimeout)
+		defer cancel()
+		if err := docker.Cleanup(ctx, logger); err != nil {
+			logger.Critical(errors.Wrap(err, "cleaning up Docker artifacts"))
+		}
+		logger.Info("Cleaned up Docker artifacts.")
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -478,11 +478,11 @@ func (s *AgentSuite) TestEndTaskResponse() {
 func (s *AgentSuite) TestAbort() {
 	s.mockCommunicator.HeartbeatShouldAbort = true
 	s.a.opts.HeartbeatInterval = time.Nanosecond
-	// TODO (EVG-19590): fix this test by splitting runTask.
+	// TODO (EVG-20390): potentially fix this test by splitting runTask.
 	// This is a little weird, but it's necessary for now because the test loads
 	// mock data, which changes the task ID.
 	// Once this is fixed, we should uncomment the assertion below about
-	// post-task commands (an aborted task should not run post).
+	// post-task commands running on abort.
 	originalTaskID := s.tc.taskConfig.Task.Id
 	_, err := s.a.runTask(s.ctx, s.tc)
 	s.NoError(err)
@@ -497,7 +497,7 @@ func (s *AgentSuite) TestAbort() {
 	)
 
 	// for _, msg := range s.mockCommunicator.GetMockMessages()[originalTaskID] {
-	//     s.NotContains(msg.Message, "Running post-task commands", "aborted task should not run post block")
+	//     s.Contains(msg.Message, "Running post-task commands", "aborted task should not run post block")
 	// }
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -623,7 +623,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	s.NoError(err)
 	tc.taskDirectory = "task_directory"
 	tc.ranSetupGroup = false
-	tc = s.a.prepareNextTask(context.Background(), nextTask, tc)
+	tc = s.a.prepareNextTask(s.ctx, nextTask, tc)
 	s.False(tc.ranSetupGroup, "if the next task is in the same group as the previous task but ranSetupGroup was false, ranSetupGroup should be false")
 	s.Equal("foo", tc.taskGroup)
 	s.Equal("", tc.taskDirectory)

--- a/agent/task.go
+++ b/agent/task.go
@@ -90,7 +90,7 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		return
 	}
 
-	a.killProcs(ctx, tc, false, "starting task")
+	a.killProcs(ctx, tc, false, "task is starting")
 
 	if err = a.runPreTaskCommands(innerCtx, tc); err != nil {
 		trySendTaskComplete(tc.logger.Execution(), complete, evergreen.TaskFailed)

--- a/agent/task.go
+++ b/agent/task.go
@@ -90,7 +90,7 @@ func (a *Agent) startTask(ctx context.Context, tc *taskContext, complete chan<- 
 		return
 	}
 
-	a.killProcs(ctx, tc, false)
+	a.killProcs(ctx, tc, false, "starting task")
 
 	if err = a.runPreTaskCommands(innerCtx, tc); err != nil {
 		trySendTaskComplete(tc.logger.Execution(), complete, evergreen.TaskFailed)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-06"
+	AgentVersion = "2023-07-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20279

### Description
`killProcs` runs in various different contexts, and it's not really that clear when/why it runs just from agent logs. I made it a little easier to trace why `killProcs` is running in the agent logs.

* Log reason why `killProcs` is called in agent logs.
* Drive-by cleanup agent tests a tiny bit.
* Drive-by rename a context since it didn't seem worth it to open a ticket just for it.

### Testing
Didn't seem worth it to unit test just an execution log addition, especially because the existing tests can't easily read from the agent logs. I tested in staging that the new `killProcs` log appears as expected.

### Documentation
N/A