### PR TITLE
EVG-18734 remove scheduler throttling (#6628)

### DIFF
--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -143,8 +143,6 @@ var (
 	taskQueueItemProjectKey       = bsonutil.MustHaveTag(TaskQueueItem{}, "Project")
 	taskQueueItemExpDurationKey   = bsonutil.MustHaveTag(TaskQueueItem{}, "ExpectedDuration")
 	taskQueueItemPriorityKey      = bsonutil.MustHaveTag(TaskQueueItem{}, "Priority")
-
-	taskQueueInfoPlanCreatedAtKey = bsonutil.MustHaveTag(DistroQueueInfo{}, "PlanCreatedAt")
 )
 
 // TaskSpec is an argument structure to formalize the way that callers
@@ -576,107 +574,6 @@ func FindDistroSecondaryTaskQueue(distroID string) (TaskQueue, error) {
 	err := db.FindOneQ(TaskSecondaryQueuesCollection, q, &queue)
 
 	return queue, errors.WithStack(err)
-}
-
-func taskQueueGenerationTimesPipeline() []bson.M {
-	return []bson.M{
-		{
-			"$group": bson.M{
-				"_id": 0,
-				"distroQueue": bson.M{"$push": bson.M{
-					"k": "$" + taskQueueDistroKey,
-					"v": "$" + taskQueueGeneratedAtKey,
-				}}},
-		},
-		{
-			"$project": bson.M{
-				"root": bson.M{"$arrayToObject": "$distroQueue"},
-			},
-		},
-		{
-			"$replaceRoot": bson.M{"newRoot": "$root"},
-		},
-	}
-}
-
-func taskQueueGenerationRuntimePipeline() []bson.M {
-	return []bson.M{
-		{
-			"$group": bson.M{
-				"_id": 0,
-				"distroQueue": bson.M{"$push": bson.M{
-					"k": "$" + taskQueueDistroKey,
-					"v": bson.M{"$multiply": []interface{}{
-						// convert ms to ns
-						// for duration value
-						1000000,
-						bson.M{"$subtract": []interface{}{
-							"$" + taskQueueGeneratedAtKey,
-							"$" + bsonutil.GetDottedKeyName(taskQueueDistroQueueInfoKey, taskQueueInfoPlanCreatedAtKey),
-						}},
-					}}}}},
-		},
-		{
-			"$project": bson.M{
-				"root": bson.M{"$arrayToObject": "$distroQueue"},
-			},
-		},
-		{
-			"$replaceRoot": bson.M{"newRoot": "$root"},
-		},
-	}
-}
-
-func runTimeMapAggregation(collection string, pipe []bson.M) (map[string]time.Time, error) {
-	out := []map[string]time.Time{}
-
-	err := db.Aggregate(collection, pipe, &out)
-
-	if err != nil {
-		return map[string]time.Time{}, errors.Wrapf(err, "aggregating times from collection '%s'", collection)
-	}
-
-	switch len(out) {
-	case 0:
-		return map[string]time.Time{}, nil
-	case 1:
-		return out[0], nil
-	default:
-		return map[string]time.Time{}, errors.Errorf("expected 0 or 1 element in the result from the aggregation on collection '%s' but actually got %d elements", collection, len(out))
-	}
-
-}
-
-func runDurationMapAggregation(collection string, pipe []bson.M) (map[string]time.Duration, error) {
-	out := []map[string]time.Duration{}
-
-	err := db.Aggregate(collection, pipe, &out)
-
-	if err != nil {
-		return map[string]time.Duration{}, errors.Wrapf(err, "aggregating durations from collection '%s'", collection)
-	}
-
-	switch len(out) {
-	case 0:
-		return map[string]time.Duration{}, nil
-	case 1:
-		return out[0], nil
-	default:
-		return map[string]time.Duration{}, errors.Errorf("expected 0 or 1 element in the result from the aggregation on collection '%s' but actually got %d elements", collection, len(out))
-	}
-
-}
-
-func FindTaskQueueGenerationRuntime() (map[string]time.Duration, error) {
-	return runDurationMapAggregation(TaskQueuesCollection, taskQueueGenerationRuntimePipeline())
-}
-
-func FindTaskQueueLastGenerationTimes() (map[string]time.Time, error) {
-	return runTimeMapAggregation(TaskQueuesCollection, taskQueueGenerationTimesPipeline())
-}
-
-func FindTaskSecondaryQueueLastGenerationTimes() (map[string]time.Time, error) {
-	return runTimeMapAggregation(TaskSecondaryQueuesCollection, taskQueueGenerationTimesPipeline())
 }
 
 // pull out the task with the specified id from both the in-memory and db

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -329,32 +329,6 @@ func TestFindNextTaskWithLastTask(t *testing.T) {
 	assert.Nil(next)
 }
 
-func TestTaskQueueGenerationTimes(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	require.NoError(db.ClearCollections(TaskQueuesCollection))
-	defer func() {
-		assert.NoError(db.ClearCollections(TaskQueuesCollection))
-	}()
-
-	now := time.Now().Round(time.Millisecond).UTC()
-	taskQueue := &TaskQueue{
-		Distro:      "foo",
-		GeneratedAt: now,
-	}
-
-	assert.NoError(db.Insert(TaskQueuesCollection, taskQueue))
-
-	times, err := FindTaskQueueLastGenerationTimes()
-	assert.NoError(err)
-	assert.NotNil(times)
-	assert.Len(times, 1)
-	genTime, ok := times["foo"]
-	assert.True(ok)
-	assert.Equal(now, genTime)
-}
-
 func TestClearTaskQueue(t *testing.T) {
 	assert := assert.New(t)
 	distro := "distro"

--- a/units/crons.go
+++ b/units/crons.go
@@ -430,12 +430,12 @@ func PopulateHostAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
 
 func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
+		config, err := evergreen.GetConfig()
 		if err != nil {
-			return errors.Wrap(err, "getting service flags")
+			return errors.Wrap(err, "getting admin settings")
 		}
 
-		if flags.SchedulerDisabled {
+		if config.ServiceFlags.SchedulerDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 				"message": "scheduler is disabled",
 				"impact":  "new tasks are not enqueued",
@@ -443,59 +443,19 @@ func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 			})
 			return nil
 		}
