### PR TITLE
EVG-20419 log otel errors

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -87,7 +87,7 @@ func (a *Agent) initOtel(ctx context.Context) error {
 	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		grip.Error(errors.Wrap(err, "encountered otel error"))
+		grip.Error(errors.Wrap(err, "otel error"))
 	}))
 
 	a.tracer = tp.Tracer(packageName)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-08"
+	AgentVersion = "2023-07-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/environment.go
+++ b/environment.go
@@ -883,7 +883,7 @@ func (e *envState) initTracer(ctx context.Context) error {
 	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		grip.Error(errors.Wrap(err, "encountered otel error"))
+		grip.Error(errors.Wrap(err, "otel error"))
 	}))
 
 	e.RegisterCloser("otel-tracer-provider", false, func(ctx context.Context) error {

--- a/environment.go
+++ b/environment.go
@@ -882,6 +882,9 @@ func (e *envState) initTracer(ctx context.Context) error {
 	)
 	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		grip.Error(errors.Wrap(err, "encountered otel error"))
+	}))
 
 	e.RegisterCloser("otel-tracer-provider", false, func(ctx context.Context) error {
 		catcher := grip.NewBasicCatcher()


### PR DESCRIPTION
[EVG-20419](https://jira.mongodb.org/browse/EVG-20419)

### Description
If the client fails to upload spans it will log the error with the otel error handler. By default this just goes to stdout which ends up in the service logs on the host. It would make things a lot easier if they went with the rest of our logging to Splunk.

We already do this for the agent [here](https://github.com/evergreen-ci/evergreen/blob/0b38c0c784757ca57aa54a8ced532d02c49435db/agent/otel.go#L89-L91).