### PR TITLE
DEVPROD-678: Document service user routes

### DIFF
--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -691,7 +691,7 @@ func makeDeleteServiceUser() gimlet.RouteHandler {
 //	@Tags			admin
 //	@Router			/admin/service_users [delete]
 //	@Security		Api-User || Api-Key
-//	@Param			id	query		string	true	"the user ID"
+//	@Param			id	query	string	true	"the user ID"
 //	@Success		200
 func (h *serviceUserDeleteHandler) Factory() gimlet.RouteHandler {
 	return &serviceUserDeleteHandler{}
@@ -729,7 +729,7 @@ func makeGetServiceUsers() gimlet.RouteHandler {
 //	@Tags			admin
 //	@Router			/admin/service_users [get]
 //	@Security		Api-User || Api-Key
-//	@Success		200			{object}	[]model.APIDBUser
+//	@Success		200	{object}	[]model.APIDBUser
 func (h *serviceUsersGetHandler) Factory() gimlet.RouteHandler {
 	return &serviceUsersGetHandler{}
 }

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -642,11 +642,11 @@ func makeUpdateServiceUser() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Create or update service user
-//	@Description	Fetches a single build using its ID
+//	@Description	Creates a new service user or updates an existing one (restricted to Evergreen admins).
 //	@Tags			admin
 //	@Router			/admin/service_users [post]
 //	@Security		Api-User || Api-Key
-//	@Param			build_id	path		string	true	"the build ID"
+//	@Param			{object}	body	model.APIDBUser	true	"parameters"
 //	@Success		200
 func (h *serviceUserPostHandler) Factory() gimlet.RouteHandler {
 	return &serviceUserPostHandler{
@@ -687,11 +687,11 @@ func makeDeleteServiceUser() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Delete service user
-//	@Description	Deletes a service user by its ID
+//	@Description	Deletes a service user by its ID (restricted to Evergreen admins).
 //	@Tags			admin
 //	@Router			/admin/service_users [delete]
 //	@Security		Api-User || Api-Key
-//	@Param			build_id	path		string	true	"the build ID"
+//	@Param			id	query		string	true	"the user ID"
 //	@Success		200
 func (h *serviceUserDeleteHandler) Factory() gimlet.RouteHandler {
 	return &serviceUserDeleteHandler{}
@@ -724,12 +724,11 @@ func makeGetServiceUsers() gimlet.RouteHandler {
 
 // Factory creates an instance of the handler.
 //
-//	@Summary		Get service user
-//	@Description	Fetches a service user using its ID
+//	@Summary		Get all service users
+//	@Description	Fetches all service users (restricted to Evergreen admins).
 //	@Tags			admin
 //	@Router			/admin/service_users [get]
 //	@Security		Api-User || Api-Key
-//	@Param			build_id	path		string	true	"the build ID"
 //	@Success		200			{object}	[]model.APIDBUser
 func (h *serviceUsersGetHandler) Factory() gimlet.RouteHandler {
 	return &serviceUsersGetHandler{}

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -639,6 +639,15 @@ func makeUpdateServiceUser() gimlet.RouteHandler {
 	}
 }
 
+// Factory creates an instance of the handler.
+//
+//	@Summary		Create or update service user
+//	@Description	Fetches a single build using its ID
+//	@Tags			admin
+//	@Router			/admin/service_users [post]
+//	@Security		Api-User || Api-Key
+//	@Param			build_id	path		string	true	"the build ID"
+//	@Success		200
 func (h *serviceUserPostHandler) Factory() gimlet.RouteHandler {
 	return &serviceUserPostHandler{
 		u: &model.APIDBUser{},
@@ -675,6 +684,15 @@ func makeDeleteServiceUser() gimlet.RouteHandler {
 	return &serviceUserDeleteHandler{}
 }
 
+// Factory creates an instance of the handler.
+//
+//	@Summary		Delete service user
+//	@Description	Deletes a service user by its ID
+//	@Tags			admin
+//	@Router			/admin/service_users [delete]
+//	@Security		Api-User || Api-Key
+//	@Param			build_id	path		string	true	"the build ID"
+//	@Success		200
 func (h *serviceUserDeleteHandler) Factory() gimlet.RouteHandler {
 	return &serviceUserDeleteHandler{}
 }
@@ -704,6 +722,15 @@ func makeGetServiceUsers() gimlet.RouteHandler {
 	return &serviceUsersGetHandler{}
 }
 
+// Factory creates an instance of the handler.
+//
+//	@Summary		Get service user
+//	@Description	Fetches a service user using its ID
+//	@Tags			admin
+//	@Router			/admin/service_users [get]
+//	@Security		Api-User || Api-Key
+//	@Param			build_id	path		string	true	"the build ID"
+//	@Success		200			{object}	[]model.APIDBUser
 func (h *serviceUsersGetHandler) Factory() gimlet.RouteHandler {
 	return &serviceUsersGetHandler{}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -80,6 +80,9 @@ func GetRouter(as *APIServer, uis *UIServer) (http.Handler, error) {
 	//	@externalDocs.description	Click here for information on authentication, pagination, and other details.
 	//	@externalDocs.url			https://docs.devprod.staging.corp.mongodb.com/evergreen/API/REST-V2-Usage/
 	//
+	//	@tag.name					admin
+	//	@tag.description			Admins are users with high-level permissions within Evergreen.
+	//
 	//	@tag.name					annotations
 	//	@tag.description			Annotations are added by users, usually programmatically, to track known and suspected causes of task failures.
 	//


### PR DESCRIPTION
DEVPROD-678

### Documentation
Documents our 3 service user-specific REST routes via swaggo. Screenshots attached. Will link in the dev guide once merged.
<img width="1460" alt="Screenshot 2024-01-12 at 3 57 20 PM" src="https://github.com/evergreen-ci/evergreen/assets/19805673/b15311a9-48fd-49f4-b05c-bf4542af67ee">
<img width="1446" alt="Screenshot 2024-01-12 at 3 57 27 PM" src="https://github.com/evergreen-ci/evergreen/assets/19805673/4502dffd-cb0e-4f5e-b909-65f3d93230e6">
<img width="1467" alt="Screenshot 2024-01-12 at 3 57 35 PM" src="https://github.com/evergreen-ci/evergreen/assets/19805673/c53e40fe-ea10-4835-9157-7ca603861540">
