### PR TITLE
EVG-20838 Update githook to only handle checks required merge group events

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	githubActionClosed      = "closed"
-	githubActionOpened      = "opened"
-	githubActionSynchronize = "synchronize"
-	githubActionReopened    = "reopened"
+	githubActionClosed          = "closed"
+	githubActionOpened          = "opened"
+	githubActionSynchronize     = "synchronize"
+	githubActionReopened        = "reopened"
+	githubActionChecksRequested = "checks_requested"
 
 	// pull request comments
 	retryComment            = "evergreen retry"
@@ -259,13 +260,15 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {
 			break
 		}
-		return gh.handleMergeGroupEvent(event)
+		if event.GetAction() == githubActionChecksRequested {
+			return gh.handleMergeGroupChecksRequested(event)
+		}
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
 }
 
-func (gh *githubHookApi) handleMergeGroupEvent(event *github.MergeGroupEvent) gimlet.Responder {
+func (gh *githubHookApi) handleMergeGroupChecksRequested(event *github.MergeGroupEvent) gimlet.Responder {
 	org := event.GetOrg().GetLogin()
 	repo := event.GetRepo().GetName()
 	branch := strings.TrimPrefix(event.MergeGroup.GetBaseRef(), "refs/heads/")

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -579,7 +579,7 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 		"githubMergeQueueSelected": func(t *testing.T) {
 			p.CommitQueue.MergeQueue = model.MergeQueueGitHub
 			require.NoError(t, p.Insert())
-			response := gh.handleMergeGroupEvent(event)
+			response := gh.handleMergeGroupChecksRequested(event)
 			// check for error returned by GitHub merge queue handler
 			str := fmt.Sprintf("%#v", response)
 			assert.Contains(t, str, "message ID cannot be empty")
@@ -588,7 +588,7 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 		"evergreenMergeQueueSelected": func(t *testing.T) {
 			p.CommitQueue.MergeQueue = model.MergeQueueEvergreen
 			require.NoError(t, p.Insert())
-			response := gh.handleMergeGroupEvent(event)
+			response := gh.handleMergeGroupChecksRequested(event)
 			// check for 200 returned in noop case
 			str := fmt.Sprintf("%#v", response)
 			assert.Contains(t, str, "200")


### PR DESCRIPTION
EVG-20838

### Description
merge group seems to be sending 2 events with different actions 

<img width="891" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/78f161da-a47a-4bb6-a4ac-3a194a47647d">


1. checks_requested
2. destroyed

it says that github will send the destroy event when a pull request is removed from a queue in the docs 
https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=checks_requested#merge_group

it looks like the merge group destroy event is sent if there's only 1 PR in the queue and it merges successfully (couldn't find documentation for this behavior) 

I updated the githook to only look at the checks_requested action for merge_group events 

