### PR TITLE
DEVPROD-753 Remove 32-bit Windows and Linux architecture options

### DIFF
--- a/agent/command/testdata/plugin_s3_copy.yml
+++ b/agent/command/testdata/plugin_s3_copy.yml
@@ -1,57 +1,44 @@
 batchtime: 180
 tasks:
-- name: copyTask
-  commands:
-  - command: s3.put
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      local_file: testdata/test.tgz
-      remote_file: ${push_path}/test.tgz
-      bucket: ${push_source_bucket}
-      permissions: public-read-write
-      content_type: application/tar
-      display_name: test_copy
-  - command: s3Copy.copy
-    params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
-      s3_copy_files:
-      - source:
+  - name: copyTask
+    commands:
+      - command: s3.put
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          local_file: testdata/test.tgz
+          remote_file: ${push_path}/test.tgz
           bucket: ${push_source_bucket}
-          path: ${push_path}/test.tgz
-        destination:
-          bucket: ${push_destination_bucket}
-          path: ${push_path}/${push_name}/test.tgz
-        display_name: test_copy
-        build_variants:
-        - linux-64
+          permissions: public-read-write
+          content_type: application/tar
+          display_name: test_copy
+      - command: s3Copy.copy
+        params:
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          s3_copy_files:
+            - source:
+                bucket: ${push_source_bucket}
+                path: ${push_path}/test.tgz
+              destination:
+                bucket: ${push_destination_bucket}
+                path: ${push_path}/${push_name}/test.tgz
+              display_name: test_copy
+              build_variants:
+                - linux-64
 buildvariants:
-- name: linux-64
-  display_name: Linux 64-bit
-  run_on:
-  - linux-64
-  tasks:
-  - name: copyTask
-    distros:
-    - rhel55
-  expansions:
-    push_name: linux
-    push_source_bucket: build-push-testing
-    push_destination_bucket: mciuploads
-    push_path: s3CopyFolder
-  push: true
-- name: linux-32
-  display_name: Linux 32-bit
-  run_on:
-  - linux-32
-  tasks:
-  - name: copyTask
-    distros:
-    - rhel55
-expansions:
-  push_name: linux
-  push_source_bucket: source-bucket
-  push_destination_bucket: mciuploads
-  push_path: s3CopyFolder
+  - name: linux-64
+    display_name: Linux 64-bit
+    run_on:
+      - linux-64
+    tasks:
+      - name: copyTask
+        distros:
+          - rhel55
+    expansions:
+      push_name: linux
+      push_source_bucket: build-push-testing
+      push_destination_bucket: mciuploads
+      push_path: s3CopyFolder
+    push: true
 push: true

--- a/globals.go
+++ b/globals.go
@@ -816,12 +816,10 @@ func (k SenderKey) String() string {
 const (
 	ArchDarwinAmd64  = "darwin_amd64"
 	ArchDarwinArm64  = "darwin_arm64"
-	ArchLinux386     = "linux_386"
 	ArchLinuxPpc64le = "linux_ppc64le"
 	ArchLinuxS390x   = "linux_s390x"
 	ArchLinuxArm64   = "linux_arm64"
 	ArchLinuxAmd64   = "linux_amd64"
-	ArchWindows386   = "windows_386"
 	ArchWindowsAmd64 = "windows_amd64"
 )
 
@@ -989,11 +987,9 @@ var (
 		ArchLinuxPpc64le: "Linux PowerPC 64-bit",
 		ArchLinuxS390x:   "Linux zSeries",
 		ArchLinuxArm64:   "Linux ARM 64-bit",
-		ArchWindows386:   "Windows 32-bit",
 		ArchDarwinAmd64:  "OSX 64-bit",
 		ArchDarwinArm64:  "OSX ARM 64-bit",
 		ArchLinuxAmd64:   "Linux 64-bit",
-		ArchLinux386:     "Linux 32-bit",
 	}
 
 	// ValidCloneMethods includes all recognized clone methods.

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -67,8 +67,8 @@ buildvariants:
 			simple := `
 buildvariants:
 - matrix_name: "test"
-  matrix_spec: {"os": ".linux", "bits":["32", "64"]}
-  exclude_spec: [{"os":"ubuntu", "bits":"32"}]
+  matrix_spec: {"os": ".linux", "bits":[ "64"]}
+  exclude_spec: [{"os":"ubuntu", "bits":"64"}]
 - matrix_name: "test2"
   matrix_spec:
     os: "windows95"
@@ -85,10 +85,10 @@ buildvariants:
 				Id: "test",
 				Spec: matrixDefinition{
 					"os":   []string{".linux"},
-					"bits": []string{"32", "64"},
+					"bits": []string{"64"},
 				},
 				Exclude: []matrixDefinition{
-					{"os": []string{"ubuntu"}, "bits": []string{"32"}},
+					{"os": []string{"ubuntu"}, "bits": []string{"64"}},
 				},
 			})
 			m2 := *p.BuildVariants[1].Matrix

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -548,7 +548,6 @@ func ensureHasValidVirtualWorkstationSettings(ctx context.Context, d *distro.Dis
 		})
 	}
 	linuxArchs := []string{
-		evergreen.ArchLinux386,
 		evergreen.ArchLinuxPpc64le,
 		evergreen.ArchLinuxS390x,
 		evergreen.ArchLinuxArm64,


### PR DESCRIPTION
DEVPROD-753

### Description
Nobody uses 32-bit architecture distros anymore, so we can delete this. 


