### PR TITLE
EVG-20609 Validate images by prefix rather than full string

### DIFF
--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
@@ -80,7 +81,7 @@ func (o *TaskIntentPodOptions) Validate(ecsConf evergreen.ECSConfig) error {
 	if o.OS == OSWindows {
 		catcher.Wrap(o.WindowsVersion.Validate(), "must specify a valid Windows version")
 	}
-	catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !utility.StringSliceContains(ecsConf.AllowedImages, o.Image), "image '%s' not allowed", o.Image)
+	catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !util.HasAllowedImageAsPrefix(o.Image, ecsConf.AllowedImages), "image '%s' not allowed", o.Image)
 	catcher.NewWhen(o.Image == "", "missing image")
 	catcher.NewWhen(o.WorkingDir == "", "missing working directory")
 	catcher.NewWhen(o.PodSecretExternalID == "", "missing pod secret external ID")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2885,7 +2885,8 @@ func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, container
 		catcher.NewWhen(container.Image == "", "image must be defined")
 		catcher.NewWhen(container.WorkingDir == "", "working directory must be defined")
 		catcher.NewWhen(container.Name == "", "name must be defined")
-		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !utility.StringSliceContains(ecsConf.AllowedImages, container.Image), "image '%s' not allowed", container.Image)
+		//here
+		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !util.HasAllowedImageAsPrefix(container.Image, ecsConf.AllowedImages), "image '%s' not allowed", container.Image)
 	}
 	return catcher.Resolve()
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2885,7 +2885,6 @@ func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, container
 		catcher.NewWhen(container.Image == "", "image must be defined")
 		catcher.NewWhen(container.WorkingDir == "", "working directory must be defined")
 		catcher.NewWhen(container.Name == "", "name must be defined")
-		//here
 		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !util.HasAllowedImageAsPrefix(container.Image, ecsConf.AllowedImages), "image '%s' not allowed", container.Image)
 	}
 	return catcher.Resolve()

--- a/util/strings.go
+++ b/util/strings.go
@@ -8,14 +8,6 @@ import (
 
 var cleanFileRegex = regexp.MustCompile(`[^a-zA-Z0-9_\-\.]`)
 
-// Truncate returns a string of at most the given length.
-func Truncate(input string, outputLength int) string {
-	if len(input) <= outputLength {
-		return input
-	}
-	return input[:outputLength]
-}
-
 func CleanForPath(name string) string {
 	return cleanFileRegex.ReplaceAllLiteralString(name, "_")
 }
@@ -26,6 +18,16 @@ func CleanName(name string) string {
 	name = strings.Replace(name, " ", "_", -1)
 	name = strings.Replace(name, "/", "_", -1)
 	return name
+}
+
+// HasAllowedImageAsPrefix returns true if the given string has one of the allowed image prefixes
+func HasAllowedImageAsPrefix(str string, imageList []string) bool {
+	for _, imagePrefix := range imageList {
+		if strings.HasPrefix(str, imagePrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // IndexWhiteSpace returns the first index of white space in the given string.


### PR DESCRIPTION
EVG-20609

### Description
To prevent a bloated "allowed image" list where a new entry is put for every ECR repo's immutable tag, we can change the validation to treat the allowed list as an allowed list of image uri prefixes, which should be safe because publishing a new immutable tag for a project requires approval via PR approval in [this repo](https://github.com/evergreen-ci/container-initial-offering-dockerfiles)
### Testing
Tested in staging with `557821124784.dkr.ecr.us-east-1.amazonaws.com/evergreen/production-ecs` as an allowed image and confirmed that e.g. `557821124784.dkr.ecr.us-east-1.amazonaws.com/evergreen/production-ecs:1635b8ecdd264fb4f5fde38d88931b4e9a677b06` works
