### PR TITLE
BUILD-17945: use env vars for mac.sign secrets

### DIFF
--- a/agent/command/macsign.go
+++ b/agent/command/macsign.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -186,7 +188,6 @@ func (macSign *macSign) Execute(ctx context.Context,
 	}
 	args := []string{"-f", macSign.LocalZipFile,
 		"-k", macSign.KeyId,
-		"-s", macSign.Secret,
 		"-u", macSign.ServiceUrl,
 		"-m", signMode,
 		"-o", macSign.OutputZipFile,
@@ -204,7 +205,13 @@ func (macSign *macSign) Execute(ctx context.Context,
 		args = append(args, "--verify")
 	}
 
+	envs := []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+		fmt.Sprintf("MACOS_NOTARY_SECRET=%s", macSign.Secret),
+	}
+
 	cmd := exec.Command(macSign.ClientBinary, args...)
+	cmd.Env = append(os.Environ(), envs...)
 
 	stdout, err := cmd.CombinedOutput()
 	output := string(stdout)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-18"
+	AgentVersion = "2023-09-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
### Description
Previously, mac.sign was invoked with the API secret passed on the command line. As per EVG-20875, it is unsafe to pass command-line secrets to anything on a machine running the Evergreen agent because it could be captured by the "ps" commands the agent periodically runs and stores in system logs. This commit changes mac.sign to receive its API secret as an environment variable. The macnotary binary already supports configuration like this.

### Testing
I am not sure if I can submit a patch to test this, but the unit tests at least passed locally without any changes
