### PR TITLE
DEVPROD-769 add doc change for project page flags

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -65,6 +65,19 @@ Admins can also set the branch project to inherit values from a
 repo-level project settings configuration. This can be learned about at
 ['Using Repo Level Settings'](Repo-Level-Settings.md).
 
+### Project Flags
+
+Under project flags, admins have a number of options for users to configure what
+runs for their project. For example, prevent projects from creating mainline 
+commits by disabling repotracking (by default, this is enabled. Evergreen occasionally 
+misses commits due to misconfiguration or GitHub outages, in which case admins can 
+Force Repotracker Run to unblock this). 
+
+Admins can also enable the ability to unschedule old tasks if a more recent
+commit passes, or configure tasks to stepback on failure to isolate the cause.
+
+Check out the settings on the page to see more options.
+
 ### Access and Admin Settings
 
 Admins can set a project as private or public. A private project can
@@ -82,11 +95,6 @@ via the REST API. The default for this setting is to allow logged-in
 users basic access to this project. Note this is different from the
 Private/Public setting above, which restricts access for users that are
 not logged in.
-
-### Scheduling Settings
-
-Admins can enable the ability to unschedule old tasks if a more recent
-commit passes.
 
 ### Variables
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -78,7 +78,7 @@ Check out the settings on the page to see more options.
 By default, Evergreen creates mainline commits (also known as waterfall versions or 
 cron builds) for enabled projects. 
 
-Admins can prevent projects from creating mainline commits by **disabling repotrackin**g,
+Admins can prevent projects from creating mainline commits by **disabling repotracking**,
 while still allowing for other kinds of versions (periodic builds, patches, etc).
 
 Additionally, admins can **Force Repotracker Run** to check for new commits if needed 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -75,11 +75,13 @@ isolate the cause.
 Check out the settings on the page to see more options.
 
 #### Repotracker Settings
-By default, project create mainline commits (also known as waterfall versions or cron builds). 
-Admins can prevent projects from creating mainline commits by disabling repotracking,
+By default, Evergreen creates mainline commits (also known as waterfall versions or 
+cron builds) for enabled projects. 
+
+Admins can prevent projects from creating mainline commits by **disabling repotrackin**g,
 while still allowing for other kinds of versions (periodic builds, patches, etc).
 
-Additionally, admins can Force Repotracker Run to check for new commits if needed 
+Additionally, admins can **Force Repotracker Run** to check for new commits if needed 
 (Evergreen occasionally misses commits due to misconfiguration or GitHub outages).
 
 ### Access and Admin Settings

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -68,15 +68,19 @@ repo-level project settings configuration. This can be learned about at
 ### Project Flags
 
 Under project flags, admins have a number of options for users to configure what
-runs for their project. For example, prevent projects from creating mainline 
-commits by disabling repotracking (by default, this is enabled. Evergreen occasionally 
-misses commits due to misconfiguration or GitHub outages, in which case admins can 
-Force Repotracker Run to unblock this). 
-
-Admins can also enable the ability to unschedule old tasks if a more recent
-commit passes, or configure tasks to stepback on failure to isolate the cause.
+runs for their project. For example, admins can enable the ability to unschedule old 
+tasks if a more recent commit passes, or configure tasks to stepback on failure to 
+isolate the cause.
 
 Check out the settings on the page to see more options.
+
+#### Repotracker Settings
+By default, project create mainline commits (also known as waterfall versions or cron builds). 
+Admins can prevent projects from creating mainline commits by disabling repotracking,
+while still allowing for other kinds of versions (periodic builds, patches, etc).
+
+Additionally, admins can Force Repotracker Run to check for new commits if needed 
+(Evergreen occasionally misses commits due to misconfiguration or GitHub outages).
 
 ### Access and Admin Settings
 


### PR DESCRIPTION
DEVPROD-769

### Description
We don't have a doc section for this, so adding something small. I thought about adding screenshots and etc but I don't think we should need that -- these are small enough that the page itself should be explanatory, and that increases the risk of things getting outdated, so keeping it simple.
