### PR TITLE
DEVPROD-1000 Allow empty set-module patches

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-11-01"
+	ClientVersion = "2023-11-13"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-11-07"

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -400,7 +400,8 @@ The parameters for each module are:
 -   `branch`: must be the name of branch, commit hashes _are not
     accepted_.
 
-More specifically, module hash priority is as follows:
+#### Module Hash Hierarchy
+The hash used for a module during cloning is determined by the following hierarchy:
 * For commit queue and GitHub merge queue patches, Evergreen always uses the module branch name, to ensure accurate testing.
 * For other patches, the initial default is to the githash in set-module, if specified.
 * For both commits and patches, the next default is to the `<module_name>` set in revisions for the command.
@@ -921,7 +922,7 @@ Example dummy content of a test results JSON file containing `test` objects:
                 ],
                 "metrics": [],
                 "sub_tests": []
-            },
+            }
         ]
     }
 ]

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -405,7 +405,9 @@ version manifest will be inherited from its base version. You can change
 the git revision for modules by setting a module manually with 
 [evergreen set-module](../CLI.md#operating-on-existing-patches) or
 by specifying the `auto_update` option (as described below) to use the
-latest revision available for a module.
+latest revision available for a module. The full hierarchy of how
+module revisions are determined is available in the [git.get_project](Project-Commands.md#module-hash-hierarchy)
+docs.
 
 Module fields support the expansion of variables defined in the [Variables](Project-and-Distro-Settings.md#variables)
 tab of the Spruce project settings. These fields are expanded at the time of version creation, at which point 

--- a/model/project.go
+++ b/model/project.go
@@ -1100,18 +1100,6 @@ func generateId(name string, projectIdentifier string, projBV *BuildVariant, rev
 		v.CreateTime.Format(build.IdTimeLayout))
 }
 
-var (
-	// bson fields for the project struct
-	ProjectIdentifierKey    = bsonutil.MustHaveTag(Project{}, "Identifier")
-	ProjectPreKey           = bsonutil.MustHaveTag(Project{}, "Pre")
-	ProjectPostKey          = bsonutil.MustHaveTag(Project{}, "Post")
-	ProjectModulesKey       = bsonutil.MustHaveTag(Project{}, "Modules")
-	ProjectBuildVariantsKey = bsonutil.MustHaveTag(Project{}, "BuildVariants")
-	ProjectFunctionsKey     = bsonutil.MustHaveTag(Project{}, "Functions")
-	ProjectStepbackKey      = bsonutil.MustHaveTag(Project{}, "Stepback")
-	ProjectTasksKey         = bsonutil.MustHaveTag(Project{}, "Tasks")
-)
-
 // PopulateExpansions returns expansions for a task, excluding build variant
 // expansions, project variables, and project/version parameters.
 func PopulateExpansions(t *task.Task, h *host.Host, oauthToken, appToken string) (util.Expansions, error) {

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -124,18 +124,19 @@ func addModuleToPatch(params *patchParams, args cli.Args, conf *ClientSettings,
 		return err
 	}
 
-	if len(diffData.fullPatch) == 0 {
-		grip.Infof("No changes for module '%s', continuing.", module.Name)
-		return nil
-	}
 	if !params.SkipConfirm {
 		grip.Infof("Using branch '%s' for module '%s'.", module.Branch, module.Name)
 		if diffData.patchSummary != "" {
 			fmt.Println(diffData.patchSummary)
 		}
-
-		if !confirm("This is a summary of the module patch to be submitted. Include this module's changes?", true) {
-			return nil
+		if len(diffData.fullPatch) > 0 {
+			if !confirm("This is a summary of the module patch to be submitted. Include this module's changes?", true) {
+				return nil
+			}
+		} else {
+			if !confirm("Patch submission for the module is empty. Continue?", true) {
+				return nil
+			}
 		}
 	}
 	moduleParams := UpdatePatchModuleParams{
@@ -152,7 +153,7 @@ func addModuleToPatch(params *patchParams, args cli.Args, conf *ClientSettings,
 	if err != nil {
 		return err
 	}
-	grip.Infof("Module '%s' updated.", module.Name)
+	grip.Infof("Module '%s' updated, base commit is '%s' (and will override the manifest).", module.Name, diffData.base)
 	return nil
 }
 


### PR DESCRIPTION
DEVPROD-1000

### Description
`set-module` actually does already work the way that was requested in the ticket (as it will [override](https://gist.github.com/hadjri/a061cb18107bd6043cb91da240ccf223#file-git-go-L686-L711) the manifest module revision if it exists), with the caveat that a diff must be staged on the module repo first. 

 I don't see any issue with allowing empty module patches as we already allow empty regular patches, so I allowed set-module to allow a patch to use the user's local checked out module revision regardless of a diff present.

Also deleted a block of unused code that I stumbled across for a struct that we don't ever save to the DB

### Testing
Ran `evergreen -c ~/evergreen-staging.yml set-module -m evergreen -i 6551caf69dbe328b3cf21b34` in staging with no staged evergreen changes for a sandbox patch which has evergreen as one of its modules.

[Confirmed](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_git_env_test_bynntask_patch_81dd13ebce8b573651e1d613febc2fb82d8887e9_6551caf69dbe328b3cf21b34_23_11_13_07_15_08/0?type=E#L44) in staging to confirm a task cloned the module revision from set-module and overrided the revision listed in the manifest
### Documentation
In order to make the nuances of module hash hierarchies clearer, I updated the docs on the project configuration and project commands side to make them clearer.