### PR TITLE
EVG-19841 Error on adding github intent for repos with no config path

### DIFF
--- a/docs/Project-Configuration/Repo-Level-Settings.md
+++ b/docs/Project-Configuration/Repo-Level-Settings.md
@@ -40,7 +40,7 @@ Exceptions to this behavior:
 
 ## How to Use PR Testing for Untracked Branches
 
-A highly requested feature is to allow PR testing to be possible for untracked branches (i.e. branches without an explicit project, waterfall, etc). To create PR patches for any Github PR for a repo, simply define PR aliases on the repo project page and set PR testing to Enabled. 
+A highly requested feature is to allow PR testing to be possible for untracked branches (i.e. branches without an explicit project, waterfall, etc). To create PR patches for any Github PR for a repo, simply set a config file path, define PR aliases, and toggle PR testing to Enabled on the repo settings page. 
 
 ![repo_pr_testing.png](../images/repo_pr_testing.png)
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1554,7 +1554,7 @@ func FindOneProjectRefByRepoAndBranchWithPRTesting(owner, repo, branch, calledBy
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding merged repo refs for repo '%s/%s'", owner, repo)
 	}
-	if repoRef == nil || !repoRef.IsPRTestingEnabledByCaller(calledBy) || repoRef.RemotePath == "" {
+	if repoRef == nil || !repoRef.IsPRTestingEnabledByCaller(calledBy) {
 		grip.Debug(message.Fields{
 			"source":  "find project ref for PR testing",
 			"message": "repo ref not configured for PR testing untracked branches",
@@ -1563,6 +1563,16 @@ func FindOneProjectRefByRepoAndBranchWithPRTesting(owner, repo, branch, calledBy
 			"branch":  branch,
 		})
 		return nil, nil
+	}
+	if repoRef.RemotePath == "" {
+		grip.Error(message.Fields{
+			"source":  "find project ref for PR testing",
+			"message": "repo ref has no remote path, cannot use for PR testing",
+			"owner":   owner,
+			"repo":    repo,
+			"branch":  branch,
+		})
+		return nil, errors.Wrapf(err, "repo ref '%s' has no remote path, cannot use for PR testing", repoRef.Id)
 	}
 
 	projectRefs, err = FindMergedProjectRefsThatUseRepoSettingsByRepoAndBranch(owner, repo, branch)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1572,7 +1572,7 @@ func FindOneProjectRefByRepoAndBranchWithPRTesting(owner, repo, branch, calledBy
 			"repo":    repo,
 			"branch":  branch,
 		})
-		return nil, errors.Wrapf(err, "repo ref '%s' has no remote path, cannot use for PR testing", repoRef.Id)
+		return nil, errors.Errorf("repo ref '%s' has no remote path, cannot use for PR testing", repoRef.Id)
 	}
 
 	projectRefs, err = FindMergedProjectRefsThatUseRepoSettingsByRepoAndBranch(owner, repo, branch)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1411,9 +1411,10 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NotNil(projectRef)
 
 	repoDoc := RepoRef{ProjectRef{
-		Id:    "my_repo",
-		Owner: "mongodb",
-		Repo:  "mci",
+		Id:         "my_repo",
+		Owner:      "mongodb",
+		Repo:       "mci",
+		RemotePath: "",
 	}}
 	assert.NoError(repoDoc.Upsert())
 	doc = &ProjectRef{
@@ -1492,6 +1493,8 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NotNil(projectRef)
 
 	// project explicitly disabled
+	repoDoc.RemotePath = "my_path"
+	assert.NoError(repoDoc.Upsert())
 	doc.Enabled = false
 	doc.PRTestingEnabled = utility.TruePtr()
 	assert.NoError(doc.Upsert())
@@ -1499,9 +1502,11 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NoError(err)
 	assert.Nil(projectRef)
 
-	// branch with no project doesn't work if repo not configured right
+	// branch with no project doesn't work and returns an error if repo not configured with a remote path
+	repoDoc.RemotePath = ""
+	assert.NoError(repoDoc.Upsert())
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting("mongodb", "mci", "yours", "")
-	assert.NoError(err)
+	assert.Error(err)
 	assert.Nil(projectRef)
 
 	repoDoc.RemotePath = "my_path"


### PR DESCRIPTION
EVG-19841

### Description
Stemming from the finding in the comment of this ticket, return an error if a repo has PR testing enabled but has an empty remote config path when creating PR patches for untracked branches.

### Testing
In staging, confirmed that an[ error surfaces](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%7C%20spath%20%22metadata.level%22%20%7C%20search%20%22metadata.level%22%3D70%7C%20spath%20repo%20%7C%20search%20repo%3D%22commit-queue-sandbox%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1696002688&latest=1696003588&sid=1696004850.5318722) when attempting to create a PR patch for an untracked branch when the remote config path is set to empty.
### Documentation
Updated docs.