### PR TITLE
EVG-20459 Lookup project id for RequireProjectAccess directive variables

### DIFF
--- a/graphql/tests/mutation/attachProjectToRepo/results.json
+++ b/graphql/tests/mutation/attachProjectToRepo/results.json
@@ -16,7 +16,7 @@
         "data": null,
         "errors": [
           {
-            "message": "user testuser does not have permission to access settings for the project nonexistent",
+            "message": "Could not find project with projectId: nonexistent",
             "path": [
               "attachProjectToRepo",
               "projectId"

--- a/graphql/tests/mutation/attachProjectToRepo/results.json
+++ b/graphql/tests/mutation/attachProjectToRepo/results.json
@@ -22,7 +22,7 @@
               "projectId"
             ],
             "extensions": {
-              "code": "FORBIDDEN"
+              "code": "RESOURCE_NOT_FOUND"
             }
           }
         ]

--- a/graphql/tests/mutation/defaultSectionToRepo/results.json
+++ b/graphql/tests/mutation/defaultSectionToRepo/results.json
@@ -21,7 +21,7 @@
               "defaultSectionToRepo"
             ],
             "extensions": {
-              "code": "INTERNAL_SERVER_ERROR"
+              "code": "RESOURCE_NOT_FOUND"
             }
           }
         ]

--- a/graphql/tests/mutation/defaultSectionToRepo/results.json
+++ b/graphql/tests/mutation/defaultSectionToRepo/results.json
@@ -18,7 +18,8 @@
           {
             "message": "Could not find project with projectId: repo_id",
             "path": [
-              "defaultSectionToRepo"
+              "defaultSectionToRepo",
+              "projectId"
             ],
             "extensions": {
               "code": "RESOURCE_NOT_FOUND"

--- a/graphql/tests/mutation/defaultSectionToRepo/results.json
+++ b/graphql/tests/mutation/defaultSectionToRepo/results.json
@@ -16,7 +16,7 @@
         },
         "errors": [
           {
-            "message": "error defaulting to repo for section: getting before project settings event: project ref 'repo_id' not found",
+            "message": "Could not find project with projectId: repo_id",
             "path": [
               "defaultSectionToRepo"
             ],

--- a/graphql/tests/mutation/detachProjectFromRepo/results.json
+++ b/graphql/tests/mutation/detachProjectFromRepo/results.json
@@ -16,7 +16,7 @@
         "data": null,
         "errors": [
           {
-            "message": "Could not find project with projectId: repo_id",
+            "message": "Could not find project with projectId: nonexistent",
             "path": [
               "detachProjectFromRepo",
               "projectId"

--- a/graphql/tests/mutation/detachProjectFromRepo/results.json
+++ b/graphql/tests/mutation/detachProjectFromRepo/results.json
@@ -16,7 +16,7 @@
         "data": null,
         "errors": [
           {
-            "message": "user testuser does not have permission to access settings for the project nonexistent",
+            "message": "Could not find project with projectId: repo_id",
             "path": [
               "detachProjectFromRepo",
               "projectId"

--- a/graphql/tests/mutation/detachProjectFromRepo/results.json
+++ b/graphql/tests/mutation/detachProjectFromRepo/results.json
@@ -22,7 +22,7 @@
               "projectId"
             ],
             "extensions": {
-              "code": "FORBIDDEN"
+              "code": "RESOURCE_NOT_FOUND"
             }
           }
         ]

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -762,12 +762,9 @@ func groupProjects(projects []model.ProjectRef, onlyDefaultedToRepo bool) ([]*Gr
 
 // getProjectIdFromArgs extracts a project ID from the requireProjectAccess directive args.
 func getProjectIdFromArgs(ctx context.Context, args map[string]interface{}) (res string, err error) {
+	// id should always be a repo ID.
 	if id, hasId := args["id"].(string); hasId {
-		pid, err := model.GetIdForProject(id)
-		if err != nil {
-			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with id: %s", id))
-		}
-		return pid, nil
+		return id, nil
 	}
 	if projectId, hasProjectId := args["projectId"].(string); hasProjectId {
 		pid, err := model.GetIdForProject(projectId)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -763,10 +763,18 @@ func groupProjects(projects []model.ProjectRef, onlyDefaultedToRepo bool) ([]*Gr
 // getProjectIdFromArgs extracts a project ID from the requireProjectAccess directive args.
 func getProjectIdFromArgs(ctx context.Context, args map[string]interface{}) (res string, err error) {
 	if id, hasId := args["id"].(string); hasId {
-		return id, nil
+		pid, err := model.GetIdForProject(id)
+		if err != nil {
+			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with identifier: %s", identifier))
+		}
+		return pid, nil
 	}
 	if projectId, hasProjectId := args["projectId"].(string); hasProjectId {
-		return projectId, nil
+		pid, err := model.GetIdForProject(projectId)
+		if err != nil {
+			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with identifier: %s", identifier))
+		}
+		return pid, nil
 	}
 	if identifier, hasIdentifier := args["identifier"].(string); hasIdentifier {
 		pid, err := model.GetIdForProject(identifier)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -765,14 +765,14 @@ func getProjectIdFromArgs(ctx context.Context, args map[string]interface{}) (res
 	if id, hasId := args["id"].(string); hasId {
 		pid, err := model.GetIdForProject(id)
 		if err != nil {
-			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with identifier: %s", identifier))
+			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with id: %s", id))
 		}
 		return pid, nil
 	}
 	if projectId, hasProjectId := args["projectId"].(string); hasProjectId {
 		pid, err := model.GetIdForProject(projectId)
 		if err != nil {
-			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with identifier: %s", identifier))
+			return "", ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find project with projectId: %s", projectId))
 		}
 		return pid, nil
 	}


### PR DESCRIPTION
EVG-20459

### Description
The RequireProjectAccess would take in 3 different argument types and look up the project id in only one of the cases. This could be problematic due to the differences between how ids vs identifiers are treated as seen in this thread: https://mongodb.slack.com/archives/C0V896UV8/p1689352076642169

At some point, we should consolidate the argument types for these mutations so that they are consistent in the argument naming.
