### PR TITLE
DEVPROD-2285 Create Decomissioned Host tickets in DEVPROD project

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -577,7 +577,7 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 
 // //////////////////////////////////////////////////////////////////////
 //
-// POST /rest/v2/host/{host_id}/disable
+// POST /rest/v2/hosts/{host_id}/disable
 type disableHost struct {
 	env evergreen.Environment
 

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -577,7 +577,7 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 
 // //////////////////////////////////////////////////////////////////////
 //
-// GET /rest/v2/host/{host_id}/disable
+// POST /rest/v2/host/{host_id}/disable
 type disableHost struct {
 	env evergreen.Environment
 

--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -18,6 +18,8 @@ import (
 )
 
 const decoHostNotifyJobName = "deco-host-notify"
+const fieldAssignedTeams = "customfield_12751"
+const runtimeEnvironments = "25626"
 
 func init() {
 	registry.AddJobType(decoHostNotifyJobName, func() amboy.Job { return makeDecoHostsNotifyJob() })
@@ -134,7 +136,10 @@ func (j *decoHostNotifyJob) Run(_ context.Context) {
 		Summary:     fmt.Sprintf("investigate automatically decommissioned host '%s'", j.Host.Id),
 		Type:        "Incident",
 		Description: strings.Join(descParts, "\n"),
-		Components:  []string{"Evergreen"},
+		Components:  []string{"Static Host Management"},
+		Fields: map[string]interface{}{
+			fieldAssignedTeams: []map[string]string{{"id": runtimeEnvironments}}, // Assigned Teams: Runtime Environments
+		},
 	}
 
 	msg := message.MakeJiraMessage(&issue)

--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -19,7 +19,7 @@ import (
 
 const decoHostNotifyJobName = "deco-host-notify"
 const fieldAssignedTeams = "customfield_12751"
-const runtimeEnvironments = "25626"
+const runtimeEnvironmentsId = "25626"
 
 func init() {
 	registry.AddJobType(decoHostNotifyJobName, func() amboy.Job { return makeDecoHostsNotifyJob() })
@@ -138,7 +138,7 @@ func (j *decoHostNotifyJob) Run(_ context.Context) {
 		Description: strings.Join(descParts, "\n"),
 		Components:  []string{"Static Host Management"},
 		Fields: map[string]interface{}{
-			fieldAssignedTeams: []map[string]string{{"id": runtimeEnvironments}}, // Assigned Teams: Runtime Environments
+			fieldAssignedTeams: []map[string]string{{"id": runtimeEnvironmentsId}}, // Assigned Teams: Runtime Environments
 		},
 	}
 


### PR DESCRIPTION
DEVPROD-2285

### Description
Makes Decomissioned Host tickets go to the DEVPROD Jira project (Setting will be updated in admin settings)
Assigns to the runtimeEnvironments team
### Testing
https://jira.mongodb.org/browse/DEVPROD-2474

cc @brooookemiller
