### PR TITLE
EVG-20289 Simplify down taskContext/TaskConfig usage where possible

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -721,7 +721,11 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 		}
 
 		if setupGroup.commands != nil {
-			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tc.taskConfig.TaskGroup.Name)
+			tg := ""
+			if tc.taskConfig != nil {
+				tg = tc.taskConfig.TaskGroup.Name
+			}
+			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tg)
 
 			setupGroupCtx, setupGroupCancel := context.WithCancel(ctx)
 			defer setupGroupCancel()
@@ -745,7 +749,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 					return err
 				}
 			}
-			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tc.taskConfig.TaskGroup.Name)
+			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tg)
 		}
 		tc.ranSetupGroup = true
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,12 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/command"
-	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -93,25 +91,6 @@ const (
 	// LogOutputStdout indicates that the agent will log to standard output.
 	LogOutputStdout LogOutputType = "stdout"
 )
-
-type taskContext struct {
-	currentCommand            command.Command
-	expansions                util.Expansions
-	privateVars               map[string]bool
-	logger                    client.LoggerProducer
-	task                      client.TaskData
-	taskGroup                 string
-	ranSetupGroup             bool
-	taskConfig                *internal.TaskConfig
-	taskDirectory             string
-	timeout                   timeoutInfo
-	project                   *model.Project
-	taskModel                 *task.Task
-	oomTracker                jasper.OOMTracker
-	traceID                   string
-	unsetFunctionVarsDisabled bool
-	sync.RWMutex
-}
 
 type timeoutInfo struct {
 	// idleTimeoutDuration maintains the current idle timeout in the task context;
@@ -295,8 +274,13 @@ func (a *Agent) loop(ctx context.Context) error {
 			}
 
 			a.populateEC2InstanceID(ctx)
+			tg := ""
+			if tc.taskConfig != nil {
+				tg = tc.taskConfig.TaskGroup.Name
+			}
+
 			nextTask, err := a.comm.GetNextTask(ctx, &apimodels.GetNextTaskDetails{
-				TaskGroup:     tc.taskGroup,
+				TaskGroup:     tg,
 				AgentRevision: evergreen.AgentVersion,
 				EC2InstanceID: a.ec2InstanceID,
 			})
@@ -410,6 +394,7 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 func (a *Agent) finishPrevTask(ctx context.Context, nextTask *apimodels.NextTaskResponse, tc *taskContext) (bool, string) {
 	shouldSetupGroup := false
 	taskDirectory := tc.taskDirectory
+
 	if shouldRunSetupGroup(nextTask, tc) {
 		shouldSetupGroup = true
 		taskDirectory = ""
@@ -431,7 +416,6 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 				ID:     nt.TaskId,
 				Secret: nt.TaskSecret,
 			},
-			taskGroup:                 nt.TaskGroup,
 			ranSetupGroup:             !shouldSetupGroup,
 			taskDirectory:             taskDirectory,
 			oomTracker:                jasper.NewOOMTracker(),
@@ -471,6 +455,7 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 			return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task directory"))
 		}
 	}
+
 	tc.taskConfig.WorkDir = tc.taskDirectory
 	tc.taskConfig.Expansions.Put("workdir", tc.taskConfig.WorkDir)
 
@@ -514,35 +499,26 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 		nextTask.TaskGroup == "" ||
 		nextTask.Build != tc.taskConfig.Task.BuildId { // next task has a standalone task or a new build
 		return true
-	} else if nextTask.TaskGroup != tc.taskGroup { // next task has a different task group
-		if tc.logger != nil && nextTask.TaskGroup == tc.taskConfig.Task.TaskGroup {
-			tc.logger.Task().Warning(message.Fields{
-				"message":                 "programmer error: task group in task context doesn't match task",
-				"task_config_task_group":  tc.taskConfig.Task.TaskGroup,
-				"task_context_task_group": tc.taskGroup,
-				"next_task_task_group":    nextTask.TaskGroup,
-			})
-		}
-		return true
 	}
 
 	return false
 }
 
