### PR TITLE
DEVPROD-1931 Error on module clone failure

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -877,7 +877,7 @@ func (c *gitFetchProject) fetch(ctx context.Context,
 		}
 		err = c.fetchModuleSource(ctx, comm, conf, logger, jpm, td, opts.token, opts.method, p, moduleName)
 		if err != nil {
-			logger.Execution().Error(errors.Wrap(err, "fetching module source"))
+			return errors.Wrapf(err, "fetching module source '%s'", moduleName)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-03"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-10"
+	AgentVersion = "2024-01-10a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-1931

### Description
This has been reverted in the past because DSI had broken module dependencies. 
They have since fixed the issue so we are now (presumably) safe to error on module clone failure.