### PR TITLE
Revert "DEVPROD-731 Add include limits to admin settings (#7323)"

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -17,15 +17,10 @@ type TaskLimitsConfig struct {
 	// MaxTasksPerVersion is the maximum number of tasks that a single version
 	// can have.
 	MaxTasksPerVersion int `bson:"max_tasks_per_version" json:"max_tasks_per_version" yaml:"max_tasks_per_version"`
-
-	// MaxIncludesPerVersion is the maximum number of includes that a single
-	// version can have.
-	MaxIncludesPerVersion int `bson:"max_includes_per_version" json:"max_includes_per_version" yaml:"max_includes_per_version"`
 }
 
 var (
-	maxTasksPerVersionKey    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
-	maxIncludesPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
+	maxTasksPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -50,8 +45,7 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey:    c.MaxTasksPerVersion,
-			maxIncludesPerVersionKey: c.MaxIncludesPerVersion,
+			maxTasksPerVersionKey: c.MaxTasksPerVersion,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -679,30 +679,12 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 			err = errors.New("trying to open include files with empty options")
 			return nil, errors.Wrapf(err, LoadProjectError)
 		}
-
-		settings, err := evergreen.GetConfig(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, LoadProjectError)
-		}
-		if settings == nil {
-			err = errors.New("no settings found")
-			return nil, errors.Wrap(err, LoadProjectError)
-		}
-
 		wg := sync.WaitGroup{}
 		outputYAMLs := make(chan yamlTuple, len(intermediateProject.Include))
 		includesToProcess := make(chan Include, len(intermediateProject.Include))
 
-		// Only process includes until max limit is reached.
-		catcher := grip.NewBasicCatcher()
-		numIncludes := len(intermediateProject.Include)
-		if settings.TaskLimits.MaxIncludesPerVersion > 0 && numIncludes > settings.TaskLimits.MaxIncludesPerVersion {
-			catcher.Errorf("project's total number of includes (%d) exceeds maximum limit (%d)", numIncludes, settings.TaskLimits.MaxIncludesPerVersion)
-			numIncludes = settings.TaskLimits.MaxIncludesPerVersion
-		}
-
-		for i := 0; i < numIncludes; i++ {
-			includesToProcess <- intermediateProject.Include[i]
+		for _, path := range intermediateProject.Include {
+			includesToProcess <- path
 		}
 		close(includesToProcess)
 
@@ -726,6 +708,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		close(outputYAMLs)
 
 		yamlMap := map[string][]byte{}
+		catcher := grip.NewBasicCatcher()
 		for elem := range outputYAMLs {
 			catcher.Add(elem.err)
 			if elem.yaml != nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2786,50 +2786,6 @@ func TestMergeMatrixFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "matrixes can only be defined in one YAML")
 }
 
-func TestIncludesValidation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx))
-
-	env.Settings().TaskLimits = evergreen.TaskLimitsConfig{
-		MaxIncludesPerVersion: 1,
-	}
-	require.NoError(t, env.Settings().TaskLimits.Set(ctx))
-
-	yml := `
-include:
-  - filename: toomany.yml
-    module: something_different
-  - filename: somany.yml
-tasks:
-  - name: my_task
-    commands:
-      - func: main_function
-functions:
-  main_function:
-    command: definition_1
-modules:
-- name: "something_different"
-  owner: "foo"
-  repo: "bar"
-  prefix: "src/third_party"
-  branch: "master"
-ignore:
-  - "*.md"
-  - "scripts/*"
-`
-
-	proj := &Project{}
-	opts := &GetProjectOpts{
-		UnmarshalStrict: true,
-	}
-	_, err := LoadProjectInto(ctx, []byte(yml), opts, "id", proj)
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), "project's total number of includes (2) exceeds maximum limit (1)")
-}
-
 func TestMergeMultipleProjectConfigs(t *testing.T) {
 	mainYaml := `
 include:

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2755,15 +2755,13 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion    *int `json:"max_tasks_per_version"`
-	MaxIncludesPerVersion *int `json:"max_includes_per_version"`
+	MaxTasksPerVersion *int `json:"max_tasks_per_version"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.TaskLimitsConfig:
 		c.MaxTasksPerVersion = utility.ToIntPtr(v.MaxTasksPerVersion)
-		c.MaxIncludesPerVersion = utility.ToIntPtr(v.MaxIncludesPerVersion)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2772,7 +2770,6 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion:    utility.FromIntPtr(c.MaxTasksPerVersion),
-		MaxIncludesPerVersion: utility.FromIntPtr(c.MaxIncludesPerVersion),
+		MaxTasksPerVersion: utility.FromIntPtr(c.MaxTasksPerVersion),
 	}, nil
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -581,10 +581,6 @@ Admin Settings
 										<label>Max Tasks per Version</label>
 										<input type="number" ng-model="Settings.task_limits.max_tasks_per_version">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
-										<label>Max Includes per Version</label>
-										<input type="number" ng-model="Settings.task_limits.max_includes_per_version">
-									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>


### PR DESCRIPTION
This reverts commit 981eda35e98087e960b0baecdbfa28ae8a8b7b87.

DEVPROD-731

bug report: https://mongodb.slack.com/archives/CCUJM49FT/p1703002325071159