### PR TITLE
EVG-20586 Fix flaky test-agent on OSX 

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -160,26 +160,16 @@ func (s *AgentSuite) TestNextTaskResponseShouldExit() {
 }
 
 func (s *AgentSuite) TestTaskWithoutSecret() {
-	s.mockCommunicator.NextTaskResponse = &apimodels.NextTaskResponse{
+	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     "mocktaskid",
 		TaskSecret: "",
 		ShouldExit: false}
-	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-	defer cancel()
 
-	agentCtx, agentCancel := context.WithCancel(ctx)
-	errs := make(chan error, 1)
-	go func() {
-		errs <- s.a.loop(agentCtx)
-	}()
-	time.Sleep(1 * time.Second)
-	agentCancel()
-	select {
-	case err := <-errs:
-		s.NoError(err)
-	case <-ctx.Done():
-		s.FailNow(ctx.Err().Error())
-	}
+	ntr, err := s.a.processNextTask(s.ctx, nextTask, s.tc, false)
+
+	s.NoError(err)
+	s.NotNil(ntr)
+	s.Equal(false, ntr.shouldExit)
 }
 
 func (s *AgentSuite) TestErrorGettingNextTask() {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -168,7 +168,7 @@ func (s *AgentSuite) TestTaskWithoutSecret() {
 	ntr, err := s.a.processNextTask(s.ctx, nextTask, s.tc, false)
 
 	s.NoError(err)
-	s.NotNil(ntr)
+	s.Require().NotNil(ntr)
 	s.Equal(false, ntr.shouldExit)
 }
 


### PR DESCRIPTION
EVG-20586

### Description
This rewrites the test to check the task missing a secret condition using the processNext function instead of relying on the agent loop context to test the condition which is more error prone. 

