### PR TITLE
EVG-20419 impose max length on string attributes

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -58,6 +58,8 @@ const (
 
 	RoleCollection  = "roles"
 	ScopeCollection = "scopes"
+
+	otelAttributeMaxLength = 10000
 )
 
 func init() { globalEnvLock = &sync.RWMutex{} }
@@ -869,7 +871,6 @@ func (e *envState) initTracer(ctx context.Context) error {
 	}
 
 	resource, err := resource.New(ctx,
-		resource.WithProcess(),
 		resource.WithHost(),
 		resource.WithAttributes(semconv.ServiceName("evergreen")),
 		resource.WithAttributes(semconv.ServiceVersion(BuildRevision)),
@@ -886,9 +887,13 @@ func (e *envState) initTracer(ctx context.Context) error {
 		return errors.Wrap(err, "initializing otel exporter")
 	}
 
+	spanLimits := trace.NewSpanLimits()
+	spanLimits.AttributeValueLengthLimit = otelAttributeMaxLength
+
 	tp := trace.NewTracerProvider(
 		trace.WithBatcher(exp),
 		trace.WithResource(resource),
+		trace.WithRawSpanLimits(spanLimits),
 	)
 	tp.RegisterSpanProcessor(utility.NewAttributeSpanProcessor())
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
[EVG-20419](https://jira.mongodb.org/browse/EVG-20419)

### Description
One of the reasons spans are getting dropped between the application and the collector is that [the default](https://github.com/open-telemetry/opentelemetry-go/blob/fdfc821bac8357ec1eac271c50454606c318d8de/sdk/trace/span_limits.go#L20-L22) is to allow attributes to be unlimited in length. The `db.statement` attribute in particular is often long ([Honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/nCEPHXq5ogr)). Interestingly, the [MAX](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/6xVMS9dmqTD) is capped at around 65k, which might be the cause/result of the "event exceeds max event size of 100000 bytes, API will not accept this event" errors on [refinery](https://ui.honeycomb.io/mongodb-refinery/environments/production/datasets/refinery-logs/result/JHUhMYuuEfv) (assuming it's interesting that the ASCII strings would be that many bytes, but maybe with the other fields it adds up 🤷). But since that happens _downstream_ we could be sending much larger events over the wire that'll never make it into Honeycomb.

This PR will take the first step of limiting the attribute size to a threshold that should cover us 99% of the time.

### Testing
With local-evergreen I sent [a span with a `my-long-attribute` attribute that was larger than the threshold](https://ui.honeycomb.io/mongodb-4b/environments/dev/datasets/evergreen/trace/5XR7xTjfP5X?fields[]=c_name&fields[]=c_library.name&span=c2fbbe6db609b25e) and it got truncated to 10k characters.

