### PR TITLE
EVG-20087: set container task first scheduled time

### DIFF
--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -158,9 +158,8 @@ func (q *ContainerTaskQueue) getProjectRefs(tasks []task.Task) (map[string]Proje
 func (q *ContainerTaskQueue) setFirstScheduledTime(scheduledTime time.Time) {
 	var notScheduledBefore []task.Task
 	for i := range q.queue {
-		t := q.queue[i]
-		if utility.IsZeroTime(t.ScheduledTime) {
-			notScheduledBefore = append(notScheduledBefore, t)
+		if utility.IsZeroTime(q.queue[i].ScheduledTime) {
+			notScheduledBefore = append(notScheduledBefore, q.queue[i])
 		}
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1230,6 +1230,7 @@ func (t *Task) SetGeneratedTasksToActivate(buildVariantName, taskName string) er
 func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	ids := []string{}
 	for i := range tasks {
+		tasks[i].ScheduledTime = scheduledTime
 		ids = append(ids, tasks[i].Id)
 
 		// Display tasks are considered scheduled when their first exec task is scheduled

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1230,7 +1230,6 @@ func (t *Task) SetGeneratedTasksToActivate(buildVariantName, taskName string) er
 func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	ids := []string{}
 	for i := range tasks {
-		tasks[i].ScheduledTime = scheduledTime
 		ids = append(ids, tasks[i].Id)
 
 		// Display tasks are considered scheduled when their first exec task is scheduled


### PR DESCRIPTION
EVG-20087

### Description
Set first schedule time for container tasks. This is analogous to the host scheduler first schedule time.

### Testing
Added unit test.

### Documentation
N/A