### PR TITLE
EVG-19952: Use enum for CloneMethod field

### DIFF
--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/utility"
 )
 
 // CloneMethod is the resolver for the cloneMethod field.
@@ -41,9 +42,9 @@ func (r *distroResolver) ProviderSettingsList(ctx context.Context, obj *model.AP
 func (r *distroInputResolver) CloneMethod(ctx context.Context, obj *model.APIDistro, data CloneMethod) error {
 	switch data {
 	case CloneMethodLegacySSH:
-		*obj.CloneMethod = evergreen.CloneMethodLegacySSH
+		obj.CloneMethod = utility.ToStringPtr(evergreen.CloneMethodLegacySSH)
 	case CloneMethodOauth:
-		*obj.CloneMethod = evergreen.CloneMethodOAuth
+		obj.CloneMethod = utility.ToStringPtr(evergreen.CloneMethodOAuth)
 	default:
 		return InputValidationError.Send(ctx, fmt.Sprintf("Clone method '%s' is invalid", data))
 	}

--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -11,8 +11,21 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/birch"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/model"
 )
+
+// CloneMethod is the resolver for the cloneMethod field.
+func (r *distroResolver) CloneMethod(ctx context.Context, obj *model.APIDistro) (CloneMethod, error) {
+	switch *obj.CloneMethod {
+	case evergreen.CloneMethodLegacySSH:
+		return CloneMethodLegacySSH, nil
+	case evergreen.CloneMethodOAuth:
+		return CloneMethodOauth, nil
+	default:
+		return CloneMethodLegacySSH, InternalServerError.Send(ctx, fmt.Sprintf("Clone method '%s' is invalid", *obj.CloneMethod))
+	}
+}
 
 // ProviderSettingsList is the resolver for the providerSettingsList field.
 func (r *distroResolver) ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]interface{}, error) {
@@ -22,6 +35,19 @@ func (r *distroResolver) ProviderSettingsList(ctx context.Context, obj *model.AP
 	}
 
 	return settings, nil
+}
+
+// CloneMethod is the resolver for the cloneMethod field.
+func (r *distroInputResolver) CloneMethod(ctx context.Context, obj *model.APIDistro, data CloneMethod) error {
+	switch data {
+	case CloneMethodLegacySSH:
+		*obj.CloneMethod = evergreen.CloneMethodLegacySSH
+	case CloneMethodOauth:
+		*obj.CloneMethod = evergreen.CloneMethodOAuth
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("Clone method '%s' is invalid", data))
+	}
+	return nil
 }
 
 // ProviderSettingsList is the resolver for the providerSettingsList field.

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1494,6 +1494,8 @@ type AnnotationResolver interface {
 	WebhookConfigured(ctx context.Context, obj *model.APITaskAnnotation) (bool, error)
 }
 type DistroResolver interface {
+	CloneMethod(ctx context.Context, obj *model.APIDistro) (CloneMethod, error)
+
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]interface{}, error)
 }
 type HostResolver interface {
@@ -1795,6 +1797,8 @@ type VolumeResolver interface {
 }
 
 type DistroInputResolver interface {
+	CloneMethod(ctx context.Context, obj *model.APIDistro, data CloneMethod) error
+
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro, data []map[string]interface{}) error
 }
 type HostAllocatorSettingsInputResolver interface {
@@ -15280,7 +15284,7 @@ func (ec *executionContext) _Distro_cloneMethod(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.CloneMethod, nil
+		return ec.resolvers.Distro().CloneMethod(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15292,19 +15296,19 @@ func (ec *executionContext) _Distro_cloneMethod(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(CloneMethod)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNCloneMethod2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐCloneMethod(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_cloneMethod(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Distro",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type CloneMethod does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65170,11 +65174,13 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cloneMethod"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNCloneMethod2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐCloneMethod(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.CloneMethod = data
+			if err = ec.resolvers.DistroInput().CloneMethod(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "containerPool":
 			var err error
 
@@ -70566,12 +70572,25 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 				atomic.AddUint32(&invalids, 1)
 			}
 		case "cloneMethod":
+			field := field
 
-			out.Values[i] = ec._Distro_cloneMethod(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Distro_cloneMethod(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
 			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "containerPool":
 
 			out.Values[i] = ec._Distro_containerPool(ctx, field, obj)
@@ -81174,6 +81193,16 @@ func (ec *executionContext) marshalNChildPatchAlias2githubᚗcomᚋevergreenᚑc
 
 func (ec *executionContext) marshalNClientBinary2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIClientBinary(ctx context.Context, sel ast.SelectionSet, v model.APIClientBinary) graphql.Marshaler {
 	return ec._ClientBinary(ctx, sel, &v)
+}
+
+func (ec *executionContext) unmarshalNCloneMethod2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐCloneMethod(ctx context.Context, v interface{}) (CloneMethod, error) {
+	var res CloneMethod
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCloneMethod2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐCloneMethod(ctx context.Context, sel ast.SelectionSet, v CloneMethod) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNCommitQueue2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPICommitQueue(ctx context.Context, sel ast.SelectionSet, v model.APICommitQueue) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -456,6 +456,47 @@ type VolumeHost struct {
 	HostID   string `json:"hostId"`
 }
 
+type CloneMethod string
+
+const (
+	CloneMethodLegacySSH CloneMethod = "LEGACY_SSH"
+	CloneMethodOauth     CloneMethod = "OAUTH"
+)
+
+var AllCloneMethod = []CloneMethod{
+	CloneMethodLegacySSH,
+	CloneMethodOauth,
+}
+
+func (e CloneMethod) IsValid() bool {
+	switch e {
+	case CloneMethodLegacySSH, CloneMethodOauth:
+		return true
+	}
+	return false
+}
+
+func (e CloneMethod) String() string {
+	return string(e)
+}
+
+func (e *CloneMethod) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = CloneMethod(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid CloneMethod", str)
+	}
+	return nil
+}
+
+func (e CloneMethod) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type DistroOnSaveOperation string
 
 const (

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -13,6 +13,11 @@ enum DistroOnSaveOperation {
   NONE
 }
 
+enum CloneMethod {
+  LEGACY_SSH
+  OAUTH
+}
+
 ###### INPUTS ######
 """
 CopyDistroInput is the input to the copyDistro mutation.
@@ -47,7 +52,7 @@ input DistroInput {
   arch: String!
   authorizedKeysFile: String!
   bootstrapSettings: BootstrapSettingsInput!
-  cloneMethod: String!
+  cloneMethod: CloneMethod!
   containerPool: String!
   disabled: Boolean!
   disableShallowClone: Boolean!
@@ -182,7 +187,7 @@ type Distro {
   arch: String!
   authorizedKeysFile: String!
   bootstrapSettings: BootstrapSettings!
-  cloneMethod: String!
+  cloneMethod: CloneMethod!
   containerPool: String!
   disabled: Boolean!
   disableShallowClone: Boolean!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -55,7 +55,7 @@ mutation {
             serviceUser: "",
             shellPath: "/bin/fish"
           }
-          cloneMethod: "legacy-ssh",
+          cloneMethod: LEGACY_SSH,
           sshKey: "mci",
           sshOptions: [
             "StrictHostKeyChecking=no",

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -54,7 +54,7 @@ mutation {
             serviceUser: "",
             shellPath: "/bin/fish"
           }
-          cloneMethod: "legacy-ssh",
+          cloneMethod: OAUTH,
           sshKey: "mci",
           sshOptions: [
             "StrictHostKeyChecking=no",
@@ -120,6 +120,7 @@ mutation {
     {
       distro {
         aliases
+        cloneMethod
         disableShallowClone
         isCluster
         name

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -55,7 +55,7 @@ mutation {
             serviceUser: "",
             shellPath: "/bin/fish"
           }
-          cloneMethod: "legacy-ssh",
+          cloneMethod: LEGACY_SSH,
           sshKey: "mci",
           sshOptions: [
             "StrictHostKeyChecking=no",

--- a/graphql/tests/mutation/saveDistro/results.json
+++ b/graphql/tests/mutation/saveDistro/results.json
@@ -9,6 +9,7 @@
               "aliases": [
                 "new-alias"
               ],
+              "cloneMethod": "OAUTH",
               "disableShallowClone": true,
               "isCluster": true,
               "name": "rhel71-power8-large",


### PR DESCRIPTION
Reopening because I misnamed the branch in #6895 😭 

Updates field used in UI ticket [EVG-19952](https://jira.mongodb.org/browse/EVG-19952)

### Description

- Make a distro's CloneMethod field typing more predictable by using an enum. The field resolvers convert between the GraphQL enum and Evergreen's own consts.

### Testing

- Update tests

### Documentation

N/A