### PR TITLE
EVG-20017: pass through bucket config in agent setup

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -110,6 +110,7 @@ type AgentSetupData struct {
 	SplunkServerURL        string                  `json:"splunk_server_url"`
 	SplunkClientToken      string                  `json:"splunk_client_token"`
 	SplunkChannel          string                  `json:"splunk_channel"`
+	Buckets                evergreen.BucketConfig  `json:"buckets"`
 	TaskSync               evergreen.S3Credentials `json:"task_sync"`
 	EC2Keys                []evergreen.EC2Key      `json:"ec2_keys"`
 	TraceCollectorEndpoint string                  `json:"trace_collector_endpoint"`

--- a/model/log/sender.go
+++ b/model/log/sender.go
@@ -26,6 +26,8 @@ type LoggerOptions struct {
 	LogName string
 	// Parse is the function for parsing raw log lines collected by the
 	// sender.
+	// The injectable line parser allows the sender to be agnostic to the
+	// raw log line formats it ingests.
 	Parse LineParser
 	// Local is the sender for "fallback" operations and to collect any
 	// logger error output.

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -111,6 +111,7 @@ func (h *agentSetup) Run(ctx context.Context) gimlet.Responder {
 		SplunkServerURL:   h.settings.Splunk.SplunkConnectionInfo.ServerURL,
 		SplunkClientToken: h.settings.Splunk.SplunkConnectionInfo.Token,
 		SplunkChannel:     h.settings.Splunk.SplunkConnectionInfo.Channel,
+		Buckets:           h.settings.Buckets,
 		TaskSync:          h.settings.Providers.AWS.TaskSync,
 		EC2Keys:           h.settings.Providers.AWS.EC2Keys,
 	}

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -298,6 +298,9 @@ func TestAgentSetup(t *testing.T) {
 			assert.Equal(t, data.SplunkServerURL, s.Splunk.SplunkConnectionInfo.ServerURL)
 			assert.Equal(t, data.SplunkClientToken, s.Splunk.SplunkConnectionInfo.Token)
 			assert.Equal(t, data.SplunkChannel, s.Splunk.SplunkConnectionInfo.Channel)
+			assert.Equal(t, data.Buckets, s.Buckets)
+			assert.Equal(t, data.TaskSync, s.Providers.AWS.TaskSync)
+			assert.Equal(t, data.EC2Keys, s.Providers.AWS.EC2Keys)
 		},
 		"ReturnsEmpty": func(ctx context.Context, t *testing.T, rh *agentSetup, s *evergreen.Settings) {
 			*s = evergreen.Settings{}
@@ -315,6 +318,12 @@ func TestAgentSetup(t *testing.T) {
 			defer cancel()
 
 			s := &evergreen.Settings{
+				Buckets: evergreen.BucketConfig{
+					LogBucket: evergreen.Bucket{
+						Name: "logs",
+						Type: evergreen.BucketTypeS3,
+					},
+				},
 				Splunk: evergreen.SplunkConfig{
 					SplunkConnectionInfo: send.SplunkConnectionInfo{
 						ServerURL: "server_url",
@@ -328,6 +337,14 @@ func TestAgentSetup(t *testing.T) {
 							Bucket: "bucket",
 							Key:    "key",
 							Secret: "secret",
+						},
+						EC2Keys: []evergreen.EC2Key{
+							{
+								Name:   "ec2-key",
+								Region: "us-east-1",
+								Key:    "key",
+								Secret: "secret",
+							},
 						},
 					},
 				},


### PR DESCRIPTION
EVG-20017

### Description
This passes through the admin bucket config settings for agent setup to enable the new bucket logging directly from the agent. The agent will use existing S3 keys for auth or, more idealistically, some instance role permission.

### Testing
Updated the unit tests for the agent setup route.

### Documentation
N/A
