### PR TITLE
DEVPROD-712: fix race in display task concurrency test

### DIFF
--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -5906,7 +5906,10 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 			// This goroutine will potentially see one execution task is not
 			// finished, so it may try either update the display task status to
 			// starting or success.
-			errs <- UpdateDisplayTaskForTask(&et0)
+			// The task has to be copied into the goroutine to avoid concurrent
+			// modifications of the in-memory display task.
+			et0Copy := et0
+			errs <- UpdateDisplayTaskForTask(&et0Copy)
 		}()
 	}
 
@@ -5933,7 +5936,10 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 
 		// The last goroutine initially sees that all execution tasks are
 		// finished, so it should try to update the final status to success.
-		errs <- UpdateDisplayTaskForTask(&et0)
+		// The task has to be copied into the goroutine to avoid concurrent
+		// modifications of the in-memory display task.
+		et0Copy := et0
+		errs <- UpdateDisplayTaskForTask(&et0Copy)
 	}()
 
 	updatesDone.Wait()


### PR DESCRIPTION
DEVPROD-1966

### Description
The test was triggering the race detector because `UpdateDisplayTaskForTask` was called on the same underlying task, and created a race to set the cached display task. This only affects the goroutine setup in the test, the update logic itself wouldn't have multiple goroutines modifying the same execution task.

### Testing
Ran the race detector locally a bunch of times and scheduled it in the PR patch.

### Documentation
N/A