### PR TITLE
EVG-20622: support allowed requesters list

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-08-25"
+	ClientVersion = "2023-08-29"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-08-29"

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -575,6 +575,35 @@ To cause a task to only run in versions NOT triggered from git tags, set
 To cause a task to only run in versions triggered from git tags, set
 `git_tag_only: true`.
 
+If the above settings do not provide the particular combination of conditions
+when you want a task to run, you can specify `allowed_requesters` to enumerate
+the list of conditions when a task is allowed to run. For example, if you wish
+for a task to only run for manual patches and git tag versions, you can specify
+it like this:
+
+```yaml
+tasks:
+- name: only-run-for-manual-patches-and-git-tag-versions
+  allowed_requesters: ["patch", "github_tag"]
+```
+
+The valid requester values are:
+- `patch`: manual patches.
+- `github_pr`: GitHub PR patches.
+- `github_tag`: git tag versions.
+- `commit`: mainline commits.
+- `trigger`: downstream trigger versions.
+- `ad_hoc`: periodic build versions.
+- `commit_queue`: Evergreen's commit queue.
+- `github_merge_queue`: GitHub's merge queue.
+
+By default, if no `allowed_requesters` are explicitly specified, then a task can
+run for any requester. If you specify an empty `allowed_requesters` list (i.e.
+`allowed_requesters: []`), this is also treated the same as the default.
+`allowed_requesters` is not compatible with `patchable`, `patch_only`,
+`allow_for_git_tag`, or `git_tag_only` (if combined, the
+`allowed_requesters` will always take higher precedence).
+
 To cause a task to not run at all, set `disable: true`.
 
 -   This behaves similarly to commenting out the task but will not

--- a/globals.go
+++ b/globals.go
@@ -653,6 +653,86 @@ var (
 	}
 )
 
