### PR TITLE
EVG-20400: fix race in test-rest-data

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -38,9 +38,10 @@ type createHostJob struct {
 	BuildImageStarted bool   `bson:"build_image_started" json:"build_image_started" yaml:"build_image_started"`
 	job.Base          `bson:"metadata" json:"metadata" yaml:"metadata"`
 
-	start time.Time
-	host  *host.Host
-	env   evergreen.Environment
+	start    time.Time
+	host     *host.Host
+	env      evergreen.Environment
+	settings evergreen.Settings
 }
 
 func makeCreateHostJob() *createHostJob {
@@ -108,7 +109,8 @@ func (j *createHostJob) Run(ctx context.Context) {
 	if j.env == nil {
 		j.env = evergreen.GetEnvironment()
 	}
-	j.AddError(errors.Wrap(j.env.Settings().HostInit.Get(ctx), "refreshing hostinit settings"))
+	var hostInit evergreen.HostInitConfig
+	j.AddError(errors.Wrap(hostInit.Get(ctx), "refreshing hostinit settings"))
 
 	if j.host == nil {
 		j.host, err = host.FindOneId(ctx, j.HostID)
@@ -167,7 +169,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 			lowHostNumException = true
 		}
 
-		if allRunningDynamicHosts > j.env.Settings().HostInit.MaxTotalDynamicHosts && !lowHostNumException {
+		if allRunningDynamicHosts > hostInit.MaxTotalDynamicHosts && !lowHostNumException {
 
 			grip.Info(message.Fields{
 				"host_id":                 j.HostID,
@@ -177,7 +179,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 				"provider":                j.host.Provider,
 				"message":                 "not provisioning host to respect max_total_dynamic_hosts",
 				"total_dynamic_hosts":     allRunningDynamicHosts,
-				"max_total_dynamic_hosts": j.env.Settings().HostInit.MaxTotalDynamicHosts,
+				"max_total_dynamic_hosts": hostInit.MaxTotalDynamicHosts,
 			})
 			removeHostIntent = true
 
@@ -200,7 +202,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 			return
 		}
 
-		if j.selfThrottle(ctx) {
+		if j.selfThrottle(ctx, hostInit) {
 			grip.Debug(message.Fields{
 				"host_id":  j.HostID,
 				"attempt":  j.RetryInfo().CurrentAttempt,
@@ -225,27 +227,20 @@ func (j *createHostJob) Run(ctx context.Context) {
 	j.AddRetryableError(j.createHost(ctx))
 }
 
-func (j *createHostJob) selfThrottle(ctx context.Context) bool {
-	var (
-		numProv            int
-		runningHosts       int
-		distroRunningHosts int
-		err                error
-	)
-
-	numProv, err = host.CountIdleStartedTaskHosts(ctx)
+func (j *createHostJob) selfThrottle(ctx context.Context, hostInit evergreen.HostInitConfig) bool {
+	numProv, err := host.CountIdleStartedTaskHosts(ctx)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "counting pending host pool size"))
 		return true
 	}
 
-	distroRunningHosts, err = host.CountRunningHosts(ctx, j.host.Distro.Id)
+	distroRunningHosts, err := host.CountRunningHosts(ctx, j.host.Distro.Id)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "counting host pool size for distro '%s'", j.host.Distro.Id))
 		return true
 	}
 
-	runningHosts, err = host.CountAllRunningDynamicHosts(ctx)
+	runningHosts, err := host.CountAllRunningDynamicHosts(ctx)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "counting size of entire host pool"))
 		return true
@@ -253,7 +248,7 @@ func (j *createHostJob) selfThrottle(ctx context.Context) bool {
 
 	if distroRunningHosts < runningHosts/100 || distroRunningHosts < j.host.Distro.HostAllocatorSettings.MinimumHosts {
 		return false
-	} else if numProv >= j.env.Settings().HostInit.HostThrottle {
+	} else if numProv >= hostInit.HostThrottle {
 		reason := "host creation throttle"
 		j.AddError(errors.Wrapf(j.host.SetStatusAtomically(ctx, evergreen.HostBuildingFailed, evergreen.User, reason), "getting rid of intent host '%s' for host creation throttle", j.host.Id))
 		event.LogHostCreationFailed(j.host.Id, reason)

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -38,10 +38,9 @@ type createHostJob struct {
 	BuildImageStarted bool   `bson:"build_image_started" json:"build_image_started" yaml:"build_image_started"`
 	job.Base          `bson:"metadata" json:"metadata" yaml:"metadata"`
 
-	start    time.Time
-	host     *host.Host
-	env      evergreen.Environment
-	settings evergreen.Settings
+	start time.Time
+	host  *host.Host
+	env   evergreen.Environment
 }
 
 func makeCreateHostJob() *createHostJob {


### PR DESCRIPTION
EVG-20400

### Description
This test began racing because of a few changes:

* The test is set up to use [a local queue group](https://github.com/evergreen-ci/evergreen/blob/63cc5d7f42e4f2c74ecaf550c53490c3cd7a9df8/rest/data/host_create_test.go#L134-L137). This behaves differently from the remote queue because in the local queue, all jobs are stored in-memory (unexported fields like the `evergreen.Environment` do not get cleared in between the job enqueueing and the job running because there's no roundtrip through the DB).
* The [host creation job is enqueued immediately](https://github.com/evergreen-ci/evergreen/blob/63cc5d7f42e4f2c74ecaf550c53490c3cd7a9df8/rest/data/host_create.go#L448-L450) when host.create inserts the host document.
* The job runs in the local queue, and multiple jobs run in parallel because the local queue group has 2 workers. These jobs both read and [modify the underlying hostinit settings](https://github.com/evergreen-ci/evergreen/blob/63cc5d7f42e4f2c74ecaf550c53490c3cd7a9df8/units/provisioning_create_host.go#L113). Since they all have the same underlying `evergreen.Environment`, this modifies the copy of settings shared between all the enqueued jobs.
* Race occasionally happens when one job is reading while another job is modifying.

I basically just fixed it by not modifying the shared admin settings copy.

### Testing
Ran the unit test a bunch of times.

### Documentation
N/A