### PR TITLE
EVG-20515 Fix merge group clone suffix

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -332,7 +332,7 @@ func (c *gitFetchProject) buildCloneCommand(ctx context.Context, comm client.Com
 			localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
 			remoteBranchName = fmt.Sprintf("pull/%d", conf.GithubPatchData.PRNumber)
 		} else if conf.Task.Requester == evergreen.GithubMergeRequester {
-			suffix = "" // redudant, included for clarity
+			suffix = "" // redundant, included for clarity
 			commitToTest = conf.GithubMergeData.HeadSHA
 			localBranchName = fmt.Sprintf("evg-mg-test-%s", utility.RandomString())
 			// HeadRef looks like "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -622,7 +622,7 @@ func (s *GitGetProjectSuite) TestBuildCommandForGitHubMergeQueue() {
 	cmds, err := c.buildCloneCommand(s.ctx, s.comm, logger, conf, opts)
 	s.NoError(err)
 	s.Len(cmds, 9)
-	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056/head:evg-mg-test-"))
+	s.True(strings.HasPrefix(cmds[5], "git fetch origin \"gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056:evg-mg-test-"))
 	s.True(strings.HasPrefix(cmds[6], "git checkout \"evg-mg-test-"))
 	s.Equal("git reset --hard d2a90288ad96adca4a7d0122d8d4fd1deb24db11", cmds[7])
 	s.Equal("git log --oneline -n 10", cmds[8])

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-25"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-25"
+	AgentVersion = "2023-07-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20515

### Description

It turns out that the merge group branch does not use the concept of "/head"
like the GitHub PRs do. I did not discover this in my testing, because my
staging testing used a project that did not clone. While dogfooding with the
Evergreen team, we discovered this, and I validated this by fetching the merge
group branch manually.

### Testing

I edited the unit tests to validate the branch pattern that I found in manual
testing.

### Documentation

N/A
