### PR TITLE
DEVPROD-2230 Add nil check for taskoutput

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1591,9 +1591,7 @@ func (t *Task) GetTestLogs(ctx context.Context, env evergreen.Environment, getOp
 		// it has not run yet. Return an empty iterator.
 		return log.EmptyIterator(), nil
 	}
-	if output == nil {
-		return nil, errors.New("task output is nil")
-	}
+
 	taskID := t.Id
 	if t.Archived {
 		taskID = t.OldTaskId

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1591,7 +1591,9 @@ func (t *Task) GetTestLogs(ctx context.Context, env evergreen.Environment, getOp
 		// it has not run yet. Return an empty iterator.
 		return log.EmptyIterator(), nil
 	}
-
+	if output == nil {
+		return nil, errors.New("task output is nil")
+	}
 	taskID := t.Id
 	if t.Archived {
 		taskID = t.OldTaskId

--- a/taskoutput/test_log.go
+++ b/taskoutput/test_log.go
@@ -105,7 +105,9 @@ func (o TestLogOutput) getBuildloggerLogs(ctx context.Context, env evergreen.Env
 		if err != nil {
 			return nil, errors.Wrap(err, "getting DB test logs")
 		}
-
+		if testLog == nil {
+			return nil, errors.Errorf("no test log found for '%s'", getOpts.LogPaths[0])
+		}
 		messages := make([]apimodels.LogMessage, len(testLog.Lines))
 		for i, line := range testLog.Lines {
 			messages[i] = apimodels.LogMessage{


### PR DESCRIPTION
DEVPROD-2230

### Description
This line panics because test logs can sometimes be nil so this just adds a check.
 

