### PR TITLE
EVG-20733: use ECR image instead of DockerHub for Docker tests

### DIFF
--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -50,7 +50,7 @@ func (s *DockerIntegrationSuite) TestImagePull() {
 	var err error
 	ctx := context.Background()
 	err = utility.Retry(ctx, func() (bool, error) {
-		err = s.client.pullImage(ctx, &s.host, "docker.io/library/hello-world", "", "")
+		err = s.client.pullImage(ctx, &s.host, "public.ecr.aws/docker/library/hello-world:latest", "", "")
 		if err != nil {
 			return true, err
 		}

--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -47,10 +47,11 @@ func TestDockerIntegrationSuite(t *testing.T) {
 }
 
 func (s *DockerIntegrationSuite) TestImagePull() {
+	const imageName = "public.ecr.aws/docker/library/hello-world:latest"
 	var err error
 	ctx := context.Background()
 	err = utility.Retry(ctx, func() (bool, error) {
-		err = s.client.pullImage(ctx, &s.host, "public.ecr.aws/docker/library/hello-world:latest", "", "")
+		err = s.client.pullImage(ctx, &s.host, imageName, "", "")
 		if err != nil {
 			return true, err
 		}
@@ -66,5 +67,5 @@ func (s *DockerIntegrationSuite) TestImagePull() {
 	s.NoError(err)
 	s.Require().Len(images, 1)
 	grip.Info(images)
-	s.Contains(images[0].RepoTags, "hello-world:latest")
+	s.Contains(images[0].RepoTags, imageName)
 }

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -435,7 +435,7 @@ tasks:
   commands:
   - command: host.create
     params:
-      image: docker.io/library/hello-world
+	  image: public.ecr.aws/docker/library/hello-world:latest
       distro: distro
       command: echo hi
       provider: docker
@@ -522,7 +522,7 @@ buildvariants:
 	require.Len(createdHosts, 1)
 	h := createdHosts[0]
 	assert.Equal("me", h.StartedBy)
-	assert.Equal("docker.io/library/hello-world", h.DockerOptions.Image)
+	assert.Equal("public.ecr.aws/docker/library/hello-world:latest", h.DockerOptions.Image)
 	assert.Equal("echo hi", h.DockerOptions.Command)
 	assert.Equal(distro.DockerImageBuildTypePull, h.DockerOptions.Method)
 	assert.Len(h.DockerOptions.EnvironmentVars, 2)

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -435,7 +435,7 @@ tasks:
   commands:
   - command: host.create
     params:
-	  image: public.ecr.aws/docker/library/hello-world:latest
+      image: public.ecr.aws/docker/library/hello-world:latest
       distro: distro
       command: echo hi
       provider: docker

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -532,12 +532,6 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb-useast
     tags: ["db", "test"]
     name: test-graphql
-  - name: docker-cleanup
-    commands:
-      - func: get-project-and-modules
-      - func: setup-credentials
-      - func: run-make
-        vars: { target: "test-thirdparty-docker" }
   - name: test-repotracker
     tags: ["db", "test"]
     commands:
@@ -645,7 +639,6 @@ buildvariants:
       - name: ".smoke"
       - name: ".test"
       - name: ".linter"
-      - name: "docker-cleanup"
       - name: test-db-auth
       - name: test-cloud
       - name: "js-test"

--- a/thirdparty/docker/docker_cleanup_test.go
+++ b/thirdparty/docker/docker_cleanup_test.go
@@ -28,11 +28,12 @@ func TestCleanup(t *testing.T) {
 		return
 	}
 
+	const imageName = "public.ecr.aws/docker/library/hello-world:latest"
 	for name, test := range map[string]func(*testing.T){
 		"cleanContainers": func(*testing.T) {
 			var resp container.ContainerCreateCreatedBody
 			resp, err = dockerClient.ContainerCreate(ctx, &container.Config{
-				Image: "hello-world",
+				Image: imageName,
 			}, nil, nil, nil, "")
 			require.NoError(t, err)
 			require.NoError(t, dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}))
@@ -70,7 +71,7 @@ func TestCleanup(t *testing.T) {
 		},
 		"Cleanup": func(*testing.T) {
 			resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
-				Image: "hello-world",
+				Image: imageName,
 			}, nil, nil, nil, "")
 			require.NoError(t, err)
 			require.NoError(t, dockerClient.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}))
@@ -97,7 +98,7 @@ func TestCleanup(t *testing.T) {
 			assert.Len(t, volumes.Volumes, 0)
 		},
 	} {
-		out, err := dockerClient.ImagePull(ctx, "hello-world", types.ImagePullOptions{})
+		out, err := dockerClient.ImagePull(ctx, imageName, types.ImagePullOptions{})
 		require.NoError(t, err)
 		_, err = io.Copy(io.Discard, out)
 		require.NoError(t, err)


### PR DESCRIPTION
EVG-20733

### Description
This feels a tad bit silly, but this is actually the simplest solution to DockerHub's rate limit - all the others that I tried to continue using the DockerHub image but test less often resulted in a lot of special configuration for our self-tests YAML and reorganization of the cloud package tests. It seemed not worth it to add more complexity to our testing setup, given that we plan to sunset Docker `host.create` (and will therefore one day remove all this code). The new image being tested is the same as the one on DockerHub, just from a different registry.

ECR allows [1 unauthenticated pull per second](https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html), compared to DockerHub's 100 unauthenticated pulls per 6 hours, so with retries, this is unlikely to cause pull rate limit issues for our self-tests.

* Use ECR instead of DockerHub for test pulls.
* Remove `docker-cleanup`, which is a duplicate of `test-thirdparty-docker`.

### Testing
Ran a patch.