### PR TITLE
EVG-20971 Add more helpful message to merge error

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -349,7 +349,7 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 	}
 
 	if projectRef.CommitQueue.MergeQueue == model.MergeQueueGitHub {
-		return nil, pr, errors.Wrapf(errors.New("project is using GitHub merge queue"), "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
+		return nil, pr, errors.Wrapf(errors.New("This project is using GitHub merge queue. Click the merge button instead."), "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
 	}
 
 	authorized, err := sc.IsAuthorizedToPatchAndMerge(ctx, env.Settings(), NewUserRepoInfo(info))


### PR DESCRIPTION
EVG-20971

### Description

This makes it more obvious to users who are used to typing `evergreen merge`
what to do instead.

Currently it looks like this, which doesn't tell the user what to do.

![Screenshot 2023-09-28 at 2 36 11 PM](https://github.com/evergreen-ci/evergreen/assets/624531/2b3c782a-200a-4be7-b782-572c4a41f2b0)

### Testing

String-only change, so no testing needed.

### Documentation

N/A