-func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
+func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) (*task.Task, *model.Project, util.Expansions, map[string]bool, error) {
+	// it's not getting the right project
 	project, err := a.comm.GetProject(ctx, tc.task)
 	if err != nil {
-		return errors.Wrap(err, "getting project")
+		return nil, nil, nil, nil, errors.Wrap(err, "getting project")
 	}
 
 	taskModel, err := a.comm.GetTask(ctx, tc.task)
 	if err != nil {
-		return errors.Wrap(err, "getting task")
+		return nil, nil, nil, nil, errors.Wrap(err, "getting task")
 	}
 
 	expAndVars, err := a.comm.GetExpansionsAndVars(ctx, tc.task)
 	if err != nil {
-		return errors.Wrap(err, "getting expansions and variables")
+		return nil, nil, nil, nil, errors.Wrap(err, "getting expansions and variables")
 	}
 
 	// GetExpansionsAndVars does not include build variant expansions or project
@@ -566,11 +542,7 @@ func (a *Agent) fetchProjectConfig(ctx context.Context, tc *taskContext) error {
 	// user-specified.
 	expAndVars.Expansions.Update(expAndVars.Parameters)
 
-	tc.taskModel = taskModel
-	tc.project = project
-	tc.expansions = expAndVars.Expansions
-	tc.privateVars = expAndVars.PrivateVars
-	return nil
+	return taskModel, project, expAndVars.Expansions, expAndVars.PrivateVars, nil
 }
 
 func (a *Agent) startLogging(ctx context.Context, tc *taskContext) error {
@@ -587,8 +559,8 @@ func (a *Agent) startLogging(ctx context.Context, tc *taskContext) error {
 	}
 	taskLogDir := filepath.Join(a.opts.WorkingDirectory, taskLogDirectory)
 	grip.Error(errors.Wrapf(os.RemoveAll(taskLogDir), "removing task log directory '%s'", taskLogDir))
-	if tc.project != nil && tc.project.Loggers != nil {
-		tc.logger, err = a.makeLoggerProducer(ctx, tc, tc.project.Loggers, "")
+	if tc.taskConfig.Project != nil && tc.taskConfig.Project.Loggers != nil {
+		tc.logger, err = a.makeLoggerProducer(ctx, tc, tc.taskConfig.Project.Loggers, "")
 	} else {
 		tc.logger, err = a.makeLoggerProducer(ctx, tc, &model.LoggerConfig{}, "")
 	}
@@ -710,6 +682,7 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 
 	// notify API server that the task has been started.
 	tc.logger.Execution().Info("Reporting task started.")
+
 	if err := a.comm.StartTask(execTimeoutCtx, tc.task); err != nil {
 		tc.logger.Execution().Error(errors.Wrap(err, "marking task started"))
 		return evergreen.TaskSystemFailed
@@ -741,14 +714,14 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 	defer preTaskSpan.End()
 
 	if !tc.ranSetupGroup {
-		setupGroup, err := tc.getSetupGroup(tc.taskGroup)
+		setupGroup, err := tc.getSetupGroup()
 		if err != nil {
 			tc.logger.Execution().Error(errors.Wrap(err, "fetching setup group for pre-task commands"))
 			return nil
 		}
 
 		if setupGroup.commands != nil {
-			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tc.taskGroup)
+			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tc.taskConfig.TaskGroup.Name)
 
 			setupGroupCtx, setupGroupCancel := context.WithCancel(ctx)
 			defer setupGroupCancel()
@@ -772,12 +745,12 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 					return err
 				}
 			}
-			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tc.taskGroup)
+			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tc.taskConfig.TaskGroup.Name)
 		}
 		tc.ranSetupGroup = true
 	}
 
