### PR TITLE
EVG-20914 Use parsley log link when there's no HTML link 

### DIFF
--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -386,9 +386,14 @@ func (j *jiraBuilder) getDescription() (string, error) {
 	tests := []jiraTestFailure{}
 	for _, test := range j.data.Task.LocalTestResults {
 		if test.Status == evergreen.TestFailedStatus {
+			url := test.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML)
+			if url == "" {
+				url = test.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerParsley)
+			}
+
 			tests = append(tests, jiraTestFailure{
 				Name:       cleanTestName(test.GetDisplayTestName()),
-				URL:        test.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML),
+				URL:        url,
 				HistoryURL: historyURL(j.data.Task, cleanTestName(test.TestName), j.data.UIRoot),
 				TaskID:     test.TaskID,
 				Execution:  test.Execution,


### PR DESCRIPTION
EVG-20914 

### Description
A [BF ticket ](https://jira.mongodb.org/browse/BF-28597) that was generated included empty log links for tests that didn't have HTML logs. We should check if the log is empty, and if it is, use parsley.

