### PR TITLE
EVG-16363: Add requesters field to external links

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -382,9 +382,6 @@ Options:
 Customize additional links to specify for your project under the Plugins section
 of the project page, by specifying a link and title. 
 
-Right now this is restricted to patches, but work is planned in
-EVG-16363 to extend this to other requesters.
-
 Special Fields:
 * `{version_id}` -- if this is included in the metadata link, we will sub in the ID when rendering the link
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -275,6 +275,7 @@ type ComplexityRoot struct {
 
 	ExternalLink struct {
 		DisplayName func(childComplexity int) int
+		Requesters  func(childComplexity int) int
 		URLTemplate func(childComplexity int) int
 	}
 
@@ -2620,6 +2621,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ExternalLink.DisplayName(childComplexity), true
+
+	case "ExternalLink.requesters":
+		if e.complexity.ExternalLink.Requesters == nil {
+			break
+		}
+
+		return e.complexity.ExternalLink.Requesters(childComplexity), true
 
 	case "ExternalLink.urlTemplate":
 		if e.complexity.ExternalLink.URLTemplate == nil {
@@ -16518,6 +16526,50 @@ func (ec *executionContext) _ExternalLink_displayName(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_ExternalLink_displayName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ExternalLink",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ExternalLink_requesters(ctx context.Context, field graphql.CollectedField, obj *model.APIExternalLink) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ExternalLink_requesters(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Requesters, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*string)
+	fc.Result = res
+	return ec.marshalNString2ᚕᚖstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ExternalLink_requesters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ExternalLink",
 		Field:      field,
@@ -35793,6 +35845,8 @@ func (ec *executionContext) fieldContext_Project_externalLinks(ctx context.Conte
 			switch field.Name {
 			case "displayName":
 				return ec.fieldContext_ExternalLink_displayName(ctx, field)
+			case "requesters":
+				return ec.fieldContext_ExternalLink_requesters(ctx, field)
 			case "urlTemplate":
 				return ec.fieldContext_ExternalLink_urlTemplate(ctx, field)
 			}
@@ -45230,6 +45284,8 @@ func (ec *executionContext) fieldContext_RepoRef_externalLinks(ctx context.Conte
 			switch field.Name {
 			case "displayName":
 				return ec.fieldContext_ExternalLink_displayName(ctx, field)
+			case "requesters":
+				return ec.fieldContext_ExternalLink_requesters(ctx, field)
 			case "urlTemplate":
 				return ec.fieldContext_ExternalLink_urlTemplate(ctx, field)
 			}
@@ -63546,7 +63602,7 @@ func (ec *executionContext) unmarshalInputExternalLinkInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"displayName", "urlTemplate"}
+	fieldsInOrder := [...]string{"displayName", "requesters", "urlTemplate"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -63562,6 +63618,15 @@ func (ec *executionContext) unmarshalInputExternalLinkInput(ctx context.Context,
 				return it, err
 			}
 			it.DisplayName = data
+		case "requesters":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requesters"))
+			data, err := ec.unmarshalOString2ᚕᚖstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Requesters = data
 		case "urlTemplate":
 			var err error
 
@@ -68260,6 +68325,13 @@ func (ec *executionContext) _ExternalLink(ctx context.Context, sel ast.Selection
 		case "displayName":
 
 			out.Values[i] = ec._ExternalLink_displayName(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "requesters":
+
+			out.Values[i] = ec._ExternalLink_requesters(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -60,7 +60,7 @@ input PeriodicBuildInput {
 
 input ExternalLinkInput {
   displayName: String!
-  requesters: [String!]
+  requesters: [String!] # TODO EVG-16363: Make this field non-nullable after initial PRs are merged.
   urlTemplate: String!
 }
 

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -60,6 +60,7 @@ input PeriodicBuildInput {
 
 input ExternalLinkInput {
   displayName: String!
+  requesters: [String!]
   urlTemplate: String!
 }
 
@@ -258,6 +259,7 @@ type WorkstationConfig {
 
 type ExternalLink {
   displayName: String!
+  requesters: [String!]!
   urlTemplate: String!
 }
 

--- a/graphql/tests/projectSettings/data.json
+++ b/graphql/tests/projectSettings/data.json
@@ -99,7 +99,14 @@
         "git_clone": false
       },
       "hidden": false,
-      "repo_ref_id": "my_repo"
+      "repo_ref_id": "my_repo",
+      "external_links": [
+        {
+          "display_name": "A link to somewhere",
+          "requesters": ["gitter_request", "github_pull_request"],
+          "url_template": "https://a-fake-url-for-{version_id}.com/{version_id}"
+        }
+      ]
     },
     {
       "_id": "vars_test",

--- a/graphql/tests/projectSettings/queries/project-settings-project.graphql
+++ b/graphql/tests/projectSettings/queries/project-settings-project.graphql
@@ -75,6 +75,12 @@
         configEnabled
         patchEnabled
       }
+
+      externalLinks {
+        displayName
+        requesters
+        urlTemplate
+      }
     }
   }
 }

--- a/graphql/tests/projectSettings/results.json
+++ b/graphql/tests/projectSettings/results.json
@@ -96,6 +96,14 @@
                   "cpu": 2,
                   "memoryMb": 2048
                 }
+              ],
+
+              "externalLinks": [
+                {
+                  "displayName": "A link to somewhere",
+                  "requesters": ["gitter_request", "github_pull_request"],
+                  "urlTemplate": "https://a-fake-url-for-{version_id}.com/{version_id}"
+                }
               ]
             }
           }

--- a/graphql/tests/projectSettings/results.json
+++ b/graphql/tests/projectSettings/results.json
@@ -34,7 +34,6 @@
                   "exactMatch": true
                 }
               ],
