### PR TITLE
EVG-21066 catch error finding distro

### DIFF
--- a/model/distro/aliases.go
+++ b/model/distro/aliases.go
@@ -16,6 +16,9 @@ func FindApplicableDistroIDs(ctx context.Context, id string) ([]string, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if d == nil {
+		return nil, errors.Errorf("error finding distro '%s'", id)
+	}
 
 	out := []string{id}
 	out = append(out, d.Aliases...)


### PR DESCRIPTION
EVG-21066
### Description
From the ops-alerts channel, we panicked appending the distro aliases. Seems like this could happen if a distro was deleted?