### PR TITLE
DEVPROD-743: delete clone params

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -71,8 +71,6 @@ type gitFetchProject struct {
 
 	CommitterEmail string `mapstructure:"committer_email"`
 
-	CloneParams string `mapstructure:"clone_params"`
-
 	base
 }
 
@@ -84,7 +82,6 @@ type cloneOpts struct {
 	branch                 string
 	dir                    string
 	token                  string
-	cloneParams            string
 	recurseSubmodules      bool
 	useVerbose             bool
 	usePatchMergeCommitSha bool
@@ -240,9 +237,6 @@ func (opts cloneOpts) buildHTTPCloneCommand(forApp bool) ([]string, error) {
 	if opts.branch != "" {
 		clone = fmt.Sprintf("%s --branch '%s'", clone, opts.branch)
 	}
-	if opts.cloneParams != "" {
-		clone = fmt.Sprintf("%s %s", clone, opts.cloneParams)
-	}
 
 	redactedClone := strings.Replace(clone, opts.token, "[redacted oauth token]", -1)
 	return []string{
@@ -267,9 +261,6 @@ func (opts cloneOpts) buildSSHCloneCommand() ([]string, error) {
 	}
 	if opts.branch != "" {
 		cloneCmd = fmt.Sprintf("%s --branch '%s'", cloneCmd, opts.branch)
-	}
-	if opts.cloneParams != "" {
-		cloneCmd = fmt.Sprintf("%s %s", cloneCmd, opts.cloneParams)
 	}
 
 	return []string{
@@ -484,7 +475,6 @@ func (c *gitFetchProject) opts(projectMethod, projectToken string, logger client
 		branch:                 conf.ProjectRef.Branch,
 		dir:                    c.Directory,
 		token:                  projectToken,
-		cloneParams:            c.CloneParams,
 		recurseSubmodules:      c.RecurseSubmodules,
 		usePatchMergeCommitSha: true,
 	}

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -451,13 +451,12 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 
 	// build clone command to clone by http, main branch with token into 'dir'
 	opts := cloneOpts{
-		method:      evergreen.CloneMethodOAuth,
-		owner:       projectRef.Owner,
-		repo:        projectRef.Repo,
-		branch:      projectRef.Branch,
-		dir:         "dir",
-		token:       projectGitHubToken,
-		cloneParams: "--filter=tree:0 --single-branch",
+		method: evergreen.CloneMethodOAuth,
+		owner:  projectRef.Owner,
+		repo:   projectRef.Repo,
+		branch: projectRef.Branch,
+		dir:    "dir",
+		token:  projectGitHubToken,
 	}
 	s.Require().NoError(opts.setLocation())
 	cmds, err := opts.buildHTTPCloneCommand(false)
@@ -465,8 +464,8 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
-		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
+		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 		"set -o xtrace",
 		"cd dir",
 	}))
@@ -477,8 +476,8 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --filter=tree:0 --single-branch\"",
-		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --filter=tree:0 --single-branch",
+		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir'\"",
+		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir'",
 		"set -o xtrace",
 		"cd dir",
 	}))
@@ -491,8 +490,8 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
-		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
+		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 	}))
 
 	// ensure that we aren't sending the github oauth token to other
@@ -502,26 +501,25 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch\"",
-		"git clone https://PROJECTTOKEN:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main' --filter=tree:0 --single-branch",
+		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"git clone https://PROJECTTOKEN:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 	}))
 }
 
 func (s *GitGetProjectSuite) TestBuildSSHCloneCommand() {
 	// ssh clone command with branch
 	opts := cloneOpts{
-		method:      evergreen.CloneMethodLegacySSH,
-		owner:       "evergreen-ci",
-		repo:        "sample",
-		branch:      "main",
-		dir:         "dir",
-		cloneParams: "--filter=tree:0 --single-branch",
+		method: evergreen.CloneMethodLegacySSH,
+		owner:  "evergreen-ci",
+		repo:   "sample",
+		branch: "main",
+		dir:    "dir",
 	}
 	s.Require().NoError(opts.setLocation())
 	cmds, err := opts.buildSSHCloneCommand()
 	s.NoError(err)
 	s.Len(cmds, 2)
-	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir' --branch 'main' --filter=tree:0 --single-branch", cmds[0])
+	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir' --branch 'main'", cmds[0])
 	s.Equal("cd dir", cmds[1])
 
 	// ssh clone command without branch
@@ -529,7 +527,7 @@ func (s *GitGetProjectSuite) TestBuildSSHCloneCommand() {
 	cmds, err = opts.buildSSHCloneCommand()
 	s.NoError(err)
 	s.Len(cmds, 2)
-	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir' --filter=tree:0 --single-branch", cmds[0])
+	s.Equal("git clone 'git@github.com:evergreen-ci/sample.git' 'dir'", cmds[0])
 	s.Equal("cd dir", cmds[1])
 }
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-11-20"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-11-28"
+	AgentVersion = "2023-11-29"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-732

### Description
The server was temporarily using `clone_params` to pass special git CLI flags to try making clones faster but apparently, it didn't work out. Since we never documented this and it was only used for that one experiment, we can remove it now.

### Testing
Existing git.get_project tests should pass.

### Documentation
N/A - This parameter was never documented.