+// UserRequester represents the allowed user-facing requester types.
+type UserRequester string
+
+const (
+	// User-facing requester types. These are equivalent in meaning to the above
+	// requesters, but are more user-friendly. These should only be used for
+	// user-facing functionality such as YAML configuration and expansions and
+	// should be translated into the true internal requester types so they're
+	// actually usable.
+	PatchVersionUserRequester       UserRequester = "patch"
+	GithubPRUserRequester           UserRequester = "github_pr"
+	GitTagUserRequester             UserRequester = "github_tag"
+	RepotrackerVersionUserRequester UserRequester = "commit"
+	TriggerUserRequester            UserRequester = "trigger"
+	MergeTestUserRequester          UserRequester = "commit_queue"
+	AdHocUserRequester              UserRequester = "ad_hoc"
+	GithubMergeUserRequester        UserRequester = "github_merge_queue"
+)
+
+var AllUserRequesterTypes = []UserRequester{
+	PatchVersionUserRequester,
+	GithubPRUserRequester,
+	GitTagUserRequester,
+	RepotrackerVersionUserRequester,
+	TriggerUserRequester,
+	MergeTestUserRequester,
+	AdHocUserRequester,
+	GithubMergeUserRequester,
+}
+
+// InternalRequesterToUserRequester translates an internal requester type to a
+// user-facing requester type.
+func InternalRequesterToUserRequester(requester string) UserRequester {
+	switch requester {
+	case PatchVersionRequester:
+		return PatchVersionUserRequester
+	case GithubPRRequester:
+		return GithubPRUserRequester
+	case GitTagRequester:
+		return GitTagUserRequester
+	case RepotrackerVersionRequester:
+		return RepotrackerVersionUserRequester
+	case TriggerRequester:
+		return TriggerUserRequester
+	case MergeTestRequester:
+		return MergeTestUserRequester
+	case AdHocRequester:
+		return AdHocUserRequester
+	case GithubMergeRequester:
+		return GithubMergeUserRequester
+	default:
+		return ""
+	}
+}
+
+// UserRequesterToInternalRequester translates a user-facing requester type to
+// its equivalent internal requester type.
+func UserRequesterToInternalRequester(requester UserRequester) string {
+	switch requester {
+	case PatchVersionUserRequester:
+		return PatchVersionRequester
+	case GithubPRUserRequester:
+		return GithubPRRequester
+	case GitTagUserRequester:
+		return GitTagRequester
+	case RepotrackerVersionUserRequester:
+		return RepotrackerVersionRequester
+	case TriggerUserRequester:
+		return TriggerRequester
+	case MergeTestUserRequester:
+		return MergeTestRequester
+	case AdHocUserRequester:
+		return AdHocRequester
+	case GithubMergeUserRequester:
+		return GithubMergeRequester
+	default:
+		return ""
+	}
+}
+
 // Constants for project command names.
 const (
 	GenerateTasksCommandName      = "generate.tasks"

--- a/model/generate.go
+++ b/model/generate.go
@@ -704,7 +704,7 @@ func isNonZeroBV(bv parserBV) bool {
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
 		bv.Disable != nil || len(bv.Tags) > 0 ||
 		bv.BatchTime != nil || bv.Patchable != nil || bv.PatchOnly != nil ||
-		bv.AllowForGitTag != nil || bv.GitTagOnly != nil ||
+		bv.AllowForGitTag != nil || bv.GitTagOnly != nil || len(bv.AllowedRequesters) > 0 ||
 		bv.Stepback != nil || len(bv.RunOn) > 0 {
 		return true
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -319,7 +319,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnNonPatchBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnGitTagBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		return utility.StringSliceContains(bvt.AllowedRequesters, evergreen.GitTagRequester)
+		return !utility.StringSliceContains(bvt.AllowedRequesters, evergreen.GitTagRequester)
 	}
 
 	return !utility.FromBoolTPtr(bvt.AllowForGitTag)

--- a/model/project.go
+++ b/model/project.go
@@ -390,10 +390,10 @@ type BuildVariant struct {
 	// versions when set to true. By default, the build variant runs in non-git
 	// tag versions.
 	GitTagOnly *bool `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	// AllowedRequesters lists all requester types which can run a task. If set,
-	// the allowed requesters take precedence over other requester-related
-	// filters such as Patchable, PatchOnly, AllowForGitTag, and GitTagOnly. By
-	// default, all requesters are allowed to run the task.
+	// AllowedRequesters lists all internal requester types which can run a
+	// task. If set, the allowed requesters take precedence over other
+	// requester-related filters such as Patchable, PatchOnly, AllowForGitTag,
+	// and GitTagOnly. By default, all requesters are allowed to run the task.
 	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
 
 	// Use a *bool so that there are 3 possible states:
@@ -1171,28 +1171,8 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken, appToken string)
 	expansions.Put("author_email", v.AuthorEmail)
 	expansions.Put("created_at", v.CreateTime.Format(build.IdTimeLayout))
 
-	requesterExpansion := ""
-	switch v.Requester {
-	case evergreen.PatchVersionRequester:
-		requesterExpansion = "patch"
-	case evergreen.GithubPRRequester:
-		requesterExpansion = "github_pr"
-	case evergreen.GitTagRequester:
-		requesterExpansion = "github_tag"
-	case evergreen.RepotrackerVersionRequester:
-		requesterExpansion = "commit"
-	case evergreen.TriggerRequester:
-		requesterExpansion = "trigger"
-	case evergreen.MergeTestRequester:
-		requesterExpansion = "commit_queue"
-	case evergreen.AdHocRequester:
-		requesterExpansion = "ad_hoc"
-	case evergreen.GithubMergeRequester:
-		requesterExpansion = "github_merge_queue"
-	default:
-		requesterExpansion = "unknown_requester"
-	}
-	expansions.Put("requester", requesterExpansion)
+	requesterExpansion := evergreen.InternalRequesterToUserRequester(v.Requester)
+	expansions.Put("requester", string(requesterExpansion))
 
 	if evergreen.IsGitTagRequester(v.Requester) {
 		expansions.Put("triggered_by_git_tag", v.TriggeredByGitTag.Tag)

--- a/model/project.go
+++ b/model/project.go
@@ -319,8 +319,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnNonPatchBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnGitTagBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		allowed := utility.StringSliceIntersection(bvt.AllowedRequesters, []string{evergreen.GitTagRequester})
-		return len(allowed) == 0
+		return utility.StringSliceContains(bvt.AllowedRequesters, evergreen.GitTagRequester)
 	}
 
 	return !utility.FromBoolTPtr(bvt.AllowForGitTag)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -120,6 +120,7 @@ type parserTaskGroup struct {
 	PatchOnly                *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
 	AllowForGitTag           *bool              `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
 	GitTagOnly               *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters        []string           `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
 	ExecTimeoutSecs          int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
 	Stepback                 *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
 	MaxHosts                 int                `yaml:"max_hosts,omitempty" bson:"max_hosts,omitempty"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -147,27 +147,21 @@ func (ptg *parserTaskGroup) tags() []string { return ptg.Tags }
 
 // parserTask represents an intermediary state of task definitions.
 type parserTask struct {
-	Name            string              `yaml:"name,omitempty" bson:"name,omitempty"`
-	Priority        int64               `yaml:"priority,omitempty" bson:"priority,omitempty"`
-	ExecTimeoutSecs int                 `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
-	DependsOn       parserDependencies  `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
-	Commands        []PluginCommandConf `yaml:"commands,omitempty" bson:"commands,omitempty"`
-	Tags            parserStringSlice   `yaml:"tags,omitempty" bson:"tags,omitempty"`
-	RunOn           parserStringSlice   `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
-	Patchable       *bool               `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly       *bool               `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	Disable         *bool               `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	AllowForGitTag  *bool               `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly      *bool               `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	// kim: TODO: add documentation
-	// kim: TODO: mention that specifying empty list of AllowedRequesters is
-	// not valid (i.e. it's the same as allowing all requesters). You should use
-	// disable if you want to prevent the task from running entirely.
-	// kim: TODO: mention that AllowedRequesters is higher precedence than any
-	// requester booleans.
-	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
-	Stepback          *bool    `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	MustHaveResults   *bool    `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
+	Name              string                    `yaml:"name,omitempty" bson:"name,omitempty"`
+	Priority          int64                     `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	ExecTimeoutSecs   int                       `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	DependsOn         parserDependencies        `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Commands          []PluginCommandConf       `yaml:"commands,omitempty" bson:"commands,omitempty"`
+	Tags              parserStringSlice         `yaml:"tags,omitempty" bson:"tags,omitempty"`
+	RunOn             parserStringSlice         `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
+	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool                     `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Disable           *bool                     `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Stepback          *bool                     `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	MustHaveResults   *bool                     `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
 }
 
 func (pp *ParserProject) Insert() error {
@@ -343,12 +337,12 @@ type parserBV struct {
 	DisplayTasks  []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 	DependsOn     parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
-	Activate          *bool    `yaml:"activate,omitempty" bson:"activate,omitempty"`
-	Patchable         *bool    `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly         *bool    `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	AllowForGitTag    *bool    `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly        *bool    `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Activate          *bool                     `yaml:"activate,omitempty" bson:"activate,omitempty"`
+	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool                     `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
 
 	// internal matrix stuff
 	MatrixId  string      `yaml:"matrix_id,omitempty" bson:"matrix_id,omitempty"`
@@ -425,20 +419,20 @@ func (pbv *parserBV) canMerge() bool {
 
 // parserBVTaskUnit is a helper type storing intermediary variant task configurations.
 type parserBVTaskUnit struct {
-	Name              string             `yaml:"name,omitempty" bson:"name,omitempty"`
-	Patchable         *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly         *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	Disable           *bool              `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	AllowForGitTag    *bool              `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly        *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	AllowedRequesters []string           `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
-	Priority          int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
-	DependsOn         parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
-	ExecTimeoutSecs   int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
-	Stepback          *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	Distros           parserStringSlice  `yaml:"distros,omitempty" bson:"distros,omitempty"`
-	RunOn             parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
-	CommitQueueMerge  bool               `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge,omitempty"`
+	Name              string                    `yaml:"name,omitempty" bson:"name,omitempty"`
+	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool                     `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Disable           *bool                     `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Priority          int64                     `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	DependsOn         parserDependencies        `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	ExecTimeoutSecs   int                       `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Stepback          *bool                     `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	Distros           parserStringSlice         `yaml:"distros,omitempty" bson:"distros,omitempty"`
+	RunOn             parserStringSlice         `yaml:"run_on,omitempty" bson:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
+	CommitQueueMerge  bool                      `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge,omitempty"`
 	// Use a *int for 2 possible states
 	// nil - not overriding the project setting
 	// non-nil - overriding the project setting with this BatchTime
@@ -1021,24 +1015,25 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 	var evalErrs, errs []error
 	for _, pt := range pts {
 		t := ProjectTask{
-			Name:              pt.Name,
-			Priority:          pt.Priority,
-			ExecTimeoutSecs:   pt.ExecTimeoutSecs,
-			Commands:          pt.Commands,
-			Tags:              pt.Tags,
-			RunOn:             pt.RunOn,
-			Patchable:         pt.Patchable,
-			PatchOnly:         pt.PatchOnly,
-			Disable:           pt.Disable,
-			AllowForGitTag:    pt.AllowForGitTag,
-			GitTagOnly:        pt.GitTagOnly,
-			AllowedRequesters: pt.AllowedRequesters,
-			Stepback:          pt.Stepback,
-			MustHaveResults:   pt.MustHaveResults,
+			Name:            pt.Name,
+			Priority:        pt.Priority,
+			ExecTimeoutSecs: pt.ExecTimeoutSecs,
+			Commands:        pt.Commands,
+			Tags:            pt.Tags,
+			RunOn:           pt.RunOn,
+			Patchable:       pt.Patchable,
+			PatchOnly:       pt.PatchOnly,
+			Disable:         pt.Disable,
+			AllowForGitTag:  pt.AllowForGitTag,
+			GitTagOnly:      pt.GitTagOnly,
+			Stepback:        pt.Stepback,
+			MustHaveResults: pt.MustHaveResults,
 		}
 		if strings.Contains(strings.TrimSpace(pt.Name), " ") {
 			evalErrs = append(evalErrs, errors.Errorf("spaces are not allowed in task names ('%s')", pt.Name))
 		}
+		t.AllowedRequesters, errs = evaluateRequesters(pt.AllowedRequesters)
+		evalErrs = append(evalErrs, errs...)
 		t.DependsOn, errs = evaluateDependsOn(tse.tagEval, tgse, vse, pt.DependsOn)
 		evalErrs = append(evalErrs, errs...)
 		tasks = append(tasks, t)
@@ -1088,23 +1083,24 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 	var evalErrs, errs []error
 	for _, pbv := range pbvs {
 		bv := BuildVariant{
-			DisplayName:       pbv.DisplayName,
-			Name:              pbv.Name,
-			Expansions:        pbv.Expansions,
-			Modules:           pbv.Modules,
-			Disable:           pbv.Disable,
-			BatchTime:         pbv.BatchTime,
-			CronBatchTime:     pbv.CronBatchTime,
-			Activate:          pbv.Activate,
-			Patchable:         pbv.Patchable,
-			PatchOnly:         pbv.PatchOnly,
-			AllowForGitTag:    pbv.AllowForGitTag,
-			GitTagOnly:        pbv.GitTagOnly,
-			AllowedRequesters: pbv.AllowedRequesters,
-			Stepback:          pbv.Stepback,
-			RunOn:             pbv.RunOn,
-			Tags:              pbv.Tags,
+			DisplayName:    pbv.DisplayName,
+			Name:           pbv.Name,
+			Expansions:     pbv.Expansions,
+			Modules:        pbv.Modules,
+			Disable:        pbv.Disable,
+			BatchTime:      pbv.BatchTime,
+			CronBatchTime:  pbv.CronBatchTime,
+			Activate:       pbv.Activate,
+			Patchable:      pbv.Patchable,
+			PatchOnly:      pbv.PatchOnly,
+			AllowForGitTag: pbv.AllowForGitTag,
+			GitTagOnly:     pbv.GitTagOnly,
+			Stepback:       pbv.Stepback,
+			RunOn:          pbv.RunOn,
+			Tags:           pbv.Tags,
 		}
+		bv.AllowedRequesters, errs = evaluateRequesters(pbv.AllowedRequesters)
+		evalErrs = append(evalErrs, errs...)
 		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 
 		// evaluate any rules passed in during matrix construction
@@ -1263,7 +1259,9 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 			parserTask := tasksByName[name]
 			// create a new task by copying the task that selected it,
 			// so we can preserve the "Variant" and "Status" field.
-			t := getParserBuildVariantTaskUnit(name, parserTask, pbvt, pbv)
+			var t BuildVariantTaskUnit
+			t, errs = getParserBuildVariantTaskUnit(name, parserTask, pbvt, pbv)
+			evalErrs = append(evalErrs, errs...)
 
 			// Task-level dependencies defined in the variant override variant-level dependencies which override
 			// task-level dependencies defined in the task.
@@ -1306,25 +1304,28 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 // * Task settings within a task group's list of tasks
 // * Project task's settings
 // * Build variant's settings
-func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskUnit, bv parserBV) BuildVariantTaskUnit {
+func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskUnit, bv parserBV) (BuildVariantTaskUnit, []error) {
 	res := BuildVariantTaskUnit{
-		Name:              name,
-		Variant:           bv.Name,
-		Patchable:         bvt.Patchable,
-		PatchOnly:         bvt.PatchOnly,
-		Disable:           bvt.Disable,
-		AllowForGitTag:    bvt.AllowForGitTag,
-		GitTagOnly:        bvt.GitTagOnly,
-		AllowedRequesters: bvt.AllowedRequesters,
-		Priority:          bvt.Priority,
-		ExecTimeoutSecs:   bvt.ExecTimeoutSecs,
-		Stepback:          bvt.Stepback,
-		RunOn:             bvt.RunOn,
-		CommitQueueMerge:  bvt.CommitQueueMerge,
-		CronBatchTime:     bvt.CronBatchTime,
-		BatchTime:         bvt.BatchTime,
-		Activate:          bvt.Activate,
+		Name:             name,
+		Variant:          bv.Name,
+		Patchable:        bvt.Patchable,
+		PatchOnly:        bvt.PatchOnly,
+		Disable:          bvt.Disable,
+		AllowForGitTag:   bvt.AllowForGitTag,
+		GitTagOnly:       bvt.GitTagOnly,
+		Priority:         bvt.Priority,
+		ExecTimeoutSecs:  bvt.ExecTimeoutSecs,
+		Stepback:         bvt.Stepback,
+		RunOn:            bvt.RunOn,
+		CommitQueueMerge: bvt.CommitQueueMerge,
+		CronBatchTime:    bvt.CronBatchTime,
+		BatchTime:        bvt.BatchTime,
+		Activate:         bvt.Activate,
 	}
+	var errs []error
+	catcher := grip.NewBasicCatcher()
+	res.AllowedRequesters, errs = evaluateRequesters(bvt.AllowedRequesters)
+	catcher.Extend(errs)
 	if bvt.TaskGroup != nil {
 		res.TaskGroup = &TaskGroup{
 			Name:                     bvt.Name,
@@ -1365,7 +1366,8 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.GitTagOnly = pt.GitTagOnly
 	}
 	if len(res.AllowedRequesters) == 0 {
-		res.AllowedRequesters = pt.AllowedRequesters
+		res.AllowedRequesters, errs = evaluateRequesters(pt.AllowedRequesters)
+		catcher.Extend(errs)
 	}
 	if res.ExecTimeoutSecs == 0 {
 		res.ExecTimeoutSecs = pt.ExecTimeoutSecs
@@ -1396,14 +1398,15 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 		res.GitTagOnly = bv.GitTagOnly
 	}
 	if len(res.AllowedRequesters) == 0 {
-		res.AllowedRequesters = bv.AllowedRequesters
+		res.AllowedRequesters, errs = evaluateRequesters(bv.AllowedRequesters)
+		catcher.Extend(errs)
 	}
 
 	if res.Disable == nil {
 		res.Disable = bv.Disable
 	}
 
-	return res
+	return res, catcher.Errors()
 }
 
 // evaluateDependsOn expands any selectors in a dependency definition.
@@ -1478,4 +1481,16 @@ func evaluateDependsOn(tse *tagSelectorEvaluator, tgse *tagSelectorEvaluator, vs
 		}
 	}
 	return newDeps, evalErrs
+}
+
+// evaluateRequesters translates user requesters into internal requesters.
+func evaluateRequesters(userRequesters []evergreen.UserRequester) ([]string, []error) {
+	requesters := make([]string, 0, len(userRequesters))
+	catcher := grip.NewBasicCatcher()
+	for _, userRequester := range userRequesters {
+		requester := evergreen.UserRequesterToInternalRequester(userRequester)
+		catcher.ErrorfWhen(requester == "", "invalid requester '%s'", userRequester)
+		requesters = append(requesters, requester)
+	}
+	return requesters, catcher.Errors()
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -159,8 +159,15 @@ type parserTask struct {
 	Disable         *bool               `yaml:"disable,omitempty" bson:"disable,omitempty"`
 	AllowForGitTag  *bool               `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
 	GitTagOnly      *bool               `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	Stepback        *bool               `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	MustHaveResults *bool               `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
+	// kim: TODO: add documentation
+	// kim: TODO: mention that specifying empty list of AllowedRequesters is
+	// not valid (i.e. it's the same as allowing all requesters). You should use
+	// disable if you want to prevent the task from running entirely.
+	// kim: TODO: mention that AllowedRequesters is higher precedence than any
+	// requester booleans.
+	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Stepback          *bool    `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	MustHaveResults   *bool    `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
 }
 
 func (pp *ParserProject) Insert() error {
@@ -336,11 +343,12 @@ type parserBV struct {
 	DisplayTasks  []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 	DependsOn     parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
-	Activate       *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
-	Patchable      *bool `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly      *bool `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	AllowForGitTag *bool `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly     *bool `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	Activate          *bool    `yaml:"activate,omitempty" bson:"activate,omitempty"`
+	Patchable         *bool    `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool    `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	AllowForGitTag    *bool    `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool    `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
 
 	// internal matrix stuff
 	MatrixId  string      `yaml:"matrix_id,omitempty" bson:"matrix_id,omitempty"`
@@ -408,6 +416,7 @@ func (pbv *parserBV) canMerge() bool {
 		pbv.PatchOnly == nil &&
 		pbv.AllowForGitTag == nil &&
 		pbv.GitTagOnly == nil &&
+		len(pbv.AllowedRequesters) == 0 &&
 		pbv.MatrixId == "" &&
 		pbv.MatrixVal == nil &&
 		pbv.Matrix == nil &&
@@ -416,19 +425,20 @@ func (pbv *parserBV) canMerge() bool {
 
 // parserBVTaskUnit is a helper type storing intermediary variant task configurations.
 type parserBVTaskUnit struct {
-	Name             string             `yaml:"name,omitempty" bson:"name,omitempty"`
-	Patchable        *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly        *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	Disable          *bool              `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	AllowForGitTag   *bool              `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly       *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	Priority         int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
-	DependsOn        parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
-	ExecTimeoutSecs  int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
-	Stepback         *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	Distros          parserStringSlice  `yaml:"distros,omitempty" bson:"distros,omitempty"`
-	RunOn            parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
-	CommitQueueMerge bool               `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge,omitempty"`
+	Name              string             `yaml:"name,omitempty" bson:"name,omitempty"`
+	Patchable         *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Disable           *bool              `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	AllowForGitTag    *bool              `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []string           `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Priority          int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
+	DependsOn         parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	ExecTimeoutSecs   int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
+	Stepback          *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	Distros           parserStringSlice  `yaml:"distros,omitempty" bson:"distros,omitempty"`
+	RunOn             parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"` // Alias for "Distros" TODO: deprecate Distros
+	CommitQueueMerge  bool               `yaml:"commit_queue_merge,omitempty" bson:"commit_queue_merge,omitempty"`
 	// Use a *int for 2 possible states
 	// nil - not overriding the project setting
 	// non-nil - overriding the project setting with this BatchTime
@@ -1011,19 +1021,20 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 	var evalErrs, errs []error
 	for _, pt := range pts {
 		t := ProjectTask{
-			Name:            pt.Name,
-			Priority:        pt.Priority,
-			ExecTimeoutSecs: pt.ExecTimeoutSecs,
-			Commands:        pt.Commands,
-			Tags:            pt.Tags,
-			RunOn:           pt.RunOn,
-			Patchable:       pt.Patchable,
-			PatchOnly:       pt.PatchOnly,
-			Disable:         pt.Disable,
-			AllowForGitTag:  pt.AllowForGitTag,
-			GitTagOnly:      pt.GitTagOnly,
-			Stepback:        pt.Stepback,
-			MustHaveResults: pt.MustHaveResults,
+			Name:              pt.Name,
+			Priority:          pt.Priority,
+			ExecTimeoutSecs:   pt.ExecTimeoutSecs,
+			Commands:          pt.Commands,
+			Tags:              pt.Tags,
+			RunOn:             pt.RunOn,
+			Patchable:         pt.Patchable,
+			PatchOnly:         pt.PatchOnly,
+			Disable:           pt.Disable,
+			AllowForGitTag:    pt.AllowForGitTag,
+			GitTagOnly:        pt.GitTagOnly,
+			AllowedRequesters: pt.AllowedRequesters,
+			Stepback:          pt.Stepback,
+			MustHaveResults:   pt.MustHaveResults,
 		}
 		if strings.Contains(strings.TrimSpace(pt.Name), " ") {
 			evalErrs = append(evalErrs, errors.Errorf("spaces are not allowed in task names ('%s')", pt.Name))
@@ -1077,21 +1088,22 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 	var evalErrs, errs []error
 	for _, pbv := range pbvs {
 		bv := BuildVariant{
-			DisplayName:    pbv.DisplayName,
-			Name:           pbv.Name,
-			Expansions:     pbv.Expansions,
-			Modules:        pbv.Modules,
-			Disable:        pbv.Disable,
-			BatchTime:      pbv.BatchTime,
-			CronBatchTime:  pbv.CronBatchTime,
-			Activate:       pbv.Activate,
-			Patchable:      pbv.Patchable,
-			PatchOnly:      pbv.PatchOnly,
-			AllowForGitTag: pbv.AllowForGitTag,
-			GitTagOnly:     pbv.GitTagOnly,
-			Stepback:       pbv.Stepback,
-			RunOn:          pbv.RunOn,
-			Tags:           pbv.Tags,
+			DisplayName:       pbv.DisplayName,
+			Name:              pbv.Name,
+			Expansions:        pbv.Expansions,
+			Modules:           pbv.Modules,
+			Disable:           pbv.Disable,
+			BatchTime:         pbv.BatchTime,
+			CronBatchTime:     pbv.CronBatchTime,
+			Activate:          pbv.Activate,
+			Patchable:         pbv.Patchable,
+			PatchOnly:         pbv.PatchOnly,
+			AllowForGitTag:    pbv.AllowForGitTag,
+			GitTagOnly:        pbv.GitTagOnly,
+			AllowedRequesters: pbv.AllowedRequesters,
+			Stepback:          pbv.Stepback,
+			RunOn:             pbv.RunOn,
+			Tags:              pbv.Tags,
 		}
 		bv.Tasks, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 
@@ -1296,21 +1308,22 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 // * Build variant's settings
 func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskUnit, bv parserBV) BuildVariantTaskUnit {
 	res := BuildVariantTaskUnit{
-		Name:             name,
-		Variant:          bv.Name,
-		Patchable:        bvt.Patchable,
-		PatchOnly:        bvt.PatchOnly,
-		Disable:          bvt.Disable,
-		AllowForGitTag:   bvt.AllowForGitTag,
-		GitTagOnly:       bvt.GitTagOnly,
-		Priority:         bvt.Priority,
-		ExecTimeoutSecs:  bvt.ExecTimeoutSecs,
-		Stepback:         bvt.Stepback,
-		RunOn:            bvt.RunOn,
-		CommitQueueMerge: bvt.CommitQueueMerge,
-		CronBatchTime:    bvt.CronBatchTime,
-		BatchTime:        bvt.BatchTime,
-		Activate:         bvt.Activate,
+		Name:              name,
+		Variant:           bv.Name,
+		Patchable:         bvt.Patchable,
+		PatchOnly:         bvt.PatchOnly,
+		Disable:           bvt.Disable,
+		AllowForGitTag:    bvt.AllowForGitTag,
+		GitTagOnly:        bvt.GitTagOnly,
+		AllowedRequesters: bvt.AllowedRequesters,
+		Priority:          bvt.Priority,
+		ExecTimeoutSecs:   bvt.ExecTimeoutSecs,
+		Stepback:          bvt.Stepback,
+		RunOn:             bvt.RunOn,
+		CommitQueueMerge:  bvt.CommitQueueMerge,
+		CronBatchTime:     bvt.CronBatchTime,
+		BatchTime:         bvt.BatchTime,
+		Activate:          bvt.Activate,
 	}
 	if bvt.TaskGroup != nil {
 		res.TaskGroup = &TaskGroup{
@@ -1351,6 +1364,9 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 	if res.GitTagOnly == nil {
 		res.GitTagOnly = pt.GitTagOnly
 	}
+	if len(res.AllowedRequesters) == 0 {
+		res.AllowedRequesters = pt.AllowedRequesters
+	}
 	if res.ExecTimeoutSecs == 0 {
 		res.ExecTimeoutSecs = pt.ExecTimeoutSecs
 	}
@@ -1378,6 +1394,9 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 	}
 	if res.GitTagOnly == nil {
 		res.GitTagOnly = bv.GitTagOnly
+	}
+	if len(res.AllowedRequesters) == 0 {
+		res.AllowedRequesters = bv.AllowedRequesters
 	}
 
 	if res.Disable == nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -370,8 +370,13 @@ func TestTranslateTasks(t *testing.T) {
 				},
 			},
 			{
-				Name:              "patch_requesters_allowed",
-				AllowedRequesters: evergreen.PatchRequesters,
+				Name: "patch_requesters_allowed",
+				AllowedRequesters: []evergreen.UserRequester{
+					evergreen.PatchVersionUserRequester,
+					evergreen.GithubPRUserRequester,
+					evergreen.MergeTestUserRequester,
+					evergreen.GithubMergeUserRequester,
+				},
 				Tasks: parserBVTaskUnits{
 					{
 						Name: "a_task_with_no_special_configuration",
@@ -381,7 +386,7 @@ func TestTranslateTasks(t *testing.T) {
 					},
 					{
 						Name:              "a_task_with_build_variant_task_configuration",
-						AllowedRequesters: []string{evergreen.RepotrackerVersionRequester, evergreen.GitTagRequester},
+						AllowedRequesters: []evergreen.UserRequester{evergreen.RepotrackerVersionUserRequester, evergreen.GitTagUserRequester},
 					},
 				},
 			},
@@ -405,7 +410,7 @@ func TestTranslateTasks(t *testing.T) {
 			{Name: "tg_task", PatchOnly: utility.TruePtr(), RunOn: []string{"a different distro"}},
 			{Name: "a_task_with_no_special_configuration"},
 			{Name: "a_task_with_build_variant_task_configuration"},
-			{Name: "a_task_with_allowed_requesters", AllowedRequesters: []string{evergreen.AdHocRequester}},
+			{Name: "a_task_with_allowed_requesters", AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}},
 		},
 		TaskGroups: []parserTaskGroup{{
 			Name:  "my_tg",

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2201,7 +2201,6 @@ func TestVariantTasksForSelectors(t *testing.T) {
 	}
 }
 
-// kim: TODO: test other SkipOn's as well for AllowedRequesters.
 func TestSkipOnRequester(t *testing.T) {
 	t.Run("PatchRequester", func(t *testing.T) {
 		requester := evergreen.PatchVersionRequester

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -602,6 +602,9 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 
 	// create a version document
+	// kim: NOTE: this creates a version for a mainline commit. Therefore,
+	// checking repotracker version requester is a valid way to only run some
+	// tasks in a mainline commit version.
 	v, err := ShellVersionFromRevision(ctx, projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -602,9 +602,6 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 
 	// create a version document
-	// kim: NOTE: this creates a version for a mainline commit. Therefore,
-	// checking repotracker version requester is a valid way to only run some
-	// tasks in a mainline commit version.
 	v, err := ShellVersionFromRevision(ctx, projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1379,7 +1379,7 @@ func checkTaskRuns(project *model.Project) ValidationErrors {
 				if !utility.StringSliceContains(evergreen.AllRequesterTypes, requester) {
 					errs = append(errs, ValidationError{
 						Level: Error,
-						Message: fmt.Sprintf("task '%s' in build variant '%s' has invalid requester '%s'",
+						Message: fmt.Sprintf("task '%s' in build variant '%s' has invalid allowed requester '%s'",
 							bvtu.Name, bvtu.Variant, requester),
 					})
 				}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1375,16 +1375,6 @@ func checkTaskRuns(project *model.Project) ValidationErrors {
 	var errs ValidationErrors
 	for _, bvtu := range project.FindAllBuildVariantTasks() {
 		if len(bvtu.AllowedRequesters) != 0 {
-			for _, requester := range bvtu.AllowedRequesters {
-				if !utility.StringSliceContains(evergreen.AllRequesterTypes, requester) {
-					errs = append(errs, ValidationError{
-						Level: Error,
-						Message: fmt.Sprintf("task '%s' in build variant '%s' has invalid allowed requester '%s'",
-							bvtu.Name, bvtu.Variant, requester),
-					})
-				}
-			}
-
 			if bvtu.PatchOnly != nil {
 				errs = append(errs, ValidationError{
 					Level: Warning,

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1051,6 +1051,50 @@ func TestCheckTaskRuns(t *testing.T) {
 		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		So(len(checkTaskRuns(project)), ShouldEqual, 1)
 	})
+	Convey("When a task is patch-only and also has allowed requesters, a warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Warning)
+	})
+	Convey("When a task is not patchable and also has allowed requesters, a warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Warning)
+	})
+	Convey("When a task is git-tag-only and also has allowed requesters, a warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Warning)
+	})
+	Convey("When a task is allowed for git tags and also has allowed requesters, a warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.GitTagRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].AllowForGitTag = utility.TruePtr()
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Warning)
+	})
+	Convey("When a task has valid allowed requesters, no warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.GitTagRequester, evergreen.RepotrackerVersionRequester}
+		So(checkTaskRuns(project), ShouldBeEmpty)
+	})
+	Convey("When a task has invalid allowed requesters, no warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{"foobar"}
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Error)
+	})
 }
 
 func TestValidateTaskNames(t *testing.T) {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1083,18 +1083,6 @@ func TestCheckTaskRuns(t *testing.T) {
 		So(len(errs), ShouldEqual, 1)
 		So(errs[0].Level, ShouldEqual, Warning)
 	})
-	Convey("When a task has valid allowed requesters, no warning should be thrown", t, func() {
-		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.GitTagRequester, evergreen.RepotrackerVersionRequester}
-		So(checkTaskRuns(project), ShouldBeEmpty)
-	})
-	Convey("When a task has invalid allowed requesters, no warning should be thrown", t, func() {
-		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{"foobar"}
-		errs := checkTaskRuns(project)
-		So(len(errs), ShouldEqual, 1)
-		So(errs[0].Level, ShouldEqual, Error)
-	})
 }
 
 func TestValidateTaskNames(t *testing.T) {


### PR DESCRIPTION
EVG-20622

### Description
This adds a new project YAML configuration, which lets a user enumerate the particular requesters (e.g. GitHub PR, git tag version, periodic build) for which they want to run a task. This is a generalization of the filters currently provided by `patchable`, `patch_only`, `allow_for_git_tag` and `git_tag_only` (e.g. `git_tag_only: true` is equivalent to `allowed_requesters: ["github_tag"]`). We have no plans to actually deprecate the boolean requester options though; I chose to instead add a warning that mixing requester booleans with `allowed_requesters` is incompatible.

There will be a follow-up PR to update Shrub for `generate.tasks` after this is merged.

* Add `allowed_requesters` configuration.
* Add some helpers to translate the user-facing requesters that we expose via expansions and `allowed_requesters`.

### Testing
* Added unit tests.
* Tested in staging by submitting patches with `allowed_requesters` and checking `evergreen validate`.

### Documentation
Updated docs.
