### PR TITLE
EVG-19650 use mark end for system failed tasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1350,7 +1350,6 @@ func (t *Task) MarkFailed() error {
 }
 
 func (t *Task) MarkSystemFailed(description string) error {
-	t.Status = evergreen.TaskFailed
 	t.FinishTime = time.Now()
 	t.Details = GetSystemFailureDetails(description)
 
@@ -1374,25 +1373,7 @@ func (t *Task) MarkSystemFailed(description string) error {
 		"execution_platform": t.ExecutionPlatform,
 	})
 
-	t.ContainerAllocated = false
-	t.ContainerAllocatedTime = time.Time{}
-
-	return UpdateOne(
-		bson.M{
-			IdKey: t.Id,
-		},
-		bson.M{
-			"$set": bson.M{
-				StatusKey:             evergreen.TaskFailed,
-				FinishTimeKey:         t.FinishTime,
-				DetailsKey:            t.Details,
-				ContainerAllocatedKey: false,
-			},
-			"$unset": bson.M{
-				ContainerAllocatedTimeKey: 1,
-			},
-		},
-	)
+	return t.MarkEnd(t.FinishTime, &t.Details)
 }
 
 // GetSystemFailureDetails returns a task's end details based on an input description.


### PR DESCRIPTION
EVG-19650 
### Description
We were getting tasks logged to task-end-stats that said they'd been running for 53 years, i.e. the start time was set to the zero time. It looks like this isn't unexpected for tasks that are stranded after dispatching, and we have handling for it in the MarkEnd function, but we don't do that for systsem failures, so modified this to call it, and verified we don't update a task to be finished anywhere else. 

