### PR TITLE
EVG-19086 Introduce option to match attach.artifacts with exact file names

### DIFF
--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -86,7 +86,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 	for idx := range c.Files {
 		segment, err = readArtifactsFile(getWorkingDirectory(conf, c.Prefix), c.Files[idx])
 		if err != nil {
-			if (c.Optional || c.ExactFileNames) && os.IsNotExist(errors.Cause(err)) {
+			if c.Optional && os.IsNotExist(errors.Cause(err)) {
 				// pass;
 			} else {
 				catcher.Add(err)

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -20,6 +20,10 @@ type attachArtifacts struct {
 	// Files is a list of files, using gitignore syntax.
 	Files []string `mapstructure:"files" plugin:"expand"`
 
+	// ExactFileNames, when set to true, causes this command to treat the files array as an array of exact filenames to match,
+	// rather than the default behavior, which treats files as an array of gitignore file globs.
+	ExactFileNames bool `mapstructure:"exact_file_names"`
+
 	// Prefix is an optional directory prefix to start file globbing in, relative to Evergreen's working directory.
 	Prefix string `mapstructure:"prefix" plugin:"expand"`
 
@@ -54,14 +58,16 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
-	workDir := getWorkingDirectory(conf, c.Prefix)
-	include := utility.NewGitIgnoreFileMatcher(workDir, c.Files...)
-	b := utility.FileListBuilder{
-		WorkingDir: workDir,
-		Include:    include,
-	}
-	if c.Files, err = b.Build(); err != nil {
-		return errors.Wrap(err, "building wildcard paths")
+	if !c.ExactFileNames {
+		workDir := getWorkingDirectory(conf, c.Prefix)
+		include := utility.NewGitIgnoreFileMatcher(workDir, c.Files...)
+		b := utility.FileListBuilder{
+			WorkingDir: workDir,
+			Include:    include,
+		}
+		if c.Files, err = b.Build(); err != nil {
+			return errors.Wrap(err, "building wildcard paths")
+		}
 	}
 
 	if len(c.Files) == 0 {
@@ -80,7 +86,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 	for idx := range c.Files {
 		segment, err = readArtifactsFile(getWorkingDirectory(conf, c.Prefix), c.Files[idx])
 		if err != nil {
-			if c.Optional && os.IsNotExist(errors.Cause(err)) {
+			if (c.Optional || c.ExactFileNames) && os.IsNotExist(errors.Cause(err)) {
 				// pass;
 			} else {
 				catcher.Add(err)

--- a/agent/command/attach_artifacts_test.go
+++ b/agent/command/attach_artifacts_test.go
@@ -120,7 +120,7 @@ func (s *ArtifactsSuite) TestArtifactErrorsIfDoesNotExist() {
 func (s *ArtifactsSuite) TestArtifactNoErrorIfDoesNotExistWithExactNames() {
 	s.cmd.Files = []string{"foo"}
 	s.cmd.ExactFileNames = true
-	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+	s.Error(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(s.cmd.Files, 1)
 	s.Len(s.mock.AttachedFiles, 0)
 	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 0)
@@ -160,7 +160,7 @@ func (s *ArtifactsSuite) TestCommandParsesFile() {
 func (s *ArtifactsSuite) TestCommandParsesExactFileNames() {
 	s.cmd.ExactFileNames = true
 	s.Len(s.mock.AttachedFiles, 0)
-	s.cmd.Files = []string{"exactmatch.json", "example.json", "does-not-exist.json"}
+	s.cmd.Files = []string{"exactmatch.json", "example.json"}
 	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(s.mock.AttachedFiles, 1)
 	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 2)

--- a/agent/command/attach_artifacts_test.go
+++ b/agent/command/attach_artifacts_test.go
@@ -46,6 +46,17 @@ func (s *ArtifactsSuite) SetupSuite() {
 
 	_, err := os.Stat(path)
 	s.Require().False(os.IsNotExist(err))
+
+	path = filepath.Join(s.tmpdir, "exactmatch.json")
+	s.NoError(utility.WriteJSONFile(path,
+		[]*artifact.File{
+			{
+				Name: "name_of_artifact",
+				Link: "here it is",
+			},
+		}))
+	_, err = os.Stat(path)
+	s.Require().False(os.IsNotExist(err))
 }
 
 func (s *ArtifactsSuite) SetupTest() {
@@ -102,6 +113,17 @@ func (s *ArtifactsSuite) TestArtifactErrorsIfDoesNotExist() {
 	s.cmd.Files = []string{"foo"}
 	s.Error(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(s.cmd.Files, 0)
+	s.Len(s.mock.AttachedFiles, 0)
+	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 0)
+}
+
+func (s *ArtifactsSuite) TestArtifactNoErrorIfDoesNotExistWithExactNames() {
+	s.cmd.Files = []string{"foo"}
+	s.cmd.ExactFileNames = true
+	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+	s.Len(s.cmd.Files, 1)
+	s.Len(s.mock.AttachedFiles, 0)
+	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 0)
 }
 
 func (s *ArtifactsSuite) TestArtifactSkipsErrorWithOptionalArgument() {
@@ -129,10 +151,19 @@ func (s *ArtifactsSuite) TestReadFileSucceeds() {
 
 func (s *ArtifactsSuite) TestCommandParsesFile() {
 	s.Len(s.mock.AttachedFiles, 0)
-	s.cmd.Files = []string{"example.json"}
+	s.cmd.Files = []string{"example*"}
 	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(s.mock.AttachedFiles, 1)
 	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 1)
+}
+
+func (s *ArtifactsSuite) TestCommandParsesExactFileNames() {
+	s.cmd.ExactFileNames = true
+	s.Len(s.mock.AttachedFiles, 0)
+	s.cmd.Files = []string{"exactmatch.json", "example.json", "does-not-exist.json"}
+	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
+	s.Len(s.mock.AttachedFiles, 1)
+	s.Len(s.mock.AttachedFiles[s.conf.Task.Id], 2)
 }
 
 func (s *ArtifactsSuite) TestPrefixectoryEmptySubDir() {

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -110,10 +110,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//parse from YAML file
-	path = filepath.Join(tmpdir, "example.yml")
-	s.NoError(utility.WriteYAMLFile(path, fileContent))
-	_, err = os.Stat(path)
-	s.Require().False(os.IsNotExist(err))
+
 	s.params = map[string]interface{}{
 		"file": path,
 	}

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -110,7 +110,10 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//parse from YAML file
-
+	path = filepath.Join(tmpdir, "example.yml")
+	s.NoError(utility.WriteYAMLFile(path, fileContent))
+	_, err = os.Stat(path)
+	s.Require().False(os.IsNotExist(err))
 	s.params = map[string]interface{}{
 		"file": path,
 	}

--- a/config.go
+++ b/config.go
@@ -27,7 +27,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -38,7 +37,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-09-29"
+	AgentVersion = "2023-10-04"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readconcern"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
+	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -81,6 +81,9 @@ page.
     matched - ones that would be ignored by gitignore - are included.
 - `prefix`: an optional path to start processing the files, relative
     to the working directory.
+- `exact_file_names`: an optional boolean flag which, if set to true,
+    indicates to treat the files array as a list of exact filenames to
+    match, rather than an array of gitignore file globs.
 
 #### Lifecycle Policy 
 


### PR DESCRIPTION
EVG-19086

### Description
Introducing a new `exact_file_names` flag on the attach.artifacts command, which will cause the command to match exact file names rather than performing regex style matching on the entire work directory.
### Testing
Added some new unit tests to the attach artifacts test suite.
### Documentation
Added a piece to the attach.artifacts documentation for this new field and its functionality.