### PR TITLE
EVG-19945: Use enum for distro provider

### DIFF
--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -48,6 +48,26 @@ func (r *distroResolver) CloneMethod(ctx context.Context, obj *model.APIDistro) 
 	}
 }
 
+// Provider is the resolver for the provider field.
+func (r *distroResolver) Provider(ctx context.Context, obj *model.APIDistro) (Provider, error) {
+	if obj == nil {
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve provider")
+	}
+
+	switch utility.FromStringPtr(obj.Provider) {
+	case evergreen.ProviderNameDocker:
+		return ProviderDocker, nil
+	case evergreen.ProviderNameEc2Fleet:
+		return ProviderEc2Fleet, nil
+	case evergreen.ProviderNameEc2OnDemand:
+		return ProviderEc2Ondemand, nil
+	case evergreen.ProviderNameStatic:
+		return ProviderStatic, nil
+	default:
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("provider '%s' is invalid", utility.FromStringPtr(obj.Provider)))
+	}
+}
+
 // ProviderSettingsList is the resolver for the providerSettingsList field.
 func (r *distroResolver) ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]interface{}, error) {
 	settings := []map[string]interface{}{}
@@ -116,6 +136,23 @@ func (r *distroInputResolver) CloneMethod(ctx context.Context, obj *model.APIDis
 		obj.CloneMethod = utility.ToStringPtr(evergreen.CloneMethodOAuth)
 	default:
 		return InputValidationError.Send(ctx, fmt.Sprintf("clone method '%s' is invalid", data))
+	}
+	return nil
+}
+
+// Provider is the resolver for the provider field.
+func (r *distroInputResolver) Provider(ctx context.Context, obj *model.APIDistro, data Provider) error {
+	switch data {
+	case ProviderDocker:
+		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameDocker)
+	case ProviderEc2Fleet:
+		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameEc2Fleet)
+	case ProviderEc2Ondemand:
+		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameEc2OnDemand)
+	case ProviderStatic:
+		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameStatic)
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("provider '%s' is invalid", data))
 	}
 	return nil
 }

--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -60,7 +60,7 @@ func (r *distroResolver) Provider(ctx context.Context, obj *model.APIDistro) (Pr
 	case evergreen.ProviderNameEc2Fleet:
 		return ProviderEc2Fleet, nil
 	case evergreen.ProviderNameEc2OnDemand:
-		return ProviderEc2Ondemand, nil
+		return ProviderEc2OnDemand, nil
 	case evergreen.ProviderNameStatic:
 		return ProviderStatic, nil
 	default:
@@ -147,7 +147,7 @@ func (r *distroInputResolver) Provider(ctx context.Context, obj *model.APIDistro
 		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameDocker)
 	case ProviderEc2Fleet:
 		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameEc2Fleet)
