### PR TITLE
EVG-18734 fix task updates

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1779,6 +1779,21 @@ func UpdateOne(query interface{}, update interface{}) error {
 	)
 }
 
+func UpdateOneContext(ctx context.Context, query interface{}, update interface{}) error {
+	res, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateOne(ctx,
+		query,
+		update,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "updating task")
+	}
+	if res.MatchedCount == 0 {
+		return adb.ErrNotFound
+	}
+
+	return nil
+}
+
 func UpdateAll(query interface{}, update interface{}) (*adb.ChangeInfo, error) {
 	return db.UpdateAll(
 		Collection,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2692,13 +2692,15 @@ func activateTasks(taskIDs []string, caller string, activationTime time.Time) er
 		bson.M{
 			IdKey: bson.M{"$in": taskIDs},
 		},
-		bson.M{
-			"$set": bson.M{
-				ActivatedKey:     true,
-				ActivatedByKey:   caller,
-				ActivatedTimeKey: activationTime,
-				// TODO: (EVG-20334) Remove once old tasks without the UnattainableDependency field have TTLed.
-				UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+		[]bson.M{
+			{
+				"$set": bson.M{
+					ActivatedKey:     true,
+					ActivatedByKey:   caller,
+					ActivatedTimeKey: activationTime,
+					// TODO: (EVG-20334) Remove this field and the aggregation update once old tasks without the UnattainableDependency field have TTLed.
+					UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+				},
 			},
 		})
 	if err != nil {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1926,3 +1926,90 @@ func TestHasActivatedDependentTasks(t *testing.T) {
 	assert.False(t, hasDependentTasks)
 
 }
+
+func TestActivateTasksUpdate(t *testing.T) {
+	defer func() {
+		require.NoError(t, db.Clear(Collection))
+	}()
+
+	caller := "me"
+	activationTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	t.Run("NoDependencies", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		t0 := Task{
+			Id: "t0",
+		}
+
+		require.NoError(t, t0.Insert())
+		assert.NoError(t, activateTasks([]string{t0.Id}, caller, activationTime))
+		dbTask, err := FindOneId(t0.Id)
+		assert.NoError(t, err)
+		assert.True(t, dbTask.Activated)
+		assert.Equal(t, caller, dbTask.ActivatedBy)
+		assert.True(t, activationTime.Equal(dbTask.ActivatedTime))
+		assert.False(t, dbTask.UnattainableDependency)
+	})
+
+	t.Run("UnattainableDependency", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		t0 := Task{
+			Id: "t0",
+			DependsOn: []Dependency{
+				{TaskId: "t1", Unattainable: true},
+				{TaskId: "t2", Unattainable: false},
+			},
+		}
+
+		require.NoError(t, t0.Insert())
+		assert.NoError(t, activateTasks([]string{t0.Id}, caller, activationTime))
+		dbTask, err := FindOneId(t0.Id)
+		assert.NoError(t, err)
+		assert.True(t, dbTask.Activated)
+		assert.Equal(t, caller, dbTask.ActivatedBy)
+		assert.True(t, activationTime.Equal(dbTask.ActivatedTime))
+		assert.True(t, dbTask.UnattainableDependency)
+	})
+
+	t.Run("AttainableDependencies", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		t0 := Task{
+			Id: "t0",
+			DependsOn: []Dependency{
+				{TaskId: "t1", Unattainable: false},
+				{TaskId: "t2", Unattainable: false},
+			},
+		}
+
+		require.NoError(t, t0.Insert())
+		assert.NoError(t, activateTasks([]string{t0.Id}, caller, activationTime))
+		dbTask, err := FindOneId(t0.Id)
+		assert.NoError(t, err)
+		assert.True(t, dbTask.Activated)
+		assert.Equal(t, caller, dbTask.ActivatedBy)
+		assert.True(t, activationTime.Equal(dbTask.ActivatedTime))
+		assert.False(t, dbTask.UnattainableDependency)
+	})
+
+	t.Run("DisabledTask", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		t0 := Task{
+			Id:       "t0",
+			Priority: evergreen.DisabledTaskPriority,
+		}
+
+		require.NoError(t, t0.Insert())
+		assert.NoError(t, activateTasks([]string{t0.Id}, caller, activationTime))
+		dbTask, err := FindOneId(t0.Id)
+		assert.NoError(t, err)
+		assert.True(t, dbTask.Activated)
+		assert.Equal(t, caller, dbTask.ActivatedBy)
+		assert.True(t, activationTime.Equal(dbTask.ActivatedTime))
+		assert.False(t, dbTask.UnattainableDependency)
+		assert.EqualValues(t, 0, dbTask.Priority)
+	})
+}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1654,7 +1654,12 @@ func ActivateDeactivatedDependencies(tasks []string, caller string) error {
 					ActivatedByKey:              caller,
 					ActivatedTimeKey:            time.Now(),
 					// TODO: (EVG-20334) Remove this field and the aggregation update once old tasks without the UnattainableDependency field have TTLed.
-					UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)}},
+					UnattainableDependencyKey: bson.M{"$cond": bson.M{
+						"if":   bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+						"then": bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+						"else": false,
+					}},
+				},
 			},
 		},
 	)
