### PR TITLE
EVG-20984 Update to latest utility package and replace some tests with utility function

### DIFF
--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -461,25 +461,25 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	cmds, err := opts.buildHTTPCloneCommand(false)
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
 		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
 		"set -o xtrace",
 		"cd dir",
-	}, cmds))
+	}))
 	// build clone command to clone by http with token into 'dir' w/o specified branch
 	opts.branch = ""
 	cmds, err = opts.buildHTTPCloneCommand(false)
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
 		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --filter=tree:0 --single-branch\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --filter=tree:0 --single-branch",
 		"set -o xtrace",
 		"cd dir",
-	}, cmds))
+	}))
 
 	// build clone command with a URL that uses http, and ensure it's
 	// been forced to use https
@@ -488,10 +488,10 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	cmds, err = opts.buildHTTPCloneCommand(false)
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
-	}, cmds))
+	}))
 
 	// ensure that we aren't sending the github oauth token to other
 	// servers
@@ -499,10 +499,10 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	cmds, err = opts.buildHTTPCloneCommand(false)
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
-	}, cmds))
+	}))
 }
 
 func (s *GitGetProjectSuite) TestBuildSSHCloneCommand() {
@@ -609,12 +609,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForPullRequests() {
 	cmds, err := c.buildCloneCommand(s.ctx, s.comm, logger, conf, opts)
 	s.NoError(err)
 	s.Require().Len(cmds, 10)
-	s.True(utility.StringSliceContainsOrderedPrefixSubset([]string{
+	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
 		"git fetch origin \"pull/9001/head:evg-pr-test-",
 		"git checkout \"evg-pr-test-",
 		"git reset --hard 55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
 		"git log --oneline -n 10",
-	}, cmds))
+	}))
 }
 func (s *GitGetProjectSuite) TestBuildCommandForGitHubMergeQueue() {
 	conf := s.taskConfig7
@@ -637,12 +637,12 @@ func (s *GitGetProjectSuite) TestBuildCommandForGitHubMergeQueue() {
 	cmds, err := c.buildCloneCommand(s.ctx, s.comm, logger, conf, opts)
 	s.NoError(err)
 	s.Len(cmds, 10)
-	s.True(utility.StringSliceContainsOrderedPrefixSubset([]string{
+	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
 		"git fetch origin \"gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056:evg-mg-test-",
 		"git checkout \"evg-mg-test-",
 		"git reset --hard d2a90288ad96adca4a7d0122d8d4fd1deb24db11",
 		"git log --oneline -n 10",
-	}, cmds))
+	}))
 }
 
 func (s *GitGetProjectSuite) TestBuildCommandForCLIMergeTests() {
@@ -691,13 +691,13 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	cmds, err := c.buildModuleCloneCommand(conf, opts, "main", nil)
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set -o xtrace",
 		"set -o errexit",
 		"git clone 'git@github.com:evergreen-ci/sample.git' 'module'",
 		"cd module",
 		"git checkout 'main'",
-	}, cmds))
+	}))
 
 	// ensure module clone command with http URL injects token
 	opts.method = evergreen.CloneMethodOAuth
@@ -706,7 +706,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", nil)
 	s.NoError(err)
 	s.Require().Len(cmds, 8)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set -o xtrace",
 		"set -o errexit",
 		"set +o xtrace",
@@ -715,17 +715,17 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 		"set -o xtrace",
 		"cd module",
 		"git checkout 'main'",
-	}, cmds))
+	}))
 
 	// ensure insecure github url is forced to use https
 	opts.location = "http://github.com/evergreen-ci/sample.git"
 	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", nil)
 	s.NoError(err)
 	s.Require().Len(cmds, 8)
-	s.True(utility.ContainsOrderedSubset([]string{
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'",
-	}, cmds))
+	}))
 
 	conf = s.taskConfig4
 	// with merge test-commit checkout
@@ -741,7 +741,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", module)
 	s.NoError(err)
 	s.Require().Len(cmds, 7)
-	s.True(utility.StringSliceContainsOrderedPrefixSubset([]string{
+	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
 		"set -o xtrace",
 		"set -o errexit",
 		"git clone 'git@github.com:evergreen-ci/sample.git' 'module'",
@@ -749,7 +749,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 		"git fetch origin \"pull/1234/merge:evg-merge-test-",
 		"git checkout 'evg-merge-test-",
 		"git reset --hard 1234abcd",
-	}, cmds))
+	}))
 }
 
 func (s *GitGetProjectSuite) TestGetApplyCommand() {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -746,8 +746,8 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 		"set -o errexit",
 		"git clone 'git@github.com:evergreen-ci/sample.git' 'module'",
 		"cd module",
-		"^git fetch origin \"pull/1234/merge:evg-merge-test-",
-		"^git checkout 'evg-merge-test-",
+		"git fetch origin \"pull/1234/merge:evg-merge-test-",
+		"git checkout 'evg-merge-test-",
 		"git reset --hard 1234abcd",
 	}, cmds))
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-09"
+	AgentVersion = "2023-10-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-09-06"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-19"
+	AgentVersion = "2023-10-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b
-	github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c
+	github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,6 @@ github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b/go.mod h1:2f2M
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c h1:1MsTaPMQ0eM9KXeqdbbFPPAeXuhckMDKo/DkKLFfzVA=
-github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d h1:ayWz0PCzn61cGNFxWOux4yuyLWWSbKe9SMTjxFulLbk=
 github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/go.sum
+++ b/go.sum
@@ -453,6 +453,8 @@ github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSu
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c h1:1MsTaPMQ0eM9KXeqdbbFPPAeXuhckMDKo/DkKLFfzVA=
 github.com/evergreen-ci/utility v0.0.0-20230809162904-922cba3c3c3c/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
+github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d h1:ayWz0PCzn61cGNFxWOux4yuyLWWSbKe9SMTjxFulLbk=
+github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=


### PR DESCRIPTION
EVG-20984

### Description
Some tests manually check the index of many items in a slice when the test itself only cares about the order in which the elements in the slice appear. This rewrites some tests to use a couple utility functions in our utility package that don't care about the index but care about the order in which the elements appear. 

I groomed through some of our other tests (by searching for tests that use a high index) and I didn't find many other tests that take a similar anti-pattern of checking index + order but only require order, so the scope of tests that changed were only in one file.

### Testing
Existing unit tests and unit tests in utility package for the utility functions used.