### PR TITLE
Rename materialized intelligence to Evergreen Data for Analytics.

### DIFF
--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1546,7 +1546,7 @@ defined endpoints in evergreen source:
     }
 
 ### TaskStats (DEPRECATED)
-**IMPORTANT: The task stats REST API has been deprecated, please use [Trino task stats](../Project-Configuration/Materialized-Intelligence.md) instead.**
+**IMPORTANT: The task stats REST API has been deprecated, please use [Trino task stats](../Project-Configuration/Evergreen-Data-for-Analytics.md) instead.**
 
 Task stats are aggregated task execution statistics for a given project.
 The statistics can be grouped by time period and by task, variant,

--- a/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
+++ b/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
@@ -1,6 +1,6 @@
-# Materialized Intelligence
+# Evergreen Data for Analytics
 
-Materialized Intelligence is R&D Developer Productivity's data offering for downstream analytics and business intelligence. We aim to provide a self-service platform for users to access and analyze data from Evergreen and other Dev Prod projects. This platform leverages [Mongo Trino](https://docs.dataplatform.prod.corp.mongodb.com/docs/Trino/Introduction) and [Mongo Automated Reporting System](https://docs.dataplatform.prod.corp.mongodb.com/docs/MARS/Introduction) (MARS) so that users can access any quantity of data without waiting on Dev Prod teams and without impacting production Dev Prod systems.
+We aim to provide a self-service platform for users to access and analyze data from Evergreen and other Dev Prod projects. Evergreen leverages [Mongo Trino](https://docs.dataplatform.prod.corp.mongodb.com/docs/Trino/Introduction) and [Mongo Automated Reporting System](https://docs.dataplatform.prod.corp.mongodb.com/docs/MARS/Introduction) (MARS) so that users can access any quantity of data without waiting on Dev Prod teams and without impacting production Dev Prod systems.
 
 ## Getting Started
 


### PR DESCRIPTION
It's unclear what materialized intelligence means. The new name makes it clearer that it's evergreen data to be used for analytics.
