### PR TITLE
EVG-20670: check project ID/identifier has valid characters

### DIFF
--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -101,7 +102,7 @@ func RequestS3Creds(ctx context.Context, projectIdentifier, userEmail string) er
 // Returns true if the project was successfully created.
 func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *model.ProjectRef, u *user.DBUser) (bool, error) {
 	if projectRef.Identifier != "" {
-		if err := VerifyUniqueProject(projectRef.Identifier); err != nil {
+		if err := ValidateProjectName(projectRef.Identifier); err != nil {
 			return false, err
 		}
 	}
@@ -110,7 +111,7 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 			projectRef.Id = mgobson.NewObjectId().Hex()
 		}
 	}
-	if err := VerifyUniqueProject(projectRef.Id); err != nil {
+	if err := ValidateProjectName(projectRef.Id); err != nil {
 		return false, err
 	}
 	// Always warn because created projects are never enabled.
@@ -194,8 +195,18 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	return nil
 }
 
-// VerifyUniqueProject returns a bad request error if the project ID / identifier is already in use.
-func VerifyUniqueProject(name string) error {
+// projectIDRegexp includes all the allowed characters in a project
+// ID/identifier (i.e. those that do not require percent encoding for URLs).
+// These are listed in RFC-3986:
+// https://www.rfc-editor.org/rfc/rfc3986#section-2.3
+// Note that this also includes parentheses and spaces, which may actually
+// require percent encoding, for backward compatibility because some projects
+// have already chosen to use those characters in their project ID/identifier.
+var projectIDRegexp = regexp.MustCompile(`^[0-9a-zA-Z-._~\(\) ]*$`)
+
+// ValidateProjectName checks that a project ID / identifier is not already in use
+// and has only valid characters.
+func ValidateProjectName(name string) error {
 	_, err := FindProjectById(name, false, false)
 	if err == nil {
 		return gimlet.ErrorResponse{
@@ -210,6 +221,14 @@ func VerifyUniqueProject(name string) error {
 	if apiErr.StatusCode != http.StatusNotFound {
 		return errors.Wrapf(err, "Database error verifying project '%s' doesn't already exist", name)
 	}
+
+	if !projectIDRegexp.MatchString(name) {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    fmt.Sprintf("project name '%s' contains invalid characters", name),
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
EVG-20670

### Description
Since Spruce uses the project identifier in the project settings URL and there's currently no character limitations on the identifier, we have to either 1. prevent special characters from being used for project identifiers, or 2. percent-encode the project ID/identifier in Spruce project settings URLs. I chose to just do option 1.

For valid characters, I referred to the RFC, which describes that [reserved characters should be percent-encoded for safety](https://www.rfc-editor.org/rfc/rfc3986#section-2.2):
>   If data for a URI component would conflict with a reserved character's purpose as a delimiter, then the conflicting data must be percent-encoded before the URI is formed.

And then chose a regexp pattern that matches [the set of unreserved characters](https://www.rfc-editor.org/rfc/rfc3986#section-2.3). I also had to include some special exceptions (space and parentheses) which are probably not valid characters, but are currently in use; we could opt to not allow setting these in new identifiers if we wanted (users can still include special characters in the display name).

As an aside, it's also worth noting that a lot of existing projects (> 100) currently have empty project identifiers, which Spruce doesn't have a way of handling since it uses the identifier in the project settings URL. The changes introduced in this PR still allow empty identifiers.

### Testing
* Added unit tests.
* Tested my regexp against all existing projects - only one didn't match the regexp (it had an `@`, which made the project settings unable to load anyways because it requires percent encoding).

### Documentation
N/A