### PR TITLE
EVG-20615 Use linguist detectable flag for non generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 *.sh text eol=lf
 ./public/static/dist/* binary
 ./public/package-lock.json binary
-graphql/*_resolver.go linguist-generated=false
+graphql/*_resolver.go linguist-detectable linguist-language=go


### PR DESCRIPTION
EVG-20615

### Description
Github support suggested using the following attributes to try to ensure that our go files don't get incorrectly tagged as generated

Email

> Hi Mohamed,
> 
> Thank you for your patience. I've heard back from our engineering team, and it does not appear that you can turn off linguist-generated tags. Indeed, our help docs only show turning it on, and [more specific Linguist documentation](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#using-gitattributes) suggests you can only flag it as generated, but not as not-generated.
> 
> That said, the Linguist docs point at some other things you might try as a workaround though, specifically marking it linguist-detectable and maybe giving it a language as well, i.e. linguist-language=go. Combining that I'd suggest trying this out:
> 
> *.sh text eol=lf
> 
> ./public/static/dist/* binary
> 
> ./public/package-lock.json binary
> 
> graphql/*_resolver.go linguist-detectable linguist-language=go
> 
> I hope this helps - please let me know if you have any questions.
> 
> Thank you,
> 
> Chip


