### PR TITLE
DEVPROD-2470 log to stdout again

### DIFF
--- a/config.go
+++ b/config.go
@@ -464,7 +464,7 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 	if err != nil {
 		return nil, errors.Wrap(err, "configuring error fallback logger")
 	}
-	if disableLocalLogging, err := strconv.ParseBool(os.Getenv(disableLocalLoggingEnvVar)); err == nil && !disableLocalLogging {
+	if disableLocalLogging, err := strconv.ParseBool(os.Getenv(disableLocalLoggingEnvVar)); err != nil || !disableLocalLogging {
 		// setup the base/default logger (generally direct to systemd
 		// or standard output)
 		switch s.LogPath {


### PR DESCRIPTION
[DEVPROD-2470](https://jira.mongodb.org/browse/DEVPROD-2470)

### Description
https://github.com/evergreen-ci/evergreen/pull/7332 was supposed to make that we don't log to stdout when `disableLocalLoggingEnvVar` isn't set or if it's set to false. There was a mistake in the logic: as is it won't log if it's unset, which isn't what we want.

### Testing
`make local-evergreen` spits out logs to stdout.
