### PR TITLE
EVG-18734 log number of dependencies

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1016,6 +1016,10 @@ func logTaskStartMessage(h *host.Host, t *task.Task) {
 		"variant":                t.BuildVariant,
 	}
 
+	if !t.DependenciesMetTime.IsZero() {
+		msg["dependencies_met_time"] = t.DependenciesMetTime
+	}
+
 	if strings.HasPrefix(h.Distro.Provider, "ec2") {
 		msg["provider"] = "ec2"
 	}


### PR DESCRIPTION
[EVG-18734](https://jira.mongodb.org/browse/EVG-18734)

### Description
It would be good to be able to use the `task-start-stats` message to evaluate how long it's taking end-to-end from when a task is activated until it's started (the `activated_latency_secs` field). It would only be useful, though, if we could case on whether there are dependencies (in which case the task was waiting from when the dependencies finished running) or not (in which case it was waiting since the task was activated).
