### PR TITLE
DEVPROD-2494 Add title to GitHub merge

### DIFF
--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -5,7 +5,7 @@ ensures that all pull requests pass required tests, rebased on HEAD, and it
 batches pull requests to test them as a unit to increase throughput.
 
 This is an alternative to Evergreen's commit queue, which the Evergreen team
-plans to deprecate in favor of GitHub's merge queue.
+has deprecated in favor of GitHub's merge queue.
 
 Gating every merge on a green build means every commit on the tracked branch had a green build. This way:
 
@@ -47,6 +47,16 @@ By setting this branch protection rule, the "evergreen" status will be required
 to pass before any changes can be merged into the protected branch. Alternative,
 you can require a single or multiple variants to pass before merging, instead of
 all variants.
+
+## Concurrency
+
+Concurrency is on by default for the GitHub merge queue. If there are multiple
+PRs in the queue, your PR might be tested with other commits.  This means that
+the Evergreen versions on a project patches page might be testing your PR even
+if they have a different commit queue title. This title is the title of the
+HEAD PR of a merge group, but the merge group could contain multiple PRs. Note
+that GitHub merges all commits from each PR before adding that PR to a version,
+so a given version has as many commits in it as there are PRs in it.
 
 ## Additional Resources
 

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -51,7 +51,7 @@ all variants.
 ## Concurrency
 
 Concurrency is on by default for the GitHub merge queue. If there are multiple
-PRs in the queue, your PR might be tested with other commits.  This means that
+PRs in the queue, your PR might be tested with other commits. This means that
 the Evergreen versions on a project patches page might be testing your PR even
 if they have a different commit queue title. This title is the title of the
 HEAD PR of a merge group, but the merge group could contain multiple PRs. Note

--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -90,7 +90,8 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 	}
 
 	// The head commit message is optional, as it's displayed in the UI but not
-	// used to check anything out, so we do not check if it exists.
+	// used when checking out the version or sending notifications, so we do not
+	// check if it exists.
 
 	if catcher.HasErrors() {
 		return nil, catcher.Resolve()

--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -48,8 +48,11 @@ type githubMergeIntent struct {
 	// HeadRef is the head ref of the merge group. Evergreen clones this.
 	HeadRef string `bson:"base_branch"`
 
-	// HeadHash is the SHA of the head of the merge group. Evergreen checks this out.
+	// HeadSHA is the SHA of the head of the merge group. Evergreen checks this out.
 	HeadSHA string `bson:"head_hash"`
+
+	// HeadCommit is the commit message of the head of the merge group.
+	HeadCommit string `bson:"head_commit"`
 
 	// BaseSHA is the SHA of the base of the merge group.
 	BaseSHA string `bson:"base_hash"`
@@ -85,6 +88,10 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 	if mg.GetMergeGroup().GetBaseSHA() == "" {
 		catcher.Add(errors.New("base SHA cannot be empty"))
 	}
+
+	// The head commit message is optional, as it's displayed in the UI but not
+	// used to check anything out, so we do not check if it exists.
+
 	if catcher.HasErrors() {
 		return nil, catcher.Resolve()
 	}
@@ -98,6 +105,7 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 		"Repo":       mg.GetRepo().GetName(),
 		"HeadRef":    mg.GetMergeGroup().GetHeadRef(),
 		"HeadSHA":    mg.GetMergeGroup().GetHeadSHA(),
+		"HeadCommit": mg.GetMergeGroup().GetHeadCommit().GetMessage(),
 		"BaseSHA":    mg.GetMergeGroup().GetBaseSHA(),
 		"CalledBy":   caller,
 	})
@@ -109,6 +117,7 @@ func NewGithubMergeIntent(msgDeliveryID string, caller string, mg *github.MergeG
 		Repo:       mg.GetRepo().GetName(),
 		HeadRef:    mg.GetMergeGroup().GetHeadRef(),
 		HeadSHA:    mg.GetMergeGroup().GetHeadSHA(),
+		HeadCommit: mg.GetMergeGroup().GetHeadCommit().GetMessage(),
 		BaseSHA:    mg.GetMergeGroup().GetBaseSHA(),
 		CalledBy:   caller,
 	}, nil
