### PR TITLE
EVG-20018: remove unused `Logs` field from the `Task` struct

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -74,12 +74,6 @@ type OOMTrackerInfo struct {
 	Pids     []int `bson:"pids" json:"pids"`
 }
 
-type TaskLogs struct {
-	AgentLogURLs  []LogInfo `bson:"agent" json:"agent"`
-	SystemLogURLs []LogInfo `bson:"system" json:"system"`
-	TaskLogURLs   []LogInfo `bson:"task" json:"task"`
-}
-
 type LogInfo struct {
 	Command string `bson:"command" json:"command"`
 	URL     string `bson:"url" json:"url"`

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -108,7 +108,6 @@ var (
 	GeneratedTasksToActivateKey = bsonutil.MustHaveTag(Task{}, "GeneratedTasksToActivate")
 	ResetWhenFinishedKey        = bsonutil.MustHaveTag(Task{}, "ResetWhenFinished")
 	ResetFailedWhenFinishedKey  = bsonutil.MustHaveTag(Task{}, "ResetFailedWhenFinished")
-	LogsKey                     = bsonutil.MustHaveTag(Task{}, "Logs")
 	CommitQueueMergeKey         = bsonutil.MustHaveTag(Task{}, "CommitQueueMerge")
 	DisplayStatusKey            = bsonutil.MustHaveTag(Task{}, "DisplayStatus")
 	BaseTaskKey                 = bsonutil.MustHaveTag(Task{}, "BaseTask")
@@ -1040,7 +1039,6 @@ func FindHostRunnable(ctx context.Context, distroID string, removeDeps bool) ([]
 
 	removeFields := bson.M{
 		"$project": bson.M{
-			LogsKey:      0,
 			OldTaskIdKey: 0,
 			DependsOnKey + "." + DependencyUnattainableKey: 0,
 		},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -82,18 +82,17 @@ type Task struct {
 	DependenciesMetTime    time.Time `bson:"dependencies_met_time,omitempty" json:"dependencies_met_time,omitempty"`
 	ContainerAllocatedTime time.Time `bson:"container_allocated_time,omitempty" json:"container_allocated_time,omitempty"`
 
-	Version           string              `bson:"version" json:"version,omitempty"`
-	Project           string              `bson:"branch" json:"branch,omitempty"`
-	Revision          string              `bson:"gitspec" json:"gitspec"`
-	Priority          int64               `bson:"priority" json:"priority"`
-	TaskGroup         string              `bson:"task_group" json:"task_group"`
-	TaskGroupMaxHosts int                 `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
-	TaskGroupOrder    int                 `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`
-	Logs              *apimodels.TaskLogs `bson:"logs,omitempty" json:"logs,omitempty"`
-	ResultsService    string              `bson:"results_service,omitempty" json:"results_service,omitempty"`
-	HasCedarResults   bool                `bson:"has_cedar_results,omitempty" json:"has_cedar_results,omitempty"`
-	ResultsFailed     bool                `bson:"results_failed,omitempty" json:"results_failed,omitempty"`
-	MustHaveResults   bool                `bson:"must_have_results,omitempty" json:"must_have_results,omitempty"`
+	Version           string `bson:"version" json:"version,omitempty"`
+	Project           string `bson:"branch" json:"branch,omitempty"`
+	Revision          string `bson:"gitspec" json:"gitspec"`
+	Priority          int64  `bson:"priority" json:"priority"`
+	TaskGroup         string `bson:"task_group" json:"task_group"`
+	TaskGroupMaxHosts int    `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
+	TaskGroupOrder    int    `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`
+	ResultsService    string `bson:"results_service,omitempty" json:"results_service,omitempty"`
+	HasCedarResults   bool   `bson:"has_cedar_results,omitempty" json:"has_cedar_results,omitempty"`
+	ResultsFailed     bool   `bson:"results_failed,omitempty" json:"results_failed,omitempty"`
+	MustHaveResults   bool   `bson:"must_have_results,omitempty" json:"must_have_results,omitempty"`
 	// only relevant if the task is running.  the time of the last heartbeat
 	// sent back by the agent
 	LastHeartbeat time.Time `bson:"last_heartbeat" json:"last_heartbeat"`

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -911,9 +911,6 @@ func TestEndingTask(t *testing.T) {
 			So(t.Status, ShouldEqual, evergreen.TaskFailed)
 			So(t.FinishTime.Unix(), ShouldEqual, now.Unix())
 			So(t.StartTime.Unix(), ShouldEqual, now.Add(-5*time.Minute).Unix())
-			Convey("if no logs are present, it should not be nil", func() {
-				So(t.Logs, ShouldBeNil)
-			})
 		})
 		Convey("a task with no start time set should have one added", func() {
 			now := time.Now()

--- a/service/task.go
+++ b/service/task.go
@@ -61,7 +61,6 @@ type uiTaskData struct {
 	IngestTime           time.Time               `json:"ingest_time"`
 	EstWaitTime          time.Duration           `json:"wait_time"`
 	UpstreamData         *uiUpstreamData         `json:"upstream_data,omitempty"`
-	Logs                 *apimodels.TaskLogs     `json:"logs,omitempty"`
 
 	// from the host doc (the dns name)
 	HostDNS string `json:"host_dns,omitempty"`
@@ -268,7 +267,6 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		VersionId:            projCtx.Version.Id,
 		RepoOwner:            projCtx.ProjectRef.Owner,
 		Repo:                 projCtx.ProjectRef.Repo,
-		Logs:                 projCtx.Task.Logs,
 		Archived:             archived,
 		TotalExecutions:      totalExecutions,
 		PartOfDisplay:        projCtx.Task.IsPartOfDisplay(),

--- a/service/templates/task.html
+++ b/service/templates/task.html
@@ -535,18 +535,6 @@ Evergreen - {{Trunc .Task.Revision 10}} / {{.Task.BuildVariantDisplay}} / {{.Tas
         <a class="pointer btn btn-default" ng-class="{active:currentLogs==eventLogs}" ng-click="setCurrentLogs(eventLogs)">Event logs</a>
       </div>
     </h3>
-    <div class="row" ng-show="task.logs && (task.logs.agent.length > 0 || task.logs.task.length > 0 || task.logs.system.length > 0)">
-      <div class="col-lg-12">
-        <pre>
-<span class="">External Task Logs:</span>
-<span ng-repeat="logInfo in task.logs.task"><a ng-href="[[logInfo.url]]">[[logInfo.command?logInfo.command:task.display_name]]</a><br/></span>
-<span class="">External Agent Logs:</span>
-<span ng-repeat="logInfo in task.logs.agent"><a ng-href="[[logInfo.url]]">[[logInfo.command?logInfo.command:task.display_name]]</a><br/></span>
-<span class="">External System Logs:</span>
-<span ng-repeat="logInfo in task.logs.system"><a ng-href="[[logInfo.url]]">[[logInfo.command?logInfo.command:task.display_name]]</a><br/></span></pre>
-
-      </div>
-    </div>
     <div class="row">
       <div class="col-lg-12">
         <pre ng-show="currentLogs != eventLogs && logs.length && !buildlogger"><span ng-repeat="entry in logs.slice().reverse() track by $index" class="severity-[[ entry.severity ]]" ng-bind-html="formatTimestamp(entry, 1) + (entry.message | escapeHtml) + '\n' | linkify | ansi"></span></pre>


### PR DESCRIPTION
EVG-20018

### Description
This is just cleans up the `Task` model by removing the unused `Logs` field.

### Testing
Updated unit tests and checked that task logs are loaded successfully in staging.

### Documentation
N/A