### PR TITLE
EVG-19601: allow subprocess.exec binary to search command PATH

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -297,6 +297,8 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 		return "", err
 	}
 
+	logger.Execution().Debug("could not find executable binary in the default runtime environment PATH, falling back to trying the command's PATH")
+
 	originalPath := os.Getenv("PATH")
 	defer func() {
 		// Try to reset the PATH back to its original state. If this fails, then

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -292,7 +292,12 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 		return defaultPath, err
 	}
 
+	// For non-Windows platforms, the filepath.Separator is always '/'. However,
+	// for Windows, Go accepts both '\' and '/' as valid file path separators,
+	// even though the native filepath.Separator for Windows is really '\'. This
+	// detects both '\' and '/' as valid Windows file path separators.
 	binaryIsFilePath := strings.Contains(c.Binary, string(filepath.Separator)) || runtime.GOOS == "windows" && strings.Contains(c.Binary, "/")
+
 	if len(cmdPath) == 0 || binaryIsFilePath {
 		return "", err
 	}

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -168,10 +168,13 @@ func defaultAndApplyExpansionsToEnv(env map[string]string, opts modifyEnvOptions
 	}
 
 	if len(opts.addToPath) > 0 {
-		// Prepend paths to the agent process's PATH. More reasonable behavior
-		// here would be to respect the PATH env var if it's explicitly set, but
-		// changing this could break existing workflows, so we don't do that.
-		path := append(opts.addToPath, os.Getenv("PATH"))
+		// Prepend paths to the runtime environment's PATH. More reasonable
+		// behavior here would be to respect the PATH env var if it's explicitly
+		// set for the command, but changing this could break existing
+		// workflows, so we don't do that.
+		path := make([]string, 0, len(opts.addToPath)+1)
+		path = append(path, opts.addToPath...)
+		path = append(path, os.Getenv("PATH"))
 		env["PATH"] = strings.Join(path, string(filepath.ListSeparator))
 	}
 

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -316,7 +316,7 @@ func (s *execCmdSuite) TestCommandFailsForExecutableNotFound() {
 	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should not be able to run because executable does not exist in PATH")
 }
 
