### PR TITLE
EVG-20474 add validation to submit patch

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -254,7 +254,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetVersionByID())
 	app.AddRoute("/versions/{version_id}").Version(2).Patch().Wrap(requireUser, editTasks).RouteHandler(makePatchVersion())
 	app.AddRoute("/versions/{version_id}/abort").Version(2).Post().Wrap(requireUser, editTasks).RouteHandler(makeAbortVersion())
-	app.AddRoute("/versions/{version_id}/builds").Version(2).Get().Wrap(viewTasks).RouteHandler(makeGetVersionBuilds(env))
+	app.AddRoute("/versions/{version_id}/builds").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionBuilds(env))
 	app.AddRoute("/versions/{version_id}/restart").Version(2).Post().Wrap(requireUser, editTasks).RouteHandler(makeRestartVersion())
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion())
 

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -150,6 +150,17 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	hasPermission := dbUser.HasPermission(gimlet.PermissionOpts{
+		Resource:      pref.Id,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionPatches,
+		RequiredLevel: evergreen.PatchSubmit.Value,
+	})
+	if !hasPermission {
+		as.LoggedError(w, r, http.StatusUnauthorized, errors.Errorf("not authorized to patch for project '%s'", data.Project))
+		return
+	}
+
 	patchString := string(data.PatchBytes)
 	if len(patchString) > patch.SizeLimit {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("Patch is too large"))


### PR DESCRIPTION
EVG-20474 
### Description
Added permission check for the submit patch (originally we had a SubmitPatch middleware, but Kim removed this since it didn't work, bc it relied on the query parameters). Since this is a pretty special case and the APIServer routes are already a bit wild west I think adding this to the route directly is fine.

### Testing
Will create a patch with and without permissions to test.

### Documentation
