### PR TITLE
EVG-20287 Remove TaskConflict 

### DIFF
--- a/agent/background.go
+++ b/agent/background.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/mongodb/grip/recovery"
 )
 
@@ -77,7 +76,7 @@ func (a *Agent) startHeartbeat(ctx context.Context, preAndMainCancel context.Can
 
 func (a *Agent) doHeartbeat(ctx context.Context, tc *taskContext) (string, error) {
 	resp, err := a.comm.Heartbeat(ctx, tc.task)
-	if resp == evergreen.TaskFailed || resp == client.TaskConflict {
+	if resp == evergreen.TaskFailed {
 		return resp, err
 	}
 	return "", err

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -58,9 +58,8 @@ type SharedCommunicator interface {
 	// GetProject loads the project using the task's version ID.
 	GetProject(context.Context, TaskData) (*model.Project, error)
 	// Heartbeat will return a non-empty task status if the agent should stop running the task.
-	// Returning evergreen.TaskConflict means the agent is no longer authorized to run this task and
-	// should move on to the next available one. Returning evergreen.TaskFailed means that the task
-	// has been aborted. An empty string indicates the heartbeat has succeeded.
+	// Returning evergreen.TaskFailed means that the task has been aborted. An empty string
+	// indicates the heartbeat has succeeded.
 	Heartbeat(context.Context, TaskData) (string, error)
 	// GetExpansionsAndVars returns the expansions, project variables, and
 	// version parameters. For expansions, all expansions are loaded except for

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-23"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-25"
+	AgentVersion = "2023-08-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20287

### Description
TaskConflict can be removed because it's no longer being used. 


