### PR TITLE
DEVPROD-979: terminate spawn hosts that fail to spawn

### DIFF
--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -101,10 +101,12 @@ func LogHostEvent(hostId string, eventType string, eventData HostEventData) {
 	}
 }
 
+// LogHostCreated logs an event indicating that the host was created.
 func LogHostCreated(hostId string) {
 	LogHostEvent(hostId, EventHostCreated, HostEventData{Successful: true})
 }
 
+// LogManyHostsCreated is the same as LogHostCreated but for multiple hosts.
 func LogManyHostsCreated(hostIDs []string) {
 	events := make([]EventLogEntry, 0, len(hostIDs))
 	for _, hostID := range hostIDs {

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -16,6 +16,7 @@ func init() {
 	registry.AllowSubscription(ResourceTypeHost, EventVolumeExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisioned)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisionFailed)
+	registry.AllowSubscription(ResourceTypeHost, EventHostCreated)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStarted)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStopped)
 	registry.AllowSubscription(ResourceTypeHost, EventHostModified)
@@ -101,6 +102,27 @@ func LogHostEvent(hostId string, eventType string, eventData HostEventData) {
 
 func LogHostCreated(hostId string) {
 	LogHostEvent(hostId, EventHostCreated, HostEventData{Successful: true})
+}
+
+func LogManyHostsCreated(hostIDs []string) {
+	events := make([]EventLogEntry, 0, len(hostIDs))
+	for _, hostID := range hostIDs {
+		e := EventLogEntry{
+			Timestamp:    time.Now(),
+			ResourceId:   hostID,
+			EventType:    EventHostCreated,
+			Data:         HostEventData{Successful: true},
+			ResourceType: ResourceTypeHost,
+		}
+		events = append(events, e)
+	}
+	if err := LogManyEvents(events); err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"resource_type": ResourceTypeHost,
+			"message":       "error logging event",
+			"source":        "event-log-fail",
+		}))
+	}
 }
 
 // LogHostCreationFailed logs an event indicating that the host errored while it

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -16,7 +16,7 @@ func init() {
 	registry.AllowSubscription(ResourceTypeHost, EventVolumeExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisioned)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisionFailed)
-	registry.AllowSubscription(ResourceTypeHost, EventHostCreated)
+	registry.AllowSubscription(ResourceTypeHost, EventHostCreatedError)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStarted)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStopped)
 	registry.AllowSubscription(ResourceTypeHost, EventHostModified)
@@ -28,6 +28,7 @@ const (
 
 	// event types
 	EventHostCreated                     = "HOST_CREATED"
+	EventHostCreatedError                = "HOST_CREATED_ERROR"
 	EventHostStarted                     = "HOST_STARTED"
 	EventHostStopped                     = "HOST_STOPPED"
 	EventHostModified                    = "HOST_MODIFIED"
@@ -125,10 +126,10 @@ func LogManyHostsCreated(hostIDs []string) {
 	}
 }
 
-// LogHostCreationFailed logs an event indicating that the host errored while it
+// LogHostCreatedError logs an event indicating that the host errored while it
 // was being created.
