### PR TITLE
EVG-19706: remove dead task group fields

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1317,8 +1317,7 @@ group and each individual task. Tasks in a task group will not run the `pre`
 and `post` blocks in the YAML file; instead, the tasks will run the task group's
 setup and teardown blocks.
 
-Task groups have additional options available that can be configured
-directly inline inside the config's [build
+Task groups can be configured directly inline inside the config's [build
 variants](#build-variants).
 
 ``` yaml
@@ -1425,10 +1424,7 @@ The following constraints apply:
     phase, such as "attach.results" or "attach.artifacts".
 -   Tasks within a task group will be dispatched in order declared.
 -   Any task (including members of task groups), can depend on specific
-    tasks within a task group using the existing dependency system.
--   `patchable`, `patch_only`, `disable`, and `allow_for_git_tag` from the project
-    task will overwrite the task group parameters (Note: these settings currently do not work when defined on the task
-    group due to [EVG-19706](https://jira.mongodb.org/browse/EVG-19706)).
+    tasks within a task group using [task dependencies](#task-dependencies).
 
 Tasks in a group will be displayed as
 separate tasks. Users can use display tasks if they wish to group the
@@ -1437,7 +1433,7 @@ task group tasks.
 ### Task Dependencies
 
 A task can be made to depend on other tasks by adding the depended on
-tasks to the task's depends_on field. The following additional
+tasks to the task's `depends_on` field. The following additional
 parameters are available:
 
 -   `status` - string (default: "success"). One of ["success",

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -114,33 +114,24 @@ type ParserProject struct {
 } // End of ParserProject mergeable fields (this comment is used by the linter).
 
 type parserTaskGroup struct {
-	Name                     string             `yaml:"name,omitempty" bson:"name,omitempty"`
-	Priority                 int64              `yaml:"priority,omitempty" bson:"priority,omitempty"`
-	Patchable                *bool              `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
-	PatchOnly                *bool              `yaml:"patch_only,omitempty" bson:"patch_only,omitempty"`
-	AllowForGitTag           *bool              `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
-	GitTagOnly               *bool              `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
-	AllowedRequesters        []string           `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
-	ExecTimeoutSecs          int                `yaml:"exec_timeout_secs,omitempty" bson:"exec_timeout_secs,omitempty"`
-	Stepback                 *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	MaxHosts                 int                `yaml:"max_hosts,omitempty" bson:"max_hosts,omitempty"`
-	SetupGroup               *YAMLCommandSet    `yaml:"setup_group,omitempty" bson:"setup_group,omitempty"`
-	SetupGroupCanFailTask    bool               `yaml:"setup_group_can_fail_task,omitempty" bson:"setup_group_can_fail_task,omitempty"`
-	SetupGroupTimeoutSecs    int                `yaml:"setup_group_timeout_secs,omitempty" bson:"setup_group_timeout_secs,omitempty"`
-	TeardownGroup            *YAMLCommandSet    `yaml:"teardown_group,omitempty" bson:"teardown_group,omitempty"`
-	TeardownGroupTimeoutSecs int                `yaml:"teardown_group_timeout_secs,omitempty" bson:"teardown_group_timeout_secs,omitempty"`
-	SetupTask                *YAMLCommandSet    `yaml:"setup_task,omitempty" bson:"setup_task,omitempty"`
-	SetupTaskCanFailTask     bool               `yaml:"setup_task_can_fail_task,omitempty" bson:"setup_task_can_fail_task,omitempty"`
-	SetupTaskTimeoutSecs     int                `yaml:"setup_task_timeout_secs,omitempty" bson:"setup_task_timeout_secs,omitempty"`
-	TeardownTask             *YAMLCommandSet    `yaml:"teardown_task,omitempty" bson:"teardown_task,omitempty"`
-	TeardownTaskCanFailTask  bool               `yaml:"teardown_task_can_fail_task,omitempty" bson:"teardown_task_can_fail_task,omitempty"`
-	TeardownTaskTimeoutSecs  int                `yaml:"teardown_task_timeout_secs,omitempty" bson:"teardown_task_timeout_secs,omitempty"`
-	Timeout                  *YAMLCommandSet    `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
-	CallbackTimeoutSecs      int                `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
-	Tasks                    []string           `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
-	DependsOn                parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
-	Tags                     parserStringSlice  `yaml:"tags,omitempty" bson:"tags,omitempty"`
-	ShareProcs               bool               `yaml:"share_processes,omitempty" bson:"share_processes,omitempty"`
+	Name                     string            `yaml:"name,omitempty" bson:"name,omitempty"`
+	MaxHosts                 int               `yaml:"max_hosts,omitempty" bson:"max_hosts,omitempty"`
+	SetupGroup               *YAMLCommandSet   `yaml:"setup_group,omitempty" bson:"setup_group,omitempty"`
+	SetupGroupCanFailTask    bool              `yaml:"setup_group_can_fail_task,omitempty" bson:"setup_group_can_fail_task,omitempty"`
+	SetupGroupTimeoutSecs    int               `yaml:"setup_group_timeout_secs,omitempty" bson:"setup_group_timeout_secs,omitempty"`
+	TeardownGroup            *YAMLCommandSet   `yaml:"teardown_group,omitempty" bson:"teardown_group,omitempty"`
+	TeardownGroupTimeoutSecs int               `yaml:"teardown_group_timeout_secs,omitempty" bson:"teardown_group_timeout_secs,omitempty"`
+	SetupTask                *YAMLCommandSet   `yaml:"setup_task,omitempty" bson:"setup_task,omitempty"`
+	SetupTaskCanFailTask     bool              `yaml:"setup_task_can_fail_task,omitempty" bson:"setup_task_can_fail_task,omitempty"`
+	SetupTaskTimeoutSecs     int               `yaml:"setup_task_timeout_secs,omitempty" bson:"setup_task_timeout_secs,omitempty"`
+	TeardownTask             *YAMLCommandSet   `yaml:"teardown_task,omitempty" bson:"teardown_task,omitempty"`
+	TeardownTaskCanFailTask  bool              `yaml:"teardown_task_can_fail_task,omitempty" bson:"teardown_task_can_fail_task,omitempty"`
+	TeardownTaskTimeoutSecs  int               `yaml:"teardown_task_timeout_secs,omitempty" bson:"teardown_task_timeout_secs,omitempty"`
+	Timeout                  *YAMLCommandSet   `yaml:"timeout,omitempty" bson:"timeout,omitempty"`
+	CallbackTimeoutSecs      int               `yaml:"callback_timeout_secs,omitempty" bson:"callback_timeout_secs,omitempty"`
+	Tasks                    []string          `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	Tags                     parserStringSlice `yaml:"tags,omitempty" bson:"tags,omitempty"`
+	ShareProcs               bool              `yaml:"share_processes,omitempty" bson:"share_processes,omitempty"`
 }
 
 func (ptg *parserTaskGroup) name() string   { return ptg.Name }


### PR DESCRIPTION
EVG-19706

### Description
A bunch of task fields (like priority, stepback, etc.) can be defined at the task group level. However, they don't do anything, I'm not aware of any users asking to use these fields, and I verified with `evergreen admin all-configs` + `yq` that nobody is using these fields. Therefore, I just removed them all.

### Testing
Compile and existing tests pass.

### Documentation
Removed mentions of it from the docs.