### PR TITLE
DEVPROD-759 Add error on warnings flag to evergreen validate

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-11-13"
+	ClientVersion = "2023-11-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-11-16"

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -47,6 +47,7 @@ const (
 	uncommittedChangesFlag    = "uncommitted"
 	preserveCommitsFlag       = "preserve-commits"
 	subscriptionTypeFlag      = "subscription-type"
+	errorOnWarningsFlagName   = "error-on-warnings"
 
 	anserDryRunFlagName      = "dry-run"
 	anserLimitFlagName       = "limit"


### PR DESCRIPTION
DEVPROD-759

### Description
adds a flag to evergreen validate to treat warnings as errors

### Testing
Tested locally
`❯ evgs validate self-tests.yml
[evergreen] 2023/11/20 01:36:24 [p=warning]: Couldn't find configuration file, falling back on default.
Couldn't find configuration file, falling back on default.
WARNING: no project specified; validation will proceed without checking project settings
WARNING: no project specified; validation will proceed without checking alias coverage
self-tests.yml is valid with warnings`

`❯ evgs validate -w self-tests.yml
[evergreen] 2023/11/20 01:36:33 [p=warning]: Couldn't find configuration file, falling back on default.
Couldn't find configuration file, falling back on default.
WARNING: no project specified; validation will proceed without checking project settings
WARNING: no project specified; validation will proceed without checking alias coverage
self-tests.yml is an invalid configuration`

`❯ evgs validate -error-on-warnings self-tests.yml
[evergreen] 2023/11/20 01:36:51 [p=warning]: Couldn't find configuration file, falling back on default.
Couldn't find configuration file, falling back on default.
WARNING: no project specified; validation will proceed without checking project settings
WARNING: no project specified; validation will proceed without checking alias coverage
self-tests.yml is an invalid configuration`


Documentation: doesn't seem to be any for flags