### PR TITLE
EVG-20853 Enable runtime expansions to determine a version's manifest

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -268,9 +268,14 @@ func moduleRevExpansionName(name string) string { return fmt.Sprintf("%s_rev", n
 func (c *gitFetchProject) manifestLoad(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
+	modules := conf.Project.Modules
+	for i := range modules {
+		if err := util.ExpandValues(&modules[i], &conf.Expansions); err != nil {
+			return errors.Wrap(err, "applying expansions")
+		}
+	}
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-
-	manifest, err := comm.GetManifest(ctx, td)
+	manifest, err := comm.GetManifest(ctx, td, modules)
 	if err != nil {
 		return errors.Wrapf(err, "loading manifest for task '%s'", td.ID)
 	}

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -805,13 +805,13 @@ func (c *baseCommunicator) SetDownstreamParams(ctx context.Context, downstreamPa
 	return nil
 }
 
-func (c *baseCommunicator) GetManifest(ctx context.Context, taskData TaskData) (*manifest.Manifest, error) {
+func (c *baseCommunicator) GetManifest(ctx context.Context, taskData TaskData, modules model.ModuleList) (*manifest.Manifest, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
 	}
 	info.setTaskPathSuffix("manifest/load")
-	resp, err := c.retryRequest(ctx, info, nil)
+	resp, err := c.retryRequest(ctx, info, modules)
 	if err != nil {
 		return nil, util.RespErrorf(resp, errors.Wrap(err, "loading manifest").Error())
 	}

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -98,7 +98,7 @@ type SharedCommunicator interface {
 	NewPush(context.Context, TaskData, *apimodels.S3CopyRequest) (*model.PushLog, error)
 	UpdatePushStatus(context.Context, TaskData, *model.PushLog) error
 	AttachFiles(context.Context, TaskData, []*artifact.File) error
-	GetManifest(context.Context, TaskData) (*manifest.Manifest, error)
+	GetManifest(context.Context, TaskData, model.ModuleList) (*manifest.Manifest, error)
 	KeyValInc(context.Context, TaskData, *model.KeyVal) error
 
 	// GenerateTasks posts new tasks for the `generate.tasks` command.

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -455,7 +455,7 @@ func (c *Mock) SendTestLog(ctx context.Context, td TaskData, log *serviceModel.T
 	return c.LogID, nil
 }
 
-func (c *Mock) GetManifest(ctx context.Context, td TaskData) (*manifest.Manifest, error) {
+func (c *Mock) GetManifest(ctx context.Context, td TaskData, modules serviceModel.ModuleList) (*manifest.Manifest, error) {
 	return &manifest.Manifest{}, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-02"
+	AgentVersion = "2023-10-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -568,7 +568,9 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 		AuthorEmail:         authorEmail,
 	}
 
-	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, settings, githubOauthToken)
+	// TODO: either do not error out here, or skip manifest construction for configs
+	// with expansions in their modules - bring up in PR discussion
+	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, githubOauthToken)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing manifest")
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -430,11 +430,11 @@ type ContainerSystem struct {
 }
 
 type Module struct {
-	Name       string `yaml:"name,omitempty" bson:"name"`
-	Branch     string `yaml:"branch,omitempty" bson:"branch"`
-	Repo       string `yaml:"repo,omitempty" bson:"repo"`
-	Prefix     string `yaml:"prefix,omitempty" bson:"prefix"`
-	Ref        string `yaml:"ref,omitempty" bson:"ref"`
+	Name       string `yaml:"name,omitempty" bson:"name" plugin:"expand"`
+	Branch     string `yaml:"branch,omitempty" bson:"branch" plugin:"expand"`
+	Repo       string `yaml:"repo,omitempty" bson:"repo" plugin:"expand"`
+	Prefix     string `yaml:"prefix,omitempty" bson:"prefix" plugin:"expand"`
+	Ref        string `yaml:"ref,omitempty" bson:"ref" plugin:"expand"`
 	AutoUpdate bool   `yaml:"auto_update,omitempty" bson:"auto_update"`
 }
 

--- a/model/version.go
+++ b/model/version.go
@@ -706,7 +706,7 @@ func GetVersionsToModify(projectName string, opts ModifyVersionsOptions, startTi
 }
 
 // constructManifest will construct a manifest from the given project and version.
-func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList, settings *evergreen.Settings, token string) (*manifest.Manifest, error) {
+func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList, token string) (*manifest.Manifest, error) {
 	if len(moduleList) == 0 {
 		return nil, nil
 	}
@@ -791,12 +791,12 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 }
 
 // CreateManifest inserts a newly constructed manifest into the DB.
-func CreateManifest(v *Version, proj *Project, projectRef *ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
+func CreateManifest(v *Version, modules ModuleList, projectRef *ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting GitHub token")
 	}
-	newManifest, err := constructManifest(v, projectRef, proj.Modules, settings, token)
+	newManifest, err := constructManifest(v, projectRef, modules, token)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing manifest")
 	}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -364,9 +364,9 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			}
 		}
 
-		_, err = model.CreateManifest(v, pInfo.Project, ref, repoTracker.Settings)
+		_, err = model.CreateManifest(v, pInfo.Project.Modules, ref, repoTracker.Settings)
 		if err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
+			grip.Warning(message.WrapError(err, message.Fields{
 				"message":            "error creating manifest",
 				"runner":             RunnerName,
 				"project":            ref.Id,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1173,7 +1173,7 @@ func TestCreateManifest(t *testing.T) {
 		Branch: "main",
 	}
 
-	manifest, err := model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err := model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1186,7 +1186,7 @@ func TestCreateManifest(t *testing.T) {
 	assert.Equal("b27779f856b211ffaf97cbc124b7082a20ea8bc0", module.Revision)
 
 	proj.Modules[0].AutoUpdate = true
-	manifest, err = model.CreateManifest(&patchVersion, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&patchVersion, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(patchVersion.Id, manifest.Id)
 	assert.Equal(patchVersion.Revision, manifest.Revision)
@@ -1212,7 +1212,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1237,7 +1237,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.Contains(err.Error(), "No commit found for SHA")
 }
 

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -72,7 +72,7 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 			return nil, errors.Wrapf(err, "parsing git url '%s'", module.Repo)
 		}
 		if owner == upstreamProject.Owner && repo == upstreamProject.Repo && module.Branch == upstreamProject.Branch {
-			_, err = model.CreateManifest(v, projectInfo.Project, upstreamProject, settings)
+			_, err = model.CreateManifest(v, projectInfo.Project.Modules, upstreamProject, settings)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}


### PR DESCRIPTION
EVG-20853

### Description
The request here essentially boils down to:
1. Dynamically retrieving and setting some expansions for a task in the `pre` block
2. Using those fetched expansions for the `branch` field in for the task's modules

Currently however, manifest documents representing which branch / commit of the modules to use are created upon creation of the [mainline commit version](https://gist.github.com/hadjri/884ae233018cf56cb7f00cc83af1a313#file-repotracker-go-L367-L376) or [patch](https://github.com/evergreen-ci/evergreen/blob/main/model/patch_lifecycle.go#L571-L574), and not during task runtime.

Therefore the proposed solution here is to directly send over a list of modules as part of the `manifest/load` agent route which, if expansions are set for the modules, will be a correctly expanded representation of the modules list. This is because the manifest load handler in the agent already is set up to [create a manifest if none exists](https://gist.github.com/hadjri/b26130b99a691a7ff75b45fa0b933476#file-agent-go-L1294-L1300)

The tradeoff here is that, if a user wants to do this it would mean that their manifest cannot be created upon patch creation, and will have to wait until the first task for a patch runs. Currently if manifest construction fails for a patch, the patch creation will error out. Because of this I wanted to raise here as an [open ended question](https://github.com/evergreen-ci/evergreen/pull/7117/files#diff-db2ef846d75486c0e998561c1e2b98dbf5536368af5c37b0c17b76938b09bf50R571-R573) whether it'd be best to change patch finalization to no longer depend on a successful manifest creation, or to somehow skip the manifest creation for patches that have expansions set for their modules.

### Testing
[Sample manifest](blob:https://spruce-staging.corp.mongodb.com/1865d5d8-0516-432c-b526-04a1501fa950) that was created for the sandbox repotracker version from this [commit](https://github.com/evergreen-ci/commit-queue-sandbox/commit/d9322c0388be7ef49243bf48a2f02efd37f45df1) that added expansions to the modules

### Documentation
Will update docs on expansions for modules if approval is granted.
