### PR TITLE
EVG-20365 distro Honeycomb dashboard

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -479,6 +479,7 @@ const (
 	ProjectIdentifierOtelAttribute = "evergreen.project.identifier"
 	ProjectIDOtelAttribute         = "evergreen.project.id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
+	HostIDOtelAttribute            = "evergreen.host.id"
 	AggregationNameOtelAttribute   = "db.aggregationName"
 )
 

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -19,10 +19,13 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
-	hostAllocatorJobName = "host-allocator"
+	hostAllocatorJobName         = "host-allocator"
+	hostAllocatorAttributePrefix = "evergreen.host_allocator"
 )
 
 func init() {
@@ -281,6 +284,22 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		"instance":                     j.ID(),
 		"runner":                       scheduler.RunnerName,
 	})
+
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String(evergreen.DistroIDOtelAttribute, distro.Id),
+		attribute.Int(fmt.Sprintf("%s.hosts_requested", hostAllocatorAttributePrefix), len(hostsSpawned)),
+		attribute.Int(fmt.Sprintf("%s.hosts_free", hostAllocatorAttributePrefix), nHostsFree),
+		attribute.Int(fmt.Sprintf("%s.hosts_running", hostAllocatorAttributePrefix), len(upHosts)),
+		attribute.Int(fmt.Sprintf("%s.hosts_active", hostAllocatorAttributePrefix), existingHosts.Stats().Active),
+		attribute.Int(fmt.Sprintf("%s.hosts_idle", hostAllocatorAttributePrefix), existingHosts.Stats().Idle),
+		attribute.Int(fmt.Sprintf("%s.hosts_provisioning", hostAllocatorAttributePrefix), existingHosts.Stats().Provisioning),
+		attribute.Int(fmt.Sprintf("%s.hosts_quarantined", hostAllocatorAttributePrefix), existingHosts.Stats().Quarantined),
+		attribute.Int(fmt.Sprintf("%s.hosts_decommissioned", hostAllocatorAttributePrefix), existingHosts.Stats().Decommissioned),
+		attribute.Int(fmt.Sprintf("%s.task_queue_length", hostAllocatorAttributePrefix), distroQueueInfo.Length),
+		attribute.Int(fmt.Sprintf("%s.overdue_tasks", hostAllocatorAttributePrefix), distroQueueInfo.CountWaitOverThreshold),
+		attribute.Float64(fmt.Sprintf("%s.seconds_to_empty", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Seconds()),
+	)
 }
 
 func (j *hostAllocatorJob) setTargetAndTerminate(ctx context.Context, numUpHosts int, hostQueueRatio float32, distro *distro.Distro) {

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -299,6 +299,7 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		attribute.Int(fmt.Sprintf("%s.task_queue_length", hostAllocatorAttributePrefix), distroQueueInfo.Length),
 		attribute.Int(fmt.Sprintf("%s.overdue_tasks", hostAllocatorAttributePrefix), distroQueueInfo.CountWaitOverThreshold),
 		attribute.Float64(fmt.Sprintf("%s.seconds_to_empty", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Seconds()),
+		attribute.Float64(fmt.Sprintf("%s.queue_ratio", hostAllocatorAttributePrefix), float64(noSpawnsRatio)),
 	)
 }
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -18,9 +18,14 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
-const HostTerminationJobName = "host-termination-job"
+const (
+	HostTerminationJobName         = "host-termination-job"
+	hostTerminationAttributePrefix = "evergreen.host_termination"
+)
 
 func init() {
 	registry.AddJobType(HostTerminationJobName, func() amboy.Job {
@@ -305,6 +310,18 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		terminationMessage["total_billable_secs"] = j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()
 	}
 	grip.Info(terminationMessage)
+
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String(evergreen.DistroIDOtelAttribute, j.host.Distro.Id),
+		attribute.String(evergreen.HostIDOtelAttribute, j.host.Id),
+		attribute.Float64(fmt.Sprintf("%s.idle_secs", hostTerminationAttributePrefix), j.host.TotalIdleTime.Seconds()),
+		attribute.Float64(fmt.Sprintf("%s.running_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.StartTime).Seconds()),
+		attribute.Bool(fmt.Sprintf("%s.user_host", hostTerminationAttributePrefix), j.host.UserHost),
+	)
+	if !utility.IsZeroTime(j.host.BillingStartTime) {
+		span.SetAttributes(attribute.Float64(fmt.Sprintf("%s.billable_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()))
+	}
 
 	if utility.StringSliceContains(evergreen.ProvisioningHostStatus, prevStatus) && j.host.TaskCount == 0 {
 		event.LogHostProvisionFailed(j.HostID, fmt.Sprintf("terminating host in status '%s'", prevStatus))


### PR DESCRIPTION
[EVG-20365](https://jira.mongodb.org/browse/EVG-20365)

### Description
Add metrics to the job spans that we can then query and turn into a dashboard.
This will let us do queries like:
- [task queue length and time to empty](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/5XLjchiQu6K)
- [host counts (running tasks, idle, new requested)](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/sZuLwCTxLx9)
- [host spawn count](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/9LvRiroUvpC)
- [termination stats](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/m4PAtb3STSv) (e.g. total idle time, billable time)
