### PR TITLE
EVG-20621: Fix old distro pointing to new distro struct

### DIFF
--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/mongodb/grip"
@@ -62,11 +61,6 @@ func LogDistroAdded(distroId, userId string, data interface{}) {
 
 // LogDistroModified should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroModified(distroId, userId string, before, after interface{}) {
-	// Stop if there are no changes
-	if reflect.DeepEqual(before, after) {
-		return
-	}
-
 	data := DistroEventData{
 		UserId: userId,
 		User:   userId,

--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"reflect"
 	"time"
 
 	"github.com/mongodb/grip"
@@ -61,6 +62,18 @@ func LogDistroAdded(distroId, userId string, data interface{}) {
 
 // LogDistroModified should take in DistroData in order to preserve the ProviderSettingsList
 func LogDistroModified(distroId, userId string, before, after interface{}) {
+	// Stop if there are no changes
+	if reflect.DeepEqual(before, after) {
+
+		grip.Info(message.Fields{
+			"message":   "no changes found when logging modified distro",
+			"distro_id": distroId,
+			"source":    "event-log-fail",
+			"user_id":   userId,
+		})
+		return
+	}
+
 	data := DistroEventData{
 		UserId: userId,
 		User:   userId,

--- a/service/distros.go
+++ b/service/distros.go
@@ -126,7 +126,8 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newDistro := oldDistro
+	newDistro := &distro.Distro{}
+	*newDistro = *oldDistro
 	newDistro.ProviderSettingsList = []*birch.Document{} // remove old list to prevent collisions within birch documents
 	// attempt to unmarshal data into distros field for type validation
 	if err = json.Unmarshal(b, &newDistro); err != nil {

--- a/service/distros.go
+++ b/service/distros.go
@@ -126,8 +126,7 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newDistro := &distro.Distro{}
-	*newDistro = *oldDistro
+	newDistro := *oldDistro
 	newDistro.ProviderSettingsList = []*birch.Document{} // remove old list to prevent collisions within birch documents
 	// attempt to unmarshal data into distros field for type validation
 	if err = json.Unmarshal(b, &newDistro); err != nil {
@@ -159,7 +158,7 @@ func (uis *UIServer) modifyDistro(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// check that the resulting distro is valid
-	vErrs, err := validator.CheckDistro(r.Context(), newDistro, settings, false)
+	vErrs, err := validator.CheckDistro(r.Context(), &newDistro, settings, false)
 	if err != nil {
 		message := fmt.Sprintf("error retrieving distroIds: %v", err)
 		PushFlash(uis.CookieStore, r, w, NewErrorFlash(message))


### PR DESCRIPTION
EVG-20621

### Description
- An existing bug set `newDistro` to equal the pointer of `oldDistro` when making a distro update. This meant that applying the user's changes to `newDistro` also applied them to `oldDistro`. In the updated distro modified event logger from #6878, we stop logging if the "before" and "after" structs are equal, so an event was not being added.
- I also removed the equality check for safety in the meantime (without it, the legacy distro event log functions correctly since it does not rely on a comparison between the old and new structs)

### Testing
- Tested manually since there's no test for `modifyDistro()`

### Documentation
N/A