-	case ProviderEc2Ondemand:
+	case ProviderEc2OnDemand:
 		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameEc2OnDemand)
 	case ProviderStatic:
 		obj.Provider = utility.ToStringPtr(evergreen.ProviderNameStatic)

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1518,6 +1518,7 @@ type DispatcherSettingsResolver interface {
 type DistroResolver interface {
 	CloneMethod(ctx context.Context, obj *model.APIDistro) (CloneMethod, error)
 
+	Provider(ctx context.Context, obj *model.APIDistro) (Provider, error)
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]interface{}, error)
 }
 type FinderSettingsResolver interface {
@@ -1831,6 +1832,7 @@ type DispatcherSettingsInputResolver interface {
 type DistroInputResolver interface {
 	CloneMethod(ctx context.Context, obj *model.APIDistro, data CloneMethod) error
 
+	Provider(ctx context.Context, obj *model.APIDistro, data Provider) error
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro, data []map[string]interface{}) error
 }
 type FinderSettingsInputResolver interface {
@@ -16119,7 +16121,7 @@ func (ec *executionContext) _Distro_provider(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Provider, nil
+		return ec.resolvers.Distro().Provider(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -16131,19 +16133,19 @@ func (ec *executionContext) _Distro_provider(ctx context.Context, field graphql.
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(Provider)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNProvider2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProvider(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_provider(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Distro",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type Provider does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65881,11 +65883,13 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("provider"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNProvider2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProvider(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Provider = data
+			if err = ec.resolvers.DistroInput().Provider(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "providerSettingsList":
 			var err error
 
@@ -71258,12 +71262,25 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 				atomic.AddUint32(&invalids, 1)
 			}
 		case "provider":
+			field := field
 
-			out.Values[i] = ec._Distro_provider(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Distro_provider(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
 			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "providerSettingsList":
 			field := field
 
@@ -84139,6 +84156,16 @@ func (ec *executionContext) unmarshalNProjectSettingsSection2githubᚗcomᚋever
 }
 
 func (ec *executionContext) marshalNProjectSettingsSection2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProjectSettingsSection(ctx context.Context, sel ast.SelectionSet, v ProjectSettingsSection) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNProvider2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProvider(ctx context.Context, v interface{}) (Provider, error) {
+	var res Provider
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNProvider2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProvider(ctx context.Context, sel ast.SelectionSet, v Provider) graphql.Marshaler {
 	return v
 }
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -935,6 +935,51 @@ func (e ProjectSettingsSection) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type Provider string
+
+const (
+	ProviderDocker      Provider = "DOCKER"
+	ProviderEc2Fleet    Provider = "EC2_FLEET"
+	ProviderEc2Ondemand Provider = "EC2_ONDEMAND"
+	ProviderStatic      Provider = "STATIC"
+)
+
+var AllProvider = []Provider{
+	ProviderDocker,
+	ProviderEc2Fleet,
+	ProviderEc2Ondemand,
+	ProviderStatic,
+}
+
+func (e Provider) IsValid() bool {
+	switch e {
+	case ProviderDocker, ProviderEc2Fleet, ProviderEc2Ondemand, ProviderStatic:
+		return true
+	}
+	return false
+}
+
+func (e Provider) String() string {
+	return string(e)
+}
+
+func (e *Provider) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Provider(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Provider", str)
+	}
+	return nil
+}
+
+func (e Provider) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type RequiredStatus string
 
 const (

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -940,20 +940,20 @@ type Provider string
 const (
 	ProviderDocker      Provider = "DOCKER"
 	ProviderEc2Fleet    Provider = "EC2_FLEET"
-	ProviderEc2Ondemand Provider = "EC2_ONDEMAND"
+	ProviderEc2OnDemand Provider = "EC2_ON_DEMAND"
 	ProviderStatic      Provider = "STATIC"
 )
 
 var AllProvider = []Provider{
 	ProviderDocker,
 	ProviderEc2Fleet,
-	ProviderEc2Ondemand,
+	ProviderEc2OnDemand,
 	ProviderStatic,
 }
 
 func (e Provider) IsValid() bool {
 	switch e {
-	case ProviderDocker, ProviderEc2Fleet, ProviderEc2Ondemand, ProviderStatic:
+	case ProviderDocker, ProviderEc2Fleet, ProviderEc2OnDemand, ProviderStatic:
 		return true
 	}
 	return false

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -33,7 +33,7 @@ enum PlannerVersion {
 enum Provider {
   DOCKER
   EC2_FLEET
-  EC2_ONDEMAND
+  EC2_ON_DEMAND
   STATIC
 }
 

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -30,6 +30,13 @@ enum PlannerVersion {
   TUNABLE
 }
 
+enum Provider {
+  DOCKER
+  EC2_FLEET
+  EC2_ONDEMAND
+  STATIC
+}
+
 enum DispatcherVersion {
   REVISED
   REVISED_WITH_DEPENDENCIES
@@ -97,7 +104,7 @@ input DistroInput {
   name: String! @requireDistroAccess(access: EDIT)
   note: String!
   plannerSettings: PlannerSettingsInput!
-  provider: String!
+  provider: Provider!
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!
@@ -246,7 +253,7 @@ type Distro {
   name: String!
   note: String!
   plannerSettings: PlannerSettings!
-  provider: String!
+  provider: Provider!
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -12,7 +12,7 @@ mutation {
           containerPool: "",
           workDir: "/data/mci",
           disabled: true,
-          provider: "ec2-ondemand",
+          provider: EC2_ONDEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -12,7 +12,7 @@ mutation {
           containerPool: "",
           workDir: "/data/mci",
           disabled: true,
-          provider: EC2_ONDEMAND,
+          provider: EC2_ON_DEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -11,7 +11,7 @@ mutation {
           containerPool: "",
           disabled: true,
           workDir: "/data/mci",
-          provider: EC2_ONDEMAND,
+          provider: EC2_ON_DEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -11,7 +11,7 @@ mutation {
           containerPool: "",
           disabled: true,
           workDir: "/data/mci",
-          provider: "ec2-ondemand",
+          provider: EC2_ONDEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -12,7 +12,7 @@ mutation {
           authorizedKeysFile: "",
           containerPool: "",
           disabled: true,
-          provider: "ec2-ondemand",
+          provider: EC2_ONDEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -12,7 +12,7 @@ mutation {
           authorizedKeysFile: "",
           containerPool: "",
           disabled: true,
-          provider: EC2_ONDEMAND,
+          provider: EC2_ON_DEMAND,
           providerSettingsList: [
             {
               ami: "who-ami",

--- a/graphql/tests/query/distros/queries/distro.graphql
+++ b/graphql/tests/query/distros/queries/distro.graphql
@@ -11,6 +11,7 @@ query {
     plannerSettings {
       mainlineTimeInQueueFactor
     }
+    provider
     providerSettingsList
     user
   }

--- a/graphql/tests/query/distros/results.json
+++ b/graphql/tests/query/distros/results.json
@@ -16,6 +16,7 @@
                         "plannerSettings": {
                             "mainlineTimeInQueueFactor": 0
                         },
+                        "provider": "STATIC",
                         "providerSettingsList": [
                             {
                                 "hosts": [


### PR DESCRIPTION
EVG-19945

### Description
- Use an enum for more predictable typing of a distro's provider field. This PR is in the same vein as #6896 and #6913

### Testing
- Update unit test

### Documentation
N/A