### PR TITLE
DEVPROD-3423 use easier timestamps

### DIFF
--- a/graphql/tests/task/taskLogs/results.json
+++ b/graphql/tests/task/taskLogs/results.json
@@ -11,7 +11,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "timestamp": "2024-01-01T00:00:01.000-05:00",
                   "version": 0
                 }
               ],
@@ -61,14 +61,14 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "timestamp": "2024-01-01T00:00:02.000-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "timestamp": "2024-01-01T00:00:03.000-05:00",
                   "version": 0
                 }
               ],
@@ -77,7 +77,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "timestamp": "2024-01-01T00:00:00.000-05:00",
                   "version": 0
                 }
               ],
@@ -86,28 +86,28 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "timestamp": "2024-01-01T00:00:00.000-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2019-12-07T13:31:19.393-05:00",
+                  "timestamp": "2024-01-01T00:00:01.000-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "timestamp": "2024-01-01T00:00:02.000-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2019-12-07T13:31:19.637-05:00",
+                  "timestamp": "2024-01-01T00:00:03.000-05:00",
                   "version": 0
                 }
               ]

--- a/graphql/tests/task/taskLogs/results.json
+++ b/graphql/tests/task/taskLogs/results.json
@@ -11,7 +11,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2024-01-01T00:00:01.000-05:00",
+                  "timestamp": "2024-01-01T00:00:01-05:00",
                   "version": 0
                 }
               ],
@@ -61,14 +61,14 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2024-01-01T00:00:02.000-05:00",
+                  "timestamp": "2024-01-01T00:00:02-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2024-01-01T00:00:03.000-05:00",
+                  "timestamp": "2024-01-01T00:00:03-05:00",
                   "version": 0
                 }
               ],
@@ -77,7 +77,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2024-01-01T00:00:00.000-05:00",
+                  "timestamp": "2024-01-01T00:00:00-05:00",
                   "version": 0
                 }
               ],
@@ -86,28 +86,28 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2024-01-01T00:00:00.000-05:00",
+                  "timestamp": "2024-01-01T00:00:00-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2024-01-01T00:00:01.000-05:00",
+                  "timestamp": "2024-01-01T00:00:01-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2024-01-01T00:00:02.000-05:00",
+                  "timestamp": "2024-01-01T00:00:02-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2024-01-01T00:00:03.000-05:00",
+                  "timestamp": "2024-01-01T00:00:03-05:00",
                   "version": 0
                 }
               ]

--- a/graphql/tests/task/taskLogs/task_output_data.json
+++ b/graphql/tests/task/taskLogs/task_output_data.json
@@ -7,7 +7,7 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1575743479393000000,
+          "timestamp": 1704085200000000000,
           "data": "    [javac]                    ^"
         }
       ]
@@ -19,12 +19,12 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1575743479637000000,
+          "timestamp": 1704085202000000000,
           "data": "    [javac] 9 warnings"
         },
         {
           "priority": 40,
-          "timestamp": 1575743479637000000,
+          "timestamp": 1704085203000000000,
           "data": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar"
         }
       ]
@@ -36,7 +36,7 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1575743479393000000,
+          "timestamp": 1704085201000000000,
           "data": "    [javac]     protected void finalize() {"
         }
       ]


### PR DESCRIPTION
[DEVPROD-3423](https://jira.mongodb.org/browse/DEVPROD-3423)

### Description
[task_logs_all.graphql](https://spruce.mongodb.com/task/evergreen_ubuntu2204_test_service_graphql_patch_adb6e7ef31c0deda9b9b7bc520d389e4f7d91911_659495f9306615d965b72326_24_01_02_23_02_20?execution=0&sortBy=STATUS&sortDir=ASC) sometimes fails because these two log lines are out of order. It seems that the reason is that they have identical timestamps so the order depends on the order of keys in the iterator map, which is supposed to be non-deterministic.

### Testing
Hopefully the test continues to pass.