-		config, err := evergreen.GetConfig()
+
+		// find all active distros
+		distros, err := distro.Find(distro.ByNeedsPlanning(config.ContainerPools.Pools))
 		if err != nil {
-			return errors.Wrap(err, "getting admin settings")
+			return errors.Wrap(err, "finding distros that need planning")
 		}
 
 		catcher := grip.NewBasicCatcher()
-
-		lastPlanned, err := model.FindTaskQueueLastGenerationTimes()
-		catcher.Wrap(err, "finding task queue last generation time")
-
-		lastRuntime, err := model.FindTaskQueueGenerationRuntime()
-		catcher.Wrap(err, "finding task queue generation runtime")
-
-		// find all active distros
-		distros, err := distro.Find(ctx, distro.ByNeedsPlanning(config.ContainerPools.Pools))
-		catcher.Wrap(err, "finding distros that need planning")
-
-		grip.InfoWhen(sometimes.Percent(10), message.Fields{
-			"runner":   "scheduler",
-			"previous": lastPlanned,
-			"distros":  distro.DistroGroup(distros).GetDistroIds(),
-			"op":       "dispatcher",
-		})
-
-		grip.Error(message.WrapError(err, message.Fields{
-			"cron":      schedulerJobName,
-			"impact":    "new task scheduling non-operative",
-			"operation": "background task creation",
-		}))
-
 		ts := utility.RoundPartOfMinute(0)
