### PR TITLE
DEVPROD-766 Send success for all branch protection rules for ignored PRs

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1535,7 +1535,8 @@ builds.
 To address this, project files can define a top-level `ignore`
 list of gitignore-style globs which tell Evergreen to not automatically
 run tasks for commits that only change ignored files, and we will not 
-create PR patches but instead send a successful status. 
+create PR patches but instead send a successful status for all required
+checks. 
 
 ``` yaml
 ignore:

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1536,7 +1536,7 @@ To address this, project files can define a top-level `ignore`
 list of gitignore-style globs which tell Evergreen to not automatically
 run tasks for commits that only change ignored files, and we will not 
 create PR patches but instead send a successful status for all required
-checks. 
+checks as well as the base `evergeen` check. 
 
 ``` yaml
 ignore:

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -200,7 +200,7 @@ func (j *githubStatusUpdateJob) fetch() (*message.GithubStatus, error) {
 		status.Description = j.Description
 
 	} else if j.UpdateType == githubUpdateTypeSuccessMessage {
-		status.Context = evergreenContext
+		status.Context = j.GithubContext
 		status.State = message.GithubStateSuccess
 		status.Description = j.Description
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1267,16 +1267,8 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 		return
 	}
 	// If the base evergreen context is not one of the rules, add it.
-	hasEvergreenContext := false
-	for _, rule := range rules {
-		if rule == evergreenContext {
-			hasEvergreenContext = true
-		}
-	}
-	if !hasEvergreenContext {
-		rules = append(rules, evergreenContext)
-	}
-	for _, rule := range rules {
+	uniqueRules := utility.UniqueStrings(append(rules, evergreenContext))
+	for _, rule := range uniqueRules {
 		update := NewGithubStatusUpdateJobWithSuccessMessage(
 			rule,
 			patchDoc.GithubPatchData.BaseOwner,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1266,6 +1266,7 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 		j.AddError(errors.Wrapf(err, "getting branch protection rules for %s/%s/%s", projectRef.Owner, projectRef.Repo, projectRef.Branch))
 		return
 	}
+	// If the base evergreen context is not one of the rules, add it.
 	hasEvergreenContext := false
 	for _, rule := range rules {
 		if rule == evergreenContext {


### PR DESCRIPTION
DEVPROD-766

### Description
For PRs with only ignored changes, changed the Github check status sending logic to report success for all evergreen-specific branch protection rules, instead of just for `evergreen`.
### Testing
Configured sandbox to have 3 required checks:
- evergreen
- evergreen/evg
- evergreen/ubuntu2204-small

Confirmed that before this change, an ignored PR [only reports passed for evergreen](https://github.com/evergreen-ci/commit-queue-sandbox/pull/625), but after this change, an ignored PR [reports all checks as passed](https://github.com/evergreen-ci/commit-queue-sandbox/pull/632).
### Documentation
Slightly updated doc wording