### PR TITLE
EVG-17125: remove debug log for setup group

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -414,16 +414,12 @@ func (a *Agent) prepareNextTask(ctx context.Context, nextTask *apimodels.NextTas
 }
 
 func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
-	setupGroup := false
-	var msg string
 	if !tc.ranSetupGroup { // we didn't run setup group yet
-		msg = "running setup group because we haven't yet"
-		setupGroup = true
+		return true
 	} else if tc.taskConfig == nil ||
 		nextTask.TaskGroup == "" ||
 		nextTask.Build != tc.taskConfig.Task.BuildId { // next task has a standalone task or a new build
-		msg = "running setup group because we have a new independent task"
-		setupGroup = true
+		return true
 	} else if nextTask.TaskGroup != tc.taskGroup { // next task has a different task group
 		if tc.logger != nil && nextTask.TaskGroup == tc.taskConfig.Task.TaskGroup {
 			tc.logger.Task().Warning(message.Fields{
@@ -433,14 +429,10 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 				"next_task_task_group":    nextTask.TaskGroup,
 			})
 		}
-		msg = "running setup group because new task group"
-		setupGroup = true
+		return true
 	}
 
-	if tc.logger != nil {
-		tc.logger.Task().DebugWhen(setupGroup, msg)
-	}
-	return setupGroup
+	return false
 }
 
 func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-18"
+	AgentVersion = "2023-07-20"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-17125

### Description
I read the original context for why this was added (in #4508) and it seems like it was temporary debug logging to diagnose an issue where setup group was running when it should not have. Also, the debug log appears in the agent's previous task log (instead of the current task log) because it logs before we set up the current task's logger. It seems safe to remove the debug log entirely.

### Testing
N/A

### Documentation
N/A