### PR TITLE
Revert "Revert "EVG-20281: improve callback timeout behavior (#6894)" (#6922)"

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -844,7 +844,6 @@ task_groups:
 func (s *AgentSuite) TestSetupGroupFails() {
 	const taskGroup = "task_group_name"
 	s.tc.taskGroup = taskGroup
-	s.tc.ranSetupGroup = false
 	projYml := `
 task_groups:
 - name: task_group_name
@@ -860,7 +859,70 @@ task_groups:
 	s.tc.taskConfig.Project = p
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
 
-	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc))
+	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc), "setup group command error should fail task")
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running setup group for task group 'task_group_name'",
+	}, []string{panicLog})
+}
+
+func (s *AgentSuite) TestSetupGroupTimeoutFailsTask() {
+	const taskGroup = "task_group_name"
+	s.tc.taskGroup = taskGroup
+	projYml := `
+task_groups:
+- name: task_group_name
+  setup_group_can_fail_task: true
+  setup_group_timeout_secs: 1
+  setup_group:
+  - command: shell.exec
+    params:
+      script: sleep 100
+`
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+
+	startAt := time.Now()
+	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc), "setup group timeout should fail task")
+
+	s.Less(time.Since(startAt), 5*time.Second, "timeout should have triggered after 1s")
+	s.NoError(s.tc.logger.Close())
+	s.True(s.tc.hadTimedOut(), "should have hit task timeout")
+	s.Equal(setupGroupTimeout, s.tc.getTimeoutType())
+	s.Equal(time.Second, s.tc.getTimeoutDuration())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running setup group for task group 'task_group_name'",
+	}, []string{panicLog})
+}
+
+func (s *AgentSuite) TestSetupGroupTimeoutDoesNotFailTask() {
+	const taskGroup = "task_group_name"
+	s.tc.taskGroup = taskGroup
+	projYml := `
+task_groups:
+- name: task_group_name
+  setup_group_timeout_secs: 1
+  setup_group:
+  - command: shell.exec
+    params:
+      script: sleep 100
+`
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+
+	startAt := time.Now()
+	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc), "setup group timeout should not fail task")
+
+	s.Less(time.Since(startAt), 5*time.Second, "timeout should have triggered after 1s")
+	s.False(s.tc.hadTimedOut(), "should not have hit task timeout")
+	s.Zero(s.tc.getTimeoutType())
+	s.Zero(s.tc.getTimeoutDuration())
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
 		"Running setup group for task group 'task_group_name'",

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -24,6 +24,8 @@ type TimeoutSuite struct {
 	tmpFile          *os.File
 	tmpFileName      string
 	tmpDirName       string
+	ctx              context.Context
+	cancel           context.CancelFunc
 }
 
 func TestTimeoutSuite(t *testing.T) {
@@ -54,9 +56,11 @@ func (s *TimeoutSuite) SetupTest() {
 	s.Require().NoError(s.tmpFile.Close())
 	s.a.jasper, err = jasper.NewSynchronizedManager(false)
 	s.Require().NoError(err)
+	s.ctx, s.cancel = context.WithCancel(context.Background())
 }
 
 func (s *TimeoutSuite) TearDownTest() {
+	s.cancel()
 	s.Require().NoError(os.Remove(s.tmpFileName))
 }
 
@@ -85,11 +89,9 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 0
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())
@@ -119,9 +121,6 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 // TestExecTimeoutTask tests exec_timeout_secs set on a task. exec_timeout_secs
 // has an effect only on a project or a task.
 func (s *TimeoutSuite) TestExecTimeoutTask() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	taskID := "exec_timeout_task"
 	taskSecret := "mock_task_secret"
 	tc := &taskContext{
@@ -144,9 +143,9 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 1
 
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())
@@ -176,9 +175,6 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 
 // TestIdleTimeoutFunc tests timeout_secs set in a function.
 func (s *TimeoutSuite) TestIdleTimeoutFunc() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	taskID := "idle_timeout_func"
 	taskSecret := "mock_task_secret"
 	tc := &taskContext{
@@ -201,9 +197,9 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 2
 
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())
@@ -233,9 +229,6 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 
 // TestIdleTimeout tests timeout_secs set on a function in a command.
 func (s *TimeoutSuite) TestIdleTimeoutCommand() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	taskID := "idle_timeout_task"
 	taskSecret := "mock_task_secret"
 	tc := &taskContext{
@@ -258,9 +251,9 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 3
 
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())
@@ -290,9 +283,6 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 
 // TestDynamicIdleTimeout tests that the `update.timeout` command sets timeout_secs.
 func (s *TimeoutSuite) TestDynamicIdleTimeout() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	taskID := "dynamic_idle_timeout_task"
 	taskSecret := "mock_task_secret"
 	tc := &taskContext{
@@ -315,9 +305,9 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 3
 
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())
@@ -346,9 +336,6 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 
 // TestDynamicExecTimeout tests that the `update.timeout` command sets exec_timeout_secs.
 func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	taskID := "dynamic_exec_timeout_task"
 	taskSecret := "mock_task_secret"
 	tc := &taskContext{
@@ -371,9 +358,9 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 	// tests in this suite to create differently-named task directories.
 	s.mockCommunicator.TaskExecution = 1
 
-	s.NoError(s.a.startLogging(ctx, tc))
+	s.NoError(s.a.startLogging(s.ctx, tc))
 	defer s.a.removeTaskDirectory(tc)
-	_, err := s.a.runTask(ctx, tc)
+	_, err := s.a.runTask(s.ctx, tc)
 	s.NoError(err)
 
 	s.Require().NoError(tc.logger.Close())

--- a/agent/background.go
+++ b/agent/background.go
@@ -153,9 +153,8 @@ func (tc *taskContext) getCallbackTimeout() time.Duration {
 	tc.RLock()
 	defer tc.RUnlock()
 
-	taskConfig := tc.getTaskConfig()
-	if taskConfig != nil && taskConfig.Project != nil && taskConfig.Project.CallbackTimeout != 0 {
-		return time.Duration(taskConfig.Project.CallbackTimeout) * time.Second
+	if tc.taskConfig != nil && tc.taskConfig.Project != nil && tc.taskConfig.Project.CallbackTimeout != 0 {
+		return time.Duration(tc.taskConfig.Project.CallbackTimeout) * time.Second
 	}
 	return defaultCallbackCmdTimeout
 }

--- a/agent/background_test.go
+++ b/agent/background_test.go
@@ -52,19 +52,67 @@ func (s *BackgroundSuite) SetupTest() {
 	s.tc.logger = client.NewSingleChannelLogHarness("test", s.sender)
 }
 
-func (s *BackgroundSuite) TestWithCallbackTimeoutDefault() {
-	ctx, _ := s.a.withCallbackTimeout(context.Background(), s.tc)
-	deadline, ok := ctx.Deadline()
-	s.True(deadline.Sub(time.Now()) > (defaultCallbackCmdTimeout - time.Second)) // nolint
-	s.True(ok)
+func (s *BackgroundSuite) TestStartTimeoutWatcherTimesOut() {
+	const testTimeout = 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	const timeout = time.Nanosecond
+	startAt := time.Now()
+	timeoutOpts := timeoutWatcherOptions{
+		tc:                    s.tc,
+		kind:                  callbackTimeout,
+		getTimeout:            func() time.Duration { return timeout },
+		canMarkTimeoutFailure: true,
+	}
+	s.a.startTimeoutWatcher(ctx, cancel, timeoutOpts)
+
+	s.Less(time.Since(startAt), testTimeout)
+	s.Error(ctx.Err(), "should have cancelled operation to time out")
+	s.True(s.tc.hadTimedOut())
+	s.Equal(callbackTimeout, s.tc.getTimeoutType(), "should have hit callback timeout")
+	s.Equal(timeout, s.tc.getTimeoutDuration(), "should have recorded timeout duration")
 }
 
-func (s *BackgroundSuite) TestWithCallbackTimeoutSetByProject() {
-	s.tc.taskConfig.Project.CallbackTimeout = 100
-	ctx, _ := s.a.withCallbackTimeout(context.Background(), s.tc)
-	deadline, ok := ctx.Deadline()
-	s.True(deadline.Sub(time.Now()) > 99) // nolint
-	s.True(ok)
+func (s *BackgroundSuite) TestStartTimeoutWatcherExitsWithoutTimeout() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	timeoutWatcherDone := make(chan struct{})
+	go func() {
+		timeoutOpts := timeoutWatcherOptions{
+			tc:                    s.tc,
+			kind:                  callbackTimeout,
+			getTimeout:            func() time.Duration { return time.Hour },
+			canMarkTimeoutFailure: true,
+		}
+		s.a.startTimeoutWatcher(ctx, cancel, timeoutOpts)
+		close(timeoutWatcherDone)
+	}()
+
+	cancel()
+	<-timeoutWatcherDone
+
+	s.False(s.tc.hadTimedOut())
+	s.Zero(s.tc.getTimeoutType())
+	s.Zero(s.tc.getTimeoutDuration())
+}
+
+func (s *BackgroundSuite) TestStartTimeoutWatcherTimesOutButDoesNotMarkTimeoutFailure() {
+	const testTimeout = 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	const timeout = time.Nanosecond
+	startAt := time.Now()
+	timeoutOpts := timeoutWatcherOptions{
+		tc:         s.tc,
+		kind:       callbackTimeout,
+		getTimeout: func() time.Duration { return timeout },
+	}
+	s.a.startTimeoutWatcher(ctx, cancel, timeoutOpts)
+
+	s.Less(time.Since(startAt), testTimeout)
+	s.Error(ctx.Err(), "should have cancelled operation to time out")
+	s.False(s.tc.hadTimedOut(), "should not have marked timeout failure")
+	s.Zero(s.tc.getTimeoutType())
+	s.Zero(s.tc.getTimeoutDuration())
 }
 
 const (

--- a/agent/command.go
+++ b/agent/command.go
@@ -231,12 +231,8 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		case <-cmdChan:
 		}
 
-		if ctx.Err() == context.DeadlineExceeded {
-			tc.logger.Task().Errorf("Command %s stopped early because idle timeout duration of %d seconds has been reached.", displayName, int(tc.timeout.idleTimeoutDuration.Seconds()))
-		} else {
-			tc.logger.Task().Errorf("Command %s stopped early: %s.", displayName, ctx.Err())
-		}
-		return errors.Wrap(ctx.Err(), "agent stopped early")
+		tc.logger.Task().Errorf("Command %s stopped early: %s.", displayName, ctx.Err())
+		return errors.Wrap(ctx.Err(), "command stopped early")
 	}
 	tc.logger.Task().Infof("Finished command %s in %s.", displayName, time.Since(start).String())
 	if (options.isTaskCommands || options.failPreAndPost) && a.endTaskResp != nil && !a.endTaskResp.ShouldContinue {

--- a/agent/global.go
+++ b/agent/global.go
@@ -33,7 +33,7 @@ const (
 	defaultStatsInterval = time.Minute
 
 	// defaultCallbackCmdTimeout specifies the duration after when the "post" or
-	// "timeout" command sets should be shut down.
+	// "timeout" block sets should be shut down.
 	defaultCallbackCmdTimeout = 15 * time.Minute
 
 	// maxHeartbeats is the number of failed heartbeats after which an agent

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-18"
+	AgentVersion = "2023-08-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-17"
+	AgentVersion = "2023-08-18"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project.go
+++ b/model/project.go
@@ -447,11 +447,6 @@ func GetModuleByName(moduleList ModuleList, moduleName string) (*Module, error) 
 	return nil, errors.Errorf("module '%s' doesn't exist", moduleName)
 }
 
-type TestSuite struct {
-	Name  string `yaml:"name,omitempty"`
-	Phase string `yaml:"phase,omitempty"`
-}
-
 type PluginCommandConf struct {
 	Function string `yaml:"func,omitempty" bson:"func,omitempty"`
 	// Type is used to differentiate between setup related commands and actual


### PR DESCRIPTION
This reverts commit c3d3980edc258b9c3f8e944f6f82e63912312e32 and fixes an issue where `getCallbackTimeout` double acquires the task context read lock.

[`RLock` docs](https://pkg.go.dev/sync@go1.21.0#RWMutex.RLock) say recursive read locks can deadlock when there's another goroutine calling `Lock` right before the recursive RLock.