### PR TITLE
EVG-20675 Move distro retrieval for create host to separate function

### DIFF
--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -152,7 +152,7 @@ func CreateHostsFromTask(ctx context.Context, env evergreen.Environment, t *task
 			continue
 		}
 		for i := 0; i < numHosts; i++ {
-			_, err := MakeHost(ctx, env, t.Id, user.Username(), keyVal, createHost, d)
+			_, err := MakeHost(ctx, env, t.Id, user.Username(), keyVal, createHost, *d)
 			if err != nil {
 				return errors.Wrap(err, "creating intent host")
 			}
@@ -303,18 +303,18 @@ func createHostFromCommand(cmd model.PluginCommandConf) (*apimodels.CreateHost, 
 }
 
 // MakeHost creates a host or container to run for host.create.
-func MakeHost(ctx context.Context, env evergreen.Environment, taskID, userID, publicKey string, createHost apimodels.CreateHost, distro *distro.Distro) (*host.Host, error) {
+func MakeHost(ctx context.Context, env evergreen.Environment, taskID, userID, publicKey string, createHost apimodels.CreateHost, distro distro.Distro) (*host.Host, error) {
 	if evergreen.IsDockerProvider(createHost.CloudProvider) {
 		return makeDockerIntentHost(ctx, env, taskID, userID, createHost, distro)
 	}
 	return makeEC2IntentHost(ctx, env, taskID, userID, publicKey, createHost, distro)
 }
 
-func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID, userID string, createHost apimodels.CreateHost, d *distro.Distro) (*host.Host, error) {
+func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID, userID string, createHost apimodels.CreateHost, d distro.Distro) (*host.Host, error) {
 	// Do not provision task-spawned hosts.
 	d.BootstrapSettings.Method = distro.BootstrapMethodNone
 
-	options, err := getHostCreationOptions(*d, taskID, userID, createHost)
+	options, err := getHostCreationOptions(d, taskID, userID, createHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "making intent host options")
 	}
@@ -350,7 +350,7 @@ func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID
 	if containerPool == nil {
 		return nil, errors.Errorf("distro '%s' doesn't have a container pool", d.Id)
 	}
-	containerIntents, parentIntents, err := host.MakeContainersAndParents(ctx, *d, containerPool, 1, *options)
+	containerIntents, parentIntents, err := host.MakeContainersAndParents(ctx, d, containerPool, 1, *options)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating container and parent intent hosts")
 	}
@@ -372,14 +372,14 @@ func makeDockerIntentHost(ctx context.Context, env evergreen.Environment, taskID
 
 }
 
-func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, userID, publicKey string, createHost apimodels.CreateHost, d *distro.Distro) (*host.Host, error) {
+func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, userID, publicKey string, createHost apimodels.CreateHost, d distro.Distro) (*host.Host, error) {
 	if createHost.Region == "" {
 		createHost.Region = evergreen.DefaultEC2Region
 	}
 	ec2Settings := cloud.EC2ProviderSettings{}
 	var err error
 	if createHost.Distro != "" {
-		if err = ec2Settings.FromDistroSettings(*d, createHost.Region); err != nil {
+		if err = ec2Settings.FromDistroSettings(d, createHost.Region); err != nil {
 			return nil, errors.Wrapf(err, "getting EC2 provider settings from distro '%s' in region '%s'", createHost.Distro, createHost.Region)
 		}
 	}
@@ -446,7 +446,7 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 	}
 	d.ProviderSettingsList = []*birch.Document{doc}
 
-	options, err := getHostCreationOptions(*d, taskID, userID, createHost)
+	options, err := getHostCreationOptions(d, taskID, userID, createHost)
 	if err != nil {
 		return nil, errors.Wrap(err, "making intent host options")
 	}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -24,6 +25,7 @@ import (
 type hostCreateHandler struct {
 	taskID     string
 	createHost apimodels.CreateHost
+	distro     distro.Distro
 	env        evergreen.Environment
 }
 
@@ -53,6 +55,14 @@ func (h *hostCreateHandler) Parse(ctx context.Context, r *http.Request) error {
 			Message:    err.Error(),
 		}
 	}
+	d, err := data.GetDistro(ctx, h.createHost)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    err.Error(),
+		}
+	}
+	h.distro = *d
 	return h.createHost.Validate(ctx)
 }
 
