### PR TITLE
EVG-20286: continue heartbeating after abort

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -622,8 +622,6 @@ func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status 
 
 func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, status string) {
 	if tc.hadTimedOut() && ctx.Err() == nil {
-		// kim: TODO: Timeout is likely not relevant for abort, but should
-		// double check and verify with test.
 		status = evergreen.TaskFailed
 		a.runTaskTimeoutCommands(ctx, tc)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -622,6 +622,8 @@ func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status 
 
 func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, status string) {
 	if tc.hadTimedOut() && ctx.Err() == nil {
+		// kim: TODO: Timeout is likely not relevant for abort, but should
+		// double check and verify with test.
 		status = evergreen.TaskFailed
 		a.runTaskTimeoutCommands(ctx, tc)
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1128,9 +1128,9 @@ func (s *AgentSuite) TestAbort() {
 buildvariants:
 - name: some_build_variant
 
-tasks: 
+tasks:
 - name: this_is_a_task_name
-  commands: 
+  commands:
    - command: shell.exec
      params:
        script: exit 0
@@ -1154,4 +1154,6 @@ post:
 		"Task completed - FAILED",
 		"Running post-task commands.",
 	)
+	// kim: TODO: make sure we don't run the task timeout commands because that
+	// shouldn't happen.
 }

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -104,10 +104,10 @@ func (s *CommandSuite) TestShellExec() {
 
 	s.Require().NoError(s.tc.logger.Close())
 
-	checkMockLogs(s.T(), s.mockCommunicator, taskID,
+	checkMockLogs(s.T(), s.mockCommunicator, taskID, []string{
 		"Task completed - SUCCESS",
 		"Finished command 'shell.exec' in function 'foo' (step 1 of 1)",
-	)
+	}, nil)
 
 	detail := s.mockCommunicator.GetEndTaskDetail()
 	s.Equal("success", detail.Status)

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -54,6 +54,7 @@ type Mock struct {
 	HeartbeatShouldConflict     bool
 	HeartbeatShouldErr          bool
 	HeartbeatShouldSometimesErr bool
+	HeartbeatCount              int
 	TaskExecution               int
 	CreatedHost                 apimodels.CreateHost
 
@@ -230,6 +231,7 @@ func (c *Mock) GetExpansionsAndVars(ctx context.Context, taskData TaskData) (*ap
 }
 
 func (c *Mock) Heartbeat(ctx context.Context, td TaskData) (string, error) {
+	c.HeartbeatCount++
 	if c.HeartbeatShouldAbort {
 		return evergreen.TaskFailed, nil
 	}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-06-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-12b"
+	AgentVersion = "2023-07-13"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -425,9 +425,9 @@ Fields:
 
 All projects can have a `pre` and `post` field which define a list of
 command to run at the start and end of every task that isn't in a task
-group. For task groups, setup_task and teardown_task will run instead.
-These are incredibly useful as a place for results commands or for
-cleanup and setup tasks.
+group. For task groups, `setup_task` and `teardown_task` will run instead of
+`pre` and `post`. These are incredibly useful as a place for results commands or
+for cleanup and setup tasks.
 
 **NOTE:** failures in `pre` and `post` commands will be ignored by
 default, so only use commands you know will succeed. See
@@ -463,6 +463,10 @@ timeout:
         echo "Calling the hang analyzer..."
         python buildscripts/hang_analyzer.py
 ```
+
+If a task is aborted, the task will stop running any `pre` or task commands
+early, but it still runs `post` (or the task group equivalent, `teardown_task`).
+This is done in order to perform any final cleanup for the task.
 
 **Exec timeout: exec_timeout_secs**
 You can customize the points at which the "timeout" conditions are
@@ -1567,12 +1571,13 @@ Example in a command:
 
 ### Task Fields Override Hierarchy
 
-The task's specific fields will be taken into priority in the following
-order:
+Some fields can be specified at multiple levels in the YAML. The task's specific
+fields will be taken into priority in the following order (from highest to
+lowest):
 
--   The fields in the build variant definition
--   The fields in the task definition
--   The fields in the variant task definition
+- Tasks listed under a build variant.
+- The task definition.
+- The build variant definition.
 
 Example:
 


### PR DESCRIPTION
EVG-20286

### Description
If the task gets an abort signal from the heartbeat, the agent is still expected to run the post task, so it should still heartbeat back to the app server to indicate that the task is alive. The heartbeat will continue to receive the abort message from the app server on later heartbeats, but the agent only needs to process the abort message once.

* Continue attempting to heartbeat after a task receives the abort signal.
* Drive-by clean up some existing agent tests.

### Testing
Added unit tests and tested in staging to verify that a long sleep in post continued running after the heartbeat timeout ([example](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_test_util_patch_b6222da4640b0199bb11a37c93f6b8192ff473dc_64aef970b2373697b2ba2c69_23_07_12_19_05_21/logs?execution=1&logtype=agent)).

### Documentation
Updated docs to better describe how pre/main/post interact with abort.

I also drive-by clarified a doc that's a little ambiguous about the precedence of YAML fields.