### PR TITLE
EVG-20052 Add event logs when a build/version's priority changes 

### DIFF
--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -105,8 +105,8 @@ func LogJiraIssueCreated(taskId string, execution int, jiraIssue string) {
 	logTaskEvent(taskId, TaskJiraAlertCreated, TaskEventData{Execution: execution, JiraIssue: jiraIssue})
 }
 
-func LogTaskPriority(taskId string, execution int, user string, priority int64) {
-	logTaskEvent(taskId, TaskPriorityChanged, TaskEventData{Execution: execution, UserId: user, Priority: priority})
+func LogTaskPriority(taskId string, execution int, userId string, priority int64) {
+	logTaskEvent(taskId, TaskPriorityChanged, TaskEventData{Execution: execution, UserId: userId, Priority: priority})
 }
 
 func LogTaskCreated(taskId string, execution int) {

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -198,9 +198,9 @@ func LogManyTaskAbortRequests(taskIds []string, userId string) {
 		TaskEventData{UserId: userId})
 }
 
-func LogManyTaskPriority(taskIds []string, execution int, userId string, priority int64) {
+func LogManyTaskPriority(taskIds []string, userId string, priority int64) {
 	logManyTaskEvents(taskIds, TaskPriorityChanged,
-		TaskEventData{Execution: execution, UserId: userId, Priority: priority})
+		TaskEventData{UserId: userId, Priority: priority})
 }
 
 func LogTaskContainerAllocated(taskId string, execution int, containerAllocatedTime time.Time) {

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -198,6 +198,11 @@ func LogManyTaskAbortRequests(taskIds []string, userId string) {
 		TaskEventData{UserId: userId})
 }
 
+func LogManyTaskPriority(taskIds []string, execution int, userId string, priority int64) {
+	logManyTaskEvents(taskIds, TaskPriorityChanged,
+		TaskEventData{Execution: execution, UserId: userId, Priority: priority})
+}
+
 func LogTaskContainerAllocated(taskId string, execution int, containerAllocatedTime time.Time) {
 	logTaskEvent(taskId, ContainerAllocated,
 		TaskEventData{Execution: execution, Timestamp: containerAllocatedTime})

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 const (
@@ -273,7 +272,7 @@ func SetVersionsPriority(ctx context.Context, versionIds []string, priority int6
 	return errors.Wrap(setTasksPriority(ctx, query, priority, caller), "setting priority for versions")
 }
 
-func setTasksPriority(ctx context.Context, query primitive.M, priority int64, caller string) error {
+func setTasksPriority(ctx context.Context, query bson.M, priority int64, caller string) error {
 	_, err := task.UpdateAll(query,
 		bson.M{"$set": bson.M{task.PriorityKey: priority}},
 	)


### PR DESCRIPTION
EVG-20052

### Description
We are not logging events when versions (or builds) are changed in priority. This adds the event logs when either are changed in priority.

I added it to the build priority change call as well although I think that is only used via a REST endpoint and the old UI, but it was an identical change and might help us debug in the future niche cases.

### Testing
Existing tests already test these functions. Tested (before and after) setting priority of a version and looking at event log of individual tasks (locally and in staging)

Example of setting priority for a version and it showing up in the event logs for a task:
https://github.com/evergreen-ci/evergreen/assets/64446617/33813def-9a0d-4f09-9d00-7d02f3ac240d


