### PR TITLE
EVG-18734 only activate deactivated tasks

### DIFF
--- a/graphql/tests/mutation/scheduleUndispatchedBaseTasks/data.json
+++ b/graphql/tests/mutation/scheduleUndispatchedBaseTasks/data.json
@@ -296,7 +296,8 @@
       "r": "gitter_request",
       "branch":"spruce",
       "generate_task": true,
-      "generated_tasks": true
+      "generated_tasks": true,
+      "activated": false
     },
     {
       "_id": "base_generated_task",
@@ -358,7 +359,8 @@
       "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "r": "gitter_request",
       "branch": "spruce",
-      "build_id": "5"
+      "build_id": "5",
+      "activated": false
     }
   ],
   "hosts": [

--- a/graphql/tests/mutation/scheduleUndispatchedBaseTasks/data.json
+++ b/graphql/tests/mutation/scheduleUndispatchedBaseTasks/data.json
@@ -311,7 +311,8 @@
       "branch":"spruce",
       "generate_task": false,
       "generated_by": "base_generator_task",
-      "r": "gitter_request"
+      "r": "gitter_request",
+      "activated": false
     },
     {
       "_id": "some_task_2",
@@ -323,7 +324,8 @@
       "r": "github_pull_request",
       "status": "undispatched",
       "branch": "spruce",
-      "host_id": "host1"
+      "host_id": "host1",
+      "activated": false
     },
     {
       "_id": "2",

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -65,7 +65,7 @@ func SetVersionActivation(versionId string, active bool, caller string) error {
 		if err := SetVersionActivated(versionId, active); err != nil {
 			return errors.Wrapf(err, "setting activated for version '%s'", versionId)
 		}
-		tasksToModify, err = task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey, task.BuildIdKey))
+		tasksToModify, err = task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey, task.BuildIdKey, task.ActivatedKey))
 		if err != nil {
 			return errors.Wrap(err, "getting tasks to activate")
 		}
