### PR TITLE
DEVPROD-712: allow display task updates if the updated status matches the current status

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2415,18 +2415,34 @@ func tryUpdateDisplayTaskAtomically(dt task.Task) (updated *task.Task, err error
 		update[task.FinishTimeKey] = dt.FinishTime
 	}
 
+	checkStatuses := []string{originalStatus}
+	if dt.Status != evergreen.TaskUndispatched {
+		// This is a small optimization to reduce update conflicts in the case
+		// where the updated status is the same as the current display task
+		// status.
+		// The display task update is allowed to go through if the display task
+		// status hasn't been changed (i.e. there was no race to update the
+		// status) or the updated status is the same as the current status in
+		// the DB (i.e. there was a race, but the race would ultimately still
+		// set the display task to the same resulting status). The one exception
+		// is if the display task is being updated to undispatched, then it's
+		// not sufficient to just check the status was not updated. In the case
+		// of updating to undispatched, the activation status must be up-to-date
+		// since that determines if it's scheduled to run or will not run.
+		checkStatuses = append(checkStatuses, dt.Status)
+	}
+
 	if err := task.UpdateOne(
 		bson.M{
 			task.IdKey: dt.Id,
 			// Require that the status/activation state is updated atomically.
 			// For the update to succeed, either the status has not changed
 			// since the status was originally calculated, or the updated status
-			// is already reflected in the display task status.
+			// is already the current display task status.
 			// If the status doesn't match the original or updated status, then
 			// then this update is potentially invalid because it's based on
 			// outdated data from the execution tasks.
-			task.StatusKey:    bson.M{"$in": []string{originalStatus, dt.Status}},
-			task.ActivatedKey: dt.Activated,
+			task.StatusKey: bson.M{"$in": checkStatuses},
 		},
 		bson.M{
 			"$set": update,


### PR DESCRIPTION
DEVPROD-712

### Description
Follow-on from #7229.

I read through the Splunk logs post-deploy and most of the display task update races are due to the fact that the execution tasks tend to all start around the same time and fight to update the display from undispatched -> dispatched -> starting (because the execution tasks start very soon after being dispatched). To reduce the update conflicts, I optimized it a little bit with the following reasoning - if the updated status is anything _other than_ undispatched _and_ the updated status is what's already in the DB, the update will succeed without needing to try again (because the update won't change the status anyways).

For updating to undispatched, we can't apply the above reasoning about the status update because an undispatched display task must also accurately reflect the execution tasks' activated state. This is due to the fact that activation determines if undispatched is interpreted to mean "will run" or "unscheduled" (and I don't think activation state matters for any other status). Therefore, if the display task is being updated because it's being activated/deactivated and the task is undispatched, that activation state must be up-to-date.

* Allow updates when updating to the same as the current status (except undispatched).
* Remove temporary debug log.

### Testing
Existing tests from prior PR should still pass.

### Documentation
N/A