### PR TITLE
DEVPROD-2783 Fix ec2.assume_role docs

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -100,7 +100,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 
 	creds := stscreds.NewCredentials(session1, r.RoleARN, func(arp *stscreds.AssumeRoleProvider) {
 		arp.RoleSessionName = strconv.Itoa(int(time.Now().Unix()))
-		// External ID formatted as requested by build.
+		// External ID is a combination of project ID and requester, since mainline commits might have higher trust
 		arp.ExternalID = utility.ToStringPtr(fmt.Sprintf("%s-%s", conf.ProjectRef.Id, conf.Task.Requester))
 		if r.Policy != "" {
 			arp.Policy = utility.ToStringPtr(r.Policy)

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -249,12 +249,13 @@ for more details on the assume role API.
 Parameters:
 
 -   `role_arn`: string ARN of the role you want to assume. (required)
--   `external_id`: string of external ID that can be specified in the
-    role.
 -   `policy`: string in JSON format that you want to use as an inline
     session policy.
 -   `duration_seconds`: int in seconds of how long the returned
     credentials will be valid. (default 900)
+
+This command will also send an external ID in the form
+`<project_id>-<requester>`. This cannot be modified by the user.
 
 ## expansions.update
 


### PR DESCRIPTION
DEVPROD-2783

### Description

The external_id field is not set by the user.
