### PR TITLE
EVG-20654: deprecate duplicate GetWorkingDirectory

### DIFF
--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -51,11 +51,11 @@ func (e *autoExtract) Execute(ctx context.Context,
 
 	// if the target is a relative path, join it to the working dir
 	if !filepath.IsAbs(e.TargetDirectory) {
-		e.TargetDirectory = getJoinedWithWorkDir(conf, e.TargetDirectory)
+		e.TargetDirectory = getWorkingDirectory(conf, e.TargetDirectory)
 	}
 
 	if !filepath.IsAbs(e.ArchivePath) {
-		e.ArchivePath = getJoinedWithWorkDir(conf, e.ArchivePath)
+		e.ArchivePath = getWorkingDirectory(conf, e.ArchivePath)
 	}
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -79,12 +79,12 @@ func (c *tarballCreate) Execute(ctx context.Context,
 
 	// if the source dir is a relative path, join it to the working dir
 	if !filepath.IsAbs(c.SourceDir) {
-		c.SourceDir = getJoinedWithWorkDir(conf, c.SourceDir)
+		c.SourceDir = getWorkingDirectory(conf, c.SourceDir)
 	}
 
 	// if the target is a relative path, join it to the working dir
 	if !filepath.IsAbs(c.Target) {
-		c.Target = getJoinedWithWorkDir(conf, c.Target)
+		c.Target = getWorkingDirectory(conf, c.Target)
 	}
 
 	errChan := make(chan error)

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -51,11 +51,11 @@ func (e *tarballExtract) Execute(ctx context.Context,
 
 	// if the target is a relative path, join it to the working dir
 	if !filepath.IsAbs(e.TargetDirectory) {
-		e.TargetDirectory = getJoinedWithWorkDir(conf, e.TargetDirectory)
+		e.TargetDirectory = getWorkingDirectory(conf, e.TargetDirectory)
 	}
 
 	if !filepath.IsAbs(e.ArchivePath) {
-		e.ArchivePath = getJoinedWithWorkDir(conf, e.ArchivePath)
+		e.ArchivePath = getWorkingDirectory(conf, e.ArchivePath)
 	}
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {

--- a/agent/command/archive_zip_create.go
+++ b/agent/command/archive_zip_create.go
@@ -64,12 +64,12 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 
 	// if the source dir is a relative path, join it to the working dir
 	if !filepath.IsAbs(c.SourceDir) {
-		c.SourceDir = getJoinedWithWorkDir(conf, c.SourceDir)
+		c.SourceDir = getWorkingDirectory(conf, c.SourceDir)
 	}
 
 	// if the target is a relative path, join it to the working dir
 	if !filepath.IsAbs(c.Target) {
-		c.Target = getJoinedWithWorkDir(conf, c.Target)
+		c.Target = getWorkingDirectory(conf, c.Target)
 	}
 
 	files, err := agentutil.FindContentsToArchive(ctx, c.SourceDir, c.Include, c.ExcludeFiles)

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -51,11 +51,11 @@ func (e *zipExtract) Execute(ctx context.Context,
 
 	// if the target is a relative path, join it to the working dir
 	if !filepath.IsAbs(e.TargetDirectory) {
-		e.TargetDirectory = getJoinedWithWorkDir(conf, e.TargetDirectory)
+		e.TargetDirectory = getWorkingDirectory(conf, e.TargetDirectory)
 	}
 
 	if !filepath.IsAbs(e.ArchivePath) {
-		e.ArchivePath = getJoinedWithWorkDir(conf, e.ArchivePath)
+		e.ArchivePath = getWorkingDirectory(conf, e.ArchivePath)
 	}
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -54,7 +54,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
-	workDir := getJoinedWithWorkDir(conf, c.Prefix)
+	workDir := getWorkingDirectory(conf, c.Prefix)
 	include := utility.NewGitIgnoreFileMatcher(workDir, c.Files...)
 	b := utility.FileListBuilder{
 		WorkingDir: workDir,
@@ -78,7 +78,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 	files := []*artifact.File{}
 	var segment []*artifact.File
 	for idx := range c.Files {
-		segment, err = readArtifactsFile(getJoinedWithWorkDir(conf, c.Prefix), c.Files[idx])
+		segment, err = readArtifactsFile(getWorkingDirectory(conf, c.Prefix), c.Files[idx])
 		if err != nil {
 			if c.Optional && os.IsNotExist(errors.Cause(err)) {
 				// pass;

--- a/agent/command/downstream_expansions_set.go
+++ b/agent/command/downstream_expansions_set.go
@@ -54,7 +54,7 @@ func (c *setDownstream) Execute(ctx context.Context,
 		return errors.WithStack(err)
 	}
 
-	filename := getJoinedWithWorkDir(conf, c.YamlFile)
+	filename := getWorkingDirectory(conf, c.YamlFile)
 
 	_, err = os.Stat(filename)
 	if os.IsNotExist(err) {

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -340,12 +340,12 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 			"path":            c.WorkingDir,
 			"required_prefix": conf.WorkDir,
 		})
-	c.WorkingDir, err = conf.GetWorkingDirectory(c.WorkingDir)
+	c.WorkingDir, err = conf.GetWorkingDirectoryLegacy(c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")
 	}
 
-	taskTmpDir, err := conf.GetWorkingDirectory("tmp")
+	taskTmpDir, err := conf.GetWorkingDirectoryLegacy("tmp")
 	if err != nil {
 		logger.Execution().Notice(errors.Wrap(err, "getting temporary directory"))
 	}

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -340,12 +340,12 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 			"path":            c.WorkingDir,
 			"required_prefix": conf.WorkDir,
 		})
-	c.WorkingDir, err = conf.GetWorkingDirectoryLegacy(c.WorkingDir)
+	c.WorkingDir, err = getWorkingDirectoryLegacy(conf, c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")
 	}
 
-	taskTmpDir, err := conf.GetWorkingDirectoryLegacy("tmp")
+	taskTmpDir, err := getWorkingDirectoryLegacy(conf, "tmp")
 	if err != nil {
 		logger.Execution().Notice(errors.Wrap(err, "getting temporary directory"))
 	}

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -108,7 +108,7 @@ func (c *update) Execute(ctx context.Context,
 			return errors.WithStack(err)
 		}
 
-		filename := getJoinedWithWorkDir(conf, c.YamlFile)
+		filename := getWorkingDirectory(conf, c.YamlFile)
 
 		_, err = os.Stat(filename)
 		if os.IsNotExist(err) {

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -60,7 +60,7 @@ func (c *expansionsWriter) Execute(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "marshalling expansions")
 	}
-	fn := getJoinedWithWorkDir(conf, c.File)
+	fn := getWorkingDirectory(conf, c.File)
 	if err := os.WriteFile(fn, out, 0600); err != nil {
 		return errors.Wrapf(err, "writing expansions to file '%s'", fn)
 	}

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -135,7 +135,7 @@ func (c *generateTask) Execute(ctx context.Context, comm client.Communicator, lo
 }
 
 func generateTaskForFile(fn string, conf *internal.TaskConfig) ([]byte, error) {
-	fileLoc := getJoinedWithWorkDir(conf, fn)
+	fileLoc := getWorkingDirectory(conf, fn)
 	if _, err := os.Stat(fileLoc); os.IsNotExist(err) {
 		return nil, errors.Wrapf(err, "getting information for file '%s'", fn)
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -739,7 +739,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	// read/write the buffer, so the buffer has to be thread-safe.
 	stdErr := utility.MakeSafeBuffer(bytes.Buffer{})
 	err = jpm.CreateCommand(ctx).Add([]string{"bash", "-c", strings.Join(moduleCmds, "\n")}).
-		Directory(filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))).
+		Directory(filepath.ToSlash(getWorkingDirectory(conf, c.Directory))).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorWriter(stdErr).Run(ctx)
 
 	errOutput := stdErr.String()
@@ -1050,7 +1050,7 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 		cmdsJoined := strings.Join(patchCommandStrings, "\n")
 
 		cmd := jpm.CreateCommand(ctx).Add([]string{"bash", "-c", cmdsJoined}).
-			Directory(filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))).
+			Directory(filepath.ToSlash(getWorkingDirectory(conf, c.Directory))).
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 
 		if err = cmd.Run(ctx); err != nil {

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -73,7 +73,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 	checkoutCommand := fmt.Sprintf("git checkout %s", conf.ProjectRef.Branch)
 	logger.Execution().Debugf("git checkout command %s", checkoutCommand)
 	jpm := c.JasperManager()
-	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))).Append(checkoutCommand).
+	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(getWorkingDirectory(conf, c.Directory))).Append(checkoutCommand).
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 	if err = cmd.Run(ctx); err != nil {
 		return errors.Wrapf(err, "checking out branch '%s'", conf.ProjectRef.Branch)
@@ -134,7 +134,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 		}
 
 		logger.Execution().Info("Pushing patch.")
-		params.directory = filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))
+		params.directory = filepath.ToSlash(getWorkingDirectory(conf, c.Directory))
 		params.branch = conf.ProjectRef.Branch
 		if err = c.pushPatch(ctx, logger, params); err != nil {
 			return errors.Wrap(err, "pushing patch")
@@ -184,7 +184,7 @@ func (c *gitPush) revParse(ctx context.Context, conf *internal.TaskConfig, logge
 
 	revParseCommand := fmt.Sprintf("git rev-parse %s", ref)
 	logger.Execution().Debugf("git rev-parse command: %s", revParseCommand)
-	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(getJoinedWithWorkDir(conf, c.Directory))).Append(revParseCommand).SetOutputWriter(stdout).
+	cmd := jpm.CreateCommand(ctx).Directory(filepath.ToSlash(getWorkingDirectory(conf, c.Directory))).Append(revParseCommand).SetOutputWriter(stdout).
 		SetErrorSender(level.Error, logger.Task().GetSender())
 
 	if err := cmd.Run(ctx); err != nil {

--- a/agent/command/host_create.go
+++ b/agent/command/host_create.go
@@ -55,7 +55,7 @@ func (c *createHost) ParseParams(params map[string]interface{}) error {
 
 func (c *createHost) parseParamsFromFile(fn string, conf *internal.TaskConfig) error {
 	if !filepath.IsAbs(fn) {
-		fn = getJoinedWithWorkDir(conf, fn)
+		fn = getWorkingDirectory(conf, fn)
 	}
 	return errors.Wrapf(utility.ReadYAMLFile(fn, &c.CreateHost), "reading YAML from file '%s'", fn)
 }
@@ -96,7 +96,7 @@ func (c *createHost) Execute(ctx context.Context, comm client.Communicator,
 		}
 	}
 	if c.CreateHost.StdinFile != "" {
-		c.CreateHost.StdinFile = getJoinedWithWorkDir(conf, c.CreateHost.StdinFile)
+		c.CreateHost.StdinFile = getWorkingDirectory(conf, c.CreateHost.StdinFile)
 		fileContent, err := os.ReadFile(c.CreateHost.StdinFile)
 		if err != nil {
 			return errors.Wrapf(err, "reading stdin file '%s'", c.CreateHost.StdinFile)
@@ -184,13 +184,13 @@ func (c *createHost) initializeLogBatchInfo(id string, conf *internal.TaskConfig
 		c.CreateHost.StderrFile = fmt.Sprintf("%s.err.log", id)
 	}
 	if !filepath.IsAbs(c.CreateHost.StderrFile) {
-		c.CreateHost.StderrFile = getJoinedWithWorkDir(conf, c.CreateHost.StderrFile)
+		c.CreateHost.StderrFile = getWorkingDirectory(conf, c.CreateHost.StderrFile)
 	}
 	if c.CreateHost.StdoutFile == "" {
 		c.CreateHost.StdoutFile = fmt.Sprintf("%s.out.log", id)
 	}
 	if !filepath.IsAbs(c.CreateHost.StdoutFile) {
-		c.CreateHost.StdoutFile = getJoinedWithWorkDir(conf, c.CreateHost.StdoutFile)
+		c.CreateHost.StdoutFile = getWorkingDirectory(conf, c.CreateHost.StdoutFile)
 	}
 
 	// initialize files

--- a/agent/command/host_list.go
+++ b/agent/command/host_list.go
@@ -67,7 +67,7 @@ func (c *listHosts) Execute(ctx context.Context, comm client.Communicator, logge
 
 	if c.Path != "" {
 		if !filepath.IsAbs(c.Path) {
-			c.Path = getJoinedWithWorkDir(conf, c.Path)
+			c.Path = getWorkingDirectory(conf, c.Path)
 		}
 	}
 

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -61,7 +61,7 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 	}
 
 	// Read the file and add the Evergreen info.
-	filename := getJoinedWithWorkDir(conf, c.File)
+	filename := getWorkingDirectory(conf, c.File)
 	report, err := poplar.LoadTests(filename)
 	if err != nil {
 		return errors.Wrapf(err, "reading tests from file '%s'", filename)

--- a/agent/command/results_gotest.go
+++ b/agent/command/results_gotest.go
@@ -67,7 +67,7 @@ func (c *goTestResults) Execute(ctx context.Context,
 
 	// All file patterns should be relative to the task's working directory.
 	for i, file := range c.Files {
-		c.Files[i] = getJoinedWithWorkDir(conf, file)
+		c.Files[i] = getWorkingDirectory(conf, file)
 	}
 
 	// will be all files containing test results

--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -112,7 +112,7 @@ func (c *attachResults) Execute(ctx context.Context,
 
 	reportFileLoc := c.FileLoc
 	if !filepath.IsAbs(c.FileLoc) {
-		reportFileLoc = getJoinedWithWorkDir(conf, c.FileLoc)
+		reportFileLoc = getWorkingDirectory(conf, c.FileLoc)
 	}
 
 	// attempt to open the file

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -158,7 +158,7 @@ func (c *s3get) Execute(ctx context.Context,
 	// working dir
 	if c.LocalFile != "" {
 		if !filepath.IsAbs(c.LocalFile) {
-			c.LocalFile = getJoinedWithWorkDir(conf, c.LocalFile)
+			c.LocalFile = getWorkingDirectory(conf, c.LocalFile)
 		}
 
 		if err := createEnclosingDirectoryIfNeeded(c.LocalFile); err != nil {
@@ -168,7 +168,7 @@ func (c *s3get) Execute(ctx context.Context,
 
 	if c.ExtractTo != "" {
 		if !filepath.IsAbs(c.ExtractTo) {
-			c.ExtractTo = getJoinedWithWorkDir(conf, c.ExtractTo)
+			c.ExtractTo = getWorkingDirectory(conf, c.ExtractTo)
 		}
 
 		if err := createEnclosingDirectoryIfNeeded(c.ExtractTo); err != nil {

--- a/agent/command/s3_pull.go
+++ b/agent/command/s3_pull.go
@@ -130,7 +130,7 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	if err := createEnclosingDirectoryIfNeeded(c.WorkingDir); err != nil {
 		return errors.Wrapf(err, "creating parent directories for working directory '%s'", c.WorkingDir)
 	}
-	wd, err := conf.GetWorkingDirectoryLegacy(c.WorkingDir)
+	wd, err := getWorkingDirectoryLegacy(conf, c.WorkingDir)
 	if err != nil {
 		return errors.Wrapf(err, "getting working directory")
 	}

--- a/agent/command/s3_pull.go
+++ b/agent/command/s3_pull.go
@@ -130,7 +130,10 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	if err := createEnclosingDirectoryIfNeeded(c.WorkingDir); err != nil {
 		return errors.Wrapf(err, "creating parent directories for working directory '%s'", c.WorkingDir)
 	}
-	wd := getJoinedWithWorkDir(conf, c.WorkingDir)
+	wd, err := conf.GetWorkingDirectoryLegacy(c.WorkingDir)
+	if err != nil {
+		return errors.Wrapf(err, "getting working directory")
+	}
 
 	pullMsg := fmt.Sprintf("Pulling task directory files from S3 from task '%s' on build variant '%s'", c.Task, c.FromBuildVariant)
 	if c.ExcludeFilter != "" {
@@ -138,7 +141,7 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	}
 	pullMsg += "."
 	logger.Task().Infof(pullMsg)
-	if err := c.bucket.Pull(ctx, pail.SyncOptions{
+	if err = c.bucket.Pull(ctx, pail.SyncOptions{
 		Local:   wd,
 		Remote:  remotePath,
 		Exclude: c.ExcludeFilter,

--- a/agent/command/s3_pull.go
+++ b/agent/command/s3_pull.go
@@ -130,10 +130,7 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	if err := createEnclosingDirectoryIfNeeded(c.WorkingDir); err != nil {
 		return errors.Wrapf(err, "creating parent directories for working directory '%s'", c.WorkingDir)
 	}
-	wd, err := conf.GetWorkingDirectory(c.WorkingDir)
-	if err != nil {
-		return errors.Wrapf(err, "getting working directory")
-	}
+	wd := getJoinedWithWorkDir(conf, c.WorkingDir)
 
 	pullMsg := fmt.Sprintf("Pulling task directory files from S3 from task '%s' on build variant '%s'", c.Task, c.FromBuildVariant)
 	if c.ExcludeFilter != "" {
@@ -141,7 +138,7 @@ func (c *s3Pull) Execute(ctx context.Context, comm client.Communicator, logger c
 	}
 	pullMsg += "."
 	logger.Task().Infof(pullMsg)
-	if err = c.bucket.Pull(ctx, pail.SyncOptions{
+	if err := c.bucket.Pull(ctx, pail.SyncOptions{
 		Local:   wd,
 		Remote:  remotePath,
 		Exclude: c.ExcludeFilter,

--- a/agent/command/s3_push.go
+++ b/agent/command/s3_push.go
@@ -40,7 +40,10 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		return errors.Wrap(err, "creating S3 task bucket")
 	}
 
-	wd := getJoinedWithWorkDir(conf, "")
+	wd, err := conf.GetWorkingDirectoryLegacy("")
+	if err != nil {
+		return errors.Wrap(err, "getting working directory")
+	}
 
 	pushMsg := fmt.Sprintf("Pushing task directory files from directory '%s' into S3", wd)
 	if c.ExcludeFilter != "" {

--- a/agent/command/s3_push.go
+++ b/agent/command/s3_push.go
@@ -40,7 +40,7 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		return errors.Wrap(err, "creating S3 task bucket")
 	}
 
-	wd, err := conf.GetWorkingDirectoryLegacy("")
+	wd, err := getWorkingDirectoryLegacy(conf, "")
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")
 	}

--- a/agent/command/s3_push.go
+++ b/agent/command/s3_push.go
@@ -40,10 +40,7 @@ func (c *s3Push) Execute(ctx context.Context, comm client.Communicator, logger c
 		return errors.Wrap(err, "creating S3 task bucket")
 	}
 
-	wd, err := conf.GetWorkingDirectory("")
-	if err != nil {
-		return errors.Wrap(err, "getting working directory")
-	}
+	wd := getJoinedWithWorkDir(conf, "")
 
 	pushMsg := fmt.Sprintf("Pushing task directory files from directory '%s' into S3", wd)
 	if c.ExcludeFilter != "" {

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -126,12 +126,12 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		fmt.Sprintf("The working directory is an absolute path [%s], which isn't supported except when prefixed by '%s'.",
 			c.WorkingDir, conf.WorkDir))
 
-	c.WorkingDir, err = conf.GetWorkingDirectory(c.WorkingDir)
+	c.WorkingDir, err = conf.GetWorkingDirectoryLegacy(c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")
 	}
 
-	taskTmpDir, err := conf.GetWorkingDirectory("tmp")
+	taskTmpDir, err := conf.GetWorkingDirectoryLegacy("tmp")
 	if err != nil {
 		logger.Execution().Notice(errors.Wrap(err, "getting task temporary directory"))
 	}

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -126,12 +126,12 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		fmt.Sprintf("The working directory is an absolute path [%s], which isn't supported except when prefixed by '%s'.",
 			c.WorkingDir, conf.WorkDir))
 
-	c.WorkingDir, err = conf.GetWorkingDirectoryLegacy(c.WorkingDir)
+	c.WorkingDir, err = getWorkingDirectoryLegacy(conf, c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")
 	}
 
-	taskTmpDir, err := conf.GetWorkingDirectoryLegacy("tmp")
+	taskTmpDir, err := getWorkingDirectoryLegacy(conf, "tmp")
 	if err != nil {
 		logger.Execution().Notice(errors.Wrap(err, "getting task temporary directory"))
 	}

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -2,10 +2,7 @@ package internal
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/evergreen-ci/evergreen"
@@ -105,31 +102,6 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	taskConfig.Timeout = &Timeout{}
 
 	return taskConfig, nil
-}
-
-// GetWorkingDirectoryLegacy is a legacy function to get the working directory for a
-// path, ensure that the path is always prefixed with the task working
-// directory, and check that the directory exists. This is a legacy function.
-// Commands that need to get the working directory should instead use
-// getJoinedWithWorkDir.
-func (c *TaskConfig) GetWorkingDirectoryLegacy(dir string) (string, error) {
-	if dir == "" {
-		dir = c.WorkDir
-	} else if strings.HasPrefix(dir, c.WorkDir) {
-		// pass
-	} else {
-		dir = filepath.Join(c.WorkDir, dir)
-	}
-
-	if stat, err := os.Stat(dir); os.IsNotExist(err) {
-		return "", errors.Errorf("path '%s' does not exist", dir)
-	} else if err != nil || stat == nil {
-		return "", errors.Wrapf(err, "retrieving file info for path '%s'", dir)
-	} else if !stat.IsDir() {
-		return "", errors.Errorf("path '%s' is not a directory", dir)
-	}
-
-	return dir, nil
 }
 
 func (c *TaskConfig) GetCloneMethod() string {

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -107,7 +107,12 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	return taskConfig, nil
 }
 
-func (c *TaskConfig) GetWorkingDirectory(dir string) (string, error) {
+// GetWorkingDirectoryLegacy is a legacy function to get the working directory for a
+// path, ensure that the path is always prefixed with the task working
+// directory, and check that the directory exists. This is a legacy function.
+// Commands that need to get the working directory should instead use
+// getJoinedWithWorkDir.
+func (c *TaskConfig) GetWorkingDirectoryLegacy(dir string) (string, error) {
 	if dir == "" {
 		dir = c.WorkDir
 	} else if strings.HasPrefix(dir, c.WorkDir) {

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -24,22 +24,22 @@ func TestTaskConfigGetWorkingDirectory(t *testing.T) {
 	}
 
 	// make sure that we fall back to the configured working directory
-	out, err := conf.GetWorkingDirectory("")
+	out, err := conf.GetWorkingDirectoryLegacy("")
 	assert.NoError(t, err)
 	assert.Equal(t, conf.WorkDir, out)
 
 	// check for a directory that we know exists
-	out, err = conf.GetWorkingDirectory("testutil")
+	out, err = conf.GetWorkingDirectoryLegacy("testutil")
 	require.NoError(t, err)
 	assert.Equal(t, out, filepath.Join(curdir, "testutil"))
 
 	// check for a file not a directory
-	out, err = conf.GetWorkingDirectory("task_config.go")
+	out, err = conf.GetWorkingDirectoryLegacy("task_config.go")
 	assert.Error(t, err)
 	assert.Equal(t, "", out)
 
 	// presumably for a directory that doesn't exist
-	out, err = conf.GetWorkingDirectory("does-not-exist")
+	out, err = conf.GetWorkingDirectoryLegacy("does-not-exist")
 	assert.Error(t, err)
 	assert.Equal(t, "", out)
 }

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -15,34 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestTaskConfigGetWorkingDirectory(t *testing.T) {
-	curdir := testutil.GetDirectoryOfFile()
-
-	conf := &TaskConfig{
-		WorkDir: curdir,
-	}
-
-	// make sure that we fall back to the configured working directory
-	out, err := conf.GetWorkingDirectoryLegacy("")
-	assert.NoError(t, err)
-	assert.Equal(t, conf.WorkDir, out)
-
-	// check for a directory that we know exists
-	out, err = conf.GetWorkingDirectoryLegacy("testutil")
-	require.NoError(t, err)
-	assert.Equal(t, out, filepath.Join(curdir, "testutil"))
-
-	// check for a file not a directory
-	out, err = conf.GetWorkingDirectoryLegacy("task_config.go")
-	assert.Error(t, err)
-	assert.Equal(t, "", out)
-
-	// presumably for a directory that doesn't exist
-	out, err = conf.GetWorkingDirectoryLegacy("does-not-exist")
-	assert.Error(t, err)
-	assert.Equal(t, "", out)
-}
 
 func TestTaskConfigGetTaskGroup(t *testing.T) {
 	require.NoError(t, db.ClearCollections(model.VersionCollection))

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-31"
+	AgentVersion = "2023-09-01"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20654

### Description
The agent commands that need to work in a directory can use either `GetWorkingDirectory` or `getJoinedWithWorkDir`, both of which accomplish the general goal of resolving a working directory. The major difference is that `getJoinedWithWorkDir` allows absolute paths outside of the task working directory, whereas `GetWorkingDirectory` will force all paths to be prefixed by the task working directory, even if they're specified like absolute paths. For example, if you set a working directory of `/home/mci/directory`, `getJoinedWithWorkDir` would keep it as-is while `GetWorkingDirectory` would convert this into `${workdir}/home/mci/directory`.

Since `GetWorkingDirectory` behaves differently for absolute paths and is also used in `subprocess.exec` and `shell.exec`, it would be difficult to get rid of `GetWorkingDirectory` entirely because of the widespread usage of those commands. I instead opted to just mark it as legacy so we don't try to extend usage of it further.

### Testing
Existing tests pass.

### Documentation
N/A