### PR TITLE
EVG-20910 abort with display tasks

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3205,6 +3205,7 @@ type GetTasksByProjectAndCommitOptions struct {
 	Limit          int
 }
 
+// AddParentDisplayTasks adds the display task to the task struct if applicable, rather than the task list.
 func AddParentDisplayTasks(tasks []Task) ([]Task, error) {
 	if len(tasks) == 0 {
 		return tasks, nil


### PR DESCRIPTION
EVG-20910
### Description
If the display task isn't included in the list of taskIds for RestartVersion, then we don't mark it as ResetWhenFinished, and then we bail [here](https://github.com/evergreen-ci/evergreen/blob/89de5ebcb3801d5750db68dcfad11e467818d00c/model/task_lifecycle.go#L2308) and never restart the task. 

### Testing
Added a unit test.

