### PR TITLE
EVG-20289 Simplify down taskContext/TaskConfig usage where possible

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -735,7 +735,11 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 		}
 
 		if setupGroup.commands != nil {
-			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tc.taskConfig.TaskGroup)
+			tg := ""
+			if tc.taskConfig != nil {
+				tg = tc.taskConfig.TaskGroup.Name
+			}
+			tc.logger.Task().Infof("Running setup-group commands for task group '%s'.", tg)
 
 			setupGroupCtx, setupGroupCancel := context.WithCancel(ctx)
 			defer setupGroupCancel()
@@ -759,7 +763,7 @@ func (a *Agent) runPreTaskCommands(ctx context.Context, tc *taskContext) error {
 					return err
 				}
 			}
-			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tc.taskConfig.TaskGroup.Name)
+			tc.logger.Task().Infof("Finished running setup group for task group '%s'.", tg)
 		}
 		tc.ranSetupGroup = true
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -449,26 +449,12 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "setting up logger producer"))
 	}
 
-	tc.logger.Execution().Info("chayaMtesting setupTask")
-	tc.logger.Execution().Infof("chayaMtesting execution infof 461 ")
-	// name is nil here
-	tc.logger.Execution().Infof("chayaMtesting tc.taskConfig.TaskGroup.Name 462: '%s'.", tc.taskConfig.TaskGroup.Name)
-	tc.logger.Execution().Infof("chayaMtesting tc.taskConfig.TaskGroup.Name 462: '%s'.", tc.taskConfig.TaskGroup.SetupGroup)
-	tc.logger.Execution().Infof("chayaMtesting tc.taskConfig.TaskGroup.Name 462: '%s'.", tc.taskConfig.TaskGroup.TeardownGroup)
-	tc.logger.Execution().Infof("chayaMtesting tc.taskConfig.TaskGroup.Name 462: '%s'.", tc.taskConfig.TaskGroup.SetupTask)
-
 	if !tc.ranSetupGroup {
 		tc.taskDirectory, err = a.createTaskDirectory(tc)
 		if err != nil {
 			return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task directory"))
 		}
 	}
-
-	tc.logger.Execution().Infof("chayaMtesting execution infof 472")
-	grip.Infof("chayaMtesting execution infof 472")
-	// tc.taskConfig.WorkDir = tc.taskConfig.WorkDir
-
-	tc.logger.Execution().Infof("chayaMtesting tc.taskConfig.TaskGroup.Name 462: '%s'.", tc.taskConfig.TaskGroup.Name)
 
 	tc.taskConfig.WorkDir = tc.taskDirectory
 	tc.taskConfig.Expansions.Put("workdir", tc.taskConfig.WorkDir)

--- a/agent/agent_timeout_test.go
+++ b/agent/agent_timeout_test.go
@@ -81,7 +81,6 @@ func (s *TimeoutSuite) TestExecTimeoutProject() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -140,7 +139,6 @@ func (s *TimeoutSuite) TestExecTimeoutTask() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -198,7 +196,6 @@ func (s *TimeoutSuite) TestIdleTimeoutFunc() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -256,7 +253,6 @@ func (s *TimeoutSuite) TestIdleTimeoutCommand() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -314,7 +310,6 @@ func (s *TimeoutSuite) TestDynamicIdleTimeout() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}
@@ -371,7 +366,6 @@ func (s *TimeoutSuite) TestDynamicExecTimeoutTask() {
 				Execution: 0,
 			},
 		},
-		taskModel:     &task.Task{},
 		ranSetupGroup: false,
 		oomTracker:    &mock.OOMTracker{},
 	}