-
               "gitTagAuthorizedUsers": ["ablack12"],
               "gitTagAuthorizedTeams": null,
               "triggers": [
@@ -71,7 +70,6 @@
                 "bfSuggestionTimeoutSecs": 0,
                 "bfSuggestionUsername": ""
               },
-
               "taskAnnotationSettings": {
                 "jiraCustomFields": [
                   {
@@ -84,7 +82,6 @@
                   "secret": "shh"
                 }
               },
-
               "containerSizeDefinitions": [
                 {
                   "name": "size1",
@@ -97,7 +94,6 @@
                   "memoryMb": 2048
                 }
               ],
-
               "externalLinks": [
                 {
                   "displayName": "A link to somewhere",

--- a/graphql/tests/version/externalLinksForMetadata/data.json
+++ b/graphql/tests/version/externalLinksForMetadata/data.json
@@ -41,6 +41,48 @@
       "remote_path": ".evergreen.yml",
       "r": "gitter_request",
       "author_id": "chaya.malik"
+    },
+    {
+      "_id": "unmatching_requester",
+      "create_time": {
+        "$date": {
+          "$numberLong": "1608660785000"
+        }
+      },
+      "start_time": {
+        "$date": {
+          "$numberLong": "1608660866659"
+        }
+      },
+      "finish_time": {
+        "$date": {
+          "$numberLong": "1608664451646"
+        }
+      },
+      "gitspec": "e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d",
+      "author": "Chaya Malik",
+      "author_email": "chaya.malik@mongodb.com",
+      "message": "EVG-13168 Display Issues and Suspected Issues (#560)",
+      "status": "success",
+      "order": {
+        "$numberInt": "655"
+      },
+      "config_number": {
+        "$numberInt": "0"
+      },
+      "ignored": false,
+      "owner_name": "evergreen-ci",
+      "repo_name": "spruce",
+      "branch_name": "master",
+      "repo_kind": "github",
+      "builds": [
+        "spruce_ubuntu1604_e0e5f60e32e6dfeb02ff0ea8d6ea5473d49eaa9d_20_12_22_18_13_05"
+      ],
+      "identifier": "spruce",
+      "remote": false,
+      "remote_path": ".evergreen.yml",
+      "r": "patch_request",
+      "author_id": "chaya.malik"
     }
   ],
   "project_ref": [
@@ -50,6 +92,7 @@
       "external_links": [
         {
           "display_name": "A link to somewhere",
+          "requesters": ["gitter_request", "github_pull_request"],
           "url_template": "https://a-fake-url-for-{version_id}.com/{version_id}"
         }
       ]

--- a/graphql/tests/version/externalLinksForMetadata/queries/external_links_unmatching_requester.graphql
+++ b/graphql/tests/version/externalLinksForMetadata/queries/external_links_unmatching_requester.graphql
@@ -1,0 +1,8 @@
+{
+  version(id: "unmatching_requester") {
+    externalLinksForMetadata {
+      url
+      displayName
+    }
+  }
+}

--- a/graphql/tests/version/externalLinksForMetadata/results.json
+++ b/graphql/tests/version/externalLinksForMetadata/results.json
@@ -14,6 +14,16 @@
           }
         }
       }
