### PR TITLE
EVG-19885 Show errors correctly for patch command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,6 +53,8 @@ To skip all (y/n) prompts, the `-y` keyword can be given:
 evergreen patch -y
 ```
 
+The patch command ignores warnings. If you want to view warnings, look at the [validate](#validating-changes-to-config-files) command.
+
 Working Tree Changes
 ---
 By default patches will include only committed changes, not changes in Git's working tree or index. To include changes from the working tree use the `--uncommitted, -u` flag or set a default by inserting `patch_uncommitted_changes: true` in the `~/.evergreen.yml` file.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,6 +14,8 @@ On macOS, the evergreen binary is currently not notarized. To allow running it, 
 Basic Patch Usage
 --
 
+`evergreen patch` allows you to submit patches to test your local changes. It will also check your project YAML any for validation errors before submission. If you want to view warnings, look at the [validate](#validating-changes-to-config-files) command.
+
 To submit a patch, run this from your local copy of the mongodb/mongo repo:
 ```bash
 evergreen patch -p <project-id>
@@ -52,8 +54,6 @@ To skip all (y/n) prompts, the `-y` keyword can be given:
 ```
 evergreen patch -y
 ```
-
-The patch command ignores warnings. If you want to view warnings, look at the [validate](#validating-changes-to-config-files) command.
 
 Working Tree Changes
 ---

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -283,13 +283,13 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchedParserProject = patchConfig.PatchedParserProject
 		patchedProjectConfig = patchConfig.PatchedProjectConfig
 	}
-	if errs := validator.CheckProjectErrors(ctx, patchedProject, false); len(errs.AtLevel(validator.Error)) != 0 {
+	if errs := validator.CheckProjectErrors(ctx, patchedProject, false).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched config syntax: %s", validator.ValidationErrorsToString(errs))
 	}
-	if errs := validator.CheckProjectSettings(ctx, j.env.Settings(), patchedProject, pref, false); len(errs.AtLevel(validator.Error)) != 0 {
+	if errs := validator.CheckProjectSettings(ctx, j.env.Settings(), patchedProject, pref, false).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched config for current project settings: %s", validator.ValidationErrorsToString(errs))
 	}
-	if errs := validator.CheckPatchedProjectConfigErrors(patchedProjectConfig); len(errs.AtLevel(validator.Error)) != 0 {
+	if errs := validator.CheckPatchedProjectConfigErrors(patchedProjectConfig).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched project config syntax: %s", validator.ValidationErrorsToString(errs))
 	}
 	if validationCatcher.HasErrors() {


### PR DESCRIPTION
EVG-19885

### Description
The patch command ouputs warnings when it runs in to an error. Instead, the patch command should only output errors- never warnings. If users want to view present warnings, they can run `evergreen validate` or look at the UI.

Makes a change to filter by errors only at the 'error' level and only output's those at that 'error' level.

### Testing
Forced warnings/errors in staging and it displays only the error- not the warning.

Before
![Screen Shot 2023-09-05 at 4 38 43 PM](https://github.com/evergreen-ci/evergreen/assets/64446617/d3bd3605-9352-4b25-ba71-5844930eb6df)
(Shows error, invalid patched config, and version control for project warnings)

After:
![Screen Shot 2023-09-05 at 4 38 20 PM](https://github.com/evergreen-ci/evergreen/assets/64446617/f3863d86-7ee4-4183-b022-649747e4a0e8)
(Shows only error)

### Documentation
Add documentation for patch command not displaying warnings and to use the validate command if you want to see warnings.