### PR TITLE
EVG-20987 Add push trigger sha to version doc

### DIFF
--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -429,6 +429,11 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *restModel.AP
 			Revision: upstreamBuild.Revision,
 			Version:  &apiVersion,
 		}
+	} else if v.TriggerType == model.ProjectTriggerLevelPush {
+		projectID = v.TriggerID
+		upstreamProject = &UpstreamProject{
+			Revision: v.TriggerSHA,
+		}
 	}
 	upstreamProjectRef, err := model.FindBranchProjectRef(projectID)
 	if err != nil {

--- a/model/version.go
+++ b/model/version.go
@@ -79,10 +79,14 @@ type Version struct {
 
 	SatisfiedTriggers []string `bson:"satisfied_triggers,omitempty" json:"satisfied_triggers,omitempty"`
 	// Fields set if triggered by an upstream build
+	// TriggerID is the ID of the entity that triggered the downstream version. Depending on the trigger type, this
+	// could be a build ID, a task ID, or a project ID, for build, task, and push triggers respectively.
 	TriggerID    string `bson:"trigger_id,omitempty" json:"trigger_id,omitempty"`
 	TriggerType  string `bson:"trigger_type,omitempty" json:"trigger_type,omitempty"`
 	TriggerEvent string `bson:"trigger_event,omitempty" json:"trigger_event,omitempty"`
-	TriggerSHA   string `bson:"trigger_sha,omitempty" json:"trigger_sha,omitempty"`
+	// TriggerSHA is the SHA of the untracked commit that triggered the downstream version,
+	// this field is only populated for push level triggers.
+	TriggerSHA string `bson:"trigger_sha,omitempty" json:"trigger_sha,omitempty"`
 
 	// this is only used for aggregations, and is not stored in the DB
 	Builds []build.Build `bson:"build_variants,omitempty" json:"build_variants,omitempty"`

--- a/model/version.go
+++ b/model/version.go
@@ -82,6 +82,7 @@ type Version struct {
 	TriggerID    string `bson:"trigger_id,omitempty" json:"trigger_id,omitempty"`
 	TriggerType  string `bson:"trigger_type,omitempty" json:"trigger_type,omitempty"`
 	TriggerEvent string `bson:"trigger_event,omitempty" json:"trigger_event,omitempty"`
+	TriggerSHA   string `bson:"trigger_sha,omitempty" json:"trigger_sha,omitempty"`
 
 	// this is only used for aggregations, and is not stored in the DB
 	Builds []build.Build `bson:"build_variants,omitempty" json:"build_variants,omitempty"`

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -723,7 +723,11 @@ func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metada
 		Activated:            utility.ToBoolPtr(metadata.Activate),
 	}
 	if metadata.TriggerType != "" {
-		revision := metadata.SourceCommit
+		var revision string
+		if metadata.TriggerType == model.ProjectTriggerLevelPush {
+			revision = metadata.SourceCommit
+			v.TriggerSHA = revision
+		}
 		createTime := metadata.Revision.CreateTime
 		if metadata.SourceVersion != nil {
 			revision = metadata.SourceVersion.Revision

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -97,7 +97,6 @@ type ProcessorArgs struct {
 	EventID                      string
 	DefinitionID                 string
 	Alias                        string
-	ProjectID                    string
 	UnscheduleDownstreamVersions bool
 	PushRevision                 model.Revision
 }
@@ -314,9 +313,9 @@ func TriggerDownstreamProjectsForPush(ctx context.Context, projectId string, eve
 				DownstreamProject:            ref,
 				ConfigFile:                   trigger.ConfigFile,
 				TriggerType:                  model.ProjectTriggerLevelPush,
+				TriggerID:                    trigger.Project,
 				DefinitionID:                 trigger.DefinitionID,
 				Alias:                        trigger.Alias,
-				ProjectID:                    trigger.Project,
 				UnscheduleDownstreamVersions: trigger.UnscheduleDownstreamVersions,
 				PushRevision: model.Revision{
 					Revision:        utility.FromStringPtr(event.GetHeadCommit().SHA),

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -318,7 +318,7 @@ func TriggerDownstreamProjectsForPush(ctx context.Context, projectId string, eve
 				Alias:                        trigger.Alias,
 				UnscheduleDownstreamVersions: trigger.UnscheduleDownstreamVersions,
 				PushRevision: model.Revision{
-					Revision:        utility.FromStringPtr(event.GetHeadCommit().SHA),
+					Revision:        utility.FromStringPtr(event.GetHeadCommit().ID),
 					CreateTime:      event.GetHeadCommit().Timestamp.Time,
 					Author:          utility.FromStringPtr(event.GetHeadCommit().Author.Name),
 					AuthorEmail:     utility.FromStringPtr(event.GetHeadCommit().Author.Email),

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -575,7 +575,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 
 	pushEvent := &github.PushEvent{
 		HeadCommit: &github.HeadCommit{
-			SHA:     utility.ToStringPtr("abc"),
+			ID:      utility.ToStringPtr("abc"),
 			Message: utility.ToStringPtr("message"),
 			Author: &github.CommitAuthor{
 				Email: utility.ToStringPtr("hello@example.com"),
@@ -596,6 +596,8 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	assert.Equal(downstreamProjectRef.Id, dbVersions[0].Identifier)
 	assert.Equal(evergreen.TriggerRequester, dbVersions[0].Requester)
 	assert.Equal(model.ProjectTriggerLevelPush, dbVersions[0].TriggerType)
+	assert.Equal("abc", dbVersions[0].TriggerSHA)
+	assert.Equal("upstream", dbVersions[0].TriggerID)
 
 	builds, err := build.Find(build.ByVersion(dbVersions[0].Id))
 	assert.NoError(err)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -54,8 +54,7 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 	// Since push triggers have no source version (unlike build and task level triggers), we need to
 	// extract the project ID from the trigger definition's project ID, which is populated in the TriggerID field
 	// for push triggers.
-	var versionID string
-	var projectID string
+	var versionID, projectID string
 	if args.TriggerType == model.ProjectTriggerLevelPush {
 		projectID = args.TriggerID
 	} else {

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -51,11 +51,14 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 	if err != nil {
 		return nil, errors.Wrap(err, "getting Evergreen settings")
 	}
-	var versionID string
 	// Since push triggers have no source version (unlike build and task level triggers), we need to
 	// extract the project ID from the trigger definition's project ID, which is populated in the ProjectID field.
-	projectID := args.ProjectID
-	if projectID == "" {
+	// UPDATE
+	var versionID string
+	var projectID string
+	if args.TriggerType == model.ProjectTriggerLevelPush {
+		projectID = args.TriggerID
+	} else {
 		projectID = args.SourceVersion.Identifier
 		versionID = args.SourceVersion.Id
 	}

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -52,8 +52,8 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 		return nil, errors.Wrap(err, "getting Evergreen settings")
 	}
 	// Since push triggers have no source version (unlike build and task level triggers), we need to
-	// extract the project ID from the trigger definition's project ID, which is populated in the ProjectID field.
-	// UPDATE
+	// extract the project ID from the trigger definition's project ID, which is populated in the TriggerID field
+	// for push triggers.
 	var versionID string
 	var projectID string
 	if args.TriggerType == model.ProjectTriggerLevelPush {


### PR DESCRIPTION
EVG-20987

### Description
This PR is a required precursor to [this Spruce PR](https://github.com/evergreen-ci/spruce/pull/2098). 

Spruce's construction of links pointing to upstream triggers is dependent on the [UpstreamProject](https://gist.github.com/hadjri/a00d402d3f674bf0301cfe0752b71a48#file-version_resolver-go-L374) resolver, which requires both `TriggerType` and `TriggerID` to be populated for the downstream version. For downstream versions triggered by builds / tasks, this TriggerID is set to the upstream task ID or upstream version ID respectively, but for push level triggers there is no Spruce page that can be associated with a github commit so prior to this change `TriggerID` was empty.

I've made a change to assign the upstream project ID as the `TriggerID` when creating versions from push triggers, and also added a new `TriggerSHA` field for the version, which will be set when it is a downstream version triggered from a push, to allow Spruce to later construct an external GitHub link to the commit push that started the trigger. 
### Testing
Confirmed that the `UpstreamProject` resolver used to populate links from triggered versions to the source of their trigger is now populated for push trigger versions, where it was previously returned as null (see screenshots)

Before change (id: `sandbox_d631380317a8478b879cc27d6171508dea2b11df_c6db985b8c9ffb231c10085b09efa348`):
<img width="391" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/19805673/a9712403-e2fd-4b23-b030-e7b589b37feb">


After change (id: `sandbox_2ab3e8f46ad29e30432bbe30c4da723d879c3044_c6db985b8c9ffb231c10085b09efa348`): 
<img width="676" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/19805673/92294e15-f0c1-491d-b6d7-a2cc5ed0f406">
