### PR TITLE
DEVPROD-2669 Update getInstallationIDFromCache to not error on no documents

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -188,7 +188,7 @@ func getInstallationIDFromCache(ctx context.Context, owner, repo string) (int64,
 	installation := &GitHubAppInstallation{}
 	res := GetEnvironment().DB().Collection(GitHubAppCollection).FindOne(ctx, byOwnerRepo(owner, repo))
 	if err := res.Err(); err != nil {
-		if err == mongo.ErrNoDocuments {
+		if errors.Is(err, mongo.ErrNoDocuments) {
 			return 0, nil
 		}
 		return 0, errors.Wrapf(err, "finding cached installation ID for '%s/%s", owner, repo)

--- a/github_app.go
+++ b/github_app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -187,6 +188,9 @@ func getInstallationIDFromCache(ctx context.Context, owner, repo string) (int64,
 	installation := &GitHubAppInstallation{}
 	res := GetEnvironment().DB().Collection(GitHubAppCollection).FindOne(ctx, byOwnerRepo(owner, repo))
 	if err := res.Err(); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return 0, nil
+		}
 		return 0, errors.Wrapf(err, "finding cached installation ID for '%s/%s", owner, repo)
 	}
 	if err := res.Decode(&installation); err != nil {


### PR DESCRIPTION
DEVPROD-2669

### Description
Erroring on no documents causes new repos to never cache installation IDs 