### PR TITLE
EVG-20622: do not translate user requester for project

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -656,6 +656,23 @@ var (
 // UserRequester represents the allowed user-facing requester types.
 type UserRequester string
 
+// Validate checks that the user-facing requester type is valid.
+func (r UserRequester) Validate() error {
+	switch r {
+	case PatchVersionUserRequester,
+		GithubPRUserRequester,
+		GitTagUserRequester,
+		RepotrackerVersionUserRequester,
+		TriggerUserRequester,
+		MergeTestUserRequester,
+		AdHocUserRequester,
+		GithubMergeUserRequester:
+		return nil
+	default:
+		return errors.Errorf("invalid user requester '%s'", r)
+	}
+}
+
 const (
 	// User-facing requester types. These are equivalent in meaning to the above
 	// requesters, but are more user-friendly. These should only be used for

--- a/model/project.go
+++ b/model/project.go
@@ -111,14 +111,14 @@ type BuildVariantTaskUnit struct {
 	Variant string `yaml:"-" bson:"-"`
 
 	// fields to overwrite ProjectTask settings.
-	Patchable         *bool                `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly         *bool                `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	Disable           *bool                `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	AllowForGitTag    *bool                `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly        *bool                `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	AllowedRequesters []string             `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
-	Priority          int64                `yaml:"priority,omitempty" bson:"priority"`
-	DependsOn         []TaskUnitDependency `yaml:"depends_on,omitempty" bson:"depends_on"`
+	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool                     `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Disable           *bool                     `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Priority          int64                     `yaml:"priority,omitempty" bson:"priority"`
+	DependsOn         []TaskUnitDependency      `yaml:"depends_on,omitempty" bson:"depends_on"`
 
 	// the distros that the task can be run on
 	RunOn []string `yaml:"run_on,omitempty" bson:"run_on"`
@@ -290,7 +290,7 @@ func (bvt *BuildVariantTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error
 
 func (bvt *BuildVariantTaskUnit) SkipOnRequester(requester string) bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		return !utility.StringSliceContains(bvt.AllowedRequesters, requester)
+		return !utility.StringSliceContains(evaluateRequesters(bvt.AllowedRequesters), requester)
 	}
 
 	return evergreen.IsPatchRequester(requester) && bvt.SkipOnPatchBuild() ||
@@ -301,7 +301,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnRequester(requester string) bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnPatchBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		allowed := utility.StringSliceIntersection(bvt.AllowedRequesters, evergreen.PatchRequesters)
+		allowed := utility.StringSliceIntersection(evaluateRequesters(bvt.AllowedRequesters), evergreen.PatchRequesters)
 		return len(allowed) == 0
 	}
 
@@ -310,7 +310,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnPatchBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnNonPatchBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		allowed, _ := utility.StringSliceSymmetricDifference(bvt.AllowedRequesters, evergreen.PatchRequesters)
+		allowed, _ := utility.StringSliceSymmetricDifference(evaluateRequesters(bvt.AllowedRequesters), evergreen.PatchRequesters)
 		return len(allowed) == 0
 	}
 
@@ -319,7 +319,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnNonPatchBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnGitTagBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		return !utility.StringSliceContains(bvt.AllowedRequesters, evergreen.GitTagRequester)
+		return !utility.StringSliceContains(evaluateRequesters(bvt.AllowedRequesters), evergreen.GitTagRequester)
 	}
 
 	return !utility.FromBoolTPtr(bvt.AllowForGitTag)
