### PR TITLE
EVG-20773: move killProcs for completion of task back to its original location

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -625,6 +625,8 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 		return tc, shouldExit, errors.Wrap(err, "setting up task")
 	}
 
+	defer a.killProcs(ctx, tc, false, "task is finished")
+
 	grip.Info(message.Fields{
 		"message": "running task",
 		"task_id": tc.task.ID,
@@ -667,7 +669,6 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		_ = a.logPanic(tc.logger, pErr, nil, op)
 		status = evergreen.TaskSystemFailed
 	}()
-	defer a.killProcs(ctx, tc, false, "task is finished")
 
 	if ctx.Err() != nil {
 		tc.logger.Execution().Infof("Stopping task execution during setup: %s", ctx.Err())


### PR DESCRIPTION
EVG-20773

### Description
#6893 moved the call to `killProcs`, which kills both running processes and any child processes that it started. Originally, it ran after a task was fully complete (i.e. had already sent its final task status and had no more commands to run), but the PR moved it to run after the main task block runs. We don't want to kill child processes immediately since the server relies on the main task block child processes still being alive for the `timeout` block.

### Testing
Since we don't have a good way of directly testing Go parent/child process behavior, I just reasoned about whether the kill processes conditions were different.

### Documentation
The process-killing decision making seems to be rather arbitrary as of right now, but I'm going to make a follow-up PR to document the agent process-killing behavior a little better and the conditions when the agent cleans up processes.