### PR TITLE
EVG-20744 Add unique senders for github apps

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -273,6 +273,9 @@ type closerOp struct {
 	closerFn   func(context.Context) error
 }
 
+// cachedSender stores a GitHub sender and the time it was created
+// because GitHub app tokens, and by extension, the senders, will expire
+// one hour after creation.
 type cachedSender struct {
 	sender send.Sender
 	time   time.Time
@@ -1063,44 +1066,58 @@ func (e *envState) SaveConfig(ctx context.Context) error {
 	return errors.WithStack(UpdateConfig(ctx, &copy))
 }
 
+// GetGitHubSender returns a cached sender with a GitHub app generated token. Each org in GitHub needs a separate token
+// for authentication so we cache a sender for each org and return it if the token has not expired.
+// If the sender for the org doesn't exist or has expired, we create a new one and cache it.
+// In case of GitHub app errors, the function returns the legacy GitHub sender with a global token attached.
+// The senders are only unique to orgs, not repos, but the repo name is needed to generate a token if necessary.
 func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
 	githubSender, ok := e.githubSenders[owner]
-	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
-	if !ok || time.Since(githubSender.time) > githubTokenTimeout {
-		token, err := e.settings.CreateInstallationToken(e.ctx, owner, repo, nil)
-		if err != nil {
-			// TODO EVG-19966: Delete fallback to legacy GitHub sender
-			grip.Debug(message.WrapError(err, message.Fields{
-				"message": "error creating installation token for GitHub sender",
-				"owner":   owner,
-				"repo":    repo,
-				"ticket":  "EVG-19966",
-			}))
-			return e.GetSender(SenderGithubStatus)
-		}
-		sender, err := send.NewGithubStatusLogger("evergreen", &send.GithubOptions{
-			Token: token,
-		}, "")
-		if err != nil {
-			// TODO EVG-19966: Delete fallback to legacy GitHub sender
-			grip.Debug(message.WrapError(err, message.Fields{
-				"message": "error setting up GitHub status logger with GitHub app",
-				"owner":   owner,
-				"repo":    repo,
-				"ticket":  "EVG-19966",
-			}))
-			return e.GetSender(SenderGithubStatus)
-		}
-		e.githubSenders[owner] = cachedSender{
-			sender: sender,
-			time:   time.Now(),
-		}
-		return sender, nil
+	// If githubSender exists and has not expired, return it.
+	if ok && time.Since(githubSender.time) < githubTokenTimeout {
+		return githubSender.sender, nil
 	}
-	return githubSender.sender, nil
+	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
+	token, err := e.settings.CreateInstallationToken(e.ctx, owner, repo, nil)
+	if err != nil {
+		// TODO EVG-19966: Delete fallback to legacy GitHub sender
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message": "error creating installation token for GitHub sender",
+			"owner":   owner,
+			"repo":    repo,
+			"ticket":  "EVG-19966",
+		}))
+		legacySender, ok := e.senders[SenderGithubStatus]
+		if !ok {
+			return nil, errors.Errorf("Legacy GitHub status sender not found")
+		}
+		return legacySender, nil
+	}
+	sender, err := send.NewGithubStatusLogger("evergreen", &send.GithubOptions{
+		Token: token,
+	}, "")
+	if err != nil {
+		// TODO EVG-19966: Delete fallback to legacy GitHub sender
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message": "error setting up GitHub status logger with GitHub app",
+			"owner":   owner,
+			"repo":    repo,
+			"ticket":  "EVG-19966",
+		}))
+		legacySender, ok := e.senders[SenderGithubStatus]
+		if !ok {
+			return nil, errors.Errorf("Legacy GitHub status sender not found")
+		}
+		return legacySender, nil
+	}
+	e.githubSenders[owner] = cachedSender{
+		sender: sender,
+		time:   time.Now(),
+	}
+	return sender, nil
 }
 
 func (e *envState) GetSender(key SenderKey) (send.Sender, error) {

--- a/environment.go
+++ b/environment.go
@@ -251,7 +251,7 @@ type envState struct {
 	clientConfig            *ClientConfig
 	closers                 []closerOp
 	senders                 map[SenderKey]send.Sender
-	githubSenders           map[string]cachedSender
+	githubSenders           map[string]cachedGitHubSender
 	roleManager             gimlet.RoleManager
 	userManager             gimlet.UserManager
 	userManagerInfo         UserManagerInfo
@@ -273,10 +273,10 @@ type closerOp struct {
 	closerFn   func(context.Context) error
 }
 
-// cachedSender stores a GitHub sender and the time it was created
+// cachedGitHubSender stores a GitHub sender and the time it was created
 // because GitHub app tokens, and by extension, the senders, will expire
 // one hour after creation.
-type cachedSender struct {
+type cachedGitHubSender struct {
 	sender send.Sender
 	time   time.Time
 }
@@ -747,7 +747,7 @@ func (e *envState) initSenders(ctx context.Context) error {
 		}
 		e.senders[SenderGithubStatus] = sender
 	}
-	e.githubSenders = make(map[string]cachedSender)
+	e.githubSenders = make(map[string]cachedGitHubSender)
 
 	if jira := &e.settings.Jira; len(jira.GetHostURL()) != 0 {
 		sender, err = send.NewJiraLogger(ctx, jira.Export(), levelInfo)
@@ -1113,7 +1113,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 		}
 		return legacySender, nil
 	}
-	e.githubSenders[owner] = cachedSender{
+	e.githubSenders[owner] = cachedGitHubSender{
 		sender: sender,
 		time:   time.Now(),
 	}

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -262,6 +262,10 @@ func (e *Environment) ClientConfig() *evergreen.ClientConfig {
 	}
 }
 
+func (e *Environment) GetGitHubSender(owner, repo string) (send.Sender, error) {
+	return nil, nil
+}
+
 func (e *Environment) GetSender(key evergreen.SenderKey) (send.Sender, error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -263,7 +263,9 @@ func (e *Environment) ClientConfig() *evergreen.ClientConfig {
 }
 
 func (e *Environment) GetGitHubSender(owner, repo string) (send.Sender, error) {
-	return nil, nil
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.InternalSender, nil
 }
 
 func (e *Environment) GetSender(key evergreen.SenderKey) (send.Sender, error) {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -1267,7 +1267,8 @@ func SendCommitQueueResult(ctx context.Context, p *patch.Patch, status message.G
 		Description: description,
 		URL:         url,
 	}
-	sender, err := evergreen.GetEnvironment().GetSender(evergreen.SenderGithubStatus)
+	// TODO EVG-19966: Delete fallback to legacy GitHub sender
+	sender, err := evergreen.GetEnvironment().GetGitHubSender(projectRef.Owner, projectRef.Repo)
 	if err != nil {
 		return errors.Wrap(err, "getting GitHub sender")
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -1267,7 +1267,7 @@ func SendCommitQueueResult(ctx context.Context, p *patch.Patch, status message.G
 		Description: description,
 		URL:         url,
 	}
-	// TODO EVG-19966: Delete fallback to legacy GitHub sender
+
 	sender, err := evergreen.GetEnvironment().GetGitHubSender(projectRef.Owner, projectRef.Repo)
 	if err != nil {
 		return errors.Wrap(err, "getting GitHub sender")

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -530,7 +530,6 @@ func SendPendingStatusToGithub(ctx context.Context, input SendGithubStatusInput,
 		Description: input.Desc,
 	}
 
-	// TODO EVG-19966: Delete fallback to legacy GitHub sender
 	sender, err := env.GetGitHubSender(input.Owner, input.Repo)
 	if err != nil {
 		return errors.Wrap(err, "getting github status sender")
@@ -1715,7 +1714,6 @@ func SendCommitQueueGithubStatus(ctx context.Context, env evergreen.Environment,
 	owner := utility.FromStringPtr(pr.Base.Repo.Owner.Login)
 	repo := utility.FromStringPtr(pr.Base.Repo.Name)
 
-	// TODO EVG-19966: Delete fallback to legacy GitHub sender
 	sender, err := env.GetGitHubSender(owner, repo)
 	if err != nil {
 		return errors.Wrap(err, "getting github status sender")

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/pkg/errors"
 )
@@ -129,9 +130,22 @@ func (j *eventSendJob) send(n *notification.Notification) error {
 		return errors.Wrap(err, "getting sender key for notification")
 	}
 
-	sender, err := j.env.GetSender(key)
-	if err != nil {
-		return errors.Wrap(err, "getting global notification sender")
+	var sender send.Sender
+	if key == evergreen.SenderGithubStatus {
+		payload, ok := n.Payload.(*message.GithubStatus)
+		if !ok || payload == nil {
+			return errors.New("github status payload is invalid")
+		}
+		// TODO EVG-19966: Delete fallback to legacy GitHub sender
+		sender, err = j.env.GetGitHubSender(payload.Owner, payload.Repo)
+		if err != nil {
+			return errors.Wrap(err, "getting github status sender")
+		}
+	} else {
+		sender, err = j.env.GetSender(key)
+		if err != nil {
+			return errors.Wrap(err, "getting global notification sender")
+		}
 	}
 	sender.Send(c)
 	return nil

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -136,7 +136,6 @@ func (j *eventSendJob) send(n *notification.Notification) error {
 		if !ok || payload == nil {
 			return errors.New("github status payload is invalid")
 		}
-		// TODO EVG-19966: Delete fallback to legacy GitHub sender
 		sender, err = j.env.GetGitHubSender(payload.Owner, payload.Repo)
 		if err != nil {
 			return errors.Wrap(err, "getting github status sender")

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -247,7 +247,6 @@ func (j *githubStatusUpdateJob) fetch() (*message.GithubStatus, error) {
 }
 
 func (j *githubStatusUpdateJob) setSender(owner, repo string) error {
-	// TODO EVG-19966: Delete fallback to legacy GitHub sender
 	var err error
 	j.sender, err = j.env.GetGitHubSender(owner, repo)
 	return err

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -172,15 +172,6 @@ func (j *githubStatusUpdateJob) preamble(ctx context.Context) error {
 	if len(j.urlBase) == 0 {
 		return errors.New("UI URL is empty")
 	}
-
-	if j.sender == nil {
-		var err error
-		j.sender, err = j.env.GetSender(evergreen.SenderGithubStatus)
-		if err != nil {
-			return err
-		}
-	}
-
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting service flags")
@@ -255,6 +246,13 @@ func (j *githubStatusUpdateJob) fetch() (*message.GithubStatus, error) {
 	return &status, nil
 }
 
+func (j *githubStatusUpdateJob) setSender(owner, repo string) error {
+	// TODO EVG-19966: Delete fallback to legacy GitHub sender
+	var err error
+	j.sender, err = j.env.GetGitHubSender(owner, repo)
+	return err
+}
+
 func (j *githubStatusUpdateJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
@@ -264,6 +262,12 @@ func (j *githubStatusUpdateJob) Run(ctx context.Context) {
 	}
 
 	status, err := j.fetch()
+	if err != nil {
+		j.AddError(err)
+		return
+	}
+
+	err = j.setSender(status.Owner, status.Repo)
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -235,7 +235,6 @@ func (s *githubStatusUpdateSuite) TestPreamble() {
 	s.NoError(j.preamble(s.ctx))
 	s.NotNil(j.env)
 	s.NotEmpty(j.urlBase)
-	s.NotNil(j.sender)
 	s.Equal(s.env, j.env)
 
 	uiConfig := evergreen.UIConfig{}

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -96,7 +96,6 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 	if j.urlBase == "" {
 		return errors.New("url base doesn't exist")
 	}
-	// TODO EVG-19966: Delete fallback to legacy GitHub sender
 	j.sender, err = j.env.GetGitHubSender(j.patch.GithubPatchData.BaseOwner, j.patch.GithubPatchData.BaseRepo)
 	if err != nil {
 		return err

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -96,12 +96,10 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 	if j.urlBase == "" {
 		return errors.New("url base doesn't exist")
 	}
-	if j.sender == nil {
-		var err error
-		j.sender, err = j.env.GetSender(evergreen.SenderGithubStatus)
-		if err != nil {
-			return err
-		}
+	// TODO EVG-19966: Delete fallback to legacy GitHub sender
+	j.sender, err = j.env.GetGitHubSender(j.patch.GithubPatchData.BaseOwner, j.patch.GithubPatchData.BaseRepo)
+	if err != nil {
+		return err
 	}
 	if j.patch == nil {
 		j.patch, err = patch.FindOneId(j.FetchID)


### PR DESCRIPTION
EVG-20744

### Description
GitHub apps don't support cross-org authentication so you need to generate a new access token for every owner. 
This change makes senders for each owner and caches it to the env.
GitHub app tokens expire after 1 hour so we re-create the token and sender after it expires 

### Testing
Can't test on staging as the staging github app is only installed on 1 org so I can't test the cross-org authing 
But confirmed that the fallback works and we use the legacy global sender when the app fails to create a sender 
