### PR TITLE
DEVPROD-2921 Use SHA of push trigger if it is a module of the downstream project

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -259,7 +259,7 @@ Options:
 -   Level: Accepted values are task, build, and push. Task and build levels will trigger
     based on the completion of either a task or a build in the upstream project. 
     - Push level triggers do not require any upstream build or task to run, but instead trigger a downstream version once
-        a commit is pushed to the upstream project.
+    a commit is pushed to the upstream project.
     - For push level triggers, if the upstream project is a module of the downstream project's YAML,
     the manifest of the downstream version will use the commit hash of the upstream project's commit.
 -   Status: Only applicable to build and task level triggers. Specify which status of the upstream 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -257,9 +257,11 @@ Options:
 
 -   Project: The upstream project.
 -   Level: Accepted values are task, build, and push. Task and build levels will trigger
-    based on the completion of either a task or a build in the upstream project. Push level triggers do 
-    not require any upstream build or task to run, but instead trigger a downstream version once
-    a commit is pushed to the upstream project.
+    based on the completion of either a task or a build in the upstream project. 
+    - Push level triggers do not require any upstream build or task to run, but instead trigger a downstream version once
+        a commit is pushed to the upstream project.
+    - For push level triggers, if the upstream project is a module of the downstream project's YAML,
+    the manifest of the downstream version will use the commit hash of the upstream project's commit.
 -   Status: Only applicable to build and task level triggers. Specify which status of the upstream 
     build or task should trigger a downstream version.
 -   Date cutoff: Do not trigger a downstream build if a user manually

--- a/model/version.go
+++ b/model/version.go
@@ -828,12 +828,12 @@ func getManifestModule(v *Version, projectRef *ProjectRef, token string, module 
 }
 
 // CreateManifest inserts a newly constructed manifest into the DB.
-func CreateManifest(v *Version, proj *Project, projectRef *ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
+func CreateManifest(v *Version, modules ModuleList, projectRef *ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
 	token, err := settings.GetGithubOauthToken()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting GitHub token")
 	}
-	newManifest, err := constructManifest(v, projectRef, proj.Modules, token)
+	newManifest, err := constructManifest(v, projectRef, modules, token)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing manifest")
 	}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -364,7 +364,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			}
 		}
 
-		_, err = model.CreateManifest(v, pInfo.Project, ref, repoTracker.Settings)
+		_, err = model.CreateManifest(v, pInfo.Project.Modules, ref, repoTracker.Settings)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":            "error creating manifest",

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1184,7 +1184,7 @@ func TestCreateManifest(t *testing.T) {
 	}
 	require.NoError(t, projVars.Insert())
 
