### PR TITLE
DEVPROD-963 Remove panic from docker status err status code

### DIFF
--- a/agent/command/host_create.go
+++ b/agent/command/host_create.go
@@ -177,7 +177,10 @@ func (c *createHost) getLogsFromNewDockerHost(ctx context.Context, logger client
 
 func (c *createHost) initializeLogBatchInfo(id string, conf *internal.TaskConfig, startTime time.Time) (*logBatchInfo, error) {
 	const permissions = os.O_APPEND | os.O_CREATE | os.O_WRONLY
-	info := &logBatchInfo{batchStart: startTime}
+	info := &logBatchInfo{
+		batchStart: startTime,
+		hostID:     id,
+	}
 
 	// initialize file names
 	if c.CreateHost.StderrFile == "" {

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -942,7 +942,7 @@ func (c *baseCommunicator) GetDockerStatus(ctx context.Context, hostID string) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, util.RespErrorf(resp, errors.Wrapf(err, "getting status for container '%s'", hostID).Error())
+		return nil, util.RespErrorf(resp, "getting status for container '%s'", hostID)
 	}
 	status := cloud.ContainerStatus{}
 	if err := utility.ReadJSON(resp.Body, &status); err != nil {

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-11-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-11-28"
+	AgentVersion = "2023-11-28a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-963

### Description
- Fix error where `GetDockerStatus` panics on a nil error (which is already handled in earlier logic)
- Fix error noticed along the way where the host Id is nil for `GetDockerStatus` causing the request to always fail because its format is always `/rest/v2/hosts//status`
### Testing
Confirmed the command [panics](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu2004_unit_tests_patch_d631380317a8478b879cc27d6171508dea2b11df_6566317497b1d30a5e2119dd_23_11_28_19_19_38/0?type=T#L38) without the change, and [no longer panics ](https://evergreen-staging.corp.mongodb.com/task_log_raw/sandbox_ubuntu2004_unit_tests_patch_d631380317a8478b879cc27d6171508dea2b11df_6566561c97b1d31bc0262a66_23_11_28_21_05_44/0?type=T#L37)with the change (though now checking for docker logs times out, I confirmed this is because the Docker response is continuoulsly:
```
{
    "IsRunning": false,
    "HasStarted": false
}
```
until it eventually times out. Filed [DEVPROD-2983](https://jira.mongodb.org/browse/DEVPROD-2983) to fix)