### PR TITLE
DEVPROD-1771 Separate all validation and saving in to their respective functions

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3163,17 +3163,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
 	assert.NoError(err)
 
-	// Test failing external link update
-	update = &ProjectRef{
-		ExternalLinks: []ExternalLink{
-			{URLTemplate: "invalid URL template", DisplayName: "way tooooooooooooooooooooo long display name"},
-		},
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.Error(err)
-	assert.Contains(err.Error(), "validating external links: link display name, way tooooooooooooooooooooo long display name, must be 40 characters or less")
-	assert.Contains(err.Error(), "parse \"invalid URL template\": invalid URI for request")
-
 	// Test parsley filters and view update
 	update = &ProjectRef{
 		ParsleyFilters: []ParsleyFilter{
@@ -3213,7 +3202,7 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	assert.NoError(err)
 
 	projectRef, err = FindBranchProjectRef("iden_")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(t, projectRef)
 	assert.Len(projectRef.ParsleyFilters, 1)
 	assert.Equal(projectRef.ProjectHealthView, ProjectHealthViewAll)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3154,15 +3154,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
 	assert.NoError(err)
 
-	// Test successful external link update
-	update = &ProjectRef{
-		ExternalLinks: []ExternalLink{
-			{URLTemplate: "https://arnars.com/{version_id}", DisplayName: "A link"},
-		},
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.NoError(err)
-
 	// Test parsley filters and view update
 	update = &ProjectRef{
 		ParsleyFilters: []ParsleyFilter{
@@ -3171,27 +3162,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 		ProjectHealthView: ProjectHealthViewAll,
 	}
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageViewsAndFiltersSection, false)
-	assert.NoError(err)
-
-	// Test performance plugin updates errors when id and identifier are different.
-	update = &ProjectRef{
-		PerfEnabled: utility.ToBoolPtr(true),
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.Error(err)
-
-	// Test performance plugin updates correctly when id and identifier are the same.
-	// Set the id and identifier to the same value.
-	update = &ProjectRef{
-		Identifier: "iden_",
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
-	assert.NoError(err)
-	// Attempt to enable the performance plugin.
-	update = &ProjectRef{
-		PerfEnabled: utility.ToBoolPtr(true),
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
 	assert.NoError(err)
 
 	// Test private field does not get updated

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -298,7 +298,6 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			}
 		}
 	case model.ProjectPagePluginSection:
-		catcher := grip.NewSimpleCatcher()
 		for _, link := range mergedSection.ExternalLinks {
 			if link.DisplayName != "" && link.URLTemplate != "" {
 				// check length of link display name

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -381,24 +381,14 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Contains(t, err.Error(), "cannot enable performance plugin")
 		},
 		"enabling performance plugin should succeed if id and identifier are the same": func(t *testing.T, ref model.ProjectRef) {
-			// Set identifier
+			// Try enabling performance plugin
 			apiProjectRef := restModel.APIProjectRef{
-				Identifier: utility.ToStringPtr("myRepoId"),
+				PerfEnabled: utility.TruePtr(),
 			}
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
-			require.NoError(t, err)
-			assert.NotNil(t, settings)
-			// Try enabling performance plugin
-			apiProjectRef = restModel.APIProjectRef{
-				PerfEnabled: utility.TruePtr(),
-			}
-			apiChanges = &restModel.APIProjectSettings{
-				ProjectRef: apiProjectRef,
-			}
-			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 		},
@@ -758,7 +748,6 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 
 		pRef := model.ProjectRef{
 			Id:                  "myId",
-			Identifier:          "myId",
 			Owner:               "evergreen-ci",
 			Repo:                "evergreen",
 			Branch:              "main",
@@ -770,6 +759,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 		assert.NoError(t, pRef.Insert())
 		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 			Id:               pRef.RepoRefId,
+			Identifier:       "myRepoId",
 			Restricted:       utility.TruePtr(),
 			PRTestingEnabled: utility.TruePtr(),
 		}}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -323,6 +323,23 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Contains(t, err.Error(), "PR testing (projects: conflicting-project) and commit checks (projects: conflicting-project)")
 			assert.NotContains(t, err.Error(), "the commit queue")
 		},
+		"invalid URL should error when saving": func(t *testing.T, ref model.ProjectRef) {
+			apiProjectRef := restModel.APIProjectRef{
+				ExternalLinks: []restModel.APIExternalLink{
+					{
+						URLTemplate: utility.ToStringPtr("invalid URL template"),
+						DisplayName: utility.ToStringPtr("display name"),
+					},
+				},
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.Error(t, err)
+			assert.Nil(t, settings)
+			assert.Contains(t, err.Error(), "validating external links")
+		},
 		"github conflicts on Commit Queue page when defaulting to repo": func(t *testing.T, ref model.ProjectRef) {
 			conflictingRef := model.ProjectRef{
 				Identifier:          "conflicting-project",

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -335,7 +335,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.Error(t, err)
 			assert.Nil(t, settings)
 			assert.Contains(t, err.Error(), "validating external links")
@@ -352,7 +352,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 		},
@@ -364,7 +364,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 
@@ -375,7 +375,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges = &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.Error(t, err)
 			assert.Nil(t, settings)
 			assert.Contains(t, err.Error(), "cannot enable performance plugin")
@@ -388,7 +388,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 
@@ -399,7 +399,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges = &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 		},

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -364,7 +364,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.RepoRefId, apiChanges, model.ProjectPageGeneralSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.RepoRefId, apiChanges, model.ProjectPageGeneralSection, true, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -381,14 +381,24 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Contains(t, err.Error(), "cannot enable performance plugin")
 		},
 		"enabling performance plugin should succeed if id and identifier are the same": func(t *testing.T, ref model.ProjectRef) {
-			// Try enabling performance plugin
+			// Set identifier
 			apiProjectRef := restModel.APIProjectRef{
-				PerfEnabled: utility.TruePtr(),
+				Identifier: utility.ToStringPtr("myRepoId"),
 			}
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+			// Try enabling performance plugin
+			apiProjectRef = restModel.APIProjectRef{
+				PerfEnabled: utility.TruePtr(),
+			}
+			apiChanges = &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 		},

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -381,25 +381,14 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Contains(t, err.Error(), "cannot enable performance plugin")
 		},
 		"enabling performance plugin should succeed if id and identifier are the same": func(t *testing.T, ref model.ProjectRef) {
-			// Set identifier
+			// Try enabling performance plugin
 			apiProjectRef := restModel.APIProjectRef{
-				Identifier: utility.ToStringPtr("myId"),
+				PerfEnabled: utility.TruePtr(),
 			}
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
-			require.NoError(t, err)
-			assert.NotNil(t, settings)
-
-			// Try enabling performance plugin
-			apiProjectRef = restModel.APIProjectRef{
-				PerfEnabled: utility.TruePtr(),
-			}
-			apiChanges = &restModel.APIProjectSettings{
-				ProjectRef: apiProjectRef,
-			}
-			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 		},
@@ -759,6 +748,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 
 		pRef := model.ProjectRef{
 			Id:                  "myId",
+			Identifier:          "myId",
 			Owner:               "evergreen-ci",
 			Repo:                "evergreen",
 			Branch:              "main",

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -340,6 +340,69 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, settings)
 			assert.Contains(t, err.Error(), "validating external links")
 		},
+		"valid URL should succeed when saving": func(t *testing.T, ref model.ProjectRef) {
+			apiProjectRef := restModel.APIProjectRef{
+				ExternalLinks: []restModel.APIExternalLink{
+					{
+						URLTemplate: utility.ToStringPtr("https://arnars.com/{version_id}"),
+						DisplayName: utility.ToStringPtr("A link"),
+					},
+				},
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+		},
+		"enabling performance plugin should fail if id and identifier are different": func(t *testing.T, ref model.ProjectRef) {
+			// Set identifer
+			apiProjectRef := restModel.APIProjectRef{
+				Identifier: utility.ToStringPtr("different"),
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+
+			// Try enabling performance plugin
+			apiProjectRef = restModel.APIProjectRef{
+				PerfEnabled: utility.TruePtr(),
+			}
+			apiChanges = &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.Error(t, err)
+			assert.Nil(t, settings)
+			assert.Contains(t, err.Error(), "cannot enable performance plugin")
+		},
+		"enabling performance plugin should succeed if id and identifer are the same": func(t *testing.T, ref model.ProjectRef) {
+			// Set identifer
+			apiProjectRef := restModel.APIProjectRef{
+				Identifier: utility.ToStringPtr("myId"),
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+
+			// Try enabling performance plugin
+			apiProjectRef = restModel.APIProjectRef{
+				PerfEnabled: utility.TruePtr(),
+			}
+			apiChanges = &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageViewsAndFiltersSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+		},
 		"github conflicts on Commit Queue page when defaulting to repo": func(t *testing.T, ref model.ProjectRef) {
 			conflictingRef := model.ProjectRef{
 				Identifier:          "conflicting-project",

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -364,7 +364,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			apiChanges := &restModel.APIProjectSettings{
 				ProjectRef: apiProjectRef,
 			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGeneralSection, false, "me")
+			settings, err := SaveProjectSettingsForSection(ctx, ref.RepoRefId, apiChanges, model.ProjectPageGeneralSection, false, "me")
 			require.NoError(t, err)
 			assert.NotNil(t, settings)
 

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -357,7 +357,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotNil(t, settings)
 		},
 		"enabling performance plugin should fail if id and identifier are different": func(t *testing.T, ref model.ProjectRef) {
-			// Set identifer
+			// Set identifier
 			apiProjectRef := restModel.APIProjectRef{
 				Identifier: utility.ToStringPtr("different"),
 			}
@@ -380,8 +380,8 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, settings)
 			assert.Contains(t, err.Error(), "cannot enable performance plugin")
 		},
-		"enabling performance plugin should succeed if id and identifer are the same": func(t *testing.T, ref model.ProjectRef) {
-			// Set identifer
+		"enabling performance plugin should succeed if id and identifier are the same": func(t *testing.T, ref model.ProjectRef) {
+			// Set identifier
 			apiProjectRef := restModel.APIProjectRef{
 				Identifier: utility.ToStringPtr("myId"),
 			}


### PR DESCRIPTION
DEVPROD-1771

### Description
This is just tech debt cleanup. Moving the validation logic to the respective function and keeping the save function clean of all validating.

### Testing
Existing unit tests and TBA testing on stage to make sure validation still functions as expected.
