### PR TITLE
EVG-20483: show project identifiers with conflicting GitHub settings

### DIFF
--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -252,7 +252,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				return nil, errors.Wrap(err, "validating new owner/repo")
 			}
 		}
-		// Only need to check Github conflicts once so we use else if statements to handle this.
+		// Only need to check GitHub conflicts once so we use else if statements to handle this.
 		// Handle conflicts using the ref from the DB, since only general section settings are passed in from the UI.
 		if mergedSection.Owner != mergedBeforeRef.Owner || mergedSection.Repo != mergedBeforeRef.Repo {
 			if err = handleGithubConflicts(mergedBeforeRef, "Changing owner/repo"); err != nil {
@@ -469,13 +469,16 @@ func handleGithubConflicts(pRef *model.ProjectRef, reason string) error {
 		return errors.Wrapf(err, "getting GitHub project conflicts")
 	}
 	if pRef.IsPRTestingEnabled() && len(conflicts.PRTestingIdentifiers) > 0 {
-		conflictMsgs = append(conflictMsgs, "PR testing")
+		conflictingIdentifiers := strings.Join(conflicts.PRTestingIdentifiers, ", ")
+		conflictMsgs = append(conflictMsgs, fmt.Sprintf("PR testing (projects: %s)", conflictingIdentifiers))
 	}
 	if pRef.CommitQueue.IsEnabled() && len(conflicts.CommitQueueIdentifiers) > 0 {
-		conflictMsgs = append(conflictMsgs, "the commit queue")
+		conflictingIdentifiers := strings.Join(conflicts.CommitQueueIdentifiers, ", ")
+		conflictMsgs = append(conflictMsgs, fmt.Sprintf("the commit queue (projects: %s)", conflictingIdentifiers))
 	}
 	if pRef.IsGithubChecksEnabled() && len(conflicts.CommitCheckIdentifiers) > 0 {
-		conflictMsgs = append(conflictMsgs, "commit checks")
+		conflictingIdentifiers := strings.Join(conflicts.CommitCheckIdentifiers, ", ")
+		conflictMsgs = append(conflictMsgs, fmt.Sprintf("commit checks (projects: %s)", conflictingIdentifiers))
 	}
 
 	if len(conflictMsgs) > 0 {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -297,6 +297,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 		},
 		"github conflicts with enabling": func(t *testing.T, ref model.ProjectRef) {
 			conflictingRef := model.ProjectRef{
+				Identifier:          "conflicting-project",
 				Owner:               ref.Owner,
 				Repo:                ref.Repo,
 				Branch:              ref.Branch,
@@ -319,11 +320,12 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			}
 			_, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "PR testing and commit checks")
+			assert.Contains(t, err.Error(), "PR testing (projects: conflicting-project) and commit checks (projects: conflicting-project)")
 			assert.NotContains(t, err.Error(), "the commit queue")
 		},
 		"github conflicts on Commit Queue page when defaulting to repo": func(t *testing.T, ref model.ProjectRef) {
 			conflictingRef := model.ProjectRef{
+				Identifier:          "conflicting-project",
 				Owner:               ref.Owner,
 				Repo:                ref.Repo,
 				Branch:              ref.Branch,
@@ -348,7 +350,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			}
 			_, err := SaveProjectSettingsForSection(ctx, changes.Id, apiChanges, model.ProjectPageGithubAndCQSection, false, "me")
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "PR testing")
+			assert.Contains(t, err.Error(), "PR testing (projects: conflicting-project)")
 			assert.NotContains(t, err.Error(), "the commit queue")
 			assert.NotContains(t, err.Error(), "commit checks")
 		},


### PR DESCRIPTION
EVG-20483

### Description
Include the conflicting identifiers in the error message when GitHub settings conflict between projects that have the same owner/repo. There is a very small concern that this technically doesn't follow the permissions model since it can allow a user to deduce the project GitHub settings of a project that they don't have access to, but assuming no malicious user intent, I thought it was too small a concern to actually be exploitable in any meaningful way.

### Testing
Added a unit test.

### Documentation
N/A