### PR TITLE
EVG-20703 Expand testing and improve style for expansions.update

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -178,8 +178,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 				}
 			}
 			tc.taskConfig.Expansions.Update(prevExp)
-			tc.taskConfig.DynamicExpansions = util.EmptyExpansion()
-
+			tc.taskConfig.DynamicExpansions = *util.NewExpansions(map[string]string{})
 		}
 	}()
 

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -43,7 +43,7 @@ func TestExpansionsPlugin(t *testing.T) {
 		}
 
 		So(updateCommand.ExecuteUpdates(ctx, &taskConfig), ShouldBeNil)
-		So(taskConfig.DynamicExpansions, ShouldResemble, &util.Expansions{"base": "eggs", "topping": "bacon,sausage"})
+		So(taskConfig.DynamicExpansions, ShouldResemble, util.Expansions{"base": "eggs", "topping": "bacon,sausage"})
 		So(expansions.Get("base"), ShouldEqual, "eggs")
 		So(expansions.Get("topping"), ShouldEqual, "bacon,sausage")
 	})
@@ -63,7 +63,7 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 			cmd := &update{YamlFile: "foo"}
 			So(cmd.Execute(ctx, comm, logger, conf), ShouldNotBeNil)
 			So(cmd.YamlFile, ShouldEqual, "foo")
