### PR TITLE
DEVPROD-957 increase GitHub installation page limit

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1348,7 +1348,8 @@ func authorizedForOrg(ctx context.Context, token, requiredOrganization, name str
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
-	opts := &github.ListOptions{PerPage: 100}
+	const numInstallationsLimit = 2000
+	opts := &github.ListOptions{PerPage: numInstallationsLimit}
 	for {
 		installations, resp, err := githubClient.Organizations.ListInstallations(ctx, requiredOrganization, opts)
 		if err != nil {


### PR DESCRIPTION
DEVPROD-957

### Description
100 was too small a page limit here; increasing to something larger. I'm hesitant to say we should need pagination here; I don't expect us to have so many installations that we can't handle it in a call. 

### Testing
No testing needed 
