### PR TITLE
EVG-20593 Delete Previously set function key instead of updating it

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -166,8 +166,8 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 			for key, functionValue := range commandInfo.Vars {
 				currentValue := tc.taskConfig.Expansions.Get(key)
 				if currentValue != functionValue {
-					// If a command in the func updates the expansion value, persist it.
-					prevExp[key] = currentValue
+					// If a command in the func updates the expansion value, don't reset it.
+					delete(prevExp, key)
 				}
 			}
 			tc.taskConfig.Expansions.Update(prevExp)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-08"
+	AgentVersion = "2023-08-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20593

### Description
If an expansion updates a function var and we want to persist it, there's no need to update the saved previous list to the current value. We can just delete the key so that it doesn't get reset. 

### Testing
There are two existing tests for this condition 