-		settings, err := evergreen.GetConfig()
-		if err != nil {
-			grip.Critical(message.WrapError(err, message.Fields{
-				"cron":      schedulerJobName,
-				"operation": "retrieving settings object",
-			}))
-			return catcher.Resolve()
-		}
 		for _, d := range distros {
-			if d.IsParent(settings) {
+			if d.IsParent(config) {
 				continue
 			}
-
-			lastRun, ok := lastPlanned[d.Id]
-			if ok && time.Since(lastRun) < 2*time.Minute {
-				continue
-			}
-
-			if ok && time.Since(lastRun)+10*time.Second < lastRuntime[d.Id] {
-				continue
-			}
-
 			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewDistroSchedulerJob(env, d.Id, ts)), "enqueueing scheduler job for distro '%s'", d.Id)
 		}
 
@@ -505,12 +465,12 @@ func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 
 func PopulateAliasSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		flags, err := evergreen.GetServiceFlags()
+		config, err := evergreen.GetConfig()
 		if err != nil {
-			return errors.WithStack(err)
+			return errors.Wrap(err, "getting admin settings")
 		}
 
-		if flags.SchedulerDisabled {
+		if config.ServiceFlags.SchedulerDisabled {
 			grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 				"message": "scheduler is disabled",
 				"impact":  "new tasks are not enqueued",
@@ -518,34 +478,17 @@ func PopulateAliasSchedulerJobs(env evergreen.Environment) amboy.QueueOperation 
 			})
 			return nil
 		}
-		config, err := evergreen.GetConfig()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		catcher := grip.NewBasicCatcher()
-
-		lastPlanned, err := model.FindTaskSecondaryQueueLastGenerationTimes()
-		catcher.Add(err)
 
 		// find all active distros
-		distros, err := distro.Find(ctx, distro.ByNeedsPlanning(config.ContainerPools.Pools))
-		catcher.Add(err)
+		distros, err := distro.Find(distro.ByNeedsPlanning(config.ContainerPools.Pools))
+		if err != nil {
+			return errors.Wrap(err, "finding distros that need planning")
+		}
 
-		lastRuntime, err := model.FindTaskQueueGenerationRuntime()
-		catcher.Add(err)
-
+		catcher := grip.NewBasicCatcher()
 		ts := utility.RoundPartOfMinute(0)
 		for _, d := range distros {
-			// do not create scheduler jobs for parent distros
 			if d.IsParent(config) {
-				continue
-			}
-
-			lastRun, ok := lastPlanned[d.Id]
-			if ok && time.Since(lastRun) < 2*time.Minute {
-				continue
-			}
-			if ok && time.Since(lastRun)+10*time.Second < lastRuntime[d.Id] {
 				continue
 			}
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -445,7 +445,7 @@ func PopulateSchedulerJobs(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByNeedsPlanning(config.ContainerPools.Pools))
+		distros, err := distro.Find(ctx, distro.ByNeedsPlanning(config.ContainerPools.Pools))
 		if err != nil {
 			return errors.Wrap(err, "finding distros that need planning")
 		}
@@ -480,7 +480,7 @@ func PopulateAliasSchedulerJobs(env evergreen.Environment) amboy.QueueOperation 
 		}
 
 		// find all active distros
-		distros, err := distro.Find(distro.ByNeedsPlanning(config.ContainerPools.Pools))
+		distros, err := distro.Find(ctx, distro.ByNeedsPlanning(config.ContainerPools.Pools))
 		if err != nil {
 			return errors.Wrap(err, "finding distros that need planning")
 		}


### PR DESCRIPTION
[EVG-18734](https://jira.mongodb.org/browse/EVG-18734)

### Description
With https://github.com/evergreen-ci/evergreen/pull/6797 in production we can see the query is much faster and we shouldn't need to throttle the scheduler any more. 

This is a vert of #6628 which removed the throttling. Because it's already been reviewed I will skip asking for a review, assuming tests pass.
