### PR TITLE
EVG-20633 Log for default merge queue status

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -534,6 +534,14 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 	}))
 	// If we don't find any rules, send the default.
 	if len(rules) == 0 {
+		grip.Debug(message.Fields{
+			"job":      j.ID(),
+			"job_type": j.Type,
+			"message":  "could not find branch protection rules, sending default status",
+			"org":      p.GithubMergeData.Org,
+			"repo":     p.GithubMergeData.Repo,
+			"branch":   p.GithubMergeData.BaseBranch,
+		})
 		input.Context = "evergreen"
 		catcher.Wrap(thirdparty.SendPendingStatusToGithub(ctx, input, j.env.Settings().Ui.Url), "failed to send pending status to GitHub")
 	} else {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -541,6 +541,7 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 			"org":      p.GithubMergeData.Org,
 			"repo":     p.GithubMergeData.Repo,
 			"branch":   p.GithubMergeData.BaseBranch,
+			"project":  p.Project,
 		})
 		input.Context = "evergreen"
 		catcher.Wrap(thirdparty.SendPendingStatusToGithub(ctx, input, j.env.Settings().Ui.Url), "failed to send pending status to GitHub")


### PR DESCRIPTION
EVG-20633

### Description

I'd like to use this debug logging to check to see what projects, if any, either aren't setting branch protection rules or don't have permission for Evergreen to view them. This will help with the migration.

### Testing

None needed. It's debug logging.

### Documentation

N/A
