### PR TITLE
Revert "EVG-20463: allow Docker host.create to read file to stdin (#6901)"

### DIFF
--- a/agent/command/host_create.go
+++ b/agent/command/host_create.go
@@ -95,14 +95,6 @@ func (c *createHost) Execute(ctx context.Context, comm client.Communicator,
 			return err
 		}
 	}
-	if c.CreateHost.StdinFile != "" {
-		c.CreateHost.StdinFile = getJoinedWithWorkDir(conf, c.CreateHost.StdinFile)
-		fileContent, err := os.ReadFile(c.CreateHost.StdinFile)
-		if err != nil {
-			return errors.Wrapf(err, "reading stdin file '%s'", c.CreateHost.StdinFile)
-		}
-		c.CreateHost.StdinFileContents = fileContent
-	}
 	startTime := time.Now()
 
 	c.logAMI(ctx, comm, logger, taskData)

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -153,21 +153,17 @@ type CreateHost struct {
 	KeyName         string      `mapstructure:"key_name" json:"key_name" yaml:"key_name" plugin:"expand"`
 
 	// docker-related settings
-	Image                    string           `mapstructure:"image" json:"image" yaml:"image" plugin:"expand"`
-	Command                  string           `mapstructure:"command" json:"command" yaml:"command" plugin:"expand"`
-	PublishPorts             bool             `mapstructure:"publish_ports" json:"publish_ports" yaml:"publish_ports"`
-	Registry                 RegistrySettings `mapstructure:"registry" json:"registry" yaml:"registry" plugin:"expand"`
-	Background               bool             `mapstructure:"background" json:"background" yaml:"background"` // default is true
-	ContainerWaitTimeoutSecs int              `mapstructure:"container_wait_timeout_secs" json:"container_wait_timeout_secs" yaml:"container_wait_timeout_secs"`
-	PollFrequency            int              `mapstructure:"poll_frequency_secs" json:"poll_frequency_secs" yaml:"poll_frequency_secs"` // poll frequency in seconds
-	StdinFile                string           `mapstructure:"stdin_file_name" json:"stdin_file_name" yaml:"stdin_file_name" plugin:"expand"`
-	// StdinFileContents is the full file content of the StdinFile on the host,
-	// which is then sent to the app server.
-	StdinFileContents []byte            `mapstructure:"-" json:"stdin_file_contents" yaml:"-"`
-	StdoutFile        string            `mapstructure:"stdout_file_name" json:"stdout_file_name" yaml:"stdout_file_name" plugin:"expand"`
-	StderrFile        string            `mapstructure:"stderr_file_name" json:"stderr_file_name" yaml:"stderr_file_name" plugin:"expand"`
-	EnvironmentVars   map[string]string `mapstructure:"environment_vars" json:"environment_vars" yaml:"environment_vars" plugin:"expand"`
-	ExtraHosts        []string          `mapstructure:"extra_hosts" json:"extra_hosts" yaml:"extra_hosts" plugin:"expand"`
+	Image                    string            `mapstructure:"image" json:"image" yaml:"image" plugin:"expand"`
+	Command                  string            `mapstructure:"command" json:"command" yaml:"command" plugin:"expand"`
+	PublishPorts             bool              `mapstructure:"publish_ports" json:"publish_ports" yaml:"publish_ports"`
+	Registry                 RegistrySettings  `mapstructure:"registry" json:"registry" yaml:"registry" plugin:"expand"`
+	Background               bool              `mapstructure:"background" json:"background" yaml:"background"` // default is true
+	ContainerWaitTimeoutSecs int               `mapstructure:"container_wait_timeout_secs" json:"container_wait_timeout_secs" yaml:"container_wait_timeout_secs"`
+	PollFrequency            int               `mapstructure:"poll_frequency_secs" json:"poll_frequency_secs" yaml:"poll_frequency_secs"` // poll frequency in seconds
+	StdoutFile               string            `mapstructure:"stdout_file_name" json:"stdout_file_name" yaml:"stdout_file_name" plugin:"expand"`
+	StderrFile               string            `mapstructure:"stderr_file_name" json:"stderr_file_name" yaml:"stderr_file_name" plugin:"expand"`
+	EnvironmentVars          map[string]string `mapstructure:"environment_vars" json:"environment_vars" yaml:"environment_vars" plugin:"expand"`
+	ExtraHosts               []string          `mapstructure:"extra_hosts" json:"extra_hosts" yaml:"extra_hosts" plugin:"expand"`
 }
 
 type EbsDevice struct {

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -1,22 +1,17 @@
 package cloud
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
 )
 
