### PR TITLE
DEVPROD-3615 fix test-thirdparty on Ubuntu 22.04

### DIFF
--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -269,7 +269,7 @@ func (s *githubSuite) TestGetPullRequestMergeBase() {
 }
 
 func (s *githubSuite) TestGithubUserInOrganization() {
-	isMember, err := GithubUserInOrganization(s.ctx, s.token, "evergreen-ci", "evrg-bot-webhook")
+	isMember, err := GithubUserInOrganization(s.ctx, s.token, "evergreen-ci", "malikchaya2")
 	s.NoError(err)
 	s.True(isMember)
 

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -269,11 +269,7 @@ func (s *githubSuite) TestGetPullRequestMergeBase() {
 }
 
 func (s *githubSuite) TestGithubUserInOrganization() {
-	isMember, err := GithubUserInOrganization(s.ctx, s.token, "evergreen-ci", "malikchaya2")
-	s.NoError(err)
-	s.True(isMember)
-
-	isMember, err = GithubUserInOrganization(s.ctx, s.token, "evergreen-ci", "octocat")
+	isMember, err := GithubUserInOrganization(s.ctx, s.token, "evergreen-ci", "octocat")
 	s.NoError(err)
 	s.False(isMember)
 }


### PR DESCRIPTION
DEVPROD-3615

### Description
This fix uses a user that is in the organization. An argument can also be made to remove this test now. More information in the ticket. 

### Testing
The test itself. 
