### PR TITLE
EVG-20369: allow activate: true for new build variants in generate.tasks

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -530,7 +530,9 @@ func (b *specificActivationInfo) taskOrVariantHasSpecificActivation(variant, tas
 func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester string) specificActivationInfo {
 	res := newSpecificActivationInfo()
 	for _, bv := range g.BuildVariants {
-		// Only consider batchtime for mainline builds. We should always respect activate if it is set.
+		// Only consider batchtime for mainline builds. A task/BV will have
+		// specific activation if activate if it is explicitly set to false;
+		// otherwise, if it's explicitly set to true, activate it immediately.
 		if evergreen.ShouldConsiderBatchtime(requester) && bv.hasSpecificActivation() {
 			res.activationVariants = append(res.activationVariants, bv.name())
 		} else if !utility.FromBoolTPtr(bv.Activate) {

--- a/model/generate.go
+++ b/model/generate.go
@@ -30,6 +30,7 @@ type GeneratedProject struct {
 	Functions     map[string]*YAMLCommandSet `yaml:"functions"`
 	TaskGroups    []parserTaskGroup          `yaml:"task_groups"`
 
+	// Task is the task that is running generate.tasks.
 	Task           *task.Task
 	ActivationInfo *specificActivationInfo
 	NewTVPairs     *TaskVariantPairs
@@ -532,7 +533,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 		// Only consider batchtime for mainline builds. We should always respect activate if it is set.
 		if evergreen.ShouldConsiderBatchtime(requester) && bv.hasSpecificActivation() {
 			res.activationVariants = append(res.activationVariants, bv.name())
-		} else if bv.Activate != nil {
+		} else if !utility.FromBoolTPtr(bv.Activate) {
 			res.activationVariants = append(res.activationVariants, bv.name())
 		}
 		// Regardless of whether the build variant has batchtime, there may be tasks with different batchtime
@@ -546,7 +547,7 @@ func (g *GeneratedProject) findTasksAndVariantsWithSpecificActivations(requester
 			}
 			if evergreen.ShouldConsiderBatchtime(requester) && bvt.hasSpecificActivation() {
 				batchTimeTasks = append(batchTimeTasks, bvt.Name)
-			} else if bvt.Activate != nil {
+			} else if !utility.FromBoolTPtr(bvt.Activate) {
 				batchTimeTasks = append(batchTimeTasks, bvt.Name)
 			}
 		}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1480,129 +1480,198 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 }
 
 func TestFilterInactiveTasks(t *testing.T) {
-	v := &Version{Requester: evergreen.PatchVersionRequester}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	t.Run("ActiveNonExistentBuild", func(t *testing.T) {
-		g := GeneratedProject{
-			BuildVariants: []parserBV{
-				{
-					Name: "bv0",
-					Tasks: []parserBVTaskUnit{
-						{Name: "generated"},
+	defer func() {
+		assert.NoError(t, db.ClearCollections(build.Collection))
+	}()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version){
+		"DoesNotFilterActiveNewBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"DoesNotFilterExplicitlyActiveNewBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			g.BuildVariants[0].Activate = utility.TruePtr()
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"FiltersInactiveNewBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			g.BuildVariants[0].Activate = utility.FalsePtr()
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Empty(t, tasks)
+		},
+		"FiltersNewBuildsWithBatchTime": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			g.BuildVariants[0].BatchTime = utility.ToIntPtr(10)
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Empty(t, tasks)
+		},
+		"DoesNotFilterNewBuildWithBatchTimeForPatch": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			v.Requester = evergreen.PatchVersionRequester
+			g.BuildVariants[0].BatchTime = utility.ToIntPtr(10)
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"FiltersExplicitlyActiveNewBuildWithBatchTime": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			// When activate and batchtime are both defined on the build
+			// variant, batchtime takes priority. This is a little unintuitive
+			// because if activate is defined in the build variant task, it can
+			// override build variant-level batchtime.
+			g.BuildVariants[0].Activate = utility.TruePtr()
+			g.BuildVariants[0].BatchTime = utility.ToIntPtr(10)
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Empty(t, tasks)
+		},
+		"DoesNotFilterActiveExistingBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			b := &build.Build{
+				BuildVariant: g.BuildVariants[0].Name,
+				Version:      v.Id,
+			}
+			assert.NoError(t, b.Insert())
+
+			p := &Project{
+				BuildVariants: []BuildVariant{
+					{Name: g.BuildVariants[0].Name},
+				},
+			}
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, p)
+
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"DoesNotFilterExplicitlyActiveExistingBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			b := &build.Build{
+				BuildVariant: g.BuildVariants[0].Name,
+				Version:      v.Id,
+			}
+			assert.NoError(t, b.Insert())
+
+			p := &Project{
+				BuildVariants: []BuildVariant{
+					{
+						Name:     g.BuildVariants[0].Name,
+						Activate: utility.TruePtr(),
 					},
 				},
-			},
-			Task: &task.Task{},
-		}
+			}
 
-		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
-		assert.NoError(t, err)
-		assert.Len(t, tasks, 1)
-	})
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, p)
 
