### PR TITLE
EVG-21033: increase timeout for getting commit for manifest

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -717,8 +717,6 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 		Branch:      projectRef.Branch,
 		IsBase:      v.Requester == evergreen.RepotrackerVersionRequester,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	var baseManifest *manifest.Manifest
 	var err error
@@ -744,6 +742,10 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing git url '%s'", module.Repo)
 		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
 		if module.Ref == "" {
 			var commit *github.RepositoryCommit
 			commit, err = thirdparty.GetCommitEvent(ctx, token, projectRef.Owner, projectRef.Repo, v.Revision)

--- a/model/version.go
+++ b/model/version.go
@@ -16,7 +16,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
-	"github.com/google/go-github/v52/github"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
@@ -728,7 +727,6 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 		}
 	}
 
-	var gitCommit *github.RepositoryCommit
 	modules := map[string]*manifest.Module{}
 	for _, module := range moduleList {
 		if isPatch && !module.AutoUpdate && baseManifest != nil {
@@ -737,59 +735,78 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 				continue
 			}
 		}
-		var sha, url string
-		owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
+
+		mfstModule, err := getManifestModule(v, projectRef, token, module)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing git url '%s'", module.Repo)
+			return nil, errors.Wrapf(err, "module '%s'", module.Name)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		modules[module.Name] = mfstModule
+	}
+	newManifest.Modules = modules
+	return newManifest, nil
+}
+
+func getManifestModule(v *Version, projectRef *ProjectRef, token string, module Module) (*manifest.Module, error) {
+	owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing git url '%s'", module.Repo)
+	}
+
+	if module.Ref == "" {
+		ghCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 
-		if module.Ref == "" {
-			var commit *github.RepositoryCommit
-			commit, err = thirdparty.GetCommitEvent(ctx, token, projectRef.Owner, projectRef.Repo, v.Revision)
-			if err != nil {
-				return nil, errors.Wrapf(err, "can't get commit '%s' on '%s/%s'", v.Revision, projectRef.Owner, projectRef.Repo)
-			}
-			if commit == nil || commit.Commit == nil || commit.Commit.Committer == nil {
-				return nil, errors.New("malformed GitHub commit response")
-			}
-			// If this is a mainline commit, retrieve the module's commit from the time of the mainline commit.
-			// Otherwise, retrieve the module's commit from the time of the patch creation.
-			revisionTime := time.Unix(0, 0)
-			if !evergreen.IsPatchRequester(v.Requester) {
-				revisionTime = commit.Commit.Committer.GetDate().Time
-			}
-			var branchCommits []*github.RepositoryCommit
-			branchCommits, _, err = thirdparty.GetGithubCommits(ctx, token, owner, repo, module.Branch, revisionTime, 0)
-			if err != nil {
-				return nil, errors.Wrapf(err, "retrieving git branch for module '%s'", module.Name)
-			}
-			if len(branchCommits) > 0 {
-				sha = branchCommits[0].GetSHA()
-				url = branchCommits[0].GetURL()
-			}
-		} else {
-			sha = module.Ref
-			gitCommit, err = thirdparty.GetCommitEvent(ctx, token, owner, repo, module.Ref)
-			if err != nil {
-				return nil, errors.Wrapf(err, "retrieving getting git commit for module %s with hash %s", module.Name, module.Ref)
-			}
-			url = gitCommit.GetURL()
+		commit, err := thirdparty.GetCommitEvent(ghCtx, token, projectRef.Owner, projectRef.Repo, v.Revision)
+		if err != nil {
+			return nil, errors.Wrapf(err, "can't get commit '%s' on '%s/%s'", v.Revision, projectRef.Owner, projectRef.Repo)
+		}
+		if commit == nil || commit.Commit == nil || commit.Commit.Committer == nil {
+			return nil, errors.New("malformed GitHub commit response")
+		}
+		// If this is a mainline commit, retrieve the module's commit from the time of the mainline commit.
+		// Otherwise, retrieve the module's commit from the time of the patch creation.
+		revisionTime := time.Unix(0, 0)
+		if !evergreen.IsPatchRequester(v.Requester) {
+			revisionTime = commit.Commit.Committer.GetDate().Time
 		}
 
-		modules[module.Name] = &manifest.Module{
+		branchCommits, _, err := thirdparty.GetGithubCommits(ghCtx, token, owner, repo, module.Branch, revisionTime, 0)
+		if err != nil {
+			return nil, errors.Wrapf(err, "retrieving git branch for module '%s'", module.Name)
+		}
+		var sha, url string
+		if len(branchCommits) > 0 {
+			sha = branchCommits[0].GetSHA()
+			url = branchCommits[0].GetURL()
+		}
+
+		return &manifest.Module{
 			Branch:   module.Branch,
 			Revision: sha,
 			Repo:     repo,
 			Owner:    owner,
 			URL:      url,
-		}
-
+		}, nil
 	}
-	newManifest.Modules = modules
-	return newManifest, nil
+
+	ghCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	sha := module.Ref
+	gitCommit, err := thirdparty.GetCommitEvent(ghCtx, token, owner, repo, module.Ref)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving getting git commit for module '%s' with hash '%s'", module.Name, module.Ref)
+	}
+	url := gitCommit.GetURL()
+
+	return &manifest.Module{
+		Branch:   module.Branch,
+		Revision: sha,
+		Repo:     repo,
+		Owner:    owner,
+		URL:      url,
+	}, nil
 }
 
 // CreateManifest inserts a newly constructed manifest into the DB.


### PR DESCRIPTION
EVG-21033

### Description
A user noticed that they were unable to schedule a patch because it was timing out getting the commit. I also noticed that this same timeout has been hit before in the past, so it's just not this patch affected by the timeout. Bumped it higher and made the timeout per-module to see if it'll resolve the patch scheduling problem.

* Increase timeout for getting commits for modules.
* Move existing logic to helper function for cleanliness + to avoid defer cancelling in a for loop.

### Testing
Existing tests pass. The timeout increase didn't seem significant enough a change to explicitly test.

### Documentation
N/A