### PR TITLE
EVG-19128 Case on non mainline commits for FindTaskOnPreviousCommit calculation

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -575,7 +575,7 @@ func ByPreviousCommit(buildVariant, displayName, project, requester string, orde
 		BuildVariantKey:        buildVariant,
 		DisplayNameKey:         displayName,
 		ProjectKey:             project,
-		RevisionOrderNumberKey: order - 1,
+		RevisionOrderNumberKey: bson.M{"$lt": order},
 	}
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -852,7 +852,7 @@ func (t *Task) FindTaskOnBaseCommit() (*Task, error) {
 }
 
 func (t *Task) FindTaskOnPreviousCommit() (*Task, error) {
-	return FindOne(db.Query(ByPreviousCommit(t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester, t.RevisionOrderNumber)))
+	return FindOne(db.Query(ByPreviousCommit(t.BuildVariant, t.DisplayName, t.Project, evergreen.RepotrackerVersionRequester, t.RevisionOrderNumber)).Sort([]string{"-" + RevisionOrderNumberKey}))
 }
 
 // FindIntermediateTasks returns the tasks from most recent to least recent between two tasks.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3774,7 +3774,7 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 }
 
 func TestFindTaskOnPreviousCommit(t *testing.T) {
-	require.NoError(t, db.ClearCollections(Collection, OldCollection))
+	require.NoError(t, db.ClearCollections(Collection))
 	t1 := Task{
 		Id:                  "t1",
 		Version:             "v1",
@@ -3802,7 +3802,7 @@ func TestFindTaskOnPreviousCommit(t *testing.T) {
 
 	task, err := t2.FindTaskOnPreviousCommit()
 	assert.NoError(t, err)
-	assert.NotNil(t, task)
+	require.NotNil(t, task)
 	assert.Equal(t, t1.Id, task.Id)
 	assert.Equal(t, t1.Version, task.Version)
 	t3 := Task{
@@ -3833,10 +3833,9 @@ func TestFindTaskOnPreviousCommit(t *testing.T) {
 	// Should fetch the latest mainline commit task and should not consider non gitter tasks
 	task, err = t4.FindTaskOnPreviousCommit()
 	assert.NoError(t, err)
-	assert.NotNil(t, task)
+	require.NotNil(t, task)
 	assert.Equal(t, t2.Id, task.Id)
 	assert.Equal(t, t2.Version, task.Version)
-
 }
 
 type TaskConnectorFetchByIdSuite struct {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3773,6 +3773,72 @@ func TestByExecutionTasksAndMaxExecution(t *testing.T) {
 	})
 }
 
+func TestFindTaskOnPreviousCommit(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection, OldCollection))
+	t1 := Task{
+		Id:                  "t1",
+		Version:             "v1",
+		Execution:           0,
+		Status:              evergreen.TaskSucceeded,
+		RevisionOrderNumber: 1,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildVariant:        "bv",
+		DisplayName:         "dn",
+		Project:             "p",
+	}
+	assert.NoError(t, db.Insert(Collection, t1))
+	t2 := Task{
+		Id:                  "t2",
+		Version:             "v2",
+		Execution:           0,
+		Status:              evergreen.TaskSucceeded,
+		RevisionOrderNumber: 2,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildVariant:        "bv",
+		DisplayName:         "dn",
+		Project:             "p",
+	}
+	assert.NoError(t, db.Insert(Collection, t2))
+
+	task, err := t2.FindTaskOnPreviousCommit()
+	assert.NoError(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, t1.Id, task.Id)
+	assert.Equal(t, t1.Version, task.Version)
+	t3 := Task{
+		Id:                  "t3",
+		Version:             "v3",
+		Execution:           0,
+		Status:              evergreen.TaskSucceeded,
+		RevisionOrderNumber: 3,
+		Requester:           evergreen.TriggerRequester,
+		BuildVariant:        "bv",
+		DisplayName:         "dn",
+		Project:             "p",
+	}
+	assert.NoError(t, db.Insert(Collection, t3))
+	t4 := Task{
+		Id:                  "t4",
+		Version:             "v4",
+		Execution:           0,
+		Status:              evergreen.TaskSucceeded,
+		RevisionOrderNumber: 4,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildVariant:        "bv",
+		DisplayName:         "dn",
+		Project:             "p",
+	}
+	assert.NoError(t, db.Insert(Collection, t4))
+
+	// Should fetch the latest mainline commit task and should not consider non gitter tasks
+	task, err = t4.FindTaskOnPreviousCommit()
+	assert.NoError(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, t2.Id, task.Id)
+	assert.Equal(t, t2.Version, task.Version)
+
+}
+
 type TaskConnectorFetchByIdSuite struct {
 	suite.Suite
 }


### PR DESCRIPTION
EVG-19128

### Description
It's possible for some versions to increment the order number value used to keep track of the order of commits. This query would sometimes fail because we only compared against order number - 1 and if the previous order number was a non-mainline commit this query would fail. This change adds a `$lt` so that we attempt to fetch the most recent `gitter_request` commit

### Testing
Wrote unit tests.

