### PR TITLE
EVG-19763 Validate requester-level fields with override hierarchy

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -155,6 +155,7 @@ var projectWarningValidators = []projectValidator{
 	checkTaskRuns,
 	checkModules,
 	checkTasks,
+	checkRequestersForTaskDependencies,
 	checkBuildVariants,
 }
 
@@ -1533,31 +1534,48 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 // run for the same requesters. For example, a task that runs in a mainline
 // commit cannot depend on a patch only task since the dependency will only be
 // satisfiable in patches.
-func checkRequestersForTaskDependencies(task *model.ProjectTask, allTasks map[string]model.ProjectTask) ValidationErrors {
-	errs := ValidationErrors{}
+func checkRequestersForTaskDependencies(project *model.Project) ValidationErrors {
+	bvtus := map[model.TVPair]model.BuildVariantTaskUnit{}
+	bvs := map[string]struct{}{}
+	tasks := map[string]struct{}{}
+	for _, bvtu := range project.FindAllBuildVariantTasks() {
+		bvtus[model.TVPair{Variant: bvtu.Variant, TaskName: bvtu.Name}] = bvtu
+		bvs[bvtu.Variant] = struct{}{}
+		tasks[bvtu.Name] = struct{}{}
+	}
 
-	for _, dep := range task.DependsOn {
-		dependent, exists := allTasks[dep.Name]
-		if !exists {
-			continue
-		}
-		if utility.FromBoolPtr(dependent.PatchOnly) && !utility.FromBoolPtr(task.PatchOnly) {
-			errs = append(errs, ValidationError{
-				Level:   Warning,
-				Message: fmt.Sprintf("Task '%s' depends on patch-only task '%s'. Both will only run in patches", task.Name, dep.Name),
-			})
-		}
-		if !utility.FromBoolTPtr(dependent.Patchable) && utility.FromBoolTPtr(task.Patchable) {
-			errs = append(errs, ValidationError{
-				Level:   Warning,
-				Message: fmt.Sprintf("Task '%s' depends on non-patchable task '%s'. Neither will run in patches", task.Name, dep.Name),
-			})
-		}
-		if utility.FromBoolPtr(dependent.GitTagOnly) && !utility.FromBoolPtr(task.GitTagOnly) {
-			errs = append(errs, ValidationError{
-				Level:   Warning,
-				Message: fmt.Sprintf("Task '%s' depends on git-tag-only task '%s'. Both will only run when pushing git tags", task.Name, dep.Name),
-			})
+	var errs ValidationErrors
+	for _, bvtu := range bvtus {
+		for _, d := range bvtu.DependsOn {
+			dep := model.TVPair{Variant: d.Variant, TaskName: d.Name}
+			if dep.Variant == "" {
+				// Implicit build variant - if no build variant is explicitly
+				// stated, the task and dependency should both run in the same
+				// build variant.
+				dep.Variant = bvtu.Variant
+			}
+			dependent := project.FindTaskForVariant(dep.TaskName, dep.Variant)
+			if dependent == nil {
+				continue
+			}
+			if utility.FromBoolPtr(dependent.PatchOnly) && !utility.FromBoolPtr(bvtu.PatchOnly) {
+				errs = append(errs, ValidationError{
+					Level:   Warning,
+					Message: fmt.Sprintf("Task '%s' depends on patch-only task '%s'. Both will only run in patches", bvtu.Name, d.Name),
+				})
+			}
+			if !utility.FromBoolTPtr(dependent.Patchable) && utility.FromBoolTPtr(bvtu.Patchable) {
+				errs = append(errs, ValidationError{
+					Level:   Warning,
+					Message: fmt.Sprintf("Task '%s' depends on non-patchable task '%s'. Neither will run in patches", bvtu.Name, d.Name),
+				})
+			}
+			if utility.FromBoolPtr(dependent.GitTagOnly) && !utility.FromBoolPtr(bvtu.GitTagOnly) {
+				errs = append(errs, ValidationError{
+					Level:   Warning,
+					Message: fmt.Sprintf("Task '%s' depends on git-tag-only task '%s'. Both will only run when pushing git tags", bvtu.Name, d.Name),
+				})
+			}
 		}
 	}
 
@@ -2180,7 +2198,6 @@ func parseS3PullParameters(c model.PluginCommandConf) (task, bv string, err erro
 func checkTasks(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 	execTimeoutWarningAdded := false
-	allTasks := project.FindAllTasksMap()
 	for _, task := range project.Tasks {
 		if len(task.Commands) == 0 {
 			errs = append(errs,
@@ -2203,7 +2220,6 @@ func checkTasks(project *model.Project) ValidationErrors {
 			execTimeoutWarningAdded = true
 		}
 		errs = append(errs, checkLoggerConfig(&task)...)
-		errs = append(errs, checkRequestersForTaskDependencies(&task, allTasks)...)
 		errs = append(errs, checkTaskNames(project, &task)...)
 	}
 	if project.Loggers != nil {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -649,22 +649,74 @@ buildvariants:
 }
 
 func TestCheckRequestersForTaskDependencies(t *testing.T) {
-	t.Run("DependingOnNonPatchableTaskGeneratesWarning", func(t *testing.T) {
-		p := model.Project{
-			Tasks: []model.ProjectTask{
-				{Name: "t1", DependsOn: []model.TaskUnitDependency{
-					{Name: "t2", Variant: model.AllVariants},
-				}},
-				{Name: "t2", Patchable: utility.FalsePtr()},
-			},
-		}
-		allTasks := p.FindAllTasksMap()
-		errs := checkRequestersForTaskDependencies(&p.Tasks[0], allTasks)
-		errs = append(errs, checkRequestersForTaskDependencies(&p.Tasks[1], allTasks)...)
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "'t1' depends on non-patchable task 't2'")
-	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert := assert.New(t)
+	exampleYml := `
+exec_timeout_secs: 3600
+tasks:
+  - name: dep1
+    patchable: false
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            echo "hi"
+
+  - name: dep2
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            echo "hi"
+      
+  - name: dep3
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            echo "hi"
+  
+  - name: task1
+    patchable: true
+    depends_on:
+      - name: dep1
+      - name: dep2
+      - name: dep3
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            echo "hi"
+
+buildvariants:
+  - name: ubuntu2204
+    display_name: Ubuntu 22.04
+    patchable: false
+    run_on:
+      - localhost
+    tasks:
+      - name: "task1"
+      - name: "dep1"
+      - name: "dep2"
+        patchable: false
+      - name: "dep3"
+`
+	proj := model.Project{}
+	pp, err := model.LoadProjectInto(ctx, []byte(exampleYml), nil, "example_project", &proj)
+	assert.NotNil(proj)
+	assert.NotNil(pp)
+	assert.NoError(err)
+	warnings := CheckProjectWarnings(&proj)
+	require.Len(t, warnings, 3)
+	assert.Contains(warnings[0].Message, "'task1' depends on non-patchable task 'dep1'")
+	assert.Contains(warnings[1].Message, "'task1' depends on non-patchable task 'dep2'")
+	assert.Contains(warnings[2].Message, "'task1' depends on non-patchable task 'dep3'")
 }
 
 func TestValidateDependencyGraph(t *testing.T) {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -664,7 +664,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: true
     depends_on:
       - name: dep
     commands:
@@ -693,7 +693,7 @@ buildvariants:
 		projYAML := `
 tasks:
   - name: dep
-    patchable: true
+    patch_only: true
     commands:
       - command: shell.exec
         params:
@@ -702,7 +702,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: true
     depends_on:
       - name: dep
     commands:
@@ -739,7 +739,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: true
     depends_on:
       - name: dep
     commands:
@@ -750,7 +750,7 @@ tasks:
             echo "hi"
 buildvariants:
   - name: ubuntu2204
-    patchable: true
+    patch_only: true
     display_name: Ubuntu 22.04
     run_on:
       - localhost
@@ -777,7 +777,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: true
     depends_on:
       - name: dep
     commands:
@@ -794,7 +794,7 @@ buildvariants:
     tasks:
       - name: "task"
       - name: "dep"
-        patchable: true
+        patch_only: true
 `
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
@@ -807,7 +807,7 @@ buildvariants:
 		projYAML := `
 tasks:
   - name: dep
-    patchable: false
+    patch_only: true
     commands:
       - command: shell.exec
         params:
@@ -815,7 +815,7 @@ tasks:
           script: |
             echo "hi"
   - name: task
-    patchable: true
+    patch_only: false
     depends_on:
       - name: dep
     commands:
@@ -841,7 +841,7 @@ buildvariants:
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, errs[0].Level, Warning)
-		assert.Contains(t, errs[0].Message, "'task' depends on non-patchable task 'dep'")
+		assert.Contains(t, errs[0].Message, "'task' depends on patch-only task 'dep'")
 	})
 	t.Run("WarnsWithVariantLevelConflict", func(t *testing.T) {
 		projYAML := `
@@ -855,7 +855,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: false
     depends_on:
       - name: dep
     commands:
@@ -867,7 +867,7 @@ tasks:
 
 buildvariants:
   - name: ubuntu2204
-    patchable: false
+    patch_only: true
     display_name: Ubuntu 22.04
     run_on:
       - localhost
@@ -882,7 +882,7 @@ buildvariants:
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, errs[0].Level, Warning)
-		assert.Contains(t, errs[0].Message, "'task' depends on non-patchable task 'dep'")
+		assert.Contains(t, errs[0].Message, "'task' depends on patch-only task 'dep'")
 	})
 	t.Run("WarnsWithBuildVariantTaskLevelConflict", func(t *testing.T) {
 		projYAML := `
@@ -896,7 +896,7 @@ tasks:
             echo "hi"
 
   - name: task
-    patchable: true
+    patch_only: false
     depends_on:
       - name: dep
     commands:
@@ -914,7 +914,7 @@ buildvariants:
     tasks:
       - name: "task"
       - name: "dep"
-        patchable: false
+        patch_only: true
 `
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
@@ -923,7 +923,7 @@ buildvariants:
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, errs[0].Level, Warning)
-		assert.Contains(t, errs[0].Message, "'task' depends on non-patchable task 'dep'")
+		assert.Contains(t, errs[0].Message, "'task' depends on patch-only task 'dep'")
 	})
 }
 


### PR DESCRIPTION
EVG-19763

### Description
Refactored the warning validations to respect the [override hierarchy](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#task-fields-override-hierarchy) for requester-level settings by checking the merged `BuildVariantTaskUnit` rather than the non-merged `ProjectTask `
### Testing
Added a new unit test that checks for all 3 of the levels described here to be respected when checking requester level fields like patchable, patch_only, etc.
