### PR TITLE
DEVPROD-69 PutMany for minutely jobs

### DIFF
--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -58,13 +58,11 @@ func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
 	if t == nil {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("task '%s' not found", h.taskID))
 	}
-	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	j, err := units.CreateAndEnqueueGenerateTasks(ctx, h.env, *t, ts)
-	grip.Warning(message.WrapError(err, message.Fields{
+	appCtx, _ := h.env.Context()
+	grip.Warning(message.WrapError(units.CreateAndEnqueueGenerateTasks(appCtx, ctx, h.env, []task.Task{*t}, utility.RoundPartOfMinute(1).Format(units.TSFormat)), message.Fields{
 		"message": "could not enqueue generate tasks job",
 		"version": t.Version,
 		"task_id": t.Id,
-		"job_id":  j.ID(),
 	}))
 
 	return gimlet.NewJSONResponse(struct{}{})

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -58,8 +58,7 @@ func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
 	if t == nil {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("task '%s' not found", h.taskID))
 	}
-	appCtx, _ := h.env.Context()
-	grip.Warning(message.WrapError(units.CreateAndEnqueueGenerateTasks(appCtx, ctx, h.env, []task.Task{*t}, utility.RoundPartOfMinute(1).Format(units.TSFormat)), message.Fields{
+	grip.Warning(message.WrapError(units.CreateAndEnqueueGenerateTasks(ctx, h.env, []task.Task{*t}, utility.RoundPartOfMinute(1).Format(units.TSFormat)), message.Fields{
 		"message": "could not enqueue generate tasks job",
 		"version": t.Version,
 		"task_id": t.Id,

--- a/units/crons.go
+++ b/units/crons.go
@@ -600,13 +600,13 @@ func agentMonitorDeployJobs(ctx context.Context, ts time.Time) ([]amboy.Job, err
 // Since the original generate.tasks request kicks off a job immediately, this function only serves as a fallback in case the
 // original job fails to run. If the original job has already completed, the job will not be created here. If the original job is in flight,
 // the job will be created here, but will no-op unless the original job fails to complete.
-func enqueueFallbackGenerateTasksJobs(appCtx, ctx context.Context, env evergreen.Environment, ts time.Time) error {
+func enqueueFallbackGenerateTasksJobs(ctx context.Context, env evergreen.Environment, ts time.Time) error {
 	tasks, err := task.GenerateNotRun()
 	if err != nil {
 		return errors.Wrap(err, "getting tasks that need generators run")
 	}
 
-	return CreateAndEnqueueGenerateTasks(appCtx, ctx, env, tasks, ts.Format(TSFormat))
+	return CreateAndEnqueueGenerateTasks(ctx, env, tasks, ts.Format(TSFormat))
 }
 
 func hostCreationJobs(ctx context.Context, ts time.Time) ([]amboy.Job, error) {

--- a/units/crons.go
+++ b/units/crons.go
@@ -269,7 +269,7 @@ func parentDecommissionJobs(ctx context.Context, ts time.Time) ([]amboy.Job, err
 	}
 	containerPools := settings.ContainerPools.Pools
 
-	// Create ParentDecommissionJob for each distro
+	// Create a ParentDecommissionJob for each distro.
 	var jobs []amboy.Job
 	for _, c := range containerPools {
 		jobs = append(jobs, NewParentDecommissionJob(ts.Format(TSFormat), c.Distro, c.MaxContainers))
@@ -285,7 +285,7 @@ func containerStateJobs(ctx context.Context, ts time.Time) ([]amboy.Job, error) 
 	}
 
 	var jobs []amboy.Job
-	// create job to check container state consistency for each parent
+	// Create a job to check container state consistency for each parent.
 	for _, p := range parents {
 		jobs = append(jobs, NewHostMonitorContainerStateJob(nil, &p, evergreen.ProviderNameDocker, ts.Format(TSFormat)))
 	}
@@ -299,7 +299,7 @@ func oldestImageRemovalJobs(ctx context.Context, ts time.Time) ([]amboy.Job, err
 	}
 
 	var jobs []amboy.Job
-	// Create oldestImageJob when images take up too much disk space
+	// Create an oldestImageJob when images take up too much disk space.
 	for _, p := range parents {
 		jobs = append(jobs, NewOldestImageRemovalJob(&p, evergreen.ProviderNameDocker, ts.Format(TSFormat)))
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -176,7 +176,7 @@ func eventNotifierJobs(ctx context.Context, ts time.Time) ([]amboy.Job, error) {
 
 	var jobs []amboy.Job
 	for _, evt := range events {
-		jobs = append(jobs, NewEventNotifierJob(nil, evt.ID, utility.RoundPartOfMinute(0).Format(TSFormat)))
+		jobs = append(jobs, NewEventNotifierJob(nil, evt.ID, ts.Format(TSFormat)))
 	}
 	return jobs, nil
 }
@@ -210,7 +210,7 @@ func hostTerminationJobs(ctx context.Context, _ time.Time) ([]amboy.Job, error) 
 	if flags.MonitorDisabled {
 		grip.InfoWhen(sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
 			"message": "monitor is disabled",
-			"impact":  "not submitting termination flags for dead/killable hosts",
+			"impact":  "not submitting termination jobs for dead/killable hosts",
 			"mode":    "degraded",
 		})
 		return nil, nil
@@ -281,7 +281,7 @@ func parentDecommissionJobs(ctx context.Context, ts time.Time) ([]amboy.Job, err
 func containerStateJobs(ctx context.Context, ts time.Time) ([]amboy.Job, error) {
 	parents, err := host.FindAllRunningParents(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error finding parent hosts")
+		return nil, errors.Wrap(err, "finding parent hosts")
 	}
 
 	var jobs []amboy.Job
@@ -596,7 +596,7 @@ func agentMonitorDeployJobs(ctx context.Context, ts time.Time) ([]amboy.Job, err
 	return jobs, nil
 }
 
-// fallbackGenerateTasksJobs populates generate.tasks jobs for tasks that have started running their generate.tasks command.
+// enqueueFallbackGenerateTasksJobs populates generate.tasks jobs for tasks that have started running their generate.tasks command.
 // Since the original generate.tasks request kicks off a job immediately, this function only serves as a fallback in case the
 // original job fails to run. If the original job has already completed, the job will not be created here. If the original job is in flight,
 // the job will be created here, but will no-op unless the original job fails to complete.

--- a/units/crons.go
+++ b/units/crons.go
@@ -1227,7 +1227,8 @@ func PopulatePodResourceCleanupJobs() amboy.QueueOperation {
 	}
 }
 
-func populateQueueGroup(appCtx, ctx context.Context, env evergreen.Environment, queueGroupName string, factory cronJobFactory, ts time.Time) error {
+func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGroupName string, factory cronJobFactory, ts time.Time) error {
+	appCtx, _ := env.Context()
 	queueGroup, err := env.RemoteQueueGroup().Get(appCtx, queueGroupName)
 	if err != nil {
 		return errors.Wrapf(err, "getting '%s' queue", queueGroupName)

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -11,16 +11,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/testutil"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
@@ -50,12 +49,7 @@ func (s *cronsEventSuite) TearDownSuite() {
 }
 
 func (s *cronsEventSuite) SetupTest() {
-	env := &mock.Environment{}
 	s.ctx = testutil.TestSpan(s.suiteCtx, s.T())
-
-	s.Require().NoError(env.Configure(s.ctx))
-	evergreen.SetEnvironment(env)
-
 	s.Require().NoError(db.ClearCollections(event.EventCollection, evergreen.ConfigCollection, notification.Collection,
 		event.SubscriptionsCollection, patch.Collection, model.ProjectRefCollection))
 
@@ -202,6 +196,12 @@ func (s *cronsEventSuite) TestNotificationIsEnabled() {
 }
 
 func (s *cronsEventSuite) TestEndToEnd() {
+	defer evergreen.SetEnvironment(evergreen.GetEnvironment())
+
+	env := &mock.Environment{}
+	s.Require().NoError(env.Configure(s.ctx))
+	evergreen.SetEnvironment(env)
+
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	s.Require().NoError(err)
 	defer ln.Close()

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -140,7 +140,7 @@ func (s *cronsEventSuite) TestDegradedMode() {
 
 	// degraded mode shouldn't process events
 	s.NoError(e.Log())
-	s.NoError(PopulateEventNotifierJobs(s.env)(s.ctx, s.env.LocalQueue()))
+	s.NoError(eventNotifierJobs(s.env)(s.ctx, s.env.LocalQueue()))
 
 	out, err := event.FindUnprocessedEvents(-1)
 	s.NoError(err)
@@ -163,7 +163,7 @@ func (s *cronsEventSuite) TestSenderDegradedModeDoesntDispatchJobs() {
 
 	startingStats := s.env.LocalQueue().Stats(ctx)
 
-	s.NoError(dispatchNotifications(ctx, s.n, s.env.LocalQueue(), &flags))
+	s.NoError(notificationJobs(ctx, s.n, s.env.LocalQueue(), &flags))
 
 	out := []notification.Notification{}
 	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))
@@ -294,7 +294,7 @@ func (s *cronsEventSuite) TestEndToEnd() {
 	go httpServer(ln, handler)
 
 	q := s.env.RemoteQueue()
-	s.NoError(PopulateEventNotifierJobs(s.env)(s.ctx, q))
+	s.NoError(eventNotifierJobs(s.env)(s.ctx, q))
 
 	// Wait for event notifier to finish.
 	amboy.WaitInterval(s.ctx, q, 10*time.Millisecond)

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -72,10 +72,9 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
 
 	// Create dedicated queues for pod allocation.
-	appCtx, _ := j.env.Context()
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, podAllocationQueueGroup, podAllocatorJobs, ts))
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, podDefinitionCreationQueueGroup, podDefinitionCreationJobs, ts))
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, podCreationQueueGroup, podCreationJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, podAllocationQueueGroup, podAllocatorJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, podDefinitionCreationQueueGroup, podDefinitionCreationJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, podCreationQueueGroup, podCreationJobs, ts))
 
 	j.ErrorCount = catcher.Len()
 	grip.Error(message.WrapError(catcher.Resolve(), message.Fields{

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -79,10 +79,9 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	catcher.Add(enqueueHostSetupJobs(ctx, j.env.RemoteQueue(), ts))
 
 	// Create dedicated queues for host creation, event notifier, and commit queue jobs.
-	appCtx, _ := j.env.Context()
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
-	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
 
 	// Add generate tasks fallbacks to their versions' queues.
 	catcher.Add(enqueueFallbackGenerateTasksJobs(ctx, j.env, ts))

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -85,7 +85,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
 
 	// Add generate tasks fallbacks to their versions' queues.
-	catcher.Add(enqueueFallbackGenerateTasksJobs(appCtx, ctx, j.env, ts))
+	catcher.Add(enqueueFallbackGenerateTasksJobs(ctx, j.env, ts))
 
 	j.ErrorCount = catcher.Len()
 

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -45,55 +45,47 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	ops := []amboy.QueueOperation{
-		PopulateHostSetupJobs(j.env),
-		PopulateBackgroundStatsJobs(j.env, 0),
-		PopulateContainerStateJobs(j.env),
-		PopulateEventSendJobs(j.env),
-		PopulateFallbackGenerateTasksJobs(j.env),
-		PopulateHostMonitoring(j.env),
-		PopulateHostTerminationJobs(j.env),
-		PopulateLastContainerFinishTimeJobs(),
-		PopulateOldestImageRemovalJobs(),
-		PopulateParentDecommissionJobs(),
-		PopulatePeriodicNotificationJobs(1),
-		PopulateUserDataDoneJobs(j.env),
-		PopulatePodTerminationJobs(j.env),
+	ops := map[string]cronJobFactory{
+		"host ready":                 hostReadyJob,
+		"background stats":           backgroundStatsJobs,
+		"container state":            containerStateJobs,
+		"event send":                 sendNotificationJobs,
+		"host monitoring":            hostMonitoringJobs,
+		"host termination":           hostTerminationJobs,
+		"last container finish time": lastContainerFinishTimeJobs,
+		"oldest image removal":       oldestImageRemovalJobs,
+		"parent decommission":        parentDecommissionJobs,
+		"periodic notification":      periodicNotificationJobs,
+		"user data done":             userDataDoneJobs,
+		"pod termination":            podTerminationJobs,
 	}
 
+	var allJobs []amboy.Job
 	catcher := grip.NewBasicCatcher()
+	ts := utility.RoundPartOfMinute(0)
 
-	queue := j.env.RemoteQueue()
-	for _, op := range ops {
+	for name, op := range ops {
 		if ctx.Err() != nil {
 			j.AddError(errors.New("operation aborted"))
 		}
-		catcher.Add(op(ctx, queue))
+		jobs, err := op(ctx, ts)
+		if err != nil {
+			catcher.Wrapf(err, "getting '%s' jobs", name)
+			continue
+		}
+		allJobs = append(allJobs, jobs...)
 	}
+	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
+	catcher.Add(enqueueHostSetupJobs(ctx, j.env.RemoteQueue(), ts))
 
-	// Create dedicated queues for host creation, event notifier, and commit
-	// queue jobs.
+	// Create dedicated queues for host creation, event notifier, and commit queue jobs.
 	appCtx, _ := j.env.Context()
-	hcqueue, err := j.env.RemoteQueueGroup().Get(appCtx, CreateHostQueueGroup)
-	if err != nil {
-		catcher.Wrap(err, "getting host create queue")
-	} else {
-		catcher.Add(PopulateHostCreationJobs(j.env, 0)(ctx, hcqueue))
-	}
+	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
+	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
+	catcher.Add(populateQueueGroup(appCtx, ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
 
-	commitQueueQueue, err := j.env.RemoteQueueGroup().Get(appCtx, commitQueueQueueGroup)
-	if err != nil {
-		catcher.Wrap(err, "getting commit queue queue")
-	} else {
-		catcher.Add(PopulateCommitQueueJobs(j.env)(ctx, commitQueueQueue))
-	}
-
-	eventNotifierQueue, err := j.env.RemoteQueueGroup().Get(appCtx, eventNotifierQueueGroup)
-	if err != nil {
-		catcher.Wrap(err, "getting event notifier queue")
-	} else {
-		catcher.Add(PopulateEventNotifierJobs(j.env)(ctx, eventNotifierQueue))
-	}
+	// Add generate tasks fallbacks to their versions' queues.
+	catcher.Add(enqueueFallbackGenerateTasksJobs(appCtx, ctx, j.env, ts))
 
 	j.ErrorCount = catcher.Len()
 

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -120,6 +120,7 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 	}
 
 	jobs, err := notificationJobs(ctx, n, j.flags, utility.RoundPartOfMinute(0))
+	// Continue on error even if some jobs couldn't be marked disabled.
 	catcher.Add(errors.Wrap(err, "getting notification jobs"))
 	catcher.Add(errors.Wrap(j.q.PutMany(ctx, jobs), "enqueueing notification jobs"))
 

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -49,10 +49,9 @@ func makeEventNotifierJob() *eventNotifierJob {
 	return j
 }
 
-func NewEventNotifierJob(env evergreen.Environment, q amboy.Queue, eventID, ts string) amboy.Job {
+func NewEventNotifierJob(env evergreen.Environment, eventID, ts string) amboy.Job {
 	j := makeEventNotifierJob()
 	j.env = env
-	j.q = q
 
 	j.SetID(fmt.Sprintf("%s.%s.%s", eventNotifierName, eventID, ts))
 	j.EventID = eventID
@@ -120,7 +119,9 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 		catcher.AddWhen(shouldLogError, errors.Wrap(err, "bulk inserting notifications"))
 	}
 
-	catcher.Add(dispatchNotifications(ctx, n, j.q, j.flags))
+	jobs, err := notificationJobs(ctx, n, j.flags, utility.RoundPartOfMinute(0))
+	catcher.Add(errors.Wrap(err, "getting notification jobs"))
+	catcher.Add(errors.Wrap(j.q.PutMany(ctx, jobs), "enqueueing notification jobs"))
 
 	endTime := time.Now()
 	totalDuration := endTime.Sub(startTime)
@@ -211,20 +212,17 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 	return n, err
 }
 
-func dispatchNotifications(ctx context.Context, notifications []notification.Notification, q amboy.Queue, flags *evergreen.ServiceFlags) error {
+func notificationJobs(ctx context.Context, notifications []notification.Notification, flags *evergreen.ServiceFlags, ts time.Time) ([]amboy.Job, error) {
 	catcher := grip.NewBasicCatcher()
+	var jobs []amboy.Job
 	for i := range notifications {
 		if notificationIsEnabled(flags, &notifications[i]) {
-			if err := q.Put(ctx, NewEventSendJob(notifications[i].ID, utility.RoundPartOfMinute(1).Format(TSFormat))); !amboy.IsDuplicateJobError(err) {
-				catcher.Wrapf(err, "enqueueing event send job for notification '%s'", notifications[i].ID)
-			}
+			jobs = append(jobs, NewEventSendJob(notifications[i].ID, ts.Format(TSFormat)))
 		} else {
-			err := errors.New("notifications are disabled")
-			catcher.Wrapf(notifications[i].MarkError(err), "setting error for notification '%s'", notifications[i].ID)
+			catcher.Wrapf(notifications[i].MarkError(errors.New("notification is disabled")), "setting error for notification '%s'", notifications[i].ID)
 		}
 	}
-
-	return catcher.Resolve()
+	return jobs, catcher.Resolve()
 }
 
 func notificationIsEnabled(flags *evergreen.ServiceFlags, n *notification.Notification) bool {

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -278,12 +278,12 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 // CreateAndEnqueueGenerateTasks enqueues a generate.tasks job for each task.
 // Jobs are segregated by task version into separate queues.
-func CreateAndEnqueueGenerateTasks(appCtx, ctx context.Context, env evergreen.Environment, tasks []task.Task, ts string) error {
+func CreateAndEnqueueGenerateTasks(ctx context.Context, env evergreen.Environment, tasks []task.Task, ts string) error {
 	versionTasksMap := make(map[string][]task.Task)
 	for _, t := range tasks {
 		versionTasksMap[t.Version] = append(versionTasksMap[t.Version], t)
 	}
-
+	appCtx, _ := env.Context()
 	for versionID, tasks := range versionTasksMap {
 		var jobs []amboy.Job
 		for _, t := range tasks {

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -276,19 +276,30 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	}
 }
 
-// CreateAndEnqueueGenerateTasks returns a job and enqueues it into the generate.tasks queue for the given task.
-func CreateAndEnqueueGenerateTasks(ctx context.Context, env evergreen.Environment, t task.Task, ts string) (amboy.Job, error) {
-	appCtx, _ := env.Context()
-	j := NewGenerateTasksJob(t.Version, t.Id, ts)
-	queueName := fmt.Sprintf("service.generate.tasks.version.%s", t.Version)
-	queue, err := env.RemoteQueueGroup().Get(appCtx, queueName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "getting generate tasks queue '%s' for version '%s'", queueName, t.Version)
+// CreateAndEnqueueGenerateTasks enqueues a generate.tasks job for each task.
+// Jobs are segregated by task version into separate queues.
+func CreateAndEnqueueGenerateTasks(appCtx, ctx context.Context, env evergreen.Environment, tasks []task.Task, ts string) error {
+	versionTasksMap := make(map[string][]task.Task)
+	for _, t := range tasks {
+		versionTasksMap[t.Version] = append(versionTasksMap[t.Version], t)
 	}
-	if err = amboy.EnqueueUniqueJob(ctx, queue, j); err != nil {
-		return nil, errors.Wrapf(err, "enqueueing generate tasks job '%s' for version '%s'", j.ID(), t.Version)
+
+	for versionID, tasks := range versionTasksMap {
+		var jobs []amboy.Job
+		for _, t := range tasks {
+			jobs = append(jobs, NewGenerateTasksJob(versionID, t.Id, ts))
+		}
+		queueName := fmt.Sprintf("service.generate.tasks.version.%s", versionID)
+		queue, err := env.RemoteQueueGroup().Get(appCtx, queueName)
+		if err != nil {
+			return errors.Wrapf(err, "getting generate tasks queue '%s' for version '%s'", queueName, versionID)
+		}
+		if err = amboy.EnqueueManyUniqueJobs(ctx, queue, jobs); err != nil {
+			return errors.Wrapf(err, "enqueueing generate tasks jobs for version '%s'", versionID)
+		}
 	}
-	return j, nil
+
+	return nil
 }
 
 func parseProjectsAsString(ctx context.Context, jsonStrings []string) ([]model.GeneratedProject, error) {

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -495,7 +495,7 @@ func (j *createHostJob) tryHostReplacement(ctx context.Context, cloudMgr cloud.M
 
 func EnqueueHostCreateJobs(ctx context.Context, env evergreen.Environment, hostIntents []host.Host) error {
 	appCtx, _ := env.Context()
-	queue, err := env.RemoteQueueGroup().Get(appCtx, CreateHostQueueGroup)
+	queue, err := env.RemoteQueueGroup().Get(appCtx, createHostQueueGroup)
 	if err != nil {
 		return errors.Wrap(err, "getting host create queue")
 	}


### PR DESCRIPTION
[DEVPROD-69](https://jira.mongodb.org/browse/DEVPROD-69)

### Description
This is the same as what we did with the 15 seconds jobs in https://github.com/evergreen-ci/evergreen/pull/6917. I'm particularly excited to see if there's an effect on the amboy db's performance as a result of batching the insertion of jobs to process events.

### Testing
In staging a task sent a notification when it finished.