### PR TITLE
EVG-19211 upgrade cocoa

### DIFF
--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -395,7 +395,7 @@ func TestExportECSPodDefinitionOptions(t *testing.T) {
 		require.Equal(t, containerOpts.WorkingDir, utility.FromStringPtr(cDef.WorkingDir))
 		require.Len(t, cDef.PortMappings, 1)
 		assert.Equal(t, agentPort, utility.FromIntPtr(cDef.PortMappings[0].ContainerPort))
-		assert.Equal(t, ecsTypes.LogDriverAwslogs, utility.FromStringPtr(cDef.LogConfiguration.LogDriver))
+		assert.EqualValues(t, ecsTypes.LogDriverAwslogs, utility.FromStringPtr(cDef.LogConfiguration.LogDriver))
 		assert.Equal(t, "us-east-1", cDef.LogConfiguration.Options[awsLogsRegion])
 		assert.Equal(t, "log_group", cDef.LogConfiguration.Options[awsLogsGroup])
 

--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -30,11 +30,6 @@ func TestMakeECSClient(t *testing.T) {
 		assert.NotZero(t, c)
 		assert.NoError(t, c.Close(ctx))
 	})
-	t.Run("FailsWithoutRequiredSettings", func(t *testing.T) {
-		c, err := MakeECSClient(ctx, &evergreen.Settings{})
-		assert.Error(t, err)
-		assert.Zero(t, c)
-	})
 }
 
 func TestMakeSecretsManagerClient(t *testing.T) {
@@ -46,11 +41,6 @@ func TestMakeSecretsManagerClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotZero(t, c)
 		assert.NoError(t, c.Close(ctx))
-	})
-	t.Run("FailsWithoutRequiredSettings", func(t *testing.T) {
-		c, err := MakeSecretsManagerClient(ctx, &evergreen.Settings{})
-		assert.Error(t, err)
-		assert.Zero(t, c)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3
+	github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca
 	github.com/evergreen-ci/gimlet v0.0.0-20230626223442-f6f16b3a3a98
 	github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202
 	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.26
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.98.0
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.12
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8
 	github.com/aws/smithy-go v1.13.5
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/docker/docker v20.10.12+incompatible
@@ -24,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715
 	github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3
-	github.com/evergreen-ci/utility v0.0.0-20230726191623-866cb804386e
+	github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20230323210713-a34b158b096e
+	github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3
 	github.com/evergreen-ci/gimlet v0.0.0-20230626223442-f6f16b3a3a98
 	github.com/evergreen-ci/juniper v0.0.0-20230119161755-1aced8006202
 	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3 h1:5C9s7PbF9x9k/dBQuqUP258Fdg8fNcLeT35HxYl3fcI=
-github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3/go.mod h1:biHWqESK1l8CJRr+aYtzOkdOvDUR4zixQfFCeUtS5Pk=
+github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca h1:KBnECudr743p/yCpVLU0Ph3HCtrpzcvbio8godRgeu0=
+github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/go.sum
+++ b/go.sum
@@ -117,7 +117,6 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.41.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.41.12/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go v1.44.89/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.44.127/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.266 h1:MWd775dcYf7NrwgcHLtlsIbWoWkX8p4vomfNHr88zH0=
 github.com/aws/aws-sdk-go v1.44.266/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
@@ -408,8 +407,8 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20230323210713-a34b158b096e h1:gF78PFpZWebIzDP42oKtnG6WOVLTBcOoG3eZKrhOdxA=
-github.com/evergreen-ci/cocoa v0.0.0-20230323210713-a34b158b096e/go.mod h1:9loFu7XeSsMF9tCQyJyUyjrVGkhQAEoOTgwniVzFzVI=
+github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3 h1:5C9s7PbF9x9k/dBQuqUP258Fdg8fNcLeT35HxYl3fcI=
+github.com/evergreen-ci/cocoa v0.0.0-20230814170341-875b9d0419f3/go.mod h1:biHWqESK1l8CJRr+aYtzOkdOvDUR4zixQfFCeUtS5Pk=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=
@@ -447,7 +446,6 @@ github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3 h1:ZAXkjLIYuig
 github.com/evergreen-ci/timber v0.0.0-20230731225120-893f8ec27fe3/go.mod h1:UUzYp4MuW+uz87NoorR2FmC5xkB1s6uu4+poGYa3EL0=
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
-github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c h1:1MsTaPMQ0eM9KXeqdbbFPPAeXuhckMDKo/DkKLFfzVA=
 github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
@@ -1467,7 +1465,6 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.7 h1:yb2o8oh3Y+Gg2g+wlzrWS3p
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.7/go.mod h1:1MNss6sqoIsFGisX92do/5doiUCBrN7EjhZCS/8DUjI=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.98.0 h1:WblDV33AG9dhv0zFEPEmGtD5UECSNpKMxtdENULfR8M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.98.0/go.mod h1:L3ZT0N/vBsw77mOAawXmRnREpEjcHd2v5Hzf7AkIH8M=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1 h1:54QSuWR3Pot7HqBRXd+c1yF97h2bqzDBID8qFSAkTlE=
+github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1/go.mod h1:SB6YszwN1iKvyt/Qk+ICeKsfBxjd0CTEwwkmej9qoa0=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11 h1:y2+VQzC6Zh2ojtV2LoC0MNwHWc6qXv/j2vrQtlftkdA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11/go.mod h1:iV4q2hsqtNECrfmlXyord9u4zyuFEJX9eLgLpSPzWA8=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.27 h1:QmyPCRZNMR1pFbiOi9kBZWZuKrKB9LD4cxltxQk4tNE=
@@ -148,6 +150,10 @@ github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.27/go.mod 
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.27/go.mod h1:EOwBD4J4S5qYszS5/3DpkejfuK+Z5/1uzICfPaZLtqw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28 h1:bkRyG4a929RCnpVSTvLM2j/T4ls015ZhhYApbmYs15s=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28/go.mod h1:jj7znCIg05jXlaGBlFMGP8+7UN3VtCkRBG2spnmRQkU=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.12 h1:/fvzwRqxxiNJwNK5XVE1NvnQFvNajNRYx82lkTqXlMM=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.12/go.mod h1:i/CXT+v8caoM60a7brYlrVG64srBa1Op0Q5Nl6askyo=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8 h1:eB91eEYUlh8+O2dXr189W8GJJd+/T8N/c5HocH2KzVo=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.8/go.mod h1:3ARttS6G6U3auEdKfaN4GlnfS9UxYE9nqub1+0YGycA=
 github.com/aws/aws-sdk-go-v2/service/ses v1.15.11 h1:7/MtUTSdIdZuW3jRWwDq5kKVihe+VwBGEjWkuZbhlFg=
 github.com/aws/aws-sdk-go-v2/service/ses v1.15.11/go.mod h1:iI3tHe16kyXcYA6fcoct3hW1uB/XSoe46w29wupWwho=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.22.0 h1:ikSvot5NdywduxtkOwOa2GJFzFuJq1ZjXsGjoIA82Ao=
@@ -443,8 +449,8 @@ github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuE
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20220725171106-4730479c6118/go.mod h1:J23DaXv/35hpeeDLK1ay9KX/7zMF0HdVMAitqXQW9j0=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20230726191623-866cb804386e h1:uhm66J3aNN2yIF2rLconhPk64WizMgD5Mf/DCiqMYhk=
-github.com/evergreen-ci/utility v0.0.0-20230726191623-866cb804386e/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
+github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c h1:1MsTaPMQ0eM9KXeqdbbFPPAeXuhckMDKo/DkKLFfzVA=
+github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -22,7 +22,7 @@ func CreatePod(apiPod model.APICreatePod) (*model.APICreatePodResponse, error) {
 		ctx, cancel := env.Context()
 		defer cancel()
 
-		smClient, err := cloud.MakeSecretsManagerClient(env.Settings())
+		smClient, err := cloud.MakeSecretsManagerClient(ctx, env.Settings())
 		if err != nil {
 			return nil, errors.Wrap(err, "getting Secrets Manager client")
 		}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -165,7 +165,7 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 }
 
 func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Settings, existingSecrets []model.ContainerSecret, pRef *model.ProjectRef) error {
-	smClient, err := cloud.MakeSecretsManagerClient(settings)
+	smClient, err := cloud.MakeSecretsManagerClient(ctx, settings)
 	if err != nil {
 		return errors.Wrap(err, "setting up Secrets Manager client to store newly-created project's container secrets")
 	}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/evergreen-ci/cocoa"
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -475,7 +475,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 	var vault cocoa.Vault
 	if len(h.apiNewProjectRef.DeleteContainerSecrets) != 0 || len(h.apiNewProjectRef.ContainerSecrets) != 0 {
-		smClient, err := cloud.MakeSecretsManagerClient(h.settings)
+		smClient, err := cloud.MakeSecretsManagerClient(ctx, h.settings)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "initializing Secrets Manager client"))
 		}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -440,7 +440,7 @@ func (s *ProjectPatchByIDSuite) TestRotateAndDeleteProjectPodSecret() {
 	h := s.rm.(*projectIDPatchHandler)
 	h.user = &user.DBUser{Id: "me"}
 
-	smClient, err := cloud.MakeSecretsManagerClient(s.env.Settings())
+	smClient, err := cloud.MakeSecretsManagerClient(ctx, s.env.Settings())
 	s.Require().NoError(err)
 	defer func() {
 		s.Require().NoError(smClient.Close(ctx))

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/aws-sdk-go/aws"
-	awsECS "github.com/aws/aws-sdk-go/service/ecs"
+	awsECS "github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/evergreen-ci/cocoa"
 	"github.com/evergreen-ci/cocoa/ecs"
 	"github.com/evergreen-ci/evergreen"
@@ -568,7 +568,7 @@ func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, detail ecsTaskEve
 		return nil
 	}
 
-	c, err := cloud.MakeECSClient(sns.env.Settings())
+	c, err := cloud.MakeECSClient(ctx, sns.env.Settings())
 	if err != nil {
 		return errors.Wrap(err, "getting ECS client")
 	}
@@ -622,7 +622,7 @@ func (sns *ecsSNS) listECSTasks(ctx context.Context, details ecsContainerInstanc
 		return nil, nil
 	}
 
-	c, err := cloud.MakeECSClient(sns.env.Settings())
+	c, err := cloud.MakeECSClient(ctx, sns.env.Settings())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting ECS client")
 	}