@@ -209,6 +218,7 @@ func (g *githubMergeIntent) NewPatch() *Patch {
 			BaseBranch: baseBranch,
 			HeadBranch: headBranch,
 			HeadSHA:    g.HeadSHA,
+			HeadCommit: g.HeadCommit,
 		},
 	}
 	return patchDoc

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -105,7 +105,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.Equal(t, evergreen.CommitQueueAlias, p.Alias)
 			assert.Equal(t, *mge.MergeGroup.BaseSHA, p.Githash)
 			assert.Equal(t, *mge.MergeGroup.HeadSHA, p.GithubMergeData.HeadSHA)
-			assert.Equal(t, *mge.MergeGroup.HeadCommit, p.GithubMergeData.HeadCommit)
+			assert.Equal(t, mge.MergeGroup.GetHeadCommit().GetMessage(), p.GithubMergeData.HeadCommit)
 			assert.Equal(t, *mge.Org.Login, p.GithubMergeData.Org)
 			assert.Equal(t, *mge.Repo.Name, p.GithubMergeData.Repo)
 			assert.Equal(t, "main", p.GithubMergeData.BaseBranch)

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -105,6 +105,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.Equal(t, evergreen.CommitQueueAlias, p.Alias)
 			assert.Equal(t, *mge.MergeGroup.BaseSHA, p.Githash)
 			assert.Equal(t, *mge.MergeGroup.HeadSHA, p.GithubMergeData.HeadSHA)
+			assert.Equal(t, *mge.MergeGroup.HeadCommit, p.GithubMergeData.HeadCommit)
 			assert.Equal(t, *mge.Org.Login, p.GithubMergeData.Org)
 			assert.Equal(t, *mge.Repo.Name, p.GithubMergeData.Repo)
 			assert.Equal(t, "main", p.GithubMergeData.BaseBranch)
@@ -114,6 +115,7 @@ func TestGithubMergeIntent(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.Clear(IntentCollection))
 			HeadSHA := "a"
+			HeadCommit := "commit message"
 			BaseSHA := "b"
 			HeadRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
 			OrgName := "my_org"
@@ -126,6 +128,9 @@ func TestGithubMergeIntent(t *testing.T) {
 			}
 			mg := github.MergeGroup{
 				HeadSHA: &HeadSHA,
+				HeadCommit: &github.Commit{
+					Message: &HeadCommit,
+				},
 				HeadRef: &HeadRef,
 				BaseSHA: &BaseSHA,
 			}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -933,7 +933,7 @@ func AbortPatchesWithGithubPatchData(ctx context.Context, createdBefore time.Tim
 }
 
 func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *ProjectRef, project *Project,
