### PR TITLE
EVG-20395 add aggregation name to trace spans

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -473,6 +473,7 @@ const (
 	ProjectIdentifierOtelAttribute = "evergreen.project.identifier"
 	ProjectIDOtelAttribute         = "evergreen.project.id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
+	AggregationNameOtelAttribute   = "db.aggregationName"
 )
 
 const (

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -2045,6 +2046,8 @@ func recalculateTimeTaken() bson.M {
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
 func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) ([]Task, int, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTasksByVersion")})
+
 	if opts.IncludeBuildVariantDisplayName {
 		opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
 	}
@@ -2152,6 +2155,7 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 
 // GetTaskStatusesByVersion gets all unique task display statuses for a specific version
 func GetTaskStatusesByVersion(ctx context.Context, versionID string) ([]string, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTaskStatusesByVersion")})
 
 	opts := GetTasksByVersionOptions{
 		IncludeBaseTasks:               false,
@@ -2224,6 +2228,8 @@ type GroupedTaskStatusCount struct {
 }
 
 func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) (*TaskStats, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTaskStatsByVersion")})
+
 	if opts.IncludeBuildVariantDisplayName {
 		opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
 	}
@@ -2307,6 +2313,7 @@ func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksB
 }
 
 func GetGroupedTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) ([]*GroupedTaskStatusCount, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetGroupedTaskStatsByVersion")})
 	opts.IncludeBuildVariantDisplayName = true
 	opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
 	pipeline, err := getTasksByVersionPipeline(versionID, opts)
@@ -2484,6 +2491,7 @@ type HasMatchingTasksOptions struct {
 
 // HasMatchingTasks returns true if the version has tasks with the given statuses
 func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTasksOptions) (bool, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "HasMatchingTasks")})
 	options := GetTasksByVersionOptions{
 		TaskNames:                      opts.TaskNames,
 		Variants:                       opts.Variants,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2046,7 +2046,7 @@ func recalculateTimeTaken() bson.M {
 // GetTasksByVersion gets all tasks for a specific version
 // Query results can be filtered by task name, variant name and status in addition to being paginated and limited
 func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) ([]Task, int, error) {
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTasksByVersion")})
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetTasksByVersion")})
 
 	if opts.IncludeBuildVariantDisplayName {
 		opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
@@ -2155,7 +2155,7 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 
 // GetTaskStatusesByVersion gets all unique task display statuses for a specific version
 func GetTaskStatusesByVersion(ctx context.Context, versionID string) ([]string, error) {
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTaskStatusesByVersion")})
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetTaskStatusesByVersion")})
 
 	opts := GetTasksByVersionOptions{
 		IncludeBaseTasks:               false,
@@ -2228,7 +2228,7 @@ type GroupedTaskStatusCount struct {
 }
 
 func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) (*TaskStats, error) {
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetTaskStatsByVersion")})
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetTaskStatsByVersion")})
 
 	if opts.IncludeBuildVariantDisplayName {
 		opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
@@ -2313,7 +2313,7 @@ func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksB
 }
 
 func GetGroupedTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) ([]*GroupedTaskStatusCount, error) {
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "GetGroupedTaskStatsByVersion")})
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetGroupedTaskStatsByVersion")})
 	opts.IncludeBuildVariantDisplayName = true
 	opts.UseLegacyAddBuildVariantDisplayName = shouldUseLegacyAddBuildVariantDisplayName(versionID)
 	pipeline, err := getTasksByVersionPipeline(versionID, opts)
@@ -2491,7 +2491,7 @@ type HasMatchingTasksOptions struct {
 
 // HasMatchingTasks returns true if the version has tasks with the given statuses
 func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTasksOptions) (bool, error) {
-	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String("db.aggregationName", "HasMatchingTasks")})
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "HasMatchingTasks")})
 	options := GetTasksByVersionOptions{
 		TaskNames:                      opts.TaskNames,
 		Variants:                       opts.Variants,


### PR DESCRIPTION
EVG-20395

### Description
Logs the aggregation name in the trace span to make it easier to identify certain expensive db queries.

### Testing
Example honeycomb trace.
https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen?query=%7B%22time_range%22%3A600%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%2C%7B%22op%22%3A%22AVG%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22service.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22evergreen%22%7D%2C%7B%22column%22%3A%22db.aggregationName%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22GetTasksByVersion%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D
