### PR TITLE
DEVPROD-782: Add adminOnly distro field

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -250,6 +250,7 @@ type ComplexityRoot struct {
 	}
 
 	Distro struct {
+		AdminOnly             func(childComplexity int) int
 		Aliases               func(childComplexity int) int
 		Arch                  func(childComplexity int) int
 		AuthorizedKeysFile    func(childComplexity int) int
@@ -2577,6 +2578,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DispatcherSettings.Version(childComplexity), true
+
+	case "Distro.adminOnly":
+		if e.complexity.Distro.AdminOnly == nil {
+			break
+		}
+
+		return e.complexity.Distro.AdminOnly(childComplexity), true
 
 	case "Distro.aliases":
 		if e.complexity.Distro.Aliases == nil {
@@ -15953,6 +15961,50 @@ func (ec *executionContext) fieldContext_DispatcherSettings_version(ctx context.
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type DispatcherVersion does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Distro_adminOnly(ctx context.Context, field graphql.CollectedField, obj *model.APIDistro) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Distro_adminOnly(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AdminOnly, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Distro_adminOnly(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Distro",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -42453,6 +42505,8 @@ func (ec *executionContext) fieldContext_Query_distro(ctx context.Context, field
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "adminOnly":
+				return ec.fieldContext_Distro_adminOnly(ctx, field)
 			case "aliases":
 				return ec.fieldContext_Distro_aliases(ctx, field)
 			case "arch":
@@ -42631,6 +42685,8 @@ func (ec *executionContext) fieldContext_Query_distros(ctx context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "adminOnly":
+				return ec.fieldContext_Distro_adminOnly(ctx, field)
 			case "aliases":
 				return ec.fieldContext_Distro_aliases(ctx, field)
 			case "arch":
@@ -48366,6 +48422,8 @@ func (ec *executionContext) fieldContext_SaveDistroPayload_distro(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "adminOnly":
+				return ec.fieldContext_Distro_adminOnly(ctx, field)
 			case "aliases":
 				return ec.fieldContext_Distro_aliases(ctx, field)
 			case "arch":
@@ -66964,13 +67022,20 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "cloneMethod", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "isCluster", "isVirtualWorkStation", "name", "note", "plannerSettings", "provider", "providerSettingsList", "setup", "setupAsSudo", "sshKey", "sshOptions", "user", "userSpawnAllowed", "validProjects", "workDir", "mountpoints"}
+	fieldsInOrder := [...]string{"adminOnly", "aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "cloneMethod", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "isCluster", "isVirtualWorkStation", "name", "note", "plannerSettings", "provider", "providerSettingsList", "setup", "setupAsSudo", "sshKey", "sshOptions", "user", "userSpawnAllowed", "validProjects", "workDir", "mountpoints"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "adminOnly":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("adminOnly"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AdminOnly = data
 		case "aliases":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("aliases"))
 			data, err := ec.unmarshalNString2ᚕstringᚄ(ctx, v)
@@ -72152,6 +72217,11 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Distro")
+		case "adminOnly":
+			out.Values[i] = ec._Distro_adminOnly(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "aliases":
 			out.Values[i] = ec._Distro_aliases(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -128,6 +128,10 @@ input SaveDistroInput {
 }
 
 input DistroInput {
+  """
+  TODO: require adminOnly field upon completion of DEVPROD-3533
+  """
+  adminOnly: Boolean
   aliases: [String!]!
   arch: Arch!
   authorizedKeysFile: String!
@@ -278,6 +282,7 @@ type SaveDistroPayload {
 Distro models an environment configuration for a host.
 """
 type Distro {
+  adminOnly: Boolean!
   aliases: [String!]!
   arch: Arch!
   authorizedKeysFile: String!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -4,6 +4,7 @@ mutation {
         distro: {
           name: "fake"
 
+          adminOnly: false,
           aliases: [
             "new-alias"
           ],

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -3,6 +3,7 @@ mutation {
       opts: {
         distro: {
           name: "rhel71-power8-large"
+          adminOnly: true,
           aliases: [
             "new-alias"
           ],
@@ -120,6 +121,7 @@ mutation {
     ) 
     {
       distro {
+        adminOnly
         aliases
         cloneMethod
         disableShallowClone

--- a/graphql/tests/mutation/saveDistro/results.json
+++ b/graphql/tests/mutation/saveDistro/results.json
@@ -6,6 +6,7 @@
         "data": {
           "saveDistro": {
             "distro": {
+              "adminOnly": true,
               "aliases": [
                 "new-alias"
               ],

--- a/graphql/tests/query/distros/queries/distro.graphql
+++ b/graphql/tests/query/distros/queries/distro.graphql
@@ -1,5 +1,6 @@
 query {
   distro(distroId: "rhel71-power8-large") {
+    adminOnly
     bootstrapSettings {
       communication
       resourceLimits {

--- a/graphql/tests/query/distros/results.json
+++ b/graphql/tests/query/distros/results.json
@@ -5,6 +5,7 @@
             "result": {
                 "data": {
                     "distro": {
+                        "adminOnly": false,
                         "bootstrapSettings": {
                             "communication": "LEGACY_SSH",
                             "resourceLimits": {

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -25,6 +25,7 @@ import (
 
 type Distro struct {
 	Id                    string                `bson:"_id" json:"_id,omitempty" mapstructure:"_id,omitempty"`
+	AdminOnly             bool                  `bson:"admin_only,omitempty" json:"admin_only,omitempty" mapstructure:"admin_only,omitempty"`
 	Aliases               []string              `bson:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases,omitempty"`
 	Arch                  string                `bson:"arch" json:"arch,omitempty" mapstructure:"arch,omitempty"`
 	WorkDir               string                `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -340,6 +340,7 @@ func (s *APIIceCreamSettings) ToService() distro.IceCreamSettings {
 
 type APIDistro struct {
 	Name                  *string                  `json:"name"`
+	AdminOnly             bool                     `json:"admin_only"`
 	Aliases               []string                 `json:"aliases"`
 	UserSpawnAllowed      bool                     `json:"user_spawn_allowed"`
 	Provider              *string                  `json:"provider"`
@@ -374,6 +375,7 @@ type APIDistro struct {
 // BuildFromService converts from service level distro.Distro to an APIDistro
 func (apiDistro *APIDistro) BuildFromService(d distro.Distro) {
 	apiDistro.Name = utility.ToStringPtr(d.Id)
+	apiDistro.AdminOnly = d.AdminOnly
 	apiDistro.Aliases = d.Aliases
 	apiDistro.UserSpawnAllowed = d.SpawnAllowed
 	apiDistro.Provider = utility.ToStringPtr(d.Provider)
@@ -440,6 +442,7 @@ func (apiDistro *APIDistro) BuildFromService(d distro.Distro) {
 func (apiDistro *APIDistro) ToService() *distro.Distro {
 	d := distro.Distro{}
 	d.Id = utility.FromStringPtr(apiDistro.Name)
+	d.AdminOnly = apiDistro.AdminOnly
 	d.Aliases = apiDistro.Aliases
 	d.Arch = utility.FromStringPtr(apiDistro.Arch)
 	d.WorkDir = utility.FromStringPtr(apiDistro.WorkDir)


### PR DESCRIPTION
DEVPROD-782

### Description
- Add boolean field indicating distro is admin-only. Linked tickets will add this field to distro settings and hide it from user-facing menus across Spruce.

### Testing
- Updated unit tests

### Documentation
N/A