### PR TITLE
DEVPROD-961 improve build notification failed task attachments

### DIFF
--- a/trigger/build.go
+++ b/trigger/build.go
@@ -62,13 +62,13 @@ func (t *buildTriggers) Fetch(ctx context.Context, e *event.EventLogEntry) error
 
 	var tasks []task.Task
 	if e.EventType == event.BuildGithubCheckFinished {
-		query := db.Query(task.ByBuildIdAndGithubChecks(t.build.Id)).WithFields(task.StatusKey, task.DependsOnKey)
+		query := db.Query(task.ByBuildIdAndGithubChecks(t.build.Id))
 		tasks, err = task.FindAll(query)
 		if err != nil {
 			return errors.Wrapf(err, "finding tasks in build '%s' for GitHub check", t.build.Id)
 		}
 	} else {
-		query := db.Query(task.ByBuildId(t.build.Id)).WithFields(task.StatusKey, task.DependsOnKey)
+		query := db.Query(task.ByBuildId(t.build.Id))
 		tasks, err = task.FindAll(query)
 		if err != nil {
 			return errors.Wrapf(err, "finding tasks in build '%s'", t.build.Id)

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -275,7 +275,7 @@ func (t *buildTriggers) buildAttachments(data *commonTemplateData) []message.Sla
 		if attachmentsCount == slackAttachmentsLimit {
 			break
 		}
-		if t.tasks[i].Status == evergreen.TaskSucceeded {
+		if t.tasks[i].Status == evergreen.TaskSucceeded || t.tasks[i].Status == evergreen.TaskUnscheduled {
 			continue
 		}
 		attachments = append(attachments, message.SlackAttachment{

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -315,5 +315,5 @@ func taskFormatFromCache(t task.Task) string {
 		return fmt.Sprintf("took %s", t.TimeTaken)
 	}
 
-	return fmt.Sprintf("took %s, the task failed %s", t.TimeTaken, detailStatusToHumanSpeak(t.Details.Status))
+	return fmt.Sprintf("took %s, the task failed %s", t.TimeTaken, detailStatusToHumanSpeak(t.GetDisplayStatus()))
 }

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -1023,6 +1023,8 @@ func detailStatusToHumanSpeak(status string) string {
 		return "because the system was unresponsive"
 	case evergreen.TaskSystemTimedOut:
 		return "because the system timed out"
+	case evergreen.TaskAborted:
+		return "because the task was aborted"
 	default:
 		return fmt.Sprintf("because of something else (%s)", status)
 	}


### PR DESCRIPTION
DEVPROD-961
### Description
As frequently happens, caching only some statuses makes it easy to have bugs happen -- because we're caching these task docs to be used wherever, and task docs aren't large, there's no reason to just grab some statuses.

Also used the correct GetDisplayStatus, as referenced by Kim in the ticket comment. Not too important if all statuses are caught by the "toHumanSpeak" since there's a catch all.