### PR TITLE
EVG-20886 Uptick cocoa version

### DIFF
--- a/cloud/pod_util.go
+++ b/cloud/pod_util.go
@@ -80,7 +80,10 @@ func MakeECSPodDefinitionManager(c cocoa.ECSClient, v cocoa.Vault) (cocoa.ECSPod
 // MakeECSPodCreator creates a cocoa.ECSPodCreator to create pods backed by ECS
 // and secrets backed by an optional cocoa.Vault.
 func MakeECSPodCreator(c cocoa.ECSClient, v cocoa.Vault) (cocoa.ECSPodCreator, error) {
-	return ecs.NewBasicPodCreator(c, v)
+	return ecs.NewBasicPodCreator(*ecs.NewBasicPodCreatorOptions().
+		SetClient(c).
+		SetVault(v).
+		SetCache(definition.PodDefinitionCache{}))
 }
 
 // ExportECSPod exports the pod DB model to its equivalent cocoa.ECSPod backed

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10
-	github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca
+	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
 	github.com/evergreen-ci/gimlet v0.0.0-20230626223442-f6f16b3a3a98
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
 	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxz
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
 github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca h1:KBnECudr743p/yCpVLU0Ph3HCtrpzcvbio8godRgeu0=
 github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
+github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0 h1:q065j1sPZ2dwI+0jxcveTBHMh/xT6o/h3riJxjEN9Tc=
+github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,6 @@ github.com/evergreen-ci/bond v0.0.0-20211109152423-ba2b6b207f56/go.mod h1:EO+Oqm
 github.com/evergreen-ci/certdepot v0.0.0-20211109153348-d681ebe95b66/go.mod h1:X72gmQuA1g8E1vWg1Jfve3zdHoPxJkpwXDMLV1COs5g=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10 h1:dVNSXGxztN6t1S3vGxbSKqb5vqIRM5LiM1O5JjnVuCA=
 github.com/evergreen-ci/certdepot v0.0.0-20211117185134-dbedb3d79a10/go.mod h1:KpN0y+4m4oplnmM/PQmKAG+NQDKUbtr1BbdR4mr+6Ww=
-github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca h1:KBnECudr743p/yCpVLU0Ph3HCtrpzcvbio8godRgeu0=
-github.com/evergreen-ci/cocoa v0.0.0-20230814190926-efd8ab60efca/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
 github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0 h1:q065j1sPZ2dwI+0jxcveTBHMh/xT6o/h3riJxjEN9Tc=
 github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -383,7 +383,7 @@ func TestPodTerminationJob(t *testing.T) {
 // generateTestingECSPod creates a pod in ECS from the given options. The
 // cluster must exist before this is called.
 func generateTestingECSPod(ctx context.Context, t *testing.T, client cocoa.ECSClient, cluster string, creationOpts pod.TaskContainerCreationOptions) cocoa.ECSPod {
-	pc, err := ecs.NewBasicPodCreator(client, nil)
+	pc, err := ecs.NewBasicPodCreator(*ecs.NewBasicPodCreatorOptions().SetClient(client))
 	require.NoError(t, err)
 
 	containerDef := cocoa.NewECSContainerDefinition().


### PR DESCRIPTION
EVG-20886

### Description
Ran `go get github.com/evergreen-ci/cocoa@69a3ef4b69a0964b1f1ac59c613296a06ecaea5a`.  Upticking the cocoa version on the Evergreen side as a followup to [EVG-17274](https://jira.mongodb.org/browse/EVG-17274)