### PR TITLE
EVG-16363: Remove temporary workarounds for external links

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -63622,7 +63622,7 @@ func (ec *executionContext) unmarshalInputExternalLinkInput(ctx context.Context,
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requesters"))
-			data, err := ec.unmarshalOString2ᚕᚖstringᚄ(ctx, v)
+			data, err := ec.unmarshalNString2ᚕᚖstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -60,7 +60,7 @@ input PeriodicBuildInput {
 
 input ExternalLinkInput {
   displayName: String!
-  requesters: [String!] # TODO EVG-16363: Make this field non-nullable after initial PRs are merged.
+  requesters: [String!]!
   urlTemplate: String!
 }
 

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -160,9 +160,7 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *res
 	var externalLinks []*ExternalLinkForMetadata
 
 	for _, link := range pRef.ExternalLinks {
-		// TODO EVG-16363: Remove the len check after initial PRs are merged and database updates are complete.
-		// Existing metadata links will have a requesters array of length 0 due to the field not existing before.
-		if len(link.Requesters) == 0 || utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
+		if utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
 			// replace {version_id} with the actual version id
 			formattedURL := strings.Replace(link.URLTemplate, "{version_id}", *obj.Id, -1)
 			externalLinks = append(externalLinks, &ExternalLinkForMetadata{


### PR DESCRIPTION
EVG-16363

### Description
This PR removes the temporary workarounds that were in place to support external links without the `requesters` field. Now that the documents have been updated with the `requesters` field and the front-end companion PR has been merged, it should be safe to remove.

### Testing
- Downstream Spruce tests should pass
