### PR TITLE
DEVPROD-2652: close task logger after testing file logger

### DIFF
--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -101,10 +101,12 @@ func TestAgentFileLogging(t *testing.T) {
 			Expansions: *util.NewExpansions(nil),
 		},
 	}
-	assert.NoError(agt.startLogging(ctx, tc))
-	defer agt.removeTaskDirectory(tc)
-	err = agt.runTaskCommands(ctx, tc)
-	require.NoError(err)
+	require.NoError(agt.startLogging(ctx, tc))
+	defer func() {
+		agt.removeTaskDirectory(tc)
+		assert.NoError(t, tc.logger.Close())
+	}()
+	require.NoError(t, agt.runTaskCommands(ctx, tc))
 
 	// Verify log contents.
 	f, err := os.Open(fmt.Sprintf("%s/%s/%s/task.log", tmpDirName, taskLogDirectory, "shell.exec"))

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -104,9 +104,9 @@ func TestAgentFileLogging(t *testing.T) {
 	require.NoError(agt.startLogging(ctx, tc))
 	defer func() {
 		agt.removeTaskDirectory(tc)
-		assert.NoError(t, tc.logger.Close())
+		assert.NoError(tc.logger.Close())
 	}()
-	require.NoError(t, agt.runTaskCommands(ctx, tc))
+	require.NoError(agt.runTaskCommands(ctx, tc))
 
 	// Verify log contents.
 	f, err := os.Open(fmt.Sprintf("%s/%s/%s/task.log", tmpDirName, taskLogDirectory, "shell.exec"))


### PR DESCRIPTION
DEVPROD-2652

### Description
This fixes `test-agent` on windows where an open file descriptor prevents the task directory from getting cleaned up.

### Testing
[Passing unit tests on windows.](https://spruce.mongodb.com/version/655d11de32f417fe8e5144dd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Documentation
N/A
