### PR TITLE
EVG-20440 Move getNewTasksWithDependencies to its own function

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -31,8 +31,8 @@ type GeneratedProject struct {
 	TaskGroups    []parserTaskGroup          `yaml:"task_groups"`
 
 	Task           *task.Task
-	ActivationInfo specificActivationInfo
-	NewTVPairs     TaskVariantPairs
+	ActivationInfo *specificActivationInfo
+	NewTVPairs     *TaskVariantPairs
 }
 
 // MergeGeneratedProjects takes a slice of generated projects and returns a single, deduplicated project.
@@ -234,17 +234,18 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		buildSet[b.BuildVariant] = struct{}{}
 	}
 
+	newTVPairs, activationInfo := g.GetNewTasksAndActivationInfo(ctx, v, p)
 	// Group into new builds and new tasks for existing builds.
 	newTVPairsForExistingVariants := TaskVariantPairs{}
 	newTVPairsForNewVariants := TaskVariantPairs{}
-	for _, execTask := range g.NewTVPairs.ExecTasks {
+	for _, execTask := range newTVPairs.ExecTasks {
 		if _, ok := buildSet[execTask.Variant]; ok {
 			newTVPairsForExistingVariants.ExecTasks = append(newTVPairsForExistingVariants.ExecTasks, execTask)
 		} else {
 			newTVPairsForNewVariants.ExecTasks = append(newTVPairsForNewVariants.ExecTasks, execTask)
 		}
 	}
-	for _, dispTask := range g.NewTVPairs.DisplayTasks {
+	for _, dispTask := range newTVPairs.DisplayTasks {
 		if _, ok := buildSet[dispTask.Variant]; ok {
 			newTVPairsForExistingVariants.DisplayTasks = append(newTVPairsForExistingVariants.DisplayTasks, dispTask)
 		} else {
@@ -255,7 +256,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	// This will only be populated for patches, not mainline commits.
 	var syncAtEndOpts patch.SyncAtEndOptions
 	if patchDoc, _ := patch.FindOne(patch.ByVersion(v.Id)); patchDoc != nil {
-		if err = patchDoc.AddSyncVariantsTasks(g.NewTVPairs.TVPairsToVariantTasks()); err != nil {
+		if err = patchDoc.AddSyncVariantsTasks(newTVPairs.TVPairsToVariantTasks()); err != nil {
 			return errors.Wrap(err, "updating sync variants and tasks")
 		}
 		syncAtEndOpts = patchDoc.SyncAtEndOpts
@@ -273,7 +274,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 		ProjectRef:     projectRef,
 		Version:        v,
 		Pairs:          newTVPairsForExistingVariants,
-		ActivationInfo: g.ActivationInfo,
+		ActivationInfo: *activationInfo,
 		SyncAtEndOpts:  syncAtEndOpts,
 		GeneratedBy:    g.Task.Id,
 		// If the parent generator is required to finish, then its generated
@@ -299,13 +300,16 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, v *Version
 	return nil
 }
 
-// SetNewTasksAndActivationInfo sets the NewTVPairs and ActivationInfo fields on the generator.
-func (g *GeneratedProject) SetNewTasksAndActivationInfo(ctx context.Context, v *Version, p *Project) {
-	// Only consider batchtime for mainline builds. We should always respect activate if it is set.
+// GetNewTasksAndActivationInfo computes the NewTVPairs and ActivationInfo fields on the generator if they are nil.
+func (g *GeneratedProject) GetNewTasksAndActivationInfo(ctx context.Context, v *Version, p *Project) (*TaskVariantPairs, *specificActivationInfo) {
+	if g.NewTVPairs != nil && g.ActivationInfo != nil {
+		return g.NewTVPairs, g.ActivationInfo
+	}
 	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
 	newTasks := g.getNewTasksWithDependencies(ctx, v, p, &activationInfo)
-	g.NewTVPairs = newTasks
-	g.ActivationInfo = activationInfo
+	g.NewTVPairs = &newTasks
+	g.ActivationInfo = &activationInfo
+	return g.NewTVPairs, g.ActivationInfo
 }
 
 // CheckForCycles builds a dependency graph from the existing tasks in the version and simulates
@@ -334,19 +338,20 @@ func (g *GeneratedProject) CheckForCycles(ctx context.Context, v *Version, p *Pr
 // simulateNewTasks adds the tasks we're planning to add to the version to the graph and
 // adds simulated edges from each task that depends on the generator to each of the generated tasks.
 func (g *GeneratedProject) simulateNewTasks(ctx context.Context, graph task.DependencyGraph, v *Version, p *Project, projectRef *ProjectRef) (task.DependencyGraph, error) {
+	newTVPairs, _ := g.GetNewTasksAndActivationInfo(ctx, v, p)
 	creationInfo := TaskCreationInfo{
 		Project:    p,
 		ProjectRef: projectRef,
 		Version:    v,
-		Pairs:      g.NewTVPairs,
+		Pairs:      *newTVPairs,
 	}
 	taskIDs, err := getTaskIdTables(creationInfo)
 	if err != nil {
 		return graph, errors.Wrap(err, "getting task ids")
 	}
 
-	graph = addTasksToGraph(g.NewTVPairs.ExecTasks, graph, p, taskIDs)
-	return g.addDependencyEdgesToGraph(g.NewTVPairs.ExecTasks, v, p, graph, taskIDs)
+	graph = addTasksToGraph(newTVPairs.ExecTasks, graph, p, taskIDs)
+	return g.addDependencyEdgesToGraph(ctx, newTVPairs.ExecTasks, v, p, graph, taskIDs)
 }
 
 // getNewTasksWithDependencies returns the generated tasks and their recursive dependencies.
@@ -397,8 +402,8 @@ func addTasksToGraph(tasks TVPairSet, graph task.DependencyGraph, p *Project, ta
 }
 
 // addDependencyEdgesToGraph adds edges from the tasks that depend on the generator to activated generated tasks.
-func (g *GeneratedProject) addDependencyEdgesToGraph(newTasks TVPairSet, v *Version, p *Project, graph task.DependencyGraph, taskIDs TaskIdConfig) (task.DependencyGraph, error) {
-	activatedNewTasks, err := g.filterInactiveTasks(newTasks, v, p)
+func (g *GeneratedProject) addDependencyEdgesToGraph(ctx context.Context, newTasks TVPairSet, v *Version, p *Project, graph task.DependencyGraph, taskIDs TaskIdConfig) (task.DependencyGraph, error) {
+	activatedNewTasks, err := g.filterInactiveTasks(ctx, newTasks, v, p)
 	if err != nil {
 		return graph, errors.Wrap(err, "filtering inactive tasks")
 	}
@@ -417,8 +422,7 @@ func (g *GeneratedProject) addDependencyEdgesToGraph(newTasks TVPairSet, v *Vers
 }
 
 // filterInactiveTasks returns a copy of tasks with the tasks that will not be activated by the generator removed.
-func (g *GeneratedProject) filterInactiveTasks(tasks TVPairSet, v *Version, p *Project) (TVPairSet, error) {
-	activationInfo := g.findTasksAndVariantsWithSpecificActivations(v.Requester)
+func (g *GeneratedProject) filterInactiveTasks(ctx context.Context, tasks TVPairSet, v *Version, p *Project) (TVPairSet, error) {
 	existingBuilds, err := build.Find(build.ByVersion(v.Id))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding builds for version")
@@ -433,6 +437,7 @@ func (g *GeneratedProject) filterInactiveTasks(tasks TVPairSet, v *Version, p *P
 		buildSet[t.Variant] = append(buildSet[t.Variant], t.TaskName)
 	}
 
+	_, activationInfo := g.GetNewTasksAndActivationInfo(ctx, v, p)
 	activatedTasks := make(TVPairSet, 0, len(tasks))
 	for bv, tasks := range buildSet {
 		if existingBuildMap[bv] {
@@ -524,7 +529,7 @@ func (b *specificActivationInfo) taskOrVariantHasSpecificActivation(variant, tas
 func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester string) specificActivationInfo {
 	res := newSpecificActivationInfo()
 	for _, bv := range g.BuildVariants {
-		// Only consider batchtime for certain requesters
+		// Only consider batchtime for mainline builds. We should always respect activate if it is set.
 		if evergreen.ShouldConsiderBatchtime(requester) && bv.hasSpecificActivation() {
 			res.activationVariants = append(res.activationVariants, bv.name())
 		} else if bv.Activate != nil {

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -855,7 +855,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.Require().NoError(err)
-	g.SetNewTasksAndActivationInfo(ctx, v, p)
+	g.GetNewTasksAndActivationInfo(ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	// verify we stopped saving versions
@@ -974,7 +974,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	s.NoError(err)
 	s.Len(pp.UpdatedByGenerators, 1) // Not modified again.
 
-	g.SetNewTasksAndActivationInfo(ctx, v, p)
+	g.GetNewTasksAndActivationInfo(ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	tasks := []task.Task{}
@@ -1049,7 +1049,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.NoError(err)
-	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
+	g.GetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)
@@ -1157,7 +1157,7 @@ buildvariants:
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.NoError(err)
-	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
+	g.GetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	// the depended-on task is created in the existing variant
@@ -1210,7 +1210,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.Require().NoError(err)
-	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
+	g.GetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)
@@ -1373,7 +1373,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1403,7 +1403,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 			},
 		}
 
-		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1437,7 +1437,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1472,7 +1472,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 }
@@ -1493,7 +1493,7 @@ func TestFilterInactiveTasks(t *testing.T) {
 			Task: &task.Task{},
 		}
 
-		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
 		assert.NoError(t, err)
 		assert.Len(t, tasks, 1)
 	})
@@ -1512,7 +1512,7 @@ func TestFilterInactiveTasks(t *testing.T) {
 			Task: &task.Task{},
 		}
 
-		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
 		assert.NoError(t, err)
 		assert.Empty(t, tasks)
 	})
@@ -1544,7 +1544,7 @@ func TestFilterInactiveTasks(t *testing.T) {
 			},
 		}
 
-		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
+		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
 		assert.NoError(t, err)
 		assert.Len(t, tasks, 1)
 	})
@@ -1576,7 +1576,7 @@ func TestFilterInactiveTasks(t *testing.T) {
 			},
 		}
 
-		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
+		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
 		assert.NoError(t, err)
 		assert.Empty(t, tasks)
 	})
@@ -1597,7 +1597,7 @@ func TestFilterInactiveTasks(t *testing.T) {
 			Task: &task.Task{},
 		}
 
-		tasks, err := g.filterInactiveTasks(TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
+		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
 		assert.NoError(t, err)
 		assert.Empty(t, tasks)
 	})

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -855,6 +855,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasks() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.Require().NoError(err)
+	g.SetNewTasksAndActivationInfo(ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	// verify we stopped saving versions
@@ -973,6 +974,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	s.NoError(err)
 	s.Len(pp.UpdatedByGenerators, 1) // Not modified again.
 
+	g.SetNewTasksAndActivationInfo(ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	tasks := []task.Task{}
@@ -1047,6 +1049,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.NoError(err)
+	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)
@@ -1154,6 +1157,7 @@ buildvariants:
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.NoError(err)
+	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	// the depended-on task is created in the existing variant
@@ -1206,6 +1210,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.Require().NoError(err)
 	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
 	s.Require().NoError(err)
+	g.SetNewTasksAndActivationInfo(s.ctx, v, p)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	v, err = VersionFindOneId(v.Id)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1373,6 +1373,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
+		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1402,6 +1403,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 			},
 		}
 
+		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1435,6 +1437,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
+		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1469,6 +1472,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
+		g.SetNewTasksAndActivationInfo(context.Background(), v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 }

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1337,6 +1337,8 @@ func (s *GenerateSuite) TestMergeGeneratedProjectsWithNoTasks() {
 }
 
 func TestSimulateNewDependencyGraph(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	defer func() {
 		assert.NoError(t, db.Clear(task.Collection))
 	}()
@@ -1373,7 +1375,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(ctx, v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1403,7 +1405,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 			},
 		}
 
-		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(ctx, v, project)
 		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1437,7 +1439,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(ctx, v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
@@ -1472,7 +1474,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-		g.GetNewTasksAndActivationInfo(context.Background(), v, project)
+		g.GetNewTasksAndActivationInfo(ctx, v, project)
 		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 }

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -152,7 +152,6 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return j.handleError(errors.WithStack(err))
 	}
 
