### PR TITLE
EVG-19998 use UnattainableDependency field for the schedulable tasks query

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -32,7 +32,7 @@ var (
 		{Key: ActivatedKey, Value: 1},
 		{Key: PriorityKey, Value: 1},
 		{Key: OverrideDependenciesKey, Value: 1},
-		{Key: bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey), Value: 1},
+		{Key: UnattainableDependencyKey, Value: 1},
 	}
 )
 
@@ -724,7 +724,7 @@ func schedulableHostTasksQuery() bson.M {
 		ByExecutionPlatform(ExecutionPlatformHost),
 		// Filter tasks containing unattainable dependencies
 		{"$or": []bson.M{
-			{bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey): bson.M{"$ne": true}},
+			{UnattainableDependencyKey: false},
 			{OverrideDependenciesKey: true},
 		}},
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1266,7 +1266,7 @@ func UnscheduleStaleUnderwaterHostTasks(ctx context.Context, distroID string) (i
 		},
 	}
 
-	// Force the query to use 'distro_1_status_1_activated_1_priority_1_override_dependencies_1_depends_on.unattainable_1'
+	// Force the query to use 'distro_1_status_1_activated_1_priority_1_override_dependencies_1_unattainable_dependency_1'
 	// instead of defaulting to 'status_1_depends_on.status_1_depends_on.unattainable_1'.
 	info, err := UpdateAllWithHint(query, update, ActivatedTasksByDistroIndex)
 	if err != nil {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1598,7 +1598,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: true,
 				},
 			},
-			Priority: 0,
+			UnattainableDependency: true,
+			Priority:               0,
 		},
 		{
 			Id:        "t1",
@@ -1614,7 +1615,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: false,
 				},
 			},
-			Priority: 0,
+			UnattainableDependency: false,
+			Priority:               0,
 		},
 		{
 			Id:        "t2",
@@ -1627,7 +1629,8 @@ func TestUnattainableSchedulableHostTasksQuery(t *testing.T) {
 					Unattainable: true,
 				},
 			},
-			OverrideDependencies: true,
+			UnattainableDependency: true,
+			OverrideDependencies:   true,
 		},
 	}
 	for _, task := range tasks {


### PR DESCRIPTION
[EVG-19998](https://jira.mongodb.org/browse/EVG-19998)

### Description
This is a vert of https://github.com/evergreen-ci/evergreen/pull/6627 which was reverted because the queries didn't match. Now that it's been fixed we can reapply the changes.

We can verify it's been fixed with the following (in mongosh):
```javascript
var session = db.getMongo().startSession({readConcern: "snapshot"});
db = session.getDatabase(db.getName());

var before = db.tasks.find({
    "distro": {"$in": distros},
    "status": "undispatched",
    "activated": true,
    "priority": {"$gt": -1},
    "$and": [
        {"$or": [{"execution_platform": {"$exists": false}}, {"execution_platform": "host"}]},
        {"$or": [{"depends_on.unattainable": {"$ne": true}}, {"override_dependencies": true}]}
    ]
}).toArray().map(x => x._id);

var after = db.tasks.find({
    "distro": {"$in": distros},
    "status": "undispatched",
    "activated": true,
    "priority": {"$gt": -1},
    "$and": [
        {"$or": [{"execution_platform": {"$exists": false}}, {"execution_platform": "host"}]},
        {"$or": [{"unattainable_dependency": false}, {"override_dependencies": true}]}
    ]
}).toArray().map(x => x._id);

var onlyBefore = before.filter(x => !after.includes(x));
var onlyAfter = after.filter(x => !before.includes(x));
```
`onlyBefore` and `onlyAfter` will be empty.

(`snapshot` readConcern is documented [here](https://www.mongodb.com/docs/manual/reference/read-concern/#read-concern-levels) and mongosh sessions [here](https://www.mongodb.com/docs/manual/reference/method/Mongo.startSession/))

Because it's already been reviewed I'll merge this once tests pass without waiting on a review.