### PR TITLE
EVG-19951: Use enums for host allocator fields

### DIFF
--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -180,20 +180,20 @@ func (r *hostAllocatorSettingsResolver) FeedbackRule(ctx context.Context, obj *m
 }
 
 // HostsOverallocatedRule is the resolver for the hostsOverallocatedRule field.
-func (r *hostAllocatorSettingsResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocationRule, error) {
+func (r *hostAllocatorSettingsResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocatedRule, error) {
 	if obj == nil {
-		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve overallocation rule")
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve overallocated rule")
 	}
 
 	switch utility.FromStringPtr(obj.HostsOverallocatedRule) {
 	case evergreen.HostsOverallocatedTerminate:
-		return OverallocationRuleTerminate, nil
+		return OverallocatedRuleTerminate, nil
 	case evergreen.HostsOverallocatedIgnore:
-		return OverallocationRuleIgnore, nil
+		return OverallocatedRuleIgnore, nil
 	case evergreen.HostsOverallocatedUseDefault:
-		return OverallocationRuleDefault, nil
+		return OverallocatedRuleDefault, nil
 	default:
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("overallocation rule '%s' is invalid", utility.FromStringPtr(obj.HostsOverallocatedRule)))
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("overallocated rule '%s' is invalid", utility.FromStringPtr(obj.HostsOverallocatedRule)))
 	}
 }
 
@@ -398,16 +398,16 @@ func (r *hostAllocatorSettingsInputResolver) FeedbackRule(ctx context.Context, o
 }
 
 // HostsOverallocatedRule is the resolver for the hostsOverallocatedRule field.
-func (r *hostAllocatorSettingsInputResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocationRule) error {
+func (r *hostAllocatorSettingsInputResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocatedRule) error {
 	switch data {
-	case OverallocationRuleTerminate:
+	case OverallocatedRuleTerminate:
 		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedTerminate)
-	case OverallocationRuleIgnore:
+	case OverallocatedRuleIgnore:
 		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedIgnore)
-	case OverallocationRuleDefault:
+	case OverallocatedRuleDefault:
 		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedUseDefault)
 	default:
-		return InputValidationError.Send(ctx, fmt.Sprintf("overallocation rule '%s' is invalid", data))
+		return InputValidationError.Send(ctx, fmt.Sprintf("overallocated rule '%s' is invalid", data))
 	}
 	return nil
 }

--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -98,6 +98,74 @@ func (r *finderSettingsResolver) Version(ctx context.Context, obj *model.APIFind
 	}
 }
 
