### PR TITLE
DEVPROD-2717: Merge logs deterministically

### DIFF
--- a/graphql/tests/task/taskLogs/results.json
+++ b/graphql/tests/task/taskLogs/results.json
@@ -11,7 +11,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2024-01-01T00:00:01-05:00",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
                   "version": 0
                 }
               ],
@@ -61,14 +61,14 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2024-01-01T00:00:02-05:00",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2024-01-01T00:00:03-05:00",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
                   "version": 0
                 }
               ],
@@ -77,7 +77,7 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2024-01-01T00:00:00-05:00",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
                   "version": 0
                 }
               ],
@@ -86,28 +86,28 @@
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]                    ^",
-                  "timestamp": "2024-01-01T00:00:00-05:00",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac]     protected void finalize() {",
-                  "timestamp": "2024-01-01T00:00:01-05:00",
+                  "timestamp": "2019-12-07T13:31:19.393-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "    [javac] 9 warnings",
-                  "timestamp": "2024-01-01T00:00:02-05:00",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
                   "version": 0
                 },
                 {
                   "type": "",
                   "severity": "I",
                   "message": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar",
-                  "timestamp": "2024-01-01T00:00:03-05:00",
+                  "timestamp": "2019-12-07T13:31:19.637-05:00",
                   "version": 0
                 }
               ]

--- a/graphql/tests/task/taskLogs/task_output_data.json
+++ b/graphql/tests/task/taskLogs/task_output_data.json
@@ -7,7 +7,7 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1704085200000000000,
+          "timestamp": 1575743479393000000,
           "data": "    [javac]                    ^"
         }
       ]
@@ -19,12 +19,12 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1704085202000000000,
+          "timestamp": 1575743479637000000,
           "data": "    [javac] 9 warnings"
         },
         {
           "priority": 40,
-          "timestamp": 1704085203000000000,
+          "timestamp": 1575743479637000000,
           "data": "      [jar] Building MANIFEST-only jar: C:\\data\\mci\\fd27d777b88be249b1059d842a975a6d\\mms\\server\\build\\classpath.all.jar"
         }
       ]
@@ -36,7 +36,7 @@
       "lines": [
         {
           "priority": 40,
-          "timestamp": 1704085201000000000,
+          "timestamp": 1575743479393000000,
           "data": "    [javac]     protected void finalize() {"
         }
       ]

--- a/model/log/basic_iterator.go
+++ b/model/log/basic_iterator.go
@@ -1,0 +1,44 @@
+package log
+
+type basicIterator struct {
+	i      int
+	items  []LogLine
+	closed bool
+}
+
+// newBasicIterator returns a LogIterator that iterates over in-memory log
+// lines.
+func newBasicIterator(items []LogLine) *basicIterator {
+	return &basicIterator{
+		i:     -1,
+		items: items,
+	}
+}
+
+func (it *basicIterator) Next() bool {
+	if it.closed || it.Exhausted() {
+		return false
+	}
+
+	it.i++
+
+	return true
+}
+
+func (it *basicIterator) Item() LogLine {
+	if len(it.items) > 0 {
+		return it.items[it.i]
+	}
+
+	return LogLine{}
+}
+
+func (it *basicIterator) Exhausted() bool { return it.i == len(it.items)-1 }
+
+func (*basicIterator) Err() error { return nil }
+
+func (it *basicIterator) Close() error {
+	it.closed = true
+
+	return nil
+}

