### PR TITLE
DEVPROD-2475: only generate JSON for swaggo output file

### DIFF
--- a/makefile
+++ b/makefile
@@ -376,7 +376,7 @@ swaggo-format:
 	swag fmt -g service/service.go
 
 swaggo-build:
-	swag init -g service/service.go -o $(buildDir)
+	swag init -g service/service.go -o $(buildDir) --outputTypes json
 
 swaggo-render:
 	npx @redocly/cli build-docs $(buildDir)/swagger.json -o $(buildDir)/redoc-static.html


### PR DESCRIPTION
DEVPROD-2475

### Description
By default, `make swaggo-build` will create output in JSON, YAML, and a plain Go source file. We don't want the plain Go source file to be created because `go mod` will count this as a Go source file that's part of Evergreen (and try to add swaggo as a dependency), which we don't want because swaggo is not actually part of Evergreen. Now, `swaggo-build` should only make the JSON file (which is all that's needed to generate the HTML docs).

### Testing
Ran it locally to verify that the static HTML docs could still be generated.

### Documentation
N/A