@@ -138,7 +138,7 @@ func setTaskActivationForBuilds(buildIds []string, active, withDependencies bool
 		if len(ignoreTasks) > 0 {
 			q[task.IdKey] = bson.M{"$nin": ignoreTasks}
 		}
-		tasksToActivate, err := task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey))
+		tasksToActivate, err := task.FindAll(db.Query(q).WithFields(task.IdKey, task.DependsOnKey, task.ExecutionKey, task.ActivatedKey))
 		if err != nil {
 			return errors.Wrap(err, "getting tasks to activate")
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2709,7 +2709,8 @@ func (t *Task) FindAllMarkedUnattainableDependencies() ([]Task, error) {
 func activateTasks(taskIDs []string, caller string, activationTime time.Time) error {
 	_, err := UpdateAll(
 		bson.M{
-			IdKey: bson.M{"$in": taskIDs},
+			IdKey:        bson.M{"$in": taskIDs},
+			ActivatedKey: false,
 		},
 		[]bson.M{
 			{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1519,8 +1519,14 @@ func (t *Task) ActivateTask(caller string) error {
 
 // ActivateTasks sets all given tasks to active, logs them as activated, and proceeds to activate any dependencies that were deactivated.
 func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bool, caller string) error {
+	tasksToActivate := make([]Task, 0, len(tasks))
 	taskIDs := make([]string, 0, len(tasks))
 	for _, t := range tasks {
+		// Activating an activated task is a noop.
+		if t.Activated {
+			continue
+		}
+		tasksToActivate = append(tasksToActivate, t)
 		taskIDs = append(taskIDs, t.Id)
 	}
 	err := activateTasks(taskIDs, caller, activationTime)
@@ -1528,7 +1534,7 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 		return errors.Wrap(err, "activating tasks")
 	}
 	logs := []event.EventLogEntry{}
-	for _, t := range tasks {
+	for _, t := range tasksToActivate {
 		logs = append(logs, event.GetTaskActivatedEvent(t.Id, t.Execution, caller))
 	}
 	grip.Error(message.WrapError(event.LogManyEvents(logs), message.Fields{
@@ -1550,7 +1556,7 @@ func ActivateTasksByIdsWithDependencies(ids []string, caller string) error {
 		StatusKey: evergreen.TaskUndispatched,
 	})
 
-	tasks, err := FindAll(q.WithFields(IdKey, DependsOnKey, ExecutionKey))
+	tasks, err := FindAll(q.WithFields(IdKey, DependsOnKey, ExecutionKey, ActivatedKey))
 	if err != nil {
 		return errors.Wrap(err, "getting tasks for activation")
 	}
@@ -2127,7 +2133,7 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 		return nil, nil
 	}
 
-	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey)
+	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dependencies")
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2054,7 +2054,7 @@ func TestActivateTasks(t *testing.T) {
 		assert.Len(t, dbTasks, 6)
 
 		for _, task := range dbTasks {
-			assert.Equal(t, task.Priority, int64(0))
+			assert.EqualValues(t, 0, task.Priority)
 			if utility.StringSliceContains(updatedIDs, task.Id) {
 				assert.True(t, task.Activated)
 				events, err := event.FindAllByResourceID(task.Id)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2027,46 +2027,76 @@ func TestTopologicalSort(t *testing.T) {
 }
 
 func TestActivateTasks(t *testing.T) {
-	require.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+	}()
 
-	tasks := []Task{
-		{Id: "t0", Priority: evergreen.DisabledTaskPriority},
-		{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false},
-		{Id: "t2", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t1"}}, Activated: false, DeactivatedForDependency: true},
-		{Id: "t3", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false, DeactivatedForDependency: true},
-		{Id: "t4", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t3"}}, Activated: false, DeactivatedForDependency: true},
-		{Id: "t5", Activated: true},
-	}
-	for _, task := range tasks {
-		require.NoError(t, task.Insert())
-	}
-
-	updatedIDs := []string{"t0", "t3", "t4"}
-	err := ActivateTasks([]Task{tasks[0]}, time.Time{}, true, "")
-	assert.NoError(t, err)
-
-	dbTasks, err := FindAll(All)
-	assert.NoError(t, err)
-	assert.Len(t, dbTasks, 6)
-
-	for _, task := range dbTasks {
-		assert.Equal(t, task.Priority, int64(0))
-		if utility.StringSliceContains(updatedIDs, task.Id) {
-			assert.True(t, task.Activated)
-			events, err := event.FindAllByResourceID(task.Id)
-			require.NoError(t, err)
-			require.Len(t, events, 1)
-		} else {
-			for _, origTask := range tasks {
-				if origTask.Id == task.Id {
-					assert.Equal(t, origTask.Activated, task.Activated, fmt.Sprintf("task '%s' mismatch", task.Id))
-				}
-			}
-			events, err := event.FindAllByResourceID(task.Id)
-			require.NoError(t, err)
-			require.Empty(t, events)
+	t.Run("DependencyChain", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+		tasks := []Task{
+			{Id: "t0", Priority: evergreen.DisabledTaskPriority},
+			{Id: "t1", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false},
+			{Id: "t2", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t1"}}, Activated: false, DeactivatedForDependency: true},
+			{Id: "t3", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: false, DeactivatedForDependency: true},
+			{Id: "t4", DependsOn: []Dependency{{TaskId: "t0"}, {TaskId: "t3"}}, Activated: false, DeactivatedForDependency: true},
+			{Id: "t5", DependsOn: []Dependency{{TaskId: "t0"}}, Activated: true, DeactivatedForDependency: true},
 		}
-	}
+		for _, task := range tasks {
+			require.NoError(t, task.Insert())
+		}
+
+		updatedIDs := []string{"t0", "t3", "t4"}
+		err := ActivateTasks([]Task{tasks[0]}, time.Time{}, true, "")
+		assert.NoError(t, err)
+
+		dbTasks, err := FindAll(All)
+		assert.NoError(t, err)
+		assert.Len(t, dbTasks, 6)
+
+		for _, task := range dbTasks {
+			assert.Equal(t, task.Priority, int64(0))
+			if utility.StringSliceContains(updatedIDs, task.Id) {
+				assert.True(t, task.Activated)
+				events, err := event.FindAllByResourceID(task.Id)
+				require.NoError(t, err)
+				assert.Len(t, events, 1)
+			} else {
+				for _, origTask := range tasks {
+					if origTask.Id == task.Id {
+						assert.Equal(t, origTask.Activated, task.Activated, fmt.Sprintf("task '%s' mismatch", task.Id))
+					}
+				}
+				events, err := event.FindAllByResourceID(task.Id)
+				require.NoError(t, err)
+				assert.Empty(t, events)
+			}
+		}
+	})
+
+	t.Run("NoopActivatedTask", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+		task := Task{
+			Id:            "t0",
+			Activated:     true,
+			ActivatedTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+			ActivatedBy:   "octocat",
+		}
+		require.NoError(t, task.Insert())
+
+		err := ActivateTasks([]Task{task}, time.Now(), true, "abyssinian")
+		assert.NoError(t, err)
+
+		events, err := event.FindAllByResourceID(task.Id)
+		require.NoError(t, err)
+		assert.Empty(t, events)
+
+		dbTask, err := FindOneId(task.Id)
+		require.NoError(t, err)
+		require.NotNil(t, dbTask)
+		assert.True(t, task.Activated)
+		assert.True(t, task.ActivatedTime.Equal(dbTask.ActivatedTime))
+		assert.Equal(t, task.ActivatedBy, dbTask.ActivatedBy)
+	})
 }
 
 func TestDeactivateTasks(t *testing.T) {


### PR DESCRIPTION
[EVG-18734](https://jira.mongodb.org/browse/EVG-18734)

### Description
I'm looking to track the time it takes from when a task is activated until the time begins to run. This will allow us to evaluate timing improvements that we can't see today. I ran into cases where tasks were getting activated after they were already activated, sometimes even after a task has started to run, and it was throwing off the numbers.

This PR makes activating an already activated task a noop. If there's an issue with this I could add a separate field to track the last time it was actually activated, but if not it seemed to make sense to only activate a deactivated task.

Idk if we want to do the same for deactivating tasks, but I'm happy to if someone suggests they should be consistent. 

### Testing
Added to the `ActivateTask` test.