### PR TITLE
EVG-19937: Add context to distro db methods

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -93,7 +93,7 @@ func CopyDistro(ctx context.Context, u *user.DBUser, opts CopyDistroOpts) error 
 			Message:    "new and existing distro IDs are identical",
 		}
 	}
-	distroToCopy, err := distro.FindOneId(opts.DistroIdToCopy)
+	distroToCopy, err := distro.FindOneId(ctx, opts.DistroIdToCopy)
 	if err != nil {
 		return errors.Wrapf(err, "finding distro '%s'", opts.DistroIdToCopy)
 	}
@@ -122,7 +122,7 @@ func newDistro(ctx context.Context, d *distro.Distro, u *user.DBUser) error {
 		return errors.Errorf("validator encountered errors: '%s'", vErrs.String())
 	}
 
-	if err = d.Add(u); err != nil {
+	if err = d.Add(ctx, u); err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrapf(err, "inserting distro '%s'", d.Id).Error(),

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -57,10 +57,10 @@ func TestCopyDistro(t *testing.T) {
 	config, err := evergreen.GetConfig()
 	assert.NoError(t, err)
 	config.Keys = map[string]string{"abc": "123"}
-	assert.NoError(t, config.Set())
+	assert.NoError(t, config.Set(ctx))
 	defer func() {
 		config.Keys = map[string]string{}
-		assert.NoError(t, config.Set())
+		assert.NoError(t, config.Set(ctx))
 	}()
 
 	for tName, tCase := range map[string]func(t *testing.T, ctx context.Context, u user.DBUser){
@@ -72,7 +72,7 @@ func TestCopyDistro(t *testing.T) {
 			}
 			assert.NoError(t, CopyDistro(ctx, &u, opts))
 
-			newDistro, err := distro.FindOneId("new-distro")
+			newDistro, err := distro.FindOneId(ctx, "new-distro")
 			assert.NoError(t, err)
 			assert.NotNil(t, newDistro)
 
@@ -154,10 +154,10 @@ func TestCopyDistro(t *testing.T) {
 				WorkDir:  "/tmp",
 				User:     "admin",
 			}
-			assert.NoError(t, d.Insert())
+			assert.NoError(t, d.Insert(tctx))
 
 			d.Id = "distro2"
-			assert.NoError(t, d.Insert())
+			assert.NoError(t, d.Insert(tctx))
 
 			adminUser := user.DBUser{
 				Id: "admin",


### PR DESCRIPTION
Fixes collision introduced in #6764 for EVG-19937

### Description
- #6732 added context across distro DB methods. Since #6764 did not have the latest changes, it lacked the context argument for these methods