### PR TITLE
DEVPROD-974 Add project validation warnings for projects using ssh cloning for modules

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -986,6 +986,16 @@ func checkModules(project *model.Project) ValidationErrors {
 			})
 		}
 
+		if strings.Contains(module.Repo, "git@github.com:") {
+			text := fmt.Sprintf("The project config has a module '%s' with a repo '%s' that is in git@github.com:owner/repo.git format. "+
+				"This is deprecated, please update to specify an owner and repo separately", module.Name, module.Repo)
+			errs = append(errs, ValidationError{
+				Level:   Warning,
+				Message: text,
+			})
+		}
+
+		// if the module does not use the new owner and repo format, make sure that the repo is a valid url
 		if module.Owner == "" {
 			// Warn if repo is empty or does not conform to Git URL format
 			owner, repo, err := thirdparty.ParseGitUrl(module.Repo)
@@ -1014,7 +1024,6 @@ func checkModules(project *model.Project) ValidationErrors {
 				Message: fmt.Sprintf("module '%s' should have a set repo", module.Name),
 			})
 		}
-
 	}
 
 	return errs

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1485,7 +1485,7 @@ func TestCheckModules(t *testing.T) {
 			So(len(cm), ShouldEqual, 2)
 		})
 
-		Convey("An error should be returned when the module's repo is empty, in the deprecated format or invalid", func() {
+		Convey("An error should be returned when the module's repo is empty or invalid", func() {
 			project := &model.Project{
 				Modules: model.ModuleList{
 					model.Module{
@@ -1504,6 +1504,13 @@ func TestCheckModules(t *testing.T) {
 						Branch: "main",
 						Repo:   "evergreen",
 					},
+				},
+			}
+			So(len(checkModules(project)), ShouldEqual, 2)
+		})
+		Convey("An error should be returned when the module's repo is in the deprecated format", func() {
+			project := &model.Project{
+				Modules: model.ModuleList{
 					model.Module{
 						Name:   "module-4",
 						Branch: "main",
@@ -1512,7 +1519,7 @@ func TestCheckModules(t *testing.T) {
 				},
 			}
 			cm := checkModules(project)
-			So(len(cm), ShouldEqual, 3)
+			So(len(cm), ShouldEqual, 1)
 		})
 	})
 }

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1423,31 +1423,37 @@ func TestCheckModules(t *testing.T) {
 					model.Module{
 						Name:   "module-0",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
 						Name:   "module-0",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
 						Name:   "module-1",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
 						Name:   "module-2",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
 						Name:   "module-1",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 				},
 			}
@@ -1458,24 +1464,28 @@ func TestCheckModules(t *testing.T) {
 			project := &model.Project{
 				Modules: model.ModuleList{
 					model.Module{
-						Name: "module-0",
-						Repo: "git@github.com:evergreen-ci/evergreen.git",
+						Name:  "module-0",
+						Owner: "evergreen-ci",
+						Repo:  "evergreen",
 					},
 					model.Module{
 						Name:   "module-1",
 						Branch: "main",
-						Repo:   "git@github.com:evergreen-ci/evergreen.git",
+						Owner:  "evergreen-ci",
+						Repo:   "evergreen",
 					},
 					model.Module{
-						Name: "module-2",
-						Repo: "git@github.com:evergreen-ci/evergreen.git",
+						Name:  "module-2",
+						Owner: "evergreen-ci",
+						Repo:  "evergreen",
 					},
 				},
 			}
-			So(len(checkModules(project)), ShouldEqual, 2)
+			cm := checkModules(project)
+			So(len(cm), ShouldEqual, 2)
 		})
 
-		Convey("An error should be returned when the module's repo is empty or invalid", func() {
+		Convey("An error should be returned when the module's repo is empty, in the deprecated format or invalid", func() {
 			project := &model.Project{
 				Modules: model.ModuleList{
 					model.Module{
@@ -1501,7 +1511,8 @@ func TestCheckModules(t *testing.T) {
 					},
 				},
 			}
-			So(len(checkModules(project)), ShouldEqual, 2)
+			cm := checkModules(project)
+			So(len(cm), ShouldEqual, 3)
 		})
 	})
 }


### PR DESCRIPTION
DEVPROD-974

### Description

The original plan for this ticket was to add project level warning banners in the UI for any projects that use ssh cloning for modules. I decided against this for a few reasons. The biggest reason is that we are not currently set up to add project level warning banners programmatically in a way that reflects the real time state of the project config and in a way that doesn't interfere with a manually set up banner that may take higher precedence (it's a one banner per project setup right now). If we did indeed add a project banner if a project failed validation, we wouldn't really have a setup to scan the project config after it was fixed to see if it now passes and remove the banner. I think implementing that would be a bit of too much effort for what it is trying to accomplish and too much of a deviation from how project banners are intended to be used. I therefore opted for a validation warning instead. 

### Testing
Added to the test 

### Note
I will hold off merging this until an email is sent out to users.