@@ -650,10 +650,7 @@ func (sns *ecsSNS) listECSTasks(ctx context.Context, details ecsContainerInstanc
 		}
 
 		for _, arn := range resp.TaskArns {
-			if arn == nil {
-				continue
-			}
-			taskARNs = append(taskARNs, utility.FromStringPtr(arn))
+			taskARNs = append(taskARNs, arn)
 		}
 
 		token = resp.NextToken

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -649,10 +649,7 @@ func (sns *ecsSNS) listECSTasks(ctx context.Context, details ecsContainerInstanc
 			return nil, errors.New("listing ECS tasks returned no response")
 		}
 
-		for _, arn := range resp.TaskArns {
-			taskARNs = append(taskARNs, arn)
-		}
-
+		taskARNs = append(taskARNs, resp.TaskArns...)
 		token = resp.NextToken
 		if token == nil {
 			return taskARNs, nil

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -238,8 +238,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
-					Status:     utility.ToStringPtr(status),
-					GoalStatus: utility.ToStringPtr(desiredStatus),
+					Status:     status,
+					GoalStatus: desiredStatus,
 				},
 			}
 
@@ -255,7 +255,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			assert.NoError(t, rh.handleNotification(ctx, notification))
 
 			assert.Len(t, cocoaMock.GlobalECSService.Clusters[clusterID], 1)
