### PR TITLE
EVG-20516 Only search for project when one is known

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -100,10 +100,21 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 	}
 
 	patchDoc := j.intent.NewPatch()
-	if patchDoc.GithubPatchData.BaseOwner == "" || patchDoc.GithubPatchData.BaseRepo == "" {
+
+	// set owner and repo for child patches
+	if j.IntentType == patch.TriggerIntentType {
+		if patchDoc.Project == "" {
+			j.AddError(errors.New("cannot search for an empty project"))
+			return
+		}
 		p, err := model.FindBranchProjectRef(patchDoc.Project)
 		if err != nil {
 			j.AddError(errors.Wrapf(err, "finding project '%s'", patchDoc.Project))
+			return
+		}
+		if p == nil {
+			j.AddError(errors.Errorf("project '%s' not found", patchDoc.Project))
+			return
 		}
 		patchDoc.GithubPatchData.BaseOwner = p.Owner
 		patchDoc.GithubPatchData.BaseRepo = p.Repo
@@ -1179,13 +1190,27 @@ func (j *patchIntentProcessor) isUserAuthorized(ctx context.Context, patchDoc *p
 }
 
 func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchDoc *patch.Patch) {
-	update := NewGithubStatusUpdateJobForProcessingError(
-		evergreenContext,
-		patchDoc.GithubPatchData.BaseOwner,
-		patchDoc.GithubPatchData.BaseRepo,
-		patchDoc.GithubPatchData.HeadHash,
-		j.gitHubError,
-	)
+	var update amboy.Job
+	if j.IntentType == patch.GithubIntentType {
+		update = NewGithubStatusUpdateJobForProcessingError(
+			evergreenContext,
+			patchDoc.GithubPatchData.BaseOwner,
+			patchDoc.GithubPatchData.BaseRepo,
+			patchDoc.GithubPatchData.HeadHash,
+			j.gitHubError,
+		)
+	} else if j.IntentType == patch.GithubMergeIntentType {
+		update = NewGithubStatusUpdateJobForProcessingError(
+			evergreenContext,
+			patchDoc.GithubMergeData.Org,
+			patchDoc.GithubMergeData.Repo,
+			patchDoc.GithubMergeData.HeadSHA,
+			j.gitHubError,
+		)
+	} else {
+		j.AddError(errors.Errorf("unexpected intent type '%s'", j.IntentType))
+		return
+	}
 	update.Run(ctx)
 
 	j.AddError(update.Error())

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -102,7 +102,7 @@ func (j *patchIntentProcessor) Run(ctx context.Context) {
 	patchDoc := j.intent.NewPatch()
 
 	// set owner and repo for child patches
-	if j.IntentType == patch.TriggerIntentType {
+	if j.IntentType == patch.TriggerIntentType || j.IntentType == patch.CliIntentType {
 		if patchDoc.Project == "" {
 			j.AddError(errors.New("cannot search for an empty project"))
 			return


### PR DESCRIPTION
EVG-20516

### Description

This fixes a bug introduced by
https://github.com/evergreen-ci/evergreen/pull/6778. That PR always attempted to
set owner and repo using the project name. However, only CLI and trigger types
already set a name. GitHub PR and merge group types do not set a name until
later in the process. This means that the code was finding a project by passing
an empty identifier.

Note that this PR also adds some returns, whereas before we continued on error.

This PR also passes the GitHub merge group data instead of PR data to the update 
message.

### Testing

Ran existing unit tests.

### Documentation

N/A