@@ -66,10 +61,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 		return nil, err
 	}
 
-	if err := m.attachStdinStream(parentHost, h); err != nil {
-		return nil, errors.Wrapf(err, "attaching stdin to container for host '%s'", h.Id)
-	}
-
 	if err = h.SetAgentRevision(ctx, evergreen.AgentVersion); err != nil {
 		return nil, errors.Wrapf(err, "setting agent revision on host '%s' to '%s'", h.Id, evergreen.AgentVersion)
 	}
@@ -100,88 +91,6 @@ func (m *dockerManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host
 	})
 
 	return h, nil
-}
-
-// attachStdinStream attaches to the container's stdin and streams data to it.
-// Note that the stream to stdin has to run in the background because stdin is
-// not open until the container command is up and running.
-func (m *dockerManager) attachStdinStream(parent *host.Host, container *host.Host) error {
-	if len(container.DockerOptions.StdinData) == 0 {
-		return nil
-	}
-
-	// This needs to use a context that's not attached to the container creation
-	// request because the request does not live as long as the container does.
-	// For example, the context could be from a REST request to start a
-	// container, and the container will still be starting/running after the
-	// REST request finishes. Streaming to stdin occurs asynchronously once the
-	// container is up and running, so we have to ensure that the attached stdin
-	// lives beyond the request and eventually streams to the running container.
-	var timeoutAt time.Time
-	if !utility.IsZeroTime(container.ExpirationTime) {
-		timeoutAt = container.ExpirationTime
-	}
-	if !utility.IsZeroTime(container.SpawnOptions.TimeoutTeardown) {
-		timeoutAt = container.SpawnOptions.TimeoutTeardown
-	}
-	if utility.IsZeroTime(timeoutAt) {
-		// There's no reasonable deadline to use, so just time out after a
-		// little bit. Realistically, the data will likely stream to the
-		// container well within this deadline.
-		timeoutAt = time.Now().Add(15 * time.Minute)
-	}
-	stdinCtx, stdinCancel := context.WithDeadline(context.Background(), timeoutAt)
-
-	dockerOpts := container.DockerOptions
-
-	// Once the stdin data is used, clear it from the host to be safe in case it
-	// contains sensitive data.
-	grip.Error(message.WrapError(container.ClearDockerStdinData(stdinCtx), message.Fields{
-		"message":        "could not clear Docker stdin data from container, so it may linger in the document",
-		"container":      container.Id,
-		"task_id":        container.SpawnOptions.TaskID,
-		"task_execution": container.SpawnOptions.TaskExecutionNumber,
-		"build_id":       container.SpawnOptions.BuildID,
-	}))
-
-	stream, err := m.client.AttachToContainer(stdinCtx, parent, container.Id, dockerOpts)
-	if err != nil {
-		stdinCancel()
-		return errors.Wrap(err, "attaching stdin stream to container")
-	}
-
-	go func() {
-		defer stdinCancel()
-		m.runContainerStdinStream(stream, container, dockerOpts.StdinData)
-	}()
-
-	return nil
-}
-
-// runContainerStdinStream streams data to the container's stdin.
-func (m *dockerManager) runContainerStdinStream(stream *types.HijackedResponse, container *host.Host, stdinData []byte) {
-	defer func() {
-		if err := recovery.HandlePanicWithError(recover(), nil, "streaming stdin to container"); err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message":        "panicked while streaming stdin to container",
-				"container":      container.Id,
-				"task_id":        container.SpawnOptions.TaskID,
-				"task_execution": container.SpawnOptions.TaskExecutionNumber,
-				"build_id":       container.SpawnOptions.BuildID,
-			}))
-		}
-
-		stream.Close()
-	}()
-
-	_, err := io.Copy(stream.Conn, bytes.NewBuffer(stdinData))
-	grip.Error(message.WrapError(err, message.Fields{
-		"message":        "could not stream stdin data to container",
-		"container":      container.Id,
-		"task_id":        container.SpawnOptions.TaskID,
-		"task_execution": container.SpawnOptions.TaskExecutionNumber,
-		"build_id":       container.SpawnOptions.BuildID,
-	}))
 }
 
 func (m *dockerManager) ModifyHost(context.Context, *host.Host, host.HostModifyOptions) error {

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -40,7 +40,6 @@ type DockerClient interface {
 	RemoveImage(context.Context, *host.Host, string) error
 	RemoveContainer(context.Context, *host.Host, string) error
 	StartContainer(context.Context, *host.Host, string) error
-	AttachToContainer(context.Context, *host.Host, string, host.DockerOptions) (*types.HijackedResponse, error)
 	ListImages(context.Context, *host.Host) ([]types.ImageSummary, error)
 }
 
@@ -379,11 +378,6 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		PublishAllPorts: containerHost.DockerOptions.PublishPorts,
 		ExtraHosts:      containerHost.DockerOptions.ExtraHosts,
 	}
