### PR TITLE
EVG-20924 Get project file includes asynchonously

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -664,9 +664,9 @@ func processIntermediateProjectInludes(ctx context.Context, identifier string, i
 	}
 	if err != nil {
 		yamlChan <- yamlTuple{nil, include.FileName, errors.Wrapf(err, "%s: retrieving file '%s'", LoadProjectError, include.FileName)}
-	} else {
-		yamlChan <- yamlTuple{yaml, include.FileName, nil}
+		return
 	}
+	yamlChan <- yamlTuple{yaml, include.FileName, nil}
 }
 
 type yamlTuple struct {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -719,9 +719,8 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		yamlMap := map[string][]byte{}
 		catcher := grip.NewBasicCatcher()
 		for elem := range yamlChan {
-			if elem.err != nil {
-				catcher.Add(err)
-			} else {
+			catcher.Add(elem.err)
+			if elem.yaml != nil {
 				yamlMap[elem.name] = elem.yaml
 			}
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -630,6 +631,11 @@ func GetProjectFromBSON(data []byte) (*Project, error) {
 	return TranslateProject(pp)
 }
 
+type yamlNamePair struct {
+	yaml []byte
+	name string
+}
+
 // LoadProjectInto loads the raw data from the config file into project
 // and sets the project's identifier field to identifier. Tags are evaluated. Returns the intermediate step.
 // If reading from a version config, LoadProjectInfoForVersion should be used to persist the resulting parser project.
@@ -644,40 +650,73 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		return nil, errors.Wrapf(err, LoadProjectError)
 	}
 
-	// return intermediateProject even if we run into issues to show merge progress
-	for _, path := range intermediateProject.Include {
-		if opts == nil {
-			err = errors.New("trying to open include files with empty options")
-			return nil, errors.Wrapf(err, LoadProjectError)
-		}
-		opts.UpdateForFile(path.FileName)
+	if opts == nil {
+		err = errors.New("trying to open include files with empty options")
+		return nil, errors.Wrapf(err, LoadProjectError)
+	}
 
-		var yaml []byte
-		opts.Identifier = identifier
-		opts.RemotePath = path.FileName
-		grip.Debug(message.Fields{
-			"message":     "retrieving included YAML file",
-			"remote_path": opts.RemotePath,
-			"read_from":   opts.ReadFileFrom,
-			"module":      path.Module,
-		})
-		if path.Module != "" {
-			yaml, err = retrieveFileForModule(ctx, *opts, intermediateProject.Modules, path.Module)
-		} else {
-			yaml, err = retrieveFile(ctx, *opts)
-		}
+	wg := sync.WaitGroup{}
+	catcher := grip.NewBasicCatcher()
+	yamlNamePairs := make(chan yamlNamePair, len(intermediateProject.Include))
+
+	for _, path := range intermediateProject.Include {
+		wg.Add(1)
+		go func(include Include, projectOpts *GetProjectOpts) {
+			defer wg.Done()
+			// Make a copy of opts because otherwise parts opts would be
+			// modified concurrenly.  Note, however, that Ref and PatchOpts are
+			// themselves pointers, so should not be modified.
+			localOpts := &GetProjectOpts{
+				Ref:             opts.Ref,
+				PatchOpts:       opts.PatchOpts,
+				LocalModules:    opts.LocalModules,
+				RemotePath:      projectOpts.RemotePath,
+				Revision:        projectOpts.Revision,
+				Token:           projectOpts.Token,
+				ReadFileFrom:    projectOpts.ReadFileFrom,
+				Identifier:      projectOpts.Identifier,
+				UnmarshalStrict: projectOpts.UnmarshalStrict,
+			}
+			localOpts.UpdateForFile(include.FileName)
+
+			var yaml []byte
+			localOpts.Identifier = identifier
+			localOpts.RemotePath = include.FileName
+			grip.Debug(message.Fields{
+				"message":     "retrieving included YAML file",
+				"remote_path": localOpts.RemotePath,
+				"read_from":   localOpts.ReadFileFrom,
+				"module":      include.Module,
+			})
+			if include.Module != "" {
+				yaml, err = retrieveFileForModule(ctx, *localOpts, intermediateProject.Modules, include.Module)
+				if err == nil && yaml != nil {
+					yamlNamePairs <- yamlNamePair{yaml, include.FileName}
+				}
+			} else {
+				yaml, err = retrieveFile(ctx, *localOpts)
+				if err == nil && yaml != nil {
+					yamlNamePairs <- yamlNamePair{yaml, include.FileName}
+				}
+			}
+			catcher.Add(errors.Wrapf(err, "%s: retrieving file '%s'", LoadProjectError, include.FileName))
+		}(path, opts)
+	}
+	wg.Wait()
+	close(yamlNamePairs)
+
+	// return intermediateProject even if we run into issues to show merge progress
+	for pair := range yamlNamePairs {
+		add, err := createIntermediateProject(pair.yaml, opts.UnmarshalStrict)
 		if err != nil {
-			return intermediateProject, errors.Wrapf(err, "%s: retrieving file '%s'", LoadProjectError, path.FileName)
-		}
-		add, err := createIntermediateProject(yaml, opts.UnmarshalStrict)
-		if err != nil {
-			return intermediateProject, errors.Wrapf(err, "%s: loading file '%s'", LoadProjectError, path.FileName)
+			return intermediateProject, errors.Wrapf(err, "%s: loading file '%s'", LoadProjectError, pair.name)
 		}
 		err = intermediateProject.mergeMultipleParserProjects(add)
 		if err != nil {
-			return intermediateProject, errors.Wrapf(err, "%s: merging file '%s'", LoadProjectError, path.FileName)
+			return intermediateProject, errors.Wrapf(err, "%s: merging file '%s'", LoadProjectError, pair.name)
 		}
 	}
+
 	intermediateProject.Include = nil
 
 	// return project even with errors

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -719,8 +719,8 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 
 		// This order is deliberate:
 		// 1. Close `includesToProcess` so that the workers stop `range`ing over it.
-		// 2. Wait for the workers, since closing on a `nil` `outputYAMLs` would panic.
-		// 3. Close `outputYAMLs` so that they later `range` statement over it will stop after the channel is drained.
+		// 2. Wait for the workers, since sending on a `nil` `outputYAMLs` would panic.
+		// 3. Close `outputYAMLs` so that the later `range` statement over it will stop after it's is drained.
 		close(includesToProcess)
 		wg.Wait()
 		close(outputYAMLs)
@@ -738,6 +738,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 			return intermediateProject, errors.Wrap(catcher.Resolve(), "getting includes")
 		}
 
+		// We promise to iterate over includes in the order they are defined.
 		for _, path := range intermediateProject.Include {
 			add, err := createIntermediateProject(yamlMap[path.FileName], opts.UnmarshalStrict)
 			if err != nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2694,7 +2694,7 @@ buildvariants:
 	assert.Error(t, err)
 }
 
-func TestUpdateForFile(t *testing.T) {
+func TestUpdateReadFileFrom(t *testing.T) {
 	p := &patch.Patch{
 		Id: "p1",
 		Patches: []patch.ModulePatch{
@@ -2717,15 +2717,15 @@ func TestUpdateForFile(t *testing.T) {
 			patch: p,
 		},
 	}
-	opts.UpdateForFile("small.yml")
+	opts.UpdateReadFileFrom("small.yml")
 	assert.Equal(t, opts.ReadFileFrom, ReadFromPatchDiff) // should be changed to patch diff bc it's not a github patch
 	p.GithubPatchData = thirdparty.GithubPatch{
 		HeadOwner: "me", // indicates this is a github PR patch
 	}
-	opts.UpdateForFile("small.yml")
+	opts.UpdateReadFileFrom("small.yml")
 	assert.Equal(t, opts.ReadFileFrom, ReadFromPatch) // should be changed to patch bc it is a github patch
 
-	opts.UpdateForFile("nonexistent.yml")
+	opts.UpdateReadFileFrom("nonexistent.yml")
 	// should be changed to patch diff because it's not a modified file
 
 }


### PR DESCRIPTION
EVG-20924

### Description

Getting files serially from GitHub was causing projects with many file includes
to exceed a timeout.

### Testing

This is a refactor, so it should be tested by existing tests.

### Documentation

N/A