### PR TITLE
DEVPROD-2473 remove amboy db user/password setting

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1451,14 +1451,6 @@ Admin Settings
 										<label>DB name</label>
 										<input type="text" ng-model="Settings.amboy.db_connection.database">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>DB user</label>
-										<input type="text" ng-model="Settings.amboy.db_connection.username">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
-										<label>DB password</label>
-										<input type="text" ng-model="Settings.amboy.db_connection.password">
-									</md-input-container>
 									<md-input-container class="control" style="width:45%">
 										<label>Local pool size</label>
 										<input type="number" ng-model="Settings.amboy.pool_size_local">


### PR DESCRIPTION
[DEVPROD-2473](https://jira.mongodb.org/browse/DEVPROD-2473)

### Description
https://github.com/evergreen-ci/evergreen/pull/7292 removed the amboy username/password setting from the db but neglected to remove the setting from the admin page. This PR removes it.


![Screenshot 2023-12-11 at 1 15 18 PM](https://github.com/evergreen-ci/evergreen/assets/17027265/c337392e-2c93-417a-af0d-4d351cea0301)