### PR TITLE
EVG-20867 Update shouldSkipWebhook to check if token can be created

### DIFF
--- a/config.go
+++ b/config.go
@@ -537,8 +537,8 @@ type githubAppAuth struct {
 	privateKey []byte
 }
 
-// GetGithubAppAuth returns app id and app private key if it exists.
-func (s *Settings) GetGithubAppAuth() *githubAppAuth {
+// getGithubAppAuth returns app id and app private key if it exists.
+func (s *Settings) getGithubAppAuth() *githubAppAuth {
 	if s.AuthConfig.Github == nil || s.AuthConfig.Github.AppId == 0 {
 		return nil
 	}
@@ -566,7 +566,7 @@ func (s *Settings) CreateInstallationToken(ctx context.Context, owner, repo stri
 	if owner == "" || repo == "" {
 		return "", errors.New("no owner/repo specified to create installation token")
 	}
-	authFields := s.GetGithubAppAuth()
+	authFields := s.getGithubAppAuth()
 	if authFields == nil {
 		// TODO EVG-19966: Return error here
 		grip.Debug(message.Fields{

--- a/config_test.go
+++ b/config_test.go
@@ -84,17 +84,17 @@ func TestGetGithubSettings(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(settings.Credentials["github"], tokens[0])
 
-	authFields := settings.GetGithubAppAuth()
+	authFields := settings.getGithubAppAuth()
 	assert.Nil(authFields)
 
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 1234,
 	}
-	authFields = settings.GetGithubAppAuth()
+	authFields = settings.getGithubAppAuth()
 	assert.Nil(authFields)
 
 	settings.Expansions[githubAppPrivateKey] = "key"
-	authFields = settings.GetGithubAppAuth()
+	authFields = settings.getGithubAppAuth()
 	assert.NotNil(authFields)
 	assert.Equal(int64(1234), authFields.AppId)
 	assert.Equal([]byte("key"), authFields.privateKey)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -101,8 +101,8 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-// shouldSkipWebhook returns true if the event is from a GitHub app and the app is not set up or,
-// the event is from webhooks and app is set up.
+// shouldSkipWebhook returns true if the event is from a GitHub app and the app is available for the owner/repo or,
+// the event is from webhooks and the app is not available for the owner/repo.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
 	token, _ := gh.settings.CreateInstallationToken(ctx, owner, repo, nil)
 	hasApp := token != ""

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -103,8 +103,9 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 
 // shouldSkipWebhook returns true if the event is from a GitHub app and the app is not set up or,
 // the event is from webhooks and app is set up.
-func (gh *githubHookApi) shouldSkipWebhook(fromApp bool) bool {
-	hasApp := gh.settings.GetGithubAppAuth() != nil
+func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
+	token, _ := gh.settings.CreateInstallationToken(ctx, owner, repo, nil)
+	hasApp := token != ""
 	return (fromApp && !hasApp) || (!fromApp && hasApp)
 }
 
@@ -112,7 +113,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		if event.HookID == nil {
@@ -130,7 +131,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.PullRequestEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		if event.Action == nil {
@@ -198,7 +199,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		}
 	case *github.PushEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		grip.Debug(message.Fields{
@@ -223,7 +224,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.IssueCommentEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		if err := gh.handleComment(ctx, event); err != nil {
@@ -232,7 +233,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MetaEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		if event.GetAction() == "deleted" {
@@ -255,7 +256,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 
 	case *github.MergeGroupEvent:
 		fromApp := event.GetInstallation() != nil
-		if gh.shouldSkipWebhook(fromApp) {
+		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
 		return gh.handleMergeGroupEvent(event)


### PR DESCRIPTION
EVG-20867

### Description
the github webhooks are currently skipped for orgs without the github app if the github app is defined in the evergreen admin side.

instead of just checking that the app is defined on the evergreen side, we should check that the specific repos are able to create a token, meaning that the app can actually be used by the repo

### Testing
made sure that the app still worked
