### PR TITLE
EVG-20700: bump timeout for flaky ps tests

### DIFF
--- a/agent/util/subtree_unix_test.go
+++ b/agent/util/subtree_unix_test.go
@@ -106,18 +106,20 @@ func TestWaitForExit(t *testing.T) {
 
 	for testName, test := range map[string]func(*testing.T){
 		"non-existent process": func(t *testing.T) {
-			waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 			pids, err := waitForExit(waitCtx, []int{1234567890})
+			assert.NoError(t, waitCtx.Err())
 			assert.NoError(t, err)
 			assert.Empty(t, pids)
 		},
 		"long-running process": func(t *testing.T) {
 			longProcess := exec.CommandContext(ctx, "sleep", "30")
 			require.NoError(t, longProcess.Start())
-			waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 			pids, err := waitForExit(waitCtx, []int{longProcess.Process.Pid})
+			assert.NoError(t, waitCtx.Err())
 			assert.Error(t, err)
 			require.Len(t, pids, 1)
 			assert.Equal(t, longProcess.Process.Pid, pids[0])

--- a/agent/util/subtree_unix_test.go
+++ b/agent/util/subtree_unix_test.go
@@ -108,7 +108,7 @@ func TestWaitForExit(t *testing.T) {
 	for testName, test := range map[string]func(ctx context.Context, t *testing.T){
 		"DoesNotReturnNonexistentProcess": func(ctx context.Context, t *testing.T) {
 			pids, err := waitForExit(ctx, []int{1234567890})
-			assert.NoError(t, ctx.Err())
+			require.NoError(t, ctx.Err())
 			assert.NoError(t, err)
 			assert.Empty(t, pids)
 		},
@@ -116,7 +116,7 @@ func TestWaitForExit(t *testing.T) {
 			longProcess := exec.CommandContext(ctx, "sleep", "30")
 			require.NoError(t, longProcess.Start())
 			pids, err := waitForExit(ctx, []int{longProcess.Process.Pid})
-			assert.NoError(t, ctx.Err())
+			require.NoError(t, ctx.Err())
 			assert.Error(t, err)
 			require.Len(t, pids, 1)
 			assert.Equal(t, longProcess.Process.Pid, pids[0])


### PR DESCRIPTION
EVG-20700

### Description
The test output shows that some machines are occasionally slow at running `ps` to get the running process, so it's hitting the 5-second context timeout. Just bumping the timeout and checking for no context timeout seems sufficient to stop the test from flaking.

* Increase flaky test timeout.
* Refactor agent process-related tests a little bit.

### Testing
I ran it locally, but if it's really fixed, we will no longer see this test flake on the waterfall.