### PR TITLE
EVG-19943: Only clear task queue if it exists when deleting distros

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -69,10 +69,13 @@ func DeleteDistroById(ctx context.Context, u *user.DBUser, distroId string) erro
 			Message:    errors.Wrapf(err, "deleting distro '%s'", distroId).Error(),
 		}
 	}
-	if err = model.ClearTaskQueue(distroId); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "clearing task queue for distro '%s'", distroId).Error(),
+	// If a task queue exists for the distro, clear it.
+	if _, err := model.GetDistroQueueInfo(distroId); err == nil {
+		if clearQueueErr := model.ClearTaskQueue(distroId); clearQueueErr != nil {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrapf(err, "clearing task queue for distro '%s'", distroId).Error(),
+			}
 		}
 	}
 


### PR DESCRIPTION
EVG-19943

### Description
Opening this PR because I ran into problems while trying to implement the frontend portion of this ticket \_( ┐「ε:)\_ …

Deleting a distro will also clear its associated task queue. The code assumes that the task queue already exists, so if the distro doesn't have a task queue yet, this will cause an error ([reference](https://github.com/evergreen-ci/evergreen/blob/21410dd55cfb6c35e5e3742b436f32eaf981949b/model/task_queue.go#L334-L338)). 

A newly created distro doesn't appear to have a task queue. I'm not really sure how the task queue creation is managed but I think it happens [here](https://github.com/evergreen-ci/evergreen/blob/21410dd55cfb6c35e5e3742b436f32eaf981949b/scheduler/scheduler.go#L115) and [here](https://github.com/evergreen-ci/evergreen/blob/21410dd55cfb6c35e5e3742b436f32eaf981949b/scheduler/scheduler.go#L50). To get around this error, I just modified the distro deletion code so that we it only clear the task queue if it exists.

### Testing
* Modified existing tests