-	manifest, err := model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err := model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1197,7 +1197,7 @@ func TestCreateManifest(t *testing.T) {
 	assert.Equal("b27779f856b211ffaf97cbc124b7082a20ea8bc0", module.Revision)
 
 	proj.Modules[0].AutoUpdate = true
-	manifest, err = model.CreateManifest(&patchVersion, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&patchVersion, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(patchVersion.Id, manifest.Id)
 	assert.Equal(patchVersion.Revision, manifest.Revision)
@@ -1224,7 +1224,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1249,7 +1249,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, &proj, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.Contains(err.Error(), "No commit found for SHA")
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1259,7 +1259,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// attempt to insert a manifest after making GitHub API calls
-	manifest, err := model.CreateManifest(v, project, projectRef, h.settings)
+	manifest, err := model.CreateManifest(v, project.Modules, projectRef, h.settings)
 	if err != nil {
 		if apiErr, ok := errors.Cause(err).(thirdparty.APIRequestError); ok && apiErr.StatusCode == http.StatusNotFound {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "manifest resource not found"))

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -627,6 +627,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	assert.Equal(downstreamProjectRef.Id, mani.ProjectName)
 	assert.Equal(uptreamProjectRef.Branch, mani.Branch)
 	assert.Len(mani.Modules, 1)
+	require.NotNil(mani.Modules["sample"])
 	assert.Equal("3585388b1591dfca47ac26a5b9a564ec8f138a5e", mani.Modules["sample"].Revision)
 	assert.Equal("main", mani.Modules["sample"].Branch)
 	assert.Equal("sample", mani.Modules["sample"].Repo)

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -575,7 +575,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 
 	pushEvent := &github.PushEvent{
 		HeadCommit: &github.HeadCommit{
-			ID:      utility.ToStringPtr("abc"),
+			ID:      utility.ToStringPtr("3585388b1591dfca47ac26a5b9a564ec8f138a5e"),
 			Message: utility.ToStringPtr("message"),
 			Author: &github.CommitAuthor{
 				Email: utility.ToStringPtr("hello@example.com"),
@@ -590,13 +590,13 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	assert.NoError(err)
 	require.Len(dbVersions, 1)
 	assert.True(utility.FromBoolPtr(dbVersions[0].Activated))
-	assert.Equal("downstream_abc_def1", dbVersions[0].Id)
+	assert.Equal("downstream_3585388b1591dfca47ac26a5b9a564ec8f138a5e_def1", dbVersions[0].Id)
 	assert.Equal(downstreamRevision, dbVersions[0].Revision)
 	assert.Equal(evergreen.VersionCreated, dbVersions[0].Status)
 	assert.Equal(downstreamProjectRef.Id, dbVersions[0].Identifier)
 	assert.Equal(evergreen.TriggerRequester, dbVersions[0].Requester)
 	assert.Equal(model.ProjectTriggerLevelPush, dbVersions[0].TriggerType)
-	assert.Equal("abc", dbVersions[0].TriggerSHA)
+	assert.Equal("3585388b1591dfca47ac26a5b9a564ec8f138a5e", dbVersions[0].TriggerSHA)
 	assert.Equal("upstream", dbVersions[0].TriggerID)
 
 	builds, err := build.Find(build.ByVersion(dbVersions[0].Id))
@@ -626,6 +626,11 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	require.NotNil(mani)
 	assert.Equal(downstreamProjectRef.Id, mani.ProjectName)
 	assert.Equal(uptreamProjectRef.Branch, mani.Branch)
+	assert.Len(mani.Modules, 1)
+	assert.Equal("3585388b1591dfca47ac26a5b9a564ec8f138a5e", mani.Modules["sample"].Revision)
+	assert.Equal("main", mani.Modules["sample"].Branch)
+	assert.Equal("sample", mani.Modules["sample"].Repo)
+	assert.Equal("evergreen-ci", mani.Modules["sample"].Owner)
 
 	// verify that triggering this version again does nothing
 	assert.NoError(TriggerDownstreamProjectsForPush(ctx, uptreamProjectRef.Id, pushEvent, TriggerDownstreamVersion))


### PR DESCRIPTION
DEVPROD-2921

### Description
- When triggering a downstream patch via upstream push, set the downstream patch's manifest to the revision of the upstream project push, if the upstream project is a module of the downstream project.
- Refactored CreateManifest to just take in a list of modules for simplicity.

Note: While this would be doable by adding `auto_update: true` to the module in YAML, it would also mean that it would no longer be possible for users to make patches off of old versions in a way that replicates the old version's behavior fully, as its module would pull from the most recent revision rather than the module revision that existed at time of the base revision.

### Testing
Confirmed [before](https://spruce-staging.corp.mongodb.com/version/sandbox_6d59ba219b13b10cce97beec439977bc88639aa6_c6db985b8c9ffb231c10085b09efa348/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the change that a push trigger does not necessarily use the same push revision for the manifest (and instead defaults to the manifest of the base revision).

Confirmed [after](https://spruce-staging.corp.mongodb.com/version/sandbox_fa8f1ad2f504826cfe0f6ad8052c9aba337d46b4_c6db985b8c9ffb231c10085b09efa348/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) change that a push trigger where the upstream project is a module of the downstream project has the downstream manifest pulling from the upstream push revision.
### Documentation
Updated trigger docs to mention this.