### PR TITLE
EVG-19725: add more logging for IsGroup and GitHub checks alias

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1465,12 +1465,16 @@ func (p *Project) findBuildVariantsWithTag(tags []string) []string {
 // GetTaskNameAndTags checks the project for a task or task group matching the
 // build variant task unit, and returns the name and tags
 func (p *Project) GetTaskNameAndTags(bvt BuildVariantTaskUnit) (string, []string, bool) {
-	if bvt.IsGroup {
+	if bvt.IsGroup || bvt.IsPartOfGroup {
 		grip.InfoWhen(bvt.IsPartOfGroup, message.Fields{
-			"message": "task unit IsGroup is referring to task within a task group",
-			"ticket":  "EVG-19725",
-			"stack":   string(debug.Stack()),
+			"message":            "task unit IsGroup is referring to task within a task group",
+			"ticket":             "EVG-19725",
+			"project_identifier": p.Identifier,
+			"task_name":          bvt.Name,
+			"task_group_name":    bvt.GroupName,
+			"stack":              string(debug.Stack()),
 		})
+
 		ptg := bvt.TaskGroup
 		if ptg == nil {
 			ptg = p.FindTaskGroup(bvt.Name)


### PR DESCRIPTION
EVG-19725

### Description
[Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20EVG-19725&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1696996800&latest=1697083200&display.events.timelineEarliestTime=1697054400&display.events.timelineLatestTime=1697058000&sid=1697057289.828061) shows there's [a single case](https://github.com/evergreen-ci/evergreen/blob/4f0849f6a717202b7fc5ba8de25b81422a175e3f/model/lifecycle.go#L1154) where `IsGroup` is being used incorrectly. `buildVarTask` is a task within a task group, but `GetTaskNameAndTags` only handles task groups, not tasks within task groups. I filed EVG-21068 for that issue, and added a bit more logging to ensure that my understanding of the bug is correct.

Once I have more confirmation that this is the only incorrect usage of `IsGroup`, I'll complete the follow-up described in #7125.

### Testing
Seems like the bug in EVG-21068 is the current behavior, and this only preserves the current bug behavior, so I didn't think it was worth testing a bug.

### Documentation
N/A