### PR TITLE
EVG-20653 Add a temporary flag that lets projects to test unsetting FunctionVars

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -164,7 +164,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		tc.taskConfig.Expansions.Put(key, newVal)
 	}
 	defer func() {
-		if !tc.unsetFunctionVarsDisabled {
+		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over.
 			for key, functionValue := range commandInfo.Vars {
 				currentValue := tc.taskConfig.Expansions.Get(key)

--- a/agent/command.go
+++ b/agent/command.go
@@ -164,10 +164,6 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		tc.taskConfig.Expansions.Put(key, newVal)
 	}
 	defer func() {
-		admin := tc.unsetFunctionVarsDisabled
-		notadmin := !tc.unsetFunctionVarsDisabled
-		project := tc.project.UnsetFunctionVars
-		print(admin, notadmin, project)
 		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over.
 			for key, functionValue := range commandInfo.Vars {

--- a/agent/command.go
+++ b/agent/command.go
@@ -164,6 +164,10 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		tc.taskConfig.Expansions.Put(key, newVal)
 	}
 	defer func() {
+		admin := tc.unsetFunctionVarsDisabled
+		notadmin := !tc.unsetFunctionVarsDisabled
+		project := tc.project.UnsetFunctionVars
+		print(admin, notadmin, project)
 		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over.
 			for key, functionValue := range commandInfo.Vars {

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -230,7 +230,7 @@ func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	s.tc.taskConfig.Project = p
 }
 
-func (s *CommandSuite) TestUnsetFunctionVarsProjectFlag() {
+func (s *CommandSuite) TestFunctionVarsUnsetWhenProjectFlagTrue() {
 	s.tc.unsetFunctionVarsDisabled = true
 	projYml := `
 unset_function_vars: true 
@@ -260,9 +260,12 @@ functions:
 	key1Value := s.tc.taskConfig.Expansions.Get("key1")
 	s.Equal("expansionVar", key1Value, "globalVar should be set back to what it was before the function ran")
 
+}
+
+func (s *CommandSuite) TestFunctionVarsDontUnsetWithoutFlag() {
 	s.tc.unsetFunctionVarsDisabled = true
 
-	projYml = `
+	projYml := `
 functions:
   yes:
     vars: 
@@ -273,11 +276,18 @@ functions:
         script: |
           echo "hi"
 `
+	func1 := model.PluginCommandConf{
+		Function:    "yes",
+		DisplayName: "function",
+		Vars:        map[string]string{"key1": "functionVar"},
+	}
+
+	cmds := []model.PluginCommandConf{func1}
 	s.setUpConfigAndProject(projYml)
-	err = s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
+	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
 	s.NoError(err)
 
-	key1Value = s.tc.taskConfig.Expansions.Get("key1")
+	key1Value := s.tc.taskConfig.Expansions.Get("key1")
 	s.Equal("functionVar", key1Value, "globalVar should not be set back to what it was before if it's disabled")
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-09"
+	AgentVersion = "2023-08-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project.go
+++ b/model/project.go
@@ -44,6 +44,7 @@ type Project struct {
 	RemotePath         string                     `yaml:"remote_path,omitempty" bson:"remote_path"` // deprecated
 	Branch             string                     `yaml:"branch,omitempty" bson:"branch_name"`      // deprecated
 	Stepback           bool                       `yaml:"stepback,omitempty" bson:"stepback"`
+	UnsetFunctionVars  bool                       `yaml:"unset_function_vars,omitempty" bson:"unset_function_vars,omitempty"`
 	PreErrorFailsTask  bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask bool                       `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
 	OomTracker         bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -78,6 +78,7 @@ type ParserProject struct {
 
 	// Beginning of ParserProject mergeable fields (this comment is used by the linter).
 	Stepback           *bool                      `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	UnsetFunctionVars  *bool                      `yaml:"unset_function_vars,omitempty" bson:"unset_function_vars,omitempty"`
 	PreErrorFailsTask  *bool                      `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask *bool                      `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
 	OomTracker         *bool                      `yaml:"oom_tracker,omitempty" bson:"oom_tracker,omitempty"`
@@ -899,6 +900,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 	proj := &Project{
 		Enabled:            utility.FromBoolPtr(pp.Enabled),
 		Stepback:           utility.FromBoolPtr(pp.Stepback),
+		UnsetFunctionVars:  utility.FromBoolPtr(pp.UnsetFunctionVars),
 		PreErrorFailsTask:  utility.FromBoolPtr(pp.PreErrorFailsTask),
 		PostErrorFailsTask: utility.FromBoolPtr(pp.PostErrorFailsTask),
 		OomTracker:         utility.FromBoolPtr(pp.OomTracker),

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -18,6 +18,7 @@ var (
 	ParserProjectEnabledKey           = bsonutil.MustHaveTag(ParserProject{}, "Enabled")
 	ParserProjectStepbackKey          = bsonutil.MustHaveTag(ParserProject{}, "Stepback")
 	ParserProjectPreErrorFailsTaskKey = bsonutil.MustHaveTag(ParserProject{}, "PreErrorFailsTask")
+	ParserProjectUnsetFunctionVarsKey = bsonutil.MustHaveTag(ParserProject{}, "UnsetFunctionVars")
 	ParserProjectOomTracker           = bsonutil.MustHaveTag(ParserProject{}, "OomTracker")
 	ParserProjectBatchTimeKey         = bsonutil.MustHaveTag(ParserProject{}, "BatchTime")
 	ParserProjectOwnerKey             = bsonutil.MustHaveTag(ParserProject{}, "Owner")

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -18,7 +18,6 @@ var (
 	ParserProjectEnabledKey           = bsonutil.MustHaveTag(ParserProject{}, "Enabled")
 	ParserProjectStepbackKey          = bsonutil.MustHaveTag(ParserProject{}, "Stepback")
 	ParserProjectPreErrorFailsTaskKey = bsonutil.MustHaveTag(ParserProject{}, "PreErrorFailsTask")
-	ParserProjectUnsetFunctionVarsKey = bsonutil.MustHaveTag(ParserProject{}, "UnsetFunctionVars")
 	ParserProjectOomTracker           = bsonutil.MustHaveTag(ParserProject{}, "OomTracker")
 	ParserProjectBatchTimeKey         = bsonutil.MustHaveTag(ParserProject{}, "BatchTime")
 	ParserProjectOwnerKey             = bsonutil.MustHaveTag(ParserProject{}, "Owner")

--- a/model/project_parser_merge_functions.go
+++ b/model/project_parser_merge_functions.go
@@ -157,6 +157,12 @@ func (pp *ParserProject) mergeUnique(toMerge *ParserProject) error {
 		pp.PreErrorFailsTask = toMerge.PreErrorFailsTask
 	}
 
+	if pp.UnsetFunctionVars != nil && toMerge.UnsetFunctionVars != nil {
+		catcher.New("unset function vars can only be defined in one YAML")
+	} else if toMerge.UnsetFunctionVars != nil {
+		pp.UnsetFunctionVars = toMerge.UnsetFunctionVars
+	}
+
 	if pp.PostErrorFailsTask != nil && toMerge.PostErrorFailsTask != nil {
 		catcher.New("post error fails task can only be defined in one YAML")
 	} else if toMerge.PostErrorFailsTask != nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2261,6 +2261,7 @@ func TestMergeUnique(t *testing.T) {
 
 	add := &ParserProject{
 		PreErrorFailsTask: utility.ToBoolPtr(true),
+		UnsetFunctionVars: utility.ToBoolPtr(true),
 		CommandType:       utility.ToStringPtr("type"),
 		CallbackTimeout:   utility.ToIntPtr(1),
 		ExecTimeoutSecs:   utility.ToIntPtr(1),
@@ -2273,6 +2274,7 @@ func TestMergeUnique(t *testing.T) {
 	assert.NotNil(t, main.OomTracker)
 	assert.NotNil(t, main.DisplayName)
 	assert.NotNil(t, main.PreErrorFailsTask)
+	assert.NotNil(t, main.UnsetFunctionVars)
 	assert.NotNil(t, main.CommandType)
 	assert.NotNil(t, main.CallbackTimeout)
 	assert.NotNil(t, main.ExecTimeoutSecs)
@@ -2284,6 +2286,7 @@ func TestMergeUniqueFail(t *testing.T) {
 		BatchTime:         utility.ToIntPtr(1),
 		OomTracker:        utility.ToBoolPtr(true),
 		PreErrorFailsTask: utility.ToBoolPtr(true),
+		UnsetFunctionVars: utility.ToBoolPtr(true),
 		DisplayName:       utility.ToStringPtr("name"),
 		CommandType:       utility.ToStringPtr("type"),
 		CallbackTimeout:   utility.ToIntPtr(1),
@@ -2295,6 +2298,7 @@ func TestMergeUniqueFail(t *testing.T) {
 		BatchTime:         utility.ToIntPtr(1),
 		OomTracker:        utility.ToBoolPtr(true),
 		PreErrorFailsTask: utility.ToBoolPtr(true),
+		UnsetFunctionVars: utility.ToBoolPtr(true),
 		DisplayName:       utility.ToStringPtr("name"),
 		CommandType:       utility.ToStringPtr("type"),
 		CallbackTimeout:   utility.ToIntPtr(1),


### PR DESCRIPTION
EVG-20653

### Description
This allows users to specify `unset_function_vars: true` in their project yaml to test how they will be affected by this change. 

### Testing
unit test 

### Documentation
An email will be sent out. This will not be formally documented because it's temporary 
