### PR TITLE
EVG-20286: lock mock heartbeat count

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1086,7 +1086,7 @@ timeout:
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status, "task that aborts during main block should fail")
 	// The exact count is not of particular importance, we're only interested in
 	// knowing that the heartbeat is still going despite receiving an abort.
-	s.GreaterOrEqual(s.mockCommunicator.HeartbeatCount, 10, "heartbeat should be still running for post block even when abort signal is received, so count should be high")
+	s.GreaterOrEqual(s.mockCommunicator.GetHeartbeatCount(), 10, "heartbeat should be still running for post block even when abort signal is received, so count should be high")
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
 		"Heartbeat received signal to abort task.",
 		"Task completed - FAILURE",
@@ -1134,7 +1134,7 @@ timeout:
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status, "task that aborts during main block should fail")
 	// The exact count is not of particular importance, we're only interested in
 	// knowing that the heartbeat is still going despite receiving an abort.
-	s.GreaterOrEqual(s.mockCommunicator.HeartbeatCount, 10, "heartbeat should be still running for teardown_task block even when abort signal is received, so count should be high")
+	s.GreaterOrEqual(s.mockCommunicator.GetHeartbeatCount(), 10, "heartbeat should be still running for teardown_task block even when abort signal is received, so count should be high")
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
 		"Heartbeat received signal to abort task.",
 		"Task completed - FAILURE",

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -254,6 +254,14 @@ func (c *Mock) Heartbeat(ctx context.Context, td TaskData) (string, error) {
 	return "", nil
 }
 
+// GetHeartbeatCount returns the current number of recorded heartbeats. This is
+// thread-safe.
+func (c *Mock) GetHeartbeatCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.HeartbeatCount
+}
+
 // GetNextTask returns a mock NextTaskResponse.
 func (c *Mock) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDetails) (*apimodels.NextTaskResponse, error) {
 	if c.NextTaskIsNil {


### PR DESCRIPTION
EVG-20286

### Description
The test had a race to access the mock `HeartbeatCount` because the heartbeat goroutine was still going by the time the test assertions started checking the count.

### Testing
Race detector passed the test locally and I configured the PR patch to run the race detector.

### Documentation
N/A