-func (s *execCmdSuite) TestCommandFallsBackToSearchingPathFromEnvForExecutable() {
+func (s *execCmdSuite) TestCommandFallsBackToSearchingPathFromEnvForBinaryExecutable() {
 	executableName := "evergreen"
 	if runtime.GOOS == "windows" {
 		executableName = executableName + ".exe"
@@ -333,7 +333,7 @@ func (s *execCmdSuite) TestCommandFallsBackToSearchingPathFromEnvForExecutable()
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should be able to run locally compiled evergreen executable from PATH")
 }
 
-func (s *execCmdSuite) TestCommandDoesNotFallBackToSearchingPathFromEnvForExecutableFilePath() {
+func (s *execCmdSuite) TestCommandDoesNotFallBackToSearchingPathFromEnvWhenBinaryExecutableIsAFilePath() {
 	executableName := "./evergreen"
 	if runtime.GOOS == "windows" {
 		executableName = executableName + ".exe"

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,7 +116,6 @@ func (s *execCmdSuite) TestWeirdAndBadExpansions() {
 	s.Equal("baf}}r", cmd.Binary)
 	s.Equal("a", cmd.Args[0])
 	s.Equal("b", cmd.Args[1])
-
 }
 
 func (s *execCmdSuite) TestParseParamsInitializesEnvMap() {
@@ -177,7 +177,7 @@ func (s *execCmdSuite) TestRunCommand() {
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	exec := cmd.getProc(s.ctx, "foo", s.logger)
+	exec := cmd.getProc(s.ctx, cmd.Binary, "foo", s.logger)
 	s.NoError(cmd.runCommand(s.ctx, "foo", exec, s.logger))
 }
 
@@ -187,7 +187,7 @@ func (s *execCmdSuite) TestRunCommandPropagatesError() {
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	exec := cmd.getProc(s.ctx, "foo", s.logger)
+	exec := cmd.getProc(s.ctx, cmd.Binary, "foo", s.logger)
 	err := cmd.runCommand(s.ctx, "foo", exec, s.logger)
 	s.Require().NotNil(err)
 	s.Contains(err.Error(), "process encountered problem: exit code 1")
@@ -201,7 +201,7 @@ func (s *execCmdSuite) TestRunCommandContinueOnErrorNoError() {
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	exec := cmd.getProc(s.ctx, "foo", s.logger)
+	exec := cmd.getProc(s.ctx, cmd.Binary, "foo", s.logger)
 	s.NoError(cmd.runCommand(s.ctx, "foo", exec, s.logger))
 }
 
@@ -213,13 +213,13 @@ func (s *execCmdSuite) TestRunCommandBackgroundAlwaysNil() {
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.NoError(cmd.ParseParams(map[string]interface{}{}))
-	exec := cmd.getProc(s.ctx, "foo", s.logger)
+	exec := cmd.getProc(s.ctx, cmd.Binary, "foo", s.logger)
 	s.NoError(cmd.runCommand(s.ctx, "foo", exec, s.logger))
 }
 
 func (s *execCmdSuite) TestCommandFailsWithoutWorkingDirectorySet() {
-	// this is a situation that won't happen in production code,
-	// but should happen logicaly, but means if you don't specify
+	// This is a situation that won't happen in production code,
+	// but should happen logically, but means if you don't specify
 	// a directory and there's not one configured on the distro,
 	// then you're in trouble.
 	cmd := &subprocessExec{
@@ -304,40 +304,7 @@ func (s *execCmdSuite) TestKeepEmptyArgs() {
 	s.Len(cmd.Args, 2)
 }
 
-func (s *execCmdSuite) TestPathSetting() {
-	cmd := &subprocessExec{
-		// just set up enough so that we don't fail parse params
-		Env:        map[string]string{},
-		WorkingDir: testutil.GetDirectoryOfFile(),
-		Path:       []string{"foo", "bar"},
-	}
-	exp := util.NewExpansions(map[string]string{})
-	s.Len(cmd.Env, 0)
-	s.NoError(cmd.doExpansions(exp))
-	s.Len(cmd.Env, 1)
-
-	path, ok := cmd.Env["PATH"]
-	s.True(ok)
-	s.Len(filepath.SplitList(path), len(filepath.SplitList(os.Getenv("PATH")))+2)
-}
-
-func (s *execCmdSuite) TestNoPathSetting() {
-	cmd := &subprocessExec{
-		// just set up enough so that we don't fail parse params
-		Env:        map[string]string{},
-		WorkingDir: testutil.GetDirectoryOfFile(),
-	}
-	exp := util.NewExpansions(map[string]string{})
-	s.Len(cmd.Env, 0)
-	s.NoError(cmd.doExpansions(exp))
-	s.Len(cmd.Env, 0)
-
-	path, ok := cmd.Env["PATH"]
-	s.False(ok)
-	s.Zero(path)
-}
-
-func (s *execCmdSuite) TestExpansionsEnvOptionDisabled() {
+func (s *execCmdSuite) TestExpansionsForEnv() {
 	cmd := &subprocessExec{
 		Env:        map[string]string{},
 		WorkingDir: testutil.GetDirectoryOfFile(),
@@ -350,6 +317,17 @@ func (s *execCmdSuite) TestExpansionsEnvOptionDisabled() {
 	s.Len(cmd.Env, 1)
 	s.NotEqual("two", cmd.Env["two"])
 	s.Equal("one", cmd.Env["one"])
+}
+
+func (s *execCmdSuite) TestExpansionsForPath() {
+	cmd := &subprocessExec{
+		Path:       []string{"${my_path}", "another_path"},
+		WorkingDir: testutil.GetDirectoryOfFile(),
+	}
+
+	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{"my_path": "/my/expanded/path"})))
+	s.Require().Len(cmd.Path, 2)
+	s.Equal([]string{"/my/expanded/path", "another_path"}, cmd.Path)
 }
 
 func (s *execCmdSuite) TestEnvIsSetAndDefaulted() {
@@ -438,6 +416,14 @@ func TestAddTemp(t *testing.T) {
 
 func TestDefaultAndApplyExpansionsToEnv(t *testing.T) {
 	for testName, testCase := range map[string]func(t *testing.T, exp util.Expansions){
+		"NoOptionsSetsExpectedDefaults": func(t *testing.T, exp util.Expansions) {
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, modifyEnvOptions{})
+			for _, key := range []string{"GOCACHE", "CI", "TEMP", "TMPDIR", "TMP"} {
+				_, ok := env[key]
+				assert.True(t, ok, "expected default env var '%s' not set", key)
+			}
+			assert.Zero(t, env["PATH"], "PATH should not be set by default")
+		},
 		"SetsDefaultAndRequiredEnvWhenStandardValuesAreGiven": func(t *testing.T, exp util.Expansions) {
 			opts := modifyEnvOptions{
 				taskID:     "task_id",
@@ -476,7 +462,7 @@ func TestDefaultAndApplyExpansionsToEnv(t *testing.T) {
 			assert.Equal(t, strconv.Itoa(os.Getpid()), env[agentutil.MarkerAgentPID])
 			assert.Equal(t, opts.taskID, env[agentutil.MarkerTaskID])
 		},
-		"ExplicitlySetEnVVarsOverrideDefaultEnvVars": func(t *testing.T, exp util.Expansions) {
+		"ExplicitlySetEnvVarsOverrideDefaultEnvVars": func(t *testing.T, exp util.Expansions) {
 			gocache := "/path/to/gocache"
 			ci := "definitely not Jenkins"
 			tmpDir := "/some/tmpdir"
@@ -600,6 +586,28 @@ func TestDefaultAndApplyExpansionsToEnv(t *testing.T) {
 			for _, expName := range include {
 				assert.NotContains(t, env, expName)
 			}
+		},
+		"AddToPathPrependsToInheritedPATH": func(t *testing.T, exp util.Expansions) {
+			opts := modifyEnvOptions{
+				addToPath: []string{"foo", "bar"},
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{}, opts)
+
+			inheritedPath := os.Getenv("PATH")
+			path := env["PATH"]
+			assert.NotEmpty(t, path)
+			assert.Len(t, filepath.SplitList(path), len(filepath.SplitList(inheritedPath))+len(opts.addToPath))
+		},
+		"AddToPathOverwritesExplicitPATHEnvVar": func(t *testing.T, exp util.Expansions) {
+			const expectedPath = "overwrite_the_path_with_this"
+			opts := modifyEnvOptions{
+				addToPath: []string{expectedPath},
+			}
+			env := defaultAndApplyExpansionsToEnv(map[string]string{"PATH": "some_path_to_overwrite"}, opts)
+			path := env["PATH"]
+			assert.True(t, strings.HasPrefix(path, expectedPath), "expected path to add should appear and should be prepended to path")
+			assert.True(t, strings.HasSuffix(path, os.Getenv("PATH")), "path should be inherited from current process")
+			assert.NotContains(t, path, "some_path_to_overwrite", "add_to_path ignores explicit PATH env var")
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -136,15 +136,11 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		logger.Execution().Notice(errors.Wrap(err, "getting task temporary directory"))
 	}
 
-	var exp util.Expansions
-	if conf.Expansions != nil {
-		exp = *conf.Expansions
-	}
 	c.Env = defaultAndApplyExpansionsToEnv(c.Env, modifyEnvOptions{
 		taskID:                 conf.Task.Id,
 		workingDir:             c.WorkingDir,
 		tmpDir:                 taskTmpDir,
-		expansions:             exp,
+		expansions:             *conf.Expansions,
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
 	})

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-07-28"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-01-B"
+	AgentVersion = "2023-08-02"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1080,7 +1080,7 @@ Parameters:
 
 -   `binary`: a binary to run
 -   `args`: a list of arguments to the binary
--   `env`: a map of environment variables and their values.  In case of
+-   `env`: a map of environment variables and their values. In case of
     conflicting environment variables defined by `add_expansions_to_env` or
     `include_expansions_in_env`, this has the lowest priority. Unless
     overridden, the following environment variables will be set by default:
@@ -1118,8 +1118,24 @@ Parameters:
     not exist, it is ignored. In case of conflicting environment variables
     defined by `env` or `add_expansions_to_env`, this has highest
     priority.
--   `add_to_path`: specify one or more paths which are prepended to the
-    `PATH` environment variable.
+-   `add_to_path`: specify one or more paths to prepend to the command `PATH`,
+    which has the following effects:
+    - If `PATH` is explicitly set in `env`, that `PATH` is ignored.
+    - The command automatically inherits the runtime environment's `PATH`
+      environment variable. Then, any paths specified in `add_to_path` are
+      prepended in the given order.
+    - This can be used to specify fallback paths to search for the `binary`
+      executable (see [PATH special case](#path-environment-variable-special-case)).
+
+### PATH Environment Variable Special Case
+The `PATH` environment variable (specified either via explicitly setting `PATH`
+in `env` or via `add_to_path`) is a special variable that has two effects:
+
+- It sets the `PATH` environment variable for the command that runs.
+- It adds fallback paths to search for the command's `binary`. If the `binary`
+  is not found in the default runtime environment's `PATH`, it will try
+  searching for a matching executable `binary` in any of the paths in
+  `add_to_path` or in the `PATH` specified in `env`.
 
 ## timeout.update
 

--- a/makefile
+++ b/makefile
@@ -315,7 +315,7 @@ html-coverage-%:$(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
 lint-%:$(buildDir)/output.%.lint
 	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
+# end convenience targets
 
 
 # start test and coverage artifacts
@@ -362,6 +362,9 @@ $(buildDir)/output.%.test: .FORCE
 # Codegen is special because it requires that the repository be compiled for goimports to resolve imports properly.
 $(buildDir)/output.cmd-codegen-core.test: build-codegen .FORCE
 	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) 2>&1 | tee $@
+# test-agent-command is special because it requires that the Evergreen binary be compiled to run some of the tests.
+$(buildDir)/output.agent-command.test: build .FORCE
+	$(testRunEnv) $(gobin) test $(testArgs) ./agent/command 2>&1 | tee $@
 $(buildDir)/output-dlv.%.test: .FORCE
 	$(testRunEnv) dlv test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -- $(dlvArgs) 2>&1 | tee $@
 $(buildDir)/output.%.coverage: .FORCE


### PR DESCRIPTION
EVG-19601

### Description
* Extend the places where `subprocess.exec` can search for a `binary` to run. First, try finding binary to run for `subprocess.exec` from either the agent's `PATH` (i.e. the current behavior), then fall back to searching the command's `PATH` (if any).
* Slightly refactor how `env` is handled for `PATH`. (No behavioral change, just reorganization)

### Testing
* Added unit tests.
* Tested in staging that `subprocess.exec` behaved the same as it did before when no `PATH` is given, but additionally searches the command `PATH` for matching executables.

### Documentation
Updated docs for `subprocess.exec` and its special interaction with `PATH`. I also improved docs for how `add_to_path` actually works.