### PR TITLE
EVG-19917 run idle-host-termination more frequently

### DIFF
--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -49,6 +49,7 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		PopulateSchedulerJobs(j.env),
 		PopulateAliasSchedulerJobs(j.env),
 		PopulateHostAllocatorJobs(j.env),
+		PopulateIdleHostJobs(j.env),
 		PopulateAgentDeployJobs(j.env),
 		PopulateAgentMonitorDeployJobs(j.env),
 	}

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -53,7 +53,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		PopulateFallbackGenerateTasksJobs(j.env),
 		PopulateHostMonitoring(j.env),
 		PopulateHostTerminationJobs(j.env),
-		PopulateIdleHostJobs(j.env),
 		PopulateLastContainerFinishTimeJobs(),
 		PopulateOldestImageRemovalJobs(),
 		PopulateParentDecommissionJobs(),


### PR DESCRIPTION
[EVG-19917](https://jira.mongodb.org/browse/EVG-19917)

### Description
Now that the idle-host-termination job is consistently faster than 15s (https://github.com/evergreen-ci/evergreen/pull/6790) we can run it more frequently. Hopefully this will help us to decrease idle time without a corresponding increase in wait time. I'll need to check on this a day or two after it deploys.

### Testing
In staging these changes made the job run [every fifteen seconds instead of once a minute](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/32rYi4CRRvi).
