### PR TITLE
EVG-20474 check if project is empty for middleware

### DIFF
--- a/model/version_db.go
+++ b/model/version_db.go
@@ -152,7 +152,7 @@ func VersionByProjectIdAndOrder(projectId string, revisionOrderNumber int) db.Q 
 		}).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
-// ByLastVariantActivation finds the most recent non-patch, non-ignored
+// VersionByLastVariantActivation finds the most recent non-patch, non-ignored
 // versions in a project that have a particular variant activated.
 func VersionByLastVariantActivation(projectId, variant string) db.Q {
 	return db.Query(
@@ -172,6 +172,8 @@ func VersionByLastVariantActivation(projectId, variant string) db.Q {
 	).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
+// VersionByLastTaskActivation finds the most recent non-patch, non-ignored
+// versions in a project that have a particular task activated.
 func VersionByLastTaskActivation(projectId, variant, taskName string) db.Q {
 	return db.Query(
 		bson.M{

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -768,6 +768,11 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 	if projectRef == nil {
 		return nil, http.StatusNotFound, errors.Errorf("project '%s' not found", projectID)
 	}
+	usr := gimlet.GetUser(r.Context())
+	if usr == nil && projectRef.IsPrivate() {
+		return nil, http.StatusUnauthorized, errors.New("unauthorized")
+	}
+
 	res := []string{projectRef.Id}
 	if destProjectID != "" {
 		res = append(res, destProjectID)

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -756,24 +756,17 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 		return []string{repoID}, http.StatusOK, nil
 	}
 
+	// Return an error if the project isn't found
+	if projectID == "" {
+		return nil, http.StatusNotFound, errors.New("no project found")
+	}
+
 	projectRef, err := model.FindMergedProjectRef(projectID, versionID, true)
 	if err != nil {
-		return nil, http.StatusNotFound, errors.Wrap(err, "finding project")
+		return nil, http.StatusInternalServerError, errors.Wrap(err, "finding project")
 	}
 	if projectRef == nil {
 		return nil, http.StatusNotFound, errors.Errorf("project '%s' not found", projectID)
-	}
-	projectID = projectRef.Id
-
-	// check to see if this is an anonymous user requesting a private project
-	user := gimlet.GetUser(r.Context())
-	if user == nil && projectRef.IsPrivate() {
-		projectID = ""
-	}
-
-	// no project found - return a 404
-	if projectID == "" {
-		return nil, http.StatusNotFound, errors.New("no project found")
 	}
 	res := []string{projectRef.Id}
 	if destProjectID != "" {

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -837,11 +837,11 @@ func TestProjectViewPermission(t *testing.T) {
 	assert.Equal(http.StatusOK, rw.Code)
 	assert.Equal(1, counter)
 
-	// private project with no user attached should 404
+	// private project with no user attached should 401
 	req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj1"})
 	rw = httptest.NewRecorder()
 	authHandler.ServeHTTP(rw, req, checkPermission)
-	assert.Equal(http.StatusNotFound, rw.Code)
+	assert.Equal(http.StatusUnauthorized, rw.Code)
 	assert.Equal(1, counter)
 
 	// attach a user, but with no permissions yet
@@ -938,11 +938,11 @@ func TestEventLogPermission(t *testing.T) {
 	authHandler := gimlet.NewAuthenticationHandler(authenticator, um)
 	req := httptest.NewRequest(http.MethodGet, "http://foo.com/bar", nil)
 
-	// no user + private project should 404
+	// no user + private project should 401
 	rw := httptest.NewRecorder()
 	req = gimlet.SetURLVars(req, map[string]string{"resource_type": event.EventResourceTypeProject, "resource_id": proj1.Id})
 	authHandler.ServeHTTP(rw, req, checkPermission)
-	assert.Equal(http.StatusNotFound, rw.Code)
+	assert.Equal(http.StatusUnauthorized, rw.Code)
 	assert.Equal(0, counter)
 
 	// have user, project event


### PR DESCRIPTION
EVG-20474
### Description
This change is a bit risky, since if it's being called somewhere where we aren't actually using urlVars then this will start failing, whereas before it just succeeded using an empty project identifier. However after auditing our code base for it, I believe I've caught the cases.

### Testing
Can't really test every route, but will poke around in staging.
