### PR TITLE
EVG-20856 Fix getMatchingAliasForVersion to take in project and version

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1878,7 +1878,7 @@ func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]Proj
 			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}
 	} else if patchDoc.Version != "" {
-		aliases, err = getMatchingAliasForVersion(patchDoc.Version, alias)
+		aliases, err = getMatchingAliasesForProjectConfig(projectId, patchDoc.Version, alias)
 		if err != nil {
 			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -197,9 +197,9 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, er
 	return out, nil
 }
 
-// getMatchingAliasForVersion finds any aliases matching the alias input in the project config.
-func getMatchingAliasForVersion(versionID, alias string) ([]ProjectAlias, error) {
-	projectConfig, err := FindProjectConfigById(versionID)
+// getMatchingAliasesForProjectConfig finds any aliases matching the alias input in the project config.
+func getMatchingAliasesForProjectConfig(projectID, versionID, alias string) ([]ProjectAlias, error) {
+	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, versionID)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project config")
 	}
@@ -243,7 +243,7 @@ func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, er
 	if len(aliases) > 0 {
 		return aliases, nil
 	}
-	return getMatchingAliasForVersion(projectID, alias)
+	return getMatchingAliasesForProjectConfig(projectID, "", alias)
 }
 
 // patchAliasKey is used internally to group patch aliases together.

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -522,7 +522,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	// Test project config
 	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-6")
 	s.NoError(err)
-	s.Len(found, 1)
+	s.Require().Len(found, 1)
 	s.Equal(found[0].Alias, "alias-6")
 	s.Equal(found[0].Task, "*")
 	s.Equal(found[0].Variant, "*")
@@ -530,7 +530,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	// Test non-patch aliases defined in config
 	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, evergreen.CommitQueueAlias)
 	s.NoError(err)
-	s.Len(found, 1)
+	s.Require().Len(found, 1)
 	s.Equal(found[0].Alias, evergreen.CommitQueueAlias)
 	s.Equal(found[0].Task, "cq-.*")
 	s.Equal(found[0].Variant, "cq-.*")

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -428,7 +428,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 	}
 }
 
-func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
+func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	s.Require().NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))
 
 	repoRef := RepoRef{ProjectRef{
@@ -444,9 +444,34 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
 		Id:        "p2",
 		RepoRefId: repoRef.Id,
 	}
+	projectConfig := ProjectConfig{
+		Project: pRef1.Id,
+		ProjectConfigFields: ProjectConfigFields{
+			PatchAliases: []ProjectAlias{
+				{
+					// This alias should be ignored because it's already defined at the higher project level
+					Alias:   "alias-3",
+					Variant: "*",
+					Task:    "*",
+				},
+				{
+					// This alias should not be ignored because it's not defined at any higher level
+					Alias:   "alias-6",
+					Variant: "*",
+					Task:    "*",
+				},
+			},
+			CommitQueueAliases: []ProjectAlias{
+				{
+					Variant: "*",
+					Task:    "*",
+				},
+			},
+		}}
 	s.NoError(repoRef.Upsert())
 	s.NoError(pRef1.Upsert())
 	s.NoError(pRef2.Upsert())
+	s.NoError(projectConfig.Insert())
 
 	for i := 0; i < 3; i++ {
 		alias := ProjectAlias{
@@ -493,6 +518,16 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrRepo() {
 	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-5")
 	s.NoError(err)
 	s.Len(found, 0)
+
+	// Test project config
+	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-6")
+	s.NoError(err)
+	s.Len(found, 1)
+
+	// Test non-patch aliases defined in config
+	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, evergreen.CommitQueueAlias)
+	s.NoError(err)
+	s.Len(found, 1)
 }
 
 func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -429,7 +429,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 }
 
 func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
-	s.Require().NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection))
+	s.Require().NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection, ProjectConfigCollection))
 
 	repoRef := RepoRef{ProjectRef{
 		Id:    "repo_ref",
@@ -463,8 +463,8 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 			},
 			CommitQueueAliases: []ProjectAlias{
 				{
-					Variant: "*",
-					Task:    "*",
+					Variant: "cq-.*",
+					Task:    "cq-.*",
 				},
 			},
 		}}
@@ -523,11 +523,17 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-6")
 	s.NoError(err)
 	s.Len(found, 1)
+	s.Equal(found[0].Alias, "alias-6")
+	s.Equal(found[0].Task, "*")
+	s.Equal(found[0].Variant, "*")
 
 	// Test non-patch aliases defined in config
 	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, evergreen.CommitQueueAlias)
 	s.NoError(err)
 	s.Len(found, 1)
+	s.Equal(found[0].Alias, evergreen.CommitQueueAlias)
+	s.Equal(found[0].Task, "cq-.*")
+	s.Equal(found[0].Variant, "cq-.*")
 }
 
 func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {


### PR DESCRIPTION
EVG-20856

### Description
There's a bug in `FindAliasInProjectRepoOrConfig` in the project config retrieval step as it passes a `projectID` to `getMatchingAliasForVersion` which prevents the project config from being retrieved correctly.

Changed `getMatchingAliasForVersion` to accept both a project ID and an optional version ID, allowing it to retrieve the project config by id if version ID is provided, and otherwise default to the most recent project config for the given project.

### Testing
Confirmed [without change](https://evergreen-staging.corp.mongodb.com/version/65009595b237360dc882e498), periodic build does not respect the alias defined in config, and that [with the change](https://evergreen-staging.corp.mongodb.com/version/65009911b2373618aa36ba17) the alias is respected.

<img width="523" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/19805673/5bf4b39c-6443-4d5b-b80d-eb06a8daf03d">
