### PR TITLE
DEVPROD-981 Support notifications when SUCCESSFUL task exceeds some duration

### DIFF
--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -85,6 +85,7 @@ const (
 	TriggerFamilySuccess             = "family-success"
 	TriggerRegression                = "regression"
 	TriggerExceedsDuration           = "exceeds-duration"
+	TriggerSuccessfulExceedsDuration = "successful-exceeds-duration"
 	TriggerRuntimeChangeByPercent    = "runtime-change"
 	TriggerExpiration                = "expiration"
 	TriggerPatchStarted              = "started"

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -667,28 +667,11 @@ func shouldSendTaskRegression(sub *event.Subscription, t *task.Task, previousTas
 }
 
 func (t *taskTriggers) taskSuccessfulExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
-		return nil, nil
-	}
-
 	if t.task.Status != evergreen.TaskSucceeded {
 		return nil, nil
 	}
 
-	thresholdString, ok := sub.TriggerData[event.TaskDurationKey]
-	if !ok {
-		return nil, errors.Errorf("subscription '%s' has no task time threshold", sub.ID)
-	}
-	threshold, err := strconv.Atoi(thresholdString)
-	if err != nil {
-		return nil, errors.Errorf("subscription '%s' has an invalid time threshold", sub.ID)
-	}
-
-	maxDuration := time.Duration(threshold) * time.Second
-	if !t.task.StartTime.Add(maxDuration).Before(t.task.FinishTime) {
-		return nil, nil
-	}
-	return t.generate(sub, fmt.Sprintf("exceeded %d seconds", threshold), "")
+	return t.taskExceedsDuration(sub)
 }
 
 func (t *taskTriggers) taskExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1198,6 +1198,25 @@ func (s *taskSuite) TestTaskExceedsTime() {
 	s.Nil(n)
 }
 
+func (s *taskSuite) TestSuccessfulTaskExceedsTime() {
+	// successful task that exceeds time should generate
+	s.t.event = &event.EventLogEntry{
+		EventType: event.TaskFinished,
+	}
+	s.t.data.Status = evergreen.TaskSucceeded
+	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	n, err := s.t.taskExceedsDuration(&s.subs[3])
+	s.NoError(err)
+	s.NotNil(n)
+
+	// task that is not successful should not generate
+	s.t.data.Status = evergreen.TaskFailed
+	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	n, err = s.t.taskSuccessfulExceedsDuration(&s.subs[3])
+	s.NoError(err)
+	s.Nil(n)
+}
+
 func (s *taskSuite) TestTaskRuntimeChange() {
 	// no previous task should not generate
 	s.t.event = &event.EventLogEntry{


### PR DESCRIPTION
DEVPROD-981

### Description
This allows projects to set up notifications for a task succeeding a duration only if the task is successful. 

### Testing
Tested on staging 

### Spruce Changes 
The UI change to add the option to the dropdown will be merged after this backend change is merged. 
PR: [2155](https://github.com/evergreen-ci/spruce/pull/2155)
