### PR TITLE
EVG-19960 Create fallback for annotation lookup when it hits the $facet size limit

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/db/mgo"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func IsDuplicateKey(err error) bool {
@@ -29,3 +30,15 @@ func IsDocumentLimit(err error) bool {
 	}
 	return strings.Contains(errors.Cause(err).Error(), "an inserted document is too large")
 }
+
+func IsErrorCode(err error, errorCode int) bool {
+	var mongoError mongo.CommandError
+	if errors.As(err, &mongoError) && mongoError.HasErrorCode(errorCode) {
+		return true
+	}
+	return false
+}
+
+// ErrorCode constants for mongo errors
+
+const FACET_PIPELINE_STAGE_TOO_LARGE_CODE = 4031700 // https://github.com/mongodb/mongo/blob/a1732172ed5d66d98582ea1059c0ede9d8cd5065/src/mongo/db/pipeline/document_source_facet.cpp#L165

--- a/db/errors.go
+++ b/db/errors.go
@@ -44,4 +44,4 @@ func IsErrorCode(err error, errorCode int) bool {
 
 // FacetPipelineStageTooLargeCode is the error code for when a facet pipeline stage is too large.
 // https://github.com/mongodb/mongo/blob/a1732172ed5d66d98582ea1059c0ede9d8cd5065/src/mongo/db/pipeline/document_source_facet.cpp#L165
-const FacetPipelineStageTooLargeCode = 4031700 //
+const FacetPipelineStageTooLargeCode = 4031700

--- a/db/errors.go
+++ b/db/errors.go
@@ -31,6 +31,7 @@ func IsDocumentLimit(err error) bool {
 	return strings.Contains(errors.Cause(err).Error(), "an inserted document is too large")
 }
 
+// IsErrorCode checks if the error is a mongo error with the given error code.
 func IsErrorCode(err error, errorCode int) bool {
 	var mongoError mongo.CommandError
 	if errors.As(err, &mongoError) && mongoError.HasErrorCode(errorCode) {
@@ -41,4 +42,6 @@ func IsErrorCode(err error, errorCode int) bool {
 
 // ErrorCode constants for mongo errors
 
-const FACET_PIPELINE_STAGE_TOO_LARGE_CODE = 4031700 // https://github.com/mongodb/mongo/blob/a1732172ed5d66d98582ea1059c0ede9d8cd5065/src/mongo/db/pipeline/document_source_facet.cpp#L165
+// FacetPipelineStageTooLargeCode is the error code for when a facet pipeline stage is too large.
+// https://github.com/mongodb/mongo/blob/a1732172ed5d66d98582ea1059c0ede9d8cd5065/src/mongo/db/pipeline/document_source_facet.cpp#L165
+const FacetPipelineStageTooLargeCode = 4031700 //

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -169,7 +169,7 @@ func (r *patchResolver) TaskCount(ctx context.Context, obj *restModel.APIPatch) 
 
 // TaskStatuses is the resolver for the taskStatuses field.
 func (r *patchResolver) TaskStatuses(ctx context.Context, obj *restModel.APIPatch) ([]string, error) {
-	statuses, err := task.GetTaskStatusesByVersion(ctx, utility.FromStringPtr(obj.Id))
+	statuses, err := task.GetTaskStatusesByVersion(ctx, utility.FromStringPtr(obj.Id), false)
 	if err != nil {
 		return nil, nil
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -333,14 +333,14 @@ func (r *queryResolver) Patch(ctx context.Context, id string) (*restModel.APIPat
 	}
 
 	if evergreen.IsFinishedPatchStatus(*patch.Status) {
-		statuses, err := task.GetTaskStatusesByVersion(ctx, id)
+		statuses, err := task.GetTaskStatusesByVersion(ctx, id, false)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch task statuses for patch: %s ", err.Error()))
 		}
 
 		if len(patch.ChildPatches) > 0 {
 			for _, cp := range patch.ChildPatches {
-				childPatchStatuses, err := task.GetTaskStatusesByVersion(ctx, *cp.Id)
+				childPatchStatuses, err := task.GetTaskStatusesByVersion(ctx, *cp.Id, false)
 				if err != nil {
 					return nil, InternalServerError.Send(ctx, fmt.Sprintf("Could not fetch task statuses for child patch: %s ", err.Error()))
 				}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -345,7 +345,7 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 
 // TaskStatuses is the resolver for the taskStatuses field.
 func (r *versionResolver) TaskStatuses(ctx context.Context, obj *restModel.APIVersion) ([]string, error) {
-	statuses, err := task.GetTaskStatusesByVersion(ctx, *obj.Id)
+	statuses, err := task.GetTaskStatusesByVersion(ctx, *obj.Id, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task statuses for version with id '%s': %s", *obj.Id, err.Error()))
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -335,6 +335,38 @@ var (
 		{"$unwind": "$tasks"},
 		{"$replaceRoot": bson.M{"newRoot": "$tasks"}},
 	}
+
+	// AddAnnotationsSlowLookup adds the annotations to the task document. This is a slower version of AddAnnotations that does not use a facet and does not run into the 104mb pipeline stage limit.
+	AddAnnotationsSlowLookup = []bson.M{
+		{
+			"$lookup": bson.M{
+				"from": annotations.Collection,
+				"let":  bson.M{"task_annotation_id": "$" + IdKey, "task_annotation_execution": "$" + ExecutionKey},
+				"pipeline": []bson.M{
+					{
+						"$match": bson.M{
+							"$expr": bson.M{
+								"$and": []bson.M{
+									{
+										"$eq": []string{"$" + annotations.TaskIdKey, "$$task_annotation_id"},
+									},
+									{
+										"$eq": []string{"$" + annotations.TaskExecutionKey, "$$task_annotation_execution"},
+									},
+									{
+										"$ne": []interface{}{
+											bson.M{
+												"$size": bson.M{"$ifNull": []interface{}{"$" + annotations.IssuesKey, []bson.M{}}},
+											}, 0,
+										},
+									},
+								},
+							},
+						}}},
+				"as": "annotation_docs",
+			},
+		},
+	}
 )
 
 var StatusFields = []string{
@@ -2112,7 +2144,12 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 
 	env := evergreen.GetEnvironment()
 	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
+
 	if err != nil {
+		if db.IsErrorCode(err, db.FACET_PIPELINE_STAGE_TOO_LARGE_CODE) {
+			opts.UseSlowAnnotationsLookup = true
+			return GetTasksByVersion(ctx, versionID, opts)
+		}
 		return nil, 0, err
 	}
 
@@ -2528,6 +2565,7 @@ type GetTasksByVersionOptions struct {
 	IncludeExecutionTasks      bool
 	IncludeNeverActivatedTasks bool // NeverActivated tasks are tasks that lack an activation time
 	BaseVersionID              string
+	UseSlowAnnotationsLookup   bool // In some cases, where there are many tasks, we can hit the 104mb limit on the aggregation pipeline. This flag allows us to use a slower lookup method to avoid this limit.
 }
 
 func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) ([]bson.M, error) {
@@ -2582,7 +2620,11 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		})
 	}
 
-	pipeline = append(pipeline, AddAnnotations...)
+	if opts.UseSlowAnnotationsLookup {
+		pipeline = append(pipeline, AddAnnotationsSlowLookup...)
+	} else {
+		pipeline = append(pipeline, AddAnnotations...)
+	}
 	pipeline = append(pipeline,
 		// Add a field for the display status of each task
 		addDisplayStatus,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2146,6 +2146,7 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
 
 	if err != nil {
+		// If the pipeline stage is too large we should use the slow annotations lookup
 		if db.IsErrorCode(err, db.FACET_PIPELINE_STAGE_TOO_LARGE_CODE) {
 			opts.UseSlowAnnotationsLookup = true
 			return GetTasksByVersion(ctx, versionID, opts)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2147,7 +2147,7 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 
 	if err != nil {
 		// If the pipeline stage is too large we should use the slow annotations lookup
-		if db.IsErrorCode(err, db.FACET_PIPELINE_STAGE_TOO_LARGE_CODE) {
+		if db.IsErrorCode(err, db.FacetPipelineStageTooLargeCode) {
 			opts.UseSlowAnnotationsLookup = true
 			return GetTasksByVersion(ctx, versionID, opts)
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2147,7 +2147,7 @@ func GetTasksByVersion(ctx context.Context, versionID string, opts GetTasksByVer
 
 	if err != nil {
 		// If the pipeline stage is too large we should use the slow annotations lookup
-		if db.IsErrorCode(err, db.FacetPipelineStageTooLargeCode) {
+		if db.IsErrorCode(err, db.FacetPipelineStageTooLargeCode) && !opts.UseSlowAnnotationsLookup {
 			opts.UseSlowAnnotationsLookup = true
 			return GetTasksByVersion(ctx, versionID, opts)
 		}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2,6 +2,8 @@ package task
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -1093,6 +1095,50 @@ func TestGetTasksByVersionBaseTasks(t *testing.T) {
 	assert.NotNil(t, tasks[0].BaseTask)
 	assert.Equal(t, "t1", tasks[0].BaseTask.Id)
 	assert.Equal(t, t1.Status, tasks[0].BaseTask.Status)
+}
+
+func TestGetTasksByVersionErrorHandling(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+
+	// Generate 40000 tasks that average 5kb each in size. This will result in over 200MB of data.
+	// This is a test to ensure we can handle the 100mb memory limitations present in the $facet stage of our query when querying for versions with a large amount of tasks.
+	// See https://jira.mongodb.org/browse/SERVER-59837
+	fiveKBString := strings.Repeat("a", 1024*5)
+	task := Task{
+		Version:             "v1",
+		BuildVariant:        "bv",
+		DisplayName:         "displayName",
+		Execution:           0,
+		Status:              evergreen.TaskSucceeded,
+		RevisionOrderNumber: 1,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		Revision:            fiveKBString,
+		DisplayTaskId:       utility.ToStringPtr(""),
+	}
+
+	for i := 0; i < 40; i++ {
+		tasksToInsert := []interface{}{}
+		for j := 0; j < 1000; j++ {
+			task.Id = fmt.Sprintf("t_%d_%d", i, j)
+			task.BuildVariant = fmt.Sprintf("bv_%d", j)
+			tasksToInsert = append(tasksToInsert, task)
+		}
+		assert.NoError(t, db.InsertMany(Collection, tasksToInsert...))
+	}
+	// Normal Patch builds
+	opts := GetTasksByVersionOptions{}
+	ctx := context.TODO()
+	tasks, count, err := GetTasksByVersion(ctx, "v1", opts)
+	assert.NoError(t, err)
+	assert.Equal(t, 40000, count)
+	assert.Equal(t, 40000, len(tasks))
+
+	opts.Limit = 10
+	tasks, count, err = GetTasksByVersion(ctx, "v1", opts)
+	assert.NoError(t, err)
+	assert.Equal(t, 40000, count)
+	assert.Equal(t, 10, len(tasks))
+
 }
 
 func TestGetTaskStatusesByVersion(t *testing.T) {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1192,7 +1192,7 @@ func TestGetTaskStatusesByVersion(t *testing.T) {
 	}
 	assert.NoError(t, db.InsertMany(Collection, t1, t2, t3, t4))
 	ctx := context.TODO()
-	tasks, err := GetTaskStatusesByVersion(ctx, "v1")
+	tasks, err := GetTaskStatusesByVersion(ctx, "v1", false)
 	assert.NoError(t, err)
 	assert.Len(t, tasks, 4)
 	assert.Equal(t, []string{evergreen.TaskFailed, evergreen.TaskSetupFailed, evergreen.TaskStarted, evergreen.TaskSucceeded}, tasks)


### PR DESCRIPTION
EVG-19960

### Description
On certain very large patches, there is a chance  that the `getTasksByVersion` aggregation encounters the following error `(Location4031700) PlanExecutor error during aggregation :: caused by :: document constructed by $facet is 104858682 bytes, which exceeds the limit of 104857600 bytes`  

This error stumped me because it lead me to believe that this was something that could be resolved by toggling the `allowDiskUsage` flag to get around MongoDB's 100mb stage limit. In reality, this is actually a limitation with the `$facet` stage that is described in [SERVER-59837](https://jira.mongodb.org/browse/SERVER-59837)

In order to get past this I decided to introduce an additional parameter that will not use the optimization introduced in EVG-15279 - #4997 and instead fallback to looking up annotations for all tasks not just the failed ones. 
If the original query fails this aggregation will use the fallback. 
 
### Testing
Created 200 MB worth of task documents and asserted the aggregation returns task results.

### Documentation
remember to add or edit docs in the docs/ directory if relevant
