### PR TITLE
EVG-20014: Implement Cedar-backed log fetching for task and test log output

### DIFF
--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -46,6 +46,7 @@ type GetBuildloggerLogsOptionsV2 struct {
 // log iterator.
 // TODO (EVG-20019): Remove the "V2" suffix once log fetching is consolidated
 // and the original GetBuildloggerLogs function is deleted.
+// TODO (EVG-21010): Remove this once Cedar logs have TTL'ed.
 func GetBuildloggerLogsV2(ctx context.Context, opts GetBuildloggerLogsOptionsV2) (log.LogIterator, error) {
 	usr := gimlet.GetUser(ctx)
 	if usr == nil {
@@ -85,6 +86,7 @@ func GetBuildloggerLogsV2(ctx context.Context, opts GetBuildloggerLogsOptionsV2)
 	return newBuildloggerIterator(r), nil
 }
 
+// TODO (EVG-21010): Remove this once Cedar logs have TTL'ed.
 type buildloggerIterator struct {
 	readCloser io.ReadCloser
 	reader     *bufio.Reader

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -42,8 +42,8 @@ type GetBuildloggerLogsOptionsV2 struct {
 	Tail      int      `json:"-"`
 }
 
-// GetBuildloggerLogs makes request to Cedar for a specifc log and returns an
-// io.ReadCloser.
+// GetBuildloggerLogs makes request to Cedar for a specifc log and returns a
+// log iterator.
 // TODO (EVG-20019): Remove the "V2" suffix once log fetching is consolidated
 // and the original GetBuildloggerLogs function is deleted.
 func GetBuildloggerLogsV2(ctx context.Context, opts GetBuildloggerLogsOptionsV2) (log.LogIterator, error) {

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -1,9 +1,155 @@
 package apimodels
 
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/evergreen-ci/evergreen/model/log"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/timber"
+	"github.com/evergreen-ci/timber/buildlogger"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/pkg/errors"
+)
+
 type CedarConfig struct {
 	BaseURL  string `json:"base_url"`
 	RPCPort  string `json:"rpc_port"`
 	Username string `json:"username"`
 	APIKey   string `json:"api_key,omitempty"`
 	Insecure bool   `json:"insecure"`
+}
+
+// GetBuildloggerLogsOptions represents the arguments passed into the
+// GetBuildloggerLogs function.
+// TODO (EVG-20019): Remove the "V2" suffix once log fetching is consolidated
+// and the original GetBuildloggerLogsOptions struct is deleted.
+type GetBuildloggerLogsOptionsV2 struct {
+	BaseURL   string   `json:"_"`
+	TaskID    string   `json:"-"`
+	Execution *int     `json:"-"`
+	TestName  string   `json:"-"`
+	Tags      []string `json:"-"`
+	Start     int64    `json:"-"`
+	End       int64    `json:"-"`
+	Limit     int      `json:"-"`
+	Tail      int      `json:"-"`
+}
+
+// GetBuildloggerLogs makes request to Cedar for a specifc log and returns an
+// io.ReadCloser.
+// TODO (EVG-20019): Remove the "V2" suffix once log fetching is consolidated
+// and the original GetBuildloggerLogs function is deleted.
+func GetBuildloggerLogsV2(ctx context.Context, opts GetBuildloggerLogsOptionsV2) (log.LogIterator, error) {
+	usr := gimlet.GetUser(ctx)
+	if usr == nil {
+		return nil, errors.New("error getting user from context")
+	}
+
+	var start, end time.Time
+	if opts.Start > 0 {
+		start = time.Unix(0, opts.Start).UTC()
+	}
+	if opts.End > 0 {
+		end = time.Unix(0, opts.Start).UTC()
+	}
+
+	getOpts := buildlogger.GetOptions{
+		Cedar: timber.GetOptions{
+			BaseURL:  fmt.Sprintf("https://%s", opts.BaseURL),
+			UserKey:  usr.GetAPIKey(),
+			UserName: usr.Username(),
+		},
+		TaskID:        opts.TaskID,
+		Execution:     opts.Execution,
+		TestName:      opts.TestName,
+		Tags:          opts.Tags,
+		PrintTime:     true,
+		PrintPriority: true,
+		Start:         start,
+		End:           end,
+		Limit:         opts.Limit,
+		Tail:          opts.Tail,
+	}
+	r, err := buildlogger.Get(ctx, getOpts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting logs from Cedar Buildlogger")
+	}
+
+	return newBuildloggerIterator(r), nil
+}
+
+type buildloggerIterator struct {
+	readCloser io.ReadCloser
+	reader     *bufio.Reader
+	item       log.LogLine
+	catcher    grip.Catcher
+	exhausted  bool
+	closed     bool
+}
+
+func newBuildloggerIterator(r io.ReadCloser) *buildloggerIterator {
+	return &buildloggerIterator{
+		readCloser: r,
+		reader:     bufio.NewReader(r),
+		catcher:    grip.NewBasicCatcher(),
+	}
+}
+
+func (it *buildloggerIterator) Next() bool {
+	if it.closed || it.exhausted {
+		return false
+	}
+
+	line, err := it.reader.ReadString('\n')
+	if err != nil {
+		it.exhausted = err == io.EOF
+		it.catcher.AddWhen(err != io.EOF, errors.Wrap(err, "reading log lines"))
+		return false
+	}
+
+	// Parse prefixed priority with format "[P:3%d] %s".
+	priority, err := strconv.Atoi(strings.TrimSpace(line[3:6]))
+	if err != nil {
+		it.catcher.Wrap(err, "parsing log line priority")
+		return false
+	}
+	line = line[8:]
+
+	// Parse prefixed timestamp with format "[2006/01/02 15:04:05.000] %s".
+	ts, err := time.Parse("2006/01/02 15:04:05.000", line[1:24])
+	if err != nil {
+		it.catcher.Wrap(err, "parsing log line timestamp")
+		return false
+	}
+	line = line[26:]
+
+	it.item = log.LogLine{
+		Priority:  level.Priority(priority),
+		Timestamp: ts.UnixNano(),
+		Data:      strings.TrimSuffix(line, "\n"),
+	}
+
+	return true
+}
+
+func (it *buildloggerIterator) Item() log.LogLine { return it.item }
+
+func (it *buildloggerIterator) Exhausted() bool { return it.exhausted }
+
+func (it *buildloggerIterator) Err() error { return it.catcher.Resolve() }
+
+func (it *buildloggerIterator) Close() error {
+	if it.closed {
+		return nil
+	}
+	it.closed = true
+
+	return it.readCloser.Close()
 }

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -57,7 +57,7 @@ func GetBuildloggerLogsV2(ctx context.Context, opts GetBuildloggerLogsOptionsV2)
 		start = time.Unix(0, opts.Start).UTC()
 	}
 	if opts.End > 0 {
-		end = time.Unix(0, opts.Start).UTC()
+		end = time.Unix(0, opts.End).UTC()
 	}
 
 	getOpts := buildlogger.GetOptions{
@@ -111,6 +111,14 @@ func (it *buildloggerIterator) Next() bool {
 	if err != nil {
 		it.exhausted = err == io.EOF
 		it.catcher.AddWhen(err != io.EOF, errors.Wrap(err, "reading log lines"))
+		return false
+	}
+
+	// Each log line is expected to have the format:
+	//     [P:3%d] [2006/01/02 15:04:05.000] %s
+	// Fail if we cannot parse the first 34 characters to avoid panicking.
+	if len(line) < 34 {
+		it.catcher.Errorf("malformed line '%s'", line)
 		return false
 	}
 

--- a/taskoutput/task_log.go
+++ b/taskoutput/task_log.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/log"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
 
@@ -62,6 +64,10 @@ func (o TaskLogOutput) Get(ctx context.Context, env evergreen.Environment, taskO
 		return nil, err
 	}
 
+	if o.Version == 0 {
+		return o.getBuildloggerLogs(ctx, env, taskOpts, getOpts)
+	}
+
 	return log.Get(ctx, env, log.GetOptions{
 		LogNames:  []string{o.getLogName(taskOpts, getOpts.LogType)},
 		Start:     getOpts.Start,
@@ -95,4 +101,28 @@ func (o TaskLogOutput) getLogServiceVersion() int {
 	default:
 		return 0
 	}
+}
+
+// getBuildloggerLogs makes request to Cedar Buildlogger for logs.
+func (o TaskLogOutput) getBuildloggerLogs(ctx context.Context, env evergreen.Environment, taskOpts TaskOptions, getOpts TaskLogGetOptions) (log.LogIterator, error) {
+	opts := apimodels.GetBuildloggerLogsOptionsV2{
+		BaseURL:   env.Settings().Cedar.BaseURL,
+		TaskID:    taskOpts.TaskID,
+		Execution: utility.ToIntPtr(taskOpts.Execution),
+		Start:     getOpts.Start,
+		End:       getOpts.End,
+		Limit:     getOpts.LineLimit,
+		Tail:      getOpts.TailN,
+	}
+	if getOpts.LogType == TaskLogTypeAll {
+		opts.Tags = []string{
+			string(TaskLogTypeAgent),
+			string(TaskLogTypeSystem),
+			string(TaskLogTypeTask),
+		}
+	} else {
+		opts.Tags = []string{string(getOpts.LogType)}
+	}
+
+	return apimodels.GetBuildloggerLogsV2(ctx, opts)
 }


### PR DESCRIPTION
EVG-20014

### Description
Implement Cedar-backed log fetching for the new `TaskOutput` interface.
Nothing will actually start using this yet until EVG-20019 is complete.

### Testing
Tested in staging.

### Documentation
N/A
