### PR TITLE
DEVPROD-948: Return repo level filters with project

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1029,7 +1029,25 @@ func mergeBranchAndRepoSettings(pRef *ProjectRef, repoRef *RepoRef) (*ProjectRef
 	reflectedRepo := reflect.ValueOf(repoRef).Elem().Field(0) // specifically references the ProjectRef part of RepoRef
 
 	util.RecursivelySetUndefinedFields(reflectedBranch, reflectedRepo)
+
+	// Include Parsley filters defined at repo level alongside project filters.
+	mergeParsleyFilters(pRef, repoRef)
+
 	return pRef, err
+}
+
+func mergeParsleyFilters(pRef *ProjectRef, repoRef *RepoRef) {
+	if repoRef.ParsleyFilters == nil || len(repoRef.ParsleyFilters) == 0 {
+		return
+	}
+
+	if pRef.ParsleyFilters == nil {
+		pRef.ParsleyFilters = []ParsleyFilter{}
+	}
+
+	for _, filter := range repoRef.ParsleyFilters {
+		pRef.ParsleyFilters = append(pRef.ParsleyFilters, filter)
+	}
 }
 
 func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1045,9 +1045,7 @@ func mergeParsleyFilters(pRef *ProjectRef, repoRef *RepoRef) {
 		pRef.ParsleyFilters = []ParsleyFilter{}
 	}
 
-	for _, filter := range repoRef.ParsleyFilters {
-		pRef.ParsleyFilters = append(pRef.ParsleyFilters, filter)
-	}
+	pRef.ParsleyFilters = append(pRef.ParsleyFilters, repoRef.ParsleyFilters...)
 }
 
 func setRepoFieldsFromProjects(repoRef *RepoRef, projectRefs []ProjectRef) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1028,10 +1028,10 @@ func mergeBranchAndRepoSettings(pRef *ProjectRef, repoRef *RepoRef) (*ProjectRef
 	reflectedBranch := reflect.ValueOf(pRef).Elem()
 	reflectedRepo := reflect.ValueOf(repoRef).Elem().Field(0) // specifically references the ProjectRef part of RepoRef
 
-	util.RecursivelySetUndefinedFields(reflectedBranch, reflectedRepo)
-
 	// Include Parsley filters defined at repo level alongside project filters.
 	mergeParsleyFilters(pRef, repoRef)
+
+	util.RecursivelySetUndefinedFields(reflectedBranch, reflectedRepo)
 
 	return pRef, err
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1037,7 +1037,7 @@ func mergeBranchAndRepoSettings(pRef *ProjectRef, repoRef *RepoRef) (*ProjectRef
 }
 
 func mergeParsleyFilters(pRef *ProjectRef, repoRef *RepoRef) {
-	if repoRef.ParsleyFilters == nil || len(repoRef.ParsleyFilters) == 0 {
+	if len(repoRef.ParsleyFilters) == 0 {
 		return
 	}
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -86,6 +86,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 		CommitQueue:       CommitQueueParams{Enabled: nil, Message: "using repo commit queue"},
 		WorkstationConfig: WorkstationConfig{GitClone: utility.TruePtr()},
 		TaskSync:          TaskSyncOptions{ConfigEnabled: utility.FalsePtr()},
+		ParsleyFilters: []ParsleyFilter{
+			{
+				Expression:    "project-filter",
+				CaseSensitive: true,
+				ExactMatch:    false,
+			},
+		},
 	}
 	assert.NoError(t, projectRef.Insert())
 	repoRef := &RepoRef{ProjectRef{
@@ -105,6 +112,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 		TaskSync:          TaskSyncOptions{ConfigEnabled: utility.TruePtr(), PatchEnabled: utility.TruePtr()},
 		CommitQueue:       CommitQueueParams{Enabled: utility.TruePtr()},
 		WorkstationConfig: WorkstationConfig{SetupCommands: []WorkstationSetupCommand{{Command: "my-command"}}},
+		ParsleyFilters: []ParsleyFilter{
+			{
+				Expression:    "repo-filter",
+				CaseSensitive: false,
+				ExactMatch:    true,
+			},
+		},
 	}}
 	assert.NoError(t, repoRef.Upsert())
 
@@ -138,6 +152,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	assert.True(t, mergedProject.WorkstationConfig.ShouldGitClone())
 	assert.Len(t, mergedProject.WorkstationConfig.SetupCommands, 1)
 	assert.Equal(t, "random2", mergedProject.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
+	assert.Len(t, mergedProject.ParsleyFilters, 2)
 }
 
 func TestGetNumberOfEnabledProjects(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -153,6 +153,17 @@ func TestFindMergedProjectRef(t *testing.T) {
 	assert.Len(t, mergedProject.WorkstationConfig.SetupCommands, 1)
 	assert.Equal(t, "random2", mergedProject.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
 	assert.Len(t, mergedProject.ParsleyFilters, 2)
+
+	projectRef.ParsleyFilters = []ParsleyFilter{}
+
+	assert.NoError(t, projectRef.Upsert())
+	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	assert.Len(t, mergedProject.ParsleyFilters, 1)
+
+	projectRef.ParsleyFilters = nil
+	assert.NoError(t, projectRef.Upsert())
+	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	assert.Len(t, mergedProject.ParsleyFilters, 1)
 }
 
 func TestGetNumberOfEnabledProjects(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -154,6 +154,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	assert.Equal(t, "random2", mergedProject.TaskAnnotationSettings.FileTicketWebhook.Endpoint)
 	assert.Len(t, mergedProject.ParsleyFilters, 2)
 
+	// Assert that mergeParsleyFilters correctly handles projects with repo filters but not project filters.
 	projectRef.ParsleyFilters = []ParsleyFilter{}
 
 	assert.NoError(t, projectRef.Upsert())

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -158,11 +158,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 
 	assert.NoError(t, projectRef.Upsert())
 	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 
 	projectRef.ParsleyFilters = nil
 	assert.NoError(t, projectRef.Upsert())
 	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 }
 


### PR DESCRIPTION
DEVPROD-948

### Description
- `FindMergedProjectRef` should return a merged list of repo- and project-level Parsley filters (similar to how variables are merged) instead of the default "if null then use repo settings" pattern

### Testing
- Update unit test

### Documentation
N/A