### PR TITLE
EVG-20434 Toggle merge queue with project ref

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -342,6 +342,10 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 		return nil, pr, errors.Wrapf(errNoCommitQueueForBranch, "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
 	}
 
+	if projectRef.CommitQueue.MergeQueue == model.MergeQueueGitHub {
+		return nil, pr, errors.Wrapf(errors.New("project is using GitHub merge queue"), "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
+	}
+
 	authorized, err := sc.IsAuthorizedToPatchAndMerge(ctx, env.Settings(), NewUserRepoInfo(info))
 	if err != nil {
 		return nil, pr, errors.Wrap(err, "getting user info from GitHub API")

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -272,7 +272,6 @@ func (gh *githubHookApi) handleMergeGroupEvent(event *github.MergeGroupEvent) gi
 			"head_sha": event.GetMergeGroup().GetHeadSHA(),
 			"message":  "no matching project ref",
 		})
-		fmt.Println("org/repo/branch", org, repo, branch)
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "no matching project ref"))
 	}
 	if ref.CommitQueue.MergeQueue == model.MergeQueueGitHub {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -39,9 +39,6 @@ const (
 	resetDefinitionsComment = "evergreen reset-definitions"
 
 	refTags = "refs/tags/"
-
-	// This will be removed when EVG-19964 is ready.
-	disableMergeGroup = true
 )
 
 // skipCILabels are a set of labels which will skip creating PR patch if part of the commit description or message.
@@ -230,43 +227,73 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 
 	case *github.MergeGroupEvent:
-		var msg string
-		if disableMergeGroup {
-			msg = "merge group received, skipping"
-		} else {
-			msg = "merge group received, attempting to queue"
-		}
-		grip.Info(message.Fields{
-			"source":   "GitHub hook",
-			"msg_id":   gh.msgID,
-			"event":    gh.eventType,
-			"org":      event.GetOrg().GetLogin(),
-			"repo":     event.GetRepo().GetName(),
-			"base_sha": event.GetMergeGroup().GetBaseSHA(),
-			"head_sha": event.GetMergeGroup().GetHeadSHA(),
-			"message":  msg,
-		})
-
-		// This will be removed when EVG-19964 is ready.
-		if disableMergeGroup {
-			return gimlet.NewJSONResponse(struct{}{})
-		}
-		if err := gh.AddIntentForGithubMerge(event); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"source":   "GitHub hook",
-				"msg_id":   gh.msgID,
-				"event":    gh.eventType,
-				"org":      event.GetOrg().GetLogin(),
-				"repo":     event.GetRepo().GetName(),
-				"base_sha": event.GetMergeGroup().GetBaseSHA(),
-				"head_sha": event.GetMergeGroup().GetHeadSHA(),
-				"message":  "can't add intent",
-			}))
-			return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "adding patch intent"))
-		}
+		return gh.handleMergeGroupEvent(event)
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
+}
+
+func (gh *githubHookApi) handleMergeGroupEvent(event *github.MergeGroupEvent) gimlet.Responder {
+	org := event.GetOrg().GetLogin()
+	repo := event.GetRepo().GetName()
+	branch := strings.TrimPrefix(event.MergeGroup.GetBaseRef(), "refs/heads/")
+	grip.Info(message.Fields{
+		"source":   "GitHub hook",
+		"msg_id":   gh.msgID,
+		"event":    gh.eventType,
+		"org":      org,
+		"repo":     repo,
+		"base_sha": event.GetMergeGroup().GetBaseSHA(),
+		"head_sha": event.GetMergeGroup().GetHeadSHA(),
+		"message":  "merge group received",
+	})
+	ref, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(org, repo, branch)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"source":   "GitHub hook",
+			"msg_id":   gh.msgID,
+			"event":    gh.eventType,
+			"org":      org,
+			"repo":     repo,
+			"base_sha": event.GetMergeGroup().GetBaseSHA(),
+			"head_sha": event.GetMergeGroup().GetHeadSHA(),
+			"message":  "finding project ref",
+		}))
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "finding project ref"))
+	}
+	if ref == nil {
+		grip.Error(message.Fields{
+			"source":   "GitHub hook",
+			"msg_id":   gh.msgID,
+			"event":    gh.eventType,
+			"org":      org,
+			"repo":     repo,
+			"base_sha": event.GetMergeGroup().GetBaseSHA(),
+			"head_sha": event.GetMergeGroup().GetHeadSHA(),
+			"message":  "no matching project ref",
+		})
+		fmt.Println("org/repo/branch", org, repo, branch)
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "no matching project ref"))
+	}
+	if ref.CommitQueue.MergeQueue == model.MergeQueueGitHub {
+		err = gh.AddIntentForGithubMerge(event)
+	} else {
+		return gimlet.NewJSONResponse(struct{}{})
+	}
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"source":   "GitHub hook",
+			"msg_id":   gh.msgID,
+			"event":    gh.eventType,
+			"org":      org,
+			"repo":     repo,
+			"base_sha": event.GetMergeGroup().GetBaseSHA(),
+			"head_sha": event.GetMergeGroup().GetHeadSHA(),
+			"message":  "adding project intent",
+		}))
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "adding patch intent"))
+	}
+	return nil
 }
 
 // AddIntentForGithubMerge creates and inserts an intent document in response to a GitHub merge group event.


### PR DESCRIPTION
EVG-20434

### Description
This executes the correct merge queue behavior (Evergreen or GitHub) based on
the field in the project ref.

### Testing
I added a unit test for the behavior.

### Documentation
TBD in a later ticket.
