### PR TITLE
EVG-19587: Update GQL context canceled error comparison

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -16,8 +16,6 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-const ContextCanceledErrorMessage = "context canceled"
-
 // Handler returns a gimlet http handler func used as the gql route handler
 func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv := handler.NewDefaultServer(NewExecutableSchema(New(apiURL)))
@@ -57,7 +55,7 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 			queryPath = fieldCtx.Path().String()
 			args = fieldCtx.Args
 		}
-		if err != nil && !strings.HasSuffix(err.Error(), ContextCanceledErrorMessage) {
+		if err != nil && !strings.HasSuffix(err.Error(), context.Canceled.Error()) {
 			grip.Error(message.WrapError(err, message.Fields{
 				"path":    "/graphql/query",
 				"query":   queryPath,


### PR DESCRIPTION
EVG-19587

### Description
The current comparison using `errors.Is(err, context.Canceled)` doesn't work because the error propagated to GQL diverges from the original context.Canceled error. The original PR can be viewed here: https://github.com/evergreen-ci/evergreen/pull/6520
