### PR TITLE
DEVPROD-3230 Fix shouldKill panics when makeTaskConfig errors 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1068,13 +1068,13 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 
 }
 
-func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string, additionalKillOverride bool) {
+func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string, additionalShouldKillCheck bool) {
 	logger := grip.NewJournaler("killProcs")
 	if tc.logger != nil && !tc.logger.Closed() {
 		logger = tc.logger.Execution()
 	}
 
-	if !additionalKillOverride || !a.shouldKill(tc, ignoreTaskGroupCheck) {
+	if !additionalShouldKillCheck || !a.shouldKill(tc, ignoreTaskGroupCheck) {
 		return
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -427,19 +427,23 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 	taskConfig, err := a.makeTaskConfig(setupCtx, tc)
 	if err != nil {
 		tc.logger = client.NewSingleChannelLogHarness("agent.error", a.defaultLogger)
-		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "making task config"))
+		// When makeTaskConfig errors, we should check if the taskgroup is nil in nextTask and
+		// use that as the killProcsOverride. Because the taskConfig will be nil in this case, killProcs
+		// will not be able to use the taskConfig task group to determine if it should kill processes.
+		taskGroupIsNil := nt.TaskGroup == ""
+		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "making task config"), taskGroupIsNil)
 	}
 	tc.taskConfig = taskConfig
 
 	if err := a.startLogging(agentCtx, tc); err != nil {
 		tc.logger = client.NewSingleChannelLogHarness("agent.error", a.defaultLogger)
-		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "setting up logger producer"))
+		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "setting up logger producer"), false)
 	}
 
 	if !tc.ranSetupGroup {
 		taskDirectory, err = a.createTaskDirectory(tc)
 		if err != nil {
-			return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task directory"))
+			return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task directory"), false)
 		}
 	}
 
@@ -458,7 +462,7 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 	tc.logger.Execution().Error(errors.Wrap(tc.getDeviceNames(setupCtx), "getting device names for disks"))
 
 	if err := setupCtx.Err(); err != nil {
-		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "making task config"))
+		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "making task config"), false)
 	}
 
 	hostname, err := os.Hostname()
@@ -471,13 +475,13 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 	return tc, shouldExit, nil
 }
 
-func (a *Agent) handleSetupError(ctx context.Context, tc *taskContext, err error) (*taskContext, bool, error) {
+func (a *Agent) handleSetupError(ctx context.Context, tc *taskContext, err error, killProcsOverride bool) (*taskContext, bool, error) {
 	catcher := grip.NewBasicCatcher()
 	grip.Error(err)
 	catcher.Wrap(err, "handling setup error")
 	tc.logger.Execution().Error(err)
 	grip.Infof("Task complete: '%s'.", tc.task.ID)
-	shouldExit, err := a.handleTaskResponse(ctx, tc, evergreen.TaskSystemFailed, err.Error())
+	shouldExit, err := a.handleTaskResponse(ctx, tc, evergreen.TaskSystemFailed, err.Error(), killProcsOverride)
 	catcher.Wrap(err, "handling task response")
 	return tc, shouldExit, catcher.Resolve()
 }
@@ -591,7 +595,7 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 		return tc, shouldExit, errors.Wrap(err, "setting up task")
 	}
 
-	defer a.killProcs(ctx, tc, false, "task is finished")
+	defer a.killProcs(ctx, tc, false, "task is finished", false)
 
 	grip.Info(message.Fields{
 		"message": "running task",
@@ -618,7 +622,7 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 	go a.startHeartbeat(tskCtx, preAndMainCancel, tc)
 
 	status := a.runPreAndMain(preAndMainCtx, tc)
-	shouldExit, err = a.handleTaskResponse(tskCtx, tc, status, "")
+	shouldExit, err = a.handleTaskResponse(tskCtx, tc, status, "", false)
 	return tc, shouldExit, err
 }
 
@@ -701,7 +705,7 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 		return evergreen.TaskSystemFailed
 	}
 
