### PR TITLE
EVG-20892 Set users setting for spruce UI when clearing them

### DIFF
--- a/model/user/db.go
+++ b/model/user/db.go
@@ -488,7 +488,7 @@ func ClearLoginCache(user gimlet.User) error {
 
 // ClearUser clears one user's settings, roles, and login cache.
 func ClearUser(userId string) error {
-	update := bson.M{
+	unsetUpdate := bson.M{
 		"$unset": bson.M{
 			SettingsKey: bson.M{
 				userSettingsGithubUserKey:    1,
@@ -498,19 +498,21 @@ func ClearUser(userId string) error {
 			RolesKey:      1,
 			LoginCacheKey: 1,
 		},
+	}
+	query := bson.M{IdKey: userId}
+	if err := UpdateOne(query, unsetUpdate); err != nil {
+		return errors.Wrap(err, "unsetting user settings")
+	}
+	setUpdate := bson.M{
 		"$set": bson.M{
 			SettingsKey: bson.M{
 				UseSpruceOptionsKey: bson.M{
 					SpruceV1Key: 1,
 				},
 			},
-		}}
-	query := bson.M{IdKey: userId}
-	if err := UpdateOne(query, update); err != nil {
-		return errors.Wrap(err, "unsetting user settings")
+		},
 	}
-
-	return nil
+	return errors.Wrap(UpdateOne(query, setUpdate), "unsetting user settings")
 }
 
 // ClearAllLoginCaches clears all users' login caches, forcibly logging them

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -487,6 +487,9 @@ func ClearLoginCache(user gimlet.User) error {
 }
 
 // ClearUser clears one user's settings, roles, and login cache.
+// ClearUser clears the users sensitive settings (GitHub and Slack credentials),
+// roles, and invalidates their login cache. It sets their settings to use Spruce,
+// or else if this user ever becomes active, they will revert to the old UI.
 func ClearUser(userId string) error {
 	unsetUpdate := bson.M{
 		"$unset": bson.M{

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -504,7 +504,7 @@ func ClearUser(userId string) error {
 		"$set": bson.M{
 			SettingsKey: bson.M{
 				UseSpruceOptionsKey: bson.M{
-					SpruceV1Key: "true",
+					SpruceV1Key: true,
 				},
 			},
 		},

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -490,9 +490,20 @@ func ClearLoginCache(user gimlet.User) error {
 func ClearUser(userId string) error {
 	update := bson.M{
 		"$unset": bson.M{
-			SettingsKey:   1,
+			SettingsKey: bson.M{
+				userSettingsGithubUserKey:    1,
+				userSettingsSlackUsernameKey: 1,
+				userSettingsSlackMemberIdKey: 1,
+			},
 			RolesKey:      1,
 			LoginCacheKey: 1,
+		},
+		"$set": bson.M{
+			SettingsKey: bson.M{
+				UseSpruceOptionsKey: bson.M{
+					SpruceV1Key: 1,
+				},
+			},
 		}}
 	query := bson.M{IdKey: userId}
 	if err := UpdateOne(query, update); err != nil {

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -509,7 +509,7 @@ func ClearUser(userId string) error {
 			},
 		},
 	}
-	return errors.Wrap(UpdateOne(query, setUpdate), "unsetting user settings")
+	return errors.Wrap(UpdateOne(query, setUpdate), "defaulting spruce setting")
 }
 
 // ClearAllLoginCaches clears all users' login caches, forcibly logging them

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -486,18 +486,12 @@ func ClearLoginCache(user gimlet.User) error {
 	return nil
 }
 
-// ClearUser clears one user's settings, roles, and login cache.
-// ClearUser clears the users sensitive settings (GitHub and Slack credentials),
-// roles, and invalidates their login cache. It sets their settings to use Spruce,
-// or else if this user ever becomes active, they will revert to the old UI.
+// ClearUser clears the users settings, roles and invalidates their login cache.
+// It also sets their settings to use Spruce so rehires have Spruce enabled by default.
 func ClearUser(userId string) error {
 	unsetUpdate := bson.M{
 		"$unset": bson.M{
-			SettingsKey: bson.M{
-				userSettingsGithubUserKey:    1,
-				userSettingsSlackUsernameKey: 1,
-				userSettingsSlackMemberIdKey: 1,
-			},
+			SettingsKey:   1,
 			RolesKey:      1,
 			LoginCacheKey: 1,
 		},
@@ -510,7 +504,7 @@ func ClearUser(userId string) error {
 		"$set": bson.M{
 			SettingsKey: bson.M{
 				UseSpruceOptionsKey: bson.M{
-					SpruceV1Key: 1,
+					SpruceV1Key: "true",
 				},
 			},
 		},

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -48,6 +48,9 @@ func (s *UserTestSuite) SetupTest() {
 					UID:         1234,
 					LastKnownAs: "octocat",
 				},
+				UseSpruceOptions: UseSpruceOptions{
+					SpruceV1: true,
+				},
 			},
 			LoginCache: LoginCache{
 				AccessToken:  "access_token",
@@ -809,7 +812,7 @@ func TestViewableProjectSettings(t *testing.T) {
 }
 
 func (s *UserTestSuite) TestClearUser() {
-	// Error on non-existent user
+	// Error on non-existent user.
 	s.Error(ClearUser("asdf"))
 
 	u, err := FindOneById(s.users[0].Id)
@@ -817,17 +820,32 @@ func (s *UserTestSuite) TestClearUser() {
 	s.NotNil(u)
 	s.NotEmpty(u.Settings)
 	s.Equal("Test1", u.Id)
+	s.Equal(true, u.Settings.UseSpruceOptions.SpruceV1)
 	s.NoError(u.AddRole("r1p1"))
 	s.NotEmpty(u.SystemRoles)
 
 	s.NoError(ClearUser(u.Id))
 
-	// Settings and roles should now be empty
+	// Sensitive settings and roles should now be empty.
 	u, err = FindOneById(s.users[0].Id)
 	s.NoError(err)
 	s.NotNil(u)
 
-	s.Empty(u.Settings)
+	s.Empty(u.Settings.GithubUser)
+	s.Empty(u.Settings.SlackUsername)
+	s.Empty(u.Settings.SlackMemberId)
 	s.Empty(u.Roles())
 	s.Empty(u.LoginCache)
+
+	// User should have spruce UI enabled.
+	s.True(u.Settings.UseSpruceOptions.SpruceV1)
+
+	// Should enable for user that previously had it false
+	u, err = FindOneById(s.users[1].Id)
+	s.NoError(err)
+	s.NotNil(u)
+	s.False(u.Settings.UseSpruceOptions.SpruceV1)
+	s.NoError(ClearUser(u.Id))
+	u, err = FindOneById(s.users[1].Id)
+	s.True(u.Settings.UseSpruceOptions.SpruceV1)
 }

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -847,5 +847,6 @@ func (s *UserTestSuite) TestClearUser() {
 	s.False(u.Settings.UseSpruceOptions.SpruceV1)
 	s.NoError(ClearUser(u.Id))
 	u, err = FindOneById(s.users[1].Id)
+	s.NoError(err)
 	s.True(u.Settings.UseSpruceOptions.SpruceV1)
 }


### PR DESCRIPTION
EVG-20892

### Description
Recent returning interns have had their settings wiped when offboarded which caused them to use the old ui when they returned. This prevents that issue in the future by setting the spruce UI setting when offboarding a user.

### Testing
Unit tests