### PR TITLE
DEVPROD-731 Add include limits to admin settings

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -17,10 +17,15 @@ type TaskLimitsConfig struct {
 	// MaxTasksPerVersion is the maximum number of tasks that a single version
 	// can have.
 	MaxTasksPerVersion int `bson:"max_tasks_per_version" json:"max_tasks_per_version" yaml:"max_tasks_per_version"`
+
+	// MaxIncludesPerVersion is the maximum number of includes that a single
+	// version can have.
+	MaxIncludesPerVersion int `bson:"max_includes_per_version" json:"max_includes_per_version" yaml:"max_includes_per_version"`
 }
 
 var (
-	maxTasksPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxTasksPerVersionKey    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxIncludesPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -45,7 +50,8 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey: c.MaxTasksPerVersion,
+			maxTasksPerVersionKey:    c.MaxTasksPerVersion,
+			maxIncludesPerVersionKey: c.MaxIncludesPerVersion,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -697,7 +697,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		catcher := grip.NewBasicCatcher()
 		numIncludes := len(intermediateProject.Include)
 		if settings.TaskLimits.MaxIncludesPerVersion > 0 && numIncludes > settings.TaskLimits.MaxIncludesPerVersion {
-			catcher.Add(errors.Errorf("project's total number of includes (%d) exceeds maximum limit (%d)", numIncludes, settings.TaskLimits.MaxIncludesPerVersion))
+			catcher.Errorf("project's total number of includes (%d) exceeds maximum limit (%d)", numIncludes, settings.TaskLimits.MaxIncludesPerVersion)
 			numIncludes = settings.TaskLimits.MaxIncludesPerVersion
 		}
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -680,7 +680,6 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 			return nil, errors.Wrapf(err, LoadProjectError)
 		}
 
-		// Validate that there are fewer includes than the limit.
 		settings, err := evergreen.GetConfig(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, LoadProjectError)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -680,7 +680,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 			return nil, errors.Wrapf(err, LoadProjectError)
 		}
 
-		// Validate that there are less includes than the limit.
+		// Validate that there are fewer includes than the limit.
 		settings, err := evergreen.GetConfig(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, LoadProjectError)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2796,7 +2796,7 @@ func TestIncludesValidation(t *testing.T) {
 	env.Settings().TaskLimits = evergreen.TaskLimitsConfig{
 		MaxIncludesPerVersion: 1,
 	}
-	env.Settings().TaskLimits.Set(ctx)
+	require.NoError(t, env.Settings().TaskLimits.Set(ctx))
 
 	yml := `
 include:

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2758,13 +2758,15 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion *int `json:"max_tasks_per_version"`
+	MaxTasksPerVersion    *int `json:"max_tasks_per_version"`
+	MaxIncludesPerVersion *int `json:"max_includes_per_version"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.TaskLimitsConfig:
 		c.MaxTasksPerVersion = utility.ToIntPtr(v.MaxTasksPerVersion)
+		c.MaxIncludesPerVersion = utility.ToIntPtr(v.MaxIncludesPerVersion)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2773,6 +2775,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion: utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxTasksPerVersion:    utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxIncludesPerVersion: utility.FromIntPtr(c.MaxIncludesPerVersion),
 	}, nil
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -581,6 +581,10 @@ Admin Settings
 										<label>Max Tasks per Version</label>
 										<input type="number" ng-model="Settings.task_limits.max_tasks_per_version">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Includes per Version</label>
+										<input type="number" ng-model="Settings.task_limits.max_includes_per_version">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>


### PR DESCRIPTION
DEVPROD-731

### Description
add limit for the number of includes users can specify 
<img width="617" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/51e0e69f-c6de-4b15-a15f-3562eab28994">

### Testing
local evergreen saves 
unit tests 
staging with low include number to fail 
![image](https://github.com/evergreen-ci/evergreen/assets/26491602/8da09a2a-411c-4be3-8765-433589aa05fb)
<img width="923" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/647ce55f-2123-4444-882e-98e697144722">