+    },
+    {
+      "query_file": "external_links_unmatching_requester.graphql",
+      "result": {
+        "data": {
+          "version": {
+            "externalLinksForMetadata": []
+          }
+        }
+      }
     }
   ]
 }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -159,13 +159,16 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *res
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Project `%s` not found", *obj.Project))
 	}
 	var externalLinks []*ExternalLinkForMetadata
+
 	for _, link := range pRef.ExternalLinks {
-		// replace {version_id} with the actual version id
-		formattedURL := strings.Replace(link.URLTemplate, "{version_id}", *obj.Id, -1)
-		externalLinks = append(externalLinks, &ExternalLinkForMetadata{
-			URL:         formattedURL,
-			DisplayName: link.DisplayName,
-		})
+		if utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
+			// replace {version_id} with the actual version id
+			formattedURL := strings.Replace(link.URLTemplate, "{version_id}", *obj.Id, -1)
+			externalLinks = append(externalLinks, &ExternalLinkForMetadata{
+				URL:         formattedURL,
+				DisplayName: link.DisplayName,
+			})
+		}
 	}
 	return externalLinks, nil
 }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -161,7 +161,9 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *res
 	var externalLinks []*ExternalLinkForMetadata
 
 	for _, link := range pRef.ExternalLinks {
-		if utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
+		// TODO EVG-16363: Remove the len check after initial PRs are merged and database updates are complete.
+		// Existing metadata links will have a requesters array of length 0 due to the field not existing before.
+		if len(link.Requesters) == 0 || utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
 			// replace {version_id} with the actual version id
 			formattedURL := strings.Replace(link.URLTemplate, "{version_id}", *obj.Id, -1)
 			externalLinks = append(externalLinks, &ExternalLinkForMetadata{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,8 +148,9 @@ type ProjectBanner struct {
 }
 
 type ExternalLink struct {
-	DisplayName string `bson:"display_name,omitempty" json:"display_name,omitempty" yaml:"display_name,omitempty"`
-	URLTemplate string `bson:"url_template,omitempty" json:"url_template,omitempty" yaml:"url_template,omitempty"`
+	DisplayName string   `bson:"display_name,omitempty" json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Requesters  []string `bson:"requesters,omitempty" json:"requesters,omitempty" yaml:"requesters,omitempty"`
+	URLTemplate string   `bson:"url_template,omitempty" json:"url_template,omitempty" yaml:"url_template,omitempty"`
 }
 
 type MergeQueue string

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -175,20 +175,23 @@ func (t *APIParsleyFilter) BuildFromService(h model.ParsleyFilter) {
 }
 
 type APIExternalLink struct {
-	URLTemplate *string `json:"url_template"`
-	DisplayName *string `json:"display_name"`
+	DisplayName *string   `json:"display_name"`
+	Requesters  []*string `json:"requesters"`
+	URLTemplate *string   `json:"url_template"`
 }
 
 func (t *APIExternalLink) ToService() model.ExternalLink {
 	return model.ExternalLink{
-		URLTemplate: utility.FromStringPtr(t.URLTemplate),
 		DisplayName: utility.FromStringPtr(t.DisplayName),
+		Requesters:  utility.FromStringPtrSlice(t.Requesters),
+		URLTemplate: utility.FromStringPtr(t.URLTemplate),
 	}
 }
 
 func (t *APIExternalLink) BuildFromService(h model.ExternalLink) {
-	t.URLTemplate = utility.ToStringPtr(h.URLTemplate)
 	t.DisplayName = utility.ToStringPtr(h.DisplayName)
+	t.Requesters = utility.ToStringPtrSlice(h.Requesters)
+	t.URLTemplate = utility.ToStringPtr(h.URLTemplate)
 }
 
 type APIProjectBanner struct {


### PR DESCRIPTION
EVG-16363

### Description
The purpose of this ticket is to allow users to specify where metadata links will show up. The `requesters` field is going to be used for that specification (so you can choose to show external links on commits, patches, both, etc).

Note: Following this ticket, I will need to update all existing external links definitions to have requesters of `["patch_request", "github_pull_request", "merge_test"]`. This is because we currently show external links for patches only (i.e. anything that matches [`IsPatchRequester`](https://github.com/evergreen-ci/evergreen/blob/20a22068d7cd254c667ca8d7c3d51982d59f3c4b/globals.go#L901)).

### Testing
- Added GraphQL tests

### Documentation
- Updated Metadata Links section