-	a.killProcs(execTimeoutCtx, tc, false, "task is starting")
+	a.killProcs(execTimeoutCtx, tc, false, "task is starting", false)
 
 	if err := a.runPreTaskCommands(execTimeoutCtx, tc); err != nil {
 		return evergreen.TaskFailed
@@ -803,8 +807,8 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 	ctx, span := a.tracer.Start(ctx, "post-task-commands")
 	defer span.End()
 
-	a.killProcs(ctx, tc, false, "post task commands are starting")
-	defer a.killProcs(ctx, tc, false, "post task commands are finished")
+	a.killProcs(ctx, tc, false, "post task commands are starting", false)
+	defer a.killProcs(ctx, tc, false, "post task commands are finished", false)
 
 	post, err := tc.getPost()
 	if err != nil {
@@ -829,7 +833,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	// Only killProcs if tc.taskConfig is not nil. This avoids passing an
 	// empty working directory to killProcs, and is okay because this
 	// killProcs is only for the processes run in runTeardownGroupCommands.
-	defer a.killProcs(ctx, tc, true, "teardown group commands are finished")
+	defer a.killProcs(ctx, tc, true, "teardown group commands are finished", false)
 
 	defer func() {
 		if tc.logger != nil {
@@ -849,7 +853,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	}
 
 	if teardownGroup.commands != nil {
-		a.killProcs(ctx, tc, true, "teardown group commands are starting")
+		a.killProcs(ctx, tc, true, "teardown group commands are starting", false)
 
 		_ = a.runCommandsInBlock(ctx, tc, *teardownGroup)
 	}
@@ -885,8 +889,8 @@ func (a *Agent) runEndTaskSync(ctx context.Context, tc *taskContext, detail *api
 	_ = a.runCommandsInBlock(ctx, tc, taskSync)
 }
 
-func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status string, systemFailureDescription string) (bool, error) {
-	resp, err := a.finishTask(ctx, tc, status, systemFailureDescription)
+func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status string, systemFailureDescription string, killProcsOverride bool) (bool, error) {
+	resp, err := a.finishTask(ctx, tc, status, systemFailureDescription, killProcsOverride)
 	if err != nil {
 		return false, errors.Wrap(err, "marking task complete")
 	}
@@ -922,7 +926,7 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, status
 
 // finishTask finishes up a running task. It runs any post-task command blocks
 // such as timeout and post, then sends the final end task response.
-func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, systemFailureDescription string) (*apimodels.EndTaskResponse, error) {
+func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, systemFailureDescription string, killProcsOverride bool) (*apimodels.EndTaskResponse, error) {
 	detail := a.endTaskResponse(ctx, tc, status, systemFailureDescription)
 	switch detail.Status {
 	case evergreen.TaskSucceeded:
@@ -964,7 +968,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		}
 	}
 
-	a.killProcs(ctx, tc, false, "task is ending")
+	a.killProcs(ctx, tc, false, "task is ending", killProcsOverride)
 
 	if tc.logger != nil {
 		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
@@ -1061,13 +1065,13 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 
 }
 
-func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string) {
+func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string, additionalKillOverride bool) {
 	logger := grip.NewJournaler("killProcs")
 	if tc.logger != nil && !tc.logger.Closed() {
 		logger = tc.logger.Execution()
 	}
 
-	if !a.shouldKill(tc, ignoreTaskGroupCheck) {
+	if !additionalKillOverride || !a.shouldKill(tc, ignoreTaskGroupCheck) {
 		return
 	}
 
@@ -1106,7 +1110,7 @@ func (a *Agent) shouldKill(tc *taskContext, ignoreTaskGroupCheck bool) bool {
 		return false
 	}
 	// Kill if the task is not in a task group.
-	if tc.taskConfig.TaskGroup == nil {
+	if tc.taskConfig != nil && tc.taskConfig.TaskGroup == nil {
 		return true
 	}
 	// This is a task group, kill if ignoreTaskGroupCheck is true
@@ -1115,7 +1119,7 @@ func (a *Agent) shouldKill(tc *taskContext, ignoreTaskGroupCheck bool) bool {
 	}
 	// This is a task group, kill if not sharing processes between tasks in the
 	// task group.
-	return !tc.taskConfig.TaskGroup.ShareProcs
+	return tc.taskConfig != nil && !tc.taskConfig.TaskGroup.ShareProcs
 }
 
 // logPanic logs a panic to the task log and returns the panic error, along with

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -431,6 +431,9 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 		// use that as the killProcsOverride. Because the taskConfig will be nil in this case, killProcs
 		// will not be able to use the taskConfig task group to determine if it should kill processes.
 		taskGroupIsNil := nt.TaskGroup == ""
+		if initialTC != nil && initialTC.taskConfig != nil {
+			taskGroupIsNil = initialTC.taskConfig.TaskGroup == nil
+		}
 		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "making task config"), taskGroupIsNil)
 	}
 	tc.taskConfig = taskConfig

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -261,7 +261,7 @@ func (s *AgentSuite) TestFinishTaskWithNormalCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 
 	for _, status := range evergreen.TaskCompletedStatuses {
-		resp, err := s.a.finishTask(s.ctx, s.tc, status, "")
+		resp, err := s.a.finishTask(s.ctx, s.tc, status, "", false)
 		s.Equal(&apimodels.EndTaskResponse{}, resp)
 		s.NoError(err)
 		s.NoError(s.tc.logger.Close())
@@ -275,7 +275,7 @@ func (s *AgentSuite) TestFinishTaskWithAbnormallyCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 
 	const status = evergreen.TaskSystemFailed
-	resp, err := s.a.finishTask(s.ctx, s.tc, status, "")
+	resp, err := s.a.finishTask(s.ctx, s.tc, status, "", false)
 	s.Equal(&apimodels.EndTaskResponse{}, resp)
 	s.NoError(err)
 
@@ -293,7 +293,7 @@ func (s *AgentSuite) TestFinishTaskWithAbnormallyCompletedTask() {
 
 func (s *AgentSuite) TestFinishTaskEndTaskError() {
 	s.mockCommunicator.EndTaskShouldFail = true
-	resp, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	resp, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "", false)
 	s.Nil(resp)
 	s.Error(err)
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 	ClientVersion = "2023-11-30"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2023-12-14"
+	AgentVersion = "2023-12-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-3230

### Description
The shouldKill function relies on the taskConfig to know if the task is not part of a taskgroup and should therefore kill processes. If makeTaskConfig fails, the taskConfig will be nil, and then when it eventually get's to a.shouldKill() via handleSetupError, it will panic when it tries to check tc.taskConfig.TaskGroup. 



### Testing
There's no good way to test this, and the changes are simple enough so I think we are okay without it. 
