### PR TITLE
EVG-20174 use intent create time for github patch create time

### DIFF
--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -285,7 +285,7 @@ func (g *githubIntent) NewPatch() *Patch {
 		Description: fmt.Sprintf("'%s' pull request #%d by %s: %s (%s)", g.BaseRepoName, g.PRNumber, g.User, g.Title, pullURL),
 		Author:      evergreen.GithubPatchUser,
 		Status:      evergreen.PatchCreated,
-		CreateTime:  g.PushedAt,
+		CreateTime:  g.CreatedAt,
 		Githash:     g.BaseHash,
 		GithubPatchData: thirdparty.GithubPatch{
 			PRNumber:   g.PRNumber,

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -209,34 +209,34 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-				},
+		},
 		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-				},
+		},
 	}
 
 	for _, intent := range intents {

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -205,38 +205,38 @@ func (s *GithubSuite) TestSetProcessed() {
 
 func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 	intents := []githubIntent{
-		githubIntent{
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
 			Processed:  true,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-		},
-		githubIntent{
+				},
+		{
 			DocumentID: utility.RandomString(),
 			IntentType: GithubIntentType,
-		},
+				},
 	}
 
 	for _, intent := range intents {
@@ -249,9 +249,11 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 }
 
 func (s *GithubSuite) TestNewPatch() {
+	s.NoError(db.Clear(IntentCollection))
 	intent, err := NewGithubIntent("4", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
+	s.NoError(intent.Insert())
 
 	patchDoc := intent.NewPatch()
 	s.NotNil(patchDoc)

--- a/rest/data/patch_intent.go
+++ b/rest/data/patch_intent.go
@@ -16,7 +16,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// AddPatchIntent inserts the intent and adds it to the queue if PR testing is enabled for the branch.
 func AddPatchIntent(intent patch.Intent, queue amboy.Queue) error {
+	// Verify that the owner/repo uses PR testing before inserting the intent.
 	patchDoc := intent.NewPatch()
 	projectRef, err := model.FindOneProjectRefByRepoAndBranchWithPRTesting(patchDoc.GithubPatchData.BaseOwner,
 		patchDoc.GithubPatchData.BaseRepo, patchDoc.GithubPatchData.BaseBranch, intent.GetCalledBy())


### PR DESCRIPTION
[EVG-20174](https://jira.mongodb.org/browse/EVG-20174)

### Description
We incorrectly use the push time for create time, but we have the actual create time. This is important for patches made via comment.
### Testing
Tested using an old PR on staging:
https://github.com/evergreen-ci/commit-queue-sandbox/pull/567
https://spruce-staging.corp.mongodb.com/version/64f8a8139dbe32fa25b98240/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
