### PR TITLE
EVG-20612 add logging to understand batchtime calls

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -566,7 +566,9 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		if !utility.StringSliceContains(tasksWithActivationTime, t.DisplayName) {
 			continue
 		}
-		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(creationInfo.Project.FindTaskForVariant(t.DisplayName, creationInfo.Build.BuildVariant))
+		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(
+			creationInfo.Project.FindTaskForVariant(t.DisplayName, creationInfo.Build.BuildVariant),
+			t.Id)
 		batchTimeCatcher.Wrapf(err, "getting activation time for task '%s'", t.DisplayName)
 		batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 			TaskName: t.DisplayName,
@@ -1627,7 +1629,8 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			batchTimeCatcher.Wrapf(err, "getting activation time for variant '%s'", pair.Variant)
 		}
 		for taskName, id := range batchTimeTasksToIds {
-			activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(creationInfo.Project.FindTaskForVariant(taskName, pair.Variant))
+			activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(
+				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant), id)
 			batchTimeCatcher.Wrapf(err, "getting activation time for task '%s' in variant '%s'", taskName, pair.Variant)
 			batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 				TaskId:   id,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -2274,7 +2275,9 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 	return defaultRes, nil
 }
 
-func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Time, error) {
+// GetActivationTimeForTask returns the time at which this task should next be activated.
+// Temporarily takes in the task ID that prompted this query, for logging.
+func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, taskId string) (time.Time, error) {
 	defaultRes := time.Now()
 	// if we don't want to activate the task, set batchtime to the zero time
 	if !utility.FromBoolTPtr(t.Activate) || t.IsDisabled() {
@@ -2292,6 +2295,16 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 	if err != nil {
 		return defaultRes, errors.Wrap(err, "finding version")
 	}
+	grip.Debug(message.Fields{
+		"ticket":                "EVG-20612",
+		"last_activated_exists": lastActivated != nil,
+		"task_id":               taskId,
+		"variant":               t.Variant,
+		"task_name":             t.Name,
+		"bvtu_batchtime":        t.BatchTime,
+		"bvtu_activate":         t.Activate,
+		"stack":                 debug.Stack(),
+	})
 	if lastActivated == nil {
 		return defaultRes, nil
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -394,11 +394,11 @@ func TestGetActivationTimeForTask(t *testing.T) {
 	assert.NoError(t, versionWithoutTask.Insert())
 	assert.NoError(t, versionWithTask.Insert())
 
-	activationTime, err := projectRef.GetActivationTimeForTask(bvt)
+	activationTime, err := projectRef.GetActivationTimeForTask(bvt, "t0")
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(prevTime.Add(time.Hour)))
 
-	activationTime, err = projectRef.GetActivationTimeForTask(bvt2)
+	activationTime, err = projectRef.GetActivationTimeForTask(bvt2, "t0")
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(utility.ZeroTime))
 }

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -934,7 +934,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt)
+				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, tId)
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 
 				taskStatuses = append(taskStatuses,


### PR DESCRIPTION
EVG-20612

### Description
I looked into adding an index for this query but it'd be very expensive. I also started digging into some of the traces and it looks like these queries don't return any versions, which shouldn't be the case; I'm wondering if there's a bug in the code so that we're calling this function too often or something but it's hard to know without more info, so my next thought is to add some info to continue investigating.