-			assert.EqualValues(t, ecs.TaskStatusStopped, utility.FromStringPtr(cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status), "unrecognized cloud pod should have been stopped")
+			assert.EqualValues(t, ecs.TaskStatusStopped, cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status, "unrecognized cloud pod should have been stopped")
 		},
 		"NoopsWhenUnrecognizedPodIsTryingToStartInUnrecognizedCluster": func(ctx context.Context, t *testing.T, rh *ecsSNS) {
 			originalFlags, err := evergreen.GetServiceFlags(ctx)
@@ -282,8 +282,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
-					Status:     utility.ToStringPtr(status),
-					GoalStatus: utility.ToStringPtr(desiredStatus),
+					Status:     status,
+					GoalStatus: desiredStatus,
 				},
 			}
 
@@ -298,7 +298,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			assert.NoError(t, rh.handleNotification(ctx, notification))
 
-			assert.EqualValues(t, status, utility.FromStringPtr(cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status), "unrecognized cloud pod in unrecognized cluster should not have been stopped")
+			assert.EqualValues(t, status, cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status, "unrecognized cloud pod in unrecognized cluster should not have been stopped")
 		},
 		"NoopsWhenUnrecognizedPodIsDetectedButAlreadyShuttingDown": func(ctx context.Context, t *testing.T, rh *ecsSNS) {
 			originalFlags, err := evergreen.GetServiceFlags(ctx)
@@ -331,8 +331,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
-					Status:     utility.ToStringPtr(status),
-					GoalStatus: utility.ToStringPtr(desiredStatus),
+					Status:     status,
+					GoalStatus: desiredStatus,
 				},
 			}
 