-	if len(containerHost.DockerOptions.StdinData) != 0 {
-		containerConf.AttachStdin = true
-		containerConf.StdinOnce = true
-		containerConf.OpenStdin = true
-	}
 
 	grip.Info(makeDockerLogMessage("ContainerCreate", parentHost.Id, message.Fields{"image": containerConf.Image}))
 
@@ -546,26 +540,6 @@ func (c *dockerClientImpl) StartContainer(ctx context.Context, h *host.Host, con
 	}
 
 	return nil
-}
-
-func (c *dockerClientImpl) AttachToContainer(ctx context.Context, h *host.Host, containerID string, opts host.DockerOptions) (*types.HijackedResponse, error) {
-	if len(opts.StdinData) == 0 {
-		return nil, nil
-	}
-	dockerClient, err := c.generateClient(h)
-	if err != nil {
-		return nil, errors.Wrap(err, "generating Docker client")
-	}
-
-	stream, err := dockerClient.ContainerAttach(ctx, containerID, types.ContainerAttachOptions{
-		Stream: true,
-		Stdin:  true,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "attaching stdin to container")
-	}
-
-	return &stream, nil
 }
 
 func makeDockerLogMessage(name, parent string, data interface{}) message.Fields {

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -25,12 +25,10 @@ type dockerClientMock struct {
 	failList     bool
 	failRemove   bool
 	failStart    bool
-	failAttach   bool
 
 	// Other options
-	hasOpenPorts        bool
-	baseImage           string
-	containerAttachment *types.HijackedResponse
+	hasOpenPorts bool
+	baseImage    string
 }
 
 func GetMockClient() *dockerClientMock {
@@ -168,11 +166,4 @@ func (c *dockerClientMock) StartContainer(context.Context, *host.Host, string) e
 		return errors.New("failed to start container")
 	}
 	return nil
-}
-
-func (c *dockerClientMock) AttachToContainer(context.Context, *host.Host, string, host.DockerOptions) (*types.HijackedResponse, error) {
-	if c.failAttach {
-		return c.containerAttachment, errors.New("failed to attach to container")
-	}
-	return c.containerAttachment, nil
 }

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -415,7 +415,7 @@ Parse From A File:
 
 Agent Parameters:
 
