### PR TITLE
DEVPROD-3140: document notifications in project settings

### DIFF
--- a/docs/Project-Configuration/Notifications.md
+++ b/docs/Project-Configuration/Notifications.md
@@ -1,10 +1,12 @@
 # Notifications
 
+These are for setting up personal user notifications. For project-level notifications, see [project settings](Project-and-Distro-Settings.md#project-level-notifications).
+
 Evergreen has the ability to issue notifications based on events that happen in the system.
 
 ## Notifications Setup
 Evergreen can notify you based on the outcome of your patches. To enable these, go to your [user profile](https://evergreen.mongodb.com/settings) and:
-1. Enter your Github Username (so we can identify which commits you make)
+1. Enter your GitHub Username (so we can identify which commits you make)
 2. Optionally, enter your Slack username (if you want to be notified on Slack). Your Slack username is available from https://YOUR_ORGANIZATION.slack.com/account/settings#username (This is NOT your slack display name.)
 3. Under Notification Settings, select the Slack or Email next to the notifications you'd like.
 4. Click save!
@@ -12,7 +14,7 @@ Evergreen can notify you based on the outcome of your patches. To enable these, 
 ## Options for Notifications
 
 ### Patch Finish
-For all new patches you create in the future (including Github Pull Requests), you'll receive an email or slack message when the patch has completed.
+For all new patches you create in the future (including GitHub Pull Requests), you'll receive an email or slack message when the patch has completed.
 
 ### Tasks
 For new tasks that fit the desired requester and finish type, you'll receive a notification. Note that for system unresponsive tasks, we only send a notification on the last execution, since we auto-retry these.

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -394,6 +394,30 @@ Options:
 Users can enable the performance plugin for tracking historical
 performance of tasks and tests.
 
+
+### Project-Level Notifications
+
+Project admins can set up notifications for when some events happen within the project. Admins can set up events when:
+
+- Any version/build/task finishes/fails - these can be filtered by build initiator (commit, patch, PR, commit queue,
+  periodic build).
+- First failure occurs in a version, for each build or for each task name - these can be filtered by build initiator
+  (commit, patch, PR, commit queue, periodic build).
+- A previously-passing task fails - these can be filtered by failure type (any, test, system, setup). Furthermore, to
+  reduce the amount of notifications received, the re-notification interval can be explicitly set.
+- A previously-passing test fails - these can be filtered by test name and failure type (any, test, system, setup).
+  Furthermore, to reduce the amount of notifications received, the re-notification interval can be explicitly set.
+- The runtime for any/failed task exceeds some duration (in seconds).
+- The runtime for a successful task changes by a percentage.
+
+When the event happens, the notification can be delivered via:
+
+- Jira comment under a specific Jira issue.
+- New Jira issue - must specify a Jira project and issue type.
+- Slack channel or user.
+- Email address.
+- Webhook URL - admins can configure the behavior for resending notifications in case of failure.
+
 ### Ticket Creation
 
 Configure task Failure Details tab options.


### PR DESCRIPTION
DEVPROD-3140

### Description
* Clarify that the notifications section in the docs is for user notifications.
* Add docs and links to project-level notifications.

### Testing
Checked the rendered Markdown looked reasonable.