### PR TITLE
EVG-20608 Reduce the noise for the task missing secret condition

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -383,7 +383,9 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 			"message": "task response missing secret",
 			"task":    tc.task.ID,
 		})
-		return processNextResponse{}, nil
+		return processNextResponse{
+			noTaskToRun: true,
+		}, nil
 	}
 
 	prevLogger := tc.logger

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -169,8 +169,8 @@ func (s *AgentSuite) TestTaskWithoutSecret() {
 
 	s.NoError(err)
 	s.Require().NotNil(ntr)
-	s.Equal(false, ntr.shouldExit)
-	s.Equal(true, ntr.noTaskToRun)
+	s.False(ntr.shouldExit)
+	s.True(ntr.noTaskToRun)
 }
 
 func (s *AgentSuite) TestErrorGettingNextTask() {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -170,6 +170,7 @@ func (s *AgentSuite) TestTaskWithoutSecret() {
 	s.NoError(err)
 	s.Require().NotNil(ntr)
 	s.Equal(false, ntr.shouldExit)
+	s.Equal(true, ntr.noTaskToRun)
 }
 
 func (s *AgentSuite) TestErrorGettingNextTask() {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-07"
+	AgentVersion = "2023-08-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20608 

### Description
If the agent encounters a task that is missing a secret, there is no point in immediately trying to get another task, because it will keep getting the same task with the missing secret until enough time has passed. Instead, we should make it sleep for longer to reduce the amount of times it logs "task response missing secret". 

### Testing
Added to the unit test. 
