### PR TITLE
EVG-20701: stop heartbeat on timeout

### DIFF
--- a/agent/background_test.go
+++ b/agent/background_test.go
@@ -331,7 +331,7 @@ func (s *BackgroundSuite) TestHeartbeatTimesOut() {
 
 	// Set the initial state so the heartbeat has already timed out.
 	s.tc.setHeartbeatTimeout(heartbeatTimeoutOptions{
-		startAt:    time.Now().Add(-10 * defaultHeartbeatInterval),
+		startAt:    time.Now().Add(-10 * defaultHeartbeatTimeout),
 		getTimeout: func() time.Duration { return defaultHeartbeatTimeout },
 	})
 	go s.a.startHeartbeat(heartbeatCtx, childCancel, s.tc)

--- a/agent/background_test.go
+++ b/agent/background_test.go
@@ -331,7 +331,7 @@ func (s *BackgroundSuite) TestHeartbeatTimesOut() {
 
 	// Set the initial state so the heartbeat has already timed out.
 	s.tc.setHeartbeatTimeout(heartbeatTimeoutOptions{
-		startAt:    time.Now().Add(-time.Hour),
+		startAt:    time.Now().Add(-10 * defaultHeartbeatInterval),
 		getTimeout: func() time.Duration { return defaultHeartbeatTimeout },
 	})
 	go s.a.startHeartbeat(heartbeatCtx, childCancel, s.tc)

--- a/agent/global.go
+++ b/agent/global.go
@@ -30,7 +30,7 @@ const (
 
 	// defaultHeartbeatTimeout is how long the agent can perform operations when
 	// there is no other applicable timeout before the heartbeat times out.
-	defaultHeartbeatTimeout = time.Minute
+	defaultHeartbeatTimeout = time.Hour
 
 	// defaultStatsInterval is the interval after which agent sends system stats
 	// to API server

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-14"
+	AgentVersion = "2023-09-18"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20701

### Description
* Follow-up to #7014 to actually stop the heartbeat after gathering enough data to verify that this only occurs in exceptional cases.
* I also increased the default timeout because `killProcs` was quite slow - in two tasks ran over the past 4 days, it took more than 8 minutes to complete (but it did complete).

### Testing
I wrote a unit test.

I also investigated the prod logs to see if the heartbeat timeout logged to Splunk. It did log the alert once, but in a very exceptional case where timing out was the appropriate action. The [one case where it logged](https://mongodb.splunkcloud.com/en-US/app/search/search?s=Heartbeat%20timeout&now=1694772000&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&q=search%20index%3Devergreen%20%22Heartbeat%20has%20hit%20maximum%22&earliest=1694768400&latest=1694772000&sid=1694794575.2174028) is a case where the heartbeat validly timed out - the task was frozen for long enough (seems like it tried sending a huge log to Logkeeper and overwhelmed the network) that it failed to heartbeat for several minutes, which caused the task to system fail at 12:30 am. The host was also terminated at 12:30 am. However, it seems from the logs that the agent on the host _was still running_ five hours after it was terminated, because it managed to log the alert to Splunk. In this case, the heartbeat should time out because the task already exceeded its exec timeout _and_ the host was already terminated long ago.

As an aside, if anyone is curious how the agent could send to Splunk hours after the host was terminated, we've seen instances where Evergreen terminates a host but the agent is still alive and pinging the app server with requests. AWS doesn't bill us for these hosts, but we have had to add [some special handling to deal with hosts that are truly terminated but are still pinging Evergreen](https://github.com/evergreen-ci/evergreen/blob/f9a9cc1723ba6bed3ea42bf1433f8c9eeb44ac61/rest/route/host_agent.go#L1389-L1392).

### Documentation
N/A