### PR TITLE
DEVPROD-3473 buildrevision version

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2024-01-03"
+	ClientVersion = "2024-01-11"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2024-01-10a"

--- a/operations/version.go
+++ b/operations/version.go
@@ -7,13 +7,26 @@ import (
 	"github.com/urfave/cli"
 )
 
+const buildRevisionFlag = "build-revision"
+
 func Version() cli.Command {
 	return cli.Command{
 		Name:    "version",
 		Aliases: []string{"v"},
 		Usage:   "prints the revision of the current binary",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  joinFlagNames(buildRevisionFlag, "b"),
+				Usage: "print the build revision instead of the client version",
+			},
+		},
 		Action: func(c *cli.Context) error {
-			fmt.Println(evergreen.ClientVersion)
+			if c.Bool(buildRevisionFlag) {
+				fmt.Println(evergreen.BuildRevision)
+			} else {
+				fmt.Println(evergreen.ClientVersion)
+			}
+
 			return nil
 		},
 	}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -645,7 +645,7 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-linux_arm64
-    tags: ["build"]
+    tags: ["build", "build-staging"]
   - <<: *build-and-push-client
     name: build-linux_ppc64le
     tags: ["build"]


### PR DESCRIPTION
[DEVPROD-3473](https://jira.mongodb.org/browse/DEVPROD-3473)

### Description
Add an option to the `evergreen version` command to print the BuildRevision. This is necessary for [the deploy emails PR](https://github.com/evergreen-ci/evergreen-deploys/pull/2).

Also, the staging only build needs to include linux_arm64 since the apps will be running on arm.