-	pre, err := tc.getPre(tc.taskGroup)
+	pre, err := tc.getPre()
 	if err != nil {
 		tc.logger.Execution().Error(errors.Wrap(err, "fetching task group for pre-task commands"))
 		return nil
@@ -877,7 +850,7 @@ func (a *Agent) runTaskTimeoutCommands(ctx context.Context, tc *taskContext) {
 	tc.logger.Task().Info("Running task-timeout commands.")
 	start := time.Now()
 
-	timeout, err := tc.getTimeout(tc.taskGroup)
+	timeout, err := tc.getTimeout()
 	if err != nil {
 		tc.logger.Execution().Error(errors.Wrap(err, "fetching task group for task timeout commands"))
 		return
@@ -1049,7 +1022,7 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 	defer a.killProcs(ctx, tc, false, "post task commands are finished")
 	tc.logger.Task().Info("Running post-task commands.")
 
-	post, err := tc.getPost(tc.taskGroup)
+	post, err := tc.getPost()
 	if err != nil {
 		tc.logger.Execution().Error(errors.Wrap(err, "fetching task group for post-task commands"))
 		return nil
@@ -1108,7 +1081,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 		logger = grip.GetDefaultJournaler()
 	}
 
-	teardownGroup, err := tc.getTeardownGroup(tc.taskGroup)
+	teardownGroup, err := tc.getTeardownGroup()
 	if err != nil {
 		if tc.logger != nil {
 			tc.logger.Execution().Error(errors.Wrap(err, "fetching task group for teardown-group commands"))
@@ -1117,7 +1090,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	}
 
 	if teardownGroup.commands != nil {
-		grip.Infof("Running teardown-group commands for task group '%s'.", tc.taskGroup)
+		grip.Infof("Running teardown-group commands for task group '%s'.", tc.taskConfig.TaskGroup.Name)
 		a.killProcs(ctx, tc, true, "teardown group commands are starting")
 
 		teardownGroupCtx, teardownGroupCancel := context.WithCancel(ctx)
@@ -1139,7 +1112,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 
 // runEndTaskSync runs task sync if it was requested for the end of this task.
 func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) {
-	if tc.taskModel == nil {
+	if tc.taskConfig.Task == nil {
 		tc.logger.Task().Error("Task model not found for running task sync.")
 		return
 	}
@@ -1151,7 +1124,7 @@ func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *api
 
 	var syncCtx context.Context
 	var cancel context.CancelFunc
-	if timeout := tc.taskModel.SyncAtEndOpts.Timeout; timeout != 0 {
+	if timeout := tc.taskConfig.Task.SyncAtEndOpts.Timeout; timeout != 0 {
 		syncCtx, cancel = context.WithTimeout(ctx, timeout)
 	} else {
 		// Default to a generously long timeout if none is specified, since
@@ -1210,19 +1183,15 @@ func (a *Agent) shouldKill(tc *taskContext, ignoreTaskGroupCheck bool) bool {
 		return false
 	}
 	// kill if the task is not in a task group
-	if tc.taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return true
 	}
 	// kill if ignoreTaskGroupCheck is true
 	if ignoreTaskGroupCheck {
 		return true
 	}
-	taskGroup, err := tc.taskConfig.GetTaskGroup(tc.taskGroup)
-	if err != nil {
-		return false
-	}
 	// do not kill if share_processes is set
-	if taskGroup != nil && taskGroup.ShareProcs {
+	if tc.taskConfig.TaskGroup.Name != "" && tc.taskConfig.TaskGroup.ShareProcs {
 		return false
 	}
 	// return true otherwise

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -113,11 +113,8 @@ func (s *AgentSuite) SetupTest() {
 			Secret: "task_secret",
 		},
 		taskConfig:    taskConfig,
-		project:       project,
-		taskModel:     &s.task,
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
-		expansions:    util.Expansions{},
 		taskDirectory: s.tmpDirName,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -131,7 +128,7 @@ func (s *AgentSuite) SetupTest() {
 	s.tc.setCurrentCommand(factory())
 	s.tmpDirName, err = os.MkdirTemp("", filepath.Base(s.T().Name()))
 	s.Require().NoError(err)
-	s.tc.taskDirectory = s.tmpDirName
+	s.tc.taskConfig.WorkDir = s.tmpDirName
 	sender, err := s.a.GetSender(ctx, LogOutputStdout, "agent", "task_id", 2)
 	s.Require().NoError(err)
 	s.a.SetDefaultLogger(sender)
@@ -649,8 +646,17 @@ func (s *AgentSuite) setupRunTask(projYml string) {
 	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
 	s.Require().NoError(err)
 	s.tc.taskConfig.Project = p
-	s.tc.project = p
+
 	s.mockCommunicator.GetProjectResponse = p
+
+	t := &task.Task{
+		Id:           "task_id",
+		BuildVariant: "mock_build_variant",
+		DisplayName:  "this_is_a_task_name",
+		Version:      "my_version",
+	}
+	s.mockCommunicator.GetTaskResponse = t
+	s.tc.taskConfig.Task = t
 }
 
 func (s *AgentSuite) TestFailingPostWithPostErrorFailsTaskSetsEndTaskResults() {
@@ -676,9 +682,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
@@ -724,9 +729,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 
 	s.NoError(err)
 	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
@@ -770,9 +774,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 
 	s.NoError(err)
 	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
@@ -818,9 +821,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
@@ -861,9 +863,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 
 	s.NoError(err)
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
@@ -981,9 +982,8 @@ post:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 	s.NoError(err)
 	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
 	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
@@ -996,10 +996,10 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	tc := &taskContext{}
 	tc.logger, err = s.a.comm.GetLoggerProducer(s.ctx, s.tc.task, nil)
 	s.Require().NoError(err)
-	tc.taskModel = &task.Task{}
 	tc.taskConfig = &internal.TaskConfig{
 		Task: &task.Task{
-			Version: "not_a_task_group_version",
+			Version:   "not_a_task_group_version",
+			TaskGroup: "foo",
 		},
 	}
 	tc.taskDirectory = "task_directory"
@@ -1009,7 +1009,6 @@ func (s *AgentSuite) TestPrepareNextTask() {
 
 	const versionID = "task_group_version"
 	nextTask.TaskGroup = "foo"
-	tc.taskGroup = "foo"
 	nextTask.Version = versionID
 	tc.taskConfig = &internal.TaskConfig{
 		Task: &task.Task{
@@ -1018,7 +1017,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	}
 	tc.logger, err = s.a.comm.GetLoggerProducer(s.ctx, s.tc.task, nil)
 	s.NoError(err)
-	tc.taskDirectory = "task_directory"
+	tc.taskConfig.WorkDir = "task_directory"
 	tc.ranSetupGroup = false
 	shouldSetupGroup, taskDirectory = s.a.finishPrevTask(s.ctx, nextTask, tc)
 	s.True(shouldSetupGroup, "if the next task is in the same group as the previous task but ranSetupGroup was false, ranSetupGroup should be true")
@@ -1030,7 +1029,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 		},
 	}
 	tc.ranSetupGroup = true
-	tc.taskDirectory = "task_directory"
+	tc.taskConfig.WorkDir = "task_directory"
 	shouldSetupGroup, taskDirectory = s.a.finishPrevTask(s.ctx, nextTask, tc)
 	s.False(shouldSetupGroup, "if the next task is in the same group as the previous task and we already ran the setup group, shouldSetupGroup should be false")
 	s.Equal("task_directory", taskDirectory)
@@ -1038,8 +1037,9 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	const newVersionID = "new_task_group_version"
 	tc.taskConfig = &internal.TaskConfig{
 		Task: &task.Task{
-			Version: newVersionID,
-			BuildId: "build_id_1",
+			Version:   newVersionID,
+			BuildId:   "build_id_1",
+			TaskGroup: "bar",
 		},
 	}
 	tc.logger, err = s.a.comm.GetLoggerProducer(s.ctx, s.tc.task, nil)
@@ -1047,9 +1047,7 @@ func (s *AgentSuite) TestPrepareNextTask() {
 	nextTask.TaskGroup = "bar"
 	nextTask.Version = newVersionID
 	nextTask.Build = "build_id_2"
-	tc.taskGroup = "bar"
-	tc.taskDirectory = "task_directory"
-	tc.taskModel = &task.Task{}
+	tc.taskConfig.WorkDir = "task_directory"
 	shouldSetupGroup, taskDirectory = s.a.finishPrevTask(s.ctx, nextTask, tc)
 	s.True(shouldSetupGroup, "if the next task is in the same version and task group name but a different build, shouldSetupGroup should be true")
 	s.Empty(taskDirectory)
@@ -1076,7 +1074,6 @@ func (s *AgentSuite) TestGeneralTaskSetupSucceeds() {
 
 func (s *AgentSuite) TestSetupGroupSucceeds() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1086,8 +1083,9 @@ task_groups:
           script: echo hi
 `
 
-	s.tc.taskConfig.Task.TaskGroup = taskGroup
 	s.setupRunTask(projYml)
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc))
 	s.NoError(s.tc.logger.Close())
@@ -1100,9 +1098,38 @@ task_groups:
 	}, []string{panicLog})
 }
 
+func (s *AgentSuite) TestSetupGroupTimeout() {
+	const taskGroup = "task_group_name"
+	projYml := `
+task_groups:
+- name: task_group_name
+  setup_group_timeout_secs: 3
+  setup_group_can_fail_task: true
+  setup_group:
+  - command: shell.exec
+    params:
+      script: "sleep 10"
+`
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.TaskGroup = *p.FindTaskGroup(taskGroup)
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+
+	err = s.a.runPreTaskCommands(s.ctx, s.tc)
+	s.Require().Error(err)
+	s.True(utility.IsContextError(errors.Cause(err)))
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running pre-task commands",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'setup_group'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'setup_group'",
+	}, []string{panicLog})
+}
+
 func (s *AgentSuite) TestSetupGroupFails() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1114,6 +1141,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc), "setup group command error should fail task")
 
@@ -1125,7 +1153,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupGroupTimeoutDoesNotFailTask() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1137,6 +1164,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc), "setup group timeout should not fail task")
@@ -1156,7 +1184,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupGroupTimeoutFailsTask() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1167,11 +1194,14 @@ task_groups:
         params:
           script: sleep 5
 `
-	s.setupRunTask(projYml)
-	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.Require().NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
-	err := s.a.runPreTaskCommands(s.ctx, s.tc)
+	err = s.a.runPreTaskCommands(s.ctx, s.tc)
 	s.Error(err, "setup group timeout should fail task")
 	s.True(utility.IsContextError(errors.Cause(err)))
 
@@ -1191,7 +1221,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupTaskSucceeds() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1202,6 +1231,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc))
 
@@ -1217,7 +1247,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupTaskFails() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1229,6 +1258,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.Error(s.a.runPreTaskCommands(s.ctx, s.tc), "setup task command error should fail task")
 
@@ -1243,7 +1273,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupTaskTimeoutDoesNotFailTask() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1255,6 +1284,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
 	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc), "setup task timeout should not fail task")
@@ -1273,7 +1303,6 @@ task_groups:
 
 func (s *AgentSuite) TestSetupTaskTimeoutFailsTask() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1286,6 +1315,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
 	err := s.a.runPreTaskCommands(s.ctx, s.tc)
@@ -1305,8 +1335,61 @@ task_groups:
 	}, []string{panicLog})
 }
 
+func (s *AgentSuite) TestTeardownTaskFails() {
+	const taskGroup = "task_group_name"
+	projYml := `
+task_groups:
+  - name: task_group_name
+    teardown_task_can_fail_task: true
+    teardown_task:
+      - command: shell.exec
+        params:
+          script: exit 1
+`
+	s.setupRunTask(projYml)
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
+
+	s.Error(s.a.runPostTaskCommands(s.ctx, s.tc))
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running post-task commands",
+	}, []string{panicLog})
+}
+
+func (s *AgentSuite) TestTeardownTaskTimeoutDoesNotFailTask() {
+	const taskGroup = "task_group_name"
+	projYml := `
+task_groups:
+  - name: task_group_name
+    teardown_task_timeout_secs: 1
+    setup_task:
+      - command: shell.exec
+        params:
+          script: echo hi
+`
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.Require().NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *p.FindTaskGroup(taskGroup)
+
+	s.NoError(s.a.runPreTaskCommands(s.ctx, s.tc))
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running pre-task commands",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'setup_task'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'setup_task'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'setup_task'",
+		"Finished running pre-task commands",
+	}, []string{panicLog})
+}
+
 func (s *AgentSuite) TestTeardownTaskSucceeds() {
-	s.tc.taskGroup = "task_group_name"
+	taskGroup := "task_group_name"
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1316,7 +1399,8 @@ task_groups:
           script: exit 0
 `
 	s.setupRunTask(projYml)
-	s.tc.taskConfig.Task.TaskGroup = s.tc.taskGroup
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
 
@@ -1332,63 +1416,8 @@ task_groups:
 	})
 }
 
-func (s *AgentSuite) TestTeardownTaskFails() {
-	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
-	projYml := `
-task_groups:
-  - name: task_group_name
-    teardown_task_can_fail_task: true
-    teardown_task:
-      - command: shell.exec
-        params:
-          script: exit 1
-`
-	s.setupRunTask(projYml)
-	s.tc.taskConfig.Task.TaskGroup = taskGroup
-
-	s.Error(s.a.runPostTaskCommands(s.ctx, s.tc))
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running post-task commands",
-	}, []string{panicLog})
-}
-
-func (s *AgentSuite) TestTeardownTaskTimeoutDoesNotFailTask() {
-	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
-	projYml := `
-task_groups:
-  - name: task_group_name
-    teardown_task_timeout_secs: 1
-    teardown_task:
-      - command: shell.exec
-        params:
-          script: sleep 5
-`
-	s.setupRunTask(projYml)
-	s.tc.taskConfig.Task.TaskGroup = taskGroup
-
-	startAt := time.Now()
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc), "teardown task timeout should not fail task")
-
-	s.Less(time.Since(startAt), 5*time.Second, "timeout should have triggered after 1s")
-	s.False(s.tc.hadTimedOut(), "should not have hit task timeout")
-	s.Zero(s.tc.getTimeoutType())
-	s.Zero(s.tc.getTimeoutDuration())
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running post-task commands",
-		"Running command 'shell.exec' (step 1 of 1) in block 'teardown_task'",
-		"Hit teardown task timeout (1s)",
-	}, []string{panicLog})
-}
-
 func (s *AgentSuite) TestTeardownTaskTimeoutFailsTask() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1401,6 +1430,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
 	err := s.a.runPostTaskCommands(s.ctx, s.tc)
@@ -1421,7 +1451,7 @@ task_groups:
 }
 
 func (s *AgentSuite) TestTeardownGroupSucceeds() {
-	s.tc.taskGroup = "task_group_name"
+	taskGroup := "task_group_name"
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1430,8 +1460,12 @@ task_groups:
         params:
           script: echo hi
 `
-	s.setupRunTask(projYml)
-	s.tc.taskConfig.Task.TaskGroup = s.tc.taskGroup
+	p := &model.Project{}
+	_, err := model.LoadProjectInto(s.ctx, []byte(projYml), nil, "", p)
+	s.Require().NoError(err)
+	s.tc.taskConfig.Project = p
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *p.FindTaskGroup(taskGroup)
 
 	s.a.runTeardownGroupCommands(s.ctx, s.tc)
 
@@ -1447,7 +1481,6 @@ task_groups:
 
 func (s *AgentSuite) TestTeardownGroupTimeout() {
 	const taskGroup = "task_group_name"
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1459,6 +1492,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
 	s.a.runTeardownGroupCommands(s.ctx, s.tc)
@@ -1478,7 +1512,6 @@ func (s *AgentSuite) TestTaskGroupTimeout() {
 		ID:     "task_id",
 		Secret: "task_secret",
 	}
-	s.tc.taskGroup = taskGroup
 	projYml := `
 task_groups:
   - name: task_group_name
@@ -1489,6 +1522,7 @@ task_groups:
 `
 	s.setupRunTask(projYml)
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	s.a.runTaskTimeoutCommands(s.ctx, s.tc)
 
@@ -1541,15 +1575,16 @@ func (s *AgentSuite) TestFetchProjectConfig() {
 		Identifier: "some_cool_project",
 	}
 
-	s.NoError(s.a.fetchProjectConfig(s.ctx, s.tc))
+	_, project, expansions, pv, err := s.a.fetchProjectConfig(s.ctx, s.tc)
+	s.NoError(err)
 
-	s.Require().NotZero(s.tc.project)
-	s.Equal(s.mockCommunicator.GetProjectResponse.Identifier, s.tc.project.Identifier)
-	s.Require().NotZero(s.tc.expansions)
-	s.Equal("bar", s.tc.expansions["foo"], "should include mock communicator expansions")
-	s.Equal("new-parameter-value", s.tc.expansions["overwrite-this-parameter"], "user-specified parameter should overwrite any other conflicting expansion")
-	s.Require().NotZero(s.tc.privateVars)
-	s.True(s.tc.privateVars["some_private_var"], "should include mock communicator private variables")
+	s.Require().NotZero(s.tc.taskConfig.Project)
+	s.Equal(s.mockCommunicator.GetProjectResponse.Identifier, project.Identifier)
+	s.Require().NotZero(expansions)
+	s.Equal("bar", expansions["foo"], "should include mock communicator expansions")
+	s.Equal("new-parameter-value", expansions["overwrite-this-parameter"], "user-specified parameter should overwrite any other conflicting expansion")
+	s.Require().NotZero(pv)
+	s.True(pv["some_private_var"], "should include mock communicator private variables")
 }
 
 func (s *AgentSuite) TestAbortExitsMainAndRunsPost() {
@@ -1582,9 +1617,8 @@ timeout:
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 	s.NoError(err)
 
 	s.WithinDuration(start, time.Now(), 4*time.Second, "abort should prevent commands in the main block from continuing to run")
@@ -1633,14 +1667,17 @@ timeout:
       script: exit 0
 `
 	s.setupRunTask(projYml)
-	s.tc.taskGroup = "some_task_group"
+	taskGroup := "some_task_group"
+	s.tc.taskConfig.Task.TaskGroup = taskGroup
+	s.tc.taskConfig.TaskGroup = *s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
+
 	start := time.Now()
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
-		TaskGroup:  s.tc.taskGroup,
+		TaskGroup:  taskGroup,
 	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskDirectory)
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, !s.tc.ranSetupGroup, s.tc.taskConfig.WorkDir)
 	s.NoError(err)
 
 	s.WithinDuration(start, time.Now(), 4*time.Second, "abort should prevent commands in the main block from continuing to run")

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -81,7 +81,6 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -140,7 +139,6 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -198,7 +196,6 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -256,7 +253,6 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -314,7 +310,6 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -371,7 +366,6 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}

--- a/agent/command.go
+++ b/agent/command.go
@@ -168,7 +168,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		tc.taskConfig.Expansions.Put(key, newVal)
 	}
 	defer func() {
-		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
+		if !tc.unsetFunctionVarsDisabled || tc.taskConfig.Project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over
 			// unless they were updated using expansions.update
 			if cmd.Name() == "expansions.update" {
@@ -224,7 +224,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		if err != nil {
 			tc.logger.Task().Errorf("Command %s failed: %s.", displayName, err)
 			if options.canFailTask ||
-				(cmd.Name() == "git.get_project" && tc.taskModel.Requester == evergreen.MergeTestRequester) {
+				(cmd.Name() == "git.get_project" && tc.taskConfig.Task.Requester == evergreen.MergeTestRequester) {
 				// any git.get_project in the commit queue should fail
 				return errors.Wrap(err, "command failed")
 			}
@@ -272,14 +272,14 @@ func getCommandNameForFileLogger(commandInfo model.PluginCommandConf) string {
 // endTaskSyncCommands returns the commands to sync the task to S3 if it was
 // requested when the task completes.
 func endTaskSyncCommands(tc *taskContext, detail *apimodels.TaskEndDetail) *model.YAMLCommandSet {
-	if tc.taskModel == nil {
+	if tc.taskConfig.Task == nil {
 		tc.logger.Task().Error("Task model not found for running task sync.")
 		return nil
 	}
-	if !tc.taskModel.SyncAtEndOpts.Enabled {
+	if !tc.taskConfig.Task.SyncAtEndOpts.Enabled {
 		return nil
 	}
-	if statusFilter := tc.taskModel.SyncAtEndOpts.Statuses; len(statusFilter) != 0 {
+	if statusFilter := tc.taskConfig.Task.SyncAtEndOpts.Statuses; len(statusFilter) != 0 {
 		if detail.Status == evergreen.TaskSucceeded {
 			if !utility.StringSliceContains(statusFilter, evergreen.TaskSucceeded) {
 				return nil

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -56,7 +56,6 @@ func (a *Agent) removeTaskDirectory(tc *taskContext) {
 		return
 	}
 	grip.Infof("Deleting task directory '%s' for completed task.", tc.taskDirectory)
-
 	// Removing long relative paths hangs on Windows https://github.com/golang/go/issues/36375,
 	// so we have to convert to an absolute path before removing.
 	abs, err := filepath.Abs(tc.taskDirectory)

--- a/agent/directory_test.go
+++ b/agent/directory_test.go
@@ -33,7 +33,9 @@ func TestRemoveTaskDirectory(t *testing.T) {
 
 	// remove the task directory
 	agent := Agent{}
+
 	tc := &taskContext{taskDirectory: filepath.Base(tmpDir)}
+
 	agent.removeTaskDirectory(tc)
 	_, err = os.Stat(tmpDir)
 	require.True(os.IsNotExist(err), "directory should have been deleted")

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -1,17 +1,10 @@
 package internal
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/apimodels"
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/patch"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,91 +35,4 @@ func TestTaskConfigGetWorkingDirectory(t *testing.T) {
 	out, err = conf.GetWorkingDirectory("does-not-exist")
 	assert.Error(t, err)
 	assert.Equal(t, "", out)
-}
-
-func TestTaskConfigGetTaskGroup(t *testing.T) {
-	require.NoError(t, db.ClearCollections(model.VersionCollection))
-	tgName := "example_task_group"
-	projYml := `
-timeout:
-  - command: shell.exec
-    params:
-      script: "echo timeout"
-tasks:
-- name: example_task_1
-- name: example_task_2
-task_groups:
-- name: example_task_group
-  max_hosts: 2
-  setup_group:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  teardown_group:
-  - command: shell.exec
-    params:
-      script: "echo teardown_group"
-  setup_task:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  teardown_task:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  tasks:
-  - example_task_1
-  - example_task_2
-`
-	p := &model.Project{}
-	ctx := context.Background()
-	_, err := model.LoadProjectInto(ctx, []byte(projYml), nil, "", p)
-	require.NoError(t, err)
-	v := model.Version{
-		Id: "v1",
-	}
-	t1 := task.Task{
-		Id:        "t1",
-		TaskGroup: tgName,
-		Version:   v.Id,
-	}
-
-	tc := TaskConfig{Task: &t1, Project: p}
-	tg, err := tc.GetTaskGroup(tgName)
-	assert.NoError(t, err)
-	assert.Equal(t, tgName, tg.Name)
-	assert.Len(t, tg.Tasks, 2)
-	assert.Equal(t, 2, tg.MaxHosts)
-}
-
-func TestNewTaskConfig(t *testing.T) {
-	curdir := testutil.GetDirectoryOfFile()
-	taskName := "some_task"
-	bvName := "bv"
-	p := &model.Project{
-		Tasks: []model.ProjectTask{
-			{
-				Name: taskName,
-			},
-		},
-		BuildVariants: []model.BuildVariant{{Name: bvName}},
-	}
-	task := &task.Task{
-		Id:           "task_id",
-		DisplayName:  taskName,
-		BuildVariant: bvName,
-		Version:      "v1",
-	}
-
-	taskConfig, err := NewTaskConfig(curdir, &apimodels.DistroView{}, p, task, &model.ProjectRef{
-		Id:         "project_id",
-		Identifier: "project_identifier",
-	}, &patch.Patch{}, util.Expansions{})
-	assert.NoError(t, err)
-
-	assert.Equal(t, util.Expansions{}, taskConfig.DynamicExpansions)
-	assert.Equal(t, &util.Expansions{}, taskConfig.Expansions)
-	assert.Equal(t, &apimodels.DistroView{}, taskConfig.Distro)
-	assert.Equal(t, p, taskConfig.Project)
-	assert.Equal(t, task, taskConfig.Task)
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -147,11 +147,11 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 }
 
 func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, fileName string) client.LogOpts {
-	splunkServer, err := tc.expansions.ExpandString(in.SplunkServer)
+	splunkServer, err := tc.taskConfig.Expansions.ExpandString(in.SplunkServer)
 	if err != nil {
 		grip.Error(errors.Wrap(err, "expanding Splunk server"))
 	}
-	splunkToken, err := tc.expansions.ExpandString(in.SplunkToken)
+	splunkToken, err := tc.taskConfig.Expansions.ExpandString(in.SplunkToken)
 	if err != nil {
 		grip.Error(errors.Wrap(err, "expanding Splunk token"))
 	}
@@ -160,7 +160,7 @@ func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, file
 		logDir = in.LogDirectory
 	}
 	return client.LogOpts{
-		BuilderID:       tc.taskModel.Id,
+		BuilderID:       tc.taskConfig.Task.Id,
 		Sender:          in.Type,
 		SplunkServerURL: splunkServer,
 		SplunkToken:     splunkToken,

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -61,7 +61,6 @@ func TestAgentFileLogging(t *testing.T) {
 		DisplayName: "task1",
 	}
 	tc := &taskContext{
-		taskDirectory: tmpDirName,
 		task: client.TaskData{
 			ID:     taskID,
 			Secret: taskSecret,
@@ -95,7 +94,6 @@ func TestAgentFileLogging(t *testing.T) {
 			WorkDir:    tmpDirName,
 			Expansions: util.NewExpansions(nil),
 		},
-		taskModel: task,
 	}
 	assert.NoError(agt.startLogging(ctx, tc))
 	defer agt.removeTaskDirectory(tc)
@@ -130,17 +128,24 @@ func TestStartLogging(t *testing.T) {
 			ID:     "logging",
 			Secret: "task_secret",
 		},
-		taskConfig: &internal.TaskConfig{
-			Task: &task.Task{},
-		},
 	}
 
 	ctx := context.Background()
-	assert.NoError(agt.fetchProjectConfig(ctx, tc))
-	require.NotNil(t, tc.project)
-	assert.EqualValues(model.EvergreenLogSender, tc.project.Loggers.Agent[0].Type)
-	assert.EqualValues(model.SplunkLogSender, tc.project.Loggers.System[0].Type)
-	assert.EqualValues(model.FileLogSender, tc.project.Loggers.Task[0].Type)
+	task, project, expansion, _, err := agt.fetchProjectConfig(ctx, tc)
+	assert.NoError(err)
+	require.NotNil(t, project)
+
+	tc.taskConfig = &internal.TaskConfig{
+		Task:       task,
+		Project:    project,
+		Expansions: &expansion,
+	}
+	_, err = agt.makeTaskConfig(ctx, tc)
+	assert.NoError(err)
+
+	assert.EqualValues(model.EvergreenLogSender, project.Loggers.Agent[0].Type)
+	assert.EqualValues(model.SplunkLogSender, project.Loggers.System[0].Type)
+	assert.EqualValues(model.FileLogSender, project.Loggers.Task[0].Type)
 
 	assert.NoError(agt.startLogging(ctx, tc))
 	tc.logger.Execution().Info("foo")
@@ -148,12 +153,8 @@ func TestStartLogging(t *testing.T) {
 	msgs := agt.comm.(*client.Mock).GetMockMessages()
 	assert.Equal("foo", msgs[tc.task.ID][0].Message)
 
-	config, err := agt.makeTaskConfig(ctx, tc)
-	assert.NoError(err)
-	assert.NotNil(config.Project)
-
 	// check that expansions are correctly populated
-	logConfig := agt.prepLogger(tc, tc.project.Loggers, "")
+	logConfig := agt.prepLogger(tc, project.Loggers, "")
 	assert.Equal("bar", logConfig.System[0].SplunkToken)
 }
 
@@ -181,34 +182,33 @@ func TestDefaultSender(t *testing.T) {
 			ID:     taskID,
 			Secret: taskSecret,
 		},
-		project: &model.Project{},
 		taskConfig: &internal.TaskConfig{
 			Task:         task,
 			BuildVariant: &model.BuildVariant{Name: "bv"},
 			Timeout:      &internal.Timeout{IdleTimeoutSecs: 15, ExecTimeoutSecs: 15},
+			Project:      &model.Project{},
 		},
-		taskModel: task,
 	}
 
 	t.Run("Valid", func(t *testing.T) {
-		tc.project.Loggers = &model.LoggerConfig{}
+		tc.taskConfig.Project.Loggers = &model.LoggerConfig{}
 		tc.taskConfig.ProjectRef = &model.ProjectRef{DefaultLogger: model.BuildloggerLogSender}
 
 		assert.NoError(t, agt.startLogging(ctx, tc))
 		expectedLogOpts := []model.LogOpts{{Type: model.BuildloggerLogSender}}
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Agent)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.System)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Task)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Agent)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.System)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Task)
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		tc.project.Loggers = &model.LoggerConfig{}
+		tc.taskConfig.Project.Loggers = &model.LoggerConfig{}
 		tc.taskConfig.ProjectRef = &model.ProjectRef{DefaultLogger: model.SplunkLogSender}
 
 		assert.NoError(t, agt.startLogging(ctx, tc))
 		expectedLogOpts := []model.LogOpts{{Type: model.EvergreenLogSender}}
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Agent)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.System)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Task)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Agent)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.System)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Task)
 	})
 }
 
@@ -236,19 +236,18 @@ func TestTimberSender(t *testing.T) {
 			ID:     taskID,
 			Secret: taskSecret,
 		},
-		project: &model.Project{
-			Loggers: &model.LoggerConfig{
-				Agent:  []model.LogOpts{{Type: model.BuildloggerLogSender}},
-				System: []model.LogOpts{{Type: model.BuildloggerLogSender}},
-				Task:   []model.LogOpts{{Type: model.BuildloggerLogSender}},
-			},
-		},
 		taskConfig: &internal.TaskConfig{
 			Task:         task,
 			BuildVariant: &model.BuildVariant{Name: "bv"},
 			Timeout:      &internal.Timeout{IdleTimeoutSecs: 15, ExecTimeoutSecs: 15},
+			Project: &model.Project{
+				Loggers: &model.LoggerConfig{
+					Agent:  []model.LogOpts{{Type: model.BuildloggerLogSender}},
+					System: []model.LogOpts{{Type: model.BuildloggerLogSender}},
+					Task:   []model.LogOpts{{Type: model.BuildloggerLogSender}},
+				},
+			},
 		},
-		taskModel: task,
 	}
 	assert.NoError(t, agt.startLogging(ctx, tc))
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-31"
+	AgentVersion = "2023-09-01-A"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20289

### Description
This removes fields that were duplicated between task config and task context. It also fetches the task group when making the task config. that way it doesn't need to be fetched. 

### Testing
Existing tests 


