### PR TITLE
DEVPROD-3092 Use unique directory for app server patch application

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -451,15 +451,6 @@ func MakePatchedConfig(ctx context.Context, env evergreen.Environment, p *patch.
 			return nil, errors.Wrap(err, "running patch command (possibly due to merge conflict on evergreen configuration file)")
 		}
 
-		grip.Info(message.Fields{
-			"message":          "MALIK5",
-			"output":           output.String(),
-			"workingDirectory": workingDirectory,
-			"localConfigPath":  localConfigPath,
-			"remoteConfigPath": remoteConfigPath,
-			"configFilePath":   configFilePath,
-		})
-
 		// read in the patched config file
 		data, err := os.ReadFile(localConfigPath)
 		if err != nil {


### PR DESCRIPTION
DEVPROD-3092

### Description
[This logic](https://github.com/evergreen-ci/evergreen/blob/main/model/project_parser.go#L692-L726) for processing the includes of a version uses workers/goroutines that can potentially run in multiple parallel threads on the same machine.

For patches that change a large number of included files at once, this is problematic as the same directory on the app host can get [cleaned](https://github.com/evergreen-ci/evergreen/blob/main/model/patch_lifecycle.go#L424) before another goroutine has the chance to later apply its [patch command](https://github.com/evergreen-ci/evergreen/blob/main/model/patch_lifecycle.go#L448), resulting in flaky errors like this:

```
error: etc/evergreen_yml_components/variants/in_memory.yml: No such file or directory
```

Since getting files serially from GitHub causes projects with many file includes to exceed a timeout (see #7083), rather than convert back to serially patching the includes:

- Ensure each config file we want to patch is written to a unique working directory, such that multiple parallel patch commands can apply without interfering with each other
- Ensure the unique directory is cleaned at the end of the function
- Remove the patching logic that cleans the working directory as this is unnecessary since the files are now written to unique directories

### Testing
Updated & existing tests

Was able to reproduce the original user's error via a dummy server project in staging by replicating their exact patch.

Confirmed that post change, patch submissions consistently go [through](https://spruce-staging.corp.mongodb.com/patch/6580de169dbe32fa272ccef6/configure/changes) without error, and SSHed into the relevant staging app host to ensure that post patch creation, `/tmp/evergreen` was in a clean state.