-	t.Run("InactiveNonExistentBuild", func(t *testing.T) {
-		g := GeneratedProject{
-			BuildVariants: []parserBV{
-				{
-					Name: "bv0",
-					Tasks: []parserBVTaskUnit{
-						{Name: "generated"},
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"FiltersInactiveExistingBuild": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			b := &build.Build{
+				BuildVariant: g.BuildVariants[0].Name,
+				Version:      v.Id,
+			}
+			assert.NoError(t, b.Insert())
+
+			p := &Project{
+				BuildVariants: []BuildVariant{
+					{
+						Name:     g.BuildVariants[0].Name,
+						Activate: utility.FalsePtr(),
 					},
-					Activate: utility.FalsePtr(),
 				},
-			},
-			Task: &task.Task{},
-		}
+			}
 
-		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
-		assert.NoError(t, err)
-		assert.Empty(t, tasks)
-	})
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, p)
 
-	t.Run("ActiveExistingBuild", func(t *testing.T) {
-		defer func() {
-			assert.NoError(t, db.Clear(build.Collection))
-		}()
-		assert.NoError(t, db.Clear(build.Collection))
-		assert.NoError(t, (&build.Build{DisplayName: "bv0"}).Insert())
+			assert.NoError(t, err)
+			assert.Empty(t, tasks)
+		},
+		"DoesNotFilterExplicitlyActiveTask": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			g.BuildVariants[0].Tasks[0].Activate = utility.TruePtr()
 
-		g := GeneratedProject{
-			BuildVariants: []parserBV{
-				{
-					Name: "bv0",
-					Tasks: []parserBVTaskUnit{
-						{
-							Name: "generated",
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Len(t, tasks, 1)
+		},
+		"FiltersInactiveTask": func(ctx context.Context, t *testing.T, g GeneratedProject, v *Version) {
+			g.BuildVariants[0].Tasks[0].Activate = utility.FalsePtr()
+
+			tasks, err := g.filterInactiveTasks(ctx, TVPairSet{{
+				TaskName: g.BuildVariants[0].Tasks[0].Name,
+				Variant:  g.BuildVariants[0].Name,
+			}}, v, &Project{})
+
+			assert.NoError(t, err)
+			assert.Empty(t, tasks)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+
+			require.NoError(t, db.ClearCollections(build.Collection))
+
+			g := GeneratedProject{
+				BuildVariants: []parserBV{
+					{
+						Name: "bv0",
+						Tasks: []parserBVTaskUnit{
+							{Name: "generated"},
 						},
 					},
 				},
-			},
-			Task: &task.Task{},
-		}
+				Task: &task.Task{},
+			}
+			v := &Version{Id: "version_id", Requester: evergreen.RepotrackerVersionRequester}
 
-		p := &Project{
-			BuildVariants: []BuildVariant{
-				{Name: "bv0"},
-			},
-		}
-
-		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
-		assert.NoError(t, err)
-		assert.Len(t, tasks, 1)
-	})
-
-	t.Run("InactiveExistingBuild", func(t *testing.T) {
-		defer func() {
-			assert.NoError(t, db.Clear(build.Collection))
-		}()
-		assert.NoError(t, db.Clear(build.Collection))
-		assert.NoError(t, (&build.Build{BuildVariant: "bv0"}).Insert())
-
-		g := GeneratedProject{
-			BuildVariants: []parserBV{
-				{
-					Name: "bv0",
-					Tasks: []parserBVTaskUnit{
-						{
-							Name: "generated",
-						},
-					},
-				},
-			},
-			Task: &task.Task{},
-		}
-
-		p := &Project{
-			BuildVariants: []BuildVariant{
-				{Name: "bv0", Activate: utility.FalsePtr()},
-			},
-		}
-
-		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, p)
-		assert.NoError(t, err)
-		assert.Empty(t, tasks)
-	})
-
-	t.Run("InactiveTask", func(t *testing.T) {
-		g := GeneratedProject{
-			BuildVariants: []parserBV{
-				{
-					Name: "bv0",
-					Tasks: []parserBVTaskUnit{
-						{
-							Name:     "generated",
-							Activate: utility.FalsePtr(),
-						},
-					},
-				},
-			},
-			Task: &task.Task{},
-		}
-
-		tasks, err := g.filterInactiveTasks(context.Background(), TVPairSet{{TaskName: "generated", Variant: "bv0"}}, v, &Project{})
-		assert.NoError(t, err)
-		assert.Empty(t, tasks)
-	})
+			tCase(tctx, t, g, v)
+		})
+	}
 }
 
 func TestAddDependencies(t *testing.T) {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1617,7 +1617,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			if t.Activated {
 				newActivatedTaskIds = append(newActivatedTaskIds, t.Id)
 			}
-			if creationInfo.ActivationInfo.taskHasSpecificActivation(t.BuildVariant, t.DisplayName) {
+			if evergreen.ShouldConsiderBatchtime(t.Requester) && creationInfo.ActivationInfo.taskHasSpecificActivation(t.BuildVariant, t.DisplayName) {
 				batchTimeTasksToIds[t.DisplayName] = t.Id
 			}
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -1369,7 +1369,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, *P
 }
 
 // HasSpecificActivation returns if the build variant task specifies an activation condition that
-// overrides the default, such as cron/batchtime, disabling the task, or explicitly not activating it.
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
 func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
 	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()
 }

