### PR TITLE
docs: add more links for workstation commands

### DIFF
--- a/docs/Hosts/Developer-Workstations.md
+++ b/docs/Hosts/Developer-Workstations.md
@@ -22,7 +22,7 @@ workstations can use the same configuration as build hosts, but also have:
   subjected to the termination deadline of most spawn hosts. While
   there is a global per-user limit for unexpirable hosts,
   workstations will, by default. 
-  
+
 - Evergreen supports a start/stop mode for spawn hosts. This makes it
   possible for users to change to another instance type, though
   administrators must configure the allowable instance types. Users
@@ -46,16 +46,15 @@ checked out and running on workstations, though this feature is not
 necessarily dependent on workstations, and could be used on local
 systems.
 
-Project configuration include a "Workstation Setup" section where
-administrators declare a number of simple commands (and directory
-contexts) that will run a project's setup. These commands are *not*
-shell interpolated, and are *not* meant to provision the development
-environment (e.g. install system packages or modify configuration
-files in `~/`). Use these commands to clone a repository, generate
-index files, and/or run a test build.
+Project configuration include a ["Workstation Setup" section](../Project-Configuration/Project-and-Distro-Settings.md#virtual-workstation-commands)
+where administrators declare a number of simple commands (and directory
+contexts) that will run a project's setup. These commands are *not* shell
+interpolated, and are *not* meant to provision the development environment (e.g.
+install system packages or modify configuration files in `~/`). Use these
+commands to clone a repository, generate index files, and/or run a test build.
 
 As a prerequisite, users of the project setup *must* have configured
-their SSH keys with Github, with access to the Github repositories
+their SSH keys with GitHub, with access to the GitHub repositories
 required for their project. The commands will assemble a clone
 operation for the project's core repository when selected, but
 required modules or other repositories would need to be cloned

--- a/docs/Hosts/Developer-Workstations.md
+++ b/docs/Hosts/Developer-Workstations.md
@@ -46,7 +46,7 @@ checked out and running on workstations, though this feature is not
 necessarily dependent on workstations, and could be used on local
 systems.
 
-Project configuration include a ["Workstation Setup" section](../Project-Configuration/Project-and-Distro-Settings.md#virtual-workstation-commands)
+Project settings include a ["Workstation Setup" section](../Project-Configuration/Project-and-Distro-Settings.md#virtual-workstation-commands)
 where administrators declare a number of simple commands (and directory
 contexts) that will run a project's setup. These commands are *not* shell
 interpolated, and are *not* meant to provision the development environment (e.g.

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -122,7 +122,7 @@ GitHub checks, git tag triggers, project triggers, and patch triggers.
 For most aliases, you must define a variant regex or tags, and a task
 regex or tags to match. The matching variants/tasks will be included for the
 alias. If matching by tags, alias tags support a limited set of the [tag
-selector syntax](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files/#task-and-variant-tags).
+selector syntax](Project-Configuration-Files.md#task-and-variant-tags).
 In particular, it supports tag negation and multiple tag criteria separated by
 spaces to get the set intersection of those tags. For example, when defining
 task tags:
@@ -378,7 +378,7 @@ Options:
 ### Virtual Workstation Commands
 
 Users can specify custom commands to be run when setting up their
-virtual workstation.
+virtual workstation. See more info [here](../Hosts/Developer-Workstations.md#project-setup).
 
 Options:
 

--- a/docs/Project-Configuration/Task-Runtime-Behavior.md
+++ b/docs/Project-Configuration/Task-Runtime-Behavior.md
@@ -138,8 +138,7 @@ entire task group is finished.
 The task working directory is removed when a task finishes as part of cleaning
 up the task. Note that _only_ the task directory is cleaned up - if any file is
 written outside the task directory, it will not be cleaned up. As part of
-[Evergreen best
-practices](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Best-Practices#task-directory),
+[Evergreen best practices](Best-Practices#task-directory),
 writing outside of the task directory is discouraged.
 
 For a task that's not part of a task group, the task will clean up at the end of


### PR DESCRIPTION
A user asked some questions about how to set up a project for workstations, so I added some clarification.

* Add more links to make it clearer on how to use workstation commands defined in the project settings.
* Fix a couple links (that I wrote) that hard-code the link to the docs website rather than use relative paths.