### PR TITLE
DEVPROD-982 Add project yaml to replace external repository in tests

### DIFF
--- a/model/testdata/project.yml
+++ b/model/testdata/project.yml
@@ -1,0 +1,24 @@
+tasks:
+- name: taskOne
+  depends_on: []
+  commands:
+    - command: git.get_project
+      params:
+        directory: src
+        working_dir: src
+        script: echo "lagos"
+buildvariants:
+- name: linux-64-duroff
+  display_name: Linux 64-bit DUR OFF
+  run_on:
+  - d1
+  expansions: 
+    push_path: linux
+    push_bucket: downloads.mongodb.org
+    push_name: linux-duroff
+    push_arch: x86_64
+    compile_flags: --durableDefaultOff -j$(grep -c ^processor /proc/cpuinfo)
+    has_debugsymbols: true
+    test_flags: --continue-on-failure
+  tasks:
+  - name: taskOne


### PR DESCRIPTION
DEVPROD-982

### Description
Currently we use an external repo for some tests, this is the first step in removing it (second step is pointing to the commit hash that this creates on main)

### Testing
TBA in a 2nd PR after a commit hash is created with this project yaml in main
