### PR TITLE
EVG-20812 Clone head of modules in merge queue

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -655,13 +655,13 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 	// use submodule revisions based on the main patch. If there is a need in the future,
 	// this could maybe use the most recent submodule revision of all requested patches.
-	// We ignore set-module changes for commit queue, since we should verify HEAD before merging.
+	// We ignore set-module changes for commit queue and GitHub merge queue, since we should verify HEAD before merging.
 	var modulePatch *patch.ModulePatch
 	var revision string
 	if p != nil {
 		modulePatch := p.FindModule(moduleName)
 		if modulePatch != nil {
-			if conf.Task.Requester == evergreen.MergeTestRequester {
+			if conf.Task.Requester == evergreen.MergeTestRequester || conf.Task.Requester == evergreen.GithubMergeRequester {
 				revision = module.Branch
 				c.logModuleRevision(logger, revision, moduleName, "defaulting to HEAD for merge")
 			} else {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-05"
+	AgentVersion = "2023-09-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -386,7 +386,7 @@ The parameters for each module are:
     accepted_.
 
 More specifically, module hash priority is as follows:
-* For commit queue patches, Evergreen always uses the module branch name, to ensure accurate testing.
+* For commit queue and GitHub merge queue patches, Evergreen always uses the module branch name, to ensure accurate testing.
 * For other patches, the initial default is to the githash in set-module, if specified.
 * For both commits and patches, the next default is to the `<module_name>` set in revisions for the command.
 * For commits, if this is not available, the next default is to ref, and then to branch. *Note that this 


### PR DESCRIPTION
EVG-20812

### Description

This is to ensure consistent behavior among the merge queues.

### Testing

I am intending to manually test. The existing commit queue case is not under test.

### Documentation

Edited.
