### PR TITLE
Fixup: Document ad_hoc as also for create version API

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -622,7 +622,7 @@ const (
 	RepotrackerVersionRequester = "gitter_request"
 	TriggerRequester            = "trigger_request"
 	MergeTestRequester          = "merge_test"           // Evergreen commit queue
-	AdHocRequester              = "ad_hoc"               // periodic build
+	AdHocRequester              = "ad_hoc"               // periodic build or create version endpoint
 	GithubMergeRequester        = "github_merge_request" // GitHub merge queue
 )
 


### PR DESCRIPTION
### Description

No ticket, since this is a minor comment change.

The ad_hoc version requester is used both by triggers *and* by the create version endpoint, which was confusing at first when I was considering opening a ticket about improving the create version endpoint, so I wanted a couple words to the comment.

### Testing

N/A

### Documentation

N/A
