### PR TITLE
EVG-18354 Escape file names when attaching to tasks 

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -154,13 +154,13 @@ func RotateSecrets(toReplace, replacement string, dryRun bool) (map[TaskIDAndExe
 func EscapeFiles(files []File) []File {
 	var escapedFiles []File
 	for _, file := range files {
-		file.Link = EscapeFile(file.Link)
+		file.Link = escapeFile(file.Link)
 		escapedFiles = append(escapedFiles, file)
 	}
 	return escapedFiles
 }
 
-func EscapeFile(path string) string {
+func escapeFile(path string) string {
 	base := filepath.Base(path)
 	i := strings.LastIndex(path, base)
 	return path[:i] + strings.Replace(path[i:], base, url.QueryEscape(base), 1)

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -1,6 +1,9 @@
 package artifact
 
 import (
+	"net/url"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/pail"
@@ -146,4 +149,19 @@ func RotateSecrets(toReplace, replacement string, dryRun bool) (map[TaskIDAndExe
 		}
 	}
 	return changes, catcher.Resolve()
+}
+
+func EscapeFiles(files []File) []File {
+	var escapedFiles []File
+	for _, file := range files {
+		file.Link = EscapeFile(file.Link)
+		escapedFiles = append(escapedFiles, file)
+	}
+	return escapedFiles
+}
+
+func EscapeFile(path string) string {
+	base := filepath.Base(path)
+	i := strings.LastIndex(path, base)
+	return path[:i] + strings.Replace(path[i:], base, url.QueryEscape(base), 1)
 }

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -218,3 +218,22 @@ func (s *TestArtifactFileSuite) TestRotateSecret() {
 	s.NoError(err)
 	s.Equal(entryFromDb.Files[0].AwsSecret, "changedSecret")
 }
+
+func (s *TestArtifactFileSuite) TestEscapeFiles() {
+	files := []File{
+		{
+			Name: "cat_picture",
+			Link: "https://bucket.s3.amazonaws.com/something/file#1.tar.gz",
+		},
+		{
+			Name: "not_a_cat_picture",
+			Link: "https://notacat#0.png",
+		},
+	}
+
+	escapedFiles := EscapeFiles(files)
+
+	s.Equal("https://bucket.s3.amazonaws.com/something/file%231.tar.gz", escapedFiles[0].Link)
+	s.Equal("https://notacat%230.png", escapedFiles[1].Link)
+
+}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -690,7 +690,7 @@ func (h *attachFilesHandler) Run(ctx context.Context) gimlet.Responder {
 		BuildId:         t.BuildId,
 		Execution:       t.Execution,
 		CreateTime:      time.Now(),
-		Files:           h.files,
+		Files:           artifact.EscapeFiles(h.files),
 	}
 
 	if err = entry.Upsert(); err != nil {


### PR DESCRIPTION
EVG-18354

### Description
We saw an example of a [task](https://spruce.mongodb.com/task/mms_e2e_cypress_E2E_CYPRESS_UI_patch_6a989832deb87ea30ff5c117945cc10c2d96b25b_637ce21d32f417389e6c7f9a_22_11_22_14_52_17/files?execution=2&sortBy=STATUS&sortDir=ASC) where the first file gad a broken link because the "#" character was not escaped correctly. This change ensures that the "#" at the end of the link is replaced with "%23" so that the file loads properly.

### Testing
Added a unit test for the function and [tested it on staging ](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_dist_staging_patch_a1e18399674027393f3f71e1de87cf079617b66a_650b6f1c97b1d3bc9cd5b382_23_09_20_22_16_18/files?execution=0) with a file with # in the link. 