@@ -2042,7 +2047,11 @@ func resetTaskUpdate(t *Task) []bson.M {
 				LastHeartbeatKey:               utility.ZeroTime,
 				ContainerAllocationAttemptsKey: 0,
 				// TODO: (EVG-20334) Remove this field and the aggregation update once old tasks without the UnattainableDependency field have TTLed.
-				UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+				UnattainableDependencyKey: bson.M{"$cond": bson.M{
+					"if":   bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					"then": bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					"else": false,
+				}},
 			},
 		},
 		{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1646,14 +1646,17 @@ func ActivateDeactivatedDependencies(tasks []string, caller string) error {
 	}
 	_, err = UpdateAll(
 		bson.M{IdKey: bson.M{"$in": taskIDsToActivate}},
-		bson.M{"$set": bson.M{
-			ActivatedKey:                true,
-			DeactivatedForDependencyKey: false,
-			ActivatedByKey:              caller,
-			ActivatedTimeKey:            time.Now(),
-			// TODO: (EVG-20334) Remove once old tasks without the UnattainableDependency field have TTLed.
-			UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
-		}},
+		[]bson.M{
+			{
+				"$set": bson.M{
+					ActivatedKey:                true,
+					DeactivatedForDependencyKey: false,
+					ActivatedByKey:              caller,
+					ActivatedTimeKey:            time.Now(),
+					// TODO: (EVG-20334) Remove this field and the aggregation update once old tasks without the UnattainableDependency field have TTLed.
+					UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)}},
+			},
+		},
 	)
 	if err != nil {
 		return errors.Wrap(err, "updating activation for dependencies")
@@ -1958,8 +1961,8 @@ func (t *Task) displayTaskPriority() int {
 }
 
 // Reset sets the task state to a state in which it is scheduled to re-run.
-func (t *Task) Reset() error {
-	return UpdateOne(
+func (t *Task) Reset(ctx context.Context) error {
+	return UpdateOneContext(ctx,
 		bson.M{
 			IdKey:       t.Id,
 			StatusKey:   bson.M{"$in": evergreen.TaskCompletedStatuses},
@@ -1994,7 +1997,7 @@ func ResetTasks(tasks []Task) error {
 	return nil
 }
 
-func resetTaskUpdate(t *Task) bson.M {
+func resetTaskUpdate(t *Task) []bson.M {
 	newSecret := utility.RandomString()
 	now := time.Now()
 	if t != nil {
@@ -2023,36 +2026,40 @@ func resetTaskUpdate(t *Task) bson.M {
 		t.ContainerAllocationAttempts = 0
 		t.CanReset = false
 	}
-	update := bson.M{
-		"$set": bson.M{
-			ActivatedKey:                   true,
-			ActivatedTimeKey:               now,
-			SecretKey:                      newSecret,
-			StatusKey:                      evergreen.TaskUndispatched,
-			DispatchTimeKey:                utility.ZeroTime,
-			StartTimeKey:                   utility.ZeroTime,
-			ScheduledTimeKey:               utility.ZeroTime,
-			FinishTimeKey:                  utility.ZeroTime,
-			DependenciesMetTimeKey:         utility.ZeroTime,
-			TimeTakenKey:                   0,
-			LastHeartbeatKey:               utility.ZeroTime,
-			ContainerAllocationAttemptsKey: 0,
-			// TODO: (EVG-20334) Remove once old tasks without the UnattainableDependency field have TTLed.
-			UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+	update := []bson.M{
+		{
+			"$set": bson.M{
+				ActivatedKey:                   true,
+				ActivatedTimeKey:               now,
+				SecretKey:                      newSecret,
+				StatusKey:                      evergreen.TaskUndispatched,
+				DispatchTimeKey:                utility.ZeroTime,
+				StartTimeKey:                   utility.ZeroTime,
+				ScheduledTimeKey:               utility.ZeroTime,
+				FinishTimeKey:                  utility.ZeroTime,
+				DependenciesMetTimeKey:         utility.ZeroTime,
+				TimeTakenKey:                   0,
+				LastHeartbeatKey:               utility.ZeroTime,
+				ContainerAllocationAttemptsKey: 0,
+				// TODO: (EVG-20334) Remove this field and the aggregation update once old tasks without the UnattainableDependency field have TTLed.
+				UnattainableDependencyKey: bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+			},
 		},
-		"$unset": bson.M{
-			DetailsKey:                 "",
-			ResultsServiceKey:          "",
-			ResultsFailedKey:           "",
-			HasCedarResultsKey:         "",
-			ResetWhenFinishedKey:       "",
-			ResetFailedWhenFinishedKey: "",
-			AgentVersionKey:            "",
-			HostIdKey:                  "",
-			PodIDKey:                   "",
-			HostCreateDetailsKey:       "",
-			OverrideDependenciesKey:    "",
-			CanResetKey:                "",
+		{
+			"$unset": []string{
+				DetailsKey,
+				ResultsServiceKey,
+				ResultsFailedKey,
+				HasCedarResultsKey,
+				ResetWhenFinishedKey,
+				ResetFailedWhenFinishedKey,
+				AgentVersionKey,
+				HostIdKey,
+				PodIDKey,
+				HostCreateDetailsKey,
+				OverrideDependenciesKey,
+				CanResetKey,
+			},
 		},
 	}
 	return update

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -409,7 +409,7 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 		return errors.Wrap(err, "can't restart task because it can't be archived")
 	}
 
-	if err = MarkOneTaskReset(t); err != nil {
+	if err = MarkOneTaskReset(ctx, t); err != nil {
 		return errors.WithStack(err)
 	}
 	event.LogTaskRestarted(t.Id, t.Execution, caller)
@@ -1757,7 +1757,7 @@ func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 	return nil
 }
 
-func MarkOneTaskReset(t *task.Task) error {
+func MarkOneTaskReset(ctx context.Context, t *task.Task) error {
 	if t.DisplayOnly {
 		if !t.ResetFailedWhenFinished {
 			if err := MarkTasksReset(t.ExecutionTasks); err != nil {
@@ -1778,7 +1778,7 @@ func MarkOneTaskReset(t *task.Task) error {
 		}
 	}
 
-	if err := t.Reset(); err != nil && !adb.ResultsNotFound(err) {
+	if err := t.Reset(ctx); err != nil && !adb.ResultsNotFound(err) {
 		return errors.Wrap(err, "resetting task in database")
 	}
 


### PR DESCRIPTION
[EVG-18734](https://jira.mongodb.org/browse/EVG-18734)

### Description
#6703 fixed the UnattainableDependency field. The fix was incorrect for certain updates because they weren't using an [aggregation-pipeline-style update](https://www.mongodb.com/docs/manual/tutorial/update-documents-with-aggregation-pipeline/). Instead, the field was getting set to the literal document:
```
{ '$anyElementTrue': '$depends_on.unattainable' },
```

When I checked in prod it looked like there were ~1k schedulable tasks that matched this description. We won't be able to do [EVG-19998](https://jira.mongodb.org/browse/EVG-19998) before they are addressed. We could either migrate them or wait until there aren't any because they've either run or gotten unscheduled [by the scheduler](https://github.com/evergreen-ci/evergreen/blob/638e37f61359d4a5357669a3ff99de6d170a9af7/scheduler/wrapper.go#L40-L42) (max a week). I plan to just wait it out.

The aggregation style update didn't agree with some [preprocessing anser does](https://github.com/mongodb/anser/blob/99dd61768f4a246b31e8e3ff8b2d0e51760f2194/db/wrapper.go#L191-L194) before it sends `UpdateOne`s over to the driver, so this changes them to use the driver directly.

### Testing
Added tests for these updates. I tried activating and restarting tasks in staging and the field was set correctly.
