### PR TITLE
docs: add links for shell.exec command

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1236,7 +1236,7 @@ Parameters:
 
 ## shell.exec
 
-This command runs a shell script.
+This command runs a shell script. To follow [Evergreen best practices](Best-Practices.md#subprocessexec), we recommend using [subprocess.exec](#subprocess.exec).
 
 ``` yaml
 - command: shell.exec


### PR DESCRIPTION
We mention in best practices you should use subprocess.exec, but we don't mention it on the command page itself.
https://github.com/evergreen-ci/evergreen/blob/d22ad631effdf1301dbe3e7ea2b25a392791dce4/docs/Project-Configuration/Project-Commands.md