### PR TITLE
EVG-20597 Only process one GitHub webhook event depending on app settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -537,8 +537,8 @@ type githubAppAuth struct {
 	privateKey []byte
 }
 
-// getGithubAppAuth returns app id and app private key if it exists.
-func (s *Settings) getGithubAppAuth() *githubAppAuth {
+// GetGithubAppAuth returns app id and app private key if it exists.
+func (s *Settings) GetGithubAppAuth() *githubAppAuth {
 	if s.AuthConfig.Github == nil || s.AuthConfig.Github.AppId == 0 {
 		return nil
 	}
@@ -560,7 +560,7 @@ func (s *Settings) CreateInstallationToken(ctx context.Context, owner, repo stri
 	if owner == "" || repo == "" {
 		return "", errors.New("no owner/repo specified to create installation token")
 	}
-	authFields := s.getGithubAppAuth()
+	authFields := s.GetGithubAppAuth()
 	if authFields == nil {
 		// TODO EVG-19966: Return error here
 		grip.Debug(message.Fields{

--- a/config_auth.go
+++ b/config_auth.go
@@ -192,10 +192,6 @@ func (c *AuthConfig) ValidateAndDefault() error {
 		}
 	}
 
-	if c.Github != nil && c.Github.AppId == 0 && c.Github.Users == nil && c.Github.Organization == "" {
-		catcher.New("must specify either a set of users or an organization or an app id for GitHub authentication")
-	}
-
 	if c.Multi != nil {
 		seen := map[string]bool{}
 		kinds := append([]string{}, c.Multi.ReadWrite...)

--- a/config_test.go
+++ b/config_test.go
@@ -84,17 +84,17 @@ func TestGetGithubSettings(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(settings.Credentials["github"], tokens[0])
 
-	authFields := settings.getGithubAppAuth()
+	authFields := settings.GetGithubAppAuth()
 	assert.Nil(authFields)
 
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 1234,
 	}
-	authFields = settings.getGithubAppAuth()
+	authFields = settings.GetGithubAppAuth()
 	assert.Nil(authFields)
 
 	settings.Expansions[githubAppPrivateKey] = "key"
-	authFields = settings.getGithubAppAuth()
+	authFields = settings.GetGithubAppAuth()
 	assert.NotNil(authFields)
 	assert.Equal(int64(1234), authFields.AppId)
 	assert.Equal([]byte("key"), authFields.privateKey)

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -281,7 +281,7 @@ func (s *PatchConnectorAbortByIdSuite) SetupSuite() {
 	var err error
 	s.prBody, err = os.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "..", "route", "testdata", "pull_request.json"))
 	s.NoError(err)
-	s.Len(s.prBody, 24731)
+	s.Len(s.prBody, 24692)
 }
 
 func (s *PatchConnectorAbortByIdSuite) TearDownSuite() {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -102,10 +102,12 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
+	hasApp := gh.settings.GetGithubAppAuth() != nil
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		if event.HookID == nil {
@@ -123,7 +125,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.PullRequestEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		if event.Action == nil {
@@ -191,7 +194,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 	case *github.PushEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		grip.Debug(message.Fields{
@@ -216,7 +220,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.IssueCommentEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		if err := gh.handleComment(ctx, event); err != nil {
@@ -225,7 +230,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MetaEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		if event.GetAction() == "deleted" {
@@ -248,7 +254,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MergeGroupEvent:
 		// Ignore events from GitHub app if app is not set up.
-		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+		// If the app is set up, ignore events from repo webhooks.
+		if (event.GetInstallation() != nil) != hasApp {
 			break
 		}
 		return gh.handleMergeGroupEvent(event)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -104,6 +104,10 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		if event.HookID == nil {
 			return gimlet.NewJSONErrorResponse(gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
@@ -118,6 +122,10 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		})
 
 	case *github.PullRequestEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		if event.Action == nil {
 			err := gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,
@@ -182,6 +190,10 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.NewJSONResponse(struct{}{})
 		}
 	case *github.PushEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		grip.Debug(message.Fields{
 			"source":     "GitHub hook",
 			"msg_id":     gh.msgID,
@@ -203,11 +215,19 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 
 	case *github.IssueCommentEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		if err := gh.handleComment(ctx, event); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
 
 	case *github.MetaEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		if event.GetAction() == "deleted" {
 			hookID := event.GetHookID()
 			if hookID == 0 {
@@ -227,6 +247,10 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 
 	case *github.MergeGroupEvent:
+		// Ignore events from GitHub app if app is not set up.
+		if event.GetInstallation() != nil && gh.settings.GetGithubAppAuth() == nil {
+			break
+		}
 		return gh.handleMergeGroupEvent(event)
 	}
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -106,8 +106,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		if event.HookID == nil {
@@ -125,8 +125,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.PullRequestEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		if event.Action == nil {
@@ -194,8 +194,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 	case *github.PushEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		grip.Debug(message.Fields{
@@ -220,8 +220,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.IssueCommentEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		if err := gh.handleComment(ctx, event); err != nil {
@@ -230,8 +230,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MetaEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		if event.GetAction() == "deleted" {
@@ -254,8 +254,8 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MergeGroupEvent:
 		// Ignore events from GitHub app if app is not set up.
-		// If the app is set up, ignore events from repo webhooks.
-		if (event.GetInstallation() != nil) != hasApp {
+		// Ignore events from webhooks if app is set up.
+		if (event.GetInstallation() != nil && !hasApp) || (hasApp && event.GetInstallation() == nil) {
 			break
 		}
 		return gh.handleMergeGroupEvent(event)

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -86,7 +86,7 @@ func (s *GithubWebhookRouteSuite) SetupTest() {
 	var err error
 	s.prBody, err = os.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "pull_request.json"))
 	s.NoError(err)
-	s.Len(s.prBody, 24731)
+	s.Len(s.prBody, 24692)
 	s.pushBody, err = os.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "push_event.json"))
 	s.NoError(err)
 	s.Len(s.pushBody, 7597)

--- a/rest/route/testdata/pull_request.json
+++ b/rest/route/testdata/pull_request.json
@@ -408,8 +408,5 @@
     "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
     "type": "User",
     "site_admin": false
-  },
-  "installation": {
-    "id": 234
   }
 }

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1539,13 +1539,14 @@ func GetGithubPullRequest(ctx context.Context, token, baseOwner, baseRepo string
 		return pr, nil
 	}
 	// TODO: (EVG-19966) Remove logging.
-	grip.DebugWhen(true, message.WrapError(err, message.Fields{
-		"ticket":  "EVG-19966",
-		"message": "failed to get PR from GitHub",
-		"caller":  "GetGithubPullRequest",
-		"owner":   baseOwner,
-		"repo":    baseRepo,
-		"pr_num":  prNumber,
+	grip.DebugWhen(!errors.Is(err, missingTokenError), message.WrapError(err, message.Fields{
+		"ticket":         "EVG-19966",
+		"message":        "failed to get PR from GitHub",
+		"caller":         "GetGithubPullRequest",
+		"owner":          baseOwner,
+		"repo":           baseRepo,
+		"pr_num":         prNumber,
+		"token is empty": token == "",
 	}))
 
 	return getPullRequest(ctx, token, baseOwner, baseRepo, prNumber)

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -349,7 +349,7 @@ func TestValidatePR(t *testing.T) {
 
 	prBody, err := os.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "..", "units", "testdata", "pull_request.json"))
 	assert.NoError(err)
-	assert.Len(prBody, 24745)
+	assert.Len(prBody, 24706)
 	webhookInterface, err := github.ParseWebHook("pull_request", prBody)
 	assert.NoError(err)
 	prEvent, ok := webhookInterface.(*github.PullRequestEvent)

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -50,7 +50,7 @@ func (s *commitQueueSuite) SetupSuite() {
 	var err error
 	s.prBody, err = os.ReadFile(filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "pull_request.json"))
 	s.NoError(err)
-	s.Require().Len(s.prBody, 24745)
+	s.Require().Len(s.prBody, 24706)
 
 	s.projectRef = &model.ProjectRef{
 		Id:    "mci",

--- a/units/testdata/pull_request.json
+++ b/units/testdata/pull_request.json
@@ -408,8 +408,5 @@
     "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
     "type": "User",
     "site_admin": false
-  },
-  "installation": {
-    "id": 234
   }
 }


### PR DESCRIPTION
EVG-20597

### Description
 github events from apps are now ignored if app auth is not set up 
also deletes the admin setting validation for the GitHub section because it seems irrelevant 

### Testing
created a staging pr and made sure that none of the events went through 
adding the app id back to the settings lets the event go through again
