### PR TITLE
DEVPROD-3779: Use timer instead of sleep for the test log directory watcher loop

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-12a"
+	AgentVersion = "2024-01-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -464,6 +464,9 @@ tasks:
     name: test-evergreen
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
+    name: test-taskoutput
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
     name: test-thirdparty
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]


### PR DESCRIPTION
DEVPROD-3779

### Description
Use a `time.Timer` instead of `time.Sleep` to throttle the test log directory watcher loop. This should improve goroutine clean up and avoid leaks.

Also added the `taskoutput` package tests to CI since they never got added. 

### Testing
Put the `TestTestLogDirectoryHandler` test in a loop and ran it across a bunch of platforms to ensure that it is not flakey.([patch build](https://spruce.mongodb.com/version/65a6b794d6d80a7ced34fbc0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))

### Documentation
N/A