-func LogHostCreationFailed(hostID, logs string) {
-	LogHostEvent(hostID, EventHostCreated, HostEventData{Successful: false, Logs: logs})
+func LogHostCreatedError(hostID, logs string) {
+	LogHostEvent(hostID, EventHostCreatedError, HostEventData{Successful: false, Logs: logs})
 }
 
 // LogHostStartSucceeded logs an event indicating that the host was successfully

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -756,7 +756,6 @@ func MarkStaleBuildingAsFailed(ctx context.Context, distroID string) error {
 	spawnedByTaskKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsSpawnedByTaskKey)
 	query := bson.M{
 		distroIDKey:      distroID,
-		UserHostKey:      false,
 		spawnedByTaskKey: bson.M{"$ne": true},
 		ProviderKey:      bson.M{"$in": evergreen.ProviderSpawnable},
 		StatusKey:        evergreen.HostBuilding,
@@ -1315,6 +1314,12 @@ func UnsafeReplace(ctx context.Context, env evergreen.Environment, idToRemove st
 		if err := toInsert.InsertWithContext(sessCtx, env); err != nil {
 			return nil, errors.Wrapf(err, "inserting new host '%s'", toInsert.Id)
 		}
+		grip.Info(message.Fields{
+			"message":  "inserted host to replace intent host",
+			"host_id":  toInsert.Id,
+			"host_tag": toInsert.Tag,
+			"distro":   toInsert.Distro.Id,
+		})
 		return nil, nil
 	}
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -786,7 +786,7 @@ func MarkStaleBuildingAsFailed(ctx context.Context, distroID string) error {
 	}
 
 	for _, id := range ids {
-		event.LogHostCreationFailed(id, "stale building host took too long to start")
+		event.LogHostCreatedError(id, "stale building host took too long to start")
 		grip.Info(message.Fields{
 			"message": "stale building host took too long to start",
 			"host_id": id,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1737,7 +1737,6 @@ func (h *Host) Insert(ctx context.Context) error {
 	if err := InsertOne(ctx, h); err != nil {
 		return errors.Wrap(err, "inserting host")
 	}
-	h.logHostCreated()
 	return nil
 }
 
@@ -1747,18 +1746,7 @@ func (h *Host) InsertWithContext(ctx context.Context, env evergreen.Environment)
 	if _, err := env.DB().Collection(Collection).InsertOne(ctx, h); err != nil {
 		return errors.Wrap(err, "inserting host")
 	}
-	h.logHostCreated()
 	return nil
-}
-
-func (h *Host) logHostCreated() {
-	event.LogHostCreated(h.Id)
-	grip.Info(message.Fields{
-		"message":  "host created",
-		"host_id":  h.Id,
-		"host_tag": h.Tag,
-		"distro":   h.Distro.Id,
-	})
 }
 
 // Remove removes the host document from the DB.

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3878,17 +3878,33 @@ func TestMarkStaleBuildingAsFailed(t *testing.T) {
 		{
 			Id:           "host7",
 			Distro:       distro2,
+			Status:       evergreen.HostBuilding,
+			CreationTime: now.Add(-30 * time.Minute),
+			UserHost:     true,
+			Provider:     evergreen.ProviderNameEc2Fleet,
+		},
+		{
+			Id:           "host8",
+			Distro:       distro2,
 			Status:       evergreen.HostRunning,
 			CreationTime: now.Add(-30 * time.Minute),
 			UserHost:     false,
 			Provider:     evergreen.ProviderNameEc2Fleet,
 		},
 		{
-			Id:           "host8",
+			Id:           "host9",
 			Distro:       distro2,
 			Status:       evergreen.HostBuilding,
 			CreationTime: now.Add(-30 * time.Minute),
 			UserHost:     false,
+			Provider:     evergreen.ProviderNameEc2Fleet,
+		},
+		{
+			Id:           "host10",
+			Distro:       distro2,
+			Status:       evergreen.HostBuilding,
+			CreationTime: now.Add(-30 * time.Minute),
+			UserHost:     true,
 			Provider:     evergreen.ProviderNameEc2Fleet,
 		},
 	}
@@ -3906,15 +3922,15 @@ func TestMarkStaleBuildingAsFailed(t *testing.T) {
 		assert.Equal(t, dbHost.Status, expectedStatus)
 	}
 
-	for _, h := range append([]Host{hosts[0]}, hosts[2:6]...) {
+	for _, h := range append([]Host{hosts[0]}, hosts[2:]...) {
 		checkStatus(t, h, h.Status)
 	}
 	checkStatus(t, hosts[1], evergreen.HostBuildingFailed)
 
 	require.NoError(t, MarkStaleBuildingAsFailed(ctx, distro2.Id))
 
-	checkStatus(t, hosts[6], hosts[6].Status)
-	checkStatus(t, hosts[7], evergreen.HostBuildingFailed)
+	checkStatus(t, hosts[6], evergreen.HostBuildingFailed)
+	checkStatus(t, hosts[8], evergreen.HostBuildingFailed)
 }
 
 func TestNumNewParentsNeeded(t *testing.T) {

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
@@ -55,9 +56,10 @@ func NewIntentHost(ctx context.Context, options *restmodel.HostRequestOptions, u
 	if err := intentHost.Insert(ctx); err != nil {
 		return nil, err
 	}
-
+	event.LogHostCreated(intentHost.Id)
 	grip.Info(message.Fields{
 		"message":  "inserted intent host",
+		"host_id":  intentHost.Id,
 		"host_tag": intentHost.Tag,
 		"distro":   intentHost.Distro.Id,
 		"user":     user.Username(),

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -406,6 +407,13 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 	if err = intent.Insert(ctx); err != nil {
 		return nil, errors.Wrap(err, "inserting intent host")
 	}
+	event.LogHostCreated(intent.Id)
+	grip.Info(message.Fields{
+		"message":  "intent host created",
+		"host_id":  intent.Id,
+		"host_tag": intent.Tag,
+		"distro":   intent.Distro.Id,
+	})
 
 	if err := units.EnqueueHostCreateJobs(ctx, env, []host.Host{*intent}); err != nil {
 		return nil, errors.Wrapf(err, "enqueueing host create job for '%s'", intent.Id)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
@@ -278,6 +279,12 @@ func SpawnHosts(ctx context.Context, d distro.Distro, newHostsNeeded int, pool *
 	if err := host.InsertMany(ctx, hostsSpawned); err != nil {
 		return nil, errors.Wrap(err, "inserting intent host documents")
 	}
+
+	hostIDs := make([]string, 0, len(hostsSpawned))
+	for _, h := range hostsSpawned {
+		hostIDs = append(hostIDs, h.Id)
+	}
+	event.LogManyHostsCreated(hostIDs)
 
 	grip.Info(message.Fields{
 		"runner":        RunnerName,

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -45,7 +45,7 @@ func (t *hostBase) Fetch(ctx context.Context, e *event.EventLogEntry) error {
 		return errors.Errorf("expected host event data, got %T", e.Data)
 	}
 
-	t.host, err = host.FindOneId(ctx, e.ResourceId)
+	t.host, err = host.FindOneByIdOrTag(ctx, e.ResourceId)
 	if err != nil {
 		return errors.Wrapf(err, "finding host '%s'", e.ResourceId)
 	}

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -16,6 +16,7 @@ import (
 func init() {
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisioned, makeSpawnHostProvisioningTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisionFailed, makeSpawnHostProvisioningTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostCreated, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStarted, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStopped, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostModified, makeSpawnHostStateChangeTriggers)
@@ -48,7 +49,7 @@ func (t *spawnHostProvisioningTriggers) slack() *notification.SlackPayload {
 		TitleLink: spawnHostURL(t.uiConfig.Url),
 		Color:     evergreenFailColor,
 		Fields: []*message.SlackAttachmentField{
-			&message.SlackAttachmentField{
+			{
 				Title: "Distro",
 				Value: t.host.Distro.Id,
 				Short: true,
@@ -176,8 +177,18 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 	if !t.host.UserHost {
 		return nil, nil
 	}
-	if t.event.EventType == event.EventHostStarted && t.data.Successful && !t.host.Provisioned {
-		// we'll send notification when provisioning, so return
+	if t.event.EventType == event.EventHostCreated && t.data.Successful {
+		// When a spawn host is first created, only send a notification if it
+		// encounters an error. On success, there will be a notification later
+		// on when the host is started.
+		return nil, nil
+	}
+	if t.event.EventType == event.EventHostStarted && t.data.Successful && t.host.Status != evergreen.HostStarting {
+		// When the host is starting up, send a notification only if:
+		// * There was an error starting the host or
+		// * If it successfully started the host and it's still starting up now.
+		//   There will be a notification later on when the host is up and
+		//   running.
 		return nil, nil
 	}
 	payload, err := t.makePayload(sub)
@@ -191,6 +202,8 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 func (t *spawnHostStateChangeTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
 	var action string
 	switch t.event.EventType {
+	case event.EventHostCreated:
+		action = "Creating"
 	case event.EventHostStarted:
 		action = "Starting"
 	case event.EventHostStopped:

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisioned, makeSpawnHostProvisioningTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisionFailed, makeSpawnHostProvisioningTriggers)
-	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostCreated, makeSpawnHostStateChangeTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostCreatedError, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStarted, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStopped, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostModified, makeSpawnHostStateChangeTriggers)
@@ -177,12 +177,6 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 	if !t.host.UserHost {
 		return nil, nil
 	}
-	if t.event.EventType == event.EventHostCreated && t.data.Successful {
-		// When a spawn host is first created, only send a notification if it
-		// encounters an error. On success, there will be a notification later
-		// on when the host is started.
-		return nil, nil
-	}
 	if t.event.EventType == event.EventHostStarted && t.data.Successful && t.host.Status != evergreen.HostStarting {
 		// When the host is starting up, send a notification only if:
 		// * There was an error starting the host or
@@ -202,7 +196,7 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 func (t *spawnHostStateChangeTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
 	var action string
 	switch t.event.EventType {
-	case event.EventHostCreated:
+	case event.EventHostCreatedError:
 		action = "Creating"
 	case event.EventHostStarted:
 		action = "Starting"

--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -184,10 +184,13 @@ func (j *volumeMigrationJob) startNewHost(ctx context.Context) {
 		j.AddError(errors.Wrap(err, "inserting new intent host"))
 		return
 	}
+	event.LogHostCreated(intentHost.Id)
 	grip.Info(message.Fields{
 		"message":        "new intent host created",
 		"job_id":         j.ID(),
 		"intent_host_id": intentHost.Id,
+		"host_tag":       intentHost.Tag,
+		"distro":         intentHost.Distro.Id,
 	})
 }
 

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -120,9 +120,8 @@ func TestVolumeMigrateJob(t *testing.T) {
 
 			events, err := event.FindAllByResourceID(h.Id)
 			assert.NoError(t, err)
-			assert.Len(t, events, 2)
-			assert.Equal(t, events[0].EventType, event.EventHostCreated)
-			assert.Equal(t, events[1].EventType, event.EventVolumeMigrationFailed)
+			require.Len(t, events, 1)
+			assert.Equal(t, events[0].EventType, event.EventVolumeMigrationFailed)
 		},
 		"NewHostFailsToStart": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, v *host.Volume, d *distro.Distro, spawnOptions cloud.SpawnOptions) {
 			// Invalid public key will prevent new host from spinning up
@@ -164,7 +163,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 
 			events, err := event.FindAllByResourceID(h.Id)
 			assert.NoError(t, err)
-			assert.Len(t, events, 4)
+			assert.Len(t, events, 3)
 		},
 		"DetachedVolumeMigrates": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, v *host.Volume, d *distro.Distro, spawnOptions cloud.SpawnOptions) {
 			// Spoof documents after a virtual workstation is terminated.

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -250,7 +250,7 @@ func (j *createHostJob) selfThrottle(ctx context.Context, hostInit evergreen.Hos
 	} else if numProv >= hostInit.HostThrottle {
 		reason := "host creation throttle"
 		j.AddError(errors.Wrapf(j.host.SetStatusAtomically(ctx, evergreen.HostBuildingFailed, evergreen.User, reason), "getting rid of intent host '%s' for host creation throttle", j.host.Id))
-		event.LogHostCreationFailed(j.host.Id, reason)
+		event.LogHostCreatedError(j.host.Id, reason)
 		return true
 	}
 
@@ -334,7 +334,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 
 	hostReplaced, err := j.spawnAndReplaceHost(ctx, cloudManager)
 	if err != nil {
-		event.LogHostCreationFailed(j.host.Id, err.Error())
+		event.LogHostCreatedError(j.host.Id, err.Error())
 		return errors.Wrapf(err, "spawning and updating host '%s'", j.host.Id)
 	}
 

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -134,7 +134,6 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 				TerminateIfBusy:   true,
 				TerminationReason: "failed to mount volume",
 			})
-			terminateJob.SetPriority(100)
 			j.AddError(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminateJob))
 
 			return


### PR DESCRIPTION
DEVPROD-979

### Description
This is the same as #7313 except:
* I changed the host trigger processor to deal with the fact that intent hosts are deleted and re-inserted into the DB (with a different `_id`) when the host starts in EC2. A host event's resource ID could be either its intent host ID (i.e. the original `_id` for the host) or its EC2 instance ID (i.e. the new `_id` after the host doc is replaced), so it now handles both interchangeably.
* I changed it to log a new event type (`HOST_CREATED_ERROR`) instead of reusing the existing event type (`HOST_CREATED`). This is a small optimization to reduce the amount of events that the notification system has to process. Instead of having to process all host created events (1 per host), it only processes host creation errors (which only happen if the host fails to start up in EC2).

### Testing
* Tested in staging that a notification got sent if a spawn host could not be spawned in EC2.
* Tested in staging that success notification was sent if a spawn host was successfully started up.

### Documentation
N/A