### PR TITLE
EVG-20545: check raw patch before dereferencing in patch-file

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-07-28"
+	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-08-02"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -388,7 +388,7 @@ func PatchFile() cli.Command {
 				return err
 			}
 
-			if len(rp.RawModules) > 0 {
+			if rp != nil {
 				for _, module := range rp.RawModules {
 					moduleParams := UpdatePatchModuleParams{
 						patchID: newPatch.Id.Hex(),
@@ -403,6 +403,7 @@ func PatchFile() cli.Command {
 
 				}
 			}
+
 			return params.displayPatch(newPatch, conf.UIServerHost, false)
 		},
 	}


### PR DESCRIPTION
EVG-20545

### Description
Fix a panic in `evergreen patch-file` due to dereferencing a nil raw patch pointer. The raw patch are only available if we're submitting a patch from an existing patch ID, not if we're patching with a local diff file.

### Testing
Ran `evergreen patch-file` command and it no longer panics. This CLI command doesn't have any unit tests already, so I didn't think it was worth it to add.

### Documentation
N/A