### PR TITLE
EVG-20795 avoid overwriting patch task/variants

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -247,6 +247,9 @@ func (p *Patch) IsFinished() bool {
 
 // SetDescription sets a patch's description in the database
 func (p *Patch) SetDescription(desc string) error {
+	if p.Description == desc {
+		return nil
+	}
 	p.Description = desc
 	return UpdateOne(
 		bson.M{IdKey: p.Id},

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -1159,24 +1159,18 @@ func TestAbortPatchesWithGithubPatchData(t *testing.T) {
 	}
 }
 
-func TestConfigurePatch(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(VersionCollection, patch.Collection))
+func TestConfigurePatchWithOnlyUpdatedDescription(t *testing.T) {
+	assert.NoError(t, db.ClearCollections(patch.Collection), ParserProjectCollection)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	id := mgobson.NewObjectId()
-	v := &Version{
-		Id:        id.Hex(),
-		Status:    evergreen.VersionStarted,
-		Activated: utility.TruePtr(),
-	}
-	assert.NoError(t, v.Insert())
 	p := &patch.Patch{
-		Id:         id,
-		Version:    v.Id,
-		Status:     evergreen.VersionStarted,
-		Activated:  true,
-		Project:    "project",
-		CreateTime: time.Now().Add(-time.Hour),
+		Id:                   id,
+		Status:               evergreen.VersionCreated,
+		Activated:            false,
+		Project:              "project",
+		ProjectStorageMethod: evergreen.ProjectStorageMethodDB,
+		CreateTime:           time.Now().Add(-time.Hour),
 		GithubPatchData: thirdparty.GithubPatch{
 			BaseOwner: "owner",
 			BaseRepo:  "repo",
@@ -1201,7 +1195,7 @@ func TestConfigurePatch(t *testing.T) {
 		Id: id.Hex(),
 	}
 	assert.NoError(t, pp.Insert())
-	_, err := ConfigurePatch(ctx, evergreen.GetEnvironment().Settings(), p, v, pRef, req)
+	_, err := ConfigurePatch(ctx, &evergreen.Settings{}, p, nil, pRef, req)
 	assert.NoError(t, err)
 
 	p, err = patch.FindOneId(id.Hex())
@@ -1210,4 +1204,5 @@ func TestConfigurePatch(t *testing.T) {
 	assert.Equal(t, p.Description, req.Description)
 	assert.NotEmpty(t, p.VariantsTasks)
 	assert.NotEmpty(t, p.Tasks)
+	assert.False(t, p.Activated)
 }


### PR DESCRIPTION
EVG-20795
### Description
Discovered that when we update description only (using the lil UI pencil) we overwrite existing patch task/variant definitions.

Considered making a new mutation instead, but that would be a lot more work and I think would just leave the technical debt of potentially hitting this bug with how SchedulePatch is written. 

### Testing
Added a unit test, and [tested on staging](https://evergreen-staging.corp.mongodb.com/rest/v2/patches/650e02db97b1d3cc9cd2e3da) that the fields weren't erased after updating a description, and were before.
