### PR TITLE
DEVPROD-1758: support large JSON files for generate.tasks

### DIFF
--- a/model/task/generated_json_storage.go
+++ b/model/task/generated_json_storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -30,7 +31,7 @@ func GetGeneratedJSONFileStorage(settings *evergreen.Settings, method evergreen.
 	switch method {
 	case "", evergreen.ProjectStorageMethodDB:
 		return generatedJSONDBStorage{}, nil
-	case method:
+	case evergreen.ProjectStorageMethodS3:
 		return newGeneratedJSONS3Storage(settings.Providers.AWS.ParserProject)
 	default:
 		return nil, errors.Errorf("unrecognized generated JSON storage method '%s'", method)
@@ -71,23 +72,8 @@ func GeneratedJSONInsertWithS3Fallback(ctx context.Context, settings *evergreen.
 		return method, errors.Wrap(err, "inserting generated JSON files into S3")
 	}
 
-	// This is an undesirable workaround, but for some unknown reason, inserting
-	// into the DB may fail due to the 16 MB document size limit, but no error
-	// will be returned. Therefore, checking the insertion error to verify
-	// success/failure is insufficient.
-	// It's unclear why this happens, so to mitigate this, check if the
-	// generated JSON is actually set on the task in the DB. If so, the
-	// insertion was a success; if not, try using S3.
-	checkTask, err := FindOneId(t.Id)
-	if err != nil {
-		return method, errors.Wrapf(err, "getting task '%s' to check generated JSON file", t.Id)
-	}
-	if checkTask == nil {
-		return method, errors.Errorf("task '%s' not found for generated JSON file check", t.Id)
-	}
-
-	if len(checkTask.GeneratedJSONAsString) > 0 {
-		return method, nil
+	if !db.IsDocumentLimit(err) {
+		return method, errors.Wrap(err, "inserting generated JSON files into the DB")
 	}
 
 	newMethod := evergreen.ProjectStorageMethodS3
@@ -96,7 +82,7 @@ func GeneratedJSONInsertWithS3Fallback(ctx context.Context, settings *evergreen.
 	}
 
 	grip.Info(message.Fields{
-		"message":            "successfully upserted generated JSON files into S3 as fallback due to document size limitation",
+		"message":            "successfully inserted generated JSON files into S3 as fallback due to document size limitation",
 		"task_id":            t.Id,
 		"old_storage_method": method,
 		"new_storage_method": newMethod,

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -31,7 +31,7 @@ func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID str
 	}
 
 	var files task.GeneratedJSONFiles
-	for _, f := range files {
+	for _, f := range jsonFiles {
 		files = append(files, string(f))
 	}
 	if _, err := task.GeneratedJSONInsertWithS3Fallback(ctx, settings, t, files, evergreen.ProjectStorageMethodDB); err != nil {

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GenerateTasks parses JSON files for `generate.tasks` and creates the new builds and tasks.
-func GenerateTasks(taskID string, jsonFiles []json.RawMessage) error {
+func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID string, jsonFiles []json.RawMessage) error {
 	t, err := task.FindOneId(taskID)
 	if err != nil {
 		return errors.Wrapf(err, "finding task '%s'", taskID)
@@ -31,11 +31,11 @@ func GenerateTasks(taskID string, jsonFiles []json.RawMessage) error {
 	}
 
 	var files task.GeneratedJSONFiles
-	for _, j := range jsonFiles {
-		files = append(files, string(j))
+	for _, f := range files {
+		files = append(files, string(f))
 	}
-	if err = t.SetGeneratedJSON(files); err != nil {
-		return errors.Wrapf(err, "setting generated JSON for task '%s'", t.Id)
+	if _, err := task.GeneratedJSONInsertWithS3Fallback(ctx, settings, t, files, evergreen.ProjectStorageMethodDB); err != nil {
+		return errors.Wrapf(err, "inserting generated JSON files for task '%s'", t.Id)
 	}
 
 	return nil

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -1193,7 +1193,7 @@ tasks:
 			task.GeneratedJSONAsStringKey: generatedProject,
 		}})
 	assert.NoError(t, err)
-	j := units.NewGenerateTasksJob(tasks[0].Version, tasks[0].Id, "1")
+	j := units.NewGenerateTasksJob(env, tasks[0].Version, tasks[0].Id, "1")
 	j.Run(context.Background())
 	assert.NoError(t, j.Error())
 

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -48,7 +48,7 @@ func parseJson(r *http.Request) ([]json.RawMessage, error) {
 }
 
 func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
-	if err := data.GenerateTasks(h.taskID, h.files); err != nil {
+	if err := data.GenerateTasks(ctx, h.env.Settings(), h.taskID, h.files); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "generating tasks for task '%s'", h.taskID))
 	}
 	t, err := task.FindOneId(h.taskID)

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -48,9 +48,14 @@ func parseJson(r *http.Request) ([]json.RawMessage, error) {
 }
 
 func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
+	var totalFileSize int
+	for _, f := range h.files {
+		totalFileSize += len(f)
+	}
 	if err := data.GenerateTasks(ctx, h.env.Settings(), h.taskID, h.files); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "generating tasks for task '%s'", h.taskID))
 	}
+
 	t, err := task.FindOneId(h.taskID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting task '%s'", h.taskID))

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -48,10 +48,6 @@ func parseJson(r *http.Request) ([]json.RawMessage, error) {
 }
 
 func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
-	var totalFileSize int
-	for _, f := range h.files {
-		totalFileSize += len(f)
-	}
 	if err := data.GenerateTasks(ctx, h.env.Settings(), h.taskID, h.files); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "generating tasks for task '%s'", h.taskID))
 	}

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -84,7 +84,7 @@ func TestGenerateExecuteWithSmallFileInDB(t *testing.T) {
 	dbTask, err := task.FindOneId(tsk.Id)
 	require.NoError(t, err)
 	require.NotZero(t, dbTask)
-	assert.Equal(t, dbTask.GeneratedJSONStorageMethod, evergreen.ProjectStorageMethodDB)
+	assert.Equal(t, evergreen.ProjectStorageMethodDB, dbTask.GeneratedJSONStorageMethod)
 
 	genJSONInDB, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
 	require.NoError(t, err)
@@ -158,12 +158,12 @@ func TestGenerateExecuteWithLargeFileInS3(t *testing.T) {
 	dbTask, err := task.FindOneId(tsk.Id)
 	require.NoError(t, err)
 	require.NotZero(t, dbTask)
-	assert.Equal(t, dbTask.GeneratedJSONStorageMethod, evergreen.ProjectStorageMethodS3)
+	assert.Equal(t, evergreen.ProjectStorageMethodS3, dbTask.GeneratedJSONStorageMethod)
 
 	genJSONInS3, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
 	require.NoError(t, err)
 	require.Len(t, genJSONInS3, len(h.files), "generated JSON in S3 should be non-empty")
-	assert.EqualValues(t, genJSONInS3[0], genJSON.String())
+	assert.EqualValues(t, genJSON.String(), genJSONInS3[0])
 
 	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", tsk.Version))
 	require.NoError(t, err)

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -8,12 +8,17 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,23 +56,116 @@ func TestValidateJSON(t *testing.T) {
 	}
 }
 
-func TestGenerateExecute(t *testing.T) {
+func TestGenerateExecuteWithSmallFileInDB(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, db.ClearCollections(task.Collection))
-	task1 := task.Task{
-		Id:      "task1",
-		Version: "version1",
+
+	tsk := task.Task{
+		Id:      "task_id",
+		Version: "version_id",
 	}
+	require.NoError(t, tsk.Insert())
+
 	env := &mock.Environment{}
 	require.NoError(t, env.Configure(ctx))
-	require.NoError(t, task1.Insert())
-	h := &generateHandler{env: env}
-	h.taskID = "task1"
+
+	genJSON := `{"key": "value"}`
+	h := &generateHandler{
+		env:    env,
+		files:  []json.RawMessage{[]byte(genJSON)},
+		taskID: tsk.Id,
+	}
 	r := h.Run(ctx)
+
 	assert.Equal(t, r.Data(), struct{}{})
 	assert.Equal(t, r.Status(), http.StatusOK)
-	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", task1.Version))
+
+	dbTask, err := task.FindOneId(tsk.Id)
+	require.NoError(t, err)
+	require.NotZero(t, dbTask)
+	assert.Equal(t, dbTask.GeneratedJSONStorageMethod, evergreen.ProjectStorageMethodDB)
+
+	genJSONInDB, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
+	require.NoError(t, err)
+	require.Len(t, genJSONInDB, len(h.files), "generated JSON in DB should be non-empty")
+	assert.EqualValues(t, genJSON, genJSONInDB[0])
+
+	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", tsk.Version))
+	require.NoError(t, err)
+	stats := queue.Stats(ctx)
+	assert.Equal(t, 1, stats.Total)
+}
+
+func TestGenerateExecuteWithLargeFileInS3(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
+
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
+
+	ppConf := env.Settings().Providers.AWS.ParserProject
+	bucket, err := pail.NewS3BucketWithHTTPClient(c, pail.S3Options{
+		Name:        ppConf.Bucket,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
+	}()
+
+	require.NoError(t, db.ClearCollections(task.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(task.Collection))
+	}()
+
+	tsk := task.Task{
+		Id:      "task_id",
+		Version: "version_id",
+	}
+	require.NoError(t, tsk.Insert())
+
+	// Create string that is over the DB's 16 MB document limit to ensure it
+	// gets stored in S3.
+	genJSON := bytes.NewBufferString("{")
+	for i := 0; i < 10e6; i++ {
+		_, err := genJSON.WriteString(fmt.Sprintf(`"field-%d": "value-%d"`, i, i))
+		require.NoError(t, err)
+		if i < 10e6-1 {
+			_, err := genJSON.WriteString(",")
+			require.NoError(t, err)
+		}
+	}
+	_, err = genJSON.WriteString("}")
+	require.NoError(t, err)
+
+	h := &generateHandler{
+		env:    env,
+		files:  []json.RawMessage{genJSON.Bytes()},
+		taskID: tsk.Id,
+	}
+	r := h.Run(ctx)
+
+	assert.Equal(t, r.Data(), struct{}{})
+	assert.Equal(t, r.Status(), http.StatusOK)
+
+	dbTask, err := task.FindOneId(tsk.Id)
+	require.NoError(t, err)
+	require.NotZero(t, dbTask)
+	assert.Equal(t, dbTask.GeneratedJSONStorageMethod, evergreen.ProjectStorageMethodS3)
+
+	genJSONInS3, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
+	require.NoError(t, err)
+	require.Len(t, genJSONInS3, len(h.files), "generated JSON in S3 should be non-empty")
+	assert.EqualValues(t, genJSONInS3[0], genJSON.String())
+
+	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", tsk.Version))
 	require.NoError(t, err)
 	stats := queue.Stats(ctx)
 	assert.Equal(t, 1, stats.Total)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1828,69 +1828,73 @@ Admin Settings
 										<input type="text" ng-model="Settings.providers.aws.parser_project.prefix">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%; margin-left:50px;">
+										<label>Generated JSON Files S3 Prefix</label>
+										<input type="text" ng-model="Settings.providers.aws.parser_project.generated_json_prefix">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>Default Security Group</label>
 										<input type="text" ng-model="Settings.providers.aws.default_security_group">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Total EBS Volume Size Per User</label>
 										<input type="number" ng-model="Settings.providers.aws.max_volume_size">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Allowed Instance Types</label>
 										<textarea ng-model="Settings.providers.aws.allowed_instance_types"
 											ng-list="&#10;" ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Allowed Regions</label>
 										<textarea ng-model="Settings.providers.aws.allowed_regions" ng-list="&#10;"
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Allowed Container Images</label>
 										<textarea ng-model="Settings.providers.aws.pod.ecs.allowed_images" ng-list="&#10;" ng-trim="false" rows="3"
 											md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod ECS Max CPU Units Per Pod</label>
 										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_cpu">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Max Memory (MB) Per Pod</label>
 										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_memory_mb">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod Region</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.region">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod Secrets Manager Secret Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.secrets_manager.secret_prefix">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Task Definition Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_definition_prefix">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod ECS Task Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Execution Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.execution_role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod ECS Log Region</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_region">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Log Group Name</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_group">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left:50px;">
 										<label>Pod ECS Log Stream Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_stream_prefix">
 									</md-input-container>

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -79,6 +79,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		attribute.String(evergreen.VersionRequesterOtelAttribute, t.Requester)})
 	ctx, span := tracer.Start(ctx, "task-generation")
 	defer span.End()
+
 	if t.GeneratedTasks {
 		return mongo.ErrNoDocuments
 	}

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -571,7 +571,7 @@ func TestGenerateTasksWithDifferentGeneratedJSONStorageMethods(t *testing.T) {
 			tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
 			assert.NoError(err)
 			assert.Len(tasks, 4)
-			all_tasks := map[string]bool{
+			allTasks := map[string]bool{
 				"sample_task":     false,
 				"lint-command":    false,
 				"lint-rest-route": false,
@@ -580,12 +580,12 @@ func TestGenerateTasksWithDifferentGeneratedJSONStorageMethods(t *testing.T) {
 			for _, t := range tasks {
 				assert.Equal("sample_version", t.Version)
 				assert.Equal("mci", t.Project)
-				all_tasks[t.DisplayName] = true
+				allTasks[t.DisplayName] = true
 				if t.Version == "my_display_task" {
 					assert.Len(t.ExecutionTasks, 1)
 				}
 			}
-			for _, v := range all_tasks {
+			for _, v := range allTasks {
 				assert.True(v)
 			}
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
@@ -15,6 +16,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -464,136 +467,166 @@ var sampleGeneratedProject3 = []string{`
 }
 `}
 
-func TestGenerateTasks(t *testing.T) {
+func TestGenerateTasksWithDifferentGeneratedJSONStorageMethods(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testutil.TestSpan(ctx, t)
 
-	assert := assert.New(t)
-	require := require.New(t)
-	require.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
-	defer require.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
-
 	env := &mock.Environment{}
-	require.NoError(env.Configure(ctx))
+	require.NoError(t, env.Configure(ctx))
 
-	randomVersion := model.Version{
-		Id:         "random_version",
-		Identifier: "mci",
-		BuildIds:   []string{"sample_build_id"},
-	}
-	require.NoError(randomVersion.Insert())
-	randomPatch := patch.Patch{
-		Id:      mgobson.NewObjectId(),
-		Version: randomVersion.Id,
-	}
-	require.NoError(randomPatch.Insert())
-	sampleVersion := model.Version{
-		Id:         "sample_version",
-		Identifier: "mci",
-		BuildIds:   []string{"sample_build_id"},
-	}
-	samplePatch := patch.Patch{
-		Id:      mgobson.NewObjectId(),
-		Version: sampleVersion.Id,
-	}
-	require.NoError(samplePatch.Insert())
-	require.NoError(sampleVersion.Insert())
-	sampleBuild := build.Build{
-		Id:           "sample_build_id",
-		BuildVariant: "race-detector",
-		Version:      "sample_version",
-	}
-	require.NoError(sampleBuild.Insert())
+	testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
 
-	pp := model.ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleBaseProject), &pp)
-	require.NoError(err)
-	pp.Id = "sample_version"
-	require.NoError(pp.Insert())
-	pp.Id = "random_version"
-	require.NoError(pp.Insert())
-	sampleTask := task.Task{
-		Id:                    "sample_task",
-		Version:               "sample_version",
-		BuildId:               "sample_build_id",
-		Project:               "mci",
-		DisplayName:           "sample_task",
-		GeneratedJSONAsString: sampleGeneratedProject,
-		Status:                evergreen.TaskStarted,
-	}
-	sampleDistros := []distro.Distro{
-		{
-			Id: "ubuntu1604-test",
-		},
-		{
-			Id: "archlinux-test",
-		},
-	}
-	for _, d := range sampleDistros {
-		require.NoError(d.Insert(ctx))
-	}
-	require.NoError(sampleTask.Insert())
-	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
-	require.NoError(projectRef.Insert())
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
-	j.Run(ctx)
-	assert.NoError(j.Error())
-	tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
-	assert.NoError(err)
-	assert.Len(tasks, 4)
-	all_tasks := map[string]bool{
-		"sample_task":     false,
-		"lint-command":    false,
-		"lint-rest-route": false,
-		"my_display_task": false,
-	}
-	for _, t := range tasks {
-		assert.Equal("sample_version", t.Version)
-		assert.Equal("mci", t.Project)
-		all_tasks[t.DisplayName] = true
-		if t.Version == "my_display_task" {
-			assert.Len(t.ExecutionTasks, 1)
-		}
-	}
-	for _, v := range all_tasks {
-		assert.True(v)
-	}
+	ppConf := env.Settings().Providers.AWS.ParserProject
+	bucket, err := pail.NewS3BucketWithHTTPClient(c, pail.S3Options{
+		Name:        ppConf.Bucket,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
+	}()
 
-	// Make sure first project was not changed
-	v, err := model.VersionFindOneId("random_version")
-	assert.NoError(err)
-	p, _, err := model.FindAndTranslateProjectForVersion(ctx, env.Settings(), v)
-	assert.NoError(err)
-	require.NotNil(p)
-	assert.Len(p.Tasks, 2)
-	require.Len(p.BuildVariants, 2)
-	assert.Len(p.BuildVariants[0].Tasks, 1)
-	assert.Len(p.BuildVariants[1].Tasks, 2)
+	for methodName, storageMethod := range map[string]evergreen.ParserProjectStorageMethod{
+		"DB": evergreen.ProjectStorageMethodDB,
+		"S3": evergreen.ProjectStorageMethodS3,
+	} {
+		t.Run(methodName, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 
-	// Verify second project was changed
-	v, err = model.VersionFindOneId("sample_version")
-	assert.NoError(err)
-	p, _, err = model.FindAndTranslateProjectForVersion(ctx, env.Settings(), v)
-	assert.NoError(err)
-	require.NotNil(p)
-	assert.Len(p.Tasks, 6)
-	require.Len(p.BuildVariants, 2)
-	assert.Len(p.BuildVariants[0].Tasks, 1)
-	assert.Len(p.BuildVariants[1].Tasks, 4)
-	require.Len(p.TaskGroups, 1)
-	assert.Len(p.TaskGroups[0].Tasks, 2)
+			require.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
+			defer require.NoError(db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
 
-	b, err := build.FindOneId("sample_build_id")
-	assert.NoError(err)
-	assert.Equal("mci_identifier_race_detector_display_my_display_task__01_01_01_00_00_00", b.Tasks[0].Id)
+			randomVersion := model.Version{
+				Id:         "random_version",
+				Identifier: "mci",
+				BuildIds:   []string{"sample_build_id"},
+			}
+			require.NoError(randomVersion.Insert())
+			randomPatch := patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Version: randomVersion.Id,
+			}
+			require.NoError(randomPatch.Insert())
+			sampleVersion := model.Version{
+				Id:         "sample_version",
+				Identifier: "mci",
+				BuildIds:   []string{"sample_build_id"},
+			}
+			samplePatch := patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Version: sampleVersion.Id,
+			}
+			require.NoError(samplePatch.Insert())
+			require.NoError(sampleVersion.Insert())
+			sampleBuild := build.Build{
+				Id:           "sample_build_id",
+				BuildVariant: "race-detector",
+				Version:      "sample_version",
+			}
+			require.NoError(sampleBuild.Insert())
+
+			pp := model.ParserProject{}
+			err := util.UnmarshalYAMLWithFallback([]byte(sampleBaseProject), &pp)
+			require.NoError(err)
+			pp.Id = "sample_version"
+			require.NoError(pp.Insert())
+			pp.Id = "random_version"
+			require.NoError(pp.Insert())
+
+			sampleTask := task.Task{
+				Id:          "sample_task",
+				Version:     "sample_version",
+				BuildId:     "sample_build_id",
+				Project:     "mci",
+				DisplayName: "sample_task",
+				Status:      evergreen.TaskStarted,
+			}
+			require.NoError(sampleTask.Insert())
+
+			require.NoError(task.GeneratedJSONInsert(ctx, env.Settings(), &sampleTask, sampleGeneratedProject, storageMethod))
+
+			sampleDistros := []distro.Distro{
+				{
+					Id: "ubuntu1604-test",
+				},
+				{
+					Id: "archlinux-test",
+				},
+			}
+			for _, d := range sampleDistros {
+				require.NoError(d.Insert(ctx))
+			}
+			projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
+			require.NoError(projectRef.Insert())
+
+			j := NewGenerateTasksJob(env, sampleTask.Version, sampleTask.Id, "1")
+			j.Run(ctx)
+			assert.NoError(j.Error())
+			tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
+			assert.NoError(err)
+			assert.Len(tasks, 4)
+			all_tasks := map[string]bool{
+				"sample_task":     false,
+				"lint-command":    false,
+				"lint-rest-route": false,
+				"my_display_task": false,
+			}
+			for _, t := range tasks {
+				assert.Equal("sample_version", t.Version)
+				assert.Equal("mci", t.Project)
+				all_tasks[t.DisplayName] = true
+				if t.Version == "my_display_task" {
+					assert.Len(t.ExecutionTasks, 1)
+				}
+			}
+			for _, v := range all_tasks {
+				assert.True(v)
+			}
+
+			// Make sure first project was not changed
+			v, err := model.VersionFindOneId("random_version")
+			assert.NoError(err)
+			p, _, err := model.FindAndTranslateProjectForVersion(ctx, env.Settings(), v)
+			assert.NoError(err)
+			require.NotNil(p)
+			assert.Len(p.Tasks, 2)
+			require.Len(p.BuildVariants, 2)
+			assert.Len(p.BuildVariants[0].Tasks, 1)
+			assert.Len(p.BuildVariants[1].Tasks, 2)
+
+			// Verify second project was changed
+			v, err = model.VersionFindOneId("sample_version")
+			assert.NoError(err)
+			p, _, err = model.FindAndTranslateProjectForVersion(ctx, env.Settings(), v)
+			assert.NoError(err)
+			require.NotNil(p)
+			assert.Len(p.Tasks, 6)
+			require.Len(p.BuildVariants, 2)
+			assert.Len(p.BuildVariants[0].Tasks, 1)
+			assert.Len(p.BuildVariants[1].Tasks, 4)
+			require.Len(p.TaskGroups, 1)
+			assert.Len(p.TaskGroups[0].Tasks, 2)
+
+			b, err := build.FindOneId("sample_build_id")
+			assert.NoError(err)
+			assert.Equal("mci_identifier_race_detector_display_my_display_task__01_01_01_00_00_00", b.Tasks[0].Id)
+		})
+	}
 }
 
 func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testutil.TestSpan(ctx, t)
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 
 	assert := assert.New(t)
 	require := require.New(t)
@@ -655,7 +688,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 	projectRef := model.ProjectRef{Id: "mci", Identifier: "mci_identifier"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	j := NewGenerateTasksJob(env, generateTask.Version, generateTask.Id, "1")
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	tasks, err := task.FindAll(db.Query(task.ByVersion("sample_version")))
@@ -695,7 +728,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 		Status:                evergreen.TaskStarted,
 	}
 	require.NoError(generateTaskWithoutFlag.Insert())
-	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	j = NewGenerateTasksJob(env, generateTask.Version, generateTask.Id, "1")
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
@@ -733,7 +766,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 		Status:                evergreen.TaskStarted,
 	}
 	require.NoError(generateTask.Insert())
-	j = NewGenerateTasksJob(generateTask.Version, generateTask.Id, "1")
+	j = NewGenerateTasksJob(env, generateTask.Version, generateTask.Id, "1")
 	j.Run(ctx)
 	assert.NoError(j.Error())
 	tasks, err = task.FindAll(db.Query(task.ByVersion("sample_version")))
@@ -777,6 +810,9 @@ func TestGenerateSkipsInvalidDependency(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = testutil.TestSpan(ctx, t)
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
 
 	var sampleBaseProject = `
 tasks:
@@ -873,7 +909,7 @@ buildvariants:
 	projectRef := model.ProjectRef{Id: "mci"}
 	require.NoError(projectRef.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
+	j := NewGenerateTasksJob(env, sampleTask.Version, sampleTask.Id, "1")
 	j.Run(ctx)
 	assert.NoError(j.Error())
 
@@ -895,6 +931,9 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	defer cancel()
 	ctx = testutil.TestSpan(ctx, t)
 
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
 	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection, task.Collection, distro.Collection, patch.Collection, model.ParserProjectCollection))
 	sampleTask := task.Task{
 		Id:                    "sample_task",
@@ -907,7 +946,7 @@ func TestMarkGeneratedTasksError(t *testing.T) {
 	}
 	require.NoError(t, sampleTask.Insert())
 
-	j := NewGenerateTasksJob(sampleTask.Version, sampleTask.Id, "1")
+	j := NewGenerateTasksJob(env, sampleTask.Version, sampleTask.Id, "1")
 	j.Run(ctx)
 	assert.Error(t, j.Error())
 	dbTask, err := task.FindOneId(sampleTask.Id)


### PR DESCRIPTION
DEVPROD-1758

### Description
Follow-up from #7287 to allow a task to submit input JSON files larger than 16 MB to generate.tasks. If the input file can be stored in the task collection document, it'll do that (same as how it has always done it). Otherwise if it's too large to put in a DB document, it'll be stored in S3.

* Integrate the logic from the original PR into generate.tasks.
* Fix a couple small bugs in the logic from the original PR.
* Add admin setting to UI for generated JSON S3 prefix.

### Testing
* Added unit and integration tests.
* Tested in staging to verify that [a sample patch](https://spruce-staging.corp.mongodb.com/task/evg_lint_generate_lint_patch_3c10c5e814535dc8e6d06553cce69a60e4f58c91_6573926197b1d3283b562278_23_12_08_22_02_10/logs?execution=0) used S3 to store the file when the generated JSON file exceeded 16 MB.
* Tested that a patch with a small generate.tasks file still gets stored in the DB.

### Documentation
N/A