### PR TITLE
EVG-19190 handle nil from error cases

### DIFF
--- a/service/middleware.go
+++ b/service/middleware.go
@@ -127,6 +127,7 @@ func requireUser(skipWithToggle bool, onSuccess, onFail http.HandlerFunc) http.H
 			flags, err := evergreen.GetServiceFlags(r.Context())
 			if err != nil {
 				gimlet.WriteResponse(w, gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "retrieving admin settings")))
+				return
 			}
 			if !flags.LegacyUIPublicAccessDisabled {
 				onSuccess(w, r)

--- a/service/ui.go
+++ b/service/ui.go
@@ -212,6 +212,7 @@ func (uis *UIServer) GetCommonViewData(w http.ResponseWriter, r *http.Request, n
 			"url":     r.URL,
 			"request": gimlet.GetRequestID(r.Context()),
 		}))
+		return ViewData{}
 	}
 
 	if u, ok := userCtx.(*user.DBUser); ok {


### PR DESCRIPTION
[EVG-19190](https://jira.mongodb.org/browse/EVG-19190)

### Description
Now that the settings fetch is taking a context it gets cancelled if the request is terminated in the middle and the find returns an error. There are two places where we aren't returning in the error case. These are fixed by this PR.
