### PR TITLE
DEVPROD-731 Add include limits to admin settings

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -17,10 +17,15 @@ type TaskLimitsConfig struct {
 	// MaxTasksPerVersion is the maximum number of tasks that a single version
 	// can have.
 	MaxTasksPerVersion int `bson:"max_tasks_per_version" json:"max_tasks_per_version" yaml:"max_tasks_per_version"`
+
+	// MaxIncludesPerVersion is the maximum number of includes that a single
+	// version can have.
+	MaxIncludesPerVersion int `bson:"max_includes_per_version" json:"max_includes_per_version" yaml:"max_includes_per_version"`
 }
 
 var (
-	maxTasksPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxTasksPerVersionKey    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxIncludesPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -45,7 +50,8 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey: c.MaxTasksPerVersion,
+			maxTasksPerVersionKey:    c.MaxTasksPerVersion,
+			maxIncludesPerVersionKey: c.MaxIncludesPerVersion,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/model/project.go
+++ b/model/project.go
@@ -70,7 +70,7 @@ type Project struct {
 	Private bool `yaml:"private,omitempty" bson:"private"`
 
 	// Number of includes in the project cached for validation
-	NumIncludes int
+	NumIncludes int `yaml:"-" bson:"-"`
 }
 
 type ProjectInfo struct {

--- a/model/project.go
+++ b/model/project.go
@@ -68,6 +68,9 @@ type Project struct {
 
 	// Flag that indicates a project as requiring user authentication
 	Private bool `yaml:"private,omitempty" bson:"private"`
+
+	// Number of includes in the project cached for validation
+	NumIncludes int
 }
 
 type ProjectInfo struct {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -745,7 +745,9 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 	}
 	project.Identifier = identifier
 
-	// Remove includes once the project is translated.
+	// Remove includes once the project is translated since translate project saves number of includes.
+	// Intermediate project is used to save parser project as a YAML so removing the includes verifies that
+	// they have been processed.
 	intermediateProject.Include = nil
 
 	return intermediateProject, errors.Wrapf(err, LoadProjectError)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -745,7 +745,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 	}
 	project.Identifier = identifier
 
-	// Don't remove includes until project is translated.
+	// Remove includes once the project is translated.
 	intermediateProject.Include = nil
 
 	return intermediateProject, errors.Wrapf(err, LoadProjectError)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2786,6 +2786,50 @@ func TestMergeMatrixFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "matrixes can only be defined in one YAML")
 }
 
