### PR TITLE
EVG-20477 Remove no longer necessary legacy build variant display name lookup

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -745,19 +745,9 @@ func (r *queryResolver) BuildVariantsForTaskName(ctx context.Context, projectIde
 	if repo == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find repository '%s'", pid))
 	}
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber, false)
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting build variant tasks for task '%s': %s", taskName, err.Error()))
-	}
-	// use legacy lookup pipeline if no results are found
-	if len(taskBuildVariants) == 0 {
-		taskBuildVariants, err = task.FindUniqueBuildVariantNamesByTask(pid, taskName, repo.RevisionOrderNumber, true)
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting build variant tasks using legacy pipeline for task '%s': %s", taskName, err.Error()))
-		}
-	}
-	if taskBuildVariants == nil {
-		return nil, nil
 	}
 	return taskBuildVariants, nil
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1216,7 +1216,6 @@ func FindUniqueBuildVariantNamesByTask(projectId string, taskName string, repoOr
 			{RevisionOrderNumberKey: bson.M{"$lte": repoOrderNumber}},
 		},
 	}
-	query[BuildVariantDisplayNameKey] = bson.M{"$exists": true, "$ne": ""}
 	pipeline := []bson.M{{"$match": query}}
 
 	// group the build variants by unique build variant names and get a build id for each

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -6,13 +6,12 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
+	assert.NoError(t, db.ClearCollections(task.Collection))
 	t1 := task.Task{
 		Id:                      "t1",
 		Status:                  evergreen.TaskSucceeded,

--- a/model/task_build_variant_names_test.go
+++ b/model/task_build_variant_names_test.go
@@ -13,11 +13,6 @@ import (
 
 func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(task.Collection, build.Collection))
-	b1 := build.Build{
-		Id:          "b1",
-		DisplayName: "Ubuntu 16.04 from builds collection",
-	}
-	assert.NoError(t, b1.Insert())
 	t1 := task.Task{
 		Id:                      "t1",
 		Status:                  evergreen.TaskSucceeded,
@@ -31,11 +26,6 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t1.Insert())
-	b2 := build.Build{
-		Id:          "b2",
-		DisplayName: "OSX from builds collection",
-	}
-	assert.NoError(t, b2.Insert())
 	t2 := task.Task{
 		Id:                      "t2",
 		Status:                  evergreen.TaskSucceeded,
@@ -49,11 +39,6 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t2.Insert())
-	b3 := build.Build{
-		Id:          "b3",
-		DisplayName: "Windows 64 bit from builds collection",
-	}
-	assert.NoError(t, b3.Insert())
 	t3 := task.Task{
 		Id:                      "t3",
 		Status:                  evergreen.TaskSucceeded,
@@ -67,24 +52,7 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		RevisionOrderNumber:     1,
 	}
 	assert.NoError(t, t3.Insert())
-	b4 := build.Build{
-		Id:          "b4",
-		DisplayName: "Race Detector from builds collection",
-	}
-	assert.NoError(t, b4.Insert())
-	t4 := task.Task{
-		Id:                  "t4",
-		Status:              evergreen.TaskSucceeded,
-		BuildVariant:        "race-detector",
-		DisplayName:         "test-agent",
-		Project:             "evergreen",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		BuildId:             "b4",
-		CreateTime:          time.Now().Add(-time.Hour),
-		RevisionOrderNumber: 1,
-	}
-	assert.NoError(t, t4.Insert())
-	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1, false)
+	taskBuildVariants, err := task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1)
 	assert.NoError(t, err)
 	assert.Equal(t, []*task.BuildVariantTuple{
 		{DisplayName: "OSX", BuildVariant: "osx"},
@@ -92,12 +60,4 @@ func TestFindUniqueBuildVariantNamesByTask(t *testing.T) {
 		{DisplayName: "Windows 64 bit", BuildVariant: "windows"},
 	}, taskBuildVariants)
 
-	taskBuildVariants, err = task.FindUniqueBuildVariantNamesByTask("evergreen", "test-agent", 1, true)
-	assert.NoError(t, err)
-	assert.Equal(t, []*task.BuildVariantTuple{
-		{DisplayName: "OSX from builds collection", BuildVariant: "osx"},
-		{DisplayName: "Race Detector from builds collection", BuildVariant: "race-detector"},
-		{DisplayName: "Ubuntu 16.04 from builds collection", BuildVariant: "ubuntu1604"},
-		{DisplayName: "Windows 64 bit from builds collection", BuildVariant: "windows"},
-	}, taskBuildVariants)
 }


### PR DESCRIPTION
EVG-20477

### Description
Missed removing this one. We no longer need to look up the build variant display name the legacy way because of the TTL

