### PR TITLE
EVG-20473 Prevent the same trigger from trying to create the same version twice

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -723,7 +723,7 @@ func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metada
 		Activated:            utility.ToBoolPtr(metadata.Activate),
 	}
 	if metadata.TriggerType != "" {
-		v.Id = MakeVersionIdWithTriggerId(ref.Identifier, metadata.SourceVersion.Revision, metadata.TriggerDefinitionID)
+		v.Id = util.CleanName(fmt.Sprintf("%s_%s_%s", ref.Identifier, metadata.SourceVersion.Revision, metadata.TriggerDefinitionID))
 		v.Requester = evergreen.TriggerRequester
 		v.CreateTime = metadata.SourceVersion.CreateTime
 	} else if metadata.IsAdHoc {
@@ -775,11 +775,6 @@ func makeVersionId(project, revision string) string {
 
 func makeVersionIdWithTag(project, tag, id string) string {
 	return util.CleanName(fmt.Sprintf("%s_%s_%s", project, tag, id))
-}
-
-// MakeVersionIdWithTriggerId creates a version id with the given trigger id.
-func MakeVersionIdWithTriggerId(project, revision, triggerID string) string {
-	return util.CleanName(fmt.Sprintf("%s_%s_%s", project, revision, triggerID))
 }
 
 // Verifies that the given revision order number is higher than the latest number stored for the project.

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -248,6 +248,9 @@ projectLoop:
 			if trigger.Status != "" && trigger.Status != b.Status {
 				continue
 			}
+			if utility.StringSliceContains(sourceVersion.SatisfiedTriggers, trigger.DefinitionID) {
+				continue
+			}
 			if trigger.BuildVariantRegex != "" {
 				regex, err := regexp.Compile(trigger.BuildVariantRegex)
 				if err != nil {

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func init() { testutil.Setup() }
+
 type projectTriggerSuite struct {
 	suite.Suite
 	processor projectProcessor
@@ -352,6 +354,139 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		assert.Equal(evergreen.TaskUndispatched, t.Status)
 		assert.Equal(upstreamTask.Id, t.TriggerID)
 		assert.Equal("task", t.TriggerType)
+		assert.Equal(e.ID, t.TriggerEvent)
+		assert.Contains(t.DisplayName, "task1")
+	}
+	mani, err := manifest.FindFromVersion(dbVersions[0].Id, downstreamProjectRef.Id, downstreamRevision, evergreen.RepotrackerVersionRequester)
+	assert.NoError(err)
+	require.NotNil(mani)
+	assert.Equal(downstreamProjectRef.Id, mani.ProjectName)
+	assert.Equal(uptreamProjectRef.Branch, mani.Branch)
+
+	// verify that triggering this version again does nothing
+	upstreamVersionFromDB, err := model.VersionFindOneId(upstreamVersion.Id)
+	assert.NoError(err)
+	assert.Contains(upstreamVersionFromDB.SatisfiedTriggers, "def1")
+	downstreamVersions, err = EvalProjectTriggers(&e, TriggerDownstreamVersion)
+	assert.NoError(err)
+	assert.Len(downstreamVersions, 0)
+}
+
+func TestProjectTriggerIntegrationForBuild(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+	assert.NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection, evergreen.ConfigCollection,
+		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection, model.ParserProjectCollection, manifest.Collection))
+	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+
+	config := testutil.TestConfig()
+	testutil.ConfigureIntegrationTest(t, config, "TestProjectTriggerIntegration")
+	assert.NoError(config.Set(ctx))
+	e := event.EventLogEntry{
+		ID:           "event1",
+		ResourceId:   "upstreamBuild",
+		ResourceType: event.ResourceTypeBuild,
+		EventType:    event.BuildStateChange,
+		Data: &event.BuildEventData{
+			Status: evergreen.BuildSucceeded,
+		},
+	}
+	upstreamBuild := build.Build{
+		Id:          "upstreamBuild",
+		Status:      evergreen.BuildSucceeded,
+		Requester:   evergreen.RepotrackerVersionRequester,
+		DisplayName: "upstreamBuild",
+		Version:     "upstreamVersion",
+		Project:     "upstream",
+	}
+	assert.NoError(upstreamBuild.Insert())
+	upstreamVersion := model.Version{
+		Id:         "upstreamVersion",
+		Author:     "me",
+		CreateTime: time.Now(),
+		Revision:   "abc",
+		Identifier: "upstream",
+	}
+	assert.NoError(upstreamVersion.Insert())
+	downstreamProjectRef := model.ProjectRef{
+		Id:         mgobson.NewObjectId().Hex(),
+		Identifier: "downstream",
+		Enabled:    true,
+		Owner:      "evergreen-ci",
+		Repo:       "evergreen",
+		RemotePath: "self-tests.yml",
+		Branch:     "main",
+		Triggers: []model.TriggerDefinition{
+			{Project: "upstream", Level: "build", DefinitionID: "def1", TaskRegex: "upstream*", Status: evergreen.BuildSucceeded, ConfigFile: "trigger/testdata/downstream_config.yml", Alias: "a1"},
+		},
+	}
+	assert.NoError(downstreamProjectRef.Insert())
+	uptreamProjectRef := model.ProjectRef{
+		Id:         mgobson.NewObjectId().Hex(),
+		Identifier: "upstream",
+		Enabled:    true,
+		Owner:      "evergreen-ci",
+		Repo:       "sample",
+		Branch:     "main",
+	}
+	assert.NoError(uptreamProjectRef.Insert())
+	alias := model.ProjectAlias{
+		ID:        mgobson.NewObjectId(),
+		ProjectID: downstreamProjectRef.Id,
+		Alias:     "a1",
+		Variant:   "buildvariant",
+		Task:      "task1",
+	}
+	assert.NoError(alias.Upsert())
+	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
+	assert.NoError(err)
+	downstreamRevision := "cf46076567e4949f9fc68e0634139d4ac495c89b"
+	assert.NoError(model.UpdateLastRevision(downstreamProjectRef.Id, downstreamRevision))
+
+	downstreamVersions, err := EvalProjectTriggers(&e, TriggerDownstreamVersion)
+	assert.NoError(err)
+	dbVersions, err := model.VersionFind(model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
+	assert.NoError(err)
+	require.Len(downstreamVersions, 1)
+	require.Len(dbVersions, 1)
+	versions := []model.Version{downstreamVersions[0], dbVersions[0]}
+	for _, v := range versions {
+		assert.True(utility.FromBoolPtr(v.Activated))
+		assert.Equal("downstream_abc_def1", v.Id)
+		assert.Equal(downstreamRevision, v.Revision)
+		assert.Equal(evergreen.VersionCreated, v.Status)
+		assert.Equal(downstreamProjectRef.Id, v.Identifier)
+		assert.Equal(evergreen.TriggerRequester, v.Requester)
+		assert.Equal(upstreamBuild.Id, v.TriggerID)
+		assert.Equal("build", v.TriggerType)
+		assert.Equal(e.ID, v.TriggerEvent)
+	}
+	builds, err := build.Find(build.ByVersion(downstreamVersions[0].Id))
+	assert.NoError(err)
+	assert.True(len(builds) > 0)
+	for _, b := range builds {
+		assert.True(b.Activated)
+		assert.Equal(downstreamProjectRef.Id, b.Project)
+		assert.Equal(evergreen.TriggerRequester, b.Requester)
+		assert.Equal(evergreen.BuildCreated, b.Status)
+		assert.Equal(upstreamBuild.Id, b.TriggerID)
+		assert.Equal("build", b.TriggerType)
+		assert.Equal(e.ID, b.TriggerEvent)
+		assert.Contains(b.BuildVariant, "buildvariant")
+	}
+	tasks, err := task.Find(task.ByVersion(downstreamVersions[0].Id))
+	assert.NoError(err)
+	assert.True(len(tasks) > 0)
+	for _, t := range tasks {
+		assert.True(t.Activated)
+		assert.Equal(downstreamProjectRef.Id, t.Project)
+		assert.Equal(evergreen.TriggerRequester, t.Requester)
+		assert.Equal(evergreen.TaskUndispatched, t.Status)
+		assert.Equal(upstreamBuild.Id, t.TriggerID)
+		assert.Equal("build", t.TriggerType)
 		assert.Equal(e.ID, t.TriggerEvent)
 		assert.Contains(t.DisplayName, "task1")
 	}

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func init() { testutil.Setup() }
-
 type projectTriggerSuite struct {
 	suite.Suite
 	processor projectProcessor

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -8,8 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/repotracker"
 	"github.com/evergreen-ci/evergreen/thirdparty"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -39,26 +37,6 @@ func TriggerDownstreamVersion(args ProcessorArgs) (*model.Version, error) {
 
 	// create version
 	projectInfo.Ref = &args.DownstreamProject
-
-	// The same trigger definition ID can be triggered multiple times for the same source version.
-	// Since the calculated version ID is the same for each of these, we need to check if the version
-	// was already created by an earlier trigger.
-	versionId := repotracker.MakeVersionIdWithTriggerId(projectInfo.Ref.Identifier, metadata.SourceVersion.Revision, metadata.TriggerDefinitionID)
-	existingVersion, err := model.VersionFindOneId(versionId)
-	if err != nil {
-		return nil, errors.Wrapf(err, "checking for existing version '%s'", versionId)
-	}
-	if existingVersion != nil {
-		grip.Error(message.Fields{
-			"message":            "version already exists, not triggering new downstream version",
-			"version_id":         versionId,
-			"project_identifier": projectInfo.Ref.Identifier,
-			"revision":           metadata.SourceVersion.Revision,
-			"trigger_id":         metadata.TriggerDefinitionID,
-		})
-		return nil, nil
-	}
-
 	v, err := repotracker.CreateVersionFromConfig(context.Background(), &projectInfo, metadata, false, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating version")


### PR DESCRIPTION
EVG-20473

### Description
Each trigger definition creates the same version ID. For triggers that run off of a successful build in an upstream version, multiple requests to create the same version with the same ID will run. Normally this doesn't cause a problem because they all fail with "duplicate key" errors, but we recently ran into an issue where these duplicate requests wiped the update a `generate.tasks` command performed on the version's parser project.

This was because the build triggers were ignoring the `SatisfiedTriggers` field, unlike the task triggers. Also did a drive by fix removing an unused field in a helper function.

### Testing
Created new unit test confirming this prevents the second run for the build triggers from erroring
