### PR TITLE
DEVPROD-761 Specify backport commit-sha option only allows from same github project

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2024-01-03"
+	ClientVersion = "2024-01-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2024-01-10a"

--- a/docs/Project-Configuration/Commit-Queue.md
+++ b/docs/Project-Configuration/Commit-Queue.md
@@ -180,7 +180,7 @@ Specify the tasks to run in the backport patch.
 
 * `--commit-sha, -s`, `--existing-patch, -e` (mutually exclusive)
 
-Specify changes to backport. `--commit-sha` specifies a single commit to cherry-pick on top of the target project's tracked branch. `--existing-patch` is the id of an existing commit queue patch in another project to pull changes from.
+Specify changes to backport. `--commit-sha` specifies a single commit to cherry-pick on top of the target project's tracked branch (this is from the same repository as the project). `--existing-patch` is the id of an existing commit queue patch in another project to pull changes from.
 
 ## FAQ
 > The merge test for a PR failed.  How do I resubmit?

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -362,11 +362,11 @@ func backport() cli.Command {
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(existingPatchFlag, "e"),
-					Usage: "existing commit queue patch",
+					Usage: "existing commit queue patch from another repository",
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(commitShaFlag, "s"),
-					Usage: "existing commit SHA to backport",
+					Usage: "existing commit SHA from the same repository to backport",
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(backportProjectFlag, "b"),

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -362,7 +362,7 @@ func backport() cli.Command {
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(existingPatchFlag, "e"),
-					Usage: "existing commit queue patch from another repository",
+					Usage: "existing commit queue patch from another project",
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(commitShaFlag, "s"),

--- a/operations/commit_queue.go
+++ b/operations/commit_queue.go
@@ -362,7 +362,7 @@ func backport() cli.Command {
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(existingPatchFlag, "e"),
-					Usage: "existing commit queue patch from another project",
+					Usage: "existing commit queue patch usually from another project or branch",
 				},
 				cli.StringFlag{
 					Name:  joinFlagNames(commitShaFlag, "s"),


### PR DESCRIPTION
DEVPROD-761

### Description
A user was attempting to specify commit-sha for a different repository than the project they were using it on, which caused the sha not to be found