### PR TITLE
EVG-19938: Add DeleteDistro mutation

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -205,6 +205,10 @@ type ComplexityRoot struct {
 		Name     func(childComplexity int) int
 	}
 
+	DeleteDistroPayload struct {
+		DeletedDistroID func(childComplexity int) int
+	}
+
 	Dependency struct {
 		BuildVariant   func(childComplexity int) int
 		MetStatus      func(childComplexity int) int
@@ -577,6 +581,7 @@ type ComplexityRoot struct {
 		CreatePublicKey               func(childComplexity int, publicKeyInput PublicKeyInput) int
 		DeactivateStepbackTask        func(childComplexity int, projectID string, buildVariantName string, taskName string) int
 		DefaultSectionToRepo          func(childComplexity int, projectID string, section ProjectSettingsSection) int
+		DeleteDistro                  func(childComplexity int, opts DeleteDistroInput) int
 		DeleteProject                 func(childComplexity int, projectID string) int
 		DeleteSubscriptions           func(childComplexity int, subscriptionIds []string) int
 		DetachProjectFromRepo         func(childComplexity int, projectID string) int
@@ -1502,6 +1507,7 @@ type MutationResolver interface {
 	MoveAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	RemoveAnnotationIssue(ctx context.Context, taskID string, execution int, apiIssue model.APIIssueLink, isIssue bool) (bool, error)
 	SetAnnotationMetadataLinks(ctx context.Context, taskID string, execution int, metadataLinks []*model.APIMetadataLink) (bool, error)
+	DeleteDistro(ctx context.Context, opts DeleteDistroInput) (*DeleteDistroPayload, error)
 	CopyDistro(ctx context.Context, opts data.CopyDistroOpts) (*NewDistroPayload, error)
 	ReprovisionToNew(ctx context.Context, hostIds []string) (int, error)
 	RestartJasper(ctx context.Context, hostIds []string) (int, error)
@@ -2301,6 +2307,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContainerResources.Name(childComplexity), true
+
+	case "DeleteDistroPayload.deletedDistroId":
+		if e.complexity.DeleteDistroPayload.DeletedDistroID == nil {
+			break
+		}
+
+		return e.complexity.DeleteDistroPayload.DeletedDistroID(childComplexity), true
 
 	case "Dependency.buildVariant":
 		if e.complexity.Dependency.BuildVariant == nil {
@@ -3976,6 +3989,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DefaultSectionToRepo(childComplexity, args["projectId"].(string), args["section"].(ProjectSettingsSection)), true
+
+	case "Mutation.deleteDistro":
+		if e.complexity.Mutation.DeleteDistro == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteDistro_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteDistro(childComplexity, args["opts"].(DeleteDistroInput)), true
 
 	case "Mutation.deleteProject":
 		if e.complexity.Mutation.DeleteProject == nil {
@@ -8871,6 +8896,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCopyDistroInput,
 		ec.unmarshalInputCopyProjectInput,
 		ec.unmarshalInputCreateProjectInput,
+		ec.unmarshalInputDeleteDistroInput,
 		ec.unmarshalInputDisplayTask,
 		ec.unmarshalInputDistroPermissionsOptions,
 		ec.unmarshalInputEditSpawnHostInput,
@@ -9434,6 +9460,21 @@ func (ec *executionContext) field_Mutation_defaultSectionToRepo_args(ctx context
 		}
 	}
 	args["section"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteDistro_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 DeleteDistroInput
+	if tmp, ok := rawArgs["opts"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("opts"))
+		arg0, err = ec.unmarshalNDeleteDistroInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDeleteDistroInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["opts"] = arg0
 	return args, nil
 }
 
@@ -14531,6 +14572,50 @@ func (ec *executionContext) fieldContext_ContainerResources_memoryMb(ctx context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DeleteDistroPayload_deletedDistroId(ctx context.Context, field graphql.CollectedField, obj *DeleteDistroPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DeleteDistroPayload_deletedDistroId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedDistroID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DeleteDistroPayload_deletedDistroId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DeleteDistroPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -25105,6 +25190,65 @@ func (ec *executionContext) fieldContext_Mutation_setAnnotationMetadataLinks(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_setAnnotationMetadataLinks_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteDistro(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteDistro(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteDistro(rctx, fc.Args["opts"].(DeleteDistroInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*DeleteDistroPayload)
+	fc.Result = res
+	return ec.marshalNDeleteDistroPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDeleteDistroPayload(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteDistro(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "deletedDistroId":
+				return ec.fieldContext_DeleteDistroPayload_deletedDistroId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DeleteDistroPayload", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteDistro_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -63948,6 +64092,52 @@ func (ec *executionContext) unmarshalInputCreateProjectInput(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputDeleteDistroInput(ctx context.Context, obj interface{}) (DeleteDistroInput, error) {
+	var it DeleteDistroInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"distroId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "distroId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("distroId"))
+			directive0 := func(ctx context.Context) (interface{}, error) { return ec.unmarshalNString2string(ctx, v) }
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				access, err := ec.unmarshalNDistroSettingsAccess2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDistroSettingsAccess(ctx, "ADMIN")
+				if err != nil {
+					return nil, err
+				}
+				if ec.directives.RequireDistroAccess == nil {
+					return nil, errors.New("directive requireDistroAccess is not implemented")
+				}
+				return ec.directives.RequireDistroAccess(ctx, obj, directive0, access)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.DistroID = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputDisplayTask(ctx context.Context, obj interface{}) (DisplayTask, error) {
 	var it DisplayTask
 	asMap := map[string]interface{}{}
@@ -68428,6 +68618,34 @@ func (ec *executionContext) _ContainerResources(ctx context.Context, sel ast.Sel
 	return out
 }
 
+var deleteDistroPayloadImplementors = []string{"DeleteDistroPayload"}
+
+func (ec *executionContext) _DeleteDistroPayload(ctx context.Context, sel ast.SelectionSet, obj *DeleteDistroPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, deleteDistroPayloadImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DeleteDistroPayload")
+		case "deletedDistroId":
+
+			out.Values[i] = ec._DeleteDistroPayload_deletedDistroId(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var dependencyImplementors = []string{"Dependency"}
 
 func (ec *executionContext) _Dependency(ctx context.Context, sel ast.SelectionSet, obj *Dependency) graphql.Marshaler {
@@ -70869,6 +71087,15 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_setAnnotationMetadataLinks(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteDistro":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteDistro(ctx, field)
 			})
 
 			if out.Values[i] == graphql.Null {
@@ -78990,6 +79217,25 @@ func (ec *executionContext) unmarshalNCopyProjectInput2githubᚗcomᚋevergreen�
 func (ec *executionContext) unmarshalNCreateProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIProjectRef(ctx context.Context, v interface{}) (model.APIProjectRef, error) {
 	res, err := ec.unmarshalInputCreateProjectInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNDeleteDistroInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDeleteDistroInput(ctx context.Context, v interface{}) (DeleteDistroInput, error) {
+	res, err := ec.unmarshalInputDeleteDistroInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNDeleteDistroPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDeleteDistroPayload(ctx context.Context, sel ast.SelectionSet, v DeleteDistroPayload) graphql.Marshaler {
+	return ec._DeleteDistroPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNDeleteDistroPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDeleteDistroPayload(ctx context.Context, sel ast.SelectionSet, v *DeleteDistroPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._DeleteDistroPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNDependency2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐDependency(ctx context.Context, sel ast.SelectionSet, v *Dependency) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -46,7 +46,7 @@ type DeleteDistroInput struct {
 	DistroID string `json:"distroId"`
 }
 
-// Return type representing whether a distro was deleted
+// Return type representing whether a distro was deleted.
 type DeleteDistroPayload struct {
 	DeletedDistroID string `json:"deletedDistroId"`
 }

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -41,6 +41,16 @@ type BuildVariantOptions struct {
 	Variants         []string `json:"variants,omitempty"`
 }
 
+// DeleteDistroInput is the input to the deleteDistro mutation.
+type DeleteDistroInput struct {
+	DistroID string `json:"distroId"`
+}
+
+// Return type representing whether a distro was deleted
+type DeleteDistroPayload struct {
+	DeletedDistroID string `json:"deletedDistroId"`
+}
+
 type Dependency struct {
 	BuildVariant   string         `json:"buildVariant"`
 	MetStatus      MetStatus      `json:"metStatus"`

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -123,12 +123,26 @@ func (r *mutationResolver) SetAnnotationMetadataLinks(ctx context.Context, taskI
 	return true, nil
 }
 
+// DeleteDistro is the resolver for the deleteDistro field.
+func (r *mutationResolver) DeleteDistro(ctx context.Context, opts DeleteDistroInput) (*DeleteDistroPayload, error) {
+	usr := mustHaveUser(ctx)
+	if err := data.DeleteDistroById(ctx, usr, opts.DistroID); err != nil {
+		gimletErr, ok := err.(gimlet.ErrorResponse)
+		if ok {
+			return nil, mapHTTPStatusToGqlError(ctx, gimletErr.StatusCode, err)
+		}
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("deleting distro: %s", err.Error()))
+	}
+	return &DeleteDistroPayload{
+		DeletedDistroID: opts.DistroID,
+	}, nil
+}
+
 // CopyDistro is the resolver for the copyDistro field.
 func (r *mutationResolver) CopyDistro(ctx context.Context, opts data.CopyDistroOpts) (*NewDistroPayload, error) {
 	usr := mustHaveUser(ctx)
 
 	if err := data.CopyDistro(ctx, usr, opts); err != nil {
-
 		gimletErr, ok := err.(gimlet.ErrorResponse)
 		if ok {
 			return nil, mapHTTPStatusToGqlError(ctx, gimletErr.StatusCode, err)

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -16,4 +16,4 @@ directive @requireProjectFieldAccess on FIELD_DEFINITION
 """
 requireDistroAccess is used to restrict view, edit, admin, and create access for distros.
 """
-directive @requireDistroAccess(access: DistroSettingsAccess!) on ARGUMENT_DEFINITION
+directive @requireDistroAccess(access: DistroSettingsAccess!) on ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION

--- a/graphql/schema/mutation.graphql
+++ b/graphql/schema/mutation.graphql
@@ -33,6 +33,7 @@ type Mutation {
   ): Boolean!
 
   # distros
+  deleteDistro(opts: DeleteDistroInput!): DeleteDistroPayload!
   copyDistro(opts: CopyDistroInput! @requireDistroAccess(access: CREATE)): NewDistroPayload!
 
   # hosts

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -6,6 +6,14 @@ enum DistroSettingsAccess {
 }
 
 """
+DeleteDistroInput is the input to the deleteDistro mutation.
+"""
+input DeleteDistroInput {
+  distroId: String! @requireDistroAccess(access: ADMIN)
+}
+
+
+"""
 CopyDistroInput is the input to the copyDistro mutation.
 It contains information about a distro to be duplicated.
 """
@@ -20,6 +28,14 @@ Return type representing whether a distro was created and any validation errors
 type NewDistroPayload {
   newDistroId: String!
 }
+
+"""
+Return type representing whether a distro was deleted
+"""
+type DeleteDistroPayload {
+  deletedDistroId: String!
+}
+
 
 """
 Distro models an environment configuration for a host.

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -30,7 +30,7 @@ type NewDistroPayload {
 }
 
 """
-Return type representing whether a distro was deleted
+Return type representing whether a distro was deleted.
 """
 type DeleteDistroPayload {
   deletedDistroId: String!

--- a/graphql/tests/mutation/deleteDistro/data.json
+++ b/graphql/tests/mutation/deleteDistro/data.json
@@ -1,0 +1,48 @@
+{
+  "distro": [
+    {
+      "_id": "localhost",
+      "arch": "linux_amd64",
+      "work_dir": "/home/ubuntu",
+      "provider": "static",
+      "settings": {
+        "hosts": [
+          {
+            "name": "localhost"
+          }
+        ]
+      },
+      "user": "ubuntu",
+      "spawn_allowed": false,
+      "ssh_key": "fake_ssh_key"
+    }
+  ],
+  "admin": [
+    {
+      "_id": "global",
+      "keys": {
+        "fake_ssh_key": "key"
+      }
+    }
+  ],
+  "task_queues": [
+    {
+      "queue": [
+        {
+          "project": "project_id",
+          "display_name": "compile",
+          "build_variant": "localhost",
+          "priority": { "$numberLong": "0" },
+          "version": "version_id",
+          "gitspec": "revision",
+          "requester": "patch_request",
+          "_id": "task_id",
+          "order": 0,
+          "exp_dur": { "$numberLong": "600000000000" }
+        }
+      ],
+      "_id": { "$oid": "55c230e1f9f1d47716d86fc2" },
+      "distro": "localhost"
+    }
+  ]
+}

--- a/graphql/tests/mutation/deleteDistro/queries/delete_distro.graphql
+++ b/graphql/tests/mutation/deleteDistro/queries/delete_distro.graphql
@@ -1,0 +1,9 @@
+mutation {
+  deleteDistro(
+    opts: {
+      distroId: "localhost",
+    }
+  ) {
+    deletedDistroId
+  }
+}

--- a/graphql/tests/mutation/deleteDistro/results.json
+++ b/graphql/tests/mutation/deleteDistro/results.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "query_file": "delete_distro.graphql",
+      "result": {
+        "data": {
+          "deleteDistro": {
+            "deletedDistroId": "localhost"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -43,7 +43,7 @@ func UpdateDistro(ctx context.Context, old, new *distro.Distro) error {
 }
 
 // DeleteDistroById removes a given distro from the database based on its id.
-func DeleteDistroById(ctx context.Context, distroId string) error {
+func DeleteDistroById(ctx context.Context, u *user.DBUser, distroId string) error {
 	d, err := distro.FindOneId(ctx, distroId)
 	if err != nil {
 		return gimlet.ErrorResponse{
@@ -75,6 +75,8 @@ func DeleteDistroById(ctx context.Context, distroId string) error {
 			Message:    errors.Wrapf(err, "clearing task queue for distro '%s'", distroId).Error(),
 		}
 	}
+
+	event.LogDistroRemoved(d.Id, u.Username(), d.NewDistroData())
 	return nil
 }
 

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -9,50 +9,96 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteDistroById(t *testing.T) {
-	session, _, err := db.GetGlobalSessionFactory().GetSession()
-	require.NoError(t, err)
-	defer session.Close()
-	require.NoError(t, session.DB(testConfig.Database.DB).DropDatabase())
-	defer func() {
-		assert.NoError(t, session.DB(testConfig.Database.DB).DropDatabase())
-	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := distro.Distro{
-		Id: "distro",
+	for tName, tCase := range map[string]func(t *testing.T, ctx context.Context, u user.DBUser){
+		"Successfully deletes distro": func(t *testing.T, ctx context.Context, u user.DBUser) {
+			assert.NoError(t, DeleteDistroById(ctx, &u, "distro"))
+
+			dbDistro, err := distro.FindOneId(ctx, "distro")
+			assert.NoError(t, err)
+			assert.Nil(t, dbDistro)
+
+			dbHost, err := host.FindOneId(ctx, "host")
+			assert.NoError(t, err)
+			assert.Equal(t, dbHost.Status, evergreen.HostTerminated)
+
+			dbQueue, err := model.LoadTaskQueue("distro")
+			assert.NoError(t, err)
+			assert.Empty(t, dbQueue.Queue)
+
+			events, err := event.FindLatestPrimaryDistroEvents("distro", 10)
+			assert.NoError(t, err)
+			assert.Equal(t, len(events), 1)
+		},
+		"Fails when distro does not exist": func(t *testing.T, ctx context.Context, u user.DBUser) {
+			err := DeleteDistroById(ctx, &u, "nonexistent")
+			assert.Error(t, err)
+			assert.Equal(t, err.Error(), "400 (Bad Request): distro 'nonexistent' not found")
+
+			events, err := event.FindLatestPrimaryDistroEvents("nonexistent", 10)
+			assert.NoError(t, err)
+			assert.Equal(t, len(events), 0)
+		},
+		"Fails when task queue for distro does not exist": func(t *testing.T, ctx context.Context, u user.DBUser) {
+			err := DeleteDistroById(ctx, &u, "distro-no-task-queue")
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "500 (Internal Server Error): clearing task queue for distro 'distro-no-task-queue'")
+
+			events, err := event.FindLatestPrimaryDistroEvents("distro-no-task-queue", 10)
+			assert.NoError(t, err)
+			assert.Equal(t, len(events), 0)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+			assert.NoError(t, db.ClearCollections(distro.Collection, event.EventCollection, user.Collection, model.TaskQueuesCollection, host.Collection))
+
+			d := distro.Distro{
+				Id: "distro",
+			}
+			assert.NoError(t, d.Insert(tctx))
+
+			queue := model.TaskQueue{
+				Distro: d.Id,
+				Queue:  []model.TaskQueueItem{{Id: "task"}},
+			}
+			assert.NoError(t, queue.Save())
+
+			host := host.Host{
+				Id:     "host",
+				Status: evergreen.HostRunning,
+				Distro: distro.Distro{
+					Id: "distro",
+				},
+				Provider: evergreen.HostTypeStatic,
+			}
+			assert.NoError(t, host.Insert(tctx))
+
+			d.Id = "distro-no-task-queue"
+			assert.NoError(t, d.Insert(tctx))
+
+			adminUser := user.DBUser{
+				Id: "admin",
+			}
+			assert.NoError(t, adminUser.Insert())
+
+			tCase(t, tctx, adminUser)
+		})
 	}
-	require.NoError(t, d.Insert(ctx))
-
-	queue := model.TaskQueue{
-		Distro: d.Id,
-		Queue:  []model.TaskQueueItem{{Id: "task"}},
-	}
-	require.NoError(t, queue.Save())
-
-	require.NoError(t, DeleteDistroById(ctx, d.Id))
-
-	dbDistro, err := distro.FindOneId(ctx, d.Id)
-	assert.NoError(t, err)
-	assert.Nil(t, dbDistro)
-
-	dbQueue, err := model.LoadTaskQueue(queue.Distro)
-	require.NoError(t, err)
-	assert.Empty(t, dbQueue.Queue)
 }
 
 func TestCopyDistro(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "oldAdmin"})
 
 	config, err := evergreen.GetConfig()
 	assert.NoError(t, err)

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -67,21 +67,21 @@ func TestDeleteDistroById(t *testing.T) {
 			}
 			assert.NoError(t, d.Insert(tctx))
 
+			host := host.Host{
+				Id:     "host",
+				Status: evergreen.HostRunning,
+				Distro: distro.Distro{
+					Id: d.Id,
+				},
+				Provider: evergreen.HostTypeStatic,
+			}
+			assert.NoError(t, host.Insert(tctx))
+
 			queue := model.TaskQueue{
 				Distro: d.Id,
 				Queue:  []model.TaskQueueItem{{Id: "task"}},
 			}
 			assert.NoError(t, queue.Save())
-
-			host := host.Host{
-				Id:     "host",
-				Status: evergreen.HostRunning,
-				Distro: distro.Distro{
-					Id: "distro",
-				},
-				Provider: evergreen.HostTypeStatic,
-			}
-			assert.NoError(t, host.Insert(tctx))
 
 			d.Id = "distro-no-task-queue"
 			assert.NoError(t, d.Insert(tctx))

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -244,6 +244,7 @@ func (h *distroIDDeleteHandler) Parse(ctx context.Context, r *http.Request) erro
 
 // Run deletes a distro by id.
 func (h *distroIDDeleteHandler) Run(ctx context.Context) gimlet.Responder {
+	user := MustHaveUser(ctx)
 	d, err := distro.FindOneId(ctx, h.distroID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding distro '%s'", h.distroID))
@@ -254,8 +255,7 @@ func (h *distroIDDeleteHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("distro '%s' not found", h.distroID),
 		})
 	}
-	err = data.DeleteDistroById(ctx, h.distroID)
-	if err != nil {
+	if err = data.DeleteDistroById(ctx, user, h.distroID); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting distro '%s'", h.distroID))
 	}
 

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -639,6 +639,7 @@ func (s *DistroDeleteByIDSuite) SetupTest() {
 
 func (s *DistroDeleteByIDSuite) TestParse() {
 	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
 
 	req, _ := http.NewRequest(http.MethodDelete, "http://example.com/api/rest/v2/distros/distro1", nil)
 	err := s.rm.Parse(ctx, req)
@@ -647,6 +648,7 @@ func (s *DistroDeleteByIDSuite) TestParse() {
 
 func (s *DistroDeleteByIDSuite) TestRunValidDistroId() {
 	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
 
 	now := time.Now().Round(time.Millisecond).UTC()
 	taskQueue := &model.TaskQueue{
@@ -664,6 +666,8 @@ func (s *DistroDeleteByIDSuite) TestRunValidDistroId() {
 
 func (s *DistroDeleteByIDSuite) TestRunInvalidDistroId() {
 	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
+
 	h := s.rm.(*distroIDDeleteHandler)
 	h.distroID = "distro4"
 


### PR DESCRIPTION
EVG-19938

### Description
This PR adds the `DeleteDistro` mutation.

The reason why the input & output of the mutation is an object despite it only containing one item is because of [this article](https://www.apollographql.com/blog/graphql/basics/designing-graphql-mutations/) that was shared in the UI channel. (Summary of the article: it makes it easier to change the mutation in the future since we can just add more items to the object.)

### Testing
- Augmented the existing tests in rest/data/distro_test.go
- Added GraphQL test
