### PR TITLE
EVG-20969 Add merge queue branch as expansion

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -791,6 +791,11 @@ given module
 -   `${<module_name>_owner}` is the Github repo owner for the evergreen
     module associated with this task
 
+In the [Github merge queue](Merge-Queue.md), a single additional expansion is
+available. This is the name of the temporary branch that GitHub creates for this
+merge group item. It looks something like
+"gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056".
+
 ### Task and Variant Tags
 
 Most projects have some implicit grouping at every layer. Some tests are

--- a/model/project.go
+++ b/model/project.go
@@ -1200,6 +1200,10 @@ func PopulateExpansions(t *task.Task, h *host.Host, oauthToken, appToken string)
 			expansions.Put("github_author", p.GithubPatchData.Author)
 			expansions.Put("github_commit", p.GithubPatchData.HeadHash)
 		}
+		if p.IsGithubMergePatch() {
+			// this looks like "gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+			expansions.Put("github_head_branch", p.GithubMergeData.HeadBranch)
+		}
 	} else {
 		expansions.Put("is_patch", "")
 		expansions.Put("revision_order_id", strconv.Itoa(v.RevisionOrderNumber))

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -412,13 +412,18 @@ func TestPopulateExpansions(t *testing.T) {
 	}))
 	p = patch.Patch{
 		Version: v.Id,
+		GithubMergeData: thirdparty.GithubMergeGroup{
+			HeadBranch: "merge_head_branch",
+			HeadSHA:    "merge_head_sha",
+		},
 	}
 	require.NoError(t, p.Insert())
 	expansions, err = PopulateExpansions(taskDoc, &h, oauthToken, "")
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 25)
+	assert.Len(map[string]string(expansions), 26)
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("true", expansions.Get("is_commit_queue"))
+	assert.Equal("merge_head_branch", expansions.Get("github_head_branch"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
 	assert.NoError(VersionUpdateOne(bson.M{VersionIdKey: v.Id}, bson.M{


### PR DESCRIPTION
EVG-20969

### Description

This exposes the name of the GitHub merge queue branch. This is specifically so
that Cloud can parse the PR number from it. This might not make sense when
multiple builds are being tested together, but it will work for them most of the
time.

### Testing

Added unit test.

### Documentation

Added docs.