+func TestIncludesValidation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	env.Settings().TaskLimits = evergreen.TaskLimitsConfig{
+		MaxIncludesPerVersion: 1,
+	}
+	require.NoError(t, env.Settings().TaskLimits.Set(ctx))
+
+	yml := `
+include:
+  - filename: toomany.yml
+    module: something_different
+  - filename: somany.yml
+tasks:
+  - name: my_task
+    commands:
+      - func: main_function
+functions:
+  main_function:
+    command: definition_1
+modules:
+- name: "something_different"
+  owner: "foo"
+  repo: "bar"
+  prefix: "src/third_party"
+  branch: "master"
+ignore:
+  - "*.md"
+  - "scripts/*"
+`
+
+	proj := &Project{}
+	opts := &GetProjectOpts{
+		UnmarshalStrict: true,
+	}
+	_, err := LoadProjectInto(ctx, []byte(yml), opts, "id", proj)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "project's total number of includes (2) exceeds maximum limit (1)")
+}
+
 func TestMergeMultipleProjectConfigs(t *testing.T) {
 	mainYaml := `
 include:

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2786,50 +2786,6 @@ func TestMergeMatrixFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "matrixes can only be defined in one YAML")
 }
 
-func TestIncludesValidation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx))
-
-	env.Settings().TaskLimits = evergreen.TaskLimitsConfig{
-		MaxIncludesPerVersion: 1,
-	}
-	require.NoError(t, env.Settings().TaskLimits.Set(ctx))
-
-	yml := `
-include:
-  - filename: toomany.yml
-    module: something_different
-  - filename: somany.yml
-tasks:
-  - name: my_task
-    commands:
-      - func: main_function
-functions:
-  main_function:
-    command: definition_1
-modules:
-- name: "something_different"
-  owner: "foo"
-  repo: "bar"
-  prefix: "src/third_party"
-  branch: "master"
-ignore:
-  - "*.md"
-  - "scripts/*"
-`
-
-	proj := &Project{}
-	opts := &GetProjectOpts{
-		UnmarshalStrict: true,
-	}
-	_, err := LoadProjectInto(ctx, []byte(yml), opts, "id", proj)
-	require.NotNil(t, err)
-	assert.Contains(t, err.Error(), "project's total number of includes (2) exceeds maximum limit (1)")
-}
-
 func TestMergeMultipleProjectConfigs(t *testing.T) {
 	mainYaml := `
 include:

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2758,13 +2758,15 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion *int `json:"max_tasks_per_version"`
+	MaxTasksPerVersion    *int `json:"max_tasks_per_version"`
+	MaxIncludesPerVersion *int `json:"max_includes_per_version"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.TaskLimitsConfig:
 		c.MaxTasksPerVersion = utility.ToIntPtr(v.MaxTasksPerVersion)
+		c.MaxIncludesPerVersion = utility.ToIntPtr(v.MaxIncludesPerVersion)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2773,6 +2775,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion: utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxTasksPerVersion:    utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxIncludesPerVersion: utility.FromIntPtr(c.MaxIncludesPerVersion),
 	}, nil
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -590,6 +590,10 @@ Admin Settings
 										<label>Max Tasks per Version</label>
 										<input type="number" ng-model="Settings.task_limits.max_tasks_per_version">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Includes per Version</label>
+										<input type="number" ng-model="Settings.task_limits.max_includes_per_version">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -166,6 +166,7 @@ var projectSettingsValidators = []projectSettingsValidator{
 	validateVersionControl,
 	validateContainers,
 	validateProjectLimits,
+	validateIncludeLimits,
 }
 
 // These validators have the potential to be very long, and may not be fully run unless specified.
@@ -959,6 +960,17 @@ func checkRunOn(runOnHasDistro, runOnHasContainer bool, runOn []string) []Valida
 		}}
 	}
 	return nil
+}
+
+func validateIncludeLimits(_ context.Context, settings *evergreen.Settings, project *model.Project, _ *model.ProjectRef, _ bool) ValidationErrors {
+	errs := ValidationErrors{}
+	if settings.TaskLimits.MaxIncludesPerVersion > 0 && project.NumIncludes > settings.TaskLimits.MaxIncludesPerVersion {
+		errs = append(errs, ValidationError{
+			Message: fmt.Sprintf("project's total number of includes (%d) exceeds maximum limit (%d)", project.NumIncludes, settings.TaskLimits.MaxIncludesPerVersion),
+			Level:   Error,
+		})
+	}
+	return errs
 }
 
 func validateProjectLimits(_ context.Context, settings *evergreen.Settings, project *model.Project, _ *model.ProjectRef, _ bool) ValidationErrors {


### PR DESCRIPTION
DEVPROD-731

### Description
Add a limit for how many include files a patch can have 

Because we can't access settings in the cli and we don't want to change over 100 instances of loadProjectInto to pass in a settings, I added a new field to project called `NumIncludes` which is just used for validation. But because of the way this works, `evergreen validate` won't error when there are too many includes. It will still go through every includes file and give the proper warning and errors. I think this behavior is okay. 

However, it errors when trying to create patches as shown below

### Testing
tested on staging and unit tests
![image](https://github.com/evergreen-ci/evergreen/assets/26491602/7e8c0da5-5852-492b-8db3-baca5fa62944)
<img width="957" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/011bf9dc-44d3-4aec-b105-e1ba9eba628c">



