### PR TITLE
EVG-18454: Add priority param to task_log_raw route

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -581,6 +581,7 @@ func (uis *UIServer) taskLogRaw(w http.ResponseWriter, r *http.Request) {
 	}
 
 	raw := (r.FormValue("text") == "true") || (r.Header.Get("Content-Type") == "text/plain")
+	printPriority := r.FormValue("priority") == "true" || !raw
 	execution, err := strconv.Atoi(gimlet.GetVars(r)["execution"])
 	grip.Warning(err)
 	logType := r.FormValue("type")
@@ -598,7 +599,7 @@ func (uis *UIServer) taskLogRaw(w http.ResponseWriter, r *http.Request) {
 		BaseURL:       uis.Settings.Cedar.BaseURL,
 		TaskID:        projCtx.Task.Id,
 		Execution:     utility.ToIntPtr(execution),
-		PrintPriority: !raw,
+		PrintPriority: printPriority,
 		LogType:       logType,
 	}
 	logReader, err = apimodels.GetBuildloggerLogs(ctx, opts)


### PR DESCRIPTION
EVG-18454

### Description
To facilitate printing error lines in red on Parsley, add a `priority` param to the raw task log route, which will include the line's severity at the start of each line. Calls to this route without the param will continue to omit priority.

On Parsley, the [`AnsiiRow` component](https://github.com/evergreen-ci/parsley/blob/main/src/components/LogRow/AnsiiRow/index.tsx) will be updated to:
- Strip the `[P: NN] ` prefix
- If appropriate, apply a color based on the [severity level](https://github.com/evergreen-ci/evergreen/blob/fb5b3fee0932f24caa2b6eac231bbc5581d081fb/apimodels/task_log.go#L57), as is [done in Spruce](https://github.com/evergreen-ci/spruce/blob/62a296c4030f744759f47baa897b92b8e928afaa/src/pages/task/taskTabs/logs/logTypes/logMessageLine/LogLines.tsx#L9-L28).

### Testing
- With this code deployed, you can view a raw log on staging with `&priority=true` applied as a query param. The priority will be printed at the start of the line.

<img width="1624" alt="Screenshot 2023-09-28 at 1 29 43 PM" src="https://github.com/evergreen-ci/evergreen/assets/9298431/705d63bb-9e2a-4fec-a2d8-063fc019924c"> 

### Documentation
As far as I can tell, we don't document `task_log_raw` or its query parameters anywhere. Let me know if I should add something!