### PR TITLE
EVG-19971: return 404 when task has no manifest

### DIFF
--- a/model/manifest/manifest.go
+++ b/model/manifest/manifest.go
@@ -1,10 +1,5 @@
 package manifest
 
-import (
-	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/pkg/errors"
-)
-
 const Collection = "manifest"
 
 // Manifest is a representation of the modules associated with a version.
@@ -35,23 +30,4 @@ type Module struct {
 	Revision string `json:"revision" bson:"revision"`
 	Owner    string `json:"owner" bson:"owner"`
 	URL      string `json:"url" bson:"url"`
-}
-
-// GetManifestByTask finds the manifest corresponding to the given task.
-func GetManifestByTask(taskId string) (*Manifest, error) {
-	t, err := task.FindOneId(taskId)
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding task '%s'", t)
-	}
-	if t == nil {
-		return nil, errors.Errorf("task '%s' not found", t.Id)
-	}
-	mfest, err := FindFromVersion(t.Version, t.Project, t.Revision, t.Requester)
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding manifest from version '%s'", t.Version)
-	}
-	if mfest == nil {
-		return nil, errors.Errorf("no manifest found for version '%s'", t.Version)
-	}
-	return mfest, nil
 }

--- a/rest/data/manifest.go
+++ b/rest/data/manifest.go
@@ -1,0 +1,36 @@
+package data
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen/model/manifest"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+// GetManifestByTask finds the version manifest corresponding to the given task.
+func GetManifestByTask(taskId string) (*manifest.Manifest, error) {
+	t, err := task.FindOneId(taskId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding task '%s'", t)
+	}
+	if t == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("manifest for task '%s' not found", taskId),
+		}
+	}
+	mfest, err := manifest.FindFromVersion(t.Version, t.Project, t.Revision, t.Requester)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding manifest from version '%s'", t.Version)
+	}
+	if mfest == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("manifest for version '%s' not found", t.Version),
+		}
+	}
+	return mfest, nil
+}

--- a/rest/data/manifest_test.go
+++ b/rest/data/manifest_test.go
@@ -1,0 +1,64 @@
+package data
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/manifest"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetManifestByTask(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(manifest.Collection, task.Collection))
+	}()
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, tsk *task.Task, mfest *manifest.Manifest){
+		"Succeeds": func(ctx context.Context, t *testing.T, tsk *task.Task, mfest *manifest.Manifest) {
+			require.NoError(t, tsk.Insert())
+			require.NoError(t, mfest.InsertWithContext(ctx))
+			dbManifest, err := GetManifestByTask(tsk.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbManifest)
+			assert.Equal(t, mfest.Id, dbManifest.Id)
+		},
+		"FailsWithNonexistentTask": func(ctx context.Context, t *testing.T, tsk *task.Task, mfest *manifest.Manifest) {
+			require.NoError(t, mfest.InsertWithContext(ctx))
+			dbManifest, err := GetManifestByTask(tsk.Id)
+			assert.Error(t, err)
+			gimErr, ok := err.(gimlet.ErrorResponse)
+			require.True(t, ok)
+			assert.Equal(t, http.StatusNotFound, gimErr.StatusCode)
+			assert.Zero(t, dbManifest)
+		},
+		"FailsWithNonexistentManifest": func(ctx context.Context, t *testing.T, tsk *task.Task, mfest *manifest.Manifest) {
+			require.NoError(t, tsk.Insert())
+			dbManifest, err := GetManifestByTask(tsk.Id)
+			assert.Error(t, err)
+			gimErr, ok := err.(gimlet.ErrorResponse)
+			require.True(t, ok)
+			assert.Equal(t, http.StatusNotFound, gimErr.StatusCode)
+			assert.Zero(t, dbManifest)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, db.ClearCollections(manifest.Collection, task.Collection))
+
+			tsk := &task.Task{
+				Id:      "task_id",
+				Version: "version_id",
+			}
+			mfest := &manifest.Manifest{
+				Id: tsk.Version,
+			}
+			tCase(ctx, t, tsk, mfest)
+		})
+	}
+}

--- a/rest/route/task_manifest.go
+++ b/rest/route/task_manifest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/evergreen-ci/evergreen/model/manifest"
+	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 )
@@ -31,7 +31,7 @@ func (h *getManifestHandler) Parse(ctx context.Context, r *http.Request) error {
 
 // Execute returns the manifest for the given task.
 func (h *getManifestHandler) Run(ctx context.Context) gimlet.Responder {
-	manifest, err := manifest.GetManifestByTask(h.taskID)
+	manifest, err := data.GetManifestByTask(h.taskID)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting manifest using task '%s'", h.taskID))
 	}


### PR DESCRIPTION
EVG-19971

### Description
Instead of returning 500 when the task has no manifest, return 404. I also moved the function into the REST data package to be more consistent with the other data connector functions.

### Testing
Added unit tests.

### Documentation
Our API already generally returns 404 for REST requests for nonexistent resources, so I didn't think it was worth documenting the status codes just for this one route.