### PR TITLE
DEVPROD-3045 Use downstream project ref for trigger version manifests

### DIFF
--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -78,7 +78,7 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 			if args.TriggerType == model.ProjectTriggerLevelPush {
 				moduleList[i].Ref = metadata.SourceCommit
 			}
-			_, err = model.CreateManifest(v, moduleList, upstreamProject, settings)
+			_, err = model.CreateManifest(v, moduleList, projectInfo.Ref, settings)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}


### PR DESCRIPTION
DEVPROD-3045

### Description
[Looking at Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen%22%20%22constructing%20manifest%22%7C%20spath%20%22metadata.level%22%20%7C%20search%20%22metadata.level%22%3D70&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&sid=1701452183.546977) it looks like triggered versions have never been able to create their own manifests
### Testing
Set up a trigger for a the sandbox project in staging, to evaluate when a task in Evergreen completed
- Confirmed that without the change ([Splunk error occurred](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%22constructing%20manifest%22%20%7C%20spath%20%22metadata.level%22%20%7C%20search%20%22metadata.level%22%3D70%20%7C%20spath%20error%20%7C%20search%20error%3D%22constructing%20manifest%3A%20module%20%27evergreen%27%3A%20can%27t%20get%20commit%20%2739dca53a59b5bdbe11a337bf37a9a5f924b522db%27%20on%20%27evergreen-ci%2Fevergreen%27%3A%20API%20request%20error%3A%20No%20commit%20found%20for%20SHA%3A%2039dca53a59b5bdbe11a337bf37a9a5f924b522db%0Afetching%20project%20file%20for%20project%20%27%27%20at%20revision%20%27main%27%3A%20Requested%20file%20at%20evergreen.yml%20not%20found%22%7C%20spath%20turnaround_secs%20%7C%20search%20turnaround_secs%3D%221.941577253%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-7d%40h&latest=now&sid=1701460602.569908) and the manifest link falls back 
- Confirmed after the change, the triggered version correctly 