### PR TITLE
EVG-20821 return githash with raw patch data for patch-file command

### DIFF
--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -232,6 +232,14 @@ func GetRawPatches(patchID string) (*restModel.APIRawPatch, error) {
 			rawPatch.RawModules = append(rawPatch.RawModules, module)
 		}
 	}
+	if rawPatch.Patch.Githash == "" {
+		// If there aren't any changes for the base project, we should still add this to the list,
+		// using the patch githash.
+		rawPatch.Patch = restModel.APIRawModule{
+			Name:    "",
+			Githash: patchDoc.Githash,
+		}
+	}
 
 	return &rawPatch, nil
 }

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -235,10 +235,7 @@ func GetRawPatches(patchID string) (*restModel.APIRawPatch, error) {
 	if rawPatch.Patch.Githash == "" {
 		// If there aren't any changes for the base project, we should still add this to the list,
 		// using the patch githash.
-		rawPatch.Patch = restModel.APIRawModule{
-			Name:    "",
-			Githash: patchDoc.Githash,
-		}
+		rawPatch.Patch.Githash = patchDoc.Githash
 	}
 
 	return &rawPatch, nil


### PR DESCRIPTION
EVG-20821 
### Description
If a patch has no changes (such as 64ef4f6ad6d80a0b27a2281a), it won't have the githash store in the Patch field of the doc, which we use for determining the githash for the `patch-file` command. We should just return the patch githash, since that's what this is.

### Testing
Added a unit test to test GetRawPatches, and tested the patch-file workflow on staging (using [this patch](https://spruce-staging.corp.mongodb.com/version/650e01fe9dbe32be8dba4ccb/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with no changes, `evergreen patch-file --diff-patchId 650e01fe9dbe32be8dba4ccb` errored without changes, and created [a patch](https://evergreen-staging.corp.mongodb.com/patch/650e02db97b1d3cc9cd2e3da?redirect_spruce_users=true)
with them)
