### PR TITLE
DEVPROD-962 clarify dependency space-separation logic

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1486,11 +1486,18 @@ supported as a space-separated list. For example,
   depends_on:
   - name: test
     variant: "* !E"
+```
 
+Notably, selectors return items that satisfy all of the criteria. That is,
+they return the *set intersection* of each individual criterion. So the below yaml,
+while technically valid, wouldn't match anything given that these are static variant names, so the set 
+intersection will be nothing.
+
+``` yaml
 - name: push
   depends_on:
   - name: test
-    variant: "A B C D"
+    variant: "A B"
 ```
 
 [Task/variant tags](#task-and-variant-tags) 


### PR DESCRIPTION
DEVPROD-962 
### Description
Realized that the behavior I'm seeing is actually what I see elsewhere in the docs, namely that we take an _intersection_ of all the criteria in the variant. So it's the example case we gave that was broken rather than the feature itself.  This matches the behavior I saw while testing.

### Documentation
Doc change only
