### PR TITLE
EVG-19601: fix cross-compilation on Cygwin and file path handling

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -299,7 +299,7 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 	binaryIsFilePath := strings.Contains(c.Binary, string(filepath.Separator)) || runtime.GOOS == "windows" && strings.Contains(c.Binary, "/")
 
 	if len(cmdPath) == 0 || binaryIsFilePath {
-		return "", err
+		return defaultPath, err
 	}
 
 	logger.Execution().Debug("could not find executable binary in the default runtime environment PATH, falling back to trying the command's PATH")
@@ -318,7 +318,7 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 	}()
 
 	if err := os.Setenv("PATH", cmdPath); err != nil {
-		return "", errors.Wrap(err, "setting command's PATH to try fallback executable paths")
+		return defaultPath, errors.Wrap(err, "setting command's PATH to try fallback executable paths")
 	}
 
 	return exec.LookPath(c.Binary)

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -286,12 +286,12 @@ func (c *subprocessExec) getProc(ctx context.Context, execPath, taskID string, l
 // default PATH locations, the command will fall back to checking the command's
 // PATH environment variable for a matching executable location (if any).
 func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPath string, err error) {
-	cmdPath := c.Env["PATH"]
 	defaultPath, err := exec.LookPath(c.Binary)
 	if defaultPath != "" {
-		return defaultPath, err
+		return c.Binary, err
 	}
 
+	cmdPath := c.Env["PATH"]
 	// For non-Windows platforms, the filepath.Separator is always '/'. However,
 	// for Windows, Go accepts both '\' and '/' as valid file path separators,
 	// even though the native filepath.Separator for Windows is really '\'. This
@@ -299,7 +299,7 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 	binaryIsFilePath := strings.Contains(c.Binary, string(filepath.Separator)) || runtime.GOOS == "windows" && strings.Contains(c.Binary, "/")
 
 	if len(cmdPath) == 0 || binaryIsFilePath {
-		return defaultPath, err
+		return c.Binary, nil
 	}
 
 	logger.Execution().Debug("could not find executable binary in the default runtime environment PATH, falling back to trying the command's PATH")
@@ -318,7 +318,7 @@ func (c *subprocessExec) getExecutablePath(logger client.LoggerProducer) (absPat
 	}()
 
 	if err := os.Setenv("PATH", cmdPath); err != nil {
-		return defaultPath, errors.Wrap(err, "setting command's PATH to try fallback executable paths")
+		return c.Binary, errors.Wrap(err, "setting command's PATH to try fallback executable paths")
 	}
 
 	return exec.LookPath(c.Binary)

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -333,6 +333,23 @@ func (s *execCmdSuite) TestCommandFallsBackToSearchingPathFromEnvForBinaryExecut
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should be able to run locally compiled evergreen executable from PATH")
 }
 
+func (s *execCmdSuite) TestCommandUsesFilePathExecutable() {
+	executableName := "evergreen"
+	if runtime.GOOS == "windows" {
+		executableName = executableName + ".exe"
+	}
+	executablePath := filepath.Join(os.Getenv("EVGHOME"), "clients", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), executableName)
+	cmd := &subprocessExec{
+		// Set the command to point to the locally-compiled Evergreern binary so
+		// we can test executing it when it's not in the PATH by default.
+		Command:    executablePath,
+		WorkingDir: testutil.GetDirectoryOfFile(),
+	}
+	cmd.SetJasperManager(s.jasper)
+	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should be able to run locally compiled evergreen executable from PATH")
+}
+
 func (s *execCmdSuite) TestCommandDoesNotFallBackToSearchingPathFromEnvWhenBinaryExecutableIsAFilePath() {
 	executableName := "./evergreen"
 	if runtime.GOOS == "windows" {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-02"
+	AgentVersion = "2023-08-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1088,10 +1088,12 @@ Parameters:
     - "GOCACHE" will be set to `${workdir}/.gocache`.
     - "EVR_TASK_ID" will be set to the running task's ID.
     - "TMP", "TMPDIR", and "TEMP" will be set to `${workdir}/tmp`.
--   `command`: a command string (cannot use with `binary` or `args`),
-    split on spaces for use as arguments\--note that expansions will
-    *not* be split on spaces; each expansion represents its own
-    argument.
+-   `command`: a command string (cannot use with `binary` or `args`), split
+    according to shell rules for use as arguments.
+    - Note: Expansions will *not* be split on spaces; each expansion represents
+      its own argument.
+    - Note: on Windows, the shell splitting rules may not parse the command
+      string as desired (e.g. for Windows paths containing `\`).
 -   `background`: if set to true, the process runs in the background
     instead of the foreground. `subprocess.exec` starts the process but
     does not wait for the process to exit before running the next command. 

--- a/makefile
+++ b/makefile
@@ -39,10 +39,13 @@ endif
 
 ifeq ($(OS),Windows_NT)
 gobin := $(shell cygpath $(gobin))
+nativeGobin := $(shell cygpath -m $(gobin))
 goCache := $(shell cygpath -m $(goCache))
 goModCache := $(shell cygpath -m $(goModCache))
 lintCache := $(shell cygpath -m $(lintCache))
 export GOROOT := $(shell cygpath -m $(GOROOT))
+else
+nativeGobin := $(gobin)
 endif
 
 ifneq ($(goCache),$(GOCACHE))
@@ -120,7 +123,7 @@ endif
 cli:$(localClientBinary)
 clis:$(clientBinaries)
 $(clientBuildDir)/%/$(unixBinaryBasename) $(clientBuildDir)/%/$(windowsBinaryBasename):$(buildDir)/build-cross-compile $(srcFiles) go.mod go.sum
-	@./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -gcflags="$(gcFlags)" -goBinary="$(gobin)" -directory=$(clientBuildDir) -source=$(clientSource) -output=$@
+	./$(buildDir)/build-cross-compile -buildName=$* -ldflags="$(ldFlags)" -gcflags="$(gcFlags)" -goBinary="$(nativeGobin)" -directory=$(clientBuildDir) -source=$(clientSource) -output=$@
 # Targets to upload the CLI binaries to S3.
 $(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go
 	@$(gobin) build -o $@ $<


### PR DESCRIPTION
EVG-19601

### Description
Fixes two things, only one of which is actually directly due to the PR:
1. I noticed [the Windows build variant was failing to compile the Evergreen CLI](https://evergreen.mongodb.com/task_log_raw/evergreen_windows_test_agent_command_f6657e434aaabf8816f02ddc2f4f22a514930caa_23_08_04_20_30_08/2?type=T#L509), which is necessary for the agent command unit tests to test `subprocess.exec`. Unfortunately, it seems like Windows in Evergreen CI was having difficulty compiling because the Evergreen hosts run commands in Cygwin (which follows the Unix convention for file paths rather than Windows convention), but `build-cross-compile` only allows Windows executable paths, not Cygwin paths. I fixed it so that `build-cross-compile` uses the native Windows path to the Go binary, not the Cygwin path.
2. Fix an issue where if `subprocess.exec` is supplied a file path, it needs to use that file path instead of error.

### Testing
1. For the first issue, I ran [a patch build](https://spruce.mongodb.com/task/evergreen_windows_test_agent_command_patch_f6657e434aaabf8816f02ddc2f4f22a514930caa_64d105f4306615bc23e38d85_23_08_07_14_55_49/logs?execution=0) and it succeeded.
2. For the second issue, I wrote a unit test.

### Documentation
I updated the docs for `subprocess.exec`'s `command` field, to note that it may parse the string unexpectedly in Windows (e.g. it interprets a Windows file path containing `\` as a shell escape instead of a path).