### PR TITLE
EVG-20299 Disable CLI commit queue when GitHub merge queue is on

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,10 +35,10 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-07-25"
+	ClientVersion = "2023-07-27"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-27"
+	AgentVersion = "2023-07-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-25"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-07-26"
+	AgentVersion = "2023-07-27"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -17,6 +17,8 @@ Gating every merge on a green build means every commit on the tracked branch had
 To turn it on, you must turn on Evergreen's merge queue integration, and then
 turn on the GitHub merge queue in GitHub.
 
+Note that you cannot use Evergreen's commit queue if the GitHub merge queue is on.
+
 ## Enable the merge queue
 
 ### Turn on Evergreen's merge queue integration

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -604,6 +604,9 @@ func (p *mergeParams) uploadMergePatch(conf *ClientSettings, ac *legacyClient, u
 	if !ref.CommitQueue.IsEnabled() {
 		return errors.New("commit queue not enabled for project")
 	}
+	if ref.CommitQueue.MergeQueue == model.MergeQueueGitHub {
+		return errors.New("Commit queue merge method is set to GitHub, not Evergreen, in the project settings. You must merge from a GitHub PR.")
+	}
 
 	commitCount, err := gitCommitCount(ref.Branch, p.ref, p.commits)
 	if err != nil {

--- a/service/api.go
+++ b/service/api.go
@@ -158,7 +158,7 @@ func (as *APIServer) fetchLimitedProjectRef(w http.ResponseWriter, r *http.Reque
 		CommitQueue: restModel.APICommitQueueParams{
 			Message:     utility.ToStringPtr(p.CommitQueue.Message),
 			Enabled:     p.CommitQueue.Enabled,
-			MergeMethod: utility.ToStringPtr(p.CommitQueue.MergeMethod),
+			MergeMethod: utility.ToStringPtr(string(p.CommitQueue.MergeQueue)),
 		},
 	}
 

--- a/service/api.go
+++ b/service/api.go
@@ -156,8 +156,9 @@ func (as *APIServer) fetchLimitedProjectRef(w http.ResponseWriter, r *http.Reque
 		Branch:            utility.ToStringPtr(p.Branch),
 		WorkstationConfig: wc,
 		CommitQueue: restModel.APICommitQueueParams{
-			Message: utility.ToStringPtr(p.CommitQueue.Message),
-			Enabled: p.CommitQueue.Enabled,
+			Message:     utility.ToStringPtr(p.CommitQueue.Message),
+			Enabled:     p.CommitQueue.Enabled,
+			MergeMethod: utility.ToStringPtr(p.CommitQueue.MergeMethod),
 		},
 	}
 

--- a/service/api.go
+++ b/service/api.go
@@ -156,9 +156,9 @@ func (as *APIServer) fetchLimitedProjectRef(w http.ResponseWriter, r *http.Reque
 		Branch:            utility.ToStringPtr(p.Branch),
 		WorkstationConfig: wc,
 		CommitQueue: restModel.APICommitQueueParams{
-			Message:     utility.ToStringPtr(p.CommitQueue.Message),
-			Enabled:     p.CommitQueue.Enabled,
-			MergeMethod: utility.ToStringPtr(string(p.CommitQueue.MergeQueue)),
+			Message:    utility.ToStringPtr(p.CommitQueue.Message),
+			Enabled:    p.CommitQueue.Enabled,
+			MergeQueue: p.CommitQueue.MergeQueue,
 		},
 	}
 


### PR DESCRIPTION
EVG-20299

### Description

If the merge queue is set to GitHub, you must merge from a GitHub PR. This PR
returns an error to the user if they try to merge with the Evergreen CLI while
the queue is set to GitHub.

### Testing

I didn't see a straightforward way to test this. This code does not appear to be
directly under test, and it makes some API calls that would make it difficult to mock. I think the change is small enough that the cost of writing new tests is not worth it.

### Documentation

Added a sentence about this constraint.