### PR TITLE
[doc] Fix link to default expansions and remove whitespace in Task Traces doc

### DIFF
--- a/docs/Project-Configuration/Task_Traces.md
+++ b/docs/Project-Configuration/Task_Traces.md
@@ -15,11 +15,11 @@ Evergreen provides an [OTel collector](https://opentelemetry.io/docs/collector/)
 ### Trace file parsing
 When a task finishes Evergreen will check the task's [working directory](../Reference/Glossary.md) for any [encoded](#json-protobuf-encoding) trace files written to a `${workdir}/build/OTelTraces` directory, parse them, and send them to the collector. This can be useful if a test is running without a connection to the network. Only trace files are supported, and OTel metrics/logs files in the directory will be skipped.
 
-#### JSON protobuf encoding 
+#### JSON protobuf encoding
 OTel defines [JSON protobuf encoding](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) for serializing traces to files. Some OTel SDKs support this natively (e.g. the Java SDK provides the [OtlpJsonLoggingSpanExporter exporter](https://javadoc.io/static/io.opentelemetry/opentelemetry-exporter-logging-otlp/1.10.0-rc.2/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.html)). If this isn't an option (e.g. the SDK for go doesn't provide a JSON protobuf exporter) another option is to configure the test to send its traces to a local collector running alongside the test and configure the collector to use the [file exporter](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter). The file exporter is only available in [the collector's "contrib" distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib) (release builds for many OS/architectures are available [here](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)).
 
 ## Hooking tests into command spans
-Evergreen exposes every command's trace and span IDs to a running command as hex encoded strings in the `${otel_trace_id}` and `${otel_parent_id}` [default expansions](Project-Configuration/Project-Configuration-Files.md#default-expansions). To hook a test's spans into the command's span the trace id and parent id can be added to the current context.
+Evergreen exposes every command's trace and span IDs to a running command as hex encoded strings in the `${otel_trace_id}` and `${otel_parent_id}` [default expansions](Project-Configuration-Files.md#default-expansions). To hook a test's spans into the command's span the trace id and parent id can be added to the current context.
 
 ### Language specific examples
 The following examples illustrate how to inject the trace/span IDs into the context. They assume the script has the `${otel_trace_id}` and `${otel_parent_id}` expansions expanded.


### PR DESCRIPTION
On GitHub, this link previously expanded to https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Project-Configuration/Project-Configuration-Files.md#default-expansions, which is incorrect.