### PR TITLE
EVG-21048 Deprecate Distro CloneMethod

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -170,22 +170,11 @@ func getProjectMethodAndToken(ctx context.Context, comm client.Communicator, td 
 	if err != nil {
 		return evergreen.CloneMethodLegacySSH, "", err
 	}
-
-	switch conf.GetCloneMethod() {
-	// No clone method specified is equivalent to using legacy SSH.
-	case "", evergreen.CloneMethodLegacySSH:
-		return evergreen.CloneMethodLegacySSH, token, nil
-	case evergreen.CloneMethodOAuth:
-		if token == "" {
-			return evergreen.CloneMethodLegacySSH, "", errors.New("cannot clone using OAuth if explicit token from parameter and global token are both empty")
-		}
-		token, err := parseToken(globalToken)
-		return evergreen.CloneMethodOAuth, token, err
-	case evergreen.CloneMethodAccessToken:
-		return evergreen.CloneMethodLegacySSH, "", errors.New("cannot specify clone method access token")
+	if token == "" {
+		return evergreen.CloneMethodLegacySSH, "", errors.New("cannot clone using OAuth if explicit token from parameter and global token are both empty")
 	}
-
-	return "", "", errors.Errorf("unrecognized clone method '%s'", conf.GetCloneMethod())
+	token, err = parseToken(globalToken)
+	return evergreen.CloneMethodOAuth, token, err
 }
 
 // parseToken parses the OAuth token, if it is in the format "token <token>";

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
@@ -39,8 +38,6 @@ func TestGitPush(t *testing.T) {
 	}
 	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
 	require.NoError(t, err)
-
-	assert.Equal(t, conf.GetCloneMethod(), evergreen.CloneMethodOAuth)
 
 	var splitCommand []string
 	for name, test := range map[string]func(*testing.T){

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -125,13 +125,6 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	return taskConfig, nil
 }
 
-func (c *TaskConfig) GetCloneMethod() string {
-	if c.Distro != nil {
-		return c.Distro.CloneMethod
-	}
-	return evergreen.CloneMethodOAuth
-}
-
 // Validate validates that the task config is populated with the data required
 // for a task to run.
 // Note that this is here only as legacy code. These checks are not sufficient

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -339,6 +339,7 @@ type GeneratePollResponse struct {
 // DistroView represents the view of data that the agent uses from the distro
 // it is running on.
 type DistroView struct {
+	// deprecated: will remove in EVG-21049
 	CloneMethod         string `json:"clone_method"`
 	DisableShallowClone bool   `json:"disable_shallow_clone"`
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-10-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-19"
+	AgentVersion = "2023-10-19a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -35,7 +35,7 @@ type Distro struct {
 	Setup                 string                `bson:"setup,omitempty" json:"setup,omitempty" mapstructure:"setup,omitempty"`
 	User                  string                `bson:"user,omitempty" json:"user,omitempty" mapstructure:"user,omitempty"`
 	BootstrapSettings     BootstrapSettings     `bson:"bootstrap_settings" json:"bootstrap_settings" mapstructure:"bootstrap_settings"`
-	CloneMethod           string                `bson:"clone_method" json:"clone_method,omitempty" mapstructure:"clone_method,omitempty"`
+	CloneMethod           string                `bson:"clone_method" json:"clone_method,omitempty" mapstructure:"clone_method,omitempty"` // deprecated: will remove in EVG-21049
 	SSHKey                string                `bson:"ssh_key,omitempty" json:"ssh_key,omitempty" mapstructure:"ssh_key,omitempty"`
 	SSHOptions            []string              `bson:"ssh_options,omitempty" json:"ssh_options,omitempty" mapstructure:"ssh_options,omitempty"`
 	AuthorizedKeysFile    string                `bson:"authorized_keys_file,omitempty" json:"authorized_keys_file,omitempty" mapstructure:"authorized_keys_file,omitempty"`

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -33,7 +33,6 @@ var distroSyntaxValidators = []distroValidator{
 	ensureValidArch,
 	ensureValidBootstrapSettings,
 	ensureValidStaticBootstrapSettings,
-	ensureValidCloneMethod,
 	ensureHasNoUnauthorizedCharacters,
 	ensureHasValidHostAllocatorSettings,
 	ensureHasValidPlannerSettings,
@@ -316,15 +315,6 @@ func ensureValidStaticBootstrapSettings(ctx context.Context, d *distro.Distro, s
 				Level:   Error,
 			},
 		}
-	}
-	return nil
-}
-
-// ensureValidCloneMethod checks that the clone method is one of the supported
-// methods.
-func ensureValidCloneMethod(ctx context.Context, d *distro.Distro, s *evergreen.Settings) ValidationErrors {
-	if err := evergreen.ValidateCloneMethod(d.CloneMethod); err != nil {
-		return ValidationErrors{{Level: Error, Message: err.Error()}}
 	}
 	return nil
 }


### PR DESCRIPTION
EVG-21048

### Description
Now that the distro setting no longer is relevant , this deprecates the `CloneMethod` field and its use within the agent, to be removed from the codebase as part of EVG-21049
### Testing
Existing tests
