### PR TITLE
EVG-20673 Allow expansions.update to set expansions to the same value as function vars

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
@@ -167,7 +168,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over
 			// unless they were updated using expansions.update
-			if cmd.Name() == "expansions.update" && tc.taskConfig.DynamicExpansions != nil {
+			if cmd.Name() == "expansions.update" {
 				updatedExpansions := tc.taskConfig.DynamicExpansions.Map()
 				for k := range updatedExpansions {
 					if _, ok := commandInfo.Vars[k]; ok {
@@ -177,7 +178,8 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 				}
 			}
 			tc.taskConfig.Expansions.Update(prevExp)
-			tc.taskConfig.DynamicExpansions.Update(map[string]string{})
+			tc.taskConfig.DynamicExpansions = util.EmptyExpansion()
+
 		}
 	}()
 

--- a/agent/command/downstream_expansions_test.go
+++ b/agent/command/downstream_expansions_test.go
@@ -32,10 +32,10 @@ func TestDownstreamExpansions(t *testing.T) {
 					paramsCmd[cmd.downstreamParams[i].Key] = cmd.downstreamParams[i].Value
 					paramsComm[comm.DownstreamParams[i].Key] = comm.DownstreamParams[i].Value
 				}
-				assert.Equal(t, "value_1", paramsCmd["key_1"])
-				assert.Equal(t, "my_image", paramsCmd["my_docker_image"])
-				assert.Equal(t, "value_1", paramsComm["key_1"])
-				assert.Equal(t, "my_image", paramsComm["my_docker_image"])
+				assert.Equal(t, "newValue1", paramsCmd["key1"])
+				assert.Equal(t, "newValue2", paramsCmd["key2"])
+				assert.Equal(t, "newValue1", paramsComm["key1"])
+				assert.Equal(t, "newValue2", paramsComm["key2"])
 			},
 		} {
 			t.Run(testName, func(t *testing.T) {
@@ -65,8 +65,8 @@ func TestDownstreamExpansions(t *testing.T) {
 			for i := range cmd.downstreamParams {
 				paramsCmd[cmd.downstreamParams[i].Key] = cmd.downstreamParams[i].Value
 			}
-			assert.Equal(t, "value_1", paramsCmd["key_1"])
-			assert.Equal(t, "my_image", paramsCmd["my_docker_image"])
+			assert.Equal(t, "newValue1", paramsCmd["key1"])
+			assert.Equal(t, "newValue2", paramsCmd["key2"])
 			assert.Nil(t, comm.DownstreamParams)
 		})
 	})

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -38,7 +38,8 @@ func TestExpansionsPlugin(t *testing.T) {
 		expansions.Put("topping", "bacon")
 
 		taskConfig := internal.TaskConfig{
-			Expansions: &expansions,
+			Expansions:        &expansions,
+			DynamicExpansions: &util.Expansions{},
 		}
 
 		So(updateCommand.ExecuteUpdates(ctx, &taskConfig), ShouldBeNil)

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -43,7 +43,7 @@ func TestExpansionsPlugin(t *testing.T) {
 		}
 
 		So(updateCommand.ExecuteUpdates(ctx, &taskConfig), ShouldBeNil)
-
+		So(taskConfig.DynamicExpansions, ShouldResemble, &util.Expansions{"base": "eggs", "topping": "bacon,sausage"})
 		So(expansions.Get("base"), ShouldEqual, "eggs")
 		So(expansions.Get("topping"), ShouldEqual, "bacon,sausage")
 	})
@@ -63,6 +63,7 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 			cmd := &update{YamlFile: "foo"}
 			So(cmd.Execute(ctx, comm, logger, conf), ShouldNotBeNil)
 			So(cmd.YamlFile, ShouldEqual, "foo")
