### PR TITLE
DEVPROD-941: Add authorEmail to Version GraphQL model

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1450,6 +1450,7 @@ type ComplexityRoot struct {
 	Version struct {
 		Activated                func(childComplexity int) int
 		Author                   func(childComplexity int) int
+		AuthorEmail              func(childComplexity int) int
 		BaseTaskStatuses         func(childComplexity int) int
 		BaseVersion              func(childComplexity int) int
 		Branch                   func(childComplexity int) int
@@ -8787,6 +8788,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Version.Author(childComplexity), true
+
+	case "Version.authorEmail":
+		if e.complexity.Version.AuthorEmail == nil {
+			break
+		}
+
+		return e.complexity.Version.AuthorEmail(childComplexity), true
 
 	case "Version.baseTaskStatuses":
 		if e.complexity.Version.BaseTaskStatuses == nil {
@@ -25231,6 +25239,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -25348,6 +25358,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(ctx conte
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -31514,6 +31526,8 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -34151,6 +34165,8 @@ func (ec *executionContext) fieldContext_Patch_versionFull(ctx context.Context, 
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -44382,6 +44398,8 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -52917,6 +52935,8 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(ctx context.Contex
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -58350,6 +58370,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(ctx context.Con
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -59617,6 +59639,50 @@ func (ec *executionContext) fieldContext_Version_author(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Version_authorEmail(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Version_authorEmail(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AuthorEmail, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Version_authorEmail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Version",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Version_baseTaskStatuses(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 	if err != nil {
@@ -59703,6 +59769,8 @@ func (ec *executionContext) fieldContext_Version_baseVersion(ctx context.Context
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -59984,6 +60052,8 @@ func (ec *executionContext) fieldContext_Version_childVersions(ctx context.Conte
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -60717,6 +60787,8 @@ func (ec *executionContext) fieldContext_Version_previousVersion(ctx context.Con
 				return ec.fieldContext_Version_activated(ctx, field)
 			case "author":
 				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
 			case "baseTaskStatuses":
 				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
 			case "baseVersion":
@@ -83049,6 +83121,11 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = ec._Version_activated(ctx, field, obj)
 		case "author":
 			out.Values[i] = ec._Version_author(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "authorEmail":
+			out.Values[i] = ec._Version_authorEmail(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -40,6 +40,7 @@ type Version {
   id: String!
   activated: Boolean
   author: String!
+  authorEmail: String!
   baseTaskStatuses: [String!]!
   baseVersion: Version
   branch: String!


### PR DESCRIPTION
DEVPROD-941

### Description
In order to linkify the author as described in the ticket, we need the username. The existing "author" field is a [plain string](https://github.com/evergreen-ci/evergreen/blob/f143d7fa036647cd7f923454cd1440f283626f23/graphql/schema/types/version.graphql#L42) containing either the [person's name (e.g. "Brian Samek")](https://spruce.mongodb.com/version/evergreen_f143d7fa036647cd7f923454cd1440f283626f23/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) or [username ("byron.hood")](https://spruce.mongodb.com/version/654d0a47d6d80a88e9a319bc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and it's not exactly clear to me how one or the other is chosen. 

To get the username, we need to pass through additional info; it just so happens that the Evergreen username is the same as the username attached to someone's @mongodb.com email address. Passing through the email address lets us compute the username in Spruce.

### Testing
See spruce PR: https://github.com/evergreen-ci/spruce/pull/2147

### Documentation
n/a
