### PR TITLE
DEVPROD-68: statistics of free and used inodes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -675,6 +675,7 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		"uptime",
 		"df -h",
 		"${ps|ps}",
+		"df -i",
 	)
 
 	statsCollector.logStats(execTimeoutCtx, tc.taskConfig.Expansions)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -677,7 +677,6 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		"df -h",
 		"${ps|ps}",
 	)
-
 	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
 		statsCollector.Cmds = append(statsCollector.Cmds, "df -h -i")
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -673,9 +673,8 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		a.jasper,
 		defaultStatsInterval,
 		"uptime",
-		"df -h",
+		"df -h -i",
 		"${ps|ps}",
-		"df -i",
 	)
 
 	statsCollector.logStats(execTimeoutCtx, tc.taskConfig.Expansions)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -673,9 +674,13 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		a.jasper,
 		defaultStatsInterval,
 		"uptime",
-		"df -h -i",
+		"df -h",
 		"${ps|ps}",
 	)
+
+	if runtime.GOOS == "linux" || runtime.GOOS == "windows" {
+		statsCollector.Cmds = append(statsCollector.Cmds, "df -h -i")
+	}
 
 	statsCollector.logStats(execTimeoutCtx, tc.taskConfig.Expansions)
 


### PR DESCRIPTION
[DEVPROD-68](https://jira.mongodb.org/browse/DEVPROD-68)

### Description

This pull request adds the `df -i` command to the [StatsCollector](https://github.com/evergreen-ci/evergreen/blob/main/agent/stats.go#L20-L26) struct for reporting statistics on the number of free and used inodes.

### Testing

N/A

### Documentation

N/A