### PR TITLE
docs: add example of expansions.write output

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -228,11 +228,11 @@ Parameters:
 
 ## expansions.write
 
-`expansions.write` writes the task's expansions to a file
+`expansions.write` writes the task's expansions to a file.
 
 `global_github_oauth_token`, `github_app_token`, `AWS_ACCESS_KEY_ID`,
 `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` are always redacted for
-security reasons
+security reasons.
 
 ``` yaml
 - command: expansions.write
@@ -244,6 +244,15 @@ Parameters:
 
 -   `file`: filename to write expansions to
 -   `redacted`: include redacted project variables, defaults to false
+
+For example, if the expansions are currently `fruit=apple`, `vegetable=spinach`,
+and `bread=cornbread`, then the output file will look like this:
+
+```yaml
+fruit: apple
+vegetable: spinach
+bread: cornbread
+```
 
 ## generate.tasks
 


### PR DESCRIPTION
[Slack thread](https://mongodb.slack.com/archives/C0V896UV8/p1695410142917209)

Someone asked for an example of the output format for the `expansions.write` file. Also, there's already [a test for the exact output format](https://github.com/evergreen-ci/evergreen/blob/ded75d09f9a7ac790d11fe0dd42dad9e712b6a0d/agent/command/expansion_test.go#L76), so we don't need to add any new tests for this.