### PR TITLE
EVG-20537: fix host.create Docker env vars and extra hosts

### DIFF
--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -153,6 +153,7 @@ func (s *createHostSuite) TestParamValidation() {
 	delete(s.params, "instance_type")
 	s.NoError(s.cmd.ParseParams(s.params))
 	err := s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
 	s.Contains(err.Error(), "must specify security group IDs if AMI is set")
 	s.Contains(err.Error(), "subnet ID must be set if AMI is set")
 	s.Contains(err.Error(), "instance type must be set if AMI is set")
@@ -176,13 +177,21 @@ func (s *createHostSuite) TestParamValidation() {
 	// verify errors for things controlled by the agent
 	s.params["num_hosts"] = "11"
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "num hosts must be between 1 and 10")
+	err = s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "num hosts must be between 1 and 10")
+
 	s.params["scope"] = "idk"
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "scope must be build or task")
+	err = s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "scope must be build or task")
+
 	s.params["timeout_teardown_secs"] = 55
 	s.NoError(s.cmd.ParseParams(s.params))
-	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "timeout teardown (seconds) must be between 60 and 604800")
+	err = s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "timeout teardown (seconds) must be between 60 and 604800")
 
 	// Validate num_hosts can be an int
 	s.params["timeout_teardown_secs"] = 60
@@ -195,19 +204,32 @@ func (s *createHostSuite) TestParamValidation() {
 	s.params["provider"] = apimodels.ProviderDocker
 	s.NoError(s.cmd.ParseParams(s.params))
 	s.params["distro"] = ""
-	settings, err := evergreen.GetConfig(ctx)
+	originalSettings, err := evergreen.GetConfig(ctx)
+	defer func() {
+		s.NoError(evergreen.UpdateConfig(ctx, originalSettings))
+	}()
 	s.NoError(err)
+	settings := *originalSettings
 	settings.Providers.Docker.DefaultDistro = "my-default-distro"
-	s.NoError(evergreen.UpdateConfig(ctx, settings))
+	s.NoError(evergreen.UpdateConfig(ctx, &settings))
 
-	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "Docker image must be set")
-	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "num hosts cannot be greater than 1")
+	err = s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "Docker image must be set")
+	s.Contains(err.Error(), "num hosts cannot be greater than 1")
+
 	s.params["image"] = "my-image"
 	s.params["command"] = "echo hi"
 	s.params["num_hosts"] = 1
 	s.params["distro"] = "my-default-distro"
 	s.NoError(s.cmd.ParseParams(s.params))
 	s.NoError(s.cmd.expandAndValidate(ctx, s.conf))
