### PR TITLE
DEVPROD-137 add wiki reference for distro guidelines

### DIFF
--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -48,4 +48,4 @@ echo $foo
 
 ## Distro Choice
 
-Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros)
+Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)

--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -48,4 +48,4 @@ echo $foo
 
 ## Distro Choice
 
-Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)
+Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about available distro choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)

--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -48,4 +48,4 @@ echo $foo
 
 ## Distro Choice
 
-Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible.
+Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros)

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -418,7 +418,7 @@ configurations to be used by other users.
 Distros describe machine configuration that run tasks as well as the
 worker pools were tasks execute. As a result much of the available
 configuration that controls how tasks execute occurs at the distro
-level. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros)
+level. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)
 
 ### Scheduler Options
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -418,7 +418,7 @@ configurations to be used by other users.
 Distros describe machine configuration that run tasks as well as the
 worker pools were tasks execute. As a result much of the available
 configuration that controls how tasks execute occurs at the distro
-level. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)
+level. For more information about available distro choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)
 
 ### Scheduler Options
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -418,7 +418,7 @@ configurations to be used by other users.
 Distros describe machine configuration that run tasks as well as the
 worker pools were tasks execute. As a result much of the available
 configuration that controls how tasks execute occurs at the distro
-level.
+level. For more information about avaliable distros choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/display/DBDEVPROD/Guidelines+around+Evergreen+distros)
 
 ### Scheduler Options
 


### PR DESCRIPTION
DEVPROD-137

### Description
We needed to cross reference the internal wiki and the evergreen docs. It was decided to specifically link the best-practices page and Project-and-Distro-Settings page

### Testing
I pulled down pine, changed config.yml, make website-build ; make website-serve

### Documentation
This is a docs change
