### PR TITLE
EVG-19725: do not set IsGroup for a task in a task group

### DIFF
--- a/model/dependency.go
+++ b/model/dependency.go
@@ -1,10 +1,7 @@
 package model
 
 import (
-	"runtime/debug"
-
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -210,11 +207,6 @@ func (di *dependencyIncluder) expandDependencies(pair TVPair, depends []TaskUnit
 					}
 
 					if t.IsGroup {
-						grip.InfoWhen(t.IsPartOfGroup, message.Fields{
-							"message": "task unit IsGroup is referring to task within a task group",
-							"ticket":  "EVG-19725",
-							"stack":   string(debug.Stack()),
-						})
 						if !di.dependencyMatchesTaskGroupTask(pair, t, d) {
 							continue
 						}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2490,8 +2490,7 @@ func TestCreateTasksFromGroup(t *testing.T) {
 	for _, bvtu := range bvts {
 		require.Len(t, bvtu.DependsOn, 1)
 		assert.Equal("new_dependency", bvtu.DependsOn[0].Name)
-		// TODO (EVG-19725): remove IsGroup
-		assert.True(bvtu.IsGroup)
+		assert.False(bvtu.IsGroup)
 		assert.True(bvtu.IsPartOfGroup)
 		assert.Equal(tgName, bvtu.GroupName)
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -93,18 +93,23 @@ type BuildVariantTaskUnit struct {
 	// the project level, or an error will be thrown
 	Name string `yaml:"name,omitempty" bson:"name"`
 	// IsGroup indicates that it is a task group. This is always populated for
-	// task groups after translating the parser project to the project.
+	// task groups after project translation.
 	IsGroup bool `yaml:"-" bson:"-"`
 	// IsPartOfGroup indicates that this unit is a task within a task group. If
-	// this is set, then GroupName is also set. Note that project translation
-	// does not expand task groups into their individual tasks, so this is only
-	// set for special functions that explicitly expand task groups into
-	// individual task units (such as FindAllBuildVariantTasks).
+	// this is set, then GroupName is also set.
+	// Note that project translation does not expand task groups into their
+	// individual tasks, so this is only set for special functions that
+	// explicitly expand task groups into individual task units (such as
+	// FindAllBuildVariantTasks).
 	IsPartOfGroup bool `yaml:"-" bson:"-"`
 	// GroupName is the task group name if this is a task in a task group. This
 	// is only set if the task unit is a task within a task group (i.e.
 	// IsPartOfGroup is set). If the task unit is the task group itself, it is
 	// not populated (Name is the task group name).
+	// Note that project translation does not expand task groups into their
+	// individual tasks, so this is only set for special functions that
+	// explicitly expand task groups into individual task units (such as
+	// FindAllBuildVariantTasks).
 	GroupName string `yaml:"-" bson:"-"`
 	// Variant is the build variant that the task unit is part of. This is
 	// always populated after translating the parser project to the project.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1275,9 +1275,12 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 	return bvs, evalErrs
 }
 
-// evaluateBVTasks translates intermediate tasks into true BuildVariantTaskUnit types,
-// evaluating any selectors referencing tasks, and further evaluating any selectors
-// in the DependsOn field of those tasks.
+// evaluateBVTasks translates intermediate tasks listed under build variants
+// into true BuildVariantTaskUnit types, evaluating any selectors referencing
+// tasks, and further evaluating any selectors in the DependsOn field of those
+// tasks.
+// For task units that represent task groups, the resulting BuildVariantTaskUnit
+// represents the task group itself, not the individual tasks in the task group.
 func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
 	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []error) {
 	var evalErrs, errs []error

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2464,8 +2464,7 @@ func TestFindAllBuildVariantTasks(t *testing.T) {
 		for i, bvtu := range bvts {
 			assert.Equal(t, tasks[i].Name, bvtu.Name)
 			assert.Equal(t, bvName, bvtu.Variant)
-			// TODO (EVG-19725): remove IsGroup
-			assert.True(t, bvtu.IsGroup)
+			assert.False(t, bvtu.IsGroup)
 			assert.True(t, bvtu.IsPartOfGroup)
 			assert.Equal(t, tgName, bvtu.GroupName)
 		}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -559,11 +557,6 @@ func getAliasCoverage(p *model.Project, aliasMap map[string]model.ProjectAlias) 
 				}
 				if name != "" {
 					if t.IsGroup {
-						grip.InfoWhen(t.IsPartOfGroup, message.Fields{
-							"message": "task unit IsGroup is referring to task within a task group",
-							"ticket":  "EVG-19725",
-							"stack":   string(debug.Stack()),
-						})
 						matchesTaskGroupTask, err := aliasMatchesTaskGroupTask(p, alias, name)
 						if err != nil {
 							return nil, nil, err
@@ -708,11 +701,6 @@ func validateBVFields(project *model.Project) ValidationErrors {
 				break
 			}
 			if task.IsGroup {
-				grip.InfoWhen(task.IsPartOfGroup, message.Fields{
-					"message": "task unit IsGroup is referring to task within a task group",
-					"ticket":  "EVG-19725",
-					"stack":   string(debug.Stack()),
-				})
 				for _, t := range project.FindTaskGroup(task.Name).Tasks {
 					pt := project.FindProjectTask(t)
 					if pt != nil {
@@ -1713,11 +1701,6 @@ func validateDuplicateBVTasks(p *model.Project) ValidationErrors {
 		for _, t := range bv.Tasks {
 
 			if t.IsGroup {
-				grip.InfoWhen(t.IsPartOfGroup, message.Fields{
-					"message": "task unit IsGroup is referring to task within a task group",
-					"ticket":  "EVG-19725",
-					"stack":   string(debug.Stack()),
-				})
 				tg := t.TaskGroup
 				if tg == nil {
 					tg = p.FindTaskGroup(t.Name)
@@ -1950,11 +1933,6 @@ func bvsWithTasksThatCallCommand(p *model.Project, cmd string) (map[string]map[s
 
 		for _, bvtu := range bv.Tasks {
 			if bvtu.IsGroup {
-				grip.InfoWhen(bvtu.IsPartOfGroup, message.Fields{
-					"message": "task unit IsGroup is referring to task within a task group",
-					"ticket":  "EVG-19725",
-					"stack":   string(debug.Stack()),
-				})
 				tg := bvtu.TaskGroup
 				if tg == nil {
 					tg = p.FindTaskGroup(bvtu.Name)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4169,10 +4169,8 @@ func TestTVToTaskUnit(t *testing.T) {
 					Priority:        20,
 					ExecTimeoutSecs: 20,
 				}, {TaskName: "compile", Variant: "ubuntu"}: {
-					Name:    "compile",
-					Variant: "ubuntu",
-					// TODO (EVG-19725): remove IsGroup
-					IsGroup:          true,
+					Name:             "compile",
+					Variant:          "ubuntu",
 					IsPartOfGroup:    true,
 					GroupName:        "compile_group",
 					ExecTimeoutSecs:  10,
@@ -4184,10 +4182,8 @@ func TestTVToTaskUnit(t *testing.T) {
 						},
 					},
 				}, {TaskName: "compile", Variant: "suse"}: {
-					Name:    "compile",
-					Variant: "suse",
-					// TODO (EVG-19725): remove IsGroup
-					IsGroup:         true,
+					Name:            "compile",
+					Variant:         "suse",
 					IsPartOfGroup:   true,
 					GroupName:       "compile_group",
 					ExecTimeoutSecs: 10,


### PR DESCRIPTION
EVG-19725

### Description
Follow-up from #7133 and #7125 to complete the transition away from `IsGroup`'s double meaning by splitting into `IsGroup` and `IsPartOfGroup`.

* Only set `IsGroup` if it's representing a task group. Use `IsPartOfGroup` when checking a task in a task group.
* Remove temporary logs.
* Update doc comments to clarify when a task unit can represent a task group vs. a task in a task group.

### Testing
* Monitored prod for usages, they all seemed to align with my understanding.
* Updated tests.

### Documentation
N/A