### PR TITLE
DEVPROD-959 Remove UpdateBlockedDependencies from stale/stranded task cleanup

### DIFF
--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4576,7 +4576,8 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskFailed, unschedulableTask.Status)
 
-	dependencyTask, err := task.FindOne(db.Query(task.ById("dependencyTask")))
+	dependencyTask, err := task.FindOneId("dependencyTask")
+	require.NotNil(t, dependencyTask)
 	require.NoError(t, err)
 	assert.True(dependencyTask.DependsOn[0].Unattainable)
 	assert.True(dependencyTask.DependsOn[0].Finished)
@@ -5261,7 +5262,8 @@ func TestResetStaleTask(t *testing.T) {
 			require.NotZero(t, dbVersion)
 			assert.Equal(t, evergreen.VersionCreated, dbVersion.Status, "version status should be updated for restarted task")
 
-			dependencyTask, err := task.FindOne(db.Query(task.ById("dependencyTask")))
+			dependencyTask, err := task.FindOneId("dependencyTask")
+			require.NotNil(t, dependencyTask)
 			require.NoError(t, err)
 			assert.False(t, dependencyTask.DependsOn[0].Unattainable)
 			assert.False(t, dependencyTask.DependsOn[0].Finished)
@@ -5284,7 +5286,8 @@ func TestResetStaleTask(t *testing.T) {
 			assert.False(t, dbTask.ContainerAllocated)
 			assert.Zero(t, dbTask.ContainerAllocatedTime)
 
-			dependencyTask, err := task.FindOne(db.Query(task.ById("dependencyTask")))
+			dependencyTask, err := task.FindOneId("dependencyTask")
+			require.NotNil(t, dependencyTask)
 			require.NoError(t, err)
 			assert.True(t, dependencyTask.DependsOn[0].Unattainable)
 			assert.True(t, dependencyTask.DependsOn[0].Finished)


### PR DESCRIPTION
DEVPROD-959

### Description
`ClearAndResetStrandedContainerTask` and `FixStaleTask` redundantly update the blocked dependencies of the task, because their following logic will always either:

1. update the blocked dependencies again in the end task logic
2. immediately reset the task, which renders updating blocked dependencies unnecessary.
### Testing
`ClearAndResetStrandedContainerTask` already has cases that check for proper behavior of blocked task dependencies, but added them to the test cases for `FixStaleTask`.  I also did check that commenting out the end task logic where blocked dependencies get updated causes the tests to fail.
