### PR TITLE
EVG-20358: update Dependabot for support rotation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: monthly
       time: "06:00"
       timezone: "America/New_York"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "CHORE: "
-    reviewers:
-      - evergreen-ci/evg-app

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: monthly
+      interval: weekly
       time: "06:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5


### PR DESCRIPTION
EVG-20358

### Description
Since we're absorbing Dependabot into the weekly support rotation, I tuned it so that it no longer pings evg-app (it's on the person on support to review the Dependabot PRs) and reduce the number of open PRs to limit the amount that a single person on rotation has to review. Eventually, we'll get to a point where there's very few Dependabot PRs, but for now, our dependencies are very outdated.