### PR TITLE
DEVPROD-3716 (Part 2): Convert indentation to triple backtick for code blocks

### DIFF
--- a/docs/API/REST-V2-Usage.mdx
+++ b/docs/API/REST-V2-Usage.mdx
@@ -12,10 +12,12 @@ When an error is encountered during a request, the API returns a JSON
 object with the HTTP status code and a message describing the error of
 the form:
 
-    {
-     "status": <http_status_code>,
-     "error": <error message>
-    }
+```
+{
+ "status": <http_status_code>,
+ "error": <error message>
+}
+```
 
 ### Pagination
 
@@ -25,9 +27,11 @@ additional results for the query, access to them is populated in a [Link
 HTTP header](https://www.w3.org/wiki/LinkHeader). This header has the
 form:
 
-    "Link" : <http://<EVERGREEN_HOST>/rest/v2/path/to/resource?start_at=<pagination_key>&limit=<objects_per_page>; rel="next"
+```
+"Link" : <http://<EVERGREEN_HOST>/rest/v2/path/to/resource?start_at=<pagination_key>&limit=<objects_per_page>; rel="next"
 
-    <http://<EVERGREEN_HOST>/rest/v2/path/to/resource?start_at=<pagination_key>&limit=<objects_per_page>; rel="prev"
+<http://<EVERGREEN_HOST>/rest/v2/path/to/resource?start_at=<pagination_key>&limit=<objects_per_page>; rel="prev"
+```
 
 ### Dates
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -2,6 +2,7 @@ command_type: test
 stepback: true
 ignore:
   - "*.md" # don't schedule tests if a commit only changes markdown files
+  - "*.mdx"
   - ".github/*" # github CODEOWNERS configuration
 
 post:


### PR DESCRIPTION
DEVPROD-3716

### Description
It seems that indentations and triple backticks are not created equal for code blocks in MDX 3, so I made this change in our single MDX file.

### Testing
Confirmed that Pine builds locally with Docusaurus v3 once these changes are made!