### PR TITLE
DEVPROD-3743: make it easier to trace event logging

### DIFF
--- a/trigger/process.go
+++ b/trigger/process.go
@@ -37,13 +37,13 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 
 	subscriptions, err := event.FindSubscriptionsByAttributes(e.ResourceType, h.Attributes())
 	msg := message.Fields{
-		"source":              "events-processing",
-		"message":             "processing event",
-		"event_id":            e.ID,
-		"event_type":          e.EventType,
-		"event_resource_type": e.ResourceType,
-		"event_resource":      e.ResourceId,
-		"num_subscriptions":   len(subscriptions),
+		"source":            "events-processing",
+		"message":           "processing event",
+		"event_id":          e.ID,
+		"event_type":        e.EventType,
+		"resource_id":       e.ResourceId,
+		"resource_type":     e.ResourceType,
+		"num_subscriptions": len(subscriptions),
 	}
 	if err != nil {
 		err = errors.Wrapf(err, "fetching subscriptions for event '%s' (resource type: '%s', event type: '%s')", e.ID, e.ResourceType, e.EventType)

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -161,7 +161,6 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 				"event_type":    e.EventType,
 				"resource_id":   e.ResourceId,
 				"resource_type": e.ResourceType,
-				"panic_value":   r,
 			}))
 		}
 	}()

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -132,7 +132,10 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 		"job_type":      j.Type().Name,
 		"operation":     "events-processing",
 		"message":       "event-stats",
-		"event_id":      j.EventID,
+		"event_id":      e.ID,
+		"event_type":    e.EventType,
+		"resource_id":   e.ResourceId,
+		"resource_type": e.ResourceType,
 		"start_time":    startTime.String(),
 		"end_time":      endTime.String(),
 		"duration_secs": totalDuration.Seconds(),
@@ -153,12 +156,14 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 			n = nil
 			err = errors.Errorf("panicked while processing event '%s'", e.ID)
 			grip.Alert(message.WrapError(err, message.Fields{
-				"job_id":      j.ID(),
-				"job_type":    j.Type().Name,
-				"source":      "events-processing",
-				"event_id":    e.ID,
-				"event_type":  e.ResourceType,
-				"panic_value": r,
+				"job_id":        j.ID(),
+				"job_type":      j.Type().Name,
+				"source":        "events-processing",
+				"event_id":      e.ID,
+				"event_type":    e.EventType,
+				"resource_id":   e.ResourceId,
+				"resource_type": e.ResourceType,
+				"panic_value":   r,
 			}))
 		}
 	}()
@@ -171,19 +176,23 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 		"source":        "events-processing",
 		"message":       "event processed",
 		"event_id":      e.ID,
-		"event_type":    e.ResourceType,
+		"event_type":    e.EventType,
+		"resource_id":   e.ResourceId,
+		"resource_type": e.ResourceType,
 		"notifications": len(n),
 		"duration_secs": time.Since(startDebug).Seconds(),
 		"stat":          "notifications-from-event",
 	})
 
 	grip.Error(message.WrapError(err, message.Fields{
-		"job_id":     j.ID(),
-		"job_type":   j.Type().Name,
-		"source":     "events-processing",
-		"message":    "errors processing triggers for event",
-		"event_id":   e.ID,
-		"event_type": e.ResourceType,
+		"job_id":        j.ID(),
+		"job_type":      j.Type().Name,
+		"source":        "events-processing",
+		"message":       "errors processing triggers for event",
+		"event_id":      e.ID,
+		"event_type":    e.EventType,
+		"resource_id":   e.ResourceId,
+		"resource_type": e.ResourceType,
 	}))
 
 	v, err := trigger.EvalProjectTriggers(ctx, e, trigger.TriggerDownstreamVersion)
@@ -193,7 +202,9 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 		"source":        "events-processing",
 		"message":       "project triggers evaluated",
 		"event_id":      e.ID,
-		"event_type":    e.ResourceType,
+		"event_type":    e.EventType,
+		"resource_id":   e.ResourceId,
+		"resource_type": e.ResourceType,
 		"duration_secs": time.Since(startDebug).Seconds(),
 		"stat":          "eval-project-triggers",
 	})
@@ -202,12 +213,15 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 		versions = append(versions, version.Id)
 	}
 	grip.InfoWhen(len(versions) > 0, message.Fields{
-		"job_id":   j.ID(),
-		"job_type": j.Type().Name,
-		"source":   "events-processing",
-		"message":  "triggering downstream builds",
-		"event_id": e.ID,
-		"versions": versions,
+		"job_id":        j.ID(),
+		"job_type":      j.Type().Name,
+		"source":        "events-processing",
+		"message":       "triggering downstream builds",
+		"event_id":      e.ID,
+		"event_type":    e.EventType,
+		"resource_id":   e.ResourceId,
+		"resource_type": e.ResourceType,
+		"versions":      versions,
 	})
 
 	return n, err

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -134,8 +134,6 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 		"message":       "event-stats",
 		"event_id":      e.ID,
 		"event_type":    e.EventType,
-		"resource_id":   e.ResourceId,
-		"resource_type": e.ResourceType,
 		"start_time":    startTime.String(),
 		"end_time":      endTime.String(),
 		"duration_secs": totalDuration.Seconds(),
@@ -196,7 +194,7 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 	}))
 
 	v, err := trigger.EvalProjectTriggers(ctx, e, trigger.TriggerDownstreamVersion)
-	grip.Info(message.Fields{
+	grip.InfoWhen(len(v) > 0, message.Fields{
 		"job_id":        j.ID(),
 		"job_type":      j.Type().Name,
 		"source":        "events-processing",


### PR DESCRIPTION
DEVPROD-3743

### Description
* Add logs for resource ID and resource type in event notifier job to make it easier to trace in Splunk when a resource has its subscriptions/notifications processed (e.g. a task finishes, and that event sends a Slack notification).
* Reduce the noisiness of the event notifier logs when there's no notifications to create from an event.

### Testing
I verified in staging that the logs for the job have the fields.

### Documentation
N/A