+			So(conf.DynamicExpansions, ShouldResemble, &util.Expansions{})
 		})
 
 		Convey("With an Expansion, the file name is expanded", func() {

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -54,7 +54,7 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	comm := client.NewMock("http://localhost.com")
-	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, DynamicExpansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
 	logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 
 	Convey("When running Update commands", t, func() {

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -13,7 +13,7 @@ import (
 // update reads in a set of new expansions and updates the
 // task's expansions at runtime. update can take a list
 // of update expansion pairs and/or a file of expansion pairs
-type update struct {
+type Update struct {
 	// Key-value pairs for updating the task's parameters with
 	Updates []updateParams `mapstructure:"updates"`
 
@@ -40,12 +40,12 @@ type updateParams struct {
 	Concat string
 }
 
-func updateExpansionsFactory() Command { return &update{} }
-func (c *update) Name() string         { return "expansions.update" }
+func updateExpansionsFactory() Command { return &Update{} }
+func (c *Update) Name() string         { return "expansions.update" }
 
 // ParseParams validates the input to the update, returning and error
 // if something is incorrect. Fulfills Command interface.
-func (c *update) ParseParams(params map[string]interface{}) error {
+func (c *Update) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
@@ -60,7 +60,7 @@ func (c *update) ParseParams(params map[string]interface{}) error {
 	return nil
 }
 
-func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
+func (c *Update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
 	for _, update := range c.Updates {
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "operation aborted")
@@ -88,7 +88,7 @@ func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) 
 }
 
 // Execute updates the expansions. Fulfills Command interface.
-func (c *update) Execute(ctx context.Context,
+func (c *Update) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	err := c.ExecuteUpdates(ctx, conf)

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -13,7 +13,7 @@ import (
 // update reads in a set of new expansions and updates the
 // task's expansions at runtime. update can take a list
 // of update expansion pairs and/or a file of expansion pairs
-type Update struct {
+type update struct {
 	// Key-value pairs for updating the task's parameters with
 	Updates []updateParams `mapstructure:"updates"`
 
@@ -40,12 +40,12 @@ type updateParams struct {
 	Concat string
 }
 
-func updateExpansionsFactory() Command { return &Update{} }
-func (c *Update) Name() string         { return "expansions.update" }
+func updateExpansionsFactory() Command { return &update{} }
+func (c *update) Name() string         { return "expansions.update" }
 
 // ParseParams validates the input to the update, returning and error
 // if something is incorrect. Fulfills Command interface.
-func (c *Update) ParseParams(params map[string]interface{}) error {
+func (c *update) ParseParams(params map[string]interface{}) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
@@ -60,7 +60,7 @@ func (c *Update) ParseParams(params map[string]interface{}) error {
 	return nil
 }
 
-func (c *Update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
+func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
 	for _, update := range c.Updates {
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "operation aborted")
@@ -73,6 +73,7 @@ func (c *Update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) 
 				return errors.WithStack(err)
 			}
 			conf.Expansions.Put(update.Key, newValue)
+			conf.DynamicExpansions.Put(update.Key, newValue)
 		} else {
 			newValue, err := conf.Expansions.ExpandString(update.Concat)
 			if err != nil {
@@ -81,6 +82,7 @@ func (c *Update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) 
 
 			oldValue := conf.Expansions.Get(update.Key)
 			conf.Expansions.Put(update.Key, oldValue+newValue)
+			conf.DynamicExpansions.Put(update.Key, oldValue+newValue)
 		}
 	}
 
@@ -88,7 +90,7 @@ func (c *Update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) 
 }
 
 // Execute updates the expansions. Fulfills Command interface.
-func (c *Update) Execute(ctx context.Context,
+func (c *update) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
 	err := c.ExecuteUpdates(ctx, conf)
@@ -115,6 +117,10 @@ func (c *Update) Execute(ctx context.Context,
 
 		logger.Task().Infof("Updating expansions with keys from file '%s'.", filename)
 		err := conf.Expansions.UpdateFromYaml(filename)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		err = conf.DynamicExpansions.UpdateFromYaml(filename)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -120,8 +120,7 @@ func (c *update) Execute(ctx context.Context,
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		err = conf.DynamicExpansions.UpdateFromYaml(filename)
-		if err != nil {
+		if err = conf.DynamicExpansions.UpdateFromYaml(filename); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/agent/command/testdata/git/test_expansions.yml
+++ b/agent/command/testdata/git/test_expansions.yml
@@ -1,1 +1,1 @@
-{ "key_1": "value_1", "my_docker_image": "my_image" }
+{ "key1": "newValue1", "key2": "newValue2" }

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -206,7 +206,8 @@ func TestEndTaskSyncCommands(t *testing.T) {
 
 func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	config := &internal.TaskConfig{
-		Expansions: &util.Expansions{"key1": "expansionVar", "key2": "expansionVar2", "key3": "expansionVar3"},
+		Expansions:        &util.Expansions{"key_1": "expansionVar", "key_2": "expansionVar2", "key_3": "expansionVar3"},
+		DynamicExpansions: &util.Expansions{},
 		BuildVariant: &model.BuildVariant{
 			Name: "some_build_variant",
 		},
@@ -237,7 +238,7 @@ unset_function_vars: true
 functions:
   yes:
     vars: 
-      key1: "functionVar"
+      key_1: "functionVar"
     command: shell.exec
     params:
         shell: bash
@@ -250,14 +251,14 @@ functions:
 	func1 := model.PluginCommandConf{
 		Function:    "yes",
 		DisplayName: "function",
-		Vars:        map[string]string{"key1": "functionVar"},
+		Vars:        map[string]string{"key_1": "functionVar"},
 	}
 
 	cmds := []model.PluginCommandConf{func1}
 	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
 	s.NoError(err)
 
-	key1Value := s.tc.taskConfig.Expansions.Get("key1")
+	key1Value := s.tc.taskConfig.Expansions.Get("key_1")
 	s.Equal("expansionVar", key1Value, "globalVar should be set back to what it was before the function ran")
 
 }
@@ -269,7 +270,7 @@ func (s *CommandSuite) TestFunctionVarsDontUnsetWithoutFlag() {
 functions:
   yes:
     vars: 
-      key1: "functionVar"
+      key_1: "functionVar"
     command: shell.exec
     params:
         shell: bash
@@ -279,7 +280,7 @@ functions:
 	func1 := model.PluginCommandConf{
 		Function:    "yes",
 		DisplayName: "function",
-		Vars:        map[string]string{"key1": "functionVar"},
+		Vars:        map[string]string{"key_1": "functionVar"},
 	}
 
 	cmds := []model.PluginCommandConf{func1}
@@ -287,7 +288,7 @@ functions:
 	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
 	s.NoError(err)
 
-	key1Value := s.tc.taskConfig.Expansions.Get("key1")
+	key1Value := s.tc.taskConfig.Expansions.Get("key_1")
 	s.Equal("functionVar", key1Value, "globalVar should not be set back to what it was before if it's disabled")
 }
 
@@ -296,7 +297,7 @@ func (s *CommandSuite) TestVarsAreUnsetAfterRunning() {
 functions:
   yes:
     vars: 
-      key1: "functionVar"
+      key_1: "functionVar"
     command: shell.exec
     params:
         shell: bash
@@ -309,14 +310,14 @@ functions:
 	func1 := model.PluginCommandConf{
 		Function:    "yes",
 		DisplayName: "function",
-		Vars:        map[string]string{"key1": "functionVar"},
+		Vars:        map[string]string{"key_1": "functionVar"},
 	}
 
 	cmds := []model.PluginCommandConf{func1}
 	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
 	s.NoError(err)
 
-	key1Value := s.tc.taskConfig.Expansions.Get("key1")
+	key1Value := s.tc.taskConfig.Expansions.Get("key_1")
 	s.Equal("expansionVar", key1Value, "globalVar should be set back to what it was before the function ran")
 }
 
@@ -327,30 +328,56 @@ functions:
     command: expansions.update
     params:
       updates: 
-      - key: key1
-        value: ${key1}
-      - key: key2
-        value: ${key2}
+      - key: key_1
+        value: ${key_1}
+      - key: key_2
+        value: ${key_2}
 `
 	s.setUpConfigAndProject(projYml)
 
 	func1 := model.PluginCommandConf{
 		Function:    "yes",
 		DisplayName: "function",
-		Vars:        map[string]string{"key1": "functionVar1", "key2": "functionVar2", "key3": "functionVar3"},
+		Vars:        map[string]string{"key_1": "functionVar1", "key_2": "functionVar2", "key_3": "functionVar3"},
 	}
 
 	cmds := []model.PluginCommandConf{func1}
 	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
 	s.NoError(err)
 
-	key1Value := s.tc.taskConfig.Expansions.Get("key1")
-	s.Equal("functionVar1", key1Value, "key1 should be set to what it was updated to with expansions.update")
+	key1Value := s.tc.taskConfig.Expansions.Get("key_1")
+	s.Equal("functionVar1", key1Value, "key_1 should be set to what it was updated to with expansions.update")
 
-	key2Value := s.tc.taskConfig.Expansions.Get("key2")
-	s.Equal("functionVar2", key2Value, "key2 should be set to what it was updated to with expansions.update")
+	key2Value := s.tc.taskConfig.Expansions.Get("key_2")
+	s.Equal("functionVar2", key2Value, "key_2 should be set to what it was updated to with expansions.update")
 
-	key3Value := s.tc.taskConfig.Expansions.Get("key3")
-	s.Equal("expansionVar3", key3Value, "key3 should be the original expansion value")
+	key3Value := s.tc.taskConfig.Expansions.Get("key_3")
+	s.Equal("expansionVar3", key3Value, "key_3 should be the original expansion value")
+}
 
+func (s *CommandSuite) TestVarsUnsetPreserveExpansionUpdatesFromFile() {
+	projYml := `
+functions:
+  yes:
+    command: expansions.update
+    params:
+      file: command/testdata/git/test_expansions.yml
+`
+	s.setUpConfigAndProject(projYml)
+
+	func1 := model.PluginCommandConf{
+		Function:    "yes",
+		DisplayName: "function",
+		Vars:        map[string]string{"key_1": "functionVar1", "key_2": "functionVar2", "key_3": "functionVar3"},
+	}
+
+	cmds := []model.PluginCommandConf{func1}
+	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmds, runCommandsOptions{}, "")
+	s.NoError(err)
+
+	key1Value := s.tc.taskConfig.Expansions.Get("key_1")
+	s.Equal("value_1", key1Value, "key_1 should be set to what it was updated to with expansions.update")
+
+	key2Value := s.tc.taskConfig.Expansions.Get("key_2")
+	s.Equal("expansionVar2", key2Value, "key_2 should be the original expansion value")
 }

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -206,7 +206,7 @@ func TestEndTaskSyncCommands(t *testing.T) {
 
 func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	config := &internal.TaskConfig{
-		Expansions: &util.Expansions{"key1": "expansionVar"},
+		Expansions: &util.Expansions{"key1": "expansionVar", "key2": "expansionVar2", "key3": "expansionVar3"},
 		BuildVariant: &model.BuildVariant{
 			Name: "some_build_variant",
 		},
@@ -328,14 +328,16 @@ functions:
     params:
       updates: 
       - key: key1
-        value: "expansion-update-value"
+        value: ${key1}
+      - key: key2
+        value: ${key2}
 `
 	s.setUpConfigAndProject(projYml)
 
 	func1 := model.PluginCommandConf{
 		Function:    "yes",
 		DisplayName: "function",
-		Vars:        map[string]string{"key1": "functionVar"},
+		Vars:        map[string]string{"key1": "functionVar1", "key2": "functionVar2", "key3": "functionVar3"},
 	}
 
 	cmds := []model.PluginCommandConf{func1}
@@ -343,5 +345,12 @@ functions:
 	s.NoError(err)
 
 	key1Value := s.tc.taskConfig.Expansions.Get("key1")
-	s.Equal("expansion-update-value", key1Value, "key1 should be set to what it was updated to with expansions.update")
+	s.Equal("functionVar1", key1Value, "key1 should be set to what it was updated to with expansions.update")
+
+	key2Value := s.tc.taskConfig.Expansions.Get("key2")
+	s.Equal("functionVar2", key2Value, "key2 should be set to what it was updated to with expansions.update")
+
+	key3Value := s.tc.taskConfig.Expansions.Get("key3")
+	s.Equal("expansionVar3", key3Value, "key3 should be the original expansion value")
+
 }

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -28,6 +28,7 @@ type TaskConfig struct {
 	Task               *task.Task
 	BuildVariant       *model.BuildVariant
 	Expansions         *util.Expansions
+	DynamicExpansions  *util.Expansions
 	Redacted           map[string]bool
 	WorkDir            string
 	GithubPatchData    thirdparty.GithubPatch
@@ -87,13 +88,14 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	}
 
 	taskConfig := &TaskConfig{
-		Distro:       d,
-		ProjectRef:   r,
-		Project:      p,
-		Task:         t,
-		BuildVariant: bv,
-		Expansions:   &e,
-		WorkDir:      workDir,
+		Distro:            d,
+		ProjectRef:        r,
+		Project:           p,
+		Task:              t,
+		BuildVariant:      bv,
+		Expansions:        &e,
+		DynamicExpansions: &util.Expansions{},
+		WorkDir:           workDir,
 	}
 	if patchDoc != nil {
 		taskConfig.GithubPatchData = patchDoc.GithubPatchData

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-15a"
+	AgentVersion = "2023-08-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -227,7 +227,6 @@ functions:
         OTEL_TRACE_ID: ${otel_trace_id}
         OTEL_PARENT_ID: ${otel_parent_id}
 
-
   setup-credentials:
     command: subprocess.exec
     type: setup
@@ -755,4 +754,3 @@ containers:
     system:
       cpu_architecture: x86_64
       operating_system: linux
-test

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -755,3 +755,4 @@ containers:
     system:
       cpu_architecture: x86_64
       operating_system: linux
+test

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -31,8 +31,7 @@ func (exp *Expansions) Update(newItems map[string]string) {
 	}
 }
 
-// Update all of the specified keys in the expansions to point to the specified
-// values.
+// Return an empty expansion
 func EmptyExpansion() *Expansions {
 	empty := Expansions(map[string]string{})
 	return &empty

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -31,6 +31,13 @@ func (exp *Expansions) Update(newItems map[string]string) {
 	}
 }
 
+// Update all of the specified keys in the expansions to point to the specified
+// values.
+func EmptyExpansion() *Expansions {
+	empty := Expansions(map[string]string{})
+	return &empty
+}
+
 // Read a map of keys/values from the given file, and update the expansions
 // to include them (overwriting any duplicates with the new value).
 func (exp *Expansions) UpdateFromYaml(filename string) error {


### PR DESCRIPTION
EVG-20673

### Description
Function vars wouldn't unset any vars whose values were changed by expansions.update. However, if it was set to the same value as the function var, it didn't work. We don't want that to be the case because we want users to be able to do this to persist function vars. 
<img width="339" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/13104717/d469e77c-c646-4f9b-be0e-ab094c1eb474">
 

### Testing
Unit test and tested on staging. 

