### PR TITLE
EVG-20973 fix attach.xunit_results log about logs

### DIFF
--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -198,7 +198,7 @@ func (c *xunitResults) parseAndUploadResults(ctx context.Context, conf *internal
 		}
 		cumulative.tests[cumulative.logIdxToTestIdx[i]].LineNum = 1
 	}
-	logger.Task().Infof("Posting test logs succeeded for %d of %d files.", succeeded, len(cumulative.logs))
+	logger.Task().Infof("Posting test logs succeeded for %d of %d logs.", succeeded, len(cumulative.logs))
 	if len(cumulative.tests) > 0 {
 		return sendTestResults(ctx, comm, logger, conf, cumulative.tests)
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-10-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-09"
+	AgentVersion = "2023-10-18"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-10-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-19"
+	AgentVersion = "2023-10-19b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -157,7 +157,8 @@ This command parses results in the XUnit format and posts them to the
 API server. Use this when you use a library in your programming language
 to generate XUnit results from tests. Evergreen will parse these XML
 files, creating links to individual tests in the test logs in the UI and
-API.
+API. (Logs are only generated if the test case did not succeed -- this is
+ part of the XUnit XML file design.)
 
 This command will not error if there are no test results, as XML files can still
 be valid. We will error if no file paths given are valid XML files.


### PR DESCRIPTION
EVG-20973
### Description
This caused some user confusion in the past -- we log about number of files but use the number of logs, which makes it seem like we didn't successfully find the file.

### Documentation
Added a line about logs only being generated in the failure case, since we say that in our own comments but not in the logs, and this also confused the user.
