### PR TITLE
DEVPROD-3166 Commit Queue should use the latest module revision 

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -745,9 +745,10 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 		}
 	}
 
+	isMergePatch := v.Requester == evergreen.MergeTestRequester
 	modules := map[string]*manifest.Module{}
 	for _, module := range moduleList {
-		if isPatch && !module.AutoUpdate && baseManifest != nil {
+		if isPatch && !isMergePatch && !module.AutoUpdate && baseManifest != nil {
 			if baseModule, ok := baseManifest.Modules[module.Name]; ok {
 				modules[module.Name] = baseModule
 				continue

--- a/model/version.go
+++ b/model/version.go
@@ -745,7 +745,7 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 		}
 	}
 
-	isMergePatch := v.Requester == evergreen.MergeTestRequester
+	isMergePatch := evergreen.IsCommitQueueRequester(v.Requester)
 	modules := map[string]*manifest.Module{}
 	for _, module := range moduleList {
 		if isPatch && !isMergePatch && !module.AutoUpdate && baseManifest != nil {


### PR DESCRIPTION
DEVPROD-3166

### Description
The commit queue (both the CLI queue and the PR queue after https://github.com/evergreen-ci/evergreen/pull/7310, unless auto update is set to true, gets the module revision from the base manifest. Instead, we should fetch the latest.

Otherwise, if the module has moved ahead, it can be outdated.

### Testing
Tested on staging


