### PR TITLE
DEVPROD-1943: do not use expired tokens for GitHub status sender

### DIFF
--- a/config.go
+++ b/config.go
@@ -442,6 +442,13 @@ func (settings *Settings) Validate() error {
 	return errors.WithStack(catcher.Resolve())
 }
 
+// GetSender returns the global application-wide loggers. These are special
+// universal loggers (distinct from other senders like the GitHub status sender
+// or email notification sender) and will be used when grip is invoked to log
+// messages in the application (e.g. grip.Info, grip.Error, etc). Because these
+// loggers are the main way to send logs in the application, these are essential
+// to monitoring the application and therefore have to be set up very early
+// during application startup.
 func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender, error) {
 	var (
 		sender   send.Sender

--- a/environment.go
+++ b/environment.go
@@ -1137,6 +1137,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	grip.Error(message.WrapError(e.setSenderErrorHandler(sender, owner), message.Fields{
 		"message": "could not set fallback error handler for GitHub status sender",
 		"owner":   owner,
+		"repo":    repo,
 	}))
 
 	e.githubSenders[owner] = cachedGitHubSender{

--- a/environment.go
+++ b/environment.go
@@ -229,7 +229,7 @@ func NewEnvironment(ctx context.Context, confPath string, db *DBSettings) (Envir
 
 	catcher.Add(e.initJasper())
 	catcher.Add(e.initDepot(ctx))
-	catcher.Add(e.initSenders(ctx))
+	catcher.Add(e.initThirdPartySenders(ctx))
 	catcher.Add(e.createLocalQueue(ctx))
 	catcher.Add(e.createRemoteQueues(ctx))
 	catcher.Add(e.createNotificationQueue(ctx))
@@ -702,11 +702,12 @@ func (e *envState) initClientConfig() {
 	}
 }
 
-// initSenders initializes the senders that are used to send payloads to
-// external services such as sending GitHub statuses and Jira messages. These
-// are meant to enable specific Evergreen behavior and are distinct from the
-// global application-wide logging system (see (*Settings).GetSender).
-func (e *envState) initSenders(ctx context.Context) error {
+// initThirdPartySenders initializes the senders that are used to send payloads
+// to external services such as sending GitHub statuses and Jira messages. These
+// are meant to enable specific Evergreen behaviors like notifications, and are
+// distinct from the global application-wide logging system (see
+// (*Settings).GetSender).
+func (e *envState) initThirdPartySenders(ctx context.Context) error {
 	if e.settings == nil {
 		return errors.New("no settings object, cannot build senders")
 	}

--- a/environment_test.go
+++ b/environment_test.go
@@ -130,17 +130,19 @@ func (s *EnvironmentSuite) TestInitSenders() {
 	defer cancel()
 
 	s.env.settings = &Settings{
-		Slack: SlackConfig{
-			Token: "token",
+		Notify: NotifyConfig{
+			SES: SESConfig{
+				SenderAddress: "sender_address",
+			},
 		},
 	}
 
 	s.Require().NoError(s.env.initSenders(ctx))
 
-	s.Require().Len(s.env.senders, 1)
-	sender, err := s.env.GetSender(SenderSlack)
-	s.Require().NoError(err, "Slack sender should be set up")
-	s.NotZero(sender.ErrorHandler(), "fallback error handler should be set")
+	s.Require().NotEmpty(s.env.senders, "should have set up at least one sender")
+	for _, sender := range s.env.senders {
+		s.NotZero(sender.ErrorHandler(), "fallback error handler should be set")
+	}
 }
 
 func (s *EnvironmentSuite) TestGetClientConfig() {

--- a/environment_test.go
+++ b/environment_test.go
@@ -137,7 +137,7 @@ func (s *EnvironmentSuite) TestInitSenders() {
 		},
 	}
 
-	s.Require().NoError(s.env.initSenders(ctx))
+	s.Require().NoError(s.env.initThirdPartySenders(ctx))
 
 	s.Require().NotEmpty(s.env.senders, "should have set up at least one sender")
 	for _, sender := range s.env.senders {

--- a/environment_test.go
+++ b/environment_test.go
@@ -125,6 +125,24 @@ func (s *EnvironmentSuite) TestConfigErrorsIfCannotValidateConfig() {
 	s.Contains(err.Error(), "validating settings")
 }
 
+func (s *EnvironmentSuite) TestInitSenders() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.env.settings = &Settings{
+		Slack: SlackConfig{
+			Token: "token",
+		},
+	}
+
+	s.Require().NoError(s.env.initSenders(ctx))
+
+	s.Require().Len(s.env.senders, 1)
+	sender, err := s.env.GetSender(SenderSlack)
+	s.Require().NoError(err, "Slack sender should be set up")
+	s.NotZero(sender.ErrorHandler(), "fallback error handler should be set")
+}
+
 func (s *EnvironmentSuite) TestGetClientConfig() {
 	root := filepath.Join(FindEvergreenHome(), ClientDirectory)
 	if err := os.Mkdir(root, os.ModeDir|os.ModePerm); err != nil {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -404,7 +404,7 @@ func TestGetGitHubSender(t *testing.T) {
 	defer cancel()
 
 	env := &mock.Environment{}
-	env.Configure(ctx)
+	require.NoError(t, env.Configure(ctx))
 	testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
 
 	sender, err := env.GetGitHubSender("evergreen-ci", "evergreen")

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -15,10 +15,12 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/google/go-github/v52/github"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -395,4 +397,17 @@ func TestGetRulesWithEvergreenPrefix(t *testing.T) {
 	assert.Len(t, rules, 2)
 	assert.Contains(t, rules, "evergreen")
 	assert.Contains(t, rules, "evergreen/foo")
+}
+
+func TestGetGitHubSender(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	env.Configure(ctx)
+	testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
+
+	sender, err := env.GetGitHubSender("evergreen-ci", "evergreen")
+	require.NoError(t, err)
+	assert.NotZero(t, sender.ErrorHandler, "fallback error handler should be set")
 }


### PR DESCRIPTION
DEVPROD-1943

### Description
Fixes two issues with the GitHub status sender:
* Ensure GitHub app tokens are refreshed well in advance of when they actually expire. GitHub senders are cached to reduce the amount of tokens requested, but the TTL is currently set to the same duration as the token's total lifetime (1 hour). This would cause very occasional flakes when using a token that's close to expiring. For example, if Evergreen is trying to send a GitHub status back to a PR but the sender it got back had a token that was going to expire in 1 millisecond, it would use the almost-expired sender, the token would expire, and GitHub would reject the request.
* The GitHub status sender didn't set the fallback error handler like the rest of the senders do, so it wouldn't send errors to Splunk. Any errors produced from sending to the `GetGitHubSender` sender should now appear in Splunk.
* Also added some docs for clarity around global logging/sender initialization in the env.

I'm gonna be monitoring after this is deployed to ensure that 1. GitHub app errors appear in Splunk and 2. the 401 bad credential errors for the `CreateStatus` requests go away.

### Testing
* Added unit tests for setting the fallback error handler.
  * The GitHub sender is awkwardly tested in the `thirdparty` package because `testutil.ConfigureIntegrationTest` can't be called from the root `evergreen` package. Didn't think it was worth it to move `ConfigureIntegrationTest` into the root package for a single use.
* Test in staging that patches can still get data from GitHub as per usual.

### Documentation
N/A