--   `num_hosts` - Number of hosts to start, 1 &lt;= `num_hosts` &lt;= 10.
+-   `num_hosts` - Number of hosts to start, 1 \<= `num_hosts` \<= 10.
     Defaults to 1 (must be 1 if provider is Docker).
 -   `provider` - Cloud provider. Must set `ec2` or `docker`.
 -   `retries` - How many times Evergreen should try to create this host
@@ -425,11 +425,11 @@ Agent Parameters:
     the task or build is finished. Must be either `task` or `build`.
     Defaults to `task` if not set.
 -   `timeout_setup_secs` - Stop waiting for hosts to be ready when
-    spawning. Must be 60 &lt;= `timeout_setup_secs` &lt;= 3600 (1 hour).
+    spawning. Must be 60 \<= `timeout_setup_secs` \<= 3600 (1 hour).
     Default to 600 (10 minutes).
 -   `timeout_teardown_secs` - Even if the task or build has not
     finished, tear down this host after this many seconds. Must be 60
-    &lt;= `timeout_teardown_secs` &lt;= 604800 (7 days). Default to 21600 (6
+    \<= `timeout_teardown_secs` \<= 604800 (7 days). Default to 21600 (6
     hours).
 
 EC2 Parameters:
@@ -470,7 +470,7 @@ Docker Parameters:
 -   `background` - Set to wait for logs in the background, rather than
     blocking. Default is true.
 -   `container_wait_timeout_secs` - Time to wait for the container to
-    finish running the given command. Must be &lt;= 3600 (1 hour). Default
+    finish running the given command. Must be \<= 3600 (1 hour). Default
     to 600 (10 minutes).
 -   `command` - The command to run on the container. Does not not
     support shell interpolation. If not specified, will use the default
@@ -480,7 +480,7 @@ Docker Parameters:
 -   `image` - Required. The image to use for the container. If image is
     a URL, then the image is imported, otherwise it is pulled.
 -   `poll_frequency_secs` - Check for running container and logs at this
-    interval. Must be &lt;= 60 (1 second). Default to 30.
+    interval. Must be \<= 60 (1 second). Default to 30.
 -   `publish_ports` - Set to make ports available by mapping container
     ports to ports on the Docker host. Default is false.
 -   `extra_hosts` - Optional. This is a list of hosts to be added to
@@ -492,15 +492,10 @@ Docker Parameters:
     requires authentication. Must set if `registry_password` is set.
 -   `registry_password` - Password for the `registry_name` if it
     requires authentication. Must set if `registry_username` is set.
--   `stdin_file_name` - The file containing the content to provide as stdin to
-    the container command. By default, the container command has no input to
-    stdin. Note that if you try to start a spawn host and also choose to start
-    containers started by host.create for the task, the running container will
-    *not* have the stdin file content passed to it.
 -   `stdout_file_name` - The file path to write stdout logs from the
-    container. Default is &lt;container_id&gt;.out.log.
+    container. Default is \<container_id\>.out.log.
 -   `stderr_file_name` - The file path to write stderr logs from the
-    container. Default is &lt;container_id&gt;.err.log.
+    container. Default is \<container_id\>.err.log.
 -   `environment_vars` - Environment variables to pass to the container command.
     By default, no environment variables are passed.
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -82,7 +82,6 @@ var (
 	TotalIdleTimeKey                   = bsonutil.MustHaveTag(Host{}, "TotalIdleTime")
 	HasContainersKey                   = bsonutil.MustHaveTag(Host{}, "HasContainers")
 	ParentIDKey                        = bsonutil.MustHaveTag(Host{}, "ParentID")
-	DockerOptionsKey                   = bsonutil.MustHaveTag(Host{}, "DockerOptions")
 	ContainerImagesKey                 = bsonutil.MustHaveTag(Host{}, "ContainerImages")
 	ContainerBuildAttempt              = bsonutil.MustHaveTag(Host{}, "ContainerBuildAttempt")
 	LastContainerFinishTimeKey         = bsonutil.MustHaveTag(Host{}, "LastContainerFinishTime")
@@ -110,7 +109,6 @@ var (
 	VolumeMigratingKey                 = bsonutil.MustHaveTag(Volume{}, "Migrating")
 	VolumeAttachmentIDKey              = bsonutil.MustHaveTag(VolumeAttachment{}, "VolumeID")
 	VolumeDeviceNameKey                = bsonutil.MustHaveTag(VolumeAttachment{}, "DeviceName")
-	DockerOptionsStdinDataKey          = bsonutil.MustHaveTag(DockerOptions{}, "StdinData")
 )
 
 var (

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -240,8 +240,6 @@ type DockerOptions struct {
 	SkipImageBuild bool `mapstructure:"skip_build" bson:"skip_build,omitempty" json:"skip_build,omitempty"`
 	// list of container environment variables KEY=VALUE
 	EnvironmentVars []string `mapstructure:"environment_vars" bson:"environment_vars,omitempty" json:"environment_vars,omitempty"`
-	// StdinData is the data to pass to the container command's stdin.
-	StdinData []byte `mapstructure:"stdin_data" bson:"stdin_data,omitempty" json:"stdin_data,omitempty"`
 }
 
 // FromDistroSettings loads the Docker container options from the provider
@@ -3185,26 +3183,4 @@ func CountVirtualWorkstationsByInstanceType(ctx context.Context) ([]VirtualWorks
 	}
 
 	return data, nil
-}
-
-// ClearDockerStdinData clears the Docker stdin data from the host.
-func (h *Host) ClearDockerStdinData(ctx context.Context) error {
-	if len(h.DockerOptions.StdinData) == 0 {
-		return nil
-	}
-
-	dockerStdinDataKey := bsonutil.GetDottedKeyName(DockerOptionsKey, DockerOptionsStdinDataKey)
-	if err := UpdateOne(ctx, bson.M{
-		IdKey: h.Id,
-	},
-		bson.M{
-			"$unset": bson.M{dockerStdinDataKey: true},
-		},
-	); err != nil {
-		return err
-	}
-
-	h.DockerOptions.StdinData = nil
-
-	return nil
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -5936,28 +5936,3 @@ func TestGetPaginatedRunningHosts(t *testing.T) {
 		})
 	}
 }
