### PR TITLE
DEVPROD-3130 add variables for mac signing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,9 +45,7 @@ steps:
       secret_key:
         from_secret: ecr_secret_key
       build_args:
-        - GOOS=linux
-        - GOARCH=arm64
-        - from_secret: notary_params
+        from_secret: notary_params
       repo: devprod-evergreen/${DRONE_REPO_NAME}
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       create_repository: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,7 @@ steps:
       build_args:
         - GOOS=linux
         - GOARCH=arm64
+        - from_secret: test_secret
       repo: devprod-evergreen/${DRONE_REPO_NAME}
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       create_repository: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ trigger:
     - main
   event:
     - push
+    - pull_request
 
 clone:
   depth: 1
@@ -24,6 +25,17 @@ resources:
 steps:
   - name: publish-evergreen
     image: plugins/kaniko-ecr
+    environment:
+      NOTARY_SERVER_URL:
+        from_secret: notary_server_url
+      NOTARY_CLIENT_URL:
+        from_secret: notary_client_url
+      MACOS_NOTARY_KEY:
+        from_secret: notary_key
+      MACOS_NOTARY_SECRET:
+        from_secret: notary_secret
+      EVERGREEN_BUNDLE_ID:
+        from_secret: bundle_id
     settings:
       tags:
         - git-${DRONE_COMMIT_SHA:0:7}

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ steps:
       build_args:
         - GOOS=linux
         - GOARCH=arm64
-        - from_secret: test_secret
+        - from_secret: notary_params
       repo: devprod-evergreen/${DRONE_REPO_NAME}
       registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
       create_repository: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM public.ecr.aws/docker/library/golang:1.21-bookworm as build
 WORKDIR /build
 
 COPY . .
+ENV STAGING_ONLY=1
 RUN ["make", "clis"]
 
 # Send the macos CLIs to the notary service for signing
@@ -14,7 +15,7 @@ ARG MACOS_NOTARY_SECRET
 ARG EVERGREEN_BUNDLE_ID
 
 # Send the macos CLIs to the notary service for signing
-RUN if [ -n "$MACOS_NOTARY_SECRET" ]; then make clients/darwin_amd64/.signed; fi
+RUN if [ -n "$MACOS_NOTARY_SECRET" ]; then make sign-macos; fi
 
 # Production stage with only the necessary files
 FROM debian:bookworm-slim as production


### PR DESCRIPTION
[DEVPROD-3130](https://jira.mongodb.org/browse/DEVPROD-3130)

### Description
The Dockerfile is willing to sign to mac executable if we supply the variables it's expecting.
Pull the variables out of drone secrets.

### Testing
Added the secrets to drone. Let's see if it works 😄 
