### PR TITLE
EVG-19801 add optional param to s3.get

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -62,7 +62,7 @@ type s3get struct {
 func s3GetFactory() Command   { return &s3get{} }
 func (c *s3get) Name() string { return "s3.get" }
 
-// s3get-specific implementation of ParseParams.
+// s3get implementation of ParseParams.
 func (c *s3get) ParseParams(params map[string]interface{}) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
@@ -83,7 +83,7 @@ func (c *s3get) ParseParams(params map[string]interface{}) error {
 	return nil
 }
 
-// Validate that all necessary params are set, and that only one of
+// validateParams that all necessary params are set, and that only one of
 // local_file and extract_to is specified.
 func (c *s3get) validateParams() error {
 	if c.AwsKey == "" {
@@ -144,7 +144,7 @@ func (c *s3get) expandParams(conf *internal.TaskConfig) error {
 	return nil
 }
 
-// Implementation of Execute.  Expands the parameters, and then fetches the
+// Execute expands the parameters, and then fetches the
 // resource from s3.
 func (c *s3get) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
@@ -214,7 +214,7 @@ func (c *s3get) Execute(ctx context.Context,
 
 	select {
 	case err := <-errChan:
-		if c.skipMissing {
+		if err != nil && c.skipMissing {
 			logger.Task().Infof("Problem getting file but optional is true, exiting without error (%s).", err.Error())
 			return nil
 		}

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -47,7 +48,13 @@ type s3get struct {
 	LocalFile string `mapstructure:"local_file" plugin:"expand"`
 	ExtractTo string `mapstructure:"extract_to" plugin:"expand"`
 
-	bucket pail.Bucket
+	// Optional, when set to true, causes this command to be skipped over without an error when
+	// the path specified in remote_file does not exist. Defaults to false, which triggers errors
+	// for missing files.
+	Optional string `mapstructure:"optional" plugin:"expand"`
+
+	bucket      pail.Bucket
+	skipMissing bool
 
 	base
 }
@@ -57,7 +64,14 @@ func (c *s3get) Name() string { return "s3.get" }
 
 // s3get-specific implementation of ParseParams.
 func (c *s3get) ParseParams(params map[string]interface{}) error {
-	if err := mapstructure.Decode(params, c); err != nil {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           c,
+	})
+	if err != nil {
+		return errors.Wrap(err, "initializing mapstructure decoder")
+	}
+	if err := decoder.Decode(params); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}
 
@@ -117,7 +131,17 @@ func (c *s3get) shouldRunForVariant(buildVariantName string) bool {
 // Apply the expansions from the relevant task config
 // to all appropriate fields of the s3get.
 func (c *s3get) expandParams(conf *internal.TaskConfig) error {
-	return util.ExpandValues(c, &conf.Expansions)
+	var err error
+	if err = util.ExpandValues(c, &conf.Expansions); err != nil {
+		return errors.Wrap(err, "applying expansions")
+	}
+	if c.Optional != "" {
+		c.skipMissing, err = strconv.ParseBool(c.Optional)
+		if err != nil {
+			return errors.Wrap(err, "parsing optional parameter as a boolean")
+		}
+	}
+	return nil
 }
 
 // Implementation of Execute.  Expands the parameters, and then fetches the
@@ -127,7 +151,7 @@ func (c *s3get) Execute(ctx context.Context,
 
 	// expand necessary params
 	if err := c.expandParams(conf); err != nil {
-		return errors.Wrap(err, "applying expansions")
+		return errors.Wrap(err, "expanding params")
 	}
 
 	// validate the params
@@ -190,6 +214,10 @@ func (c *s3get) Execute(ctx context.Context,
 
 	select {
 	case err := <-errChan:
+		if c.skipMissing {
+			logger.Task().Infof("Problem getting file but optional is true, exiting without error (%s).", err.Error())
+			return nil
+		}
 		return errors.WithStack(err)
 	case <-ctx.Done():
 		logger.Execution().Infof("Canceled while running command '%s': %s", c.Name(), ctx.Err())

--- a/agent/command/s3_get_test.go
+++ b/agent/command/s3_get_test.go
@@ -107,6 +107,7 @@ func TestS3GetValidateParams(t *testing.T) {
 					"remote_file": "remote",
 					"bucket":      "bck",
 					"local_file":  "local",
+					"optional":    true,
 				}
 				So(cmd.ParseParams(params), ShouldBeNil)
 				So(cmd.validateParams(), ShouldBeNil)

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-10-02"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-10-31"
+	AgentVersion = "2023-10-31b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1052,6 +1052,7 @@ Parameters:
 -   `bucket`: the S3 bucket to use.
 -   `build_variants`: list of buildvariants to run the command for, if
     missing/empty will run for all
+-   `optional`: boolean: if set, won't error if the file isn't found or there's an error with downloading.
 
 ## s3.put
 


### PR DESCRIPTION
EVG-19801
### Description
First commit is the same, second fixes the panic.

### Testing
The main change is tested in the original PR; the panic change is untested since it's harder to hit but we may be able to unit test this in the future ([DEVPROD-1746](https://jira.mongodb.org/browse/DEVPROD-1746), [DEVPROD-1747](https://jira.mongodb.org/browse/DEVPROD-1747))