### PR TITLE
EVG-20455: add new `ExcludeDisplayNames` field for test result filtering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715
-	github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78
+	github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3
 	github.com/evergreen-ci/utility v0.0.0-20230726191623-866cb804386e
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,8 @@ github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715 h1:JEr1ZoqNceEO
 github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715/go.mod h1:GT+di9PB4Fog3QKJGaNSE69iOATmPorDEZnVRfgR2pY=
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1k9SExkF87VTess4JVR7Uvwr8AAKzJ864=
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826/go.mod h1:SnQ9F63VSR6kHbC4aFE+f7+iL3yANhjaN9TT9T4skao=
-github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78 h1:Q1HuesKSJFqxNVZoIzQRRc/yha8cYVt2W7ke62hvt9I=
-github.com/evergreen-ci/timber v0.0.0-20230413164224-05a3a6e11d78/go.mod h1:iQ61Jnff5R5IMDMK/CytJSzerlXw/XC51CQFTURM0Pk=
+github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3 h1:ZAXkjLIYuig6Q33cd/fEDXPAhmZvP9YNSNXvAQGHB84=
+github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3/go.mod h1:UUzYp4MuW+uz87NoorR2FmC5xkB1s6uu4+poGYa3EL0=
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
@@ -1162,7 +1162,6 @@ go.mongodb.org/mongo-driver v1.8.2/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCu
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.8.4/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.10.1/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
-go.mongodb.org/mongo-driver v1.11.1/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/mongo-driver v1.11.6 h1:XM7G6PjiGAO5betLF13BIa5TlLUUE3uJ/2Ox3Lz1K+o=
 go.mongodb.org/mongo-driver v1.11.6/go.mod h1:G9TgswdsWjX4tmDA5zfs2+6AEPpYJwqblyjsfuh8oXY=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
@@ -1656,7 +1655,6 @@ google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ5
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
-google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
 google.golang.org/grpc v1.55.0 h1:3Oj82/tFSCeUrRTg/5E/7d/W5A1tj6Ky1ABAuZuv5ag=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -68473,7 +68473,7 @@ func (ec *executionContext) unmarshalInputTestFilterOptions(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"testName", "statuses", "groupID", "sort", "limit", "page"}