--- a/agent/command.go
+++ b/agent/command.go
@@ -168,7 +168,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		tc.taskConfig.Expansions.Put(key, newVal)
 	}
 	defer func() {
-		if !tc.unsetFunctionVarsDisabled || tc.project.UnsetFunctionVars {
+		if !tc.unsetFunctionVarsDisabled || tc.taskConfig.Project.UnsetFunctionVars {
 			// This defer ensures that the function vars do not persist in the expansions after the function is over
 			// unless they were updated using expansions.update
 			if cmd.Name() == "expansions.update" {
@@ -224,7 +224,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		if err != nil {
 			tc.logger.Task().Errorf("Command %s failed: %s.", displayName, err)
 			if options.canFailTask ||
-				(cmd.Name() == "git.get_project" && tc.taskModel.Requester == evergreen.MergeTestRequester) {
+				(cmd.Name() == "git.get_project" && tc.taskConfig.Task.Requester == evergreen.MergeTestRequester) {
 				// any git.get_project in the commit queue should fail
 				return errors.Wrap(err, "command failed")
 			}
@@ -272,14 +272,14 @@ func getCommandNameForFileLogger(commandInfo model.PluginCommandConf) string {
 // endTaskSyncCommands returns the commands to sync the task to S3 if it was
 // requested when the task completes.
 func endTaskSyncCommands(tc *taskContext, detail *apimodels.TaskEndDetail) *model.YAMLCommandSet {
-	if tc.taskModel == nil {
+	if tc.taskConfig.Task == nil {
 		tc.logger.Task().Error("Task model not found for running task sync.")
 		return nil
 	}
-	if !tc.taskModel.SyncAtEndOpts.Enabled {
+	if !tc.taskConfig.Task.SyncAtEndOpts.Enabled {
 		return nil
 	}
-	if statusFilter := tc.taskModel.SyncAtEndOpts.Statuses; len(statusFilter) != 0 {
+	if statusFilter := tc.taskConfig.Task.SyncAtEndOpts.Statuses; len(statusFilter) != 0 {
 		if detail.Status == evergreen.TaskSucceeded {
 			if !utility.StringSliceContains(statusFilter, evergreen.TaskSucceeded) {
 				return nil

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -84,8 +84,6 @@ func (s *CommandSuite) SetupTest() {
 	}, &patch.Patch{}, util.Expansions{})
 	s.Require().NoError(err)
 
-	// s.mockCommunicator.GetProjectResponse = project
-	// s.mockCommunicator.GetTaskResponse = tsk
 	s.tc = &taskContext{
 		taskConfig: taskConfig,
 		task: client.TaskData{

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -56,7 +56,6 @@ func (a *Agent) removeTaskDirectory(tc *taskContext) {
 		return
 	}
 	grip.Infof("Deleting task directory '%s' for completed task.", tc.taskDirectory)
-
 	// Removing long relative paths hangs on Windows https://github.com/golang/go/issues/36375,
 	// so we have to convert to an absolute path before removing.
 	abs, err := filepath.Abs(tc.taskDirectory)

--- a/agent/directory_test.go
+++ b/agent/directory_test.go
@@ -33,7 +33,9 @@ func TestRemoveTaskDirectory(t *testing.T) {
 
 	// remove the task directory
 	agent := Agent{}
+
 	tc := &taskContext{taskDirectory: filepath.Base(tmpDir)}
+
 	agent.removeTaskDirectory(tc)
 	_, err = os.Stat(tmpDir)
 	require.True(os.IsNotExist(err), "directory should have been deleted")

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -22,14 +22,13 @@ import (
 )
 
 type TaskConfig struct {
-	Distro            *apimodels.DistroView
-	ProjectRef        *model.ProjectRef
-	Project           *model.Project
-	Task              *task.Task
-	BuildVariant      *model.BuildVariant
-	Expansions        *util.Expansions
-	DynamicExpansions util.Expansions
-	// Redacted holds the private project variables
+	Distro             *apimodels.DistroView
+	ProjectRef         *model.ProjectRef
+	Project            *model.Project
+	Task               *task.Task
+	BuildVariant       *model.BuildVariant
+	Expansions         *util.Expansions
+	DynamicExpansions  util.Expansions
 	Redacted           map[string]bool
 	WorkDir            string
 	GithubPatchData    thirdparty.GithubPatch

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -1,17 +1,10 @@
 package internal
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/apimodels"
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/patch"
-	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,91 +35,4 @@ func TestTaskConfigGetWorkingDirectory(t *testing.T) {
 	out, err = conf.GetWorkingDirectory("does-not-exist")
 	assert.Error(t, err)
 	assert.Equal(t, "", out)
-}
-
-func TestTaskConfigGetTaskGroup(t *testing.T) {
-	require.NoError(t, db.ClearCollections(model.VersionCollection))
-	tgName := "example_task_group"
-	projYml := `
-timeout:
-  - command: shell.exec
-    params:
-      script: "echo timeout"
-tasks:
-- name: example_task_1
-- name: example_task_2
-task_groups:
-- name: example_task_group
-  max_hosts: 2
-  setup_group:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  teardown_group:
-  - command: shell.exec
-    params:
-      script: "echo teardown_group"
-  setup_task:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  teardown_task:
-  - command: shell.exec
-    params:
-      script: "echo setup_group"
-  tasks:
-  - example_task_1
-  - example_task_2
-`
-	p := &model.Project{}
-	ctx := context.Background()
-	_, err := model.LoadProjectInto(ctx, []byte(projYml), nil, "", p)
-	require.NoError(t, err)
-	v := model.Version{
-		Id: "v1",
-	}
-	t1 := task.Task{
-		Id:        "t1",
-		TaskGroup: tgName,
-		Version:   v.Id,
-	}
-
-	tc := TaskConfig{Task: &t1, Project: p}
-	tg, err := tc.GetTaskGroup(tgName)
-	assert.NoError(t, err)
-	assert.Equal(t, tgName, tg.Name)
-	assert.Len(t, tg.Tasks, 2)
-	assert.Equal(t, 2, tg.MaxHosts)
-}
-
-func TestNewTaskConfig(t *testing.T) {
-	curdir := testutil.GetDirectoryOfFile()
-	taskName := "some_task"
-	bvName := "bv"
-	p := &model.Project{
-		Tasks: []model.ProjectTask{
-			{
-				Name: taskName,
-			},
-		},
-		BuildVariants: []model.BuildVariant{{Name: bvName}},
-	}
-	task := &task.Task{
-		Id:           "task_id",
-		DisplayName:  taskName,
-		BuildVariant: bvName,
-		Version:      "v1",
-	}
-
-	taskConfig, err := NewTaskConfig(curdir, &apimodels.DistroView{}, p, task, &model.ProjectRef{
-		Id:         "project_id",
-		Identifier: "project_identifier",
-	}, &patch.Patch{}, util.Expansions{})
-	assert.NoError(t, err)
-
-	assert.Equal(t, util.Expansions{}, taskConfig.DynamicExpansions)
-	assert.Equal(t, &util.Expansions{}, taskConfig.Expansions)
-	assert.Equal(t, &apimodels.DistroView{}, taskConfig.Distro)
-	assert.Equal(t, p, taskConfig.Project)
-	assert.Equal(t, task, taskConfig.Task)
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -147,11 +147,11 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 }
 
 func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, fileName string) client.LogOpts {
-	splunkServer, err := tc.expansions.ExpandString(in.SplunkServer)
+	splunkServer, err := tc.taskConfig.Expansions.ExpandString(in.SplunkServer)
 	if err != nil {
 		grip.Error(errors.Wrap(err, "expanding Splunk server"))
 	}
-	splunkToken, err := tc.expansions.ExpandString(in.SplunkToken)
+	splunkToken, err := tc.taskConfig.Expansions.ExpandString(in.SplunkToken)
 	if err != nil {
 		grip.Error(errors.Wrap(err, "expanding Splunk token"))
 	}
@@ -160,7 +160,7 @@ func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, file
 		logDir = in.LogDirectory
 	}
 	return client.LogOpts{
-		BuilderID:       tc.taskModel.Id,
+		BuilderID:       tc.taskConfig.Task.Id,
 		Sender:          in.Type,
 		SplunkServerURL: splunkServer,
 		SplunkToken:     splunkToken,

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -61,7 +61,6 @@ func TestAgentFileLogging(t *testing.T) {
 		DisplayName: "task1",
 	}
 	tc := &taskContext{
-		taskDirectory: tmpDirName,
 		task: client.TaskData{
 			ID:     taskID,
 			Secret: taskSecret,
@@ -95,7 +94,6 @@ func TestAgentFileLogging(t *testing.T) {
 			WorkDir:    tmpDirName,
 			Expansions: util.NewExpansions(nil),
 		},
-		taskModel: task,
 	}
 	assert.NoError(agt.startLogging(ctx, tc))
 	defer agt.removeTaskDirectory(tc)
@@ -130,17 +128,24 @@ func TestStartLogging(t *testing.T) {
 			ID:     "logging",
 			Secret: "task_secret",
 		},
-		taskConfig: &internal.TaskConfig{
-			Task: &task.Task{},
-		},
 	}
 
 	ctx := context.Background()
-	assert.NoError(agt.fetchProjectConfig(ctx, tc))
-	require.NotNil(t, tc.project)
-	assert.EqualValues(model.EvergreenLogSender, tc.project.Loggers.Agent[0].Type)
-	assert.EqualValues(model.SplunkLogSender, tc.project.Loggers.System[0].Type)
-	assert.EqualValues(model.FileLogSender, tc.project.Loggers.Task[0].Type)
+	task, project, expansion, _, err := agt.fetchProjectConfig(ctx, tc)
+	assert.NoError(err)
+	require.NotNil(t, project)
+
+	tc.taskConfig = &internal.TaskConfig{
+		Task:       task,
+		Project:    project,
+		Expansions: &expansion,
+	}
+	_, err = agt.makeTaskConfig(ctx, tc)
+	assert.NoError(err)
+
+	assert.EqualValues(model.EvergreenLogSender, project.Loggers.Agent[0].Type)
+	assert.EqualValues(model.SplunkLogSender, project.Loggers.System[0].Type)
+	assert.EqualValues(model.FileLogSender, project.Loggers.Task[0].Type)
 
 	assert.NoError(agt.startLogging(ctx, tc))
 	tc.logger.Execution().Info("foo")
@@ -148,12 +153,8 @@ func TestStartLogging(t *testing.T) {
 	msgs := agt.comm.(*client.Mock).GetMockMessages()
 	assert.Equal("foo", msgs[tc.task.ID][0].Message)
 
-	config, err := agt.makeTaskConfig(ctx, tc)
-	assert.NoError(err)
-	assert.NotNil(config.Project)
-
 	// check that expansions are correctly populated
-	logConfig := agt.prepLogger(tc, tc.project.Loggers, "")
+	logConfig := agt.prepLogger(tc, project.Loggers, "")
 	assert.Equal("bar", logConfig.System[0].SplunkToken)
 }
 
@@ -181,34 +182,33 @@ func TestDefaultSender(t *testing.T) {
 			ID:     taskID,
 			Secret: taskSecret,
 		},
-		project: &model.Project{},
 		taskConfig: &internal.TaskConfig{
 			Task:         task,
 			BuildVariant: &model.BuildVariant{Name: "bv"},
 			Timeout:      &internal.Timeout{IdleTimeoutSecs: 15, ExecTimeoutSecs: 15},
+			Project:      &model.Project{},
 		},
-		taskModel: task,
 	}
 
 	t.Run("Valid", func(t *testing.T) {
-		tc.project.Loggers = &model.LoggerConfig{}
+		tc.taskConfig.Project.Loggers = &model.LoggerConfig{}
 		tc.taskConfig.ProjectRef = &model.ProjectRef{DefaultLogger: model.BuildloggerLogSender}
 
 		assert.NoError(t, agt.startLogging(ctx, tc))
 		expectedLogOpts := []model.LogOpts{{Type: model.BuildloggerLogSender}}
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Agent)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.System)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Task)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Agent)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.System)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Task)
 	})
 	t.Run("Invalid", func(t *testing.T) {
-		tc.project.Loggers = &model.LoggerConfig{}
+		tc.taskConfig.Project.Loggers = &model.LoggerConfig{}
 		tc.taskConfig.ProjectRef = &model.ProjectRef{DefaultLogger: model.SplunkLogSender}
 
 		assert.NoError(t, agt.startLogging(ctx, tc))
 		expectedLogOpts := []model.LogOpts{{Type: model.EvergreenLogSender}}
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Agent)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.System)
-		assert.Equal(t, expectedLogOpts, tc.project.Loggers.Task)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Agent)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.System)
+		assert.Equal(t, expectedLogOpts, tc.taskConfig.Project.Loggers.Task)
 	})
 }
 
@@ -236,19 +236,18 @@ func TestTimberSender(t *testing.T) {
 			ID:     taskID,
 			Secret: taskSecret,
 		},
-		project: &model.Project{
-			Loggers: &model.LoggerConfig{
-				Agent:  []model.LogOpts{{Type: model.BuildloggerLogSender}},
-				System: []model.LogOpts{{Type: model.BuildloggerLogSender}},
-				Task:   []model.LogOpts{{Type: model.BuildloggerLogSender}},
-			},
-		},
 		taskConfig: &internal.TaskConfig{
 			Task:         task,
 			BuildVariant: &model.BuildVariant{Name: "bv"},
 			Timeout:      &internal.Timeout{IdleTimeoutSecs: 15, ExecTimeoutSecs: 15},
+			Project: &model.Project{
+				Loggers: &model.LoggerConfig{
+					Agent:  []model.LogOpts{{Type: model.BuildloggerLogSender}},
+					System: []model.LogOpts{{Type: model.BuildloggerLogSender}},
+					Task:   []model.LogOpts{{Type: model.BuildloggerLogSender}},
+				},
+			},
 		},
-		taskModel: task,
 	}
 	assert.NoError(t, agt.startLogging(ctx, tc))
 }

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -18,11 +18,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// do these hae any baring on the command running
-// taskConfig is the source of truth
-// to maintian state for the task run
-// superset
-// todo: move to the task context file
 type taskContext struct {
 	currentCommand            command.Command
 	logger                    client.LoggerProducer

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -2,18 +2,40 @@ package agent
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/command"
 	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
 )
+
+// do these hae any baring on the command running
+// taskConfig is the source of truth
+// to maintian state for the task run
+// superset
+// todo: move to the task context file
+type taskContext struct {
+	currentCommand            command.Command
+	logger                    client.LoggerProducer
+	task                      client.TaskData
+	ranSetupGroup             bool
+	taskConfig                *internal.TaskConfig
+	timeout                   timeoutInfo
+	oomTracker                jasper.OOMTracker
+	traceID                   string
+	unsetFunctionVarsDisabled bool
+	taskDirectory             string
+	sync.RWMutex
+}
 
 func (tc *taskContext) setCurrentCommand(command command.Command) {
 	tc.Lock()
@@ -93,7 +115,7 @@ func (tc *taskContext) getOomTrackerInfo() *apimodels.OOMTrackerInfo {
 }
 
 func (tc *taskContext) oomTrackerEnabled(cloudProvider string) bool {
-	return tc.project.OomTracker && !utility.StringSliceContains(evergreen.ProviderContainer, cloudProvider)
+	return tc.taskConfig.Project.OomTracker && !utility.StringSliceContains(evergreen.ProviderContainer, cloudProvider)
 }
 
 func (tc *taskContext) setIdleTimeout(dur time.Duration) {
@@ -127,16 +149,18 @@ func (tc *taskContext) getTimeoutType() timeoutType {
 
 // makeTaskConfig fetches task configuration data required to run the task from the API server.
 func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.TaskConfig, error) {
-	if tc.project == nil {
-		grip.Info("Fetching project config.")
-		err := a.fetchProjectConfig(ctx, tc)
-		if err != nil {
-			return nil, err
-		}
+	if tc.taskConfig != nil && tc.taskConfig.Project != nil && tc.taskConfig.Project.Identifier != "" {
+		return tc.taskConfig, nil
 	}
+
+	grip.Info("Fetching project config.")
+	task, project, expansions, redacted, err := a.fetchProjectConfig(ctx, tc)
+	if err != nil {
+		return nil, err
+	}
+
 	grip.Info("Fetching distro configuration.")
 	var confDistro *apimodels.DistroView
-	var err error
 	if a.opts.Mode == HostMode {
 		confDistro, err = a.comm.GetDistroView(ctx, tc.task)
 		if err != nil {
@@ -154,7 +178,11 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	}
 
 	var confPatch *patch.Patch
-	if evergreen.IsGitHubPatchRequester(tc.taskModel.Requester) {
+	requester := ""
+	if tc.taskConfig != nil && tc.taskConfig.Task != nil {
+		requester = tc.taskConfig.Task.Requester
+	}
+	if evergreen.IsGitHubPatchRequester(requester) {
 		grip.Info("Fetching patch document for GitHub PR request.")
 		confPatch, err = a.comm.GetTaskPatch(ctx, tc.task, "")
 		if err != nil {
@@ -163,11 +191,11 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	}
 
 	grip.Info("Constructing task config.")
-	taskConfig, err := internal.NewTaskConfig(a.opts.WorkingDirectory, confDistro, tc.project, tc.taskModel, confRef, confPatch, tc.expansions)
+	taskConfig, err := internal.NewTaskConfig(a.opts.WorkingDirectory, confDistro, project, task, confRef, confPatch, expansions)
 	if err != nil {
 		return nil, err
 	}
-	taskConfig.Redacted = tc.privateVars
+	taskConfig.Redacted = redacted
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
 
@@ -202,12 +230,12 @@ type commandBlock struct {
 }
 
 // getPre returns a command block containing the pre task commands.
-func (tc *taskContext) getPre(taskGroup string) (*commandBlock, error) {
+func (tc *taskContext) getPre() (*commandBlock, error) {
 	if err := tc.taskConfig.Validate(); err != nil {
 		return nil, err
 	}
 
-	if taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return &commandBlock{
 			block:       command.PreBlock,
 			commands:    tc.taskConfig.Project.Pre,
@@ -217,27 +245,22 @@ func (tc *taskContext) getPre(taskGroup string) (*commandBlock, error) {
 		}, nil
 	}
 
-	tg := tc.taskConfig.Project.FindTaskGroup(taskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", taskGroup, tc.taskConfig.Project.Identifier)
-	}
-
 	return &commandBlock{
 		block:       command.SetupTaskBlock,
-		commands:    tg.SetupTask,
+		commands:    tc.taskConfig.TaskGroup.SetupTask,
 		timeoutKind: setupTaskTimeout,
-		getTimeout:  tc.getSetupTaskTimeout(tg),
-		canFailTask: tg.SetupTaskCanFailTask,
+		getTimeout:  tc.getSetupTaskTimeout(&tc.taskConfig.TaskGroup),
+		canFailTask: tc.taskConfig.TaskGroup.SetupTaskCanFailTask,
 	}, nil
 }
 
 // getPost returns a command block containing the post task commands.
-func (tc *taskContext) getPost(taskGroup string) (*commandBlock, error) {
+func (tc *taskContext) getPost() (*commandBlock, error) {
 	if err := tc.taskConfig.Validate(); err != nil {
 		return nil, err
 	}
 
-	if taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return &commandBlock{
 			block:       command.PostBlock,
 			commands:    tc.taskConfig.Project.Post,
@@ -247,80 +270,68 @@ func (tc *taskContext) getPost(taskGroup string) (*commandBlock, error) {
 		}, nil
 	}
 
-	tg := tc.taskConfig.Project.FindTaskGroup(taskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", taskGroup, tc.taskConfig.Project.Identifier)
-	}
 	return &commandBlock{
 		block:       command.TeardownTaskBlock,
-		commands:    tg.TeardownTask,
+		commands:    tc.taskConfig.TaskGroup.TeardownTask,
 		timeoutKind: teardownTaskTimeout,
-		getTimeout:  tc.getTeardownTaskTimeout(tg),
-		canFailTask: tg.TeardownTaskCanFailTask,
+		getTimeout:  tc.getTeardownTaskTimeout(&tc.taskConfig.TaskGroup),
+		canFailTask: tc.taskConfig.TaskGroup.TeardownTaskCanFailTask,
 	}, nil
 }
 
 // getSetupGroup returns the setup group for a task group task.
-func (tc *taskContext) getSetupGroup(taskGroup string) (*commandBlock, error) {
+func (tc *taskContext) getSetupGroup() (*commandBlock, error) {
 	if err := tc.taskConfig.Validate(); err != nil {
 		return nil, err
 	}
 
-	if taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return &commandBlock{}, nil
 	}
 
-	tg := tc.taskConfig.Project.FindTaskGroup(taskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", taskGroup, tc.taskConfig.Project.Identifier)
-	}
-	if tg.SetupGroup == nil {
+	if tc.taskConfig.TaskGroup.SetupGroup == nil {
 		return &commandBlock{}, nil
 	}
 
 	return &commandBlock{
 		block:       command.SetupGroupBlock,
-		commands:    tg.SetupGroup,
+		commands:    tc.taskConfig.TaskGroup.SetupGroup,
 		timeoutKind: setupGroupTimeout,
-		getTimeout:  tc.getSetupGroupTimeout(tg),
-		canFailTask: tg.SetupGroupCanFailTask,
+		getTimeout:  tc.getSetupGroupTimeout(&tc.taskConfig.TaskGroup),
+		canFailTask: tc.taskConfig.TaskGroup.SetupGroupCanFailTask,
 	}, nil
 }
 
 // getTeardownGroup returns the teardown group for a task group task.
-func (tc *taskContext) getTeardownGroup(taskGroup string) (*commandBlock, error) {
+func (tc *taskContext) getTeardownGroup() (*commandBlock, error) {
 	if err := tc.taskConfig.Validate(); err != nil {
 		return nil, err
 	}
 
-	if taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return &commandBlock{}, nil
 	}
 
-	tg := tc.taskConfig.Project.FindTaskGroup(taskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", taskGroup, tc.taskConfig.Project.Identifier)
-	}
-	if tg.TeardownGroup == nil {
+	if tc.taskConfig.TaskGroup.TeardownGroup == nil {
 		return &commandBlock{}, nil
 	}
 
 	return &commandBlock{
 		block:       command.TeardownGroupBlock,
-		commands:    tg.TeardownGroup,
+		commands:    tc.taskConfig.TaskGroup.TeardownGroup,
 		timeoutKind: teardownGroupTimeout,
-		getTimeout:  tc.getTeardownGroupTimeout(tg),
+		getTimeout:  tc.getTeardownGroupTimeout(&tc.taskConfig.TaskGroup),
 		canFailTask: false,
 	}, nil
 }
 
 // getTimeout returns a command block containing the timeout handler commands.
-func (tc *taskContext) getTimeout(taskGroup string) (*commandBlock, error) {
+func (tc *taskContext) getTimeout() (*commandBlock, error) {
 	if err := tc.taskConfig.Validate(); err != nil {
 		return nil, err
 	}
 
-	if taskGroup == "" {
+	if tc.taskConfig.TaskGroup.Name == "" {
 		return &commandBlock{
 			block:       command.TaskTimeoutBlock,
 			commands:    tc.taskConfig.Project.Timeout,
@@ -330,11 +341,7 @@ func (tc *taskContext) getTimeout(taskGroup string) (*commandBlock, error) {
 		}, nil
 	}
 
-	tg := tc.taskConfig.Project.FindTaskGroup(taskGroup)
-	if tg == nil {
-		return nil, errors.Errorf("couldn't find task group '%s' in project '%s'", taskGroup, tc.taskConfig.Project.Identifier)
-	}
-	if tg.Timeout == nil {
+	if tc.taskConfig.TaskGroup.Timeout == nil {
 		// Task group timeout defaults to the project timeout settings if not
 		// explicitly set.
 		return &commandBlock{
@@ -348,9 +355,9 @@ func (tc *taskContext) getTimeout(taskGroup string) (*commandBlock, error) {
 
 	return &commandBlock{
 		block:       command.TaskTimeoutBlock,
-		commands:    tg.Timeout,
+		commands:    tc.taskConfig.TaskGroup.Timeout,
 		timeoutKind: callbackTimeout,
-		getTimeout:  tc.getTaskGroupCallbackTimeout(tg),
+		getTimeout:  tc.getTaskGroupCallbackTimeout(&tc.taskConfig.TaskGroup),
 		canFailTask: false,
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-01"
+	AgentVersion = "2023-09-01-A"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-08-29"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-08-31"
+	AgentVersion = "2023-09-01"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20289

### Description
This removes fields that were duplicated between task config and task context. It also fetches the task group when making the task config. that way it doesn't need to be fetched. 

### Testing
Existing tests 