### PR TITLE
EVG-20310 Remove unused agent opts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,8 +63,6 @@ type Options struct {
 	LogOutput              LogOutputType
 	WorkingDirectory       string
 	HeartbeatInterval      time.Duration
-	AgentSleepInterval     time.Duration
-	MaxAgentSleepInterval  time.Duration
 	Cleanup                bool
 	SetupData              apimodels.AgentSetupData
 	CloudProvider          string
@@ -258,13 +256,6 @@ func (a *Agent) populateEC2InstanceID(ctx context.Context) {
 
 func (a *Agent) loop(ctx context.Context) error {
 	minAgentSleepInterval := defaultAgentSleepInterval
-	maxAgentSleepInterval := defaultMaxAgentSleepInterval
-	if a.opts.AgentSleepInterval != 0 {
-		minAgentSleepInterval = a.opts.AgentSleepInterval
-	}
-	if a.opts.MaxAgentSleepInterval != 0 {
-		maxAgentSleepInterval = a.opts.MaxAgentSleepInterval
-	}
 	agentSleepInterval := minAgentSleepInterval
 
 	var jitteredSleep time.Duration

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -255,12 +255,7 @@ func (a *Agent) populateEC2InstanceID(ctx context.Context) {
 }
 
 func (a *Agent) loop(ctx context.Context) error {
-	minAgentSleepInterval := defaultAgentSleepInterval
 	agentSleepInterval := minAgentSleepInterval
-
-	var jitteredSleep time.Duration
-	tskCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -348,7 +343,7 @@ func (a *Agent) loop(ctx context.Context) error {
 
 				a.jasper.Clear(ctx)
 				tc.jasper = a.jasper
-				shouldExit, err := a.runTask(tskCtx, tc)
+				shouldExit, err := a.runTask(ctx, tc)
 				if err != nil {
 					grip.Critical(message.WrapError(err, message.Fields{
 						"message": "error running task",
@@ -373,7 +368,7 @@ func (a *Agent) loop(ctx context.Context) error {
 				tc = &taskContext{}
 			}
 
-			jitteredSleep = utility.JitterInterval(agentSleepInterval)
+			jitteredSleep := utility.JitterInterval(agentSleepInterval)
 			grip.Debugf("Agent sleeping %s.", jitteredSleep)
 			timer.Reset(jitteredSleep)
 			agentSleepInterval = agentSleepInterval * 2

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -181,8 +181,6 @@ func (s *AgentSuite) TestErrorGettingNextTask() {
 }
 
 func (s *AgentSuite) TestCanceledContext() {
-	s.a.opts.AgentSleepInterval = time.Millisecond
-	s.a.opts.MaxAgentSleepInterval = time.Millisecond
 	s.mockCommunicator.NextTaskIsNil = true
 	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
 	defer cancel()

--- a/agent/global.go
+++ b/agent/global.go
@@ -7,7 +7,7 @@ import (
 const (
 	// defaultAgentSleepInterval is the default amount of time an agent sleeps in between
 	// polling for a new task if no new task is found
-	defaultAgentSleepInterval = 10 * time.Second
+	minAgentSleepInterval = 10 * time.Second
 
 	// maxAgentSleepInterval is the max amount of time an agent sleeps in between
 	// polling for a new task if no new task is found

--- a/agent/global.go
+++ b/agent/global.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	// minAgentSleepInterval is the default amount of time an agent sleeps in between
+	// minAgentSleepInterval is the minimum amount of time an agent sleeps in between
 	// polling for a new task if no new task is found
 	minAgentSleepInterval = 10 * time.Second
 

--- a/agent/global.go
+++ b/agent/global.go
@@ -9,9 +9,9 @@ const (
 	// polling for a new task if no new task is found
 	defaultAgentSleepInterval = 10 * time.Second
 
-	// defaultMaxAgentSleepInterval is the max amount of time an agent sleeps in between
+	// maxAgentSleepInterval is the max amount of time an agent sleeps in between
 	// polling for a new task if no new task is found
-	defaultMaxAgentSleepInterval = time.Minute
+	maxAgentSleepInterval = time.Minute
 
 	// defaultCmdTimeout specifies the duration after which the agent sends
 	// an IdleTimeout signal if a task's command does not produce logs on stdout.

--- a/agent/global.go
+++ b/agent/global.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	// defaultAgentSleepInterval is the default amount of time an agent sleeps in between
+	// minAgentSleepInterval is the default amount of time an agent sleeps in between
 	// polling for a new task if no new task is found
 	minAgentSleepInterval = 10 * time.Second
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-20"
+	AgentVersion = "2023-07-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-14"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-21"
+	AgentVersion = "2023-07-21b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[EVG-20310](https://jira.mongodb.org/browse/EVG-20310)

### Description
The opts AgentSleepInterval and MaxAgentSleepInterval were ready but never set (except for one test). They were removed to simplify the code. 

### Testing
Existing tests 