--- a/model/project.go
+++ b/model/project.go
@@ -1369,7 +1369,7 @@ func FindLatestVersionWithValidProject(projectId string) (*Version, *Project, *P
 }
 
 // HasSpecificActivation returns if the build variant task specifies an activation condition that
-// overrides the default, such as cron/batchtime, disabling the task, or explicitly activating it.
+// overrides the default, such as cron/batchtime, disabling the task, or explicitly not activating it.
 func (bvt *BuildVariantTaskUnit) HasSpecificActivation() bool {
 	return bvt.CronBatchTime != "" || bvt.BatchTime != nil || bvt.Activate != nil || bvt.IsDisabled()
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1165,7 +1165,7 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	errs := ValidationErrors{}
 	// check task batchtimes first
 	for _, t := range buildVariant.Tasks {
-		// setting activate explicitly to true with batchtime/cron will use batchtime/cron
+		// setting activate explicitly to true with batchtime will use batchtime
 		if utility.FromBoolPtr(t.Activate) && (t.CronBatchTime != "" || t.BatchTime != nil) {
 			errs = append(errs,
 				ValidationError{

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1165,11 +1165,11 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	errs := ValidationErrors{}
 	// check task batchtimes first
 	for _, t := range buildVariant.Tasks {
-		// setting explicitly to true with batchtime will use batchtime
+		// setting activate explicitly to true with batchtime/cron will use batchtime/cron
 		if utility.FromBoolPtr(t.Activate) && (t.CronBatchTime != "" || t.BatchTime != nil) {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' for variant '%s' activation ignored since batchtime specified",
+					Message: fmt.Sprintf("task '%s' for variant '%s' activation ignored since batchtime or cron specified",
 						t.Name, buildVariant.Name),
 					Level: Warning,
 				})


### PR DESCRIPTION
EVG-20369

### Description
The user's patch was not activating their generated tasks because they explicitly set `activate: true` in their generate.tasks JSON. The logic in generate.tasks assumed that if `activate` is set to anything, it must have specific activation conditions. However, this is only true if `activate` is set to false - a generated task that sets `activate: true` should just activate by default, the same as if `activate` was not specified at all. This only affected new BVs that explicitly set `activate: true` because existing BV definitions can't be modified.

* Fix handling of `activate: true` in new BVs for generate.tasks.
* Fix a small bug I spotted where the task creation logic didn't filter out requesters for which batchtime doesn't apply.

### Testing
* Added more unit tests for generate.tasks interacting with `activate` + other specific activation settings.
* Tested in prod with `activate: true` when generated tasks added to an existing BV ([patch](https://spruce.mongodb.com/version/6509f71032f417e430a47b6b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)) - tasks were activated as expected.
* Tested in prod with `activate: true` when generated tasks were in a new BV ([patch](https://spruce.mongodb.com/version/6509fe98d6d80a9434fad2e9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)) - tasks were not activated, which is a bug.
   * Tested in staging with the same conditions + the changes in this PR ([patch](https://spruce-staging.corp.mongodb.com/version/650b0a8fb23736dcc0932004/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)) - tasks were activated.

### Documentation
N/A