### PR TITLE
EVG-20683: remove GIT_CURL_VERBOSE

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -201,7 +201,7 @@ func (opts cloneOpts) buildHTTPCloneCommand() ([]string, error) {
 		clone = fmt.Sprintf("%s --recurse-submodules", clone)
 	}
 	if opts.useVerbose {
-		clone = fmt.Sprintf("GIT_TRACE=1 GIT_CURL_VERBOSE=1 %s", clone)
+		clone = fmt.Sprintf("GIT_TRACE=1 %s", clone)
 	}
 	if opts.cloneDepth > 0 {
 		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-16"
+	AgentVersion = "2023-08-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20683

### Description
Reduce the amount of verbose logging that is shown when `git clone` fails and retries. We could have kept the verbose logging if we had a newer version of git on all the machines (the auth header is only an issue in old versions of git which RHEL 7.x comes with by default), but older versions of RHEL can't get newer git versions (without compiling it from source).

### Testing
I tested this in a spawn host and confirmed that the verbose logs don't show the auth header.

### Documentation
N/A
