### PR TITLE
DEVPROD-705: fix YAML tags on repotracker settings

### DIFF
--- a/config_repotracker.go
+++ b/config_repotracker.go
@@ -11,9 +11,9 @@ import (
 
 // RepoTrackerConfig holds settings for polling project repositories.
 type RepoTrackerConfig struct {
-	NumNewRepoRevisionsToFetch int `bson:"revs_to_fetch" json:"revs_to_fetch" yaml:"numnewreporevisionstofetch"`
-	MaxRepoRevisionsToSearch   int `bson:"max_revs_to_search" json:"max_revs_to_search" yaml:"maxreporevisionstosearch"`
-	MaxConcurrentRequests      int `bson:"max_con_requests" json:"max_con_requests" yaml:"maxconcurrentrequests"`
+	NumNewRepoRevisionsToFetch int `bson:"revs_to_fetch" json:"revs_to_fetch" yaml:"revs_to_fetch"`
+	MaxRepoRevisionsToSearch   int `bson:"max_revs_to_search" json:"max_revs_to_search" yaml:"max_revs_to_search"`
+	MaxConcurrentRequests      int `bson:"max_con_requests" json:"max_con_requests" yaml:"max_concurrent_requests"`
 }
 
 func (c *RepoTrackerConfig) SectionId() string { return "repotracker" }


### PR DESCRIPTION
## Description
The smoke test's cached admin settings are [set in a YAML when loading the app server](https://github.com/evergreen-ci/evergreen/blob/26a9c74fb94c21556995b848c5ae9fd6b4a20192/smoke/internal/testdata/admin_settings.yml#L79-L81), but they weren't being respected because the YAML tags on the repotracker didn't match. I made the YAML tags match the existing BSON/JSON ones.

I verified that changing the YAML tags doesn't affect any other test, only the repotracker for the smoke test.

## Testing
Ran a patch and verified that the app server logs said searched the now-correctly-configured number of revisions.