### PR TITLE
EVG-20531: Set revision to base SHA for GitHub merge patches

### DIFF
--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -51,6 +51,9 @@ type githubMergeIntent struct {
 	// HeadHash is the SHA of the head of the merge group. Evergreen checks this out.
 	HeadSHA string `bson:"head_hash"`
 
+	// BaseSHA is the SHA of the base of the merge group.
+	BaseSHA string `bson:"base_hash"`
+
 	// Owner is the GitHub repository organization name.
 	Org string `bson:"org"`
 
@@ -79,6 +82,9 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 	if mg.GetMergeGroup().GetHeadSHA() == "" {
 		catcher.Add(errors.New("head SHA cannot be empty"))
 	}
+	if mg.GetMergeGroup().GetBaseSHA() == "" {
+		catcher.Add(errors.New("base SHA cannot be empty"))
+	}
 	if catcher.HasErrors() {
 		return nil, catcher.Resolve()
 	}
@@ -92,6 +98,7 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 		"Repo":       mg.GetRepo().GetName(),
 		"HeadRef":    mg.GetMergeGroup().GetHeadRef(),
 		"HeadSHA":    mg.GetMergeGroup().GetHeadSHA(),
+		"BaseSHA":    mg.GetMergeGroup().GetBaseSHA(),
 		"CalledBy":   caller,
 	})
 	return &githubMergeIntent{
@@ -102,6 +109,7 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 		Repo:       mg.GetRepo().GetName(),
 		HeadRef:    mg.GetMergeGroup().GetHeadRef(),
 		HeadSHA:    mg.GetMergeGroup().GetHeadSHA(),
+		BaseSHA:    mg.GetMergeGroup().GetBaseSHA(),
 		CalledBy:   caller,
 	}, nil
 }
@@ -194,7 +202,7 @@ func (g *githubMergeIntent) NewPatch() *Patch {
 		Alias:   g.GetAlias(),
 		Status:  evergreen.PatchCreated,
 		Author:  evergreen.GithubMergeUser,
-		Githash: g.HeadSHA,
+		Githash: g.BaseSHA,
 		GithubMergeData: thirdparty.GithubMergeGroup{
 			Org:        g.Org,
 			Repo:       g.Repo,

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -103,6 +103,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.NoError(t, intent.Insert())
 			p := intent.NewPatch()
 			assert.Equal(t, evergreen.CommitQueueAlias, p.Alias)
+			assert.Equal(t, *mge.MergeGroup.BaseSHA, p.Githash)
 			assert.Equal(t, *mge.MergeGroup.HeadSHA, p.GithubMergeData.HeadSHA)
 			assert.Equal(t, *mge.Org.Login, p.GithubMergeData.Org)
 			assert.Equal(t, *mge.Repo.Name, p.GithubMergeData.Repo)

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -113,6 +113,7 @@ func TestGithubMergeIntent(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.Clear(IntentCollection))
 			HeadSHA := "a"
+			BaseSHA := "b"
 			HeadRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
 			OrgName := "my_org"
 			RepoName := "my_repo"
@@ -125,6 +126,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			mg := github.MergeGroup{
 				HeadSHA: &HeadSHA,
 				HeadRef: &HeadRef,
+				BaseSHA: &BaseSHA,
 			}
 			mge := github.MergeGroupEvent{
 				MergeGroup: &mg,

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -937,6 +937,7 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	orgName := "evergreen-ci"
 	repoName := "commit-queue-sandbox"
 	headSHA := "d2a90288ad96adca4a7d0122d8d4fd1deb24db11"
+	baseSHA := "7a45fe6ea28f5969d885bc913e551b8b3c4f09d1"
 	org := github.Organization{
 		Login: &orgName,
 	}
@@ -946,6 +947,7 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	mg := github.MergeGroup{
 		HeadSHA: &headSHA,
 		HeadRef: &headRef,
+		BaseSHA: &baseSHA,
 	}
 	mge := github.MergeGroupEvent{
 		MergeGroup: &mg,
@@ -974,13 +976,13 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 
 	variants := []string{"ubuntu2004"}
 	tasks := []string{"bynntask"}
-	s.verifyPatchDoc(dbPatch, j.PatchID, headSHA, false, variants, tasks)
+	s.verifyPatchDoc(dbPatch, j.PatchID, baseSHA, false, variants, tasks)
 	s.projectExists(j.PatchID.Hex())
 
 	s.Zero(dbPatch.ProjectStorageMethod, "patch's project storage method should be unset after patch is finalized")
 	s.verifyParserProjectDoc(dbPatch, 4)
 
-	s.verifyVersionDoc(dbPatch, evergreen.GithubMergeRequester, evergreen.GithubMergeUser, headSHA, 1)
+	s.verifyVersionDoc(dbPatch, evergreen.GithubMergeRequester, evergreen.GithubMergeUser, baseSHA, 1)
 
 	out := []event.Subscription{}
 	s.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Query(bson.M{}), &out))


### PR DESCRIPTION
EVG-20531

### Description
This PR fixes an issue where the base commit links are sometimes undefined for GitHub merge patches. The base commit is [looked up using the revision](https://github.com/evergreen-ci/evergreen/blob/c638d4a4734917483f20a41641a4af261c63145b/graphql/version_resolver.go#L46), so it's important that the revision is correct.

There was an error in that the revision was being set to itself (the head hash) rather than the base commit (the base hash). This PR sets the revision to the base hash instead of the head hash. I believe this is what we usually do, based on the following examples ([1](https://github.com/evergreen-ci/evergreen/blob/ec428ff16dc9772d116871e17fa1849845e9c497/model/patch/patch.go#L1203), [2](https://github.com/evergreen-ci/evergreen/blob/2fac0bebf32538a259d6ff116ba1fee413c9235a/model/patch/cli_intent.go#L195), [3](https://github.com/evergreen-ci/evergreen/blob/2fac0bebf32538a259d6ff116ba1fee413c9235a/model/patch/github.go#L289)).

### Testing
- Deployed these changes on staging then used the merge queue on commit-queue-sandbox to create [this patch](https://spruce-staging.corp.mongodb.com/version/64db8e3ab23736c2573f974d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) which has the correct base commit hash `7c0bce4` (previously it would have been its own hash, `fdbe4f4`)
