### PR TITLE
DEVPROD-716 Consolidate duplicate validate logic in API and validate command

### DIFF
--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -36,18 +36,6 @@ type s3copy struct {
 	// An array of file copy configurations
 	S3CopyFiles []*s3CopyFile `mapstructure:"s3_copy_files" plugin:"expand"`
 
-	// Bucket is the s3 bucket to use when storing the desired file
-	Bucket string `mapstructure:"bucket" plugin:"expand"`
-
-	// Permissions is the ACL to apply to the uploaded file. See:
-	//  http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
-	// for some examples.
-	Permissions string `mapstructure:"permissions"`
-
-	// ContentType is the MIME type of the uploaded file.
-	//  E.g. text/html, application/pdf, image/jpeg, ...
-	ContentType string `mapstructure:"content_type" plugin:"expand"`
-
 	base
 }
 

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -190,3 +190,13 @@ func (tc *TaskConfig) TaskAttributes() []attribute.KeyValue {
 
 	return attributes
 }
+
+// createsCheckRun returns a boolean indicating if the current task creates a checkRun
+func (tc *TaskConfig) createsCheckRun() bool {
+	for _, tu := range tc.BuildVariant.Tasks {
+		if tu.Name == tc.Task.DisplayName {
+			return tu.CreateCheckRun != nil
+		}
+	}
+	return false
+}

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -43,3 +43,30 @@ func TestNewTaskConfig(t *testing.T) {
 	assert.Equal(t, p, &taskConfig.Project)
 	assert.Equal(t, task, &taskConfig.Task)
 }
