### PR TITLE
DEVPROD-2470 skip stdout logging

### DIFF
--- a/charts/values.yml
+++ b/charts/values.yml
@@ -23,6 +23,7 @@ resources:
 
 env:
   MONGO_AWS_AUTH: true
+  DISABLE_LOCAL_LOGGING: true
 
 envSecrets:
   MONGO_URL: evergreen-secrets

--- a/config.go
+++ b/config.go
@@ -457,7 +457,7 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 	if err != nil {
 		return nil, errors.Wrap(err, "configuring error fallback logger")
 	}
-	if disableLocalLogging, err := strconv.ParseBool(os.Getenv(disableLocalLogging)); err == nil && !disableLocalLogging {
+	if disableLocalLogging, err := strconv.ParseBool(os.Getenv(disableLocalLoggingEnvVar)); err == nil && !disableLocalLogging {
 		// setup the base/default logger (generally direct to systemd
 		// or standard output)
 		switch s.LogPath {

--- a/config.go
+++ b/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -456,8 +457,7 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 	if err != nil {
 		return nil, errors.Wrap(err, "configuring error fallback logger")
 	}
-
-	if _, disableLocalLogging := os.LookupEnv(disableLocalLogging); !disableLocalLogging {
+	if disableLocalLogging, err := strconv.ParseBool(os.Getenv(disableLocalLogging)); err == nil && !disableLocalLogging {
 		// setup the base/default logger (generally direct to systemd
 		// or standard output)
 		switch s.LogPath {

--- a/globals.go
+++ b/globals.go
@@ -209,9 +209,9 @@ const (
 	// standardOutputLoggingOverride is a special log path indicating that the
 	// app server should log to stdout.
 	standardOutputLoggingOverride = "STDOUT"
-	// disableLocalLogging is an environment variable to disable all local application logging
+	// disableLocalLoggingEnvVar is an environment variable to disable all local application logging
 	// besides for fallback logging to stderr.
-	disableLocalLogging = "DISABLE_LOCAL_LOGGING"
+	disableLocalLoggingEnvVar = "DISABLE_LOCAL_LOGGING"
 
 	// LegacyTaskActivator is a deprecated legacy activator that used
 	// to be a majority of non-stepback and non-API activations.

--- a/globals.go
+++ b/globals.go
@@ -209,6 +209,9 @@ const (
 	// standardOutputLoggingOverride is a special log path indicating that the
 	// app server should log to stdout.
 	standardOutputLoggingOverride = "STDOUT"
+	// disableLocalLogging is an environment variable to disable all local application logging
+	// besides for fallback logging to stderr.
+	disableLocalLogging = "DISABLE_LOCAL_LOGGING"
 
 	// LegacyTaskActivator is a deprecated legacy activator that used
 	// to be a majority of non-stepback and non-API activations.


### PR DESCRIPTION
[DEVPROD-2470](https://jira.mongodb.org/browse/DEVPROD-2470)

### Description
In Kanopy we won't want to log to stdout since that'll just land up in Splunk and we already have it in Splunk 😄 .
There's maybe a marginal benefit to having the logs go to Splunk from stdout since there the Kanopy control plane is handling sending the logs so maybe even if our logs don't make it to Splunk those will, but the volume of logs would probably make it prohibitive. Fallback logs (when sending to Splunk/Slack) will still go to stderr and end up in Kanopy splunk.

### Testing
In staging application logs went to [our Splunk index](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen-staging%0A%7C%20stats%20count%20by%20host&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1702937190&latest=1702938090&display.page.search.tab=statistics&display.general.type=statistics&sid=1702938256.4561002) and [not Kanopy's](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Ddevprod-evergreen-staging%20%0A%7C%20stats%20count%20by%20host&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-15m&latest=now&display.page.search.tab=statistics&display.general.type=statistics&sid=1702938260.4561012) (after the logger was configured).
