### PR TITLE
EVG-20866: show output from golangci-lint installation

### DIFF
--- a/makefile
+++ b/makefile
@@ -195,7 +195,7 @@ $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 120 -sSfL -o "$(buildDir)/install.sh" https://raw.githubusercontent.com/golangci/golangci-lint/$(goLintInstallerVersion)/install.sh
 	@echo "$(goLintInstallerChecksum) $(buildDir)/install.sh" | sha256sum --check
-	@bash $(buildDir)/install.sh -b $(buildDir) $(goLintInstallerVersion) >/dev/null 2>&1 && touch $@
+	@bash $(buildDir)/install.sh -b $(buildDir) $(goLintInstallerVersion) && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	$(gobin) build -ldflags "-w" -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
EVG-20866

### Description
The golangci-lint installation occasionally flakes out and causes linter failures. I'm pretty sure it's something getting stuck in the install script, like a flaky network operation. Unfortunately, we can't tell what is the cause at this point since there's no output, so I changed it to show its install output so we can diagnose the next time it flakes.

### Testing
Ran it locally to verify the output wasn't overly noisy.