### PR TITLE
EVG-20532 Create getter and setter for branch protection

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1805,8 +1805,9 @@ func HasEvergreenBranchProtection(ctx context.Context, token, owner, repo, branc
 }
 
 // InstallEvergreenBranchProtections installs "evergreen" branch protection.
-func InstallEvergreenBranchProtections(ctx context.Context, token, owner, repo, branch string) error {
-	caller := "InstallEvergreenBranchProtections"
+// We deliberately check for the prefix because users may have installed variant-level branch protections.
+func InstallEvergreenBranchProtection(ctx context.Context, token, owner, repo, branch string) error {
+	caller := "InstallEvergreenBranchProtection"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
 		attribute.String(githubEndpointAttribute, caller),
 		attribute.String(githubOwnerAttribute, owner),
@@ -1835,7 +1836,7 @@ func InstallEvergreenBranchProtections(ctx context.Context, token, owner, repo, 
 
 	found := false
 	for _, check := range protection.GetRequiredStatusChecks().Checks {
-		if check.Context == "evergreen" {
+		if strings.HasPrefix(check.Context, "evergreen") {
 			found = true
 			break
 		}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1765,22 +1765,6 @@ func GetMergeablePullRequest(ctx context.Context, issue int, githubToken, owner,
 	return pr, nil
 }
 
-// HasEvergreenBranchProtections checks if any branch protection rule begins "evergreen".
-// We deliberately check for the prefix because users may have installed variant-level branch protections.
-func HasEvergreenBranchProtection(ctx context.Context, token, owner, repo, branch string) (bool, error) {
-	rules, err := GetEvergreenBranchProtectionRules(ctx, token, owner, repo, branch)
-	if err != nil {
-		return false, errors.Wrap(err, "getting branch protection rules")
-	}
-	for _, rule := range rules {
-		if strings.HasPrefix(rule, "evergreen") {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // InstallEvergreenBranchProtections installs "evergreen" branch protection.
 // We deliberately check for the prefix because users may have installed variant-level branch protections.
 func InstallEvergreenBranchProtection(ctx context.Context, token, owner, repo, branch string) error {


### PR DESCRIPTION
EVG-20532

### Description

This creates a getter and setter for branch protection for the merge queue. However, I'm unsure how to use these, so I wanted to open an early PR to get opinions. Here are some options:

1. Hook these functions into the UI. When someone turns on the merge queue, if they haven't set "evergreen" branch protection, set it for them, with a warning in a modal.
2. Add these functions to the CLI under `evergreen admin`. When we migrate people, let them know we're going to set a branch protection rule. Set it for them.
3. Ask people to set a branch protection rule themselves.

The argument for 3 is the risk of doing this. Unlike setting a webhook, it's possible we might inadvertently remove someone's branch protection if there is a bug.

### Testing

This has not been tested yet.

### Documentation

Will add docs once we decide how we will wire this up.
