### PR TITLE
DEVPROD-2483 Fix up makefile for swaggo

### DIFF
--- a/makefile
+++ b/makefile
@@ -365,9 +365,7 @@ gqlgen:
 	go run github.com/99designs/gqlgen generate
 
 swaggo: 
-	make swaggo-format
-	make swaggo-build
-	make swaggo-render
+	$(MAKE) swaggo-format swaggo-build swaggo-render
 
 swaggo-install:
 	go install github.com/swaggo/swag/cmd/swag@latest


### PR DESCRIPTION
DEVPROD-2483

### Description

This does 2 things:

1. Put swaggo's invocations on a single line, because "If you specify several
goals, make processes each of them in turn, in the order you name them"
([source](https://www.gnu.org/software/make/manual/html_node/Goals.html)).

2. Use `$(MAKE)` instead of `make`. This is the canonical way of calling `make`
recursively, and forwards `-n`, making the output more pleasant to use.

### Testing

I ran the commands locally.