### PR TITLE
EVG-18861: warn for missing dependencies with same implicit build variant

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1487,9 +1487,9 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 	return errs
 }
 
-// checkRequestersForTaskDependencies checks that that each task's dependencies will run for
-// the same requesters. For example, a task that runs in a mainline commit
-// cannot depend on a patch only task since the dependency will only be
+// checkRequestersForTaskDependencies checks that each task's dependencies will
+// run for the same requesters. For example, a task that runs in a mainline
+// commit cannot depend on a patch only task since the dependency will only be
 // satisfiable in patches.
 func checkRequestersForTaskDependencies(task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
 	errs := ValidationErrors{}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1419,9 +1419,6 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 		for _, dep := range task.DependsOn {
 			pair := model.TVPair{TaskName: dep.Name, Variant: dep.Variant}
 			// make sure the dependency is not specified more than once
-			// kim: NOTE: easiest is to just consider if the dependency exists
-			// in the expected build variant list. Considering requesters would
-			// be better, but very difficult.
 			if depNames[pair] {
 				errs = append(errs,
 					ValidationError{

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1411,6 +1411,7 @@ func checkTaskRuns(project *model.Project) ValidationErrors {
 // correct fields, and that the fields have valid values
 func validateTaskDependencies(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
+	implicitBVDeps := map[string][]string{}
 	for _, task := range project.Tasks {
 		// create a set of the dependencies, to check for duplicates
 		depNames := map[model.TVPair]bool{}
@@ -1418,6 +1419,9 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 		for _, dep := range task.DependsOn {
 			pair := model.TVPair{TaskName: dep.Name, Variant: dep.Variant}
 			// make sure the dependency is not specified more than once
+			// kim: NOTE: easiest is to just consider if the dependency exists
+			// in the expected build variant list. Considering requesters would
+			// be better, but very difficult.
 			if depNames[pair] {
 				errs = append(errs,
 					ValidationError{
@@ -1457,12 +1461,40 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 				})
 			}
 
+			implicitBVDeps[task.Name] = append(implicitBVDeps[task.Name], dep.Name)
 		}
 	}
+
+	// If a task depends on another task but doesn't specify an explicit variant
+	// in the dependency, that task is implicitly depending on a task being in
+	// the same variant where it's listed. Check that build variants containing
+	// tasks with implicit build variant dependencies also include the
+	// dependencies in the task list.
+	for _, bv := range project.BuildVariants {
+		for taskName, depNames := range implicitBVDeps {
+			if project.FindTaskForVariant(taskName, bv.Name) == nil {
+				continue
+			}
+
+			for _, depName := range depNames {
+				if project.FindTaskForVariant(depName, bv.Name) == nil {
+					errs = append(errs, ValidationError{
+						Level:   Warning,
+						Message: fmt.Sprintf("task '%s' in build variant '%s' depends on task '%s', but that task is not listed in this build variant", taskName, bv.Name, depName),
+					})
+				}
+			}
+		}
+	}
+
 	return errs
 }
 
-func checkTaskDependencies(task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
+// checkRequestersForTaskDependencies checks that that each task's dependencies will run for
+// the same requesters. For example, a task that runs in a mainline commit
+// cannot depend on a patch only task since the dependency will only be
+// satisfiable in patches.
+func checkRequestersForTaskDependencies(task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
 	errs := ValidationErrors{}
 
 	for _, dep := range task.DependsOn {
@@ -2132,7 +2164,7 @@ func checkTasks(project *model.Project) ValidationErrors {
 			execTimeoutWarningAdded = true
 		}
 		errs = append(errs, checkLoggerConfig(&task)...)
-		errs = append(errs, checkTaskDependencies(&task, allTasks)...)
+		errs = append(errs, checkRequestersForTaskDependencies(&task, allTasks)...)
 		errs = append(errs, checkTaskNames(project, &task)...)
 	}
 	if project.Loggers != nil {


### PR DESCRIPTION
EVG-18861

### Description
If a task lists a dependency, the build variant of the task and its dependency are implicitly the same. Therefore, the dependency of the task must also be listed in the build variant task list. There was no validation for the case of an implicit build variant for a dependency, so I added a warning.

### Testing
* Added unit test for implicit dependency.
* Tested in staging with `evergreen validate` that a task that depended on another task in the same implicit build variant produced a validation warning.

### Documentation
N/A