### PR TITLE
EVG-20469: Use project ID when promoting vars to repo

### DIFF
--- a/graphql/tests/mutation/promoteVarsToRepo/data.json
+++ b/graphql/tests/mutation/promoteVarsToRepo/data.json
@@ -1,0 +1,36 @@
+{
+  "project_ref": [
+    {
+      "_id" : "sandbox_project_id",
+      "identifier" : "sandbox",
+      "display_name" : "Sandbox",
+      "enabled" : null,
+      "owner_name" : "evergreen-ci",
+      "repo_name" : "commit-queue-sandbox",
+      "branch_name" : "main",
+      "repo_ref_id": "repo_id",
+      "admins": ["me"]
+    }
+  ],
+  "repo_ref":[
+    {
+      "_id": "repo_id",
+      "owner_name": "evergreen-ci",
+      "repo_name": "commit-queue-sandbox"
+    }
+  ],
+  "project_vars": [
+    {
+      "_id": "sandbox_project_id",
+      "vars": {"hello": "world", "foo":  "bar"},
+      "private_vars": {"hello":  true, "foo":  false},
+      "admin_only_vars": {}
+    },
+    {
+      "_id": "repo_id",
+      "vars": {},
+      "private_vars": {},
+      "admin_only_vars": {}
+    }
+  ]
+}

--- a/graphql/tests/mutation/promoteVarsToRepo/queries/promote_vars.graphql
+++ b/graphql/tests/mutation/promoteVarsToRepo/queries/promote_vars.graphql
@@ -1,0 +1,3 @@
+mutation {
+  promoteVarsToRepo(projectId: "sandbox", varNames: ["hello", "foo"])
+}

--- a/graphql/tests/mutation/promoteVarsToRepo/results.json
+++ b/graphql/tests/mutation/promoteVarsToRepo/results.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "query_file": "promote_vars.graphql",
+      "result": {
+        "data": {
+          "promoteVarsToRepo": true
+        }
+      }
+    }
+  ]
+}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -104,17 +104,18 @@ func disableStartingSettings(p *model.ProjectRef) {
 // PromoteVarsToRepo moves variables from an attached project to its repo.
 // Promoted vars are removed from the project as part of this operation.
 // Variables whose names already appear in the repo settings will be overwritten.
-func PromoteVarsToRepo(projectId string, varNames []string, userId string) error {
-	project, err := model.GetProjectSettingsById(projectId, false)
+func PromoteVarsToRepo(projectIdentifier string, varNames []string, userId string) error {
+	project, err := model.GetProjectSettingsById(projectIdentifier, false)
 	if err != nil {
-		return errors.Wrapf(err, "getting project settings for project '%s'", projectId)
+		return errors.Wrapf(err, "getting project settings for project '%s'", projectIdentifier)
 	}
 
+	projectId := project.ProjectRef.Id
 	repoId := project.ProjectRef.RepoRefId
 
 	projectVars, err := model.FindOneProjectVars(projectId)
 	if err != nil {
-		return errors.Wrapf(err, "getting project variables for project '%s'", projectId)
+		return errors.Wrapf(err, "getting project variables for project '%s'", projectIdentifier)
 	}
 
 	repo, err := model.GetProjectSettingsById(repoId, true)
@@ -145,7 +146,7 @@ func PromoteVarsToRepo(projectId string, varNames []string, userId string) error
 	}
 
 	if err = UpdateProjectVars(repoId, apiRepoVars, true); err != nil {
-		return errors.Wrapf(err, "adding variables from project '%s' to repo", projectId)
+		return errors.Wrapf(err, "adding variables from project '%s' to repo", projectIdentifier)
 	}
 
 	// Log repo update
@@ -182,15 +183,15 @@ func PromoteVarsToRepo(projectId string, varNames []string, userId string) error
 	}
 
 	if err := UpdateProjectVars(projectId, apiProjectVars, true); err != nil {
-		return errors.Wrapf(err, "removing promoted project variables from project '%s'", projectId)
+		return errors.Wrapf(err, "removing promoted project variables from project '%s'", projectIdentifier)
 	}
 
 	projectAfter, err := model.GetProjectSettingsById(projectId, false)
 	if err != nil {
-		return errors.Wrapf(err, "getting settings for project '%s' after removing promoted variables", projectId)
+		return errors.Wrapf(err, "getting settings for project '%s' after removing promoted variables", projectIdentifier)
 	}
 	if err = model.LogProjectModified(projectId, userId, project, projectAfter); err != nil {
-		return errors.Wrapf(err, "logging project '%s' modified", projectId)
+		return errors.Wrapf(err, "logging project '%s' modified", projectIdentifier)
 	}
 
 	return nil


### PR DESCRIPTION
EVG-20469

### Description
- The GraphQL resolver provides the project identifier, not ID, when calling `PromoteVarsToRepo`. To successfully complete the operation, we need to first look up the ID and use it in place of the identifier.

### Testing
- Add unit test demonstrating successful execution of the resolver when a project identifier is provided

### Documentation
N/A