### PR TITLE
EVG-20846: Add validation for GenerateTaskFactor

### DIFF
--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -498,6 +498,12 @@ func ensureHasValidPlannerSettings(ctx context.Context, d *distro.Distro, s *eve
 			Level:   Error,
 		})
 	}
+	if settings.GenerateTaskFactor < 0 || settings.GenerateTaskFactor > 100 {
+		errs = append(errs, ValidationError{
+			Message: fmt.Sprintf("invalid planner_settings.generate_task_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.GenerateTaskFactor, d.Id),
+			Level:   Error,
+		})
+	}
 
 	return errs
 }


### PR DESCRIPTION
EVG-20846

### Description
- All other distro "factor" fields are enforced to be between 0 and 100, but GenerateTaskFactor had missing validation. It is enforced [here](https://github.com/evergreen-ci/evergreen/blob/dbc32765171d9a78a42e7ed4105241e489dbfadf/service/templates/distros.html#L268-L269) on the legacy front end, but we should have back end validation too.

### Testing
- Verified in GraphQL sandbox; field was saved when 0 <= n <= 100 and threw an error if not.

### Documentation
N/A