### PR TITLE
DEVPROD-964: fix ambiguous skip CI interaction with Dependabot PRs

### DIFF
--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -52,8 +52,8 @@ If you used `evergreen keep-definitions`, then `evergreen reset-definitions` wil
 #### Skip CI Testing
 
 Sometimes you may want to avoid having Evergreen create patches (perhaps because the work is in progress, or testing isn't relevant yet). 
-Simply including `[skip-ci]` or `[skip ci]` in your PR title or description will prevent us from creating a patch (both from commits and `evergreen retry` comments) 
-until the label is removed and a new comment or commit is pushed.
+Simply including `[skip-ci]` or `[skip ci]` in the PR title or the first 100 characters of the description will prevent Evergreen from creating a patch (both from commits and `evergreen retry` comments) 
+until the label is removed and a new commit or `evergreen retry` comment is pushed.
 
 
 #### Create a patch for manual testing

--- a/docs/decisions/2023-11-01_reduce_unwanted_skip_ci.md
+++ b/docs/decisions/2023-11-01_reduce_unwanted_skip_ci.md
@@ -1,0 +1,36 @@
+# 2023-11-01 Reduce Issue of Unintentionally Skipping CI in PRs
+
+* status: accepted
+* date: 2023-11-01
+* authors: Kim Tao
+
+## Context and Problem Statement
+
+Evergreen has a feature to skip PR testing by adding the `[skip ci]` label to the PR title or description.
+Unfortunately, detecting that label in the PR description can lead to unintentionally skipping CI in scenarios where it
+should not. For example, because the description for Dependabot PRs can contain commit messages from other repos, the
+description may coincidentally contain the word `[skip ci]`, thus causing Evergreen to skip testing.
+
+## Considered Options
+* Don't read the `[skip ci]` label from the PR description - this would fix the problem, but not every repo would be
+  able to put `[skip ci]` in their PR title. For example, if repos have linting rules around the PR title before
+  merging, including `[skip ci]` in it may break commit format conventions.
+* Don't read the `[skip ci]` label from the PR description, and instead allow it for commit messages - this behavior is
+  used by many other CI systems (GitHub Actions, CircleCI, GitLab CI) and eliminates the problem of false skips.
+  However, using the commit message would put pressure on the GitHub API rate limit, because Evergreen would have to
+  make a GitHub API request for each PR to detect commits containing `[skip ci]`.
+* Keep reading the `[skip ci]` label, but only read it if it's near the beginning of the description - this one will
+  preserve existing workflows that users have set up of putting `[skip ci]` in the description, but make it less likely
+  to unintentionally skip CI. However, it cannot get rid of the ambiguity entirely since the description could include
+  any text.
+
+## Decision Outcome
+Only reading the first 100 characters from the PR description was chosen as the simplest solution. It should not
+significantly change workflows for users already putting `[skip ci]` in their PR descriptions, and it sufficiently
+fixes the issue for Dependabot PRs that reference commit messages containing `[skip ci]`. While it still poses some
+small chance of a PR unintentionally skipping CI, it mitigates the problem enough that it's much less likely to occur.
+
+## More Information
+* [Skip CI in GitLab CI](https://docs.gitlab.com/ee/ci/pipelines/#skip-a-pipeline)
+* [Skip CI in GitHub Actions](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)
+* [Skip CI in CircleCI](https://circleci.com/docs/skip-build/#skip-jobs)


### PR DESCRIPTION
DEVPROD-964

### Description
Some Dependabot PRs were not running Evergreen PR tests because the PR description occasionally happened to include the label `skip ci` in the commit list (I didn't type out the actual `skip ci` label or else Evergreen will skip CI testing on this PR...). For example, in [this PR](https://github.com/evergreen-ci/spruce/pull/1985), if you toggle the commit list, you'll see one of the commits in the upgrade has the `skip ci` label, so Evergreen skips CI testing for the Dependabot PR (even though `skip ci` was only intended for the dependency repo's testing, not ours).

I considered removing the ability to put `skip ci` in the description since it could be very ambiguous (using the PR description to skip CI is not something that I've seen other CI system offer, likely for this very reason). Unfortunately, some users are already relying on putting the `skip ci` phrase in their PR description. Rather than entirely remove the ability to `skip ci` using the description, I tried narrowing it down so Evergreen will only respect `skip ci` if it's very early on in the description, which will mitigate the Dependabot PR issue.

### Testing
Tested in the sandbox to verify that `skip ci` still works in the PR title + beginning of description, but putting the `skip ci` phrase much further down in the description does not skip.

### Documentation
Updated docs.