### PR TITLE
EVG-20317 Stop on error if module cloning fails

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -830,6 +830,7 @@ func (c *gitFetchProject) fetch(ctx context.Context,
 		err = c.fetchModuleSource(ctx, conf, logger, jpm, opts.token, p, moduleName)
 		if err != nil {
 			logger.Execution().Error(errors.Wrap(err, "fetching module source"))
+			return err
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-18"
+	AgentVersion = "2023-09-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
EVG-20317

### Description
Now returning an err upon failure to clone a module rather than continuing the task's execution. 

The ticket's discussion mentions introducing a feature flag in case that this breaks some behavior server is depending on, but since this is an agent side change I believe we should just be ready to revert if needed.


