### PR TITLE
EVG-19147 remove Alerts link from admin page

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -58,7 +58,6 @@ Admin Settings
 						<li class="link" ng-click="scrollTo('degraded')">Service Flags</li>
 						<li class="link" ng-click="scrollTo('announcements')">Announcements</li>
 						<div>Runners</div>
-						<li class="link" ng-click="scrollTo('alerts')">Alerts</li>
 						<li class="link" ng-click="scrollTo('notify')">Notify</li>
 						<li class="link" ng-click="scrollTo('hostinit')">Hostinit</li>
 						<li class="link" ng-click="scrollTo('pod_lifecycle')">Pod Lifecycle</li>


### PR DESCRIPTION
[EVG-19147](https://jira.mongodb.org/browse/EVG-19147)

### Description
https://github.com/evergreen-ci/evergreen/pull/6742 removed the Alerts section from the admin page but didn't remove the link from the sidebar.