+// FeedbackRule is the resolver for the feedbackRule field.
+func (r *hostAllocatorSettingsResolver) FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (FeedbackRule, error) {
+	if obj == nil {
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve feedback rule")
+	}
+
+	switch utility.FromStringPtr(obj.FeedbackRule) {
+	case evergreen.HostAllocatorWaitsOverThreshFeedback:
+		return FeedbackRuleWaitsOverThresh, nil
+	case evergreen.HostAllocatorNoFeedback:
+		return FeedbackRuleNoFeedback, nil
+	case evergreen.HostAllocatorUseDefaultFeedback:
+		return FeedbackRuleDefault, nil
+	default:
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("feedback rule '%s' is invalid", utility.FromStringPtr(obj.FeedbackRule)))
+	}
+}
+
+// HostsOverallocatedRule is the resolver for the hostsOverallocatedRule field.
+func (r *hostAllocatorSettingsResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocationRule, error) {
+	if obj == nil {
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve overallocation rule")
+	}
+
+	switch utility.FromStringPtr(obj.HostsOverallocatedRule) {
+	case evergreen.HostsOverallocatedTerminate:
+		return OverallocationRuleTerminate, nil
+	case evergreen.HostsOverallocatedIgnore:
+		return OverallocationRuleIgnore, nil
+	case evergreen.HostsOverallocatedUseDefault:
+		return OverallocationRuleDefault, nil
+	default:
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("overallocation rule '%s' is invalid", utility.FromStringPtr(obj.HostsOverallocatedRule)))
+	}
+}
+
+// RoundingRule is the resolver for the roundingRule field.
+func (r *hostAllocatorSettingsResolver) RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (RoundingRule, error) {
+	if obj == nil {
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve rounding rule")
+	}
+
+	switch utility.FromStringPtr(obj.RoundingRule) {
+	case evergreen.HostAllocatorRoundDown:
+		return RoundingRuleDown, nil
+	case evergreen.HostAllocatorRoundUp:
+		return RoundingRuleUp, nil
+	case evergreen.HostAllocatorRoundDefault:
+		return RoundingRuleDefault, nil
+	default:
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("rounding rule '%s' is invalid", utility.FromStringPtr(obj.RoundingRule)))
+	}
+}
+
+// Version is the resolver for the version field.
+func (r *hostAllocatorSettingsResolver) Version(ctx context.Context, obj *model.APIHostAllocatorSettings) (HostAllocatorVersion, error) {
+	if obj == nil {
+		return "", InternalServerError.Send(ctx, "distro undefined when attempting to resolve host allocator version")
+	}
+
+	switch utility.FromStringPtr(obj.Version) {
+	case evergreen.HostAllocatorUtilization:
+		return HostAllocatorVersionUtilization, nil
+	default:
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("host allocator version '%s' is invalid", utility.FromStringPtr(obj.Version)))
+	}
+}
+
 // Version is the resolver for the version field.
 func (r *plannerSettingsResolver) Version(ctx context.Context, obj *model.APIPlannerSettings) (PlannerVersion, error) {
 	if obj == nil {
@@ -198,6 +266,62 @@ func (r *hostAllocatorSettingsInputResolver) AcceptableHostIdleTime(ctx context.
 	return nil
 }
 
+// FeedbackRule is the resolver for the feedbackRule field.
+func (r *hostAllocatorSettingsInputResolver) FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data FeedbackRule) error {
+	switch data {
+	case FeedbackRuleWaitsOverThresh:
+		obj.FeedbackRule = utility.ToStringPtr(evergreen.HostAllocatorWaitsOverThreshFeedback)
+	case FeedbackRuleNoFeedback:
+		obj.FeedbackRule = utility.ToStringPtr(evergreen.HostAllocatorNoFeedback)
+	case FeedbackRuleDefault:
+		obj.FeedbackRule = utility.ToStringPtr(evergreen.HostAllocatorUseDefaultFeedback)
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("feedback rule '%s' is invalid", data))
+	}
+	return nil
+}
+
+// HostsOverallocatedRule is the resolver for the hostsOverallocatedRule field.
+func (r *hostAllocatorSettingsInputResolver) HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocationRule) error {
+	switch data {
+	case OverallocationRuleTerminate:
+		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedTerminate)
+	case OverallocationRuleIgnore:
+		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedIgnore)
+	case OverallocationRuleDefault:
+		obj.HostsOverallocatedRule = utility.ToStringPtr(evergreen.HostsOverallocatedUseDefault)
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("overallocation rule '%s' is invalid", data))
+	}
+	return nil
+}
+
+// RoundingRule is the resolver for the roundingRule field.
+func (r *hostAllocatorSettingsInputResolver) RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data RoundingRule) error {
+	switch data {
+	case RoundingRuleDown:
+		obj.RoundingRule = utility.ToStringPtr(evergreen.HostAllocatorRoundDown)
+	case RoundingRuleUp:
+		obj.RoundingRule = utility.ToStringPtr(evergreen.HostAllocatorRoundUp)
+	case RoundingRuleDefault:
+		obj.RoundingRule = utility.ToStringPtr(evergreen.HostAllocatorRoundDefault)
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("rounding rule '%s' is invalid", data))
+	}
+	return nil
+}
+
+// Version is the resolver for the version field.
+func (r *hostAllocatorSettingsInputResolver) Version(ctx context.Context, obj *model.APIHostAllocatorSettings, data HostAllocatorVersion) error {
+	switch data {
+	case HostAllocatorVersionUtilization:
+		obj.Version = utility.ToStringPtr(evergreen.HostAllocatorUtilization)
+	default:
+		return InputValidationError.Send(ctx, fmt.Sprintf("host allocator version '%s' is invalid", data))
+	}
+	return nil
+}
+
 // TargetTime is the resolver for the targetTime field.
 func (r *plannerSettingsInputResolver) TargetTime(ctx context.Context, obj *model.APIPlannerSettings, data int) error {
 	obj.TargetTime = model.NewAPIDuration(time.Duration(data))
@@ -228,6 +352,11 @@ func (r *Resolver) Distro() DistroResolver { return &distroResolver{r} }
 // FinderSettings returns FinderSettingsResolver implementation.
 func (r *Resolver) FinderSettings() FinderSettingsResolver { return &finderSettingsResolver{r} }
 
+// HostAllocatorSettings returns HostAllocatorSettingsResolver implementation.
+func (r *Resolver) HostAllocatorSettings() HostAllocatorSettingsResolver {
+	return &hostAllocatorSettingsResolver{r}
+}
+
 // PlannerSettings returns PlannerSettingsResolver implementation.
 func (r *Resolver) PlannerSettings() PlannerSettingsResolver { return &plannerSettingsResolver{r} }
 
@@ -257,6 +386,7 @@ func (r *Resolver) PlannerSettingsInput() PlannerSettingsInputResolver {
 type dispatcherSettingsResolver struct{ *Resolver }
 type distroResolver struct{ *Resolver }
 type finderSettingsResolver struct{ *Resolver }
+type hostAllocatorSettingsResolver struct{ *Resolver }
 type plannerSettingsResolver struct{ *Resolver }
 type dispatcherSettingsInputResolver struct{ *Resolver }
 type distroInputResolver struct{ *Resolver }

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1550,7 +1550,7 @@ type HostResolver interface {
 type HostAllocatorSettingsResolver interface {
 	FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (FeedbackRule, error)
 
-	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocationRule, error)
+	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocatedRule, error)
 
 	RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (RoundingRule, error)
 	Version(ctx context.Context, obj *model.APIHostAllocatorSettings) (HostAllocatorVersion, error)
@@ -1868,7 +1868,7 @@ type HostAllocatorSettingsInputResolver interface {
 	AcceptableHostIdleTime(ctx context.Context, obj *model.APIHostAllocatorSettings, data int) error
 	FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data FeedbackRule) error
 
-	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocationRule) error
+	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocatedRule) error
 
 	RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data RoundingRule) error
 	Version(ctx context.Context, obj *model.APIHostAllocatorSettings, data HostAllocatorVersion) error
