### PR TITLE
EVG-20612 avoid querying if we don't need last activation time

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2279,6 +2279,20 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 // Temporarily takes in the task ID that prompted this query, for logging.
 func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, taskId string) (time.Time, error) {
 	defaultRes := time.Now()
+	// Verify that we mean to be getting activation time for task
+	if !t.HasSpecificActivation() {
+		grip.Debug(message.Fields{
+			"ticket":         "EVG-20612",
+			"message":        "incorrectly called GetActivationTimeForTask",
+			"task_id":        taskId,
+			"variant":        t.Variant,
+			"task_name":      t.Name,
+			"bvtu_batchtime": t.BatchTime,
+			"bvtu_activate":  t.Activate,
+			"stack":          string(debug.Stack()),
+		})
+		return defaultRes, nil
+	}
 	// if we don't want to activate the task, set batchtime to the zero time
 	if !utility.FromBoolTPtr(t.Activate) || t.IsDisabled() {
 		return utility.ZeroTime, nil
@@ -2291,19 +2305,22 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, taskId st
 		return time.Now(), nil
 	}
 
+	queryStart := time.Now()
 	lastActivated, err := VersionFindOne(VersionByLastTaskActivation(p.Id, t.Variant, t.Name).WithFields(VersionBuildVariantsKey))
 	if err != nil {
 		return defaultRes, errors.Wrap(err, "finding version")
 	}
 	grip.Debug(message.Fields{
 		"ticket":                "EVG-20612",
+		"message":               "queried last activated",
 		"last_activated_exists": lastActivated != nil,
 		"task_id":               taskId,
 		"variant":               t.Variant,
 		"task_name":             t.Name,
 		"bvtu_batchtime":        t.BatchTime,
 		"bvtu_activate":         t.Activate,
-		"stack":                 debug.Stack(),
+		"stack":                 string(debug.Stack()),
+		"query_time_secs":       time.Since(queryStart).Seconds(),
 	})
 	if lastActivated == nil {
 		return defaultRes, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2289,6 +2289,8 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, taskId st
 			"task_name":      t.Name,
 			"bvtu_batchtime": t.BatchTime,
 			"bvtu_activate":  t.Activate,
+			"bvtu_cron":      t.CronBatchTime,
+			"bvtu_disabled":  t.IsDisabled(),
 			"stack":          string(debug.Stack()),
 		})
 		return defaultRes, nil

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -931,7 +931,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
 				tId, ok := taskNameToId[bvt.Name]
-				if !ok || !bvt.HasSpecificActivation() {
+				if !ok {
 					continue
 				}
 				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, tId)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -931,7 +931,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
 				tId, ok := taskNameToId[bvt.Name]
-				// TODO: remove activation check
+				// TODO EVG-20162: remove activation check
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -931,7 +931,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
 				tId, ok := taskNameToId[bvt.Name]
-				if !ok {
+				// TODO: remove activation check
+				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
 				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, tId)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -931,7 +931,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
 				tId, ok := taskNameToId[bvt.Name]
-				// TODO EVG-20162: remove activation check
+				// TODO EVG-20612: remove activation check
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}


### PR DESCRIPTION
EVG-20612
### Description
1) Fix the main problem of running the query when there's no reason to
2) Log the stack (with string so it logs correctly) to understand why we'd be doing this in the first place
3) Log how long the query takes in the case that we _are_ supposed to be running it