@@ -347,7 +347,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			assert.NoError(t, rh.handleNotification(ctx, notification))
 
-			assert.EqualValues(t, status, utility.FromStringPtr(cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status), "unrecognized cloud pod in unrecognized cluster should not have been stopped")
+			assert.EqualValues(t, status, cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status, "unrecognized cloud pod in unrecognized cluster should not have been stopped")
 		},
 		"NoopsWhenUnrecognizedPodIsDetectedButUnrecognizedPodCleanupIsDisabled": func(ctx context.Context, t *testing.T, rh *ecsSNS) {
 			originalFlags, err := evergreen.GetServiceFlags(ctx)
@@ -377,8 +377,8 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					ARN:        taskID,
 					Cluster:    utility.ToStringPtr(clusterID),
 					Created:    utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
-					Status:     utility.ToStringPtr(status),
-					GoalStatus: utility.ToStringPtr(desiredStatus),
+					Status:     status,
+					GoalStatus: desiredStatus,
 				},
 			}
 
@@ -393,7 +393,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 			}
 			assert.NoError(t, rh.handleNotification(ctx, notification))
 
-			assert.EqualValues(t, status, utility.FromStringPtr(cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status), "cloud pod should not be cleaned up when the service flag flag is disabled")
+			assert.EqualValues(t, status, cocoaMock.GlobalECSService.Clusters[clusterID][taskID].Status, "cloud pod should not be cleaned up when the service flag flag is disabled")
 		},
 		"FailsWithoutStatus": func(ctx context.Context, t *testing.T, rh *ecsSNS) {
 			notification := ecsEventBridgeNotification{
@@ -459,7 +459,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 					ContainerInstance: utility.ToStringPtr(containerInstanceID),
 					Cluster:           utility.ToStringPtr(clusterID),
 					Created:           utility.ToTimePtr(time.Now().Add(-10 * time.Minute)),
-					Status:            utility.ToStringPtr(status),
+					Status:            status,
 				},
 			}
 

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -66,7 +66,7 @@ func (j *containerSecretCleanupJob) Run(ctx context.Context) {
 			j.AddError(errors.Wrap(j.tagClient.Close(ctx), "closing tag client"))
 		}
 	}()
