### PR TITLE
DEVPROD-1450 Finish generated docs

### DIFF
--- a/docs/API/REST-V2-Usage.md
+++ b/docs/API/REST-V2-Usage.md
@@ -1,4 +1,6 @@
-import ApiDocMdx from '@theme/ApiDocMdx';
+---
+hide_table_of_contents: true
+---
 
 # REST v2 API
 
@@ -38,7 +40,9 @@ A returned object will always contain its complete list of fields. Any
 field that does not have an associated value will be filled with JSON's
 null value.
 
-## Generated API Docs
+## API Docs
+
+import ApiDocMdx from '@theme/ApiDocMdx';
 
 <ApiDocMdx id="evergreen-openapi" />
 
@@ -52,162 +56,3 @@ null value.
 Create custom notifications for email or Slack issues. 
 
 We are investigating moving this out of Evergreen (EVG-21065) and won't be supporting future work for this. 
-
-## Additional Endpoints
-
-### Users
-
-#### Endpoints
-
-##### Get Users for Role
-
-NOTE: These roles are not part of the OpenAPI spec, since they are part of another package.
-
-    GET /roles/<role_id>/users
-
-Gets a list of users for the specified role. The format of the response
-is:
-```json
-{ "users": ["list", "of", "users"] }
-```
-
-##### Give Roles to User
-
-    POST /users/<user_id>/roles
-
-Adds the specified roles to the specified user. Attempting to add a
-duplicate role will result in an error. If you're unsure of what roles
-you want to add, you probably want to POST To /users/user_id/permissions
-instead. Note that usage of this endpoint requires that the requesting
-user have security to modify roles. The format of the body is: :
-
-    {
-      "roles": [ "role1", "role2" ],
-      "create_user": true,
-    }
-
--   roles - the list of roles to add for the user
--   create_user - if true, will also create a shell user document for
-    the user. By default, specifying a user that does not exist will
-    error
-
-## REST V2 Use Case Guide
-
-### Find all failures of a given build
-
-#### Endpoint
-
-`GET /builds/<build_id>/tasks`
-
-#### Description
-
-To better understand the state of a build, perhaps when attempting to
-determine the quality of a build for a release, it is helpful to be able
-to fetch information about the tasks it ran. To fetch this data, make a
-call to the `GET /builds/<build_id>/tasks` endpoint. Page through the
-results task data to produce meaningful statistics like the number of
-task failures or percentage of failures of a given build.
-
-### Find detailed information about the status of a particular tasks and its tests
-
-#### Endpoints
-
-`GET /tasks/<task_id>`
-
-`GET /tasks/<task_id>/tests`
-
-#### Description
-
-To better understand all aspects of a task failure, such as failure
-mode, which tests failed, and how long it took, it is helpful to fetch
-this information about a task. This can be accomplished using 2 API
-calls. Make one call to the endpoint for a specific task
-`GET /tasks/<task_id>` which returns information about the task itself.
-Then, make a second cal to `GET /tasks/<task_id>/tests` which delivers
-specific information about the tests that ran in a certain task.
-
-### Get all hosts
-
-#### Endpoint
-
-`GET /hosts`
-
-#### Description
-
-Retrieving information on Evergreen's hosts can be helpful for system
-monitoring. To fetch this information, make a call to `GET /hosts`,
-which returns a paginated list of hosts. Page through the results to
-inspect all hosts.
-
-By default, this endpoint will only return hosts that are considered
-"up" (status is equal to running, initializing, starting,
-provisioning, or provision failed).
-
-### Restart all failures for a commit
-
-#### Endpoints
-
-`GET /project/<project_name>/revisions/<commit_hash>/tasks`
-
-`POST /tasks/<task_id>/restart`
-
-#### Description
-
-Some Evergreen projects contain flaky tests or can endure spurious
-failures. To restart all of these tasks to gain better signal a user can
-fetch all of the tasks for a commit. Make a request to
-`GET /project/<project_name>/revisions/<commit_hash>/tasks` to fetch the
-tasks that ran and then loop over all of the returned tasks, calling
-`POST /tasks/<task_id>/restart` on each task which has failed.
-
-### Modify an Existing Project
-
-#### Endpoint
-
-`PATCH /projects/<project_id>`
-
-#### Description
-
-To modify the project, make a request to the endpoint with a JSON object
-as the body (using the project object descriptions on the REST V2 Usage
-wiki page). The result of a successful PATCH will be a 200 status. To
-see the modified project, make a request to
-`GET /projects/<project_id>`.
-
-For example, to enable the commit queue the body would be:
-
-    { "commit_queue": 
-      { "enabled": "true" } 
-    }
-
-To add and delete admins:
-
-    { "admins": ["annie.black", "brian.samek"], // does not overwrite existing admins    
-      "delete_admins": ["john.liu"] // deletes existing admin }
-
-To add/delete variables and specify which are private:
-
-    { "variables": 
-      { "vars": { // add to existing variables
-        "banana": "yellow",             
-        "apple": "red", },         
-      "private_vars": { "apple": "true", // this cannot be undone         
-      },         
-      "vars_to_delete": ["watermelon"] }}
-
-### Copy an Existing Project
-
-#### Endpoint
-
-`POST /projects/<project_id>/copy`
-
-#### Description
-
-To copy a project to a new project, this is the route you would use. To
-define the new project's name (which is required), we would include a
-query parameter, for example:
-
-    projects/my_first_project/copy?new_project=my_second_project
-
-This route will return the new project but this will not include
-variables/aliases/subscriptions; to see this, GET the new project.

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -483,8 +483,10 @@ func (h *userPermissionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 }
 
 type rolesPostRequest struct {
-	Roles      []string `json:"roles"`
-	CreateUser bool     `json:"create_user"`
+	// the list of roles to add for the user
+	Roles []string `json:"roles"`
+	// if true, will also create a shell user document for the user. By default, specifying a user that does not exist will error
+	CreateUser bool `json:"create_user"`
 }
 
 type userRolesPostHandler struct {
@@ -500,6 +502,16 @@ func makeModifyUserRoles(rm gimlet.RoleManager) gimlet.RouteHandler {
 	}
 }
 
+// Factory creates an instance of the handler.
+//
+//	@Summary		Give roles to user
+//	@Description	Adds the specified roles to the specified user. Attempting to add a duplicate role will result in an error. If you're unsure of what roles you want to add, you probably want to POST To /users/user_id/permissions instead.
+//	@Tags			users
+//	@Router			/users/{user_id}/roles [post]
+//	@Security		Api-User || Api-Key
+//	@Param			user_id		path	string				true	"user ID"
+//	@Param			{object}	body	rolesPostRequest	true	"parameters"
+//	@Success		200
 func (h *userRolesPostHandler) Factory() gimlet.RouteHandler {
 	return &userRolesPostHandler{
 		rm: h.rm,
@@ -585,6 +597,15 @@ func makeGetUsersWithRole() gimlet.RouteHandler {
 	return &usersWithRoleGetHandler{}
 }
 
+// Factory creates an instance of the handler.
+//
+//	@Summary		Get users for role
+//	@Description	Gets a list of users for the specified role
+//	@Tags			users
+//	@Router			/roles/{role_id}/users [get]
+//	@Security		Api-User || Api-Key
+//	@Param			role_id	path		string					true	"role ID"
+//	@Success		200		{object}	UsersWithRoleResponse	"list of users"
 func (h *usersWithRoleGetHandler) Factory() gimlet.RouteHandler {
 	return &usersWithRoleGetHandler{}
 }


### PR DESCRIPTION
DEVPROD-1450

### Description

This PR does three things

1. Finish documenting the routes. I'm not sure why I thought the remaining couldn't be documented.
2. Remove the use-case guide. I think these notes are redundant and not useful.
2. Remove the right-side table of contents. I think this makes the screen busy, and squeezes the contents horizontally.

### Testing

You can view the results in [staging](https://docs.devprod.staging.corp.mongodb.com/evergreen/API/REST-V2-Usage/), and compare it to [production](https://docs.devprod.prod.corp.mongodb.com/evergreen/API/REST-V2-Usage/).
