### PR TITLE
DEVPROD-3739: Downgrade incorrect git remote to CLI warning

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 	BuildRevision = ""
 
 	// ClientVersion is the commandline version string used to control auto-updating.
-	ClientVersion = "2024-01-11"
+	ClientVersion = "2024-01-12"
 
 	// Agent version to control agent rollover.
 	AgentVersion = "2024-01-10a"

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -196,7 +196,8 @@ func Patch() cli.Command {
 
 			remote, err := gitGetRemote("", ref.Owner, ref.Repo)
 			if err != nil {
-				return errors.Errorf("you do not have a remote tracking your Evergreen project. The project to track is https://github.com/%s/%s", ref.Owner, ref.Repo)
+				// TODO: DEVPROD-3740 Change this back to an error
+				grip.Warningf("warning - you do not have a remote tracking your Evergreen project. The project to track is https://github.com/%s/%s", ref.Owner, ref.Repo)
 			}
 
 			diffData, err := loadGitData("", remote, ref.Branch, params.Ref, "", params.PreserveCommits, args...)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -621,10 +621,11 @@ Continue?`, uncommittedChangesFlag), true), nil
 // If no dir is provided, we use the current working directory.
 // The branch argument is used to determine where to generate the merge base from, and any extra
 // arguments supplied are passed directly in as additional args to git diff.
+// TODO: DEVPROD-3740 Re-implement the changes for this function from https://github.com/evergreen-ci/evergreen/pull/7311
 func loadGitData(dir, remote, branch, ref, commits string, format bool, extraArgs ...string) (*localDiff, error) {
 	// branch@{upstream} refers to the branch that the branch specified by branchname is set to
-	// build on top of. This allows automatically detecting a branch based on the correct remote,
-	// if the user's repo is a fork, for example. This also works with a commit hash, if given.
+	// build on top of. For example, if a user's repo is a fork, this allows automatic detection
+	// of a branch based on the correct remote. This also works with a commit hash, if given.
 	// In the case a range is passed, we only need one commit to determine the base, so we use the first commit.
 	// For details see: https://git-scm.com/docs/gitrevisions
 


### PR DESCRIPTION
DEVPROD-3739

### Description
In order to avoid potential complexity with v7.1 and v7.2 of server (where engineers may run into this error on submitting patches), temporarily downgrading this to a warning. This also requires we revert the [loadGitData](https://github.com/evergreen-ci/evergreen/pull/7311/files#diff-8b8cc6bdad49868ce616124c6c2b682e973c6db9e89111473a319bbefda656a2R624) function change from #7311 with the understanding that it'll need to be added back along with the changes from DEVPROD-3740.

### Testing
Tested locally and confirmed warning outputs.

In sandbox, I set my local remote and origin to point to my fork, `hadjri/commit-queue-sandbox` rather than the original repo. Confirmed that without this change, the patch fails to be created, and after this change, patch creation succeeds.

(i.e., my locally built CLI makes the patch correctly, and my default `evergreen` binary does not)
<img width="1211" alt="Screenshot 2024-01-12 at 5 49 01 PM" src="https://github.com/evergreen-ci/evergreen/assets/19805673/b15f9bb2-8b03-4219-934f-3c9717b3a8e3">