+
+func TestCreatesCheckRun(t *testing.T) {
+	task := &task.Task{
+		DisplayName:  "some_task",
+		BuildVariant: "bv",
+	}
+
+	p := &model.Project{
+		BuildVariants: []model.BuildVariant{
+			{
+				Name: "bv",
+				Tasks: []model.BuildVariantTaskUnit{
+					{
+						Name: "some_task",
+						CreateCheckRun: &model.CheckRun{
+							PathToOutputs: "",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tc, err := NewTaskConfig(testutil.GetDirectoryOfFile(), &apimodels.DistroView{}, p, task, &model.ProjectRef{}, &patch.Patch{}, util.Expansions{})
+	assert.NoError(t, err)
+	assert.Equal(t, true, tc.createsCheckRun())
+}

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -101,10 +101,12 @@ func TestAgentFileLogging(t *testing.T) {
 			Expansions: *util.NewExpansions(nil),
 		},
 	}
-	assert.NoError(agt.startLogging(ctx, tc))
-	defer agt.removeTaskDirectory(tc)
-	err = agt.runTaskCommands(ctx, tc)
-	require.NoError(err)
+	require.NoError(agt.startLogging(ctx, tc))
+	defer func() {
+		agt.removeTaskDirectory(tc)
+		assert.NoError(tc.logger.Close())
+	}()
+	require.NoError(agt.runTaskCommands(ctx, tc))
 
 	// Verify log contents.
 	f, err := os.Open(fmt.Sprintf("%s/%s/%s/task.log", tmpDirName, taskLogDirectory, "shell.exec"))

--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2023-11-13"
+	ClientVersion = "2023-11-20"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2023-11-20"

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-11-13"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-11-16"
+	AgentVersion = "2023-11-20"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -576,7 +576,7 @@ func (s *Settings) GetGithubOauthString() (string, error) {
 	return "", errors.New("no github token in settings")
 }
 
-// TODO EVG-19966: Delete this function
+// TODO DEVPROD-1429: Delete this function
 func (s *Settings) GetGithubOauthToken() (string, error) {
 	if s == nil {
 		return "", errors.New("not defined")
@@ -587,7 +587,7 @@ func (s *Settings) GetGithubOauthToken() (string, error) {
 
 	oauthString, err := s.GetGithubOauthString()
 	if err != nil {
-		return "", err
+		return "", nil
 	}
 	splitToken := strings.Split(oauthString, " ")
 	if len(splitToken) != 2 || splitToken[0] != "token" {

--- a/config_test.go
+++ b/config_test.go
@@ -72,7 +72,7 @@ func TestGetGithubSettings(t *testing.T) {
 	assert.Empty(settings.Credentials["github"])
 
 	token, err := settings.GetGithubOauthToken()
-	assert.Error(err)
+	assert.NoError(err)
 	assert.Empty(token)
 
 	settings, err = NewSettings(filepath.Join(FindEvergreenHome(),
@@ -87,7 +87,7 @@ func TestGetGithubSettings(t *testing.T) {
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 0,
 	}
-	settings.Expansions[githubAppPrivateKey] = ""
+	settings.Expansions[GithubAppPrivateKey] = ""
 
 	authFields := getGithubAppAuth(settings)
 	assert.Nil(authFields)
@@ -98,7 +98,7 @@ func TestGetGithubSettings(t *testing.T) {
 	authFields = getGithubAppAuth(settings)
 	assert.Nil(authFields)
 
-	settings.Expansions[githubAppPrivateKey] = "key"
+	settings.Expansions[GithubAppPrivateKey] = "key"
 	authFields = getGithubAppAuth(settings)
 	assert.NotNil(authFields)
 	assert.Equal(int64(1234), authFields.appId)
@@ -109,7 +109,7 @@ func TestGetGithubSettings(t *testing.T) {
 		assert.Nil(settings.Credentials)
 
 		token, err = settings.GetGithubOauthToken()
-		assert.Error(err)
+		assert.NoError(err)
 		assert.Empty(token)
 	})
 }

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -65,6 +65,25 @@ Admins can also set the branch project to inherit values from a
 repo-level project settings configuration. This can be learned about at
 ['Using Repo Level Settings'](Repo-Level-Settings.md).
 
+### Project Flags
+
+Under project flags, admins have a number of options for users to configure what
+runs for their project. For example, admins can enable the ability to unschedule old 
+tasks if a more recent commit passes, or configure tasks to stepback on failure to 
+isolate the cause.
+
+Check out the settings on the page to see more options.
+
+#### Repotracker Settings
+By default, Evergreen creates mainline commits (also known as waterfall versions or 
+cron builds) for enabled projects. 
+
+Admins can prevent projects from creating mainline commits by **disabling repotracking**,
+while still allowing for other kinds of versions (periodic builds, patches, etc).
+
+Additionally, admins can **Force Repotracker Run** to check for new commits if needed 
+(Evergreen occasionally misses commits due to misconfiguration or GitHub outages).
+
 ### Access and Admin Settings
 
 Admins can set a project as private or public. A private project can
@@ -82,11 +101,6 @@ via the REST API. The default for this setting is to allow logged-in
 users basic access to this project. Note this is different from the
 Private/Public setting above, which restricts access for users that are
 not logged in.
-
-### Scheduling Settings
-
-Admins can enable the ability to unschedule old tasks if a more recent
-commit passes.
 
 ### Variables
 

--- a/github_app.go
+++ b/github_app.go
@@ -56,7 +56,7 @@ func getGithubAppAuth(s *Settings) *githubAppAuth {
 		return nil
 	}
 
-	key := s.Expansions[githubAppPrivateKey]
+	key := s.Expansions[GithubAppPrivateKey]
 	if key == "" {
 		return nil
 	}

--- a/globals.go
+++ b/globals.go
@@ -329,7 +329,7 @@ const (
 	// TODO EVG-19966: Remove GlobalGitHubTokenExpansion
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
 	GithubAppToken             = "github_app_token"
-	githubAppPrivateKey        = "github_app_key"
+	GithubAppPrivateKey        = "github_app_key"
 
 	// GitHubRetryAttempts is the github client maximum number of attempts.
 	GitHubRetryAttempts = 3

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
 	github.com/evergreen-ci/gimlet v0.0.0-20231108203524-e7de42b0623c
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
-	github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7
+	github.com/evergreen-ci/pail v0.0.0-20231031153034-c935ae102fea
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20230511194147-d00fc686c715
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/urfave/cli v1.22.13
 	github.com/vektah/gqlparser/v2 v2.5.10
 	github.com/vmware/govmomi v0.27.1
-	go.mongodb.org/mongo-driver v1.12.1
+	go.mongodb.org/mongo-driver v1.13.0
 	go.opentelemetry.io/contrib/detectors/aws/ec2 v1.17.0
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.20.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.45.0

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gophercloud/gophercloud v0.1.0
-	github.com/gorilla/csrf v1.7.1
+	github.com/gorilla/csrf v1.7.2
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/sessions v1.2.2
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,9 @@ github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/s
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
 github.com/evergreen-ci/pail v0.0.0-20211018155204-833e3187cfe7/go.mod h1:5gJ3srLW+mTEtewtmEs5qdnFiKFtwoggc/U3oFCVAdc=
 github.com/evergreen-ci/pail v0.0.0-20211028170419-8efd623fd305/go.mod h1:ch0TKjI+NK2GewovamMpY9tqoe0Fal71c/4x+4x1+Io=
-github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7 h1:XA4npSEntrWplLPkOqTiYmGTLNbNJS/9MzNWwfuC8DM=
 github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7/go.mod h1:Ten0LDyKy6zFGFtu4DwTdOa+KGpiivkwJZmXEa024mw=
+github.com/evergreen-ci/pail v0.0.0-20231031153034-c935ae102fea h1:S6aAw3AlNbdaOW01Lf6qeR7mpKxCAGOtJcfkH3sJuCI=
+github.com/evergreen-ci/pail v0.0.0-20231031153034-c935ae102fea/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20211028170046-0999224b53df/go.mod h1:xiggfkrlxlu2C2e58tvk0WAYFetgNC7U9ONqcP29xZs=

--- a/go.sum
+++ b/go.sum
@@ -677,15 +677,14 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v1.17.2 h1:fQnZVsXk8uxXIStYb0N4bGk7jeyTalG/wsZjQ25dO0g=
 github.com/gopherjs/gopherjs v1.17.2/go.mod h1:pRRIvn/QzFLrKfvEz3qUuEhtE/zLCWfreZ6J5gM2i+k=
-github.com/gorilla/csrf v1.7.1 h1:Ir3o2c1/Uzj6FBxMlAUB6SivgVMy1ONXwYgXn+/aHPE=
-github.com/gorilla/csrf v1.7.1/go.mod h1:+a/4tCmqhG6/w4oafeAZ9pEa3/NZOWYVbD9fV0FwIQA=
+github.com/gorilla/csrf v1.7.2 h1:oTUjx0vyf2T+wkrx09Trsev1TE+/EbDAeHtSTbtC2eI=
+github.com/gorilla/csrf v1.7.2/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
 github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/sessions v1.2.2 h1:lqzMYz6bOfvn2WriPUjNByzeXIlVzURcPmgMczkmTjY=

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,8 @@ go.mongodb.org/mongo-driver v1.8.2/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCu
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.8.4/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.10.1/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
-go.mongodb.org/mongo-driver v1.12.1 h1:nLkghSU8fQNaK7oUmDhQFsnrtcoNy7Z6LVFKsEecqgE=
-go.mongodb.org/mongo-driver v1.12.1/go.mod h1:/rGBTebI3XYboVmgz+Wv3Bcbl3aD0QF9zl6kDDw18rQ=
+go.mongodb.org/mongo-driver v1.13.0 h1:67DgFFjYOCMWdtTEmKFpV3ffWlFnh+CYZ8ZS/tXWUfY=
+go.mongodb.org/mongo-driver v1.13.0/go.mod h1:/rGBTebI3XYboVmgz+Wv3Bcbl3aD0QF9zl6kDDw18rQ=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -161,6 +161,7 @@ type ComplexityRoot struct {
 		BFSuggestionServer      func(childComplexity int) int
 		BFSuggestionTimeoutSecs func(childComplexity int) int
 		BFSuggestionUsername    func(childComplexity int) int
+		TicketCreateIssueType   func(childComplexity int) int
 		TicketCreateProject     func(childComplexity int) int
 		TicketSearchProjects    func(childComplexity int) int
 	}
@@ -2255,6 +2256,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.BuildBaronSettings.BFSuggestionUsername(childComplexity), true
+
+	case "BuildBaronSettings.ticketCreateIssueType":
+		if e.complexity.BuildBaronSettings.TicketCreateIssueType == nil {
+			break
+		}
+
+		return e.complexity.BuildBaronSettings.TicketCreateIssueType(childComplexity), true
 
 	case "BuildBaronSettings.ticketCreateProject":
 		if e.complexity.BuildBaronSettings.TicketCreateProject == nil {
@@ -13952,6 +13960,50 @@ func (ec *executionContext) _BuildBaronSettings_ticketSearchProjects(ctx context
 }
 
 func (ec *executionContext) fieldContext_BuildBaronSettings_ticketSearchProjects(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BuildBaronSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BuildBaronSettings_ticketCreateIssueType(ctx context.Context, field graphql.CollectedField, obj *model.APIBuildBaronSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_BuildBaronSettings_ticketCreateIssueType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TicketCreateIssueType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_BuildBaronSettings_ticketCreateIssueType(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "BuildBaronSettings",
 		Field:      field,
@@ -37945,6 +37997,8 @@ func (ec *executionContext) fieldContext_Project_buildBaronSettings(ctx context.
 				return ec.fieldContext_BuildBaronSettings_ticketCreateProject(ctx, field)
 			case "ticketSearchProjects":
 				return ec.fieldContext_BuildBaronSettings_ticketSearchProjects(ctx, field)
+			case "ticketCreateIssueType":
+				return ec.fieldContext_BuildBaronSettings_ticketCreateIssueType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type BuildBaronSettings", field.Name)
 		},
@@ -45453,6 +45507,8 @@ func (ec *executionContext) fieldContext_RepoRef_buildBaronSettings(ctx context.
 				return ec.fieldContext_BuildBaronSettings_ticketCreateProject(ctx, field)
 			case "ticketSearchProjects":
 				return ec.fieldContext_BuildBaronSettings_ticketSearchProjects(ctx, field)
+			case "ticketCreateIssueType":
+				return ec.fieldContext_BuildBaronSettings_ticketCreateIssueType(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type BuildBaronSettings", field.Name)
 		},
@@ -65818,7 +65874,7 @@ func (ec *executionContext) unmarshalInputBuildBaronSettingsInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"bfSuggestionFeaturesURL", "bfSuggestionPassword", "bfSuggestionServer", "bfSuggestionTimeoutSecs", "bfSuggestionUsername", "ticketCreateProject", "ticketSearchProjects"}
+	fieldsInOrder := [...]string{"bfSuggestionFeaturesURL", "bfSuggestionPassword", "bfSuggestionServer", "bfSuggestionTimeoutSecs", "bfSuggestionUsername", "ticketCreateProject", "ticketSearchProjects", "ticketCreateIssueType"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -65888,6 +65944,15 @@ func (ec *executionContext) unmarshalInputBuildBaronSettingsInput(ctx context.Co
 				return it, err
 			}
 			it.TicketSearchProjects = data
+		case "ticketCreateIssueType":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ticketCreateIssueType"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TicketCreateIssueType = data
 		}
 	}
 
@@ -71572,6 +71637,11 @@ func (ec *executionContext) _BuildBaronSettings(ctx context.Context, sel ast.Sel
 			}
 		case "ticketSearchProjects":
 			out.Values[i] = ec._BuildBaronSettings_ticketSearchProjects(ctx, field, obj)
+		case "ticketCreateIssueType":
+			out.Values[i] = ec._BuildBaronSettings_ticketCreateIssueType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -17258,14 +17258,11 @@ func (ec *executionContext) _Distro_mountpoints(ctx context.Context, field graph
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.([]string)
 	fc.Result = res
-	return ec.marshalNString2ᚕstring(ctx, field.Selections, res)
+	return ec.marshalOString2ᚕstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_mountpoints(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -66483,7 +66480,7 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "cloneMethod", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "isCluster", "isVirtualWorkStation", "name", "note", "plannerSettings", "provider", "providerSettingsList", "setup", "setupAsSudo", "sshKey", "sshOptions", "user", "userSpawnAllowed", "validProjects", "workDir"}
+	fieldsInOrder := [...]string{"aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "cloneMethod", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "isCluster", "isVirtualWorkStation", "name", "note", "plannerSettings", "provider", "providerSettingsList", "setup", "setupAsSudo", "sshKey", "sshOptions", "user", "userSpawnAllowed", "validProjects", "workDir", "mountpoints"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -66778,6 +66775,15 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 				return it, err
 			}
 			it.WorkDir = data
+		case "mountpoints":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mountpoints"))
+			data, err := ec.unmarshalOString2ᚕstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Mountpoints = data
 		}
 	}
 
@@ -72633,9 +72639,6 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 			}
 		case "mountpoints":
 			out.Values[i] = ec._Distro_mountpoints(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -88544,32 +88547,6 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
-}
-
-func (ec *executionContext) unmarshalNString2ᚕstring(ctx context.Context, v interface{}) ([]string, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]string, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOString2string(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalNString2ᚕstring(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalOString2string(ctx, sel, v[i])
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -157,6 +157,7 @@ input DistroInput {
   userSpawnAllowed: Boolean!
   validProjects: [String!]!
   workDir: String!
+  mountpoints: [String]
 }
 
 input BootstrapSettingsInput {
@@ -306,7 +307,7 @@ type Distro {
   userSpawnAllowed: Boolean!
   validProjects: [String]!
   workDir: String!
-  mountpoints: [String]!
+  mountpoints: [String]
 }
 
 type BootstrapSettings {

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -112,6 +112,7 @@ input BuildBaronSettingsInput {
   bfSuggestionUsername: String
   ticketCreateProject: String!
   ticketSearchProjects: [String!]
+  ticketCreateIssueType: String
 }
 
 input TriggerAliasInput {

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -135,6 +135,7 @@ type BuildBaronSettings {
   bfSuggestionUsername: String
   ticketCreateProject: String!
   ticketSearchProjects: [String!]
+  ticketCreateIssueType: String!
 }
 
 # shared by Project and RepoRef

--- a/graphql/tests/mutation/saveDistro/data.json
+++ b/graphql/tests/mutation/saveDistro/data.json
@@ -9,6 +9,7 @@
       "arch": "linux_ppc64le",
       "disabled": false,
       "work_dir": "/data/mci",
+      "mountpoints": ["/"],
       "provider": "static",
       "provider_settings": [
         {
@@ -118,6 +119,7 @@
         ],
         "arch": "linux_ppc64le",
         "work_dir": "/data/mci",
+        "mountpoints": ["/"],
         "provider": "static",
         "provider_settings": [
           {
@@ -220,6 +222,7 @@
         ],
         "arch": "linux_ppc64le",
         "work_dir": "/data/mci",
+        "mountpoints": ["/"],
         "provider": "static",
         "provider_settings": [
           {

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -11,6 +11,7 @@ mutation {
           authorizedKeysFile: "",
           containerPool: "",
           workDir: "/data/mci",
+          mountpoints: ["/"],
           disabled: true,
           provider: EC2_ON_DEMAND,
           providerSettingsList: [

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -11,6 +11,7 @@ mutation {
           containerPool: "",
           disabled: true,
           workDir: "/data/mci",
+          mountpoints: ["/"],
           provider: EC2_ON_DEMAND,
           providerSettingsList: [
             {

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -4,7 +4,7 @@ mutation {
         distro: {
           name: "rhel71-power8-large"
           workDir: "",
-
+          mountpoints: ["/"],
           aliases: [
             "new-alias"
           ],

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/plugins_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/plugins_section.graphql
@@ -1,0 +1,43 @@
+mutation {
+  saveProjectSettingsForSection(
+    projectSettings: {
+      projectRef: {
+        id: "sandbox_project_id"
+        patchTriggerAliases: []
+        githubTriggerAliases: []
+        buildBaronSettings: {
+          ticketCreateProject: ""
+          ticketSearchProjects: []
+          ticketCreateIssueType: "Incident"
+        }
+        taskAnnotationSettings: {
+          jiraCustomFields: [{ field: "a field", displayText: "display text" }]
+        }
+        externalLinks: [
+          {
+            requesters: ["github_pull_request"]
+            displayName: "display name"
+            urlTemplate: "https://thingy.com"
+          }
+        ]
+      }
+    }
+    section: PLUGINS
+  ) {
+    projectRef {
+      buildBaronSettings {
+        ticketCreateIssueType
+      }
+      taskAnnotationSettings {
+        jiraCustomFields {
+          displayText
+          field
+        }
+        fileTicketWebhook {
+          endpoint
+          secret
+        }
+      }
+    }
+  }
+}

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -1,177 +1,195 @@
 {
-    "tests": [
-        {
-            "query_file": "general_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "projectRef": {
-                            "enabled": true,
-                            "remotePath": "my_path_is_new",
-                            "spawnHostScriptPath": ""
-                        },
-                        "vars": {
-                            "vars": {
-                                "hello": "",
-                                "foo": "bar"
-                            }
-                        }
-                    }
-                }
+  "tests": [
+    {
+      "query_file": "general_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "projectRef": {
+              "enabled": true,
+              "remotePath": "my_path_is_new",
+              "spawnHostScriptPath": ""
+            },
+            "vars": {
+              "vars": {
+                "hello": "",
+                "foo": "bar"
+              }
             }
-        },
-        {
-            "query_file": "commit_queue_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "projectRef": {
-                            "commitQueue": {
-                                "enabled": true
-                            }
-                        },
-                        "vars": {
-                            "vars": {
-                                "hello": "",
-                                "foo": "bar"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "vars_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "vars": {
-                            "vars": {
-                                "goodbye": ""
-                            },
-                            "privateVars": [
-                                "goodbye"
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "change_identifier.graphql",
-            "result": {
-                "data": null,
-                "errors": [
-                    {
-                        "message": "identifier 'sandbox_project_id' is already being used for another project",
-                        "path": [
-                            "saveProjectSettingsForSection"
-                        ],
-                        "extensions": {
-                            "code": "INTERNAL_SERVER_ERROR"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "query_file": "notifications_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "projectRef": {
-                            "id": "sandbox_project_id",
-                            "banner": {
-                                "text": "banner text!!",
-                                "theme": "WARNING"
-                            }
-                        },
-                        "subscriptions": [
-                            {
-                                "subscriber": {
-                                    "subscriber": {
-                                        "webhookSubscriber": {
-                                            "url": "https://fake-website.com",
-                                            "retries": 0,
-                                            "minDelayMs": 0,
-                                            "timeoutMs": 0
-                                        }
-                                    }
-                                }
-                            }
-                        ]
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "views_and_filters_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "projectRef": {
-                            "id": "sandbox_project_id",
-                            "parsleyFilters": [
-                                {
-                                    "expression": "filter_one",
-                                    "caseSensitive": true,
-                                    "exactMatch": false
-                                },
-                                {
-                                    "expression": "filter_two",
-                                    "caseSensitive": false,
-                                    "exactMatch": false
-                                }
-                            ],
-                            "projectHealthView": "FAILED"
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "patch_alias_section.graphql",
-            "result": {
-                "data": {
-                    "saveProjectSettingsForSection": {
-                        "aliases": [
-                            {
-                                "id": "5ffe393097b1d3759dd3c1aa",
-                                "alias": "__commit_queue",
-                                "description": "",
-                                "variant": "ubuntu1604",
-                                "variantTags": [],
-                                "task": "unit_tests",
-                                "taskTags": [],
-                                "gitTag": "",
-                                "remotePath": "",
-                                "parameters": []
-                            },
-                            {
-                                "id": "64c80057d1d6f12b0d4c69d0",
-                                "alias": "test",
-                                "description": "alias",
-                                "variant": "",
-                                "variantTags": [
-                                    ".*"
-                                ],
-                                "task": "",
-                                "taskTags": [
-                                    ".*"
-                                ],
-                                "gitTag": "",
-                                "remotePath": "",
-                                "parameters": [
-                                    {
-                                        "key": "test",
-                                        "value": "thing"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            }
+          }
         }
-    ]
+      }
+    },
+    {
+      "query_file": "commit_queue_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "projectRef": {
+              "commitQueue": {
+                "enabled": true
+              }
+            },
+            "vars": {
+              "vars": {
+                "hello": "",
+                "foo": "bar"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "vars_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "vars": {
+              "vars": {
+                "goodbye": ""
+              },
+              "privateVars": ["goodbye"]
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "change_identifier.graphql",
+      "result": {
+        "data": null,
+        "errors": [
+          {
+            "message": "identifier 'sandbox_project_id' is already being used for another project",
+            "path": ["saveProjectSettingsForSection"],
+            "extensions": {
+              "code": "INTERNAL_SERVER_ERROR"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "query_file": "notifications_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "projectRef": {
+              "id": "sandbox_project_id",
+              "banner": {
+                "text": "banner text!!",
+                "theme": "WARNING"
+              }
+            },
+            "subscriptions": [
+              {
+                "subscriber": {
+                  "subscriber": {
+                    "webhookSubscriber": {
+                      "url": "https://fake-website.com",
+                      "retries": 0,
+                      "minDelayMs": 0,
+                      "timeoutMs": 0
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "views_and_filters_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "projectRef": {
+              "id": "sandbox_project_id",
+              "parsleyFilters": [
+                {
+                  "expression": "filter_one",
+                  "caseSensitive": true,
+                  "exactMatch": false
+                },
+                {
+                  "expression": "filter_two",
+                  "caseSensitive": false,
+                  "exactMatch": false
+                }
+              ],
+              "projectHealthView": "FAILED"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "patch_alias_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "aliases": [
+              {
+                "id": "5ffe393097b1d3759dd3c1aa",
+                "alias": "__commit_queue",
+                "description": "",
+                "variant": "ubuntu1604",
+                "variantTags": [],
+                "task": "unit_tests",
+                "taskTags": [],
+                "gitTag": "",
+                "remotePath": "",
+                "parameters": []
+              },
+              {
+                "id": "64c80057d1d6f12b0d4c69d0",
+                "alias": "test",
+                "description": "alias",
+                "variant": "",
+                "variantTags": [".*"],
+                "task": "",
+                "taskTags": [".*"],
+                "gitTag": "",
+                "remotePath": "",
+                "parameters": [
+                  {
+                    "key": "test",
+                    "value": "thing"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "plugins_section.graphql",
+      "result": {
+        "data": {
+          "saveProjectSettingsForSection": {
+            "projectRef": {
+              "buildBaronSettings": {
+                "ticketCreateIssueType": "Incident"
+              },
+              "taskAnnotationSettings": {
+                "jiraCustomFields": [
+                  {
+                    "displayText": "display text",
+                    "field": "a field"
+                  }
+                ],
+                "fileTicketWebhook": {
+                  "endpoint": "",
+                  "secret": ""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
+++ b/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
@@ -51,6 +51,7 @@
         bfSuggestionServer
         bfSuggestionTimeoutSecs
         bfSuggestionUsername
+        ticketCreateIssueType
       }
       containerSizeDefinitions {
         name

--- a/graphql/tests/projectSettings/projectRef/results.json
+++ b/graphql/tests/projectSettings/projectRef/results.json
@@ -69,7 +69,8 @@
                 "bfSuggestionPassword": "",
                 "bfSuggestionServer": "",
                 "bfSuggestionTimeoutSecs": 0,
-                "bfSuggestionUsername": ""
+                "bfSuggestionUsername": "",
+                "ticketCreateIssueType": ""
               },
               "taskAnnotationSettings": {
                 "jiraCustomFields": [

--- a/graphql/tests/repoSettings/projectRef/queries/project_ref.graphql
+++ b/graphql/tests/repoSettings/projectRef/queries/project_ref.graphql
@@ -41,6 +41,7 @@
         bfSuggestionServer
         bfSuggestionTimeoutSecs
         bfSuggestionUsername
+        ticketCreateIssueType
       }
 
       taskAnnotationSettings {

--- a/graphql/tests/repoSettings/projectRef/results.json
+++ b/graphql/tests/repoSettings/projectRef/results.json
@@ -45,7 +45,8 @@
                 "bfSuggestionPassword": "",
                 "bfSuggestionServer": "",
                 "bfSuggestionTimeoutSecs": 0,
-                "bfSuggestionUsername": ""
+                "bfSuggestionUsername": "",
+                "ticketCreateIssueType": ""
               },
 
               "taskAnnotationSettings": {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -85,6 +85,7 @@ const (
 	TriggerFamilySuccess             = "family-success"
 	TriggerRegression                = "regression"
 	TriggerExceedsDuration           = "exceeds-duration"
+	TriggerSuccessfulExceedsDuration = "successful-exceeds-duration"
 	TriggerRuntimeChangeByPercent    = "runtime-change"
 	TriggerExpiration                = "expiration"
 	TriggerPatchStarted              = "started"

--- a/model/log/iterator_test.go
+++ b/model/log/iterator_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/level"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -206,7 +207,7 @@ func TestChunkIterator(t *testing.T) {
 				bucket: bucket,
 				chunks: chunks,
 				parser: parser,
-				start:  chunks[1].start,
+				start:  &chunks[1].start,
 			},
 			test: func(t *testing.T, it *chunkIterator) {
 				offset := chunks[0].numLines
@@ -228,7 +229,7 @@ func TestChunkIterator(t *testing.T) {
 				bucket: bucket,
 				chunks: chunks,
 				parser: parser,
-				end:    chunks[1].start,
+				end:    &chunks[1].start,
 			},
 			test: func(t *testing.T, it *chunkIterator) {
 				var count int
@@ -249,8 +250,8 @@ func TestChunkIterator(t *testing.T) {
 				bucket: bucket,
 				chunks: chunks,
 				parser: parser,
-				start:  chunks[1].start,
-				end:    chunks[len(chunks)-1].end - int64(time.Millisecond),
+				start:  &chunks[1].start,
+				end:    utility.ToInt64Ptr(chunks[len(chunks)-1].end - int64(time.Millisecond)),
 			},
 			test: func(t *testing.T, it *chunkIterator) {
 				offset := chunks[0].numLines
@@ -315,8 +316,8 @@ func TestChunkIterator(t *testing.T) {
 				bucket:    bucket,
 				chunks:    chunks,
 				parser:    parser,
-				start:     chunks[0].start,
-				end:       chunks[1].end,
+				start:     &chunks[0].start,
+				end:       &chunks[1].end,
 				lineLimit: 5,
 				tailN:     20,
 			},

--- a/model/log/reader.go
+++ b/model/log/reader.go
@@ -42,8 +42,8 @@ type LogIteratorReaderOptions struct {
 }
 
 // NewLogIteratorReader returns a reader that reads the log lines from the
-// iterator with the given options. It is the responsibility of the caller to
-// close the iterator.
+// iterator with the given options. The reader will attempt to close the
+// iterator.
 func NewLogIteratorReader(it LogIterator, opts LogIteratorReaderOptions) *LogIteratorReader {
 	if opts.TimeZone == nil {
 		opts.TimeZone = time.UTC

--- a/model/log/service_interface.go
+++ b/model/log/service_interface.go
@@ -19,14 +19,21 @@ type GetOptions struct {
 	// be specified. At least one name must be specified.
 	LogNames []string
 	// Start is the start time (inclusive) of the time range filter,
-	// represented as a Unix timestamp in nanoseconds. Optional.
-	Start int64
+	// represented as a Unix timestamp in nanoseconds. Defaults to
+	// unbounded unless DefaultTimeRangeOfFirstLog is set to true.
+	Start *int64
 	// End is the end time (inclusive) of the time range filter,
-	// represented as a Unix timestamp in nanoseconds. Optional.
-	End int64
-	// LineLimit limits the number of lines read from the log. Optional.
+	// represented as a Unix timestamp in nanoseconds. Defaults to
+	// unbounded unless DefaultTimeRangeOfFirstLog is set to true.
+	End *int64
+	// DefaultTimeRangeOfFirstLog defaults the start and end time of the
+	// time range filter to the first and last timestamp, respectively, of
+	// the first specified log in LogNames.
+	DefaultTimeRangeOfFirstLog bool
+	// LineLimit limits the number of lines read from the log. Ignored if
+	// less than or equal to 0.
 	LineLimit int
 	// TailN is the number of lines to read from the tail of the log.
-	// Optional.
+	// Ignored if less than or equal to 0.
 	TailN int
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3154,26 +3154,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
 	assert.NoError(err)
 
-	// Test successful external link update
-	update = &ProjectRef{
-		ExternalLinks: []ExternalLink{
-			{URLTemplate: "https://arnars.com/{version_id}", DisplayName: "A link"},
-		},
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.NoError(err)
-
-	// Test failing external link update
-	update = &ProjectRef{
-		ExternalLinks: []ExternalLink{
-			{URLTemplate: "invalid URL template", DisplayName: "way tooooooooooooooooooooo long display name"},
-		},
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.Error(err)
-	assert.Contains(err.Error(), "validating external links: link display name, way tooooooooooooooooooooo long display name, must be 40 characters or less")
-	assert.Contains(err.Error(), "parse \"invalid URL template\": invalid URI for request")
-
 	// Test parsley filters and view update
 	update = &ProjectRef{
 		ParsleyFilters: []ParsleyFilter{
@@ -3184,27 +3164,6 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	_, err = SaveProjectPageForSection("iden_", update, ProjectPageViewsAndFiltersSection, false)
 	assert.NoError(err)
 
-	// Test performance plugin updates errors when id and identifier are different.
-	update = &ProjectRef{
-		PerfEnabled: utility.ToBoolPtr(true),
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.Error(err)
-
-	// Test performance plugin updates correctly when id and identifier are the same.
-	// Set the id and identifier to the same value.
-	update = &ProjectRef{
-		Identifier: "iden_",
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPageGeneralSection, false)
-	assert.NoError(err)
-	// Attempt to enable the performance plugin.
-	update = &ProjectRef{
-		PerfEnabled: utility.ToBoolPtr(true),
-	}
-	_, err = SaveProjectPageForSection("iden_", update, ProjectPagePluginSection, false)
-	assert.NoError(err)
-
 	// Test private field does not get updated
 	update = &ProjectRef{
 		Restricted: utility.TruePtr(),
@@ -3213,7 +3172,7 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	assert.NoError(err)
 
 	projectRef, err = FindBranchProjectRef("iden_")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(t, projectRef)
 	assert.Len(projectRef.ParsleyFilters, 1)
 	assert.Equal(projectRef.ProjectHealthView, ProjectHealthViewAll)

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -47,6 +47,7 @@ const (
 	uncommittedChangesFlag    = "uncommitted"
 	preserveCommitsFlag       = "preserve-commits"
 	subscriptionTypeFlag      = "subscription-type"
+	errorOnWarningsFlagName   = "error-on-warnings"
 
 	anserDryRunFlagName      = "dry-run"
 	anserLimitFlagName       = "limit"

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -624,11 +624,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 
 	settings := evergreen.GetEnvironment().Settings()
 	// validate the project
-	isConfigDefined := projectInfo.Config != nil
-	verrs := validator.CheckProjectErrors(ctx, projectInfo.Project, true)
-	verrs = append(verrs, validator.CheckProjectSettings(ctx, settings, projectInfo.Project, projectInfo.Ref, isConfigDefined)...)
-	verrs = append(verrs, validator.CheckProjectConfigErrors(projectInfo.Config)...)
-	verrs = append(verrs, validator.CheckProjectWarnings(projectInfo.Project)...)
+	verrs := validator.CheckProject(ctx, projectInfo.Project, projectInfo.Config, projectInfo.Ref, settings, true, true, false)
 	if len(verrs) > 0 || versionErrs != nil {
 		// We have errors in the project.
 		// Format them, as we need to store + display them to the user

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -622,9 +622,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 	v.Ignored = ignore
 
-	settings := evergreen.GetEnvironment().Settings()
-	// validate the project
-	verrs := validator.CheckProject(ctx, projectInfo.Project, projectInfo.Config, projectInfo.Ref, settings, true, true, false)
+	verrs := validator.CheckProject(ctx, projectInfo.Project, projectInfo.Config, projectInfo.Ref, true, projectInfo.Ref.Id, nil)
 	if len(verrs) > 0 || versionErrs != nil {
 		// We have errors in the project.
 		// Format them, as we need to store + display them to the user
@@ -645,7 +643,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 			v.Errors = append(v.Errors, versionErrs.Errors...)
 		}
 		if len(v.Errors) > 0 {
-			ppStorageMethod, err := model.ParserProjectUpsertOneWithS3Fallback(ctx, settings, evergreen.ProjectStorageMethodDB, projectInfo.IntermediateProject)
+			ppStorageMethod, err := model.ParserProjectUpsertOneWithS3Fallback(ctx, evergreen.GetEnvironment().Settings(), evergreen.ProjectStorageMethodDB, projectInfo.IntermediateProject)
 			if err != nil {
 				return nil, errors.Wrapf(err, "upserting parser project '%s' for version '%s'", projectInfo.IntermediateProject.Id, v.Id)
 			}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/evergreen-ci/cocoa"
@@ -296,7 +297,28 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				return nil, errors.Wrap(err, "validating project creation")
 			}
 		}
-
+	case model.ProjectPagePluginSection:
+		for _, link := range mergedSection.ExternalLinks {
+			if link.DisplayName != "" && link.URLTemplate != "" {
+				// check length of link display name
+				if len(link.DisplayName) > 40 {
+					catcher.Add(errors.New(fmt.Sprintf("link display name, %s, must be 40 characters or less", link.DisplayName)))
+				}
+				// validate url template
+				formattedURL := strings.Replace(link.URLTemplate, "{version_id}", "version_id", -1)
+				if _, err := url.ParseRequestURI(formattedURL); err != nil {
+					catcher.Add(err)
+				}
+			}
+		}
+		if catcher.HasErrors() {
+			return nil, errors.Wrapf(catcher.Resolve(), "validating external links")
+		}
+		// If the performance plugin is not currently enabled, and we are trying to
+		// change it to enabled but the id and identifier are different, we error.
+		if !mergedBeforeRef.IsPerfEnabled() && mergedSection.IsPerfEnabled() && mergedSection.Id != mergedSection.Identifier {
+			return nil, errors.Errorf("project '%s' does not have a matching ID and identifier, cannot enable performance plugin", mergedSection.Id)
+		}
 	case model.ProjectPageAccessSection:
 		// For any admins that are only in the original settings, remove access.
 		// For any admins that are only in the updated settings, give them access.
@@ -397,12 +419,11 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		}
 		catcher.Wrapf(DeleteSubscriptions(projectId, toDelete), "deleting subscriptions")
 	case model.ProjectPageContainerSection:
-		for i := range mergedSection.ContainerSizeDefinitions {
-			err = mergedSection.ContainerSizeDefinitions[i].Validate(evergreen.GetEnvironment().Settings().Providers.AWS.Pod.ECS)
-			catcher.Add(err)
+		for _, size := range mergedSection.ContainerSizeDefinitions {
+			catcher.Add(errors.Wrapf(size.Validate(evergreen.GetEnvironment().Settings().Providers.AWS.Pod.ECS), "invalid container size '%s'", size.Name))
 		}
 		if catcher.HasErrors() {
-			return nil, errors.Wrap(catcher.Resolve(), "invalid container size definition")
+			return nil, errors.Wrap(catcher.Resolve(), "invalid container size definitions")
 		}
 	case model.ProjectPagePeriodicBuildsSection:
 		for i := range mergedSection.PeriodicBuilds {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -323,6 +323,75 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Contains(t, err.Error(), "PR testing (projects: conflicting-project) and commit checks (projects: conflicting-project)")
 			assert.NotContains(t, err.Error(), "the commit queue")
 		},
+		"invalid URL should error when saving": func(t *testing.T, ref model.ProjectRef) {
+			apiProjectRef := restModel.APIProjectRef{
+				ExternalLinks: []restModel.APIExternalLink{
+					{
+						URLTemplate: utility.ToStringPtr("invalid URL template"),
+						DisplayName: utility.ToStringPtr("display name"),
+					},
+				},
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			require.Error(t, err)
+			assert.Nil(t, settings)
+			assert.Contains(t, err.Error(), "validating external links")
+		},
+		"valid URL should succeed when saving": func(t *testing.T, ref model.ProjectRef) {
+			apiProjectRef := restModel.APIProjectRef{
+				ExternalLinks: []restModel.APIExternalLink{
+					{
+						URLTemplate: utility.ToStringPtr("https://arnars.com/{version_id}"),
+						DisplayName: utility.ToStringPtr("A link"),
+					},
+				},
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+		},
+		"enabling performance plugin should fail if id and identifier are different": func(t *testing.T, ref model.ProjectRef) {
+			// Set identifier
+			apiProjectRef := restModel.APIProjectRef{
+				Identifier: utility.ToStringPtr("different"),
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.RepoRefId, apiChanges, model.ProjectPageGeneralSection, true, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+
+			// Try enabling performance plugin
+			apiProjectRef = restModel.APIProjectRef{
+				PerfEnabled: utility.TruePtr(),
+			}
+			apiChanges = &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			require.Error(t, err)
+			assert.Nil(t, settings)
+			assert.Contains(t, err.Error(), "cannot enable performance plugin")
+		},
+		"enabling performance plugin should succeed if id and identifier are the same": func(t *testing.T, ref model.ProjectRef) {
+			// Try enabling performance plugin
+			apiProjectRef := restModel.APIProjectRef{
+				PerfEnabled: utility.TruePtr(),
+			}
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: apiProjectRef,
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPagePluginSection, false, "me")
+			require.NoError(t, err)
+			assert.NotNil(t, settings)
+		},
 		"github conflicts on Commit Queue page when defaulting to repo": func(t *testing.T, ref model.ProjectRef) {
 			conflictingRef := model.ProjectRef{
 				Identifier:          "conflicting-project",
@@ -690,6 +759,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 		assert.NoError(t, pRef.Insert())
 		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 			Id:               pRef.RepoRefId,
+			Identifier:       "myRepoId",
 			Restricted:       utility.TruePtr(),
 			PRTestingEnabled: utility.TruePtr(),
 		}}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -537,9 +537,11 @@ func (at *APITask) ToService() (*task.Task, error) {
 	}
 
 	if at.StepbackInfo != nil {
-		st.StepbackInfo.LastFailingStepbackTaskId = at.StepbackInfo.LastFailingTaskId
-		st.StepbackInfo.LastPassingStepbackTaskId = at.StepbackInfo.LastPassingTaskId
-		st.StepbackInfo.NextStepbackTaskId = at.StepbackInfo.NextTaskId
+		st.StepbackInfo = &task.StepbackInfo{
+			LastFailingStepbackTaskId: at.StepbackInfo.LastFailingTaskId,
+			LastPassingStepbackTaskId: at.StepbackInfo.LastPassingTaskId,
+			NextStepbackTaskId:        at.StepbackInfo.NextTaskId,
+		}
 	}
 
 	if len(at.ExecutionTasks) > 0 {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -237,6 +237,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/tests/count").Version(2).Get().Wrap(addProject, viewTasks).RouteHandler(makeFetchTestCountForTask())
 	app.AddRoute("/tasks/{task_id}/sync_path").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncPathGetHandler())
 	app.AddRoute("/tasks/{task_id}/generated_tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetGeneratedTasks())
+	app.AddRoute("/tasks/{task_id}/build/task_logs").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetTaskLogs(env, opts.URL))
+	app.AddRoute("/tasks/{task_id}/build/test_logs/{path}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetTestLogs(env, opts.URL))
 	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(requireUser).RouteHandler(makeSetUserConfig())

--- a/rest/route/task_output.go
+++ b/rest/route/task_output.go
@@ -1,0 +1,271 @@
+package route
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/log"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/taskoutput"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+)
+
+type getTaskOutputLogsBaseHandler struct {
+	tsk           *task.Task
+	start         *int64
+	end           *int64
+	lineLimit     int
+	tailN         int
+	printTime     bool
+	printPriority bool
+	paginate      bool
+	softSizeLimit int
+	timeZone      *time.Location
+
+	env evergreen.Environment
+	url string
+}
+
+func (h *getTaskOutputLogsBaseHandler) parse(ctx context.Context, r *http.Request) error {
+	vals := r.URL.Query()
+
+	var (
+		execution *int
+		err       error
+	)
+	if execString := vals.Get("execution"); execString != "" {
+		exec, err := strconv.Atoi(execString)
+		if err != nil {
+			return errors.Wrap(err, "parsing execution")
+		}
+
+		execution = utility.ToIntPtr(exec)
+	}
+	h.tsk, err = task.FindByIdExecution(gimlet.GetVars(r)["task_id"], execution)
+	if err != nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "finding task").Error(),
+		}
+	}
+	if h.tsk == nil {
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    "task not found",
+		}
+	}
+
+	if start := vals.Get("start"); start != "" {
+		ts, err := time.Parse(time.RFC3339, start)
+		if err != nil {
+			return errors.Wrap(err, "parsing start time")
+		}
+
+		h.start = utility.ToInt64Ptr(ts.UnixNano())
+	}
+	if end := vals.Get("end"); end != "" {
+		ts, err := time.Parse(time.RFC3339, end)
+		if err != nil {
+			return errors.Wrap(err, "parsing end time")
+		}
+
+		h.end = utility.ToInt64Ptr(ts.UnixNano())
+	}
+
+	if limit := vals.Get("line_limit"); limit != "" {
+		h.lineLimit, err = strconv.Atoi(limit)
+		if err != nil {
+			return errors.Wrap(err, "parsing line limit")
+		}
+	}
+	if tail := vals.Get("tail_limit"); tail != "" {
+		h.tailN, err = strconv.Atoi(tail)
+		if err != nil {
+			return errors.Wrap(err, "parsing tail limit")
+		}
+	}
+
+	h.printTime = strings.ToLower(vals.Get("print_time")) == "true"
+	h.printPriority = strings.ToLower(vals.Get("print_priority")) == "true"
+	h.paginate = strings.ToLower(vals.Get("paginate")) == "true"
+	h.timeZone = getUserTimeZone(MustHaveUser(ctx))
+	h.softSizeLimit = 10 * 1024 * 1024
+
+	var count int
+	if h.lineLimit > 0 {
+		count++
+	}
+	if h.tailN > 0 {
+		count++
+	}
+	if h.paginate {
+		count++
+	}
+	if count > 1 {
+		return errors.New("cannot set more than of: line limit, tail, paginate")
+	}
+
+	return nil
+}
+
+func (h *getTaskOutputLogsBaseHandler) createResponse(it log.LogIterator) gimlet.Responder {
+	var resp gimlet.Responder
+	opts := log.LogIteratorReaderOptions{
+		PrintTime:     h.printTime,
+		TimeZone:      h.timeZone,
+		PrintPriority: h.printPriority,
+	}
+	if h.paginate {
+		opts.SoftSizeLimit = h.softSizeLimit
+		r := log.NewLogIteratorReader(it, opts)
+
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "reading paginated log lines"))
+		}
+		resp = gimlet.NewTextResponse(data)
+
+		pages := &gimlet.ResponsePages{
+			Prev: &gimlet.Page{
+				BaseURL:         h.url,
+				KeyQueryParam:   "start",
+				LimitQueryParam: "limit",
+				Key:             time.Unix(0, utility.FromInt64Ptr(h.start)).In(h.timeZone).Format(time.RFC3339),
+				Relation:        "prev",
+			},
+		}
+		if next := r.NextTimestamp(); next != nil {
+			pages.Next = &gimlet.Page{
+				BaseURL:         h.url,
+				KeyQueryParam:   "start",
+				LimitQueryParam: "limit",
+				Key:             time.Unix(0, utility.FromInt64Ptr(next)).In(h.timeZone).Format(time.RFC3339),
+				Relation:        "next",
+			}
+		}
+
+		if err := resp.SetPages(pages); err != nil {
+			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "setting response pages"))
+		}
+	} else {
+		resp = gimlet.NewTextResponse(log.NewLogIteratorReader(it, opts))
+	}
+
+	return resp
+}
+
+// GET /tasks/{task_id}/build/task_logs
+type getTaskLogsHandler struct {
+	logType taskoutput.TaskLogType
+
+	getTaskOutputLogsBaseHandler
+}
+
+func makeGetTaskLogs(env evergreen.Environment, url string) *getTaskLogsHandler {
+	return &getTaskLogsHandler{
+		getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{env: env, url: url},
+	}
+}
+
+func (h *getTaskLogsHandler) Factory() gimlet.RouteHandler {
+	return &getTaskLogsHandler{
+		getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{env: h.env, url: h.url},
+	}
+}
+
+func (h *getTaskLogsHandler) Parse(ctx context.Context, r *http.Request) error {
+	if h.logType = taskoutput.TaskLogType(r.URL.Query().Get("type")); h.logType == "" {
+		h.logType = taskoutput.TaskLogTypeAll
+	} else if err := h.logType.Validate(false); err != nil {
+		return err
+	}
+
+	if err := h.parse(ctx, r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *getTaskLogsHandler) Run(ctx context.Context) gimlet.Responder {
+	it, err := h.tsk.GetTaskLogs(ctx, h.env, taskoutput.TaskLogGetOptions{
+		LogType:   h.logType,
+		Start:     h.start,
+		End:       h.end,
+		LineLimit: h.lineLimit,
+		TailN:     h.tailN,
+	})
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting task logs"))
+	}
+
+	return h.createResponse(it)
+}
+
+// GET /tasks/{task_id}/build/test_logs/{path}
+type getTestLogsHandler struct {
+	logPaths []string
+
+	getTaskOutputLogsBaseHandler
+}
+
+func makeGetTestLogs(env evergreen.Environment, url string) *getTestLogsHandler {
+	return &getTestLogsHandler{
+		getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{env: env, url: url},
+	}
+}
+
+func (h *getTestLogsHandler) Factory() gimlet.RouteHandler {
+	return &getTestLogsHandler{
+		getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{env: h.env, url: h.url},
+	}
+}
+
+func (h *getTestLogsHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.logPaths = append([]string{gimlet.GetVars(r)["path"]}, r.URL.Query()["logs_to_merge"]...)
+
+	if err := h.parse(ctx, r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *getTestLogsHandler) Run(ctx context.Context) gimlet.Responder {
+	it, err := h.tsk.GetTestLogs(ctx, h.env, taskoutput.TestLogGetOptions{
+		LogPaths:  h.logPaths,
+		Start:     h.start,
+		End:       h.end,
+		LineLimit: h.lineLimit,
+		TailN:     h.tailN,
+	})
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting task logs"))
+	}
+
+	return h.createResponse(it)
+}
+
+// getUserTimeZone returns the time zone specified by the user settings.
+// Defaults to `America/New_York`.
+func getUserTimeZone(u *user.DBUser) *time.Location {
+	tz := u.Settings.Timezone
+	if tz == "" {
+		tz = "America/New_York"
+	}
+
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.UTC
+	}
+
+	return loc
+}

--- a/rest/route/task_output_test.go
+++ b/rest/route/task_output_test.go
@@ -1,0 +1,364 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/taskoutput"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTaskOutputLogsBaseHandlerParse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{
+		Settings: user.UserSettings{
+			Timezone: "UTC",
+		},
+	})
+	env := evergreen.GetEnvironment()
+
+	require.NoError(t, env.DB().Drop(ctx))
+	defer func() {
+		assert.NoError(t, env.DB().Drop(ctx))
+	}()
+
+	task0 := &task.Task{
+		Id:        "task_0",
+		OldTaskId: "task",
+	}
+	_, err := env.DB().Collection(task.OldCollection).InsertOne(ctx, task0)
+	require.NoError(t, err)
+	task1 := &task.Task{
+		Id:        "task",
+		Execution: 1,
+	}
+	_, err = env.DB().Collection(task.Collection).InsertOne(ctx, task1)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name     string
+		taskID   string
+		urlQuery string
+		expected *getTaskOutputLogsBaseHandler
+		hasErr   bool
+		errCode  int
+	}{
+		{
+			name:     "InvalidExecution",
+			taskID:   "task",
+			urlQuery: "execution=NaN",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:    "TaskDNE",
+			taskID:  "DNE",
+			hasErr:  true,
+			errCode: 404,
+		},
+		{
+			name:     "InvalidStart",
+			taskID:   "task",
+			urlQuery: "start=11-16-2023",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "InvalidEnd",
+			taskID:   "task",
+			urlQuery: "end=11-16-2023",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "InvalidLineLimit",
+			taskID:   "task",
+			urlQuery: "line_limit=NaN",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "InvalidTailLimit",
+			taskID:   "task",
+			urlQuery: "tail_limit=NaN",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "LineLimitAndTailLimitSet",
+			taskID:   "task",
+			urlQuery: "line_limit=100&tail_limit=100",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "LineLimitAndPaginateSet",
+			taskID:   "task",
+			urlQuery: "line_limit=99&paginate=true",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "TailLimitAndPaginateSet",
+			taskID:   "task",
+			urlQuery: "tail_limit=100&paginate=true",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "PaginateTailLimitAndLineLimitSet",
+			taskID:   "task",
+			urlQuery: "line_limit=100&tail_limit=100&paginate=true",
+			hasErr:   true,
+			errCode:  400,
+		},
+		{
+			name:     "DefaultParameters",
+			taskID:   "task",
+			expected: &getTaskOutputLogsBaseHandler{tsk: task1},
+		},
+		{
+			name:     "ValidParametersWithLineLimit",
+			taskID:   "task",
+			urlQuery: "execution=0&start=2023-11-16T07:20:50.00Z&end=2023-11-16T08:20:50Z&line_limit=100&print_time=True&print_priority=True",
+			expected: &getTaskOutputLogsBaseHandler{
+				tsk:           task0,
+				start:         utility.ToInt64Ptr(time.Date(2023, time.November, 16, 7, 20, 50, 0, time.UTC).UnixNano()),
+				end:           utility.ToInt64Ptr(time.Date(2023, time.November, 16, 8, 20, 50, 0, time.UTC).UnixNano()),
+				lineLimit:     100,
+				printTime:     true,
+				printPriority: true,
+			},
+		},
+		{
+			name:     "ValidParametersWithTailLimit",
+			taskID:   "task",
+			urlQuery: "execution=0&start=2023-11-16T07:20:50.00Z&end=2023-11-16T08:20:50Z&tail_limit=100&print_time=True&print_priority=True",
+			expected: &getTaskOutputLogsBaseHandler{
+				tsk:           task0,
+				start:         utility.ToInt64Ptr(time.Date(2023, time.November, 16, 7, 20, 50, 0, time.UTC).UnixNano()),
+				end:           utility.ToInt64Ptr(time.Date(2023, time.November, 16, 8, 20, 50, 0, time.UTC).UnixNano()),
+				tailN:         100,
+				printTime:     true,
+				printPriority: true,
+			},
+		},
+		{
+			name:     "ValidParametersWithPaginate",
+			taskID:   "task",
+			urlQuery: "execution=0&start=2023-11-16T07:20:50.00Z&end=2023-11-16T08:20:50Z&paginate=true&print_time=True&print_priority=True",
+			expected: &getTaskOutputLogsBaseHandler{
+				tsk:           task0,
+				start:         utility.ToInt64Ptr(time.Date(2023, time.November, 16, 7, 20, 50, 0, time.UTC).UnixNano()),
+				end:           utility.ToInt64Ptr(time.Date(2023, time.November, 16, 8, 20, 50, 0, time.UTC).UnixNano()),
+				printTime:     true,
+				printPriority: true,
+				paginate:      true,
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url, err := url.Parse(fmt.Sprintf("https://evergreen.mongodb.com/rest/v2/tasks/%s/build/task_logs?%s", test.taskID, test.urlQuery))
+			require.NoError(t, err)
+			req := &http.Request{Method: "GET"}
+			req.URL = url
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": test.taskID})
+
+			rh := &getTaskOutputLogsBaseHandler{}
+			err = rh.parse(ctx, req)
+			if test.hasErr {
+				require.Error(t, err)
+				errResp, ok := err.(gimlet.ErrorResponse)
+				if test.errCode == 400 {
+					// Should return a regular error and
+					// let the wrapping gimlet handler func
+					// set the default 400 HTTP error
+					// status.
+					assert.False(t, ok)
+				} else {
+					require.True(t, ok)
+					assert.Equal(t, test.errCode, errResp.StatusCode)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected.tsk.Id, rh.tsk.Id)
+				assert.Equal(t, test.expected.tsk.Execution, rh.tsk.Execution)
+				assert.Equal(t, test.expected.start, rh.start)
+				assert.Equal(t, test.expected.end, rh.end)
+				assert.Equal(t, test.expected.lineLimit, rh.lineLimit)
+				assert.Equal(t, test.expected.tailN, rh.tailN)
+				assert.Equal(t, test.expected.printTime, rh.printTime)
+				assert.Equal(t, test.expected.printPriority, rh.printPriority)
+				assert.Equal(t, test.expected.paginate, rh.paginate)
+				assert.Equal(t, 10*1024*1024, rh.softSizeLimit)
+				assert.Equal(t, time.UTC, rh.timeZone)
+			}
+		})
+	}
+}
+
+func TestGetTaskLogsHandlerParse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{
+		Settings: user.UserSettings{
+			Timezone: "UTC",
+		},
+	})
+	env := evergreen.GetEnvironment()
+
+	require.NoError(t, env.DB().Drop(ctx))
+	defer func() {
+		assert.NoError(t, env.DB().Drop(ctx))
+	}()
+
+	tsk := &task.Task{Id: "task"}
+	_, err := env.DB().Collection(task.Collection).InsertOne(ctx, tsk)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name     string
+		urlQuery string
+		expected *getTaskLogsHandler
+		hasErr   bool
+	}{
+		{
+			name:     "InvalidTaskLogType",
+			urlQuery: "type=invalid",
+			hasErr:   true,
+		},
+		{
+			name: "DefaulParameters",
+			expected: &getTaskLogsHandler{
+				logType:                      taskoutput.TaskLogTypeAll,
+				getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{tsk: tsk},
+			},
+		},
+
+		{
+			name:     "ValidParameters",
+			urlQuery: "type=agent_log&line_limit=100&print_time=true&print_priority=true",
+			expected: &getTaskLogsHandler{
+				logType: taskoutput.TaskLogTypeAgent,
+				getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{
+					tsk:           tsk,
+					lineLimit:     100,
+					printTime:     true,
+					printPriority: true,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url, err := url.Parse(fmt.Sprintf("https://evergreen.mongodb.com/rest/v2/tasks/task/build/task_logs?%s", test.urlQuery))
+			require.NoError(t, err)
+			req := &http.Request{Method: "GET"}
+			req.URL = url
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": "task"})
+
+			rh := &getTaskLogsHandler{}
+			err = rh.Parse(ctx, req)
+			if test.hasErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected.logType, rh.logType)
+				assert.Equal(t, test.expected.tsk.Id, rh.tsk.Id)
+				assert.Equal(t, test.expected.tsk.Execution, rh.tsk.Execution)
+				assert.Equal(t, test.expected.start, rh.start)
+				assert.Equal(t, test.expected.end, rh.end)
+				assert.Equal(t, test.expected.lineLimit, rh.lineLimit)
+				assert.Equal(t, test.expected.tailN, rh.tailN)
+				assert.Equal(t, test.expected.printTime, rh.printTime)
+				assert.Equal(t, test.expected.printPriority, rh.printPriority)
+				assert.Equal(t, test.expected.paginate, rh.paginate)
+				assert.Equal(t, 10*1024*1024, rh.softSizeLimit)
+				assert.Equal(t, time.UTC, rh.timeZone)
+			}
+		})
+	}
+}
+
+func TestGetTestLogsHandlerParse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{
+		Settings: user.UserSettings{
+			Timezone: "UTC",
+		},
+	})
+	env := evergreen.GetEnvironment()
+
+	require.NoError(t, env.DB().Drop(ctx))
+	defer func() {
+		assert.NoError(t, env.DB().Drop(ctx))
+	}()
+
+	tsk := &task.Task{Id: "task"}
+	_, err := env.DB().Collection(task.Collection).InsertOne(ctx, tsk)
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name     string
+		urlQuery string
+		expected *getTestLogsHandler
+	}{
+		{
+			name: "DefaultParameters",
+			expected: &getTestLogsHandler{
+				logPaths:                     []string{"test0.log"},
+				getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{tsk: tsk},
+			},
+		},
+		{
+			name:     "ValidParameters",
+			urlQuery: "logs_to_merge=test1.log&logs_to_merge=test2.log&type=agent_log&line_limit=100&print_time=true&print_priority=true",
+			expected: &getTestLogsHandler{
+				logPaths: []string{"test0.log", "test1.log", "test2.log"},
+				getTaskOutputLogsBaseHandler: getTaskOutputLogsBaseHandler{
+					tsk:           tsk,
+					lineLimit:     100,
+					printTime:     true,
+					printPriority: true,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			url, err := url.Parse(fmt.Sprintf("https://evergreen.mongodb.com/rest/v2/tasks/task/build/test_logs/test0.log?%s", test.urlQuery))
+			require.NoError(t, err)
+			req := &http.Request{Method: "GET"}
+			req.URL = url
+			req = gimlet.SetURLVars(req, map[string]string{
+				"task_id": "task",
+				"path":    "test0.log",
+			})
+
+			rh := &getTestLogsHandler{}
+			require.NoError(t, rh.Parse(ctx, req))
+			assert.Equal(t, test.expected.logPaths, rh.logPaths)
+			assert.Equal(t, test.expected.tsk.Id, rh.tsk.Id)
+			assert.Equal(t, test.expected.tsk.Execution, rh.tsk.Execution)
+			assert.Equal(t, test.expected.start, rh.start)
+			assert.Equal(t, test.expected.end, rh.end)
+			assert.Equal(t, test.expected.lineLimit, rh.lineLimit)
+			assert.Equal(t, test.expected.tailN, rh.tailN)
+			assert.Equal(t, test.expected.printTime, rh.printTime)
+			assert.Equal(t, test.expected.printPriority, rh.printPriority)
+			assert.Equal(t, test.expected.paginate, rh.paginate)
+			assert.Equal(t, 10*1024*1024, rh.softSizeLimit)
+			assert.Equal(t, time.UTC, rh.timeZone)
+		})
+	}
+}

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -65,9 +65,21 @@ auth:
       - username: "mci-nonprod"
         password: "change me"
         display_name: "MCI Nonprod"
+    github:
+      app_id: $GITHUB_APP_ID
+      default_owner: "evergreen-ci"
+      default_repo: "evergreen"
 
-plugins:
-  manifest:
-    github_token: "$GITHUB_TOKEN"
 github_pr_creator_org: "10gen"
+
+# Do not edit below this line
+expansions:
+  github_app_key: |
 EOF
+
+# Write the GitHub app key to a file for easier formatting
+echo "$GITHUB_APP_KEY" > app_key.txt
+# Linux and MacOS friendly command to add 4 spaces to the start of each line
+sed -i'' -e 's/^/    /' app_key.txt
+# Append the formatted GitHub app key to the creds.yml file
+cat app_key.txt >> creds.yml

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -235,6 +235,8 @@ functions:
       working_dir: evergreen
       env:
         GITHUB_TOKEN: ${github_token}
+        GITHUB_APP_ID: ${staging_github_app_id}
+        GITHUB_APP_KEY: ${staging_github_app_key}
         JIRA_SERVER: ${jiraserver}
         CROWD_SERVER: ${crowdserver}
         AWS_KEY: ${aws_key}

--- a/service/api.go
+++ b/service/api.go
@@ -230,61 +230,12 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	errs := validator.ValidationErrors{}
-	var projectRef *model.ProjectRef
-	if input.ProjectID != "" {
-		projectRef, err = model.FindMergedProjectRef(input.ProjectID, "", false)
-		if err != nil {
-			validationErr = validator.ValidationError{
-				Message: "error finding project; validation will proceed without checking project settings",
-				Level:   validator.Warning,
-			}
-			errs = append(errs, validationErr)
-		} else if projectRef == nil {
-			validationErr = validator.ValidationError{
-				Message: "project does not exist; validation will proceed without checking project settings",
-				Level:   validator.Warning,
-			}
-			errs = append(errs, validationErr)
-		} else {
-			isConfigDefined := projectConfig != nil
-			errs = append(errs, validator.CheckProjectSettings(ctx, evergreen.GetEnvironment().Settings(), project, projectRef, isConfigDefined)...)
-		}
-	} else {
-		validationErr = validator.ValidationError{
-			Message: "no project specified; validation will proceed without checking project settings",
-			Level:   validator.Warning,
-		}
-		errs = append(errs, validationErr)
-	}
-
-	errs = append(errs, validator.CheckProjectErrors(r.Context(), project, input.IncludeLong)...)
-	if projectConfig != nil {
-		errs = append(errs, validator.CheckProjectConfigErrors(projectConfig)...)
-	}
+	projectRef, err := model.FindMergedProjectRef(input.ProjectID, "", false)
+	errs := validator.CheckProject(ctx, project, projectConfig, projectRef, evergreen.GetEnvironment().Settings(), input.IncludeLong, input.ProjectID != "", err != nil)
 
 	if input.Quiet {
 		errs = errs.AtLevel(validator.Error)
-	} else if projectRef == nil {
-		validationErr = validator.ValidationError{
-			Message: "no project specified; validation will proceed without checking alias coverage",
-			Level:   validator.Warning,
-		}
-		errs = append(errs, validationErr)
-	} else {
-		errs = append(errs, validator.CheckProjectWarnings(project)...)
-		// Check project aliases
-		aliases, err := model.ConstructMergedAliasesByPrecedence(projectRef, projectConfig, projectRef.RepoRefId)
-		if err != nil {
-			errs = append(errs, validator.ValidationError{
-				Message: "problem finding aliases; validation will proceed without checking alias coverage",
-				Level:   validator.Warning,
-			})
-		} else {
-			errs = append(errs, validator.CheckAliasWarnings(project, aliases)...)
-		}
 	}
-
 	if len(errs) > 0 {
 		gimlet.WriteJSONError(w, errs)
 		return

--- a/service/api.go
+++ b/service/api.go
@@ -231,7 +231,7 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	}
 
 	projectRef, err := model.FindMergedProjectRef(input.ProjectID, "", false)
-	errs := validator.CheckProject(ctx, project, projectConfig, projectRef, evergreen.GetEnvironment().Settings(), input.IncludeLong, input.ProjectID != "", err != nil)
+	errs := validator.CheckProject(ctx, project, projectConfig, projectRef, input.IncludeLong, input.ProjectID, err)
 
 	if input.Quiet {
 		errs = errs.AtLevel(validator.Error)

--- a/taskoutput/test_log.go
+++ b/taskoutput/test_log.go
@@ -25,18 +25,21 @@ func (TestLogOutput) ID() string { return "test_logs" }
 // to a task run.
 type TestLogGetOptions struct {
 	// LogPaths are the paths of the logs to fetch and merge, prefixes may
-	// be specified. At least one name must be specified.
+	// be specified. At least one value must be specified.
 	LogPaths []string
 	// Start is the start time (inclusive) of the time range filter,
-	// represented as a Unix timestamp in nanoseconds. Optional.
-	Start int64
+	// represented as a Unix timestamp in nanoseconds. Defaults to the
+	// first timestamp of the first specified log.
+	Start *int64
 	// End is the end time (inclusive) of the time range filter,
-	// represented as a Unix timestamp in nanoseconds. Optional.
-	End int64
-	// LineLimit limits the number of lines read from the log. Optional.
+	// represented as a Unix timestamp in nanoseconds. Defaults to the last
+	// timestamp of the first specified log.
+	End *int64
+	// LineLimit limits the number of lines read from the log. Ignored if
+	// less than or equal to 0.
 	LineLimit int
 	// TailN is the number of lines to read from the tail of the log.
-	// Optional.
+	// Ignored if less than or equal to 0.
 	TailN int
 }
 
@@ -52,11 +55,12 @@ func (o TestLogOutput) Get(ctx context.Context, env evergreen.Environment, taskO
 	}
 
 	return svc.Get(ctx, log.GetOptions{
-		LogNames:  o.getLogNames(taskOpts, getOpts.LogPaths),
-		Start:     getOpts.Start,
-		End:       getOpts.End,
-		LineLimit: getOpts.LineLimit,
-		TailN:     getOpts.TailN,
+		LogNames:                   o.getLogNames(taskOpts, getOpts.LogPaths),
+		Start:                      getOpts.Start,
+		End:                        getOpts.End,
+		DefaultTimeRangeOfFirstLog: true,
+		LineLimit:                  getOpts.LineLimit,
+		TailN:                      getOpts.TailN,
 	})
 }
 
@@ -91,8 +95,8 @@ func (o TestLogOutput) getBuildloggerLogs(ctx context.Context, env evergreen.Env
 		TaskID:    taskOpts.TaskID,
 		Execution: utility.ToIntPtr(taskOpts.Execution),
 		TestName:  getOpts.LogPaths[0],
-		Start:     getOpts.Start,
-		End:       getOpts.End,
+		Start:     utility.FromInt64Ptr(getOpts.Start),
+		End:       utility.FromInt64Ptr(getOpts.End),
 		Limit:     getOpts.LineLimit,
 		Tail:      getOpts.TailN,
 	})

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -148,16 +148,16 @@ func (s *githubSuite) TestCheckGithubAPILimit() {
 }
 
 func (s *githubSuite) TestGetGithubCommits() {
-	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", time.Time{}, 0)
+	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "evergreen-ci", "sample", "", time.Time{}, 0)
 	s.NoError(err)
-	s.Len(githubCommits, 3)
+	s.Len(githubCommits, 8)
 }
 
 func (s *githubSuite) TestGetGithubCommitsUntil() {
-	until := time.Date(2013, time.May, 17, 15, 40, 0, 0, time.UTC)
-	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "deafgoat", "mci-test", "", until, 0)
+	until := time.Date(2015, time.January, 1, 0, 0, 0, 0, time.UTC)
+	githubCommits, _, err := GetGithubCommits(s.ctx, s.token, "evergreen-ci", "sample", "", until, 0)
 	s.NoError(err)
-	s.Len(githubCommits, 2)
+	s.Len(githubCommits, 4)
 }
 
 func (s *githubSuite) TestGetTaggedCommitFromGithub() {

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -271,25 +271,25 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	// there is no token set up in settings, but hitting this error
 	// means it's trying to finalize the patch
 	s.Require().Error(err)
-	s.Contains(err.Error(), "no github token in settings")
+	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
 	n, err = s.t.patchOutcome(&s.subs[1])
 	s.Require().Error(err)
-	s.Contains(err.Error(), "no github token in settings")
+	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
 	n, err = s.t.patchOutcome(&s.subs[2])
 	s.Require().Error(err)
-	s.Contains(err.Error(), "no github token in settings")
+	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
 	n, err = s.t.patchOutcome(&s.subs[2])
 	s.Require().Error(err)
-	s.Contains(err.Error(), "no github token in settings")
+	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 }

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -52,6 +52,7 @@ func makeTaskTriggers() eventHandler {
 		event.TriggerFailure:                     t.taskFailure,
 		event.TriggerSuccess:                     t.taskSuccess,
 		event.TriggerExceedsDuration:             t.taskExceedsDuration,
+		event.TriggerSuccessfulExceedsDuration:   t.taskSuccessfulExceedsDuration,
 		event.TriggerRuntimeChangeByPercent:      t.taskRuntimeChange,
 		event.TriggerRegression:                  t.taskRegression,
 		event.TriggerTaskFirstFailureInVersion:   t.taskFirstFailureInVersion,
@@ -663,6 +664,14 @@ func shouldSendTaskRegression(sub *event.Subscription, t *task.Task, previousTas
 		return taskFinishedTwoOrMoreDaysAgo(lastAlerted.TaskId, sub)
 	}
 	return false, nil
+}
+
+func (t *taskTriggers) taskSuccessfulExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {
+	if t.task.Status != evergreen.TaskSucceeded {
+		return nil, nil
+	}
+
+	return t.taskExceedsDuration(sub)
 }
 
 func (t *taskTriggers) taskExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -1198,6 +1198,25 @@ func (s *taskSuite) TestTaskExceedsTime() {
 	s.Nil(n)
 }
 
+func (s *taskSuite) TestSuccessfulTaskExceedsTime() {
+	// successful task that exceeds time should generate
+	s.t.event = &event.EventLogEntry{
+		EventType: event.TaskFinished,
+	}
+	s.t.data.Status = evergreen.TaskSucceeded
+	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	n, err := s.t.taskExceedsDuration(&s.subs[3])
+	s.NoError(err)
+	s.NotNil(n)
+
+	// task that is not successful should not generate
+	s.t.data.Status = evergreen.TaskFailed
+	s.NoError(db.Update(task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	n, err = s.t.taskSuccessfulExceedsDuration(&s.subs[3])
+	s.NoError(err)
+	s.Nil(n)
+}
+
 func (s *taskSuite) TestTaskRuntimeChange() {
 	// no previous task should not generate
 	s.t.event = &event.EventLogEntry{

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -261,7 +261,7 @@ func CheckProject(ctx context.Context, project *model.Project, config *model.Pro
 	aliases, err := model.ConstructMergedAliasesByPrecedence(ref, config, ref.RepoRefId)
 	if err != nil {
 		return append(verrs, ValidationError{
-			Message: "problem finding aliases; validation will proceed without checking alias coverage",
+			Message: "problem finding aliases; validation will not check alias coverage",
 			Level:   Warning,
 		})
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -228,7 +228,7 @@ func getDistrosForProject(ctx context.Context, projectID string) (ids []string, 
 // it will not check it (e.g. if the config is nil, it does not check the config).
 // projectRefId is used to determine if there is a project specified and
 // projectRefErr is used to determine if there was a problem retrieving
-// the ref, both output different warnings for the project.
+// the ref; both output different warnings for the project.
 func CheckProject(ctx context.Context, project *model.Project, config *model.ProjectConfig, ref *model.ProjectRef, includeLong bool, projectRefId string, projectRefErr error) ValidationErrors {
 	isConfigDefined := config != nil
 	verrs := CheckProjectErrors(ctx, project, includeLong)


### PR DESCRIPTION
DEVPROD-716

### Description
This consolidates some logic that we had in our API /validate route and our evergreen validate command to be the same. Previously they were the same except the validate command would surface errors from parsing the yaml and check aliases as well. Now it is only parsing the yaml errors, which isn't available when we are setting the version warnings/errors.

As well, I noticed how we were a little inconsistent with our warnings/errors. We say some duplicate messages when a project is not found for example, but if it errored earlier- we would say it errored for one message and for the other we would say the project does not exist.

We also did not follow the same ordering (we had like one of them switched I think). And this makes the ordering the same.

### Testing
Existing unit testing, I was debating about adding more unit testing for this function but I'm not sure if the overhead of testing is just duplicate testing from the functions it calls and the caller function,