### PR TITLE
DEVPROD-2665 Deprecated https urls for modules

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -743,13 +743,8 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			" to https format. Please update your project config.", module.Repo)
 	}
 
-	// if the repo is an https url, use that as the location
-	if strings.HasPrefix(opts.location, "https://") {
-		opts.location = opts.repo
-	} else {
-		if err := opts.setLocation(); err != nil {
-			return errors.Wrap(err, "setting location to clone from")
-		}
+	if err := opts.setLocation(); err != nil {
+		return errors.Wrap(err, "setting location to clone from")
 	}
 
 	if opts.method == evergreen.CloneMethodOAuth {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-11-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-11-09"
+	AgentVersion = "2023-11-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-2665

### Description
The one project that used an https url for modules switched over to specifying an owner/repo, and our docs no longer show an https example (removed in [7191](https://github.com/evergreen-ci/evergreen/pull/7191/files)). We therefore no longer need to support it. 
