### PR TITLE
EVG-20455: update Parsley test log URL to use the unique test name instead of the log test name

### DIFF
--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -138,7 +138,7 @@ func (tr TestResult) GetLogURL(env evergreen.Environment, viewer evergreen.LogVi
 			}
 		}
 
-		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, tr.TaskID, tr.Execution, tr.GetLogTestName(), tr.LineNum)
+		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, url.QueryEscape(tr.TaskID), tr.Execution, url.QueryEscape(tr.TestName), tr.LineNum)
 	default:
 		if tr.RawLogURL != "" {
 			// Some test results may have internal URLs that are

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -138,7 +138,7 @@ func (tr TestResult) GetLogURL(env evergreen.Environment, viewer evergreen.LogVi
 			}
 		}
 
-		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, url.QueryEscape(tr.TaskID), tr.Execution, url.QueryEscape(tr.TestName), tr.LineNum)
+		return fmt.Sprintf("%s/test/%s/%d/%s?shareLine=%d", parsleyURL, url.PathEscape(tr.TaskID), tr.Execution, url.QueryEscape(tr.TestName), tr.LineNum)
 	default:
 		if tr.RawLogURL != "" {
 			// Some test results may have internal URLs that are


### PR DESCRIPTION
EVG-20455

### Description
This updates the test result's Parsley log URL generation to use the unique test name instead of the log test name after [EVG-20443](https://jira.mongodb.org/browse/EVG-20443). I also added url encoding to be safe.

### Testing
Tested in staging against Parsley.

### Documentation
N/A