### PR TITLE
EVG-20567 Show head hash for GitHub merge queue builds

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -951,7 +951,8 @@ func AbortPatchesWithGithubPatchData(ctx context.Context, createdBefore time.Tim
 	return errors.Wrap(catcher.Resolve(), "aborting patches")
 }
 
-func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *ProjectRef, project *Project, githubMergePatch bool) string {
+func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *ProjectRef, project *Project,
+	githubMergePatch bool, githubMergeSHA string) string {
 	commitFmtString := "'%s' into '%s/%s:%s'"
 	description := []string{}
 	for _, p := range patches {
@@ -982,7 +983,7 @@ func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *Project
 	}
 
 	if githubMergePatch {
-		return "GitHub Merge Queue"
+		return "GitHub Merge Queue: " + githubMergeSHA[0:7]
 	} else {
 		return "Commit Queue Merge: " + strings.Join(description, " || ")
 	}
@@ -1073,7 +1074,8 @@ func MakeMergePatchFromExisting(ctx context.Context, settings *evergreen.Setting
 	if patchDoc.Patches, err = patch.MakeMergePatchPatches(existingPatch, commitMessage); err != nil {
 		return nil, errors.Wrap(err, "making merge patches from existing patch")
 	}
-	patchDoc.Description = MakeCommitQueueDescription(patchDoc.Patches, projectRef, project, patchDoc.IsGithubMergePatch())
+	patchDoc.Description = MakeCommitQueueDescription(patchDoc.Patches, projectRef, project,
+		patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData.HeadSHA)
 
 	// verify the commit queue has tasks/variants enabled that match the project
 	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -867,7 +867,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 
 	// no commits
 	patches := []patch.ModulePatch{}
-	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project, false))
+	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
 
 	// main repo commit
 	patches = []patch.ModulePatch{
@@ -876,9 +876,9 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Commit"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false))
+	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
 
-	assert.Equal(t, "GitHub Merge Queue", MakeCommitQueueDescription(patches, projectRef, project, true))
+	assert.Equal(t, "GitHub Merge Queue: 0e312ff", MakeCommitQueueDescription(patches, projectRef, project, true, "0e312ff6c06bd09eff0aed1bd1f73911a7daa350"))
 
 	// main repo + module commits
 	patches = []patch.ModulePatch{
@@ -892,7 +892,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false))
+	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
 
 	// module only commits
 	patches = []patch.ModulePatch{
@@ -904,7 +904,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Module Commit 1", "Module Commit 2"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false))
+	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
 }
 
 func TestRetryCommitQueueItems(t *testing.T) {

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -362,7 +362,7 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if p.IsCommitQueuePatch() {
-		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, project, p.IsCommitQueuePatch())); err != nil {
+		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, project, p.IsCommitQueuePatch(), p.GithubMergeData.HeadSHA)); err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -365,7 +365,7 @@ func (j *patchIntentProcessor) finishPatchWithToken(ctx context.Context, patchDo
 	}
 
 	if patchDoc.IsCommitQueuePatch() {
-		patchDoc.Description = model.MakeCommitQueueDescription(patchDoc.Patches, pref, patchedProject, patchDoc.IsGithubMergePatch())
+		patchDoc.Description = model.MakeCommitQueueDescription(patchDoc.Patches, pref, patchedProject, patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData.HeadSHA)
 	}
 
 	if patchDoc.IsBackport() {


### PR DESCRIPTION
EVG-20567

### Description

Adding the HEAD hash to the GitHub merge queue builds make them a little bit
easier to tell apart. This changes the title from "GitHub Merge Queue" to
"GitHub Merge Queue: <short_head_hash>.

### Testing

I modified the existing unit test.

### Documentation

None needed.
