### PR TITLE
DEVPROD-1158 Include project name for patch details on CLI

### DIFF
--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -30,8 +30,9 @@ const largePatchThreshold = 1024 * 1024 * 16
 // This is the template used to render a patch's summary in a human-readable output format.
 var patchDisplayTemplate = template.Must(template.New("patch").Parse(`
          ID : {{.Patch.Id.Hex}}
+    Project : {{.Patch.Project}}
     Created : {{.Patch.CreateTime}}
-    Description : {{if .Patch.Description}}{{.Patch.Description}}{{else}}<none>{{end}}
+Description : {{if .Patch.Description}}{{.Patch.Description}}{{else}}<none>{{end}}
       Build : {{.Link}}
      Status : {{.Patch.Status}}
 {{if .ShowFinalized}}      Finalized : {{if .Patch.Activated}}Yes{{else}}No{{end}}{{end}}


### PR DESCRIPTION
DEVPROD-NNNNN

### Description
Creating patch through the CLI now returns project 

### Testing
<img width="987" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/9803901c-4bf6-4702-878c-d0e2c745520f">
