### PR TITLE
EVG-18270: add omitempty to depends_on task field

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -123,7 +123,7 @@ type Task struct {
 	ContainerOpts           ContainerOptions `bson:"container_options,omitempty" json:"container_options,omitempty"`
 	BuildVariant            string           `bson:"build_variant" json:"build_variant"`
 	BuildVariantDisplayName string           `bson:"build_variant_display_name" json:"-"`
-	DependsOn               []Dependency     `bson:"depends_on" json:"depends_on"`
+	DependsOn               []Dependency     `bson:"depends_on,omitempty" json:"depends_on,omitempty"`
 	// UnattainableDependency caches the contents of DependsOn for more efficient querying.
 	UnattainableDependency bool `bson:"unattainable_dependency" json:"unattainable_dependency"`
 	NumDependents          int  `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`


### PR DESCRIPTION
EVG-18270

### Description
The `depends_on` field in the `Task` struct does not omit empty arrays. This usually isn't a problem, but with the work around [EVG-18270](https://jira.mongodb.org/browse/EVG-18270) it caused some problems. The `$out` stage used to write daily finished tasks to S3 in parquet format creates the parquet schema based on the fields fed into it from the previous stage. If the a field is omitted on all the documents in the batch, that is fine because it just won't add it to the schema stored in the metadata for that file, and Trino can handle missing fields from the data definition. In the case of an empty array, the parquet writer defaults the field to be an array of booleans (likely in a bug in the ADL code), which makes Trino unhappy because it does not match the table definition and breaks the schema. In short, null and missing fields are ok but fields that are of a different type are not.

### Testing
N/A

### Documentation
N/A