+	fieldsInOrder := [...]string{"testName", "excludeDisplayNames", "statuses", "groupID", "sort", "limit", "page"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -68489,6 +68489,15 @@ func (ec *executionContext) unmarshalInputTestFilterOptions(ctx context.Context,
 				return it, err
 			}
 			it.TestName = data
+		case "excludeDisplayNames":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excludeDisplayNames"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExcludeDisplayNames = data
 		case "statuses":
 			var err error
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -389,12 +389,13 @@ type TestFilter struct {
 // TestFilterOptions is an input for the task.Tests query.
 // It's used to filter, sort, and paginate test results of a task.
 type TestFilterOptions struct {
-	TestName *string            `json:"testName,omitempty"`
-	Statuses []string           `json:"statuses,omitempty"`
-	GroupID  *string            `json:"groupID,omitempty"`
-	Sort     []*TestSortOptions `json:"sort,omitempty"`
-	Limit    *int               `json:"limit,omitempty"`
-	Page     *int               `json:"page,omitempty"`
+	TestName            *string            `json:"testName,omitempty"`
+	ExcludeDisplayNames *bool              `json:"excludeDisplayNames,omitempty"`
+	Statuses            []string           `json:"statuses,omitempty"`
+	GroupID             *string            `json:"groupID,omitempty"`
+	Sort                []*TestSortOptions `json:"sort,omitempty"`
+	Limit               *int               `json:"limit,omitempty"`
+	Page                *int               `json:"page,omitempty"`
 }
 
 // TestSortOptions is an input for the task.Tests query.

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -13,6 +13,7 @@ It's used to filter, sort, and paginate test results of a task.
 """
 input TestFilterOptions {
   testName: String
+  excludeDisplayNames: Boolean
   statuses: [String!]
   groupID: String
   sort: [TestSortOptions!]

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -936,13 +936,14 @@ func convertTestFilterOptions(ctx context.Context, dbTask *task.Task, opts *Test
 	}
 
 	return &testresult.FilterOptions{
-		TestName:  utility.FromStringPtr(opts.TestName),
-		Statuses:  opts.Statuses,
-		GroupID:   utility.FromStringPtr(opts.GroupID),
-		Sort:      sort,
-		Limit:     utility.FromIntPtr(opts.Limit),
-		Page:      utility.FromIntPtr(opts.Page),
-		BaseTasks: baseTaskOpts,
+		TestName:            utility.FromStringPtr(opts.TestName),
+		ExcludeDisplayNames: utility.FromBoolPtr(opts.ExcludeDisplayNames),
+		Statuses:            opts.Statuses,
+		GroupID:             utility.FromStringPtr(opts.GroupID),
+		Sort:                sort,
+		Limit:               utility.FromIntPtr(opts.Limit),
+		Page:                utility.FromIntPtr(opts.Page),
+		BaseTasks:           baseTaskOpts,
 	}, nil
 }
 

--- a/model/testresult/cedar_service.go
+++ b/model/testresult/cedar_service.go
@@ -136,14 +136,14 @@ func (s *cedarService) convertOpts(taskOpts []TaskOptions, filterOpts *FilterOpt
 			})
 		}
 		cedarFilterOpts = &testresults.FilterOptions{
-			TestName: filterOpts.TestName,
-			//ExcludeDisplayNames: filterOpts.ExcludeDisplayNames,
-			Statuses:  filterOpts.Statuses,
-			GroupID:   filterOpts.GroupID,
-			Sort:      sort,
-			Limit:     filterOpts.Limit,
-			Page:      filterOpts.Page,
-			BaseTasks: baseTasks,
+			TestName:            filterOpts.TestName,
+			ExcludeDisplayNames: filterOpts.ExcludeDisplayNames,
+			Statuses:            filterOpts.Statuses,
+			GroupID:             filterOpts.GroupID,
+			Sort:                sort,
+			Limit:               filterOpts.Limit,
+			Page:                filterOpts.Page,
+			BaseTasks:           baseTasks,
 		}
 	}
 

--- a/model/testresult/cedar_service.go
+++ b/model/testresult/cedar_service.go
@@ -136,7 +136,8 @@ func (s *cedarService) convertOpts(taskOpts []TaskOptions, filterOpts *FilterOpt
 			})
 		}
 		cedarFilterOpts = &testresults.FilterOptions{
-			TestName:  filterOpts.TestName,
+			TestName: filterOpts.TestName,
+			//ExcludeDisplayNames: filterOpts.ExcludeDisplayNames,
 			Statuses:  filterOpts.Statuses,
 			GroupID:   filterOpts.GroupID,
 			Sort:      sort,

--- a/model/testresult/local_service.go
+++ b/model/testresult/local_service.go
@@ -262,8 +262,14 @@ func (s *localService) filterTestResults(results []TestResult, opts *FilterOptio
 
 	var filteredResults []TestResult
 	for _, result := range results {
-		if testNameRegex != nil && !testNameRegex.MatchString(result.GetDisplayTestName()) {
-			continue
+		if testNameRegex != nil {
+			if opts.ExcludeDisplayNames {
+				if !testNameRegex.MatchString(result.TestName) {
+					continue
+				}
+			} else if !testNameRegex.MatchString(result.GetDisplayTestName()) {
+				continue
+			}
 		}
 		if len(opts.Statuses) > 0 && !utility.StringSliceContains(opts.Statuses, result.Status) {
 			continue

--- a/model/testresult/local_service_test.go
+++ b/model/testresult/local_service_test.go
@@ -358,12 +358,6 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 			expectedCount:   4,
 		},
 		{
-			name:            "TestNameExactMatchFilter",
-			opts:            &FilterOptions{TestName: "A test"},
-			expectedResults: results[0:1],
-			expectedCount:   1,
-		},
-		{
 			name: "TestNameRegexFilter",
 			opts: &FilterOptions{TestName: "A|C"},
 			expectedResults: []TestResult{
@@ -371,6 +365,15 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 				results[2],
 			},
 			expectedCount: 2,
+		},
+		{
+			name: "TestNameExcludeDisplayNamesFilter",
+			opts: &FilterOptions{
+				TestName:            "B test",
+				ExcludeDisplayNames: true,
+			},
+			expectedResults: results[1:2],
+			expectedCount:   1,
 		},
 		{
 			name:            "DisplayTestNameFilter",

--- a/model/testresult/local_service_test.go
+++ b/model/testresult/local_service_test.go
@@ -246,10 +246,11 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 				TestEndTime:     time.Date(1996, time.August, 31, 12, 5, 16, 0, time.UTC),
 			},
 			{
-				TestName:      "C test",
-				Status:        "Fail",
-				TestStartTime: time.Date(1996, time.August, 31, 12, 5, 10, 2, time.UTC),
-				TestEndTime:   time.Date(1996, time.August, 31, 12, 5, 15, 0, time.UTC),
+				TestName:        "C test",
+				DisplayTestName: "B",
+				Status:          "Fail",
+				TestStartTime:   time.Date(1996, time.August, 31, 12, 5, 10, 2, time.UTC),
+				TestEndTime:     time.Date(1996, time.August, 31, 12, 5, 15, 0, time.UTC),
 			},
 			{
 				TestName:      "D test",
@@ -276,9 +277,10 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 			Status:          "Fail",
 		},
 		{
-			TaskID:   baseTaskID,
-			TestName: "C test",
-			Status:   "Pass",
+			TaskID:          baseTaskID,
+			TestName:        "C test",
+			DisplayTestName: "B",
+			Status:          "Pass",
 		},
 		{
 			TaskID:   baseTaskID,
@@ -359,7 +361,7 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		},
 		{
 			name: "TestNameRegexFilter",
-			opts: &FilterOptions{TestName: "A|C"},
+			opts: &FilterOptions{TestName: "A|B"},
 			expectedResults: []TestResult{
 				results[0],
 				results[2],
@@ -369,7 +371,7 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 		{
 			name: "TestNameExcludeDisplayNamesFilter",
 			opts: &FilterOptions{
-				TestName:            "B test",
+				TestName:            "B",
 				ExcludeDisplayNames: true,
 			},
 			expectedResults: results[1:2],

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -138,7 +138,7 @@ func (tr TestResult) GetLogURL(env evergreen.Environment, viewer evergreen.LogVi
 			}
 		}
 
-		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, tr.TaskID, tr.Execution, tr.TestName, tr.LineNum)
+		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, tr.TaskID, tr.Execution, tr.GetLogTestName(), tr.LineNum)
 	default:
 		if tr.RawLogURL != "" {
 			// Some test results may have internal URLs that are

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -138,7 +138,7 @@ func (tr TestResult) GetLogURL(env evergreen.Environment, viewer evergreen.LogVi
 			}
 		}
 
-		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, tr.TaskID, tr.Execution, tr.GetLogTestName(), tr.LineNum)
+		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, tr.TaskID, tr.Execution, tr.TestName, tr.LineNum)
 	default:
 		if tr.RawLogURL != "" {
 			// Some test results may have internal URLs that are

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -300,11 +300,12 @@ const (
 
 // FilterOptions represents the filtering arguments for fetching test results.
 type FilterOptions struct {
-	TestName  string
-	Statuses  []string
-	GroupID   string
-	Sort      []SortBy
-	Limit     int
-	Page      int
-	BaseTasks []TaskOptions
+	TestName            string
+	ExcludeDisplayNames bool
+	Statuses            []string
+	GroupID             string
+	Sort                []SortBy
+	Limit               int
+	Page                int
+	BaseTasks           []TaskOptions
 }


### PR DESCRIPTION
EVG-20445

### Description
This updates the test results service's `FilterOptions` to include and pipe through the new field `ExcludeDisplayNames` as well as update the graphql schema to include said field in the `TestFilterOptions` input. When set, the new field excludes display names when matching on the test name regex, the default behavior will continue to favor matching on display test name—so the changes are backwards compatible. 

### Testing
Tested in staging that this works with parsley, does not break existing filtering functionality on spruce (which is uses the default filtering on display test name), and added unit tests for the new field in local test results service.

### Documentation
N/A