@@ -64,7 +74,7 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 
 	ids := []string{}
 	for i := 0; i < numHosts; i++ {
-		intentHost, err := data.MakeHost(ctx, h.env, h.taskID, "", "", h.createHost)
+		intentHost, err := data.MakeHost(ctx, h.env, h.taskID, "", "", h.createHost, &h.distro)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating intent host"))
 		}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -74,7 +74,7 @@ func (h *hostCreateHandler) Run(ctx context.Context) gimlet.Responder {
 
 	ids := []string{}
 	for i := 0; i < numHosts; i++ {
-		intentHost, err := data.MakeHost(ctx, h.env, h.taskID, "", "", h.createHost, &h.distro)
+		intentHost, err := data.MakeHost(ctx, h.env, h.taskID, "", "", h.createHost, h.distro)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating intent host"))
 		}

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -55,12 +55,9 @@ func (h *hostCreateHandler) Parse(ctx context.Context, r *http.Request) error {
 			Message:    err.Error(),
 		}
 	}
-	d, err := data.GetDistro(ctx, h.createHost)
+	d, err := data.GetHostCreateDistro(ctx, h.createHost)
 	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    err.Error(),
-		}
+		return err
 	}
 	h.distro = *d
 	return h.createHost.Validate(ctx)

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -79,7 +79,7 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	foundDistro, err := data.GetDistro(ctx, c)
+	foundDistro, err := data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
@@ -127,7 +127,7 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
@@ -151,7 +151,7 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	require.NoError(err)
@@ -183,7 +183,7 @@ func TestMakeHost(t *testing.T) {
 		Subnet:              "subnet-123456",
 	}
 	handler.createHost = c
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
@@ -224,7 +224,7 @@ func TestMakeHost(t *testing.T) {
 		SecurityGroups:      []string{"1234"},
 	}
 	handler.createHost = c
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	require.NoError(err)
@@ -256,7 +256,7 @@ func TestMakeHost(t *testing.T) {
 		KeyName:             "mock_key",
 	}
 	handler.createHost = c
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
@@ -268,7 +268,7 @@ func TestMakeHost(t *testing.T) {
 	assert.Equal(ec2Settings2.AMI, "ami-123456")
 
 	handler.createHost.Region = "us-west-1"
-	foundDistro, err = data.GetDistro(ctx, c)
+	foundDistro, err = data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
@@ -338,7 +338,7 @@ func TestHostCreateDocker(t *testing.T) {
 	c.Registry.Name = "myregistry"
 	handler.createHost = c
 
-	foundDistro, err := data.GetDistro(ctx, c)
+	foundDistro, err := data.GetHostCreateDistro(ctx, c)
 	assert.NoError(err)
 	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -81,7 +81,7 @@ func TestMakeHost(t *testing.T) {
 	handler.taskID = "task-id"
 	foundDistro, err := data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	require.NotNil(h)
 
@@ -129,7 +129,7 @@ func TestMakeHost(t *testing.T) {
 	handler.taskID = "task-id"
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	ec2Settings = &cloud.EC2ProviderSettings{}
@@ -153,7 +153,7 @@ func TestMakeHost(t *testing.T) {
 	handler.taskID = "task-id"
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	require.NoError(err)
 	require.NotNil(h)
 
@@ -185,7 +185,7 @@ func TestMakeHost(t *testing.T) {
 	handler.createHost = c
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -226,7 +226,7 @@ func TestMakeHost(t *testing.T) {
 	handler.createHost = c
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	require.NoError(err)
 	require.NotNil(h)
 	assert.Equal("", h.Distro.Id)
@@ -258,7 +258,7 @@ func TestMakeHost(t *testing.T) {
 	handler.createHost = c
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -270,7 +270,7 @@ func TestMakeHost(t *testing.T) {
 	handler.createHost.Region = "us-west-1"
 	foundDistro, err = data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -340,7 +340,7 @@ func TestHostCreateDocker(t *testing.T) {
 
 	foundDistro, err := data.GetDistro(ctx, c)
 	assert.NoError(err)
-	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
+	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, *foundDistro)
 	assert.NoError(err)
 	require.NotNil(h)
 	assert.Equal("distro", h.Distro.Id)
@@ -416,7 +416,7 @@ func TestGetDockerLogs(t *testing.T) {
 		Image:         "my-image",
 		Command:       "echo hello",
 	}
-	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, &d)
+	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, d)
 	require.NoError(err)
 	require.NotNil(h)
 	assert.NotEmpty(h.ParentID)
@@ -530,7 +530,7 @@ func TestGetDockerStatus(t *testing.T) {
 		Image:         "my-image",
 		Command:       "echo hello",
 	}
-	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, &d)
+	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, d)
 	require.NoError(err)
 	assert.NotEmpty(h.ParentID)
 

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -79,7 +79,9 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err := data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	require.NotNil(h)
 
@@ -125,7 +127,9 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	ec2Settings = &cloud.EC2ProviderSettings{}
@@ -147,7 +151,9 @@ func TestMakeHost(t *testing.T) {
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	require.NoError(err)
 	require.NotNil(h)
 
@@ -177,7 +183,9 @@ func TestMakeHost(t *testing.T) {
 		Subnet:              "subnet-123456",
 	}
 	handler.createHost = c
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -216,7 +224,9 @@ func TestMakeHost(t *testing.T) {
 		SecurityGroups:      []string{"1234"},
 	}
 	handler.createHost = c
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	require.NoError(err)
 	require.NotNil(h)
 	assert.Equal("", h.Distro.Id)
@@ -246,7 +256,9 @@ func TestMakeHost(t *testing.T) {
 		KeyName:             "mock_key",
 	}
 	handler.createHost = c
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -256,7 +268,9 @@ func TestMakeHost(t *testing.T) {
 	assert.Equal(ec2Settings2.AMI, "ami-123456")
 
 	handler.createHost.Region = "us-west-1"
-	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err = data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err = data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	assert.NotNil(h)
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -324,7 +338,9 @@ func TestHostCreateDocker(t *testing.T) {
 	c.Registry.Name = "myregistry"
 	handler.createHost = c
 
-	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost)
+	foundDistro, err := data.GetDistro(ctx, c)
+	assert.NoError(err)
+	h, err := data.MakeHost(ctx, env, handler.taskID, "", "", handler.createHost, foundDistro)
 	assert.NoError(err)
 	require.NotNil(h)
 	assert.Equal("distro", h.Distro.Id)
@@ -335,6 +351,7 @@ func TestHostCreateDocker(t *testing.T) {
 	assert.Equal([]string{"env_key=env_value"}, h.DockerOptions.EnvironmentVars)
 	assert.Equal(extraHosts, h.DockerOptions.ExtraHosts)
 
+	handler.distro = *foundDistro
 	assert.Equal(http.StatusOK, handler.Run(ctx).Status())
 
 	hosts, err := host.Find(ctx, bson.M{})
@@ -399,7 +416,7 @@ func TestGetDockerLogs(t *testing.T) {
 		Image:         "my-image",
 		Command:       "echo hello",
 	}
-	h, err := data.MakeHost(ctx, env, "task-id", "", "", c)
+	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, &d)
 	require.NoError(err)
 	require.NotNil(h)
 	assert.NotEmpty(h.ParentID)
@@ -513,7 +530,7 @@ func TestGetDockerStatus(t *testing.T) {
 		Image:         "my-image",
 		Command:       "echo hello",
 	}
-	h, err := data.MakeHost(ctx, env, "task-id", "", "", c)
+	h, err := data.MakeHost(ctx, env, "task-id", "", "", c, &d)
 	require.NoError(err)
 	assert.NotEmpty(h.ParentID)
 


### PR DESCRIPTION
EVG-20675

### Description
The error that rises from a host.create distro not being compatible with a docker provider should be considered an improper request, not an internal server error on Evergreen's end. The fact that it is currently intertwined with the `MakeHost` means that [this retry loop](https://gist.github.com/hadjri/f0f75045653f4043b7805a1f86a96211#file-http-go-L331-L350) in the agent will keep looping until it times out, rather than returning the error immediately as it should. 

Made a refactor to separate the distro retrieval / validation from the actual host creation function to keep this as part of the route parsing logic.
### Testing
Verified in staging that the `distro '%s' provider must support Docker but actual provider is '%s'` error now is shown when host.create tries to use the docker provider for an improper distro.