### PR TITLE
EVG-19715 terminate oudated AMI hosts faster

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -161,7 +161,7 @@ func ByUserWithUnterminatedStatus(user string) bson.M {
 	}
 }
 
-// IdleEphemeralGroupedByDistroId groups and collates the following by distro.Id:
+// IdleEphemeralGroupedByDistroID groups and collates the following by distro.Id:
 // - []host.Host of ephemeral hosts without containers which having no running task, ordered by {host.CreationTime: 1}
 // - the total number of ephemeral hosts that are capable of running tasks
 func IdleEphemeralGroupedByDistroID(ctx context.Context, env evergreen.Environment) ([]IdleHostsByDistroID, error) {

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -24,7 +24,7 @@ const (
 	idleWaitingForAgentCutoff = 10 * time.Minute
 
 	// outdatedIdleTimeCutoff is the amount of time we wait for an outdated idle host to be marked idle.
-	outdatedIdleTimeCutoff = time.Minute
+	outdatedIdleTimeCutoff = 10 * time.Second
 	// MaxTimeNextPayment is the amount of time we wait to have left before marking a host as idle
 	maxTimeTilNextPayment = 5 * time.Minute
 )

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -168,17 +168,12 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig
 	if idleThreshold == 0 {
 		idleThreshold = time.Duration(schedulerConfig.AcceptableHostIdleTimeSeconds) * time.Second
 	}
-	hasOutdatedAMI := hostHasOutdatedAMI(*h, d)
 	if h.RunningTaskGroup != "" {
 		idleThreshold = idleThreshold * 2
-	} else if hasOutdatedAMI {
-		// Since tasks created after the AMI is updated will only run on new hosts,
-		// we want to terminate outdated hosts aggressively to ensure we're respecting task priorities.
-		idleThreshold = 0
 	}
 
 	var terminateReason string
-	if hasOutdatedAMI && communicationTime >= idleThreshold {
+	if hostHasOutdatedAMI(*h, d) {
 		// Since tasks created after the AMI is updated will only run on new hosts,
 		// we want to terminate outdated hosts aggressively to ensure we're respecting task priorities.
 		terminateReason = "host has an outdated AMI"

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -168,12 +168,17 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig
 	if idleThreshold == 0 {
 		idleThreshold = time.Duration(schedulerConfig.AcceptableHostIdleTimeSeconds) * time.Second
 	}
+	hasOutdatedAMI := hostHasOutdatedAMI(*h, d)
 	if h.RunningTaskGroup != "" {
 		idleThreshold = idleThreshold * 2
+	} else if hasOutdatedAMI {
+		// Since tasks created after the AMI is updated will only run on new hosts,
+		// we want to terminate outdated hosts aggressively to ensure we're respecting task priorities.
+		idleThreshold = 0
 	}
 
 	var terminateReason string
-	if hostHasOutdatedAMI(*h, d) && h.RunningTaskGroup == "" {
+	if hasOutdatedAMI && communicationTime >= idleThreshold {
 		// Since tasks created after the AMI is updated will only run on new hosts,
 		// we want to terminate outdated hosts aggressively to ensure we're respecting task priorities.
 		terminateReason = "host has an outdated AMI"

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -23,8 +23,6 @@ const (
 	idleHostJobName           = "idle-host-termination"
 	idleWaitingForAgentCutoff = 10 * time.Minute
 
-	// outdatedIdleTimeCutoff is the amount of time we wait for an outdated idle host to be marked idle.
-	outdatedIdleTimeCutoff = 5 * time.Second
 	// MaxTimeNextPayment is the amount of time we wait to have left before marking a host as idle
 	maxTimeTilNextPayment = 5 * time.Minute
 )
@@ -174,7 +172,9 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig
 	if h.RunningTaskGroup != "" {
 		idleThreshold = idleThreshold * 2
 	} else if hasOutdatedAMI {
-		idleThreshold = outdatedIdleTimeCutoff
+		// Since tasks created after the AMI is updated will only run on new hosts,
+		// we want to terminate outdated hosts aggressively to ensure we're respecting task priorities.
+		idleThreshold = 0
 	}
 
 	// if we haven't heard from the host or it's been idle for longer than the cutoff, we should terminate

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -24,7 +24,7 @@ const (
 	idleWaitingForAgentCutoff = 10 * time.Minute
 
 	// outdatedIdleTimeCutoff is the amount of time we wait for an outdated idle host to be marked idle.
-	outdatedIdleTimeCutoff = 10 * time.Second
+	outdatedIdleTimeCutoff = 5 * time.Second
 	// MaxTimeNextPayment is the amount of time we wait to have left before marking a host as idle
 	maxTimeTilNextPayment = 5 * time.Minute
 )


### PR DESCRIPTION
EVG-19715
### Description
We discussed in the ticket terminating idle hosts more aggressively. Right now we wait for a minute, which is a long time if the queue isn't empty / has a lot of tasks that started. I arbitrarily dropped it to 5 seconds.

If we don't think this is enough, then we could alternatively mark all hosts as decommissioned when an AMI is updated.
