### PR TITLE
EVG-20629: temporarily reduce default post timeout

### DIFF
--- a/agent/global.go
+++ b/agent/global.go
@@ -42,7 +42,9 @@ const (
 
 	// defaultPostTimeout specifies the default duration after when the post
 	// block should time out and stop the current command.
-	defaultPostTimeout = 2 * time.Hour
+	// TODO (EVG-20629): incrementally increase this over the course of weeks so
+	// users can adjust expectations and set post timeout accordingly.
+	defaultPostTimeout = 30 * time.Minute
 
 	// maxHeartbeats is the number of failed heartbeats after which an agent
 	// reports an error

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-04"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-23"
+	AgentVersion = "2023-08-23a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -561,7 +561,7 @@ By default, the `pre` block will time out if it runs for longer than 2 hours
 total. You can override this timeout by setting `pre_timeout_secs` at the root
 level of the YAML config.
 
-By default, the `post` block will time out if it runs for longer than 2 hours
+By default, the `post` block will time out if it runs for longer than 30 minutes
 total. You can override this timeout by setting `post_timeout_secs` at the root
 level of the YAML config.
 


### PR DESCRIPTION
EVG-20629

### Description
I had a thought about this and decided that we should give the server (the only project that hits the 15 minute post timeout limit today because of one particularly slow function) some time to adjust their YAMLs to set the new post timeout setting if they want to use it. I reduced the default timeout to 30 minutes for the interim, so post can run for at most 15 minutes more than previously.