### PR TITLE
EVG-20751 Add retryable to spawnhost start and stop

### DIFF
--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -3,10 +3,12 @@ package units
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
@@ -16,7 +18,8 @@ import (
 )
 
 const (
-	spawnhostStartName = "spawnhost-start"
+	spawnHostStartRetryLimit = 10
+	spawnhostStartName       = "spawnhost-start"
 )
 
 func init() {
@@ -50,6 +53,11 @@ func NewSpawnhostStartJob(h *host.Host, user, ts string) amboy.Job {
 	j.SetEnqueueAllScopes(true)
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(spawnHostStartRetryLimit),
+		WaitUntil:   utility.ToTimeDurationPtr(30 * time.Second),
+	})
 	return j
 }
 


### PR DESCRIPTION
EVG-20751

### Description
Spawnhost start and stop sometimes get hanged up with deploy and users cannot stop or start a host themselves on spruce, so this functionality adds retries to both jobs.

### Testing
Forced spawnhost_stop to have a retryable error and deployed to stage, stopped a host, collected corresponding logs to show that the job retries every 30 seconds (which it does fail stopping since it has already stopped from the initial execution, since the retryable error is non-blocking).

Splunk logs: https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20spawnhost-stop%7C%20spath%20job_id%20%7C%20search%20job_id%3D%22spawnhost-stop.zackary.santana.i-05636488b8dfbf329.2023-09-20.20-29-27%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1695228300&latest=1695241922&sid=1695242632.3340774