@@ -327,7 +327,7 @@ func (bvt *BuildVariantTaskUnit) SkipOnGitTagBuild() bool {
 
 func (bvt *BuildVariantTaskUnit) SkipOnNonGitTagBuild() bool {
 	if len(bvt.AllowedRequesters) != 0 {
-		allowed, _ := utility.StringSliceSymmetricDifference(bvt.AllowedRequesters, []string{evergreen.GitTagRequester})
+		allowed, _ := utility.StringSliceSymmetricDifference(evaluateRequesters(bvt.AllowedRequesters), []string{evergreen.GitTagRequester})
 		return len(allowed) == 0
 	}
 
@@ -393,7 +393,7 @@ type BuildVariant struct {
 	// task. If set, the allowed requesters take precedence over other
 	// requester-related filters such as Patchable, PatchOnly, AllowForGitTag,
 	// and GitTagOnly. By default, all requesters are allowed to run the task.
-	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
 
 	// Use a *bool so that there are 3 possible states:
 	//   1. nil   = not overriding the project setting (default)
@@ -704,14 +704,14 @@ type ProjectTask struct {
 	//   1. nil   = not overriding the project setting (default)
 	//   2. true  = overriding the project setting with true
 	//   3. false = overriding the project setting with false
-	Patchable         *bool    `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly         *bool    `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	Disable           *bool    `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	AllowForGitTag    *bool    `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly        *bool    `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	AllowedRequesters []string `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
-	Stepback          *bool    `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	MustHaveResults   *bool    `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
+	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
+	PatchOnly         *bool                     `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
+	Disable           *bool                     `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
+	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
+	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Stepback          *bool                     `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	MustHaveResults   *bool                     `yaml:"must_have_test_results,omitempty" bson:"must_have_test_results,omitempty"`
 }
 
 type LoggerConfig struct {
@@ -2241,7 +2241,7 @@ func GetVariantsAndTasksFromPatchProject(ctx context.Context, settings *evergree
 		// Note that this can return the incorrect set of tasks based on
 		// requester settings because requester settings may be overridden at
 		// the build variant task level.
-		if len(task.AllowedRequesters) != 0 && !utility.StringSliceContains(task.AllowedRequesters, p.GetRequester()) {
+		if len(task.AllowedRequesters) != 0 && !utility.StringSliceContains(evaluateRequesters(task.AllowedRequesters), p.GetRequester()) {
 			continue
 		}
 		if utility.FromBoolPtr(task.Disable) || !utility.FromBoolTPtr(task.Patchable) || utility.FromBoolPtr(task.GitTagOnly) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -496,11 +496,16 @@ func TestTranslateTasks(t *testing.T) {
 	patchRequestersAllowedBV := out.BuildVariants[5]
 	assert.Equal(t, "patch_requesters_allowed", patchRequestersAllowedBV.Name)
 	assert.Equal(t, "a_task_with_no_special_configuration", gitTagOnlyBV.Tasks[0].Name)
-	assert.Equal(t, evergreen.PatchRequesters, patchRequestersAllowedBV.Tasks[0].AllowedRequesters)
+	assert.ElementsMatch(t, []evergreen.UserRequester{
+		evergreen.PatchVersionUserRequester,
+		evergreen.GithubPRUserRequester,
+		evergreen.MergeTestUserRequester,
+		evergreen.GithubMergeUserRequester,
+	}, patchRequestersAllowedBV.Tasks[0].AllowedRequesters)
 	assert.Equal(t, "a_task_with_allowed_requesters", patchRequestersAllowedBV.Tasks[1].Name)
-	assert.Equal(t, []string{evergreen.AdHocRequester}, patchRequestersAllowedBV.Tasks[1].AllowedRequesters)
+	assert.Equal(t, []evergreen.UserRequester{evergreen.AdHocUserRequester}, patchRequestersAllowedBV.Tasks[1].AllowedRequesters)
 	assert.Equal(t, "a_task_with_build_variant_task_configuration", patchRequestersAllowedBV.Tasks[2].Name)
-	assert.Equal(t, []string{evergreen.RepotrackerVersionRequester, evergreen.GitTagRequester}, patchRequestersAllowedBV.Tasks[2].AllowedRequesters)
+	assert.Equal(t, []evergreen.UserRequester{evergreen.RepotrackerVersionUserRequester, evergreen.GitTagUserRequester}, patchRequestersAllowedBV.Tasks[2].AllowedRequesters)
 
 	disabledBV := out.BuildVariants[6]
 	assert.Equal(t, "disabled_bv", disabledBV.Name)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2204,6 +2204,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 func TestSkipOnRequester(t *testing.T) {
 	t.Run("PatchRequester", func(t *testing.T) {
 		requester := evergreen.PatchVersionRequester
+		userRequester := evergreen.PatchVersionUserRequester
 
 		t.Run("Runnable", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{}
@@ -2218,17 +2219,17 @@ func TestSkipOnRequester(t *testing.T) {
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{requester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{userRequester}}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("NotAllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GitTagRequester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GitTagUserRequester}}
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequesterHasHigherPrecedenceThanPatchableFalse", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{
 				Patchable:         utility.FalsePtr(),
-				AllowedRequesters: []string{requester},
+				AllowedRequesters: []evergreen.UserRequester{userRequester},
 			}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
@@ -2236,6 +2237,7 @@ func TestSkipOnRequester(t *testing.T) {
 
 	t.Run("NonPatchRequester", func(t *testing.T) {
 		requester := evergreen.RepotrackerVersionRequester
+		userRequester := evergreen.RepotrackerVersionUserRequester
 
 		t.Run("Runnable", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{}
@@ -2250,17 +2252,17 @@ func TestSkipOnRequester(t *testing.T) {
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{requester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{userRequester}}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("NotAllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.PatchVersionRequester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.PatchVersionUserRequester}}
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequesterHasHigherPrecedenceThanPatchOnly", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{
 				PatchOnly:         utility.TruePtr(),
-				AllowedRequesters: []string{requester},
+				AllowedRequesters: []evergreen.UserRequester{userRequester},
 			}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
@@ -2268,6 +2270,7 @@ func TestSkipOnRequester(t *testing.T) {
 
 	t.Run("GitTagRequester", func(t *testing.T) {
 		requester := evergreen.GitTagRequester
+		userRequester := evergreen.GitTagUserRequester
 
 		t.Run("Runnable", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{}
@@ -2282,17 +2285,17 @@ func TestSkipOnRequester(t *testing.T) {
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{requester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{userRequester}}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("NotAllowedRequester", func(t *testing.T) {
-			bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.PatchVersionRequester}}
+			bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.PatchVersionUserRequester}}
 			assert.True(t, bvt.SkipOnRequester(requester))
 		})
 		t.Run("AllowedRequesterHasHigherPrecedenceThanPatchOnly", func(t *testing.T) {
 			bvt := BuildVariantTaskUnit{
 				PatchOnly:         utility.TruePtr(),
-				AllowedRequesters: []string{requester},
+				AllowedRequesters: []evergreen.UserRequester{userRequester},
 			}
 			assert.False(t, bvt.SkipOnRequester(requester))
 		})
@@ -2313,15 +2316,15 @@ func TestSkipOnPatchBuild(t *testing.T) {
 		assert.True(t, bvt.SkipOnPatchBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GithubPRRequester, evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GithubPRUserRequester, evergreen.AdHocUserRequester}}
 		assert.False(t, bvt.SkipOnPatchBuild())
 	})
 	t.Run("ReturnsTrueWithNotAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}}
 		assert.True(t, bvt.SkipOnPatchBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequesterAndNotPatchable", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{Patchable: utility.FalsePtr(), AllowedRequesters: []string{evergreen.GithubPRRequester}}
+		bvt := BuildVariantTaskUnit{Patchable: utility.FalsePtr(), AllowedRequesters: []evergreen.UserRequester{evergreen.GithubPRUserRequester}}
 		assert.False(t, bvt.SkipOnPatchBuild())
 	})
 }
@@ -2340,15 +2343,15 @@ func TestSkipOnNonPatchBuild(t *testing.T) {
 		assert.True(t, bvt.SkipOnNonPatchBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GithubPRRequester, evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GithubPRUserRequester, evergreen.AdHocUserRequester}}
 		assert.False(t, bvt.SkipOnNonPatchBuild())
 	})
 	t.Run("ReturnsTrueWithNotAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GithubPRRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GithubPRUserRequester}}
 		assert.True(t, bvt.SkipOnNonPatchBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequesterAndPatchOnly", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{PatchOnly: utility.TruePtr(), AllowedRequesters: []string{evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{PatchOnly: utility.TruePtr(), AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}}
 		assert.False(t, bvt.SkipOnNonPatchBuild())
 	})
 }
@@ -2367,15 +2370,15 @@ func TestSkipOnGitTagBuild(t *testing.T) {
 		assert.True(t, bvt.SkipOnGitTagBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GitTagRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GitTagUserRequester}}
 		assert.False(t, bvt.SkipOnGitTagBuild())
 	})
 	t.Run("ReturnsTrueWithNotAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}}
 		assert.True(t, bvt.SkipOnGitTagBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequesterAndGitTagNotAllowed", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowForGitTag: utility.FalsePtr(), AllowedRequesters: []string{evergreen.GitTagRequester}}
+		bvt := BuildVariantTaskUnit{AllowForGitTag: utility.FalsePtr(), AllowedRequesters: []evergreen.UserRequester{evergreen.GitTagUserRequester}}
 		assert.False(t, bvt.SkipOnGitTagBuild())
 	})
 }
@@ -2394,15 +2397,15 @@ func TestSkipOnNonGitTagBuild(t *testing.T) {
 		assert.True(t, bvt.SkipOnNonGitTagBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}}
 		assert.False(t, bvt.SkipOnNonGitTagBuild())
 	})
 	t.Run("ReturnsTrueWithNotAllowedRequester", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{AllowedRequesters: []string{evergreen.GitTagRequester}}
+		bvt := BuildVariantTaskUnit{AllowedRequesters: []evergreen.UserRequester{evergreen.GitTagUserRequester}}
 		assert.True(t, bvt.SkipOnNonGitTagBuild())
 	})
 	t.Run("ReturnsFalseWithAllowedRequesterAndGitTagOnly", func(t *testing.T) {
-		bvt := BuildVariantTaskUnit{GitTagOnly: utility.TruePtr(), AllowedRequesters: []string{evergreen.AdHocRequester}}
+		bvt := BuildVariantTaskUnit{GitTagOnly: utility.TruePtr(), AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester}}
 		assert.False(t, bvt.SkipOnNonGitTagBuild())
 	})
 }

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1053,7 +1053,10 @@ func TestCheckTaskRuns(t *testing.T) {
 	})
 	Convey("When a task is patch-only and also has allowed requesters, a warning should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{
+			evergreen.PatchVersionUserRequester,
+			evergreen.RepotrackerVersionUserRequester,
+		}
 		project.BuildVariants[0].Tasks[0].PatchOnly = utility.TruePtr()
 		errs := checkTaskRuns(project)
 		So(len(errs), ShouldEqual, 1)
@@ -1061,7 +1064,10 @@ func TestCheckTaskRuns(t *testing.T) {
 	})
 	Convey("When a task is not patchable and also has allowed requesters, a warning should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{
+			evergreen.PatchVersionUserRequester,
+			evergreen.RepotrackerVersionUserRequester,
+		}
 		project.BuildVariants[0].Tasks[0].Patchable = utility.FalsePtr()
 		errs := checkTaskRuns(project)
 		So(len(errs), ShouldEqual, 1)
@@ -1069,7 +1075,10 @@ func TestCheckTaskRuns(t *testing.T) {
 	})
 	Convey("When a task is git-tag-only and also has allowed requesters, a warning should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.PatchVersionRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{
+			evergreen.PatchVersionUserRequester,
+			evergreen.RepotrackerVersionUserRequester,
+		}
 		project.BuildVariants[0].Tasks[0].GitTagOnly = utility.TruePtr()
 		errs := checkTaskRuns(project)
 		So(len(errs), ShouldEqual, 1)
@@ -1077,10 +1086,29 @@ func TestCheckTaskRuns(t *testing.T) {
 	})
 	Convey("When a task is allowed for git tags and also has allowed requesters, a warning should be thrown", t, func() {
 		project := makeProject()
-		project.BuildVariants[0].Tasks[0].AllowedRequesters = []string{evergreen.GitTagRequester, evergreen.RepotrackerVersionRequester}
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{
+			evergreen.GitTagUserRequester,
+			evergreen.RepotrackerVersionUserRequester,
+		}
 		project.BuildVariants[0].Tasks[0].AllowForGitTag = utility.TruePtr()
 		errs := checkTaskRuns(project)
 		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Level, ShouldEqual, Warning)
+	})
+	Convey("When a task has a valid allowed requester, no warning or error should be thrown", t, func() {
+		project := makeProject()
+		for _, userRequester := range evergreen.AllUserRequesterTypes {
+			project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{userRequester}
+			errs := checkTaskRuns(project)
+			So(len(errs), ShouldEqual, 0)
+		}
+	})
+	Convey("When a task has an invalid allowed_requester, a warning should be thrown", t, func() {
+		project := makeProject()
+		project.BuildVariants[0].Tasks[0].AllowedRequesters = []evergreen.UserRequester{"foobar"}
+		errs := checkTaskRuns(project)
+		So(len(errs), ShouldEqual, 1)
+		So(errs[0].Message, ShouldContainSubstring, "invalid allowed_requester")
 		So(errs[0].Level, ShouldEqual, Warning)
 	})
 }


### PR DESCRIPTION
EVG-20622

### Description
I forgot that the commit queue does a weird thing where [it takes the already-translated project, converts it to YAML, adds more YAML configuration to add the merge task, and re-translates the already-translated project again as if it's a parser project](https://github.com/evergreen-ci/evergreen/blob/bb4161f86a67469d8d696f7d88e769c8b4045756/units/commit_queue.go#L622-L653). This is not really supposed to be done since it requires that the project can be subbed in at any place where a parser project is supposed to be used, but I don't feel like it's worth trying to fix the commit queue given that the commit queue is going to go away soon. Instead, I changed project translation so that it does not translate the user-facing requester into the internal requester.

For example, originally, if we had `allowed_requesters: ["patch"]` for the parser project (i.e. the user-facing requester string), the project would represent this as `allowed_requesters: ["patch_request"]` (i.e. the internal requester). After this change, both the parser project and the project will store `allowed_requesters: ["patch"]`.

* Do not translate user-facing requester to internal requester during project translation to avoid mismatches between the parser project and project.
* Translate user-facing requester to internal requester at the last second when comparing internal requesters against `AllowedRequesters`.

### Testing
* Updated unit tests.
* Checked all-configs to verify that the one project using this field will not be affected - new versions created after this is deployed are not affected, but existing versions that modify the parser project after the version is created (e.g. via `generate.tasks`) would be affected. From a glance, it seems like that project will not do that.

### Documentation
N/A