### PR TITLE
DEVPROD-983 Remove legacy GitHub app token usage

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -745,19 +745,10 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		// Otherwise, create an installation token for to clone the module.
 		// Fallback to the legacy global token if the token cannot be created.
 		appToken, err := comm.CreateInstallationToken(ctx, td, opts.owner, opts.repo)
-		if err == nil {
-			opts.token = appToken
-		} else {
-			// If a token cannot be created, fallback to the legacy global token.
-			opts.method = evergreen.CloneMethodOAuth
-			opts.token = conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion)
-			logger.Execution().Warning(message.WrapError(err, message.Fields{
-				"message": "failed to create app token, falling back to global token",
-				"ticket":  "EVG-19966",
-				"owner":   opts.owner,
-				"repo":    opts.repo,
-			}))
+		if err != nil {
+			return errors.Wrap(err, "failed to create app token")
 		}
+		opts.token = appToken
 	}
 
 	if err = opts.validate(); err != nil {

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -8,8 +8,6 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/testutil"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -22,12 +20,7 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 	}
 	appToken, err := settings.CreateInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
 	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"ticket":  "EVG-19966",
-			"message": "error creating GitHub app token",
-			"caller":  "MakeTaskConfigFromModelData",
-			"task":    data.Task.Id,
-		}))
+		return nil, errors.Wrap(err, "creating GitHub app token")
 	}
 	exp, err := model.PopulateExpansions(data.Task, data.Host, oauthToken, appToken)
 	if err != nil {

--- a/github_app.go
+++ b/github_app.go
@@ -10,8 +10,6 @@ import (
 	"github.com/golang-jwt/jwt"
 	"github.com/google/go-github/v52/github"
 	"github.com/mongodb/anser/bsonutil"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -87,12 +85,7 @@ func (s *Settings) HasGitHubApp(ctx context.Context, owner, repo string) (bool, 
 // It will use the default owner/repo specified in the admin settings and error if it's not set.
 func (s *Settings) CreateInstallationTokenWithDefaultOwnerRepo(ctx context.Context, opts *github.InstallationTokenOptions) (string, error) {
 	if s.AuthConfig.Github == nil || s.AuthConfig.Github.DefaultOwner == "" || s.AuthConfig.Github.DefaultRepo == "" {
-		// TODO EVG-19966: Return error here
-		grip.Debug(message.Fields{
-			"message": "no default owner/repo",
-			"ticket":  "EVG-19966",
-		})
-		return "", nil
+		return "", errors.New("no default owner/repo")
 	}
 	return s.CreateInstallationToken(ctx, s.AuthConfig.Github.DefaultOwner, s.AuthConfig.Github.DefaultRepo, opts)
 }
@@ -237,13 +230,6 @@ func getInstallationIDFromGitHub(ctx context.Context, authFields *githubAppAuth,
 		if resp.StatusCode == http.StatusNotFound {
 			return 0, errors.Wrapf(gitHubAppNotInstalledError, "installation id for '%s/%s' not found", owner, repo)
 		}
-		grip.Debug(message.WrapError(err, message.Fields{
-			"message": "error finding installation id",
-			"owner":   owner,
-			"repo":    repo,
-			"appId":   authFields.appId,
-			"ticket":  "EVG-19966",
-		}))
 		return 0, errors.Wrapf(err, "finding installation id for '%s/%s'", owner, repo)
 	}
 	if installation == nil {

--- a/globals.go
+++ b/globals.go
@@ -334,7 +334,7 @@ const (
 
 	DefaultJasperPort = 2385
 
-	// TODO EVG-19966: Remove GlobalGitHubTokenExpansion
+	// TODO DEVPROD-778: Remove GlobalGitHubTokenExpansion
 	GlobalGitHubTokenExpansion = "global_github_oauth_token"
 	GithubAppToken             = "github_app_token"
 	GithubAppPrivateKey        = "github_app_key"

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -193,14 +193,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 
 	appToken, err := settings.CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"ticket":  "EVG-19966",
-			"message": "error creating GitHub app token",
-			"caller":  "makeProjectAndExpansionsFromTask",
-			"owner":   pRef.Owner,
-			"repo":    pRef.Repo,
-			"task":    t.Id,
-		}))
+		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}
 
 	expansions, err := model.PopulateExpansions(t, h, oauthToken, appToken)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -449,14 +449,10 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 
 	appToken, err := h.settings.CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
-		grip.Debug(message.WrapError(err, message.Fields{
-			"ticket":  "EVG-19966",
-			"message": "error creating GitHub app token",
-			"caller":  "getExpansionsAndVarsHandler",
-			"owner":   pRef.Owner,
-			"repo":    pRef.Repo,
-			"task":    t.Id,
-		}))
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    fmt.Sprintf("creating token for %s/%s failed", pRef.Owner, pRef.Repo),
+		})
 	}
 
 	e, err := model.PopulateExpansions(t, foundHost, oauthToken, appToken)


### PR DESCRIPTION
DEVPROD-983

### Description
This removes the previously added TODO EVG-19966 and related logging. It does not touch thirdparty/github.go and it moves one comment of removing the token expansion to that ticket since thirdparty/github.go uses that token expansion a lot.

### Testing
Existing unit tests and some manual testing. TBA some more tests pending review