@@ -21259,9 +21259,9 @@ func (ec *executionContext) _HostAllocatorSettings_hostsOverallocatedRule(ctx co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(OverallocationRule)
+	res := resTmp.(OverallocatedRule)
 	fc.Result = res
-	return ec.marshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx, field.Selections, res)
+	return ec.marshalNOverallocatedRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocatedRule(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HostAllocatorSettings_hostsOverallocatedRule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21271,7 +21271,7 @@ func (ec *executionContext) fieldContext_HostAllocatorSettings_hostsOverallocate
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type OverallocationRule does not have child fields")
+			return nil, errors.New("field of type OverallocatedRule does not have child fields")
 		},
 	}
 	return fc, nil
@@ -66515,7 +66515,7 @@ func (ec *executionContext) unmarshalInputHostAllocatorSettingsInput(ctx context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hostsOverallocatedRule"))
-			data, err := ec.unmarshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx, v)
+			data, err := ec.unmarshalNOverallocatedRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocatedRule(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -86075,13 +86075,13 @@ func (ec *executionContext) marshalNOomTrackerInfo2githubᚗcomᚋevergreenᚑci
 	return ec._OomTrackerInfo(ctx, sel, &v)
 }
 
-func (ec *executionContext) unmarshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx context.Context, v interface{}) (OverallocationRule, error) {
-	var res OverallocationRule
+func (ec *executionContext) unmarshalNOverallocatedRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocatedRule(ctx context.Context, v interface{}) (OverallocatedRule, error) {
+	var res OverallocatedRule
 	err := res.UnmarshalGQL(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx context.Context, sel ast.SelectionSet, v OverallocationRule) graphql.Marshaler {
+func (ec *executionContext) marshalNOverallocatedRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocatedRule(ctx context.Context, sel ast.SelectionSet, v OverallocatedRule) graphql.Marshaler {
 	return v
 }
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -51,6 +51,7 @@ type ResolverRoot interface {
 	Distro() DistroResolver
 	FinderSettings() FinderSettingsResolver
 	Host() HostResolver
+	HostAllocatorSettings() HostAllocatorSettingsResolver
 	IssueLink() IssueLinkResolver
 	LogkeeperBuild() LogkeeperBuildResolver
 	Mutation() MutationResolver
@@ -1536,6 +1537,14 @@ type HostResolver interface {
 
 	Volumes(ctx context.Context, obj *model.APIHost) ([]*model.APIVolume, error)
 }
+type HostAllocatorSettingsResolver interface {
+	FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (FeedbackRule, error)
+
+	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (OverallocationRule, error)
+
+	RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (RoundingRule, error)
+	Version(ctx context.Context, obj *model.APIHostAllocatorSettings) (HostAllocatorVersion, error)
+}
 type IssueLinkResolver interface {
 	JiraTicket(ctx context.Context, obj *model.APIIssueLink) (*thirdparty.JiraTicket, error)
 }
@@ -1840,6 +1849,12 @@ type FinderSettingsInputResolver interface {
 }
 type HostAllocatorSettingsInputResolver interface {
 	AcceptableHostIdleTime(ctx context.Context, obj *model.APIHostAllocatorSettings, data int) error
+	FeedbackRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data FeedbackRule) error
+
+	HostsOverallocatedRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data OverallocationRule) error
+
+	RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings, data RoundingRule) error
+	Version(ctx context.Context, obj *model.APIHostAllocatorSettings, data HostAllocatorVersion) error
 }
 type PlannerSettingsInputResolver interface {
 	TargetTime(ctx context.Context, obj *model.APIPlannerSettings, data int) error
@@ -21120,7 +21135,7 @@ func (ec *executionContext) _HostAllocatorSettings_feedbackRule(ctx context.Cont
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.FeedbackRule, nil
+		return ec.resolvers.HostAllocatorSettings().FeedbackRule(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21132,19 +21147,19 @@ func (ec *executionContext) _HostAllocatorSettings_feedbackRule(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(FeedbackRule)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNFeedbackRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐFeedbackRule(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HostAllocatorSettings_feedbackRule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HostAllocatorSettings",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type FeedbackRule does not have child fields")
 		},
 	}
 	return fc, nil
@@ -21208,7 +21223,7 @@ func (ec *executionContext) _HostAllocatorSettings_hostsOverallocatedRule(ctx co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.HostsOverallocatedRule, nil
+		return ec.resolvers.HostAllocatorSettings().HostsOverallocatedRule(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21220,19 +21235,19 @@ func (ec *executionContext) _HostAllocatorSettings_hostsOverallocatedRule(ctx co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(OverallocationRule)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HostAllocatorSettings_hostsOverallocatedRule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HostAllocatorSettings",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type OverallocationRule does not have child fields")
 		},
 	}
 	return fc, nil
@@ -21340,7 +21355,7 @@ func (ec *executionContext) _HostAllocatorSettings_roundingRule(ctx context.Cont
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.RoundingRule, nil
+		return ec.resolvers.HostAllocatorSettings().RoundingRule(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21352,19 +21367,19 @@ func (ec *executionContext) _HostAllocatorSettings_roundingRule(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(RoundingRule)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNRoundingRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐRoundingRule(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HostAllocatorSettings_roundingRule(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HostAllocatorSettings",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type RoundingRule does not have child fields")
 		},
 	}
 	return fc, nil
@@ -21384,7 +21399,7 @@ func (ec *executionContext) _HostAllocatorSettings_version(ctx context.Context, 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Version, nil
+		return ec.resolvers.HostAllocatorSettings().Version(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -21396,19 +21411,19 @@ func (ec *executionContext) _HostAllocatorSettings_version(ctx context.Context, 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(HostAllocatorVersion)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNHostAllocatorVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐHostAllocatorVersion(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_HostAllocatorSettings_version(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HostAllocatorSettings",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type HostAllocatorVersion does not have child fields")
 		},
 	}
 	return fc, nil
@@ -66405,11 +66420,13 @@ func (ec *executionContext) unmarshalInputHostAllocatorSettingsInput(ctx context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("feedbackRule"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNFeedbackRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐFeedbackRule(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.FeedbackRule = data
+			if err = ec.resolvers.HostAllocatorSettingsInput().FeedbackRule(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "futureHostFraction":
 			var err error
 
@@ -66423,11 +66440,13 @@ func (ec *executionContext) unmarshalInputHostAllocatorSettingsInput(ctx context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hostsOverallocatedRule"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.HostsOverallocatedRule = data
+			if err = ec.resolvers.HostAllocatorSettingsInput().HostsOverallocatedRule(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "maximumHosts":
 			var err error
 
@@ -66450,20 +66469,24 @@ func (ec *executionContext) unmarshalInputHostAllocatorSettingsInput(ctx context
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("roundingRule"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNRoundingRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐRoundingRule(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.RoundingRule = data
+			if err = ec.resolvers.HostAllocatorSettingsInput().RoundingRule(ctx, &it, data); err != nil {
+				return it, err
+			}
 		case "version":
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNHostAllocatorVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐHostAllocatorVersion(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Version = data
+			if err = ec.resolvers.HostAllocatorSettingsInput().Version(ctx, &it, data); err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -72959,43 +72982,167 @@ func (ec *executionContext) _HostAllocatorSettings(ctx context.Context, sel ast.
 		case "acceptableHostIdleTime":
 			out.Values[i] = ec._HostAllocatorSettings_acceptableHostIdleTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "feedbackRule":
-			out.Values[i] = ec._HostAllocatorSettings_feedbackRule(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._HostAllocatorSettings_feedbackRule(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "futureHostFraction":
 			out.Values[i] = ec._HostAllocatorSettings_futureHostFraction(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "hostsOverallocatedRule":
-			out.Values[i] = ec._HostAllocatorSettings_hostsOverallocatedRule(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._HostAllocatorSettings_hostsOverallocatedRule(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "maximumHosts":
 			out.Values[i] = ec._HostAllocatorSettings_maximumHosts(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "minimumHosts":
 			out.Values[i] = ec._HostAllocatorSettings_minimumHosts(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "roundingRule":
-			out.Values[i] = ec._HostAllocatorSettings_roundingRule(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._HostAllocatorSettings_roundingRule(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "version":
-			out.Values[i] = ec._HostAllocatorSettings_version(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._HostAllocatorSettings_version(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -84679,6 +84826,16 @@ func (ec *executionContext) unmarshalNExternalLinkInput2githubᚗcomᚋevergreen
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalNFeedbackRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐFeedbackRule(ctx context.Context, v interface{}) (FeedbackRule, error) {
+	var res FeedbackRule
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFeedbackRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐFeedbackRule(ctx context.Context, sel ast.SelectionSet, v FeedbackRule) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNFile2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIFile(ctx context.Context, sel ast.SelectionSet, v *model.APIFile) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -84979,6 +85136,16 @@ func (ec *executionContext) marshalNHostAllocatorSettings2githubᚗcomᚋevergre
 func (ec *executionContext) unmarshalNHostAllocatorSettingsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHostAllocatorSettings(ctx context.Context, v interface{}) (model.APIHostAllocatorSettings, error) {
 	res, err := ec.unmarshalInputHostAllocatorSettingsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNHostAllocatorVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐHostAllocatorVersion(ctx context.Context, v interface{}) (HostAllocatorVersion, error) {
+	var res HostAllocatorVersion
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNHostAllocatorVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐHostAllocatorVersion(ctx context.Context, sel ast.SelectionSet, v HostAllocatorVersion) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNHostEventLogData2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐHostAPIEventData(ctx context.Context, sel ast.SelectionSet, v *model.HostAPIEventData) graphql.Marshaler {
@@ -85697,6 +85864,16 @@ func (ec *executionContext) marshalNNewDistroPayload2ᚖgithubᚗcomᚋevergreen
 
 func (ec *executionContext) marshalNOomTrackerInfo2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIOomTrackerInfo(ctx context.Context, sel ast.SelectionSet, v model.APIOomTrackerInfo) graphql.Marshaler {
 	return ec._OomTrackerInfo(ctx, sel, &v)
+}
+
+func (ec *executionContext) unmarshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx context.Context, v interface{}) (OverallocationRule, error) {
+	var res OverallocationRule
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNOverallocationRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐOverallocationRule(ctx context.Context, sel ast.SelectionSet, v OverallocationRule) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNParameter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameter(ctx context.Context, sel ast.SelectionSet, v model.APIParameter) graphql.Marshaler {
@@ -86530,6 +86707,16 @@ func (ec *executionContext) marshalNResourceLimits2githubᚗcomᚋevergreenᚑci
 func (ec *executionContext) unmarshalNResourceLimitsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIResourceLimits(ctx context.Context, v interface{}) (model.APIResourceLimits, error) {
 	res, err := ec.unmarshalInputResourceLimitsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNRoundingRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐRoundingRule(ctx context.Context, v interface{}) (RoundingRule, error) {
+	var res RoundingRule
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRoundingRule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐRoundingRule(ctx context.Context, sel ast.SelectionSet, v RoundingRule) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNSaveDistroInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSaveDistroInput(ctx context.Context, v interface{}) (SaveDistroInput, error) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -649,6 +649,49 @@ func (e DistroSettingsAccess) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type FeedbackRule string
+
+const (
+	FeedbackRuleWaitsOverThresh FeedbackRule = "WAITS_OVER_THRESH"
+	FeedbackRuleNoFeedback      FeedbackRule = "NO_FEEDBACK"
+	FeedbackRuleDefault         FeedbackRule = "DEFAULT"
+)
+
+var AllFeedbackRule = []FeedbackRule{
+	FeedbackRuleWaitsOverThresh,
+	FeedbackRuleNoFeedback,
+	FeedbackRuleDefault,
+}
+
+func (e FeedbackRule) IsValid() bool {
+	switch e {
+	case FeedbackRuleWaitsOverThresh, FeedbackRuleNoFeedback, FeedbackRuleDefault:
+		return true
+	}
+	return false
+}
+
+func (e FeedbackRule) String() string {
+	return string(e)
+}
+
+func (e *FeedbackRule) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = FeedbackRule(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid FeedbackRule", str)
+	}
+	return nil
+}
+
+func (e FeedbackRule) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type FinderVersion string
 
 const (
@@ -691,6 +734,45 @@ func (e *FinderVersion) UnmarshalGQL(v interface{}) error {
 }
 
 func (e FinderVersion) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type HostAllocatorVersion string
+
+const (
+	HostAllocatorVersionUtilization HostAllocatorVersion = "UTILIZATION"
+)
+
+var AllHostAllocatorVersion = []HostAllocatorVersion{
+	HostAllocatorVersionUtilization,
+}
+
+func (e HostAllocatorVersion) IsValid() bool {
+	switch e {
+	case HostAllocatorVersionUtilization:
+		return true
+	}
+	return false
+}
+
+func (e HostAllocatorVersion) String() string {
+	return string(e)
+}
+
+func (e *HostAllocatorVersion) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = HostAllocatorVersion(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid HostAllocatorVersion", str)
+	}
+	return nil
+}
+
+func (e HostAllocatorVersion) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
@@ -789,6 +871,49 @@ func (e *MetStatus) UnmarshalGQL(v interface{}) error {
 }
 
 func (e MetStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type OverallocationRule string
+
+const (
+	OverallocationRuleTerminate OverallocationRule = "TERMINATE"
+	OverallocationRuleIgnore    OverallocationRule = "IGNORE"
+	OverallocationRuleDefault   OverallocationRule = "DEFAULT"
+)
+
+var AllOverallocationRule = []OverallocationRule{
+	OverallocationRuleTerminate,
+	OverallocationRuleIgnore,
+	OverallocationRuleDefault,
+}
+
+func (e OverallocationRule) IsValid() bool {
+	switch e {
+	case OverallocationRuleTerminate, OverallocationRuleIgnore, OverallocationRuleDefault:
+		return true
+	}
+	return false
+}
+
+func (e OverallocationRule) String() string {
+	return string(e)
+}
+
+func (e *OverallocationRule) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OverallocationRule(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OverallocationRule", str)
+	}
+	return nil
+}
+
+func (e OverallocationRule) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
@@ -1020,6 +1145,49 @@ func (e *RequiredStatus) UnmarshalGQL(v interface{}) error {
 }
 
 func (e RequiredStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type RoundingRule string
+
+const (
+	RoundingRuleDown    RoundingRule = "DOWN"
+	RoundingRuleUp      RoundingRule = "UP"
+	RoundingRuleDefault RoundingRule = "DEFAULT"
+)
+
+var AllRoundingRule = []RoundingRule{
+	RoundingRuleDown,
+	RoundingRuleUp,
+	RoundingRuleDefault,
+}
+
+func (e RoundingRule) IsValid() bool {
+	switch e {
+	case RoundingRuleDown, RoundingRuleUp, RoundingRuleDefault:
+		return true
+	}
+	return false
+}
+
+func (e RoundingRule) String() string {
+	return string(e)
+}
+
+func (e *RoundingRule) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = RoundingRule(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid RoundingRule", str)
+	}
+	return nil
+}
+
+func (e RoundingRule) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -1011,46 +1011,46 @@ func (e MetStatus) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
-type OverallocationRule string
+type OverallocatedRule string
 
 const (
-	OverallocationRuleTerminate OverallocationRule = "TERMINATE"
-	OverallocationRuleIgnore    OverallocationRule = "IGNORE"
-	OverallocationRuleDefault   OverallocationRule = "DEFAULT"
+	OverallocatedRuleTerminate OverallocatedRule = "TERMINATE"
+	OverallocatedRuleIgnore    OverallocatedRule = "IGNORE"
+	OverallocatedRuleDefault   OverallocatedRule = "DEFAULT"
 )
 
-var AllOverallocationRule = []OverallocationRule{
-	OverallocationRuleTerminate,
-	OverallocationRuleIgnore,
-	OverallocationRuleDefault,
+var AllOverallocatedRule = []OverallocatedRule{
+	OverallocatedRuleTerminate,
+	OverallocatedRuleIgnore,
+	OverallocatedRuleDefault,
 }
 
-func (e OverallocationRule) IsValid() bool {
+func (e OverallocatedRule) IsValid() bool {
 	switch e {
-	case OverallocationRuleTerminate, OverallocationRuleIgnore, OverallocationRuleDefault:
+	case OverallocatedRuleTerminate, OverallocatedRuleIgnore, OverallocatedRuleDefault:
 		return true
 	}
 	return false
 }
 
-func (e OverallocationRule) String() string {
+func (e OverallocatedRule) String() string {
 	return string(e)
 }
 
-func (e *OverallocationRule) UnmarshalGQL(v interface{}) error {
+func (e *OverallocatedRule) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("enums must be strings")
 	}
 
-	*e = OverallocationRule(str)
+	*e = OverallocatedRule(str)
 	if !e.IsValid() {
-		return fmt.Errorf("%s is not a valid OverallocationRule", str)
+		return fmt.Errorf("%s is not a valid OverallocatedRule", str)
 	}
 	return nil
 }
 
-func (e OverallocationRule) MarshalGQL(w io.Writer) {
+func (e OverallocatedRule) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -42,6 +42,28 @@ enum DispatcherVersion {
   REVISED_WITH_DEPENDENCIES
 }
 
+enum HostAllocatorVersion {
+  UTILIZATION
+}
+
+enum RoundingRule {
+  DOWN
+  UP
+  DEFAULT
+}
+
+enum FeedbackRule {
+  WAITS_OVER_THRESH
+  NO_FEEDBACK
+  DEFAULT
+}
+
+enum OverallocationRule {
+  TERMINATE
+  IGNORE
+  DEFAULT
+}
+
 
 ###### INPUTS ######
 """
@@ -154,13 +176,13 @@ input HomeVolumeSettingsInput {
 
 input HostAllocatorSettingsInput {
   acceptableHostIdleTime: Int!
-  feedbackRule: String!
+  feedbackRule: FeedbackRule!
   futureHostFraction: Float!
-  hostsOverallocatedRule: String!
+  hostsOverallocatedRule: OverallocationRule!
   maximumHosts: Int!
   minimumHosts: Int!
-  roundingRule: String!
-  version: String!
+  roundingRule: RoundingRule!
+  version: HostAllocatorVersion!
 }
 
 input IceCreamSettingsInput {
@@ -303,13 +325,13 @@ type HomeVolumeSettings {
 
 type HostAllocatorSettings {
   acceptableHostIdleTime: Duration!
-  feedbackRule: String!
+  feedbackRule: FeedbackRule!
   futureHostFraction: Float!
-  hostsOverallocatedRule: String!
+  hostsOverallocatedRule: OverallocationRule!
   maximumHosts: Int!
   minimumHosts: Int!
-  roundingRule: String!
-  version: String!
+  roundingRule: RoundingRule!
+  version: HostAllocatorVersion!
 }
 
 type IceCreamSettings {

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -58,7 +58,7 @@ enum FeedbackRule {
   DEFAULT
 }
 
-enum OverallocationRule {
+enum OverallocatedRule {
   TERMINATE
   IGNORE
   DEFAULT
@@ -199,7 +199,7 @@ input HostAllocatorSettingsInput {
   acceptableHostIdleTime: Int!
   feedbackRule: FeedbackRule!
   futureHostFraction: Float!
-  hostsOverallocatedRule: OverallocationRule!
+  hostsOverallocatedRule: OverallocatedRule!
   maximumHosts: Int!
   minimumHosts: Int!
   roundingRule: RoundingRule!
@@ -348,7 +348,7 @@ type HostAllocatorSettings {
   acceptableHostIdleTime: Duration!
   feedbackRule: FeedbackRule!
   futureHostFraction: Float!
-  hostsOverallocatedRule: OverallocationRule!
+  hostsOverallocatedRule: OverallocatedRule!
   maximumHosts: Int!
   minimumHosts: Int!
   roundingRule: RoundingRule!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -92,13 +92,13 @@ mutation {
           },
           hostAllocatorSettings: {
             acceptableHostIdleTime: 5407399999,
-            feedbackRule: "",
+            feedbackRule: DEFAULT,
             futureHostFraction: 0,
-            hostsOverallocatedRule: "",
+            hostsOverallocatedRule: DEFAULT,
             maximumHosts: 0,
             minimumHosts: 0,
-            roundingRule: "",
-            version: "utilization",
+            roundingRule: DEFAULT,
+            version: UTILIZATION,
           },
           disableShallowClone: true,
           note: "This is an updated note"

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -91,13 +91,13 @@ mutation {
           },
           hostAllocatorSettings: {
             acceptableHostIdleTime: 30000000000,
-            feedbackRule: "",
+            feedbackRule: DEFAULT,
             futureHostFraction: 0,
-            hostsOverallocatedRule: "",
+            hostsOverallocatedRule: DEFAULT,
             maximumHosts: 0,
             minimumHosts: 0,
-            roundingRule: "",
-            version: "utilization",
+            roundingRule: DEFAULT,
+            version: UTILIZATION,
           },
           disableShallowClone: true,
           note: "This is an updated note"

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -92,13 +92,13 @@ mutation {
           },
           hostAllocatorSettings: {
             acceptableHostIdleTime: 30000000000,
-            feedbackRule: "",
+            feedbackRule: DEFAULT,
             futureHostFraction: 0,
-            hostsOverallocatedRule: "",
+            hostsOverallocatedRule: DEFAULT,
             maximumHosts: 0,
             minimumHosts: 0,
-            roundingRule: "",
-            version: "utilization",
+            roundingRule: DEFAULT,
+            version: UTILIZATION,
           },
           disableShallowClone: true,
           note: "This is an updated note"


### PR DESCRIPTION
EVG-19951

### Description
This just adds more enums for the host settings page, in a separate PR since these fields are thematically in the same group.

I'm pretty sure that the `DEFAULT` values means that the values will be [inherited](https://github.com/evergreen-ci/evergreen/blob/2c322c18832281119433281f9026724975e9a74a/model/distro/distro.go#L665C1-L673) from Evergreen settings (see the "Scheduler" section in the admin settings).
