### PR TITLE
EVG-20365 add task count

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -318,6 +318,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		attribute.Float64(fmt.Sprintf("%s.idle_secs", hostTerminationAttributePrefix), j.host.TotalIdleTime.Seconds()),
 		attribute.Float64(fmt.Sprintf("%s.running_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.StartTime).Seconds()),
 		attribute.Bool(fmt.Sprintf("%s.user_host", hostTerminationAttributePrefix), j.host.UserHost),
+		attribute.Int(fmt.Sprintf("%s.task_count", hostTerminationAttributePrefix), j.host.TaskCount),
 	)
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
 		span.SetAttributes(attribute.Float64(fmt.Sprintf("%s.billable_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()))


### PR DESCRIPTION
[EVG-20365](https://jira.mongodb.org/browse/EVG-20365)

### Description
This would give us insight into how many tasks the hosts are running before getting terminated. For example, we would want to know if there are a lot of hosts starting and not running any tasks.
