### PR TITLE
docs: clarify slack notification recipient formatting

### DIFF
--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1651,11 +1651,11 @@ Create custom notifications for email or Slack issues.
 
 **Slack**
 
-| Name          | Type                | Description                                      |
-|--------------------|---------|--------------------------------------------------|
-| `target`      | string              | Required. @<name> or #<channel> of the recipient |
-| `msg`         | string              | Required. The message for the notification.      |
-| `attachments` | []SlackAttachment | Optional. Array of attachments to a message.     |
+| Name          | Type                | Description                                  |
+|--------------------|---------|----------------------------------------------|
+| `target`      | string              | Required. @name or #channel of the recipient |
+| `msg`         | string              | Required. The message for the notification.  |
+| `attachments` | []SlackAttachment | Optional. Array of attachments to a message. |
 
 
 **SlackAttachment**

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1631,9 +1631,11 @@ Project is mongodb-mongo-master, task is lint. Assuming today is
     GET /projects/mongodb-mongo-master/task_reliability?tasks=lint&after_date=2019-03-15&group_num_days=7
     GET /projects/mongodb-mongo-master/task_reliability?tasks=lint&after_date=2019-03-15&group_num_days=28
 
-### Notifications
+### Notifications  (DEPRECATED)
 
-Create custom notifications for email or Slack issues.
+Create custom notifications for email or Slack issues. 
+
+We are investigating moving this out of Evergreen (EVG-21065) and won't be supporting future work for this. 
 
 #### Objects
 

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1653,11 +1653,11 @@ We are investigating moving this out of Evergreen (EVG-21065) and won't be suppo
 
 **Slack**
 
-| Name          | Type                | Description                                  |
-|--------------------|---------|----------------------------------------------|
-| `target`      | string              | Required. @name or #channel of the recipient |
-| `msg`         | string              | Required. The message for the notification.  |
-| `attachments` | []SlackAttachment | Optional. Array of attachments to a message. |
+| Name          | Type                | Description                                         |
+|--------------------|---------|-----------------------------------------------------|
+| `target`      | string              | Required. @name or public #channel of the recipient |
+| `msg`         | string              | Required. The message for the notification.         |
+| `attachments` | []SlackAttachment | Optional. Array of attachments to a message.        |
 
 
 **SlackAttachment**

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1652,11 +1652,11 @@ issues.
 
 **Slack**
 
-| Name          | Type                | Description                                  |
-|--------------------|---------|-------------------------------------------|
-| `target`      | string              | Required. The name of the recipient.         |
-| `msg`         | string              | Required. The message for the notification.  |
-| `attachments` | []SlackAttachment | Optional. Array of attachments to a message. |
+| Name          | Type                | Description                                      |
+|--------------------|---------|--------------------------------------------------|
+| `target`      | string              | Required. @<name> or #<channel> of the recipient |
+| `msg`         | string              | Required. The message for the notification.      |
+| `attachments` | []SlackAttachment | Optional. Array of attachments to a message.     |
 
 
 **SlackAttachment**

--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1633,8 +1633,7 @@ Project is mongodb-mongo-master, task is lint. Assuming today is
 
 ### Notifications
 
-Create custom notifications for email or Slack.
-issues.
+Create custom notifications for email or Slack issues.
 
 #### Objects
 


### PR DESCRIPTION
From slack thread, this should be clearer. Also ticketed doing something about this route.

To view file: https://github.com/evergreen-ci/evergreen/blob/2cfd38efa32c83ffbb79333d41e18382d3412d17/docs/API/REST-V2-Usage.md#notifications