-			So(conf.DynamicExpansions, ShouldResemble, &util.Expansions{})
+			So(conf.DynamicExpansions, ShouldResemble, util.Expansions{})
 		})
 
 		Convey("With an Expansion, the file name is expanded", func() {

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -38,8 +38,7 @@ func TestExpansionsPlugin(t *testing.T) {
 		expansions.Put("topping", "bacon")
 
 		taskConfig := internal.TaskConfig{
-			Expansions:        &expansions,
-			DynamicExpansions: util.Expansions{},
+			Expansions: &expansions,
 		}
 
 		So(updateCommand.ExecuteUpdates(ctx, &taskConfig), ShouldBeNil)
@@ -54,7 +53,7 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	comm := client.NewMock("http://localhost.com")
-	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, DynamicExpansions: util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
 	logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 
 	Convey("When running Update commands", t, func() {
@@ -63,7 +62,6 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 			cmd := &update{YamlFile: "foo"}
 			So(cmd.Execute(ctx, comm, logger, conf), ShouldNotBeNil)
 			So(cmd.YamlFile, ShouldEqual, "foo")
-			So(conf.DynamicExpansions, ShouldResemble, util.Expansions{})
 		})
 
 		Convey("With an Expansion, the file name is expanded", func() {

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -39,7 +39,7 @@ func TestExpansionsPlugin(t *testing.T) {
 
 		taskConfig := internal.TaskConfig{
 			Expansions:        &expansions,
-			DynamicExpansions: &util.Expansions{},
+			DynamicExpansions: util.Expansions{},
 		}
 
 		So(updateCommand.ExecuteUpdates(ctx, &taskConfig), ShouldBeNil)
@@ -54,7 +54,7 @@ func TestExpansionsPluginWExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	comm := client.NewMock("http://localhost.com")
-	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, DynamicExpansions: &util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
+	conf := &internal.TaskConfig{Expansions: &util.Expansions{}, DynamicExpansions: util.Expansions{}, Task: &task.Task{}, Project: &model.Project{}}
 	logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
 
 	Convey("When running Update commands", t, func() {

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -92,7 +92,6 @@ func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) 
 // Execute updates the expansions. Fulfills Command interface.
 func (c *update) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
-
 	err := c.ExecuteUpdates(ctx, conf)
 
 	if err != nil {

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -61,6 +62,9 @@ func (c *update) ParseParams(params map[string]interface{}) error {
 }
 
 func (c *update) ExecuteUpdates(ctx context.Context, conf *internal.TaskConfig) error {
+	if conf.DynamicExpansions == nil {
+		conf.DynamicExpansions = util.Expansions{}
+	}
 	for _, update := range c.Updates {
 		if err := ctx.Err(); err != nil {
 			return errors.Wrap(err, "operation aborted")

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -206,8 +206,7 @@ func TestEndTaskSyncCommands(t *testing.T) {
 
 func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	config := &internal.TaskConfig{
-		Expansions:        &util.Expansions{"key1": "expansionVar", "key2": "expansionVar2", "key3": "expansionVar3"},
-		DynamicExpansions: util.Expansions{},
+		Expansions: &util.Expansions{"key1": "expansionVar", "key2": "expansionVar2", "key3": "expansionVar3"},
 		BuildVariant: &model.BuildVariant{
 			Name: "some_build_variant",
 		},

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -82,7 +82,6 @@ func (s *CommandSuite) SetupTest() {
 		Identifier: "project_identifier",
 	}, &patch.Patch{}, util.Expansions{})
 	s.Require().NoError(err)
-	s.Equal(&util.Expansions{}, taskConfig.DynamicExpansions)
 
 	s.tc = &taskContext{
 		taskConfig: taskConfig,
@@ -208,7 +207,7 @@ func TestEndTaskSyncCommands(t *testing.T) {
 func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	config := &internal.TaskConfig{
 		Expansions:        &util.Expansions{"key1": "expansionVar", "key2": "expansionVar2", "key3": "expansionVar3"},
-		DynamicExpansions: &util.Expansions{},
+		DynamicExpansions: util.Expansions{},
 		BuildVariant: &model.BuildVariant{
 			Name: "some_build_variant",
 		},
@@ -355,7 +354,7 @@ functions:
 	key3Value := s.tc.taskConfig.Expansions.Get("key3")
 	s.Equal("expansionVar3", key3Value, "key3 should be the original expansion value")
 
-	s.Equal(&util.Expansions{}, s.tc.taskConfig.DynamicExpansions)
+	s.Empty(s.tc.taskConfig.DynamicExpansions)
 }
 
 func (s *CommandSuite) TestVarsUnsetPreserveExpansionUpdatesFromFile() {
@@ -386,5 +385,5 @@ functions:
 
 	key3Value := s.tc.taskConfig.Expansions.Get("key3")
 	s.Equal("expansionVar3", key3Value, "key3 should be the original expansion value")
-	s.Equal(&util.Expansions{}, s.tc.taskConfig.DynamicExpansions)
+	s.Empty(s.tc.taskConfig.DynamicExpansions)
 }

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -28,7 +28,7 @@ type TaskConfig struct {
 	Task               *task.Task
 	BuildVariant       *model.BuildVariant
 	Expansions         *util.Expansions
-	DynamicExpansions  *util.Expansions
+	DynamicExpansions  util.Expansions
 	Redacted           map[string]bool
 	WorkDir            string
 	GithubPatchData    thirdparty.GithubPatch
@@ -94,7 +94,7 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 		Task:              t,
 		BuildVariant:      bv,
 		Expansions:        &e,
-		DynamicExpansions: &util.Expansions{},
+		DynamicExpansions: util.Expansions{},
 		WorkDir:           workDir,
 	}
 	if patchDoc != nil {

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -5,10 +5,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,4 +98,36 @@ task_groups:
 	assert.Len(t, tg.Tasks, 2)
 	assert.Equal(t, 2, tg.MaxHosts)
 	assert.NotEmpty(t, tg.Timeout) // Defaults to project-level timeout if not defined.
+}
+
+func TestNewTaskConfig(t *testing.T) {
+	curdir := testutil.GetDirectoryOfFile()
+	taskName := "some_task"
+	bvName := "bv"
+	p := &model.Project{
+		Tasks: []model.ProjectTask{
+			{
+				Name: taskName,
+			},
+		},
+		BuildVariants: []model.BuildVariant{{Name: bvName}},
+	}
+	task := &task.Task{
+		Id:           "task_id",
+		DisplayName:  taskName,
+		BuildVariant: bvName,
+		Version:      "v1",
+	}
+
+	taskConfig, err := NewTaskConfig(curdir, &apimodels.DistroView{}, p, task, &model.ProjectRef{
+		Id:         "project_id",
+		Identifier: "project_identifier",
+	}, &patch.Patch{}, util.Expansions{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, util.Expansions{}, taskConfig.DynamicExpansions)
+	assert.Equal(t, &util.Expansions{}, taskConfig.Expansions)
+	assert.Equal(t, &apimodels.DistroView{}, taskConfig.Distro)
+	assert.Equal(t, p, taskConfig.Project)
+	assert.Equal(t, task, taskConfig.Task)
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-18"
+	AgentVersion = "2023-08-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -31,12 +31,6 @@ func (exp *Expansions) Update(newItems map[string]string) {
 	}
 }
 
-// Return an empty expansion
-func EmptyExpansion() *Expansions {
-	empty := Expansions(map[string]string{})
-	return &empty
-}
-
 // Read a map of keys/values from the given file, and update the expansions
 // to include them (overwriting any duplicates with the new value).
 func (exp *Expansions) UpdateFromYaml(filename string) error {


### PR DESCRIPTION
EVG-20703

### Description
This addresses all the comments in [6911](https://github.com/evergreen-ci/evergreen/pull/6911). Some of the open threads are no longer relevant because it was switched from a pointer to a struct. 

### Testing
One more test and existing tests. 


