### PR TITLE
DEVPROD-714: remove default distro setting for Docker host.create

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -196,18 +196,9 @@ func (ch *CreateHost) validateDocker(ctx context.Context) error {
 	catcher.Add(ch.setNumHosts())
 	catcher.Add(ch.validateAgentOptions())
 
-	if ch.Image == "" {
-		catcher.New("Docker image must be set")
-	}
-	if ch.Distro == "" {
-		settings, err := evergreen.GetConfig(ctx)
-		if err != nil {
-			catcher.New("error getting config to set default distro")
-		} else {
-			ch.Distro = settings.Providers.Docker.DefaultDistro
-		}
+	catcher.NewWhen(ch.Image == "", "Docker image must be set")
+	catcher.NewWhen(ch.Distro == "", "must set a distro to run Docker container in")
 
-	}
 	if ch.ContainerWaitTimeoutSecs <= 0 {
 		ch.ContainerWaitTimeoutSecs = DefaultContainerWaitTimeoutSecs
 	} else if ch.ContainerWaitTimeoutSecs >= 3600 || ch.ContainerWaitTimeoutSecs <= 10 {

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -331,6 +331,5 @@ const (
 
 // DockerConfig stores auth info for Docker.
 type DockerConfig struct {
-	APIVersion    string `bson:"api_version" json:"api_version" yaml:"api_version"`
-	DefaultDistro string `bson:"default_distro" json:"default_distro" yaml:"default_distro"`
+	APIVersion string `bson:"api_version" json:"api_version" yaml:"api_version"`
 }

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -480,7 +480,7 @@ Parameters:
 
 ## host.create
 
-`host.create` starts a host from a task.
+`host.create` starts a host or a Docker container from a task.
 
 ``` yaml
 - command: host.create
@@ -527,9 +527,10 @@ EC2 Parameters:
 -   `aws_secret_access_key` - AWS secret key. May set to use a
     non-default account. Must set if `aws_access_key_id` is set.
 -   `device_name` - name of EBS device
--   `distro` - Evergreen distro to start. Must set `ami` or `distro` but
-    must not set both. Note that the distro setup script will not run for 
-    hosts spawned by this command, so any required initial setup must be done manually.
+-   `distro` - Evergreen distro to start. Must set `ami` (for EC2) or `distro`
+    but must not set both. Note that the distro setup script will not run for
+    hosts spawned by this command, so any required initial setup must be done
+    manually.
 -   `ebs_block_device` - list of the following parameters:
 -   `ebs_iops` - EBS provisioned IOPS.
 -   `ebs_size` - Size of EBS volume in GB.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -520,17 +520,18 @@ Agent Parameters:
 
 EC2 Parameters:
 
--   `ami` - EC2 AMI to start. Must set `ami` or `distro` but must not
-    set both.
+-   `ami` - For an `ec2` provider, the AMI to start. Must set `ami` or `distro`
+    but must not set both.
 -   `aws_access_key_id` - AWS access key ID. May set to use a
     non-default account. Must set if `aws_secret_access_key` is set.
 -   `aws_secret_access_key` - AWS secret key. May set to use a
     non-default account. Must set if `aws_access_key_id` is set.
 -   `device_name` - name of EBS device
--   `distro` - Evergreen distro to start. Must set `ami` (for EC2) or `distro`
-    but must not set both. Note that the distro setup script will not run for
-    hosts spawned by this command, so any required initial setup must be done
-    manually.
+-   `distro` - Evergreen distro to start. For the `ec2` provider, must set
+    either `ami` only) or `distro` but must not set both. For the `docker`
+    provider, `distro` must be set to the distro that will run the container.
+    Note that the distro setup script will not run for hosts spawned by this
+    command, so any required initial setup must be done manually.
 -   `ebs_block_device` - list of the following parameters:
 -   `ebs_iops` - EBS provisioned IOPS.
 -   `ebs_size` - Size of EBS volume in GB.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -528,7 +528,7 @@ EC2 Parameters:
     non-default account. Must set if `aws_access_key_id` is set.
 -   `device_name` - name of EBS device
 -   `distro` - Evergreen distro to start. For the `ec2` provider, must set
-    either `ami` only) or `distro` but must not set both. For the `docker`
+    either `ami` only or `distro` but must not set both. For the `docker`
     provider, `distro` must be set to the distro that will run the container.
     Note that the distro setup script will not run for hosts spawned by this
     command, so any required initial setup must be done manually.

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1966,15 +1966,13 @@ func (a *APISecretsManagerConfig) ToService() evergreen.SecretsManagerConfig {
 }
 
 type APIDockerConfig struct {
-	APIVersion    *string `json:"api_version"`
-	DefaultDistro *string `json:"default_distro"`
+	APIVersion *string `json:"api_version"`
 }
 
 func (a *APIDockerConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.DockerConfig:
 		a.APIVersion = utility.ToStringPtr(v.APIVersion)
-		a.DefaultDistro = utility.ToStringPtr(v.DefaultDistro)
 	default:
 		return errors.Errorf("programmatic error: expected Docker config but got type %T", h)
 	}
@@ -1983,8 +1981,7 @@ func (a *APIDockerConfig) BuildFromService(h interface{}) error {
 
 func (a *APIDockerConfig) ToService() (interface{}, error) {
 	return evergreen.DockerConfig{
-		APIVersion:    utility.FromStringPtr(a.APIVersion),
-		DefaultDistro: utility.FromStringPtr(a.DefaultDistro),
+		APIVersion: utility.FromStringPtr(a.APIVersion),
 	}, nil
 }
 

--- a/rest/route/admin_banner_test.go
+++ b/rest/route/admin_banner_test.go
@@ -120,8 +120,7 @@ func TestFetchBanner(t *testing.T) {
 				},
 			},
 			Docker: &model.APIDockerConfig{
-				APIVersion:    utility.ToStringPtr(""),
-				DefaultDistro: utility.ToStringPtr(""),
+				APIVersion: utility.ToStringPtr(""),
 			},
 		},
 	}

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -256,8 +256,7 @@ func TestGetTaskSyncReadCredentials(t *testing.T) {
 				TaskSyncRead: &creds,
 			},
 			Docker: &model.APIDockerConfig{
-				APIVersion:    utility.ToStringPtr(""),
-				DefaultDistro: utility.ToStringPtr(""),
+				APIVersion: utility.ToStringPtr(""),
 			},
 		},
 	}

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2098,10 +2098,6 @@ Admin Settings
 										<label>API version</label>
 										<input type="text" ng-model="Settings.providers.docker.api_version">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>Distro for Default Container Pool</label>
-										<input type="text" ng-model="Settings.providers.docker.default_distro">
-									</md-input-container>
 								</md-card-content>
 							</md-card>
 


### PR DESCRIPTION
DEVPROD-714

### Description
The agent validates the user's host.create inputs, but if the user uses Docker host.create without specifying a distro, it will fail because the validation logic tries to query the admin settings, even though the agent doesn't have access to the DB. Rather than try to fix a very small convenience feature and given the fact that the default distro is blank in both staging and prod, I decided it's better to remove the default distro and have the user always specify one for Docker host.create.

### Testing
Existing tests pass.

### Documentation
It's never explicitly stated how the `distro` parameter to host.create interacts with Docker, so I clarified the wording so the user knows they have to give a distro for Docker host.create.