+
+	s.params["extra_hosts"] = []string{"invalid extra host"}
+	s.NoError(s.cmd.ParseParams(s.params))
+	err = s.cmd.expandAndValidate(ctx, s.conf)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "extra host")
 }
 
 func (s *createHostSuite) TestPopulateUserdata() {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -166,7 +166,7 @@ type CreateHost struct {
 	PollFrequency            int               `mapstructure:"poll_frequency_secs" json:"poll_frequency_secs" yaml:"poll_frequency_secs"` // poll frequency in seconds
 	StdoutFile               string            `mapstructure:"stdout_file_name" json:"stdout_file_name" yaml:"stdout_file_name" plugin:"expand"`
 	StderrFile               string            `mapstructure:"stderr_file_name" json:"stderr_file_name" yaml:"stderr_file_name" plugin:"expand"`
-	EnvironmentVars          map[string]string `mapstructure:"environment_vars" json:"environment_vars" yaml:"environment_vars" plugin:"environment_vars"`
+	EnvironmentVars          map[string]string `mapstructure:"environment_vars" json:"environment_vars" yaml:"environment_vars" plugin:"expand"`
 }
 
 type EbsDevice struct {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -167,6 +167,7 @@ type CreateHost struct {
 	StdoutFile               string            `mapstructure:"stdout_file_name" json:"stdout_file_name" yaml:"stdout_file_name" plugin:"expand"`
 	StderrFile               string            `mapstructure:"stderr_file_name" json:"stderr_file_name" yaml:"stderr_file_name" plugin:"expand"`
 	EnvironmentVars          map[string]string `mapstructure:"environment_vars" json:"environment_vars" yaml:"environment_vars" plugin:"expand"`
+	ExtraHosts               []string          `mapstructure:"extra_hosts" json:"extra_hosts" yaml:"extra_hosts" plugin:"expand"`
 }
 
 type EbsDevice struct {

--- a/cloud/docker_test.go
+++ b/cloud/docker_test.go
@@ -158,16 +158,6 @@ func (s *DockerSuite) TestSpawnInvalidSettings() {
 	s.Error(err)
 	s.Contains(err.Error(), "image must not be empty")
 	s.Nil(h)
-
-	emptyHostOpts.DockerOptions.Image = "my image"
-	emptyHostOpts.DockerOptions.ExtraHosts = []string{"invalid format", "also:so:invalid"}
-	h = host.NewIntent(emptyHostOpts)
-	h, err = s.manager.SpawnHost(ctx, h)
-	s.Error(err)
-	s.Contains(err.Error(), "invalid format")
-	s.Contains(err.Error(), "also:so:invalid")
-	s.NotContains(err.Error(), "Image")
-	s.Nil(h)
 }
 
 func (s *DockerSuite) TestSpawnDuplicateHostID() {

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -483,6 +483,8 @@ Docker Parameters:
     interval. Must be \<= 60 (1 second). Default to 30.
 -   `publish_ports` - Set to make ports available by mapping container
     ports to ports on the Docker host. Default is false.
+-   `extra_hosts` - Optional. This is a list of hosts to be added to
+    /etc/hosts on the container (each should be of the form
     hostname:IP).
 -   `registry_name` - The registry from which to pull/import the image.
     Defaults to Dockerhub.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -483,8 +483,6 @@ Docker Parameters:
     interval. Must be \<= 60 (1 second). Default to 30.
 -   `publish_ports` - Set to make ports available by mapping container
     ports to ports on the Docker host. Default is false.
--   `extra_hosts` - Optional. This is a list of hosts to be added to
-    /etc/hosts on the container (each should be of the form
     hostname:IP).
 -   `registry_name` - The registry from which to pull/import the image.
     Defaults to Dockerhub.
@@ -496,6 +494,8 @@ Docker Parameters:
     container. Default is \<container_id\>.out.log.
 -   `stderr_file_name` - The file path to write stderr logs from the
     container. Default is \<container_id\>.err.log.
+-   `environment_vars` - Environment variables to pass to the container command.
+    By default, no environment variables are passed.
 
 ### Required IAM Policies for `host.create`
 

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -58,14 +58,25 @@ func (e *Environment) Configure(ctx context.Context) error {
 
 	e.EvergreenSettings = testutil.TestConfig()
 
-	e.Remote = queue.NewLocalLimitedSize(2, 1048)
+	e.Remote = queue.NewLocalLimitedSize(2, 1024)
 	if err := e.Remote.Start(ctx); err != nil {
 		return errors.WithStack(err)
 	}
-	e.Local = queue.NewLocalLimitedSize(2, 1048)
+	e.Local = queue.NewLocalLimitedSize(2, 1024)
 	if err := e.Local.Start(ctx); err != nil {
 		return errors.WithStack(err)
 	}
+	qg, err := queue.NewLocalQueueGroup(ctx, queue.LocalQueueGroupOptions{
+		DefaultQueue: queue.LocalQueueOptions{
+			Constructor: func(ctx context.Context) (amboy.Queue, error) {
+				return queue.NewLocalLimitedSize(2, 1024), nil
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	e.RemoteGroup = qg
 
 	e.InternalSender = send.MakeInternalLogger()
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -262,10 +262,6 @@ func (opts *DockerOptions) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.ErrorfWhen(opts.Image == "", "image must not be empty")
 
-	for _, h := range opts.ExtraHosts {
-		catcher.ErrorfWhen(len(strings.Split(h, ":")) != 2, "extra host '%s' must be of the form hostname:IP", h)
-	}
-
 	return catcher.Resolve()
 }
 

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -312,6 +312,7 @@ func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID
 		Method:           method,
 		SkipImageBuild:   true,
 		EnvironmentVars:  envVars,
+		ExtraHosts:       createHost.ExtraHosts,
 	}
 
 	containerPool := env.Settings().ContainerPools.GetContainerPool(d.ContainerPool)

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -24,10 +24,11 @@ func makeGenerateTasksHandler() gimlet.RouteHandler {
 type generateHandler struct {
 	files  []json.RawMessage
 	taskID string
+	env    evergreen.Environment
 }
 
 func (h *generateHandler) Factory() gimlet.RouteHandler {
-	return &generateHandler{}
+	return &generateHandler{env: h.env}
 }
 
 func (h *generateHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -58,7 +59,7 @@ func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("task '%s' not found", h.taskID))
 	}
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	j, err := units.CreateAndEnqueueGenerateTasks(ctx, evergreen.GetEnvironment(), *t, ts)
+	j, err := units.CreateAndEnqueueGenerateTasks(ctx, h.env, *t, ts)
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "could not enqueue generate tasks job",
 		"version": t.Version,

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
@@ -59,13 +59,15 @@ func TestGenerateExecute(t *testing.T) {
 		Id:      "task1",
 		Version: "version1",
 	}
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 	require.NoError(t, task1.Insert())
-	h := &generateHandler{}
+	h := &generateHandler{env: env}
 	h.taskID = "task1"
 	r := h.Run(ctx)
 	assert.Equal(t, r.Data(), struct{}{})
 	assert.Equal(t, r.Status(), http.StatusOK)
-	queue, err := evergreen.GetEnvironment().RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", task1.Version))
+	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", task1.Version))
 	require.NoError(t, err)
 	stats := queue.Stats(ctx)
 	assert.Equal(t, 1, stats.Total)


### PR DESCRIPTION
EVG-20537

### Description
* Fix host.create env var struct tag. Expansions only allow the `plugin:"expand"` to expand values.
* Fix issue where documented `extra_hosts` parameter didn't do anything because it wasn't part of the `host.create` REST parameters.
* Fix an unrelated `generate.tasks` test that I noticed is using the global remote queue group, which modifies global state and makes it difficult to re-run tests.

### Testing
Added unit tests.

### Documentation
Added documentation for host.create env vars for Docker.