-	if err := j.populate(); err != nil {
+	if err := j.populate(ctx); err != nil {
 		j.AddError(err)
 		return
 	}
@@ -87,13 +87,13 @@ func (j *containerSecretCleanupJob) Run(ctx context.Context) {
 	j.AddError(errors.Wrap(catcher.Resolve(), "deleting secrets"))
 }
 
-func (j *containerSecretCleanupJob) populate() error {
+func (j *containerSecretCleanupJob) populate(ctx context.Context) error {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
 
 	if j.smClient == nil {
-		client, err := cloud.MakeSecretsManagerClient(j.env.Settings())
+		client, err := cloud.MakeSecretsManagerClient(ctx, j.env.Settings())
 		if err != nil {
 			return errors.Wrap(err, "initializing Secrets Manager client")
 		}
@@ -109,7 +109,7 @@ func (j *containerSecretCleanupJob) populate() error {
 	}
 
 	if j.tagClient == nil {
-		client, err := cloud.MakeTagClient(j.env.Settings())
+		client, err := cloud.MakeTagClient(ctx, j.env.Settings())
 		if err != nil {
 			return errors.Wrap(err, "initializing tag client")
 		}

--- a/units/container_secret_cleanup_test.go
+++ b/units/container_secret_cleanup_test.go
@@ -6,8 +6,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	secretsmanagerTypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/cocoa/secret"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -28,7 +29,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 				createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 					Name:         aws.String(fmt.Sprintf("secret_name%d", i)),
 					SecretString: aws.String("secret_string"),
-					Tags: []*secretsmanager.Tag{{
+					Tags: []secretsmanagerTypes.Tag{{
 						Key:   aws.String(model.ContainerSecretTag),
 						Value: aws.String(strconv.FormatBool(false)),
 					}},
@@ -57,7 +58,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 				createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 					Name:         aws.String(fmt.Sprintf("secret_name%d", i)),
 					SecretString: aws.String("secret_string"),
-					Tags: []*secretsmanager.Tag{{
+					Tags: []secretsmanagerTypes.Tag{{
 						Key:   aws.String(model.ContainerSecretTag),
 						Value: aws.String(strconv.FormatBool(false)),
 					}},
@@ -85,7 +86,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 			createOut, err := j.smClient.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
 				Name:         aws.String("secret_name"),
 				SecretString: aws.String("secret_string"),
-				Tags:         []*secretsmanager.Tag{{Key: aws.String("cherry"), Value: aws.String("tomato")}},
+				Tags:         []secretsmanagerTypes.Tag{{Key: aws.String("cherry"), Value: aws.String("tomato")}},
 			})
 			require.NoError(t, err)
 

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -232,7 +232,7 @@ func (j *podAllocatorJob) populate(ctx context.Context) error {
 	}
 
 	if j.smClient == nil {
-		client, err := cloud.MakeSecretsManagerClient(&j.settings)
+		client, err := cloud.MakeSecretsManagerClient(ctx, &j.settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing Secrets Manager client")
 		}

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -94,7 +94,7 @@ func (j *podCreationJob) Run(ctx context.Context) {
 			})
 		}
 	}()
-	if err := j.populateIfUnset(); err != nil {
+	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddRetryableError(err)
 		return
 	}
@@ -155,7 +155,7 @@ func (j *podCreationJob) Run(ctx context.Context) {
 	}
 }
 
-func (j *podCreationJob) populateIfUnset() error {
+func (j *podCreationJob) populateIfUnset(ctx context.Context) error {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
@@ -178,7 +178,7 @@ func (j *podCreationJob) populateIfUnset() error {
 	settings := j.env.Settings()
 
 	if j.ecsClient == nil {
-		client, err := cloud.MakeECSClient(settings)
+		client, err := cloud.MakeECSClient(ctx, settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing ECS client")
 		}

--- a/units/pod_definition_cleanup.go
+++ b/units/pod_definition_cleanup.go
@@ -97,14 +97,14 @@ func (j *podDefinitionCleanupJob) populate(ctx context.Context) error {
 	j.settings = settings
 
 	if j.tagClient == nil {
-		client, err := cloud.MakeTagClient(&settings)
+		client, err := cloud.MakeTagClient(ctx, &settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing tag client")
 		}
 		j.tagClient = client
 	}
 	if j.ecsClient == nil {
-		client, err := cloud.MakeECSClient(&settings)
+		client, err := cloud.MakeECSClient(ctx, &settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing ECS client")
 		}

--- a/units/pod_definition_creation.go
+++ b/units/pod_definition_creation.go
@@ -147,7 +147,7 @@ func (j *podDefinitionCreationJob) populateIfUnset(ctx context.Context) error {
 	j.settings = settings
 
 	if j.ecsClient == nil {
-		client, err := cloud.MakeECSClient(&settings)
+		client, err := cloud.MakeECSClient(ctx, &settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing ECS client")
 		}

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	awsECS "github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go/aws"
-	awsECS "github.com/aws/aws-sdk-go/service/ecs"
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
@@ -59,7 +60,7 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			assert.NotZero(t, podDef.LastAccessed)
 
 			describeResp, err := j.ecsClient.DescribeTaskDefinition(ctx, &awsECS.DescribeTaskDefinitionInput{
-				Include:        []*string{aws.String("TAGS")},
+				Include:        []ecsTypes.TaskDefinitionField{ecsTypes.TaskDefinitionFieldTags},
 				TaskDefinition: aws.String(podDef.ExternalID),
 			})
 			require.NoError(t, err)

--- a/units/pod_health_check.go
+++ b/units/pod_health_check.go
@@ -90,7 +90,7 @@ func (j *podHealthCheckJob) Run(ctx context.Context) {
 		}
 	}()
 
-	if err := j.populateIfUnset(); err != nil {
+	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddError(err)
 		return
 	}
@@ -154,7 +154,7 @@ func (j *podHealthCheckJob) Run(ctx context.Context) {
 	}
 }
 
-func (j *podHealthCheckJob) populateIfUnset() error {
+func (j *podHealthCheckJob) populateIfUnset(ctx context.Context) error {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
@@ -171,7 +171,7 @@ func (j *podHealthCheckJob) populateIfUnset() error {
 	}
 
 	if j.ecsClient == nil {
-		client, err := cloud.MakeECSClient(j.env.Settings())
+		client, err := cloud.MakeECSClient(ctx, j.env.Settings())
 		if err != nil {
 			return errors.Wrap(err, "initializing ECS client")
 		}

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -165,7 +165,7 @@ func (j *podTerminationJob) populateIfUnset(ctx context.Context) error {
 	settings := j.env.Settings()
 
 	if j.ecsClient == nil {
-		client, err := cloud.MakeECSClient(settings)
+		client, err := cloud.MakeECSClient(ctx, settings)
 		if err != nil {
 			return errors.Wrap(err, "initializing ECS client")
 		}


### PR DESCRIPTION
[EVG-19211](https://jira.mongodb.org/browse/EVG-19211)

### Description
Upgrade cocoa for https://github.com/evergreen-ci/cocoa/pull/109 and https://github.com/evergreen-ci/cocoa/pull/110. This will make spans for the AWS API calls cocoa is making (e.g. [this trace](https://ui.honeycomb.io/mongodb-4b/environments/staging/trace/Ag5NPXZkVgx)).

### Testing
Ran [a containerized task in staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2004_container_test_auth_patch_1e2de6c2077425d29d40f90aa8c31c8039f8fc45_64da7ed5b237365853752a14_23_08_14_19_22_05/logs?execution=0).