--- a/model/log/basic_iterator.go
+++ b/model/log/basic_iterator.go
@@ -1,39 +1,44 @@
 package log
 
 type basicIterator struct {
-	i      int
-	items  []LogLine
-	closed bool
+	idx       int
+	items     []LogLine
+	exhausted bool
+	closed    bool
 }
 
 // newBasicIterator returns a LogIterator that iterates over in-memory log
 // lines.
 func newBasicIterator(items []LogLine) *basicIterator {
 	return &basicIterator{
-		i:     -1,
+		idx:   -1,
 		items: items,
 	}
 }
 
 func (it *basicIterator) Next() bool {
-	if it.closed || it.Exhausted() {
+	if it.exhausted || it.closed {
 		return false
 	}
 
-	it.i++
+	if it.idx == len(it.items)-1 {
+		it.exhausted = true
+		return false
+	}
+	it.idx++
 
 	return true
 }
 
 func (it *basicIterator) Item() LogLine {
-	if len(it.items) > 0 {
-		return it.items[it.i]
+	if len(it.items) > 0 && it.idx >= 0 {
+		return it.items[it.idx]
 	}
 
 	return LogLine{}
 }
 
-func (it *basicIterator) Exhausted() bool { return it.i == len(it.items)-1 }
+func (it *basicIterator) Exhausted() bool { return it.exhausted }
 
 func (*basicIterator) Err() error { return nil }
 

--- a/model/log/chunk.go
+++ b/model/log/chunk.go
@@ -1,0 +1,21 @@
+package log
+
+// A chunk is a storage abstraction representing a sequential, continuous
+// section of a single log. Logs can be coherently represented by a set of
+// ordered chunks.
+
+// chunkInfo represents a log chunk file's metadata that enables optimized
+// fetching of log files stored as a set of chunks in pail-backed bucket
+// storage.
+type chunkInfo struct {
+	key      string
+	numLines int
+	start    int64
+	end      int64
+}
+
+// chunkGroup represents a set of chunks belonging to a single log.
+type chunkGroup struct {
+	name   string
+	chunks []chunkInfo
+}

--- a/model/log/chunk_iterator.go
+++ b/model/log/chunk_iterator.go
@@ -12,13 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type chunkInfo struct {
-	key      string
-	numLines int
-	start    int64
-	end      int64
-}
-
 type chunkIterator struct {
 	opts           chunkIteratorOptions
 	lineOffset     int

--- a/model/log/iterator_interface.go
+++ b/model/log/iterator_interface.go
@@ -29,17 +29,17 @@ type LogIterator interface {
 // Only call this function with log iterators that do not support tailing
 // natively.
 func newTailIterator(it LogIterator, n int) (*basicIterator, error) {
-	tailIt := &basicIterator{}
-	catcher := grip.NewBasicCatcher()
+	var items []LogLine
 	for it.Next() {
-		tailIt.items = append(tailIt.items, it.Item())
+		items = append(items, it.Item())
 	}
+	catcher := grip.NewBasicCatcher()
 	catcher.Add(it.Err())
 	catcher.Add(it.Close())
 
-	if len(tailIt.items) > n {
-		tailIt.items = tailIt.items[len(tailIt.items)-n-1:]
+	if len(items) > n {
+		items = items[len(items)-n:]
 	}
 
-	return tailIt, errors.Wrap(catcher.Resolve(), "creating new log tail iterator")
+	return newBasicIterator(items), errors.Wrap(catcher.Resolve(), "creating new log tail iterator")
 }

--- a/model/log/iterator_interface.go
+++ b/model/log/iterator_interface.go
@@ -1,5 +1,10 @@
 package log
 
+import (
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
 // LogIterator is an interface that enables iterating over lines of Evergreen
 // logs.
 type LogIterator interface {
@@ -16,4 +21,25 @@ type LogIterator interface {
 	// Close closes the iterator. This function should be called once the
 	// iterator is no longer needed.
 	Close() error
+}
+
+// newTailIterator converts a log iterator into a basic iterator that reads the
+// the last N lines of the merged logs.
+//
+// Only call this function with log iterators that do not support tailing
+// natively.
+func newTailIterator(it LogIterator, n int) (*basicIterator, error) {
+	tailIt := &basicIterator{}
+	catcher := grip.NewBasicCatcher()
+	for it.Next() {
+		tailIt.items = append(tailIt.items, it.Item())
+	}
+	catcher.Add(it.Err())
+	catcher.Add(it.Close())
+
+	if len(tailIt.items) > n {
+		tailIt.items = tailIt.items[len(tailIt.items)-n-1:]
+	}
+
+	return tailIt, errors.Wrap(catcher.Resolve(), "creating new log tail iterator")
 }

--- a/model/log/iterator_test.go
+++ b/model/log/iterator_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"math/rand"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -125,30 +126,29 @@ func TestChunkIterator(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, test := range []struct {
-		name string
-		opts chunkIteratorOptions
-		test func(*testing.T, *chunkIterator)
+		name          string
+		opts          chunkIteratorOptions
+		expectedLines []LogLine
+		hasErr        bool
 	}{
 		{
 			name: "CorruptData",
 			opts: chunkIteratorOptions{
 				bucket: bucket,
-				chunks: chunks,
+				chunks: append(
+					[]chunkInfo{
+						{
+							key:      chunks[0].key,
+							numLines: chunks[0].numLines - 1,
+							start:    chunks[0].start,
+							end:      chunks[0].end,
+						},
+					},
+					chunks[1:len(chunks)-1]...,
+				),
 				parser: parser,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				chunks[0].numLines--
-				defer func() {
-					chunks[0].numLines++
-				}()
-
-				for it.Next() {
-					// Exhaust.
-				}
-				assert.False(t, it.Exhausted())
-				assert.Error(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			hasErr: true,
 		},
 		{
 			name: "ParsingError",
@@ -157,12 +157,7 @@ func TestChunkIterator(t *testing.T) {
 				chunks: chunks,
 				parser: func(_ string) (LogLine, error) { return LogLine{}, errors.New("parsing error") },
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				assert.False(t, it.Next())
-				assert.False(t, it.Exhausted())
-				assert.Error(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			hasErr: true,
 		},
 		{
 			name: "GetChunkError",
@@ -178,12 +173,7 @@ func TestChunkIterator(t *testing.T) {
 				},
 				parser: parser,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				assert.False(t, it.Next())
-				assert.False(t, it.Exhausted())
-				assert.Error(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			hasErr: true,
 		},
 		{
 			name: "SingleChunk",
@@ -192,17 +182,7 @@ func TestChunkIterator(t *testing.T) {
 				chunks: append([]chunkInfo{}, chunks[0]),
 				parser: parser,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				var count int
-				for it.Next() {
-					require.Less(t, count, len(lines))
-					require.Equal(t, lines[count], it.Item())
-					count++
-				}
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[:chunks[0].numLines],
 		},
 		{
 			name: "Start",
@@ -212,19 +192,7 @@ func TestChunkIterator(t *testing.T) {
 				parser: parser,
 				start:  &chunks[1].start,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				offset := chunks[0].numLines
-				var count int
-				for it.Next() {
-					require.Less(t, count+offset, len(lines))
-					require.Equal(t, lines[count+offset], it.Item())
-					count++
-				}
-				assert.Equal(t, len(lines)-chunks[0].numLines, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[chunks[0].numLines:],
 		},
 		{
 			name: "End",
@@ -234,18 +202,7 @@ func TestChunkIterator(t *testing.T) {
 				parser: parser,
 				end:    &chunks[1].start,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				var count int
-				for it.Next() {
-					require.Less(t, count, len(lines))
-					require.Equal(t, lines[count], it.Item())
-					count++
-				}
-				assert.Equal(t, chunks[0].numLines+1, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[:chunks[0].numLines+1],
 		},
 		{
 			name: "StartAndEnd",
@@ -256,62 +213,67 @@ func TestChunkIterator(t *testing.T) {
 				start:  &chunks[1].start,
 				end:    utility.ToInt64Ptr(chunks[len(chunks)-1].end - int64(time.Millisecond)),
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				offset := chunks[0].numLines
-				var count int
-				for it.Next() {
-					require.Less(t, count+offset, len(lines))
-					require.Equal(t, lines[count+offset], it.Item())
-					count++
-				}
-				assert.Equal(t, len(lines)-chunks[0].numLines-1, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[chunks[0].numLines : len(lines)-1],
 		},
 		{
-			name: "LineLimit",
+			name: "LineLimitLessThanLineCount",
 			opts: chunkIteratorOptions{
 				bucket:    bucket,
 				chunks:    chunks,
 				parser:    parser,
 				lineLimit: 35,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				var count int
-				for it.Next() {
-					require.Less(t, count, len(lines))
-					require.Equal(t, lines[count], it.Item())
-					count++
-				}
-				assert.Equal(t, 35, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[:35],
 		},
 		{
-			name: "TailN",
+			name: "LineLimitEqualToLineCount",
+			opts: chunkIteratorOptions{
+				bucket:    bucket,
+				chunks:    chunks,
+				parser:    parser,
+				lineLimit: len(lines),
+			},
+			expectedLines: lines,
+		},
+		{
+			name: "LineLimitGreaterThanLineCount",
+			opts: chunkIteratorOptions{
+				bucket:    bucket,
+				chunks:    chunks,
+				parser:    parser,
+				lineLimit: len(lines),
+			},
+			expectedLines: lines,
+		},
+		{
+			name: "TailNLessThanLineCount",
 			opts: chunkIteratorOptions{
 				bucket: bucket,
 				chunks: chunks,
 				parser: parser,
 				tailN:  20,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				offset := len(lines) - 20
-				var count int
-				for it.Next() {
-					require.Less(t, count+offset, len(lines))
-					require.Equal(t, lines[count+offset], it.Item())
-					count++
-				}
-				assert.Equal(t, 20, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
+			expectedLines: lines[len(lines)-20:],
+		},
+		{
+			name: "TailNEqualToLineCount",
+			opts: chunkIteratorOptions{
+				bucket: bucket,
+				chunks: chunks,
+				parser: parser,
+				tailN:  len(lines),
 			},
+			expectedLines: lines,
+		},
+		{
+			name: "TailNGreaterThanLineCount",
+			opts: chunkIteratorOptions{
+				bucket: bucket,
+				chunks: chunks,
+				parser: parser,
+				tailN:  2 * len(lines),
+			},
+			expectedLines: lines,
 		},
 		{
 			name: "StartEndLineLimitTailN",
@@ -324,23 +286,28 @@ func TestChunkIterator(t *testing.T) {
 				lineLimit: 5,
 				tailN:     20,
 			},
-			test: func(t *testing.T, it *chunkIterator) {
-				offset := chunks[0].numLines + chunks[1].numLines - 20
-				var count int
-				for it.Next() {
-					require.Less(t, count+offset, len(lines))
-					require.Equal(t, lines[count+offset], it.Item())
-					count++
-				}
-				assert.Equal(t, 5, count)
-				assert.True(t, it.Exhausted())
-				assert.NoError(t, it.Err())
-				assert.NoError(t, it.Close())
-			},
+			expectedLines: lines[chunks[0].numLines+chunks[1].numLines-20 : chunks[0].numLines+chunks[1].numLines-15],
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			test.test(t, newChunkIterator(ctx, test.opts))
+			it := newChunkIterator(ctx, test.opts)
+			assert.False(t, it.Exhausted())
+
+			var actualLines []LogLine
+			for it.Next() {
+				actualLines = append(actualLines, it.Item())
+			}
+
+			if test.hasErr {
+				assert.False(t, it.Exhausted())
+				assert.Error(t, it.Err())
+				assert.NoError(t, it.Close())
+			} else {
+				require.NoError(t, it.Err())
+				assert.True(t, it.Exhausted())
+				assert.NoError(t, it.Close())
+				assert.Equal(t, test.expectedLines, actualLines)
+			}
 		})
 	}
 }
@@ -349,155 +316,173 @@ func TestMergingIterator(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	t.Run("SingleLog", func(t *testing.T) {
-		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
-		require.NoError(t, err)
-		chunks, lines, parser, err := generateTestLog(ctx, bucket, 100, 10)
-		require.NoError(t, err)
-		it := newMergingIterator(0, newChunkIterator(ctx, chunkIteratorOptions{
-			bucket: bucket,
-			chunks: chunks,
-			parser: parser,
-		}))
+	bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+	require.NoError(t, err)
 
-		var count int
-		for it.Next() {
-			require.Less(t, count, len(lines))
-			require.Equal(t, lines[count], it.Item())
-			count++
-		}
-		assert.Equal(t, len(lines), count)
-		assert.NoError(t, it.Err())
-		assert.NoError(t, it.Close())
+	logs := make([][]LogLine, 2)
+	var mergedLines []LogLine
+	for i := 0; i < 2; i++ {
+		_, lines, _, err := generateTestLog(ctx, nil, 100, 10)
+		require.NoError(t, err)
+
+		logs[i] = lines
+		mergedLines = append(mergedLines, lines...)
+	}
+	sort.SliceStable(mergedLines, func(i, j int) bool {
+		return mergedLines[i].Timestamp < mergedLines[j].Timestamp
 	})
-	t.Run("MultipleLogs", func(t *testing.T) {
-		numLogs := 10
-		its := make([]LogIterator, numLogs)
-		lineMap := map[string]bool{}
-		for i := 0; i < numLogs; i++ {
-			bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
-			require.NoError(t, err)
-			chunks, lines, parser, err := generateTestLog(ctx, bucket, 100, 10)
-			require.NoError(t, err)
-			its[i] = newChunkIterator(ctx, chunkIteratorOptions{
-				bucket: bucket,
-				chunks: chunks,
-				parser: parser,
-			})
-			for _, line := range lines {
-				lineMap[line.Data] = false
+
+	generateIterators := func(logs ...[]LogLine) []LogIterator {
+		its := make([]LogIterator, len(logs))
+		for i := 0; i < len(logs); i++ {
+			its[i] = newBasicIterator(logs[i])
+		}
+
+		return its
+	}
+
+	for _, test := range []struct {
+		name          string
+		lineLimit     int
+		its           []LogIterator
+		expectedLines []LogLine
+		hasErr        bool
+	}{
+		{
+			name: "InitError",
+			its: func() []LogIterator {
+				chunks, _, _, err := generateTestLog(ctx, bucket, 100, 10)
+				require.NoError(t, err)
+				it := newChunkIterator(ctx, chunkIteratorOptions{
+					bucket: bucket,
+					chunks: chunks,
+					parser: func(_ string) (LogLine, error) { return LogLine{}, errors.New("parsing error") },
+				})
+
+				return append(generateIterators(logs...), it)
+			}(),
+			hasErr: true,
+		},
+		{
+			name: "NextError",
+			its: func() []LogIterator {
+				chunks, _, parser, err := generateTestLog(ctx, bucket, 100, 10)
+				require.NoError(t, err)
+				chunks[0].numLines--
+				it := newChunkIterator(ctx, chunkIteratorOptions{
+					bucket: bucket,
+					chunks: chunks,
+					parser: parser,
+				})
+
+				return append(generateIterators(logs...), it)
+			}(),
+			hasErr: true,
+		},
+		{
+			name:          "SingleLog",
+			its:           generateIterators(logs[0]),
+			expectedLines: logs[0],
+		},
+		{
+			name:          "MultipleLogs",
+			its:           generateIterators(logs...),
+			expectedLines: mergedLines,
+		},
+		{
+			name:          "LineLimitLessThanLineCount",
+			lineLimit:     10,
+			its:           generateIterators(logs...),
+			expectedLines: mergedLines[:10],
+		},
+		{
+			name:          "LineLimitEqualToLineCount",
+			lineLimit:     len(mergedLines),
+			its:           generateIterators(logs...),
+			expectedLines: mergedLines,
+		},
+		{
+			name:          "LineLimitGreaterThanLineCount",
+			lineLimit:     2 * len(mergedLines),
+			its:           generateIterators(logs...),
+			expectedLines: mergedLines,
+		},
+		{
+			name: "SomeExhausted",
+			its: func() []LogIterator {
+				its := generateIterators(logs[0], logs[1])
+				for its[0].Next() {
+					// Exhaust.
+				}
+
+				return its
+			}(),
+			expectedLines: logs[1],
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			it := newMergingIterator(test.lineLimit, test.its...)
+			assert.False(t, it.Exhausted())
+
+			var actualLines []LogLine
+			for it.Next() {
+				actualLines = append(actualLines, it.Item())
 			}
-		}
-		it := newMergingIterator(0, its...)
 
-		var (
-			count         int
-			lastTimestamp int64
-		)
-		for it.Next() {
-			logLine := it.Item()
-			require.LessOrEqual(t, lastTimestamp, logLine.Timestamp)
-			seen, ok := lineMap[logLine.Data]
-			require.True(t, ok)
-			require.False(t, seen)
-
-			lineMap[logLine.Data] = true
-			lastTimestamp = logLine.Timestamp
-			count++
-		}
-		assert.Len(t, lineMap, count)
-		assert.NoError(t, it.Err())
-		assert.NoError(t, it.Close())
-	})
-	t.Run("LineLimit", func(t *testing.T) {
-		numLogs := 10
-		its := make([]LogIterator, numLogs)
-		lineMap := map[string]bool{}
-		for i := 0; i < numLogs; i++ {
-			bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
-			require.NoError(t, err)
-			chunks, lines, parser, err := generateTestLog(ctx, bucket, 100, 10)
-			require.NoError(t, err)
-			its[i] = newChunkIterator(ctx, chunkIteratorOptions{
-				bucket: bucket,
-				chunks: chunks,
-				parser: parser,
-			})
-			for _, line := range lines {
-				lineMap[line.Data] = false
+			if test.hasErr {
+				assert.False(t, it.Exhausted())
+				assert.Error(t, it.Err())
+				assert.NoError(t, it.Close())
+			} else {
+				require.NoError(t, it.Err())
+				assert.True(t, it.Exhausted())
+				assert.NoError(t, it.Close())
+				assert.Equal(t, test.expectedLines, actualLines)
 			}
-		}
-		it := newMergingIterator(101, its...)
-
-		var (
-			count         int
-			lastTimestamp int64
-		)
-		for it.Next() {
-			logLine := it.Item()
-			require.LessOrEqual(t, lastTimestamp, logLine.Timestamp)
-			seen, ok := lineMap[logLine.Data]
-			require.True(t, ok)
-			require.False(t, seen)
-
-			lineMap[logLine.Data] = true
-			lastTimestamp = logLine.Timestamp
-			count++
-		}
-		assert.Equal(t, 101, count)
-		assert.NoError(t, it.Err())
-		assert.NoError(t, it.Close())
-	})
-	t.Run("SomeExhausted", func(t *testing.T) {
-		bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
-		require.NoError(t, err)
-		chunks, _, parser, err := generateTestLog(ctx, bucket, 100, 10)
-		require.NoError(t, err)
-
-		it0 := newChunkIterator(ctx, chunkIteratorOptions{
-			bucket: bucket,
-			chunks: chunks,
-			parser: parser,
 		})
-		it1 := newChunkIterator(ctx, chunkIteratorOptions{
-			bucket: bucket,
-			chunks: chunks,
-			parser: parser,
-		})
-
-		for it1.Next() {
-			// Exhaust.
-		}
-		require.True(t, it1.Exhausted())
-		require.NoError(t, it1.Err())
-
-		it := newMergingIterator(0, it0, it1)
-		assert.False(t, it.Exhausted())
-		for it.Next() {
-			// Exhaust.
-		}
-		assert.True(t, it.Exhausted())
-		assert.NoError(t, it.Err())
-		assert.NoError(t, it.Close())
-		assert.NoError(t, it1.Close())
-	})
+	}
 }
 
 func TestNewTailIterator(t *testing.T) {
 	_, lines, _, err := generateTestLog(context.TODO(), nil, 100, 10)
 	require.NoError(t, err)
 
-	it, err := newTailIterator(&basicIterator{items: lines}, 22)
-	require.NoError(t, err)
+	for _, test := range []struct {
+		name          string
+		n             int
+		expectedLines []LogLine
+	}{
+		{
+			name:          "TailLessThanTotalLineCount",
+			n:             22,
+			expectedLines: lines[len(lines)-22:],
+		},
+		{
+			name:          "TailEqualToTotalLineCount",
+			n:             len(lines),
+			expectedLines: lines,
+		},
+		{
+			name:          "TailGreaterThanTotalLineCount",
+			n:             2 * len(lines),
+			expectedLines: lines,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			it, err := newTailIterator(newBasicIterator(lines), test.n)
+			require.NoError(t, err)
+			assert.False(t, it.Exhausted())
 
-	var actualLines []LogLine
-	for it.Next() {
-		actualLines = append(actualLines, it.Item())
+			var actualLines []LogLine
+			for it.Next() {
+				actualLines = append(actualLines, it.Item())
+			}
+			require.NoError(t, it.Err())
+			assert.NoError(t, it.Close())
+
+			assert.Equal(t, test.expectedLines, actualLines)
+		})
 	}
-	require.NoError(t, it.Err())
-	assert.NoError(t, it.Close())
-
-	assert.Equal(t, lines[len(lines)-22:], actualLines)
 }
 
 // generateTestLog is a convenience function to generate random logs with 100

--- a/model/log/merging_iterator.go
+++ b/model/log/merging_iterator.go
@@ -8,17 +8,21 @@ import (
 
 type mergingIterator struct {
 	iterators    []LogIterator
+	lineLimit    int
+	lineCount    int
 	iteratorHeap *logIteratorHeap
 	currentItem  LogLine
 	catcher      grip.Catcher
 	started      bool
+	exhausted    bool
 }
 
 // newMergeIterator returns a LogIterator that merges N logs, passed in as
 // iterators, respecting the order of each line's timestamp.
-func newMergingIterator(iterators ...LogIterator) *mergingIterator {
+func newMergingIterator(lineLimit int, iterators ...LogIterator) *mergingIterator {
 	return &mergingIterator{
 		iterators:    iterators,
+		lineLimit:    lineLimit,
 		iteratorHeap: &logIteratorHeap{},
 		catcher:      grip.NewBasicCatcher(),
 	}
@@ -29,11 +33,21 @@ func (i *mergingIterator) Next() bool {
 		i.init()
 	}
 
+	if i.exhausted {
+		return false
+	}
+
+	if i.lineLimit > 0 && i.lineLimit == i.lineCount {
+		i.exhausted = true
+		return false
+	}
+
 	it := i.iteratorHeap.SafePop()
 	if it == nil {
 		return false
 	}
 	i.currentItem = it.Item()
+	i.lineCount++
 
 	if it.Next() {
 		i.iteratorHeap.SafePush(it)
@@ -49,12 +63,15 @@ func (i *mergingIterator) Next() bool {
 }
 
 func (i *mergingIterator) Exhausted() bool {
+	if i.exhausted {
+		return true
+	}
+
 	for _, it := range i.iterators {
 		if !it.Exhausted() {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/model/log/merging_iterator.go
+++ b/model/log/merging_iterator.go
@@ -55,6 +55,7 @@ func (i *mergingIterator) Next() bool {
 		i.catcher.Add(it.Err())
 		i.catcher.Add(it.Close())
 		if i.catcher.HasErrors() {
+			i.iteratorHeap = &logIteratorHeap{}
 			return false
 		}
 	}

--- a/model/log/reader_test.go
+++ b/model/log/reader_test.go
@@ -81,6 +81,7 @@ func TestLogIteratorReader(t *testing.T) {
 		{
 			name: "SoftSizeLimit",
 			it: newMergingIterator(
+				0,
 				newChunkIterator(ctx, chunkIteratorOptions{bucket: bucket, chunks: chunks, parser: parser}),
 				newChunkIterator(ctx, chunkIteratorOptions{bucket: bucket, chunks: chunks, parser: parser}),
 				newChunkIterator(ctx, chunkIteratorOptions{bucket: bucket, chunks: chunks, parser: parser}),

--- a/model/log/service_interface.go
+++ b/model/log/service_interface.go
@@ -6,15 +6,14 @@ import (
 
 // LogService is the interface for Evergreen log services.
 type LogService interface {
+	// Get returns a log iterator with the given options.
 	Get(context.Context, GetOptions) (LogIterator, error)
+	// Append appends given lines to the specified log.
 	Append(context.Context, string, []LogLine) error
 }
 
 // GetOptions represents the arguments for fetching Evergreen logs.
 type GetOptions struct {
-	// Version is the version of the underlying log service with which the
-	// specified logs were stored.
-	Version int
 	// LogNames are the names of the logs to fetch and merge, prefixes may
 	// be specified. At least one name must be specified.
 	LogNames []string

--- a/model/log/service_interface.go
+++ b/model/log/service_interface.go
@@ -4,7 +4,12 @@ import (
 	"context"
 )
 
-// LogService is the interface for Evergreen log services.
+// LogService is a simple abstraction bridging the logical representation of an
+// Evergreen log with its physical storage. Namely, it supports writing and
+// retrieving logs directly to and from an underlying storage service. Any more
+// sophisticated business logic pertaining to log handling (e.g., collection,
+// logical organization, retrieval patterns) should be implemented on top of
+// this interface in separate layers of the application.
 type LogService interface {
 	// Get returns a log iterator with the given options.
 	Get(context.Context, GetOptions) (LogIterator, error)
@@ -16,6 +21,9 @@ type LogService interface {
 type GetOptions struct {
 	// LogNames are the names of the logs to fetch and merge, prefixes may
 	// be specified. At least one name must be specified.
+	//
+	// Log lines from multiple logs are always merged in a deterministic
+	// order by timestamp.
 	LogNames []string
 	// Start is the start time (inclusive) of the time range filter,
 	// represented as a Unix timestamp in nanoseconds. Defaults to

--- a/model/log/service_test.go
+++ b/model/log/service_test.go
@@ -98,7 +98,7 @@ func TestLogService(t *testing.T) {
 						LogName:   log0,
 						Priority:  level.Info,
 						Timestamp: ts + int64(30*time.Second),
-						Data:      "Another lonley log line.",
+						Data:      "Another lonely log line.",
 					},
 				}
 				require.NoError(t, svc.Append(ctx, log0, lines0))

--- a/model/log/service_test.go
+++ b/model/log/service_test.go
@@ -1,0 +1,226 @@
+package log
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip/level"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, impl := range []struct {
+		name        string
+		constructor func(*testing.T) LogService
+	}{
+		{
+			name: "V0",
+			constructor: func(t *testing.T) LogService {
+				bucket, err := pail.NewLocalBucket(pail.LocalOptions{Path: t.TempDir()})
+				require.NoError(t, err)
+
+				return &logServiceV0{
+					bucket: bucket,
+				}
+			},
+		},
+	} {
+		t.Run(impl.name, func(t *testing.T) {
+			svc := impl.constructor(t)
+
+			t.Run("LogDNE", func(t *testing.T) {
+				lines := readLogLines(t, svc, ctx, GetOptions{LogNames: []string{"DNE"}})
+				assert.Empty(t, lines)
+			})
+			t.Run("RoundTripSingleLog", func(t *testing.T) {
+				logName := utility.RandomString()
+				lines := []LogLine{
+					{
+						Priority:  level.Debug,
+						Timestamp: time.Now().UnixNano(),
+						Data:      "This is a log line.",
+					},
+					{
+						Priority:  level.Info,
+						Timestamp: time.Now().UnixNano(),
+						Data:      "The new line at the end of this line should be handled properly.\n",
+					},
+				}
+				require.NoError(t, svc.Append(ctx, logName, lines))
+
+				foundLines := readLogLines(t, svc, ctx, GetOptions{LogNames: []string{logName}})
+				require.Len(t, foundLines, len(lines))
+
+				offset := len(lines)
+				lines = append(
+					lines,
+					LogLine{
+						Priority:  level.Warning,
+						Timestamp: time.Now().UnixNano(),
+						Data:      "Appending a warning line to an already existing log.",
+					},
+					LogLine{
+						Priority:  level.Error,
+						Timestamp: time.Now().UnixNano(),
+						Data:      "Appending an error line to an already existing log.",
+					},
+				)
+				require.NoError(t, svc.Append(ctx, logName, lines[offset:]))
+
+				foundLines = readLogLines(t, svc, ctx, GetOptions{LogNames: []string{logName}})
+				require.Len(t, foundLines, len(lines))
+				for i := 0; i < len(lines); i++ {
+					assert.Equal(t, logName, foundLines[i].LogName)
+					assert.Equal(t, lines[i].Priority, foundLines[i].Priority)
+					assert.Equal(t, lines[i].Timestamp, foundLines[i].Timestamp)
+					assert.Equal(t, strings.TrimRight(lines[i].Data, "\n"), foundLines[i].Data)
+				}
+			})
+			t.Run("RoundTripMultipleLogs", func(t *testing.T) {
+				ts := time.Now().UnixNano()
+				log0 := "lonely/alone.log"
+				lines0 := []LogLine{
+					{
+						LogName:   log0,
+						Priority:  level.Info,
+						Timestamp: ts,
+						Data:      "Alone in my prefix.",
+					},
+					{
+						LogName:   log0,
+						Priority:  level.Info,
+						Timestamp: ts + int64(30*time.Second),
+						Data:      "Another lonley log line.",
+					},
+				}
+				require.NoError(t, svc.Append(ctx, log0, lines0))
+				log1 := "common/1.log"
+				lines1 := []LogLine{
+					{
+						LogName:   log1,
+						Priority:  level.Debug,
+						Timestamp: ts,
+						Data:      "Part of the common prefix.",
+					},
+					{
+						LogName:   log1,
+						Priority:  level.Error,
+						Timestamp: ts + int64(time.Minute),
+						Data:      "Another line here.",
+					},
+				}
+				require.NoError(t, svc.Append(ctx, log1, lines1))
+				log2 := "common/2.log"
+				lines2 := []LogLine{
+					{
+						LogName:   log2,
+						Priority:  level.Debug,
+						Timestamp: ts + int64(time.Second),
+						Data:      "Also part of the common prefix.",
+					},
+					{
+						LogName:   log2,
+						Priority:  level.Debug,
+						Timestamp: ts + int64(time.Second),
+						Data:      "I have the same timestamp as the last line.",
+					},
+					{
+						LogName:   log2,
+						Priority:  level.Debug,
+						Timestamp: ts + int64(time.Hour),
+						Data:      "And this line comes way later.",
+					},
+				}
+				require.NoError(t, svc.Append(ctx, log2, lines2))
+
+				t.Run("CommonPrefix", func(t *testing.T) {
+					expectedLines := []LogLine{
+						lines1[0],
+						lines0[0],
+						lines2[0],
+						lines2[1],
+						lines0[1],
+						lines1[1],
+						lines2[2],
+					}
+					actualLines := readLogLines(t, svc, ctx, GetOptions{LogNames: []string{log0, "common"}})
+					assert.Equal(t, expectedLines, actualLines)
+				})
+				t.Run("DefaultTimeRangeOfFirstLog", func(t *testing.T) {
+					expectedLines := []LogLine{
+						lines1[0],
+						lines0[0],
+						lines0[1],
+					}
+					actualLines := readLogLines(t, svc, ctx, GetOptions{
+						LogNames:                   []string{log0, log1},
+						DefaultTimeRangeOfFirstLog: true,
+					})
+					assert.Equal(t, expectedLines, actualLines)
+				})
+				t.Run("StartAndEnd", func(t *testing.T) {
+					expectedLines := []LogLine{
+						lines2[0],
+						lines2[1],
+						lines1[1],
+					}
+					actualLines := readLogLines(t, svc, ctx, GetOptions{
+						LogNames:                   []string{log1, log2},
+						Start:                      utility.ToInt64Ptr(ts + int64(time.Second)),
+						End:                        utility.ToInt64Ptr(ts + int64(time.Minute)),
+						DefaultTimeRangeOfFirstLog: true,
+					})
+					assert.Equal(t, expectedLines, actualLines)
+				})
+				t.Run("LineLimit", func(t *testing.T) {
+					expectedLines := []LogLine{
+						lines1[0],
+						lines0[0],
+						lines2[0],
+						lines2[1],
+					}
+					actualLines := readLogLines(t, svc, ctx, GetOptions{
+						LogNames:  []string{log0, "common"},
+						LineLimit: 4,
+					})
+					assert.Equal(t, expectedLines, actualLines)
+				})
+				t.Run("TailN", func(t *testing.T) {
+					expectedLines := []LogLine{
+						lines0[1],
+						lines1[1],
+						lines2[2],
+					}
+					actualLines := readLogLines(t, svc, ctx, GetOptions{
+						LogNames: []string{log0, "common"},
+						TailN:    3,
+					})
+					assert.Equal(t, expectedLines, actualLines)
+				})
+			})
+		})
+	}
+}
+
+func readLogLines(t *testing.T, svc LogService, ctx context.Context, opts GetOptions) []LogLine {
+	var lines []LogLine
+	it, err := svc.Get(ctx, opts)
+	require.NoError(t, err)
+	require.NotNil(t, it)
+	for it.Next() {
+		lines = append(lines, it.Item())
+	}
+	require.NoError(t, it.Err())
+	assert.NoError(t, it.Close())
+
+	return lines
+
+}

--- a/model/log/service_v0.go
+++ b/model/log/service_v0.go
@@ -42,11 +42,13 @@ func (s *logServiceV0) Get(ctx context.Context, getOpts GetOptions) (LogIterator
 	var its []LogIterator
 	for _, chunks := range allLogChunks {
 		its = append(its, newChunkIterator(ctx, chunkIteratorOptions{
-			bucket: s.bucket,
-			chunks: chunks.chunks,
-			parser: s.getParser(chunks.name),
-			start:  start,
-			end:    end,
+			bucket:    s.bucket,
+			chunks:    chunks.chunks,
+			parser:    s.getParser(chunks.name),
+			start:     start,
+			end:       end,
+			lineLimit: getOpts.LineLimit,
+			tailN:     getOpts.TailN,
 		}))
 	}
 


### PR DESCRIPTION
DEVPROD-2717

### Description
- Merge logs deterministically in the Evergreen logger
- Revert changes from https://github.com/evergreen-ci/evergreen/pull/7359 (we want repeating timestamps in these tests so we know lines from different logs are merged deterministically) 
- Fix a bug where the merging iterator was not respecting the line limit and tail options passed in to `LogService.Get`
- Refactor and enhance existing testing as well as add new tests

### Testing
Added and updated unit tests.

### Documentation
N/A
