### PR TITLE
EVG-20948 Add ‘create_check_run’ field and validate parameters

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -418,7 +418,7 @@ type BuildVariant struct {
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 }
 
-// CheckRun is used to provide extra information about a github check run.
+// CheckRun is used to provide information about a github check run.
 type CheckRun struct {
 	// PathToOutputs is a local file path to an output json file for the checkrun
 	PathToOutputs string `yaml:"path_to_outputs" bson:"path_to_outputs"`

--- a/model/project.go
+++ b/model/project.go
@@ -144,6 +144,9 @@ type BuildVariantTaskUnit struct {
 	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 	// TaskGroup is set if an inline task group is defined on the build variant.
 	TaskGroup *TaskGroup `yaml:"task_group,omitempty" bson:"task_group,omitempty"`
+
+	// CreateCheckRun will create a check run on GitHub if set
+	CreateCheckRun *CheckRun `yaml:"create_check_run,omitempty" bson:"create_check_run,omitempty"`
 }
 
 func (b BuildVariant) Get(name string) (BuildVariantTaskUnit, error) {
@@ -413,6 +416,16 @@ type BuildVariant struct {
 	// all of the tasks/groups to be run on the build variant, compile through tests.
 	Tasks        []BuildVariantTaskUnit `yaml:"tasks,omitempty" bson:"tasks"`
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
+}
+
+// CheckRun is used to provide extra information about a github check run.
+type CheckRun struct {
+	// PathToOutputs is a local file path to an output json file for the checkrun
+	PathToOutputs *string `yaml:"path_to_outputs" bson:"path_to_outputs"`
+	// GithubAppId and GitubPrivateKey are the user's credentials for
+	// authenticating with github for check runs.
+	GithubAppId      string `yaml:"github_app_id" bson:"github_app_id"`
+	GithubPrivateKey string `yaml:"github_private_key" bson:"github_private_key"`
 }
 
 // ParameterInfo is used to provide extra information about a parameter.

--- a/model/project.go
+++ b/model/project.go
@@ -145,7 +145,7 @@ type BuildVariantTaskUnit struct {
 	// TaskGroup is set if an inline task group is defined on the build variant.
 	TaskGroup *TaskGroup `yaml:"task_group,omitempty" bson:"task_group,omitempty"`
 
-	// CreateCheckRun will create a check run on GitHub if set
+	// CreateCheckRun will create a check run on GitHub if set.
 	CreateCheckRun *CheckRun `yaml:"create_check_run,omitempty" bson:"create_check_run,omitempty"`
 }
 
@@ -420,7 +420,7 @@ type BuildVariant struct {
 
 // CheckRun is used to provide information about a github check run.
 type CheckRun struct {
-	// PathToOutputs is a local file path to an output json file for the checkrun
+	// PathToOutputs is a local file path to an output json file for the checkrun.
 	PathToOutputs string `yaml:"path_to_outputs" bson:"path_to_outputs"`
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -421,11 +421,7 @@ type BuildVariant struct {
 // CheckRun is used to provide extra information about a github check run.
 type CheckRun struct {
 	// PathToOutputs is a local file path to an output json file for the checkrun
-	PathToOutputs *string `yaml:"path_to_outputs" bson:"path_to_outputs"`
-	// GithubAppId and GitubPrivateKey are the user's credentials for
-	// authenticating with github for check runs.
-	GithubAppId      string `yaml:"github_app_id" bson:"github_app_id"`
-	GithubPrivateKey string `yaml:"github_private_key" bson:"github_private_key"`
+	PathToOutputs string `yaml:"path_to_outputs" bson:"path_to_outputs"`
 }
 
 // ParameterInfo is used to provide extra information about a parameter.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -469,18 +469,6 @@ func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) e
 		copy.RunOn, copy.Distros = copy.Distros, nil
 	}
 
-	// validate check runs
-	cr := copy.CreateCheckRun
-	if cr != nil {
-		if cr.PathToOutputs == nil {
-			return errors.New("'path_to_outputs' must be set")
-		}
-		if cr.GithubAppId != "" && cr.GithubPrivateKey == "" {
-			return errors.New("a github private key must be provided for check runs if a github app is provided")
-		}
-
-	}
-
 	*pbvt = parserBVTaskUnit(copy)
 	return nil
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -468,7 +468,6 @@ func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) e
 		}
 		copy.RunOn, copy.Distros = copy.Distros, nil
 	}
-
 	*pbvt = parserBVTaskUnit(copy)
 	return nil
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -436,7 +436,7 @@ type parserBVTaskUnit struct {
 	Activate *bool `yaml:"activate,omitempty" bson:"activate,omitempty"`
 	// TaskGroup is set if an inline task group is defined on the build variant config.
 	TaskGroup *parserTaskGroup `yaml:"task_group,omitempty" bson:"task_group,omitempty"`
-	// CreateCheckRun will create a check run on GitHub if set
+	// CreateCheckRun will create a check run on GitHub if set.
 	CreateCheckRun *CheckRun `yaml:"create_check_run,omitempty" bson:"create_check_run,omitempty"`
 }
 

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -768,6 +768,27 @@ tasks:
 	cr := proj.BuildVariants[0].Tasks[0].CreateCheckRun
 	assert.NotNil(cr)
 	assert.Equal("path", cr.PathToOutputs)
+
+	ymlWithEmptyString := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: ""
+tasks:
+- name: t1
+`
+
+	_, err = LoadProjectInto(ctx, []byte(ymlWithEmptyString), nil, "id", proj)
+	assert.NotNil(proj)
+	assert.Nil(err)
+	assert.Len(proj.BuildVariants, 1)
+
+	assert.Len(proj.BuildVariants[0].Tasks, 1)
+	cr = proj.BuildVariants[0].Tasks[0].CreateCheckRun
+	assert.NotNil(cr)
+	assert.Equal("", cr.PathToOutputs)
 }
 
 func TestDisplayTaskParsing(t *testing.T) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -409,7 +409,7 @@ func TestTranslateTasks(t *testing.T) {
 					{
 						Name: "a_task_with_no_special_configuration",
 						CreateCheckRun: &CheckRun{
-							PathToOutputs: utility.ToStringPtr("path"),
+							PathToOutputs: "path",
 						},
 					},
 				},
@@ -537,7 +537,7 @@ func TestTranslateTasks(t *testing.T) {
 	assert.Equal(t, "bv_with_check_run", checkRunBV.Name)
 	require.Len(t, checkRunBV.Tasks, 1)
 	assert.NotNil(t, checkRunBV.Tasks[0].CreateCheckRun)
-	assert.Equal(t, "path", utility.FromStringPtr(checkRunBV.Tasks[0].CreateCheckRun.PathToOutputs))
+	assert.Equal(t, "path", checkRunBV.Tasks[0].CreateCheckRun.PathToOutputs)
 }
 
 func TestTranslateDependsOn(t *testing.T) {
@@ -1176,72 +1176,6 @@ tasks:
 	assert.Equal("execTask3", proj.BuildVariants[0].DisplayTasks[0].ExecTasks[1])
 	assert.Equal("execTask2", proj.BuildVariants[0].DisplayTasks[1].ExecTasks[0])
 	assert.Equal("execTask4", proj.BuildVariants[0].DisplayTasks[1].ExecTasks[1])
-}
-
-func TestCheckRunParsing(t *testing.T) {
-	assert := assert.New(t)
-
-	validYml := `
-buildvariants:
-- name: "v1"
-  tasks:
-  - name: "t1"
-    create_check_run:
-      path_to_outputs: "path"
-      github_app_id: "some_id"
-      github_private_key: "some_key"
-`
-	p, err := createIntermediateProject([]byte(validYml), false)
-	require.NotNil(t, p)
-	assert.Nil(err)
-	assert.Equal(len(p.BuildVariants), 1)
-	bv := p.BuildVariants[0]
-	assert.Equal("v1", bv.Name)
-	assert.Equal(len(bv.Tasks), 1)
-	assert.Equal("t1", bv.Tasks[0].Name)
-	cr := bv.Tasks[0].CreateCheckRun
-	assert.Equal("path", utility.FromStringPtr(cr.PathToOutputs))
-	assert.Equal("some_id", cr.GithubAppId)
-	assert.Equal("some_key", cr.GithubPrivateKey)
-
-	ymlWithNoPath := `
-buildvariants:
-- name: "v1"
-  tasks:
-  - name: "t1"
-    create_check_run:
-      github_app_id: "some_id"
-      github_private_key: "some_key"
-`
-
-	p, err = createIntermediateProject([]byte(ymlWithNoPath), false)
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "'path_to_outputs' must be set")
-
-	ymlWithNoSecret := `
-buildvariants:
-- name: "v1"
-  tasks:
-  - name: "t1"
-    create_check_run:
-      path_to_outputs: "path"
-      github_app_id: "some_id"
-`
-	p, err = createIntermediateProject([]byte(ymlWithNoSecret), false)
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "a github private key must be provided for check runs if a github app is provided")
-
-	ymlWithNoCredentials := `
-buildvariants:
-- name: "v1"
-  tasks:
-  - name: "t1"
-    create_check_run:
-      path_to_outputs: "path"
-`
-	p, err = createIntermediateProject([]byte(ymlWithNoCredentials), false)
-	require.NotNil(t, p)
-	assert.Nil(err)
 }
 
 func TestTaskGroupParsing(t *testing.T) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -744,6 +744,32 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 	})
 }
 
+func TestTestCheckRunParsing(t *testing.T) {
+	assert := assert.New(t)
+	yml := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: "path"
+tasks:
+- name: t1
+`
+
+	proj := &Project{}
+	ctx := context.Background()
+	_, err := LoadProjectInto(ctx, []byte(yml), nil, "id", proj)
+	assert.NotNil(proj)
+	assert.Nil(err)
+	assert.Len(proj.BuildVariants, 1)
+
+	assert.Len(proj.BuildVariants[0].Tasks, 1)
+	cr := proj.BuildVariants[0].Tasks[0].CreateCheckRun
+	assert.NotNil(cr)
+	assert.Equal("path", cr.PathToOutputs)
+}
+
 func TestDisplayTaskParsing(t *testing.T) {
 	assert := assert.New(t)
 	yml := `

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -403,6 +403,17 @@ func TestTranslateTasks(t *testing.T) {
 					},
 				},
 			},
+			{
+				Name: "bv_with_check_run",
+				Tasks: parserBVTaskUnits{
+					{
+						Name: "a_task_with_no_special_configuration",
+						CreateCheckRun: &CheckRun{
+							PathToOutputs: utility.ToStringPtr("path"),
+						},
+					},
+				},
+			},
 		},
 		Tasks: []parserTask{
 			{Name: "my_task", PatchOnly: utility.TruePtr(), ExecTimeoutSecs: 15},
@@ -421,7 +432,7 @@ func TestTranslateTasks(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, out)
 	require.Len(t, out.Tasks, 6)
-	require.Len(t, out.BuildVariants, 7)
+	require.Len(t, out.BuildVariants, 8)
 
 	for _, bv := range out.BuildVariants {
 		for _, bvtu := range bv.Tasks {
@@ -521,6 +532,12 @@ func TestTranslateTasks(t *testing.T) {
 	assert.Equal(t, "my_task", disabledBV.Tasks[1].Name)
 	assert.True(t, utility.FromBoolPtr(disabledBV.Tasks[1].PatchOnly))
 	assert.False(t, utility.FromBoolPtr(disabledBV.Tasks[1].Disable))
+
+	checkRunBV := out.BuildVariants[7]
+	assert.Equal(t, "bv_with_check_run", checkRunBV.Name)
+	require.Len(t, checkRunBV.Tasks, 1)
+	assert.NotNil(t, checkRunBV.Tasks[0].CreateCheckRun)
+	assert.Equal(t, "path", utility.FromStringPtr(checkRunBV.Tasks[0].CreateCheckRun.PathToOutputs))
 }
 
 func TestTranslateDependsOn(t *testing.T) {
@@ -1159,6 +1176,72 @@ tasks:
 	assert.Equal("execTask3", proj.BuildVariants[0].DisplayTasks[0].ExecTasks[1])
 	assert.Equal("execTask2", proj.BuildVariants[0].DisplayTasks[1].ExecTasks[0])
 	assert.Equal("execTask4", proj.BuildVariants[0].DisplayTasks[1].ExecTasks[1])
+}
+
+func TestCheckRunParsing(t *testing.T) {
+	assert := assert.New(t)
+
+	validYml := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: "path"
+      github_app_id: "some_id"
+      github_private_key: "some_key"
+`
+	p, err := createIntermediateProject([]byte(validYml), false)
+	require.NotNil(t, p)
+	assert.Nil(err)
+	assert.Equal(len(p.BuildVariants), 1)
+	bv := p.BuildVariants[0]
+	assert.Equal("v1", bv.Name)
+	assert.Equal(len(bv.Tasks), 1)
+	assert.Equal("t1", bv.Tasks[0].Name)
+	cr := bv.Tasks[0].CreateCheckRun
+	assert.Equal("path", utility.FromStringPtr(cr.PathToOutputs))
+	assert.Equal("some_id", cr.GithubAppId)
+	assert.Equal("some_key", cr.GithubPrivateKey)
+
+	ymlWithNoPath := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      github_app_id: "some_id"
+      github_private_key: "some_key"
+`
+
+	p, err = createIntermediateProject([]byte(ymlWithNoPath), false)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "'path_to_outputs' must be set")
+
+	ymlWithNoSecret := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: "path"
+      github_app_id: "some_id"
+`
+	p, err = createIntermediateProject([]byte(ymlWithNoSecret), false)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "a github private key must be provided for check runs if a github app is provided")
+
+	ymlWithNoCredentials := `
+buildvariants:
+- name: "v1"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: "path"
+`
+	p, err = createIntermediateProject([]byte(ymlWithNoCredentials), false)
+	require.NotNil(t, p)
+	assert.Nil(err)
 }
 
 func TestTaskGroupParsing(t *testing.T) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -762,7 +762,7 @@ tasks:
 	_, err := LoadProjectInto(ctx, []byte(yml), nil, "id", proj)
 	assert.NotNil(proj)
 	assert.Nil(err)