-
-func TestClearDockerStdinData(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	defer func() {
-		assert.NoError(t, db.ClearCollections(Collection))
-	}()
-	require.NoError(t, db.ClearCollections(Collection))
-	h := Host{
-		Id: "host_id",
-		DockerOptions: DockerOptions{
-			StdinData: []byte("stdin data"),
-		},
-	}
-	require.NoError(t, h.Insert(ctx))
-
-	require.NoError(t, h.ClearDockerStdinData(ctx))
-	assert.Empty(t, h.DockerOptions.StdinData)
-
-	dbHost, err := FindOneId(ctx, h.Id)
-	require.NoError(t, err)
-	require.NotZero(t, dbHost)
-	assert.Empty(t, dbHost.DockerOptions.StdinData)
-}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -259,7 +259,6 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 	return createHost, nil
 }
 
-// MakeHost creates a host or container to run for host.create.
 func MakeHost(ctx context.Context, env evergreen.Environment, taskID, userID, publicKey string, createHost apimodels.CreateHost) (*host.Host, error) {
 	if evergreen.IsDockerProvider(createHost.CloudProvider) {
 		return makeDockerIntentHost(ctx, env, taskID, userID, createHost)
@@ -310,7 +309,6 @@ func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID
 		RegistryName:     createHost.Registry.Name,
 		RegistryUsername: createHost.Registry.Username,
 		RegistryPassword: createHost.Registry.Password,
-		StdinData:        createHost.StdinFileContents,
 		Method:           method,
 		SkipImageBuild:   true,
 		EnvironmentVars:  envVars,


### PR DESCRIPTION
Reverting because of a user report that Docker host.create is behaving strangely. I don't really understand how the new option could have caused this since they didn't specify the new option (and the existing behavior without the option should be the same as before), but reverting seems safe enough.
