### PR TITLE
DEVPROD-3733: fix error message for conflicting definitions

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1346,7 +1346,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 				// it's already in the new list, so we check to make sure the status definitions match.
 				if !reflect.DeepEqual(t, old) {
 					evalErrs = append(evalErrs, errors.Errorf(
-						"conflicting definitions of task '%s' listed under build variant '%s': %#v != %#v", name, pbvt.Name, t, old))
+						"conflicting definitions of task '%s' listed under build variant '%s': %#v != %#v", name, pbv.Name, t, old))
 					continue
 				}
 			}


### PR DESCRIPTION
DEVPROD-3733

### Description
Noticed it in a user thread. Use the build variant name in the error message (instead of the build variant task unit's name).

### Testing
Didn't seem worth testing a tiny error message bug.

### Documentation
N/A