-	assert.Len(proj.BuildVariants, 1)
+	require.Len(t, proj.BuildVariants, 1)
 
 	assert.Len(proj.BuildVariants[0].Tasks, 1)
 	cr := proj.BuildVariants[0].Tasks[0].CreateCheckRun
@@ -783,7 +783,7 @@ tasks:
 	_, err = LoadProjectInto(ctx, []byte(ymlWithEmptyString), nil, "id", proj)
 	assert.NotNil(proj)
 	assert.Nil(err)
-	assert.Len(proj.BuildVariants, 1)
+	require.Len(t, proj.BuildVariants, 1)
 
 	assert.Len(proj.BuildVariants[0].Tasks, 1)
 	cr = proj.BuildVariants[0].Tasks[0].CreateCheckRun


### PR DESCRIPTION
EVG-20948

### Description
This adds the  ‘create_check_run’ field to the build variant task unit, and validates the parameters. This will allow users to specify it in their yamls like so: 

<img width="556" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/13104717/a7422034-a5aa-4c85-abe5-24a87a8bb1df">


### Testing
Added tests

### Update

-  Some things changed and we decided not to support users passing in credentials as part of this project 

- I played with it some more and decided against adding validation to check if the path field is provided. Doing so won’t protect against instances where someone just adds `create_check_run:` and nothing else because then it’s null and validation doesn’t kick in. It only picks it up when another field is specified, such as  
 ```
         create_check_run:
           github_app_id: "some_id"
 ``` 

However, for the case when another field is provided we can just not make the path a pointer and it’ll be set to “” automatically, so we don't need the user to do that. (We also aren’t adding more fields anyway). I think the best we can do in this case is add good documentation to help users figure out how to get started. 

### Note
While it would seem that it makes more sense for create_check_run to be a string instead of a struct, I made it a struct so that we can later accommodate [EVG-21103](https://jira.mongodb.org/browse/EVG-21103) without requiring users to change their config files.  