-	githubMergePatch bool, githubMergeSHA string) string {
+	githubMergePatch bool, mergeGroup thirdparty.GithubMergeGroup) string {
 	commitFmtString := "'%s' into '%s/%s:%s'"
 	description := []string{}
 	for _, p := range patches {
@@ -965,7 +965,7 @@ func MakeCommitQueueDescription(patches []patch.ModulePatch, projectRef *Project
 	}
 
 	if githubMergePatch {
-		return "GitHub Merge Queue: " + githubMergeSHA[0:7]
+		return "GitHub Merge Queue: " + mergeGroup.HeadCommit + " (" + mergeGroup.HeadSHA[0:7] + ")"
 	} else {
 		return "Commit Queue Merge: " + strings.Join(description, " || ")
 	}
@@ -1056,7 +1056,7 @@ func MakeMergePatchFromExisting(ctx context.Context, settings *evergreen.Setting
 		return nil, errors.Wrap(err, "making merge patches from existing patch")
 	}
 	patchDoc.Description = MakeCommitQueueDescription(patchDoc.Patches, projectRef, project,
-		patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData.HeadSHA)
+		patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData)
 
 	// verify the commit queue has tasks/variants enabled that match the project
 	project.BuildProjectTVPairs(patchDoc, patchDoc.Alias)

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -819,7 +819,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 
 	// no commits
 	patches := []patch.ModulePatch{}
-	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
+	assert.Equal(t, "Commit Queue Merge: No Commits Added", MakeCommitQueueDescription(patches, projectRef, project, false, thirdparty.GithubMergeGroup{}))
 
 	// main repo commit
 	patches = []patch.ModulePatch{
@@ -828,9 +828,9 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Commit"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
+	assert.Equal(t, "Commit Queue Merge: 'Commit' into 'evergreen-ci/evergreen:main'", MakeCommitQueueDescription(patches, projectRef, project, false, thirdparty.GithubMergeGroup{}))
 
-	assert.Equal(t, "GitHub Merge Queue: 0e312ff", MakeCommitQueueDescription(patches, projectRef, project, true, "0e312ff6c06bd09eff0aed1bd1f73911a7daa350"))
+	assert.Equal(t, "GitHub Merge Queue: I'm a commit! (0e312ff)", MakeCommitQueueDescription(patches, projectRef, project, true, thirdparty.GithubMergeGroup{HeadSHA: "0e312ffabcdefghijklmnop", HeadCommit: "I'm a commit!"}))
 
 	// main repo + module commits
 	patches = []patch.ModulePatch{
@@ -844,7 +844,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
+	assert.Equal(t, "Commit Queue Merge: 'Commit 1 <- Commit 2' into 'evergreen-ci/evergreen:main' || 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, thirdparty.GithubMergeGroup{}))
 
 	// module only commits
 	patches = []patch.ModulePatch{
@@ -856,7 +856,7 @@ func TestMakeCommitQueueDescription(t *testing.T) {
 			PatchSet:   patch.PatchSet{CommitMessages: []string{"Module Commit 1", "Module Commit 2"}},
 		},
 	}
-	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, ""))
+	assert.Equal(t, "Commit Queue Merge: 'Module Commit 1 <- Module Commit 2' into 'evergreen-ci/module_repo:feature'", MakeCommitQueueDescription(patches, projectRef, project, false, thirdparty.GithubMergeGroup{}))
 }
 
 func TestRetryCommitQueueItems(t *testing.T) {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -417,6 +417,7 @@ func TestPopulateExpansions(t *testing.T) {
 			Repo:       "my_merge_repo",
 			HeadBranch: "merge_head_branch",
 			HeadSHA:    "merge_head_sha",
+			HeadCommit: "merge_head_commit",
 		},
 	}
 	require.NoError(t, p.Insert())

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -362,7 +362,7 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, errors.Errorf("finding project for patch '%s'", p.Id))
 		}
-		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, proj, p.IsGithubMergePatch(), p.GithubMergeData.HeadSHA)); err != nil {
+		if err = p.SetDescription(model.MakeCommitQueueDescription(p.Patches, projectRef, proj, p.IsGithubMergePatch(), p.GithubMergeData)); err != nil {
 			as.LoggedError(w, r, http.StatusInternalServerError, err)
 			return
 		}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -153,7 +153,17 @@ type GithubMergeGroup struct {
 	Repo       string `bson:"repo"`
 	BaseBranch string `bson:"base_branch"` // BaseBranch is what GitHub merges to
 	HeadBranch string `bson:"head_branch"` // HeadBranch is the merge group's gh-readonly-queue branch
-	HeadSHA    string `bson:"head_sha"`
+
+	// HeadSHA is the SHA of the commit at the head of the merge group. For each
+	// PR in the merge group, GitHub merges the commits from that PR together,
+	// so there are as many commits as there are PRs in the merge group. This is
+	// only the SHA of the first commit in the merge group.
+	HeadSHA string `bson:"head_sha"`
+	// HeadCommit is the title of the commit at the head of the merge group. For
+	// each PR in the merge group, GitHub merges the commits from that PR
+	// together, so there are as many commits as there are PRs in the merge
+	// group. This is only the title of the first commit in the merge group.
+	HeadCommit string `bson:"head_commit"`
 }
 
 // SendGithubStatusInput is the input to the SendPendingStatusToGithub function and contains

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -345,7 +345,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if patchDoc.IsCommitQueuePatch() {
-		patchDoc.Description = model.MakeCommitQueueDescription(patchDoc.Patches, pref, patchedProject, patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData.HeadSHA)
+		patchDoc.Description = model.MakeCommitQueueDescription(patchDoc.Patches, pref, patchedProject, patchDoc.IsGithubMergePatch(), patchDoc.GithubMergeData)
 	}
 
 	if patchDoc.IsBackport() {


### PR DESCRIPTION
DEVPROD-2494

### Description

This adds the title of the HEAD PR to merge queue versions.

### Testing

Edited the unit test for the title.

### Documentation

Added some docs and comments because the behavior is useful but potentially
confusing.
