### PR TITLE
EVG-20705 Remove expensive grip statement

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -823,6 +823,7 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 
 	// Create and update display tasks
 	tasks := task.Tasks{}
+	loggedExecutionTaskNotFound := false
 	for _, dt := range creationInfo.BuildVariant.DisplayTasks {
 		id := displayTable.GetId(creationInfo.Build.BuildVariant, dt.Name)
 		if id == "" {
@@ -837,6 +838,17 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 		for _, et := range dt.ExecTasks {
 			execTaskId := execTable.GetId(creationInfo.Build.BuildVariant, et)
 			if execTaskId == "" {
+				if !loggedExecutionTaskNotFound {
+					grip.Debug(message.Fields{
+						"message":                     "execution task not found",
+						"variant":                     creationInfo.Build.BuildVariant,
+						"exec_task":                   et,
+						"project":                     creationInfo.Project.Identifier,
+						"display_task":                id,
+						"display_task_already_exists": displayTaskAlreadyExists,
+					})
+					loggedExecutionTaskNotFound = true
+				}
 				continue
 			}
 			execTaskIds = append(execTaskIds, execTaskId)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -837,15 +837,6 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 		for _, et := range dt.ExecTasks {
 			execTaskId := execTable.GetId(creationInfo.Build.BuildVariant, et)
 			if execTaskId == "" {
-				grip.Error(message.Fields{
-					"message":                     "execution task not found",
-					"variant":                     creationInfo.Build.BuildVariant,
-					"exec_task":                   et,
-					"available_tasks":             execTable,
-					"project":                     creationInfo.Project.Identifier,
-					"display_task":                id,
-					"display_task_already_exists": displayTaskAlreadyExists,
-				})
 				continue
 			}
 			execTaskIds = append(execTaskIds, execTaskId)


### PR DESCRIPTION
EVG-20705

### Description

Apologies for the essay, this was a journey.

Although initially it seemed that the act of inserting many tasks into the DB was the bottleneck during task generation for large JSONs, after setting up more detailed honeycomb traces it appears that although the amount of time `tasks.insert` runs for is significant, but looking at the bottom of [this trace](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/aB58Z3FGywQ/trace/kfgs2RUsrid?fields[]=c_name&fields[]=c_service.name&span=67e50313e32f064c), for example, there appears to be something else happening in between each iteration of the loop where we perform `tasks.insert` that is taking a lot of time.

To investigate further I set up more detailed spans inside the bottlenecking `add-new-builds` span, creating 4 sub-spans inside the large `createTasksForBuild` function that appeared to be taking all the time in between database inserts.  From the link, you can see honeycomb reveals that the 3rd subspan `creating-display-tasks` was the expensive bit of the function, and corresponds to [this block of code](https://github.com/evergreen-ci/evergreen/blob/main/model/lifecycle.go#L824-L896), and is apparently responsible for the overwhelming majority of runtime for the entire `generate.tasks` command. This was extremely confusing to me as it seemed like a very inoffensive loop, to the point where I started to think honeycomb was incorrect in its measurements.

I started commenting out random things in this loop and submitting dists to staging to no avail, until I randomly noticed that removing this [grip statement](https://github.com/evergreen-ci/evergreen/blob/main/model/lifecycle.go#L840-L848) got rid of all slowness. What's even more confusing, is that [grepping splunk for that error message](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen%22%20%22execution%20task%20not%20found%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&sid=1692381488.5383300) in the past month yields almost zero results, so it's hard to believe this grip statement could be affecting anything. Taking a closer look, the `execTable` field it tries to log out, in server's case, is a huge map with thousands of keys. When I tried to comment out just [this line](https://github.com/evergreen-ci/evergreen/blob/main/model/lifecycle.go#L844) from the grip statement, suddenly running the command yielded [thousands of results in staging](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%22execution%20task%20not%20found%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1692244800&latest=1692417600&sid=1692381756.5384486).

The errors are basically saying that all the task names that end in `_gen` that are specified in the JSON (of which there are many) can't be found because they aren't real tasks. I'm actually still not sure how they do it, but through some sleight of hand server defines task names that end with `_gen` in their YAML, but when tasks are actually generated it gets replaced by a task of the same name, without the `_gen` prefix. Here's an example: they define a task named `ssl_gen` in YAML [here](https://github.com/mongodb/mongo/blob/master/etc/evergreen_yml_components/definitions.yml#L6857-L6863), but when the tasks actually get generated it creates a task named just [ssl](https://spruce-staging.corp.mongodb.com/task/evg_enterprise_rhel_80_64_bit_dynamic_all_feature_flags_display_ssl_patch_0b92fe04495f06f0a646c16b1309e98dc4204639_64df08229dbe32db252fa4dc_23_08_18_05_57_45?execution=0&sorts=STATUS%3AASC). These `_gen` tasks that appear to be placeholders or something aren't found looping through the large map of tasks to be created, each time with a grip error statement including the entire map as one of its properties.

So what seems to have been happening is that since all of server's generate.tasks commands work in this way, and each generated JSON they create is huge, that grip statement hits 5000+ times per command, each time attempting to log out the entire map of all execution tasks. How that condition was evaluating to be true and yet no logs show up in Splunk is still not clear to me, but a few hypotheses I have are:

- Grip tries to buffer the messages before they write them to their output destination so these very large messages overflow the buffer and cause nothing to get logged.
- Splunk is configured with some maximum message size, and messages exceeding this size are discarded. So, if the log message with the `execTable` exceeds this limit, it gets dropped and you won't find it in Splunk
- Writing such a massive amount of data to standard error at once takes a lot of I/O bandwidth and there is some failsafe that drops these statements if they become too much.

In any case, it appears to be a very expensive operation to include these logs, and dropping this single statement alone causes server's generate.tasks commands to go from running in 3 minutes to 30 seconds with no difference.

### Testing
The mock huge server JSON I created as part of [EVG-20599](https://jira.mongodb.org/browse/EVG-20599) decreased its `generate.tasks` runtime from 167 seconds [before this change](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/aB58Z3FGywQ/trace/kfgs2RUsrid?fields[]=c_name&fields[]=c_service.name&span=67e50313e32f064c), to 29 seconds [after this change](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/aB58Z3FGywQ/trace/qqk9wgPWzLQ?fields[]=c_name&fields[]=c_service.name&span=23cd6a0dfecd789d), roughly a 6x improvement.