### PR TITLE
EVG-21075 Remove recommendation to redirect ssh stderr to /dev/null when checking outcome of host.list

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -585,7 +585,7 @@ functions:
           -o IdentitiesOnly=yes \
           -o StrictHostKeyChecking=no \
           "$(printf "%s@%s" "$user" "$hostname")" \
-          exit 2> /dev/null
+          exit
         do
           [ "$attempts" -ge "$connection_attempts" ] && exit 1
           ((attempts++))


### PR DESCRIPTION
EVG-21075

### Description
This would prevent task authors from seeing the underlying issue or bug in their usage of the script.

### Testing
docs only

### Documentation
docs only