-	g.SetNewTasksAndActivationInfo(ctx, v, p)
 	if err := g.CheckForCycles(ctx, v, p, pref); err != nil {
 		return errors.Wrap(err, "checking new dependency graph for cycles")
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -152,6 +152,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return j.handleError(errors.WithStack(err))
 	}
 
+	g.SetNewTasksAndActivationInfo(ctx, v, p)
 	if err := g.CheckForCycles(ctx, v, p, pref); err != nil {
 		return errors.Wrap(err, "checking new dependency graph for cycles")
 	}


### PR DESCRIPTION
EVG-20440

### Description
Currently, the command runs `getNewTasksWithDependencies` twice: once when simulating dependencies to check for cycles, and another time when actually creating the generated tasks, with the only difference being that the latter call passes in the generator's activation info, which determines if tasks are created in an active or inactive state, but since that doesn't matter for computing dependency cycles, it's fine to consolidate the two calls.  For large JSONs, this step can take a solid chunk of time (~30 seconds or more), so running this function once and saving its output to the generator struct will speed things up.
### Testing
Created a dummy generated JSON in the sandbox project with ~20,000 tasks and 20 variants to emulate what server does. Honeycomb trace shows a reduction in execution time from 2 minutes to ~80 seconds (first spike is with change, second is without change):

![Screenshot 2023-08-04 at 4 08 23 PM](https://github.com/evergreen-ci/evergreen/assets/19805673/eaefba6a-7047-4d4b-a7d7-abc716aca55b)

[Trace with change
](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/pambB5RCdi6/trace/wpwt8yRAhPH?fields[]=c_name&fields[]=c_service.name&span=926bc920ee2817c7)

![image](https://github.com/evergreen-ci/evergreen/assets/19805673/30627434-894f-4c67-a834-1c10a1ebe13a)

[Trace without change](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/pambB5RCdi6/trace/t2dDUTmnnc6?fields[]=c_name&fields[]=c_service.name&span=ded0ab12fd66170d)

![image](https://github.com/evergreen-ci/evergreen/assets/19805673/a154ae15-7a53-4941-8c27-e53575b75657)

Inspecting these two links you can see that the reason the trace with the change is shorter is because the `get-new-tasks-with-dependencies` step doesn't run twice