### PR TITLE
EVG-19285 avoid unneeded error for fixing stale display task

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2429,12 +2429,6 @@ func ArchiveMany(tasks []Task) error {
 		}
 	}
 
-	grip.DebugWhen(len(utility.UniqueStrings(allTaskIds)) != len(allTaskIds), message.Fields{
-		"ticket":           "EVG-17261",
-		"message":          "archiving same task multiple times",
-		"tasks_to_archive": allTaskIds,
-	})
-
 	return archiveAll(allTaskIds, execTaskIds, toUpdateExecTaskIds, archivedTasks)
 }
 
@@ -2458,7 +2452,7 @@ func archiveAll(taskIds, execTaskIds, toRestartExecTaskIds []string, archivedTas
 		if len(archivedTasks) > 0 {
 			oldTaskColl := evergreen.GetEnvironment().DB().Collection(OldCollection)
 			_, err = oldTaskColl.InsertMany(sessCtx, archivedTasks)
-			if err != nil && !db.IsDuplicateKey(err) {
+			if err != nil {
 				return nil, errors.Wrap(err, "archiving tasks")
 			}
 		}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2021,8 +2021,7 @@ func ClearAndResetStrandedHostTask(ctx context.Context, settings *evergreen.Sett
 // aborted, the task is reset. If the task was aborted, we do not reset the task
 // and it is just marked as failed alongside other necessary updates to finish the task.
 func FixStaleTask(ctx context.Context, settings *evergreen.Settings, t *task.Task) error {
-	err := UpdateBlockedDependencies(t)
-	if err != nil {
+	if err := UpdateBlockedDependencies(t); err != nil {
 		return errors.Wrapf(err, "updating blocked dependencies for task '%s'", t.Id)
 	}
 
@@ -2034,7 +2033,17 @@ func FixStaleTask(ctx context.Context, settings *evergreen.Settings, t *task.Tas
 		}
 	} else {
 		if err := resetSystemFailedTask(ctx, settings, t, failureDesc); err != nil {
-			return errors.Wrap(err, "resetting heartbeat task")
+			// It's possible for display tasks to race, since multiple execution tasks can system fail at the same time.
+			// Only error if the display task hasn't actually been reset.
+			if t.IsPartOfDisplay() {
+				dt, dbErr := t.GetDisplayTask()
+				if dbErr != nil {
+					return errors.Wrap(dbErr, "confirming display task status")
+				}
+				if utility.StringSliceContains(evergreen.TaskCompletedStatuses, dt.Status) {
+					return errors.Wrap(err, "resetting heartbeat task")
+				}
+			}
 		}
 	}
 
@@ -2045,7 +2054,6 @@ func FixStaleTask(ctx context.Context, settings *evergreen.Settings, t *task.Tas
 		"execution_platform": t.ExecutionPlatform,
 		"description":        failureDesc,
 	})
-
 	return nil
 }
 


### PR DESCRIPTION
EVG-19285

### Description
For Archive, we check if archiving has a duplicate key error, I believe to avoid races. This doesn't work for ArchiveMany bc transactions don't respect error handling, they just abort if there's an issue (GODRIVER-1721).

We only actually are hitting this error for ArchiveMany for display tasks that have multiple execution tasks fail heartbeat (i.e. all of them are racing to archive the display task). 

I think we should just avoid erroring in the case that the display task actually was restarted, since there's no error here. Open question I have is whether we should log something special in this case.

### Testing
Hard to test since it requires a specific race; going to reason over and keep an eye out for this error for a week or so.
