### PR TITLE
EVG-20456 Add owner/repo field to all patches 

### DIFF
--- a/config.go
+++ b/config.go
@@ -588,11 +588,7 @@ func (s *Settings) getGithubAppAuth() *githubAppAuth {
 // and uses that id to create an installation token.
 func (s *Settings) CreateInstallationToken(ctx context.Context, owner, repo string, opts *github.InstallationTokenOptions) (string, error) {
 	if owner == "" || repo == "" {
-		// TODO EVG-19966: Return error here
-		grip.Debug(message.Fields{
-			"message": "no owner repo",
-			"ticket":  "EVG-19966",
-		})
+		return "", errors.New("no owner/repo specified to create installation token")
 	}
 	authFields := s.getGithubAppAuth()
 	if authFields == nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -525,13 +525,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			return nil, errors.Wrap(err, "getting parameters from parent patch")
 		}
 		parentPatchNumber = parentPatch.PatchNumber
-
-		pRef, err := FindBranchProjectRef(p.Project)
-		if err != nil {
-			return nil, errors.Wrapf(err, "finding project '%s'", p.Project)
-		}
-		p.GithubPatchData.BaseOwner = pRef.Owner
-		p.GithubPatchData.BaseRepo = pRef.Repo
 	}
 
 	params, err := getFullPatchParams(p)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -525,6 +525,13 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 			return nil, errors.Wrap(err, "getting parameters from parent patch")
 		}
 		parentPatchNumber = parentPatch.PatchNumber
+
+		pRef, err := FindBranchProjectRef(p.Project)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding project '%s'", p.Project)
+		}
+		p.GithubPatchData.BaseOwner = pRef.Owner
+		p.GithubPatchData.BaseRepo = pRef.Repo
 	}
 
 	params, err := getFullPatchParams(p)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -169,16 +169,6 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 }
 
 func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.Patch) error {
-	// // Add owner and repo for child patches
-	// if patchDoc.IsChild() {
-	// 	p, err := model.FindBranchProjectRef(patchDoc.Project)
-	// 	if err != nil {
-	// 		return errors.Wrapf(err, "finding project '%s'", patchDoc.Project)
-	// 	}
-	// 	patchDoc.GithubPatchData.BaseOwner = p.Owner
-	// 	patchDoc.GithubPatchData.BaseRepo = p.Repo
-	// }
-
 	// TODO EVG-19966 Delete fallback
 	appToken, err := j.env.Settings().CreateInstallationToken(ctx, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, nil)
 	if err != nil {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -159,6 +159,16 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 }
 
 func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.Patch) error {
+	// Add owner and repo for child patches
+	if patchDoc.Author == evergreen.ParentPatchUser {
+		p, err := model.FindBranchProjectRef(patchDoc.Project)
+		if err != nil {
+			return errors.Wrapf(err, "finding project '%s'", patchDoc.Project)
+		}
+		patchDoc.GithubPatchData.BaseOwner = p.Owner
+		patchDoc.GithubPatchData.BaseRepo = p.Repo
+	}
+
 	// TODO EVG-19966 Delete fallback
 	appToken, err := j.env.Settings().CreateInstallationToken(ctx, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, nil)
 	if err != nil {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -160,7 +160,7 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 
 func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.Patch) error {
 	// Add owner and repo for child patches
-	if patchDoc.Author == evergreen.ParentPatchUser {
+	if patchDoc.IsChild() {
 		p, err := model.FindBranchProjectRef(patchDoc.Project)
 		if err != nil {
 			return errors.Wrapf(err, "finding project '%s'", patchDoc.Project)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -100,6 +100,14 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 	}
 
 	patchDoc := j.intent.NewPatch()
+	if patchDoc.GithubPatchData.BaseOwner == "" || patchDoc.GithubPatchData.BaseRepo == "" {
+		p, err := model.FindBranchProjectRef(patchDoc.Project)
+		if err != nil {
+			j.AddError(errors.Wrapf(err, "finding project '%s'", patchDoc.Project))
+		}
+		patchDoc.GithubPatchData.BaseOwner = p.Owner
+		patchDoc.GithubPatchData.BaseRepo = p.Repo
+	}
 
 	if err = j.finishPatch(ctx, patchDoc); err != nil {
 		if j.IntentType == patch.GithubIntentType || j.IntentType == patch.GithubMergeIntentType {
@@ -159,16 +167,6 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 }
 
 func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.Patch) error {
-	// // Add owner and repo for child patches
-	// if patchDoc.IsChild() {
-	// 	p, err := model.FindBranchProjectRef(patchDoc.Project)
-	// 	if err != nil {
-	// 		j.AddError(errors.Wrapf(err, "finding project '%s'", patchDoc.Project))
-	// 	}
-	// 	patchDoc.GithubPatchData.BaseOwner = p.Owner
-	// 	patchDoc.GithubPatchData.BaseRepo = p.Repo
-	// }
-
 	// TODO EVG-19966 Delete fallback
 	appToken, err := j.env.Settings().CreateInstallationToken(ctx, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, nil)
 	if err != nil {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -101,16 +101,6 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 
 	patchDoc := j.intent.NewPatch()
 
-	// Add owner and repo for child patches
-	if patchDoc.IsChild() {
-		p, err := model.FindBranchProjectRef(patchDoc.Project)
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "finding project '%s'", patchDoc.Project))
-		}
-		patchDoc.GithubPatchData.BaseOwner = p.Owner
-		patchDoc.GithubPatchData.BaseRepo = p.Repo
-	}
-
 	if err = j.finishPatch(ctx, patchDoc); err != nil {
 		if j.IntentType == patch.GithubIntentType || j.IntentType == patch.GithubMergeIntentType {
 			if j.gitHubError == "" {
@@ -169,6 +159,16 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 }
 
 func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.Patch) error {
+	// // Add owner and repo for child patches
+	// if patchDoc.IsChild() {
+	// 	p, err := model.FindBranchProjectRef(patchDoc.Project)
+	// 	if err != nil {
+	// 		j.AddError(errors.Wrapf(err, "finding project '%s'", patchDoc.Project))
+	// 	}
+	// 	patchDoc.GithubPatchData.BaseOwner = p.Owner
+	// 	patchDoc.GithubPatchData.BaseRepo = p.Repo
+	// }
+
 	// TODO EVG-19966 Delete fallback
 	appToken, err := j.env.Settings().CreateInstallationToken(ctx, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, nil)
 	if err != nil {


### PR DESCRIPTION
EVG-20456

### Description
GitHub app was failing because owner/repo field wasn't set for all types of patches 

### Testing
this was caught in a unit test when i return an error that is currently being suppressed by fallback
the unit test is correctly passing now