### PR TITLE
DEVPROD-810: Avoid using app-level context for GraphQL queries

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -198,7 +198,7 @@ func (r *queryResolver) DistroTaskQueue(ctx context.Context, distroID string) ([
 
 // Host is the resolver for the host field.
 func (r *queryResolver) Host(ctx context.Context, hostID string) (*restModel.APIHost, error) {
-	host, err := host.GetHostByIdOrTagWithTask(hostID)
+	host, err := host.GetHostByIdOrTagWithTask(ctx, hostID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error Fetching host: %s", err.Error()))
 	}
@@ -527,7 +527,7 @@ func (r *queryResolver) RepoSettings(ctx context.Context, id string) (*restModel
 // ViewableProjectRefs is the resolver for the viewableProjectRefs field.
 func (r *queryResolver) ViewableProjectRefs(ctx context.Context) ([]*GroupedProjects, error) {
 	usr := mustHaveUser(ctx)
-	projectIds, err := usr.GetViewableProjectSettings()
+	projectIds, err := usr.GetViewableProjectSettings(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting viewable projects for '%s': '%s'", usr.DispName, err.Error()))
 	}

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -257,10 +257,7 @@ func UpdateAnnotation(a *TaskAnnotation, userDisplayName string) error {
 }
 
 // InsertManyAnnotations updates the source for a list of task annotations and their issues and then inserts them into the DB.
-func InsertManyAnnotations(updates []TaskUpdate) error {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
+func InsertManyAnnotations(ctx context.Context, updates []TaskUpdate) error {
 	for _, u := range updates {
 		update := createAnnotationUpdate(&u.Annotation, "")
 		ops := make([]mongo.WriteModel, len(u.TaskData))
@@ -270,7 +267,7 @@ func InsertManyAnnotations(updates []TaskUpdate) error {
 				SetFilter(ByTaskIdAndExecution(u.TaskData[idx].TaskId, u.TaskData[idx].Execution)).
 				SetUpdate(bson.M{"$push": update})
 		}
-		_, err := env.DB().Collection(Collection).BulkWrite(ctx, ops, nil)
+		_, err := evergreen.GetEnvironment().DB().Collection(Collection).BulkWrite(ctx, ops, nil)
 
 		if err != nil {
 			return errors.Wrap(err, "bulk inserting annotations")

--- a/model/context_test.go
+++ b/model/context_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -10,6 +11,9 @@ import (
 )
 
 func TestLoadContext(t *testing.T) {
+	backgroundCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, ProjectRefCollection))
 
 	assert := assert.New(t)
@@ -25,7 +29,7 @@ func TestLoadContext(t *testing.T) {
 	}
 	assert.NoError(newTask.Insert())
 	assert.NoError(oldTask.Insert())
-	assert.NoError(oldTask.Archive())
+	assert.NoError(oldTask.Archive(backgroundCtx))
 
 	// test that current tasks are loaded correctly
 	ctx, err := LoadContext(newTask.Id, "", "", "", myProject.Id)

--- a/model/event/host_event_finder.go
+++ b/model/event/host_event_finder.go
@@ -1,6 +1,8 @@
 package event
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/mongodb/anser/bsonutil"
@@ -18,7 +20,7 @@ type hostStatusDistro struct {
 func (s *hostStatusDistro) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(s) }
 func (s *hostStatusDistro) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, s) }
 
-func getRecentStatusesForHost(hostId string, n int) (int, []string) {
+func getRecentStatusesForHost(ctx context.Context, hostId string, n int) (int, []string) {
 	or := ResourceTypeKeyIs(ResourceTypeHost)
 	or[TypeKey] = EventHostTaskFinished
 	or[ResourceIdKey] = hostId
@@ -37,10 +39,7 @@ func getRecentStatusesForHost(hostId string, n int) (int, []string) {
 			"status": 1}},
 	}
 
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-	cursor, err := env.DB().Collection(EventCollection).Aggregate(ctx, pipeline, options.Aggregate().SetAllowDiskUse(true))
+	cursor, err := evergreen.GetEnvironment().DB().Collection(EventCollection).Aggregate(ctx, pipeline, options.Aggregate().SetAllowDiskUse(true))
 	if err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message": "could not get recent host statuses",
@@ -68,12 +67,12 @@ func getRecentStatusesForHost(hostId string, n int) (int, []string) {
 	return out[0].Count, out[0].Status
 }
 
-func AllRecentHostEventsMatchStatus(hostId string, n int, status string) bool {
+func AllRecentHostEventsMatchStatus(ctx context.Context, hostId string, n int, status string) bool {
 	if n == 0 {
 		return false
 	}
 
-	count, statuses := getRecentStatusesForHost(hostId, n)
+	count, statuses := getRecentStatusesForHost(ctx, hostId, n)
 	if count == 0 {
 		return false
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1772,9 +1772,7 @@ func RemoveStrict(ctx context.Context, env evergreen.Environment, id string) err
 }
 
 // Replace overwrites an existing host document with a new one. If no existing host is found, the new one will be inserted anyway.
-func (h *Host) Replace() error {
-	ctx, cancel := evergreen.GetEnvironment().Context()
-	defer cancel()
+func (h *Host) Replace(ctx context.Context) error {
 	result := evergreen.GetEnvironment().DB().Collection(Collection).FindOneAndReplace(ctx, bson.M{IdKey: h.Id}, h, options.FindOneAndReplace().SetUpsert(true))
 	err := result.Err()
 	if errors.Cause(err) == mongo.ErrNoDocuments {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2929,7 +2929,7 @@ func (h *Host) IsSubjectToHostCreationThrottle() bool {
 
 // GetHostByIdOrTagWithTask finds a host by ID or tag and includes the full
 // running task with the host.
-func GetHostByIdOrTagWithTask(hostID string) (*Host, error) {
+func GetHostByIdOrTagWithTask(ctx context.Context, hostID string) (*Host, error) {
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{
@@ -2954,12 +2954,8 @@ func GetHostByIdOrTagWithTask(hostID string) (*Host, error) {
 		},
 	}
 
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-
 	hosts := []Host{}
-	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
+	cursor, err := evergreen.GetEnvironment().DB().Collection(Collection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating host by ID or tag with task")
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4958,7 +4958,7 @@ func TestRemoveAndReplace(t *testing.T) {
 		Id:     "host2",
 		Status: evergreen.HostRunning,
 	}
-	assert.NoError(t, h2.Replace())
+	assert.NoError(t, h2.Replace(ctx))
 	dbHost, err = FindOneId(ctx, h2.Id)
 	assert.NoError(t, err)
 	assert.NotNil(t, dbHost)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4947,7 +4947,7 @@ func TestRemoveAndReplace(t *testing.T) {
 	assert.NoError(t, h.Insert(ctx))
 
 	h.DockerOptions.Command = "hello world"
-	assert.NoError(t, h.Replace())
+	assert.NoError(t, h.Replace(ctx))
 	dbHost, err := FindOneId(ctx, h.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.HostUninitialized, dbHost.Status)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -404,7 +404,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	}
 
 	// Set all the task fields to indicate restarted
-	if err := MarkTasksReset(restartIds); err != nil {
+	if err := MarkTasksReset(ctx, restartIds); err != nil {
 		return errors.WithStack(err)
 	}
 	for _, t := range allFinishedTasks {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -367,7 +367,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 			toArchive = append(toArchive, t)
 		}
 	}
-	if err := task.ArchiveMany(toArchive); err != nil {
+	if err := task.ArchiveMany(ctx, toArchive); err != nil {
 		return errors.Wrap(err, "archiving tasks")
 	}
 
@@ -1017,11 +1017,9 @@ func setNumDepsRec(t *task.Task, idToTasks map[string]*task.Task, seen map[strin
 	}
 }
 
-func RecomputeNumDependents(t task.Task) error {
+func RecomputeNumDependents(ctx context.Context, t task.Task) error {
 	pipelineDown := getAllNodesInDepGraph(t.Id, bsonutil.GetDottedKeyName(task.DependsOnKey, task.DependencyTaskIdKey), task.IdKey)
 	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
 	cursor, err := env.DB().Collection(task.Collection).Aggregate(ctx, pipelineDown)
 	if err != nil {
 		return err

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2865,6 +2865,9 @@ func TestAddNewTasks(t *testing.T) {
 }
 
 func TestRecomputeNumDependents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.Clear(task.Collection))
 	t1 := task.Task{
 		Id: "1",
@@ -2904,14 +2907,14 @@ func TestRecomputeNumDependents(t *testing.T) {
 	}
 	assert.NoError(t, t5.Insert())
 
-	assert.NoError(t, RecomputeNumDependents(t3))
+	assert.NoError(t, RecomputeNumDependents(ctx, t3))
 	tasks, err := task.Find(task.ByVersion(t1.Version))
 	assert.NoError(t, err)
 	for i, dbTask := range tasks {
 		assert.Equal(t, i, dbTask.NumDependents)
 	}
 
-	assert.NoError(t, RecomputeNumDependents(t5))
+	assert.NoError(t, RecomputeNumDependents(ctx, t5))
 	tasks, err = task.Find(task.ByVersion(t1.Version))
 	assert.NoError(t, err)
 	for i, dbTask := range tasks {
@@ -2948,7 +2951,7 @@ func TestRecomputeNumDependents(t *testing.T) {
 	}
 	assert.NoError(t, t9.Insert())
 
-	assert.NoError(t, RecomputeNumDependents(t8))
+	assert.NoError(t, RecomputeNumDependents(ctx, t8))
 	tasks, err = task.Find(task.ByVersion(t6.Version))
 	assert.NoError(t, err)
 	expected := map[string]int{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1820,11 +1820,8 @@ func UpdateAll(query interface{}, update interface{}) (*adb.ChangeInfo, error) {
 	)
 }
 
-func UpdateAllWithHint(query interface{}, update interface{}, hint interface{}) (*adb.ChangeInfo, error) {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-	res, err := env.DB().Collection(Collection).UpdateMany(ctx, query, update, options.Update().SetHint(hint))
+func UpdateAllWithHint(ctx context.Context, query interface{}, update interface{}, hint interface{}) (*adb.ChangeInfo, error) {
+	res, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateMany(ctx, query, update, options.Update().SetHint(hint))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1861,15 +1861,11 @@ func FindProjectForTask(taskID string) (string, error) {
 	return t.Project, nil
 }
 
-func (t *Task) updateAllMatchingDependenciesForTask(dependencyID string, unattainable bool) error {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-
+func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, dependencyID string, unattainable bool) error {
 	// Update the matching dependencies in the DependsOn array and the UnattainableDependency field that caches
 	// whether any of the dependencies are blocked. Combining both these updates in a single update operation makes it
 	// impervious to races because updates to single documents are atomic.
-	res := env.DB().Collection(Collection).FindOneAndUpdate(ctx,
+	res := evergreen.GetEnvironment().DB().Collection(Collection).FindOneAndUpdate(ctx,
 		bson.M{
 			IdKey: t.Id,
 		},

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -303,6 +303,7 @@ func TestFindTasksByBuildIdAndGithubChecks(t *testing.T) {
 }
 
 func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
+	ctx := context.TODO()
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection, OldCollection))
 	taskDoc := Task{
@@ -317,7 +318,7 @@ func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
 	assert.Equal(task.DisplayStatus, evergreen.TaskSucceeded)
 
 	// Should fetch tasks from the old collection
-	assert.NoError(taskDoc.Archive())
+	assert.NoError(taskDoc.Archive(ctx))
 	task, err = FindOneOldByIdAndExecution(taskDoc.Id, 0)
 	assert.NoError(err)
 	assert.NotNil(task)
@@ -346,6 +347,7 @@ func TestFindOneIdAndExecutionWithDisplayStatus(t *testing.T) {
 }
 
 func TestFindOldTasksByID(t *testing.T) {
+	ctx := context.TODO()
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection, OldCollection))
 
@@ -354,9 +356,9 @@ func TestFindOldTasksByID(t *testing.T) {
 		Status: evergreen.TaskSucceeded,
 	}
 	assert.NoError(taskDoc.Insert())
-	assert.NoError(taskDoc.Archive())
+	assert.NoError(taskDoc.Archive(ctx))
 	taskDoc.Execution += 1
-	assert.NoError(taskDoc.Archive())
+	assert.NoError(taskDoc.Archive(ctx))
 	taskDoc.Execution += 1
 
 	tasks, err := FindOld(ByOldTaskID("task"))
@@ -394,6 +396,7 @@ func TestFindAllFirstExecution(t *testing.T) {
 }
 
 func TestFindOneIdOldOrNew(t *testing.T) {
+	ctx := context.TODO()
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -404,7 +407,7 @@ func TestFindOneIdOldOrNew(t *testing.T) {
 		Status: evergreen.TaskSucceeded,
 	}
 	require.NoError(taskDoc.Insert())
-	require.NoError(taskDoc.Archive())
+	require.NoError(taskDoc.Archive(ctx))
 
 	task00, err := FindOneIdOldOrNew("task", 0)
 	assert.NoError(err)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -539,6 +539,9 @@ func TestBlockedOnDeactivatedDependency(t *testing.T) {
 }
 
 func TestMarkDependenciesFinished(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	defer func() {
 		assert.NoError(t, db.Clear(Collection))
 	}()
@@ -562,7 +565,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t1.Insert())
 			require.NoError(t, t2.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(true))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, true))
 
 			dbTask2, err := FindOneId(t2.Id)
 			require.NoError(t, err)
@@ -587,7 +590,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t0.Insert())
 			require.NoError(t, t1.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(true))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, true))
 
 			dbTask1, err := FindOneId(t1.Id)
 			require.NoError(t, err)
@@ -612,7 +615,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t0.Insert())
 			require.NoError(t, t1.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(true))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, true))
 
 			dbTask1, err := FindOneId(t1.Id)
 			require.NoError(t, err)
@@ -640,7 +643,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t0.Insert())
 			require.NoError(t, t1.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(true))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, true))
 
 			dbTask1, err := FindOneId(t1.Id)
 			require.NoError(t, err)
@@ -672,7 +675,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t1.Insert())
 			require.NoError(t, t2.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(true))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, true))
 
 			dbTask1, err := FindOneId(t1.Id)
 			require.NoError(t, err)
@@ -703,7 +706,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, t0.Insert())
 			require.NoError(t, t1.Insert())
 
-			require.NoError(t, t0.MarkDependenciesFinished(false))
+			require.NoError(t, t0.MarkDependenciesFinished(ctx, false))
 
 			dbTask1, err := FindOneId(t1.Id)
 			require.NoError(t, err)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1647,12 +1647,15 @@ func TestFindVariantsWithTask(t *testing.T) {
 }
 
 func TestAddDependency(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection))
 	}()
 	for tName, tCase := range map[string]func(t *testing.T, tsk *Task){
 		"AddingDuplicateDependencyIsNoop": func(t *testing.T, tsk *Task) {
-			assert.NoError(t, tsk.AddDependency(depTaskIds[0]))
+			assert.NoError(t, tsk.AddDependency(ctx, depTaskIds[0]))
 
 			updated, err := FindOneId(tsk.Id)
 			assert.NoError(t, err)
@@ -1661,7 +1664,7 @@ func TestAddDependency(t *testing.T) {
 			assert.Len(t, updated.DependsOn, len(depTaskIds))
 		},
 		"UpdatesDuplicateDependencyForUnattainability": func(t *testing.T, tsk *Task) {
-			assert.NoError(t, tsk.AddDependency(Dependency{
+			assert.NoError(t, tsk.AddDependency(ctx, Dependency{
 				TaskId:       depTaskIds[0].TaskId,
 				Status:       evergreen.TaskSucceeded,
 				Unattainable: true,
@@ -1674,7 +1677,7 @@ func TestAddDependency(t *testing.T) {
 			assert.True(t, updated.DependsOn[0].Unattainable)
 		},
 		"AddsDependencyForSameTaskButDifferentStatus": func(t *testing.T, tsk *Task) {
-			assert.NoError(t, tsk.AddDependency(Dependency{
+			assert.NoError(t, tsk.AddDependency(ctx, Dependency{
 				TaskId: depTaskIds[0].TaskId,
 				Status: evergreen.TaskFailed,
 			}))
@@ -1685,7 +1688,7 @@ func TestAddDependency(t *testing.T) {
 			assert.Len(t, updated.DependsOn, len(depTaskIds)+1)
 		},
 		"AddingSelfDependencyShouldNoop": func(t *testing.T, tsk *Task) {
-			assert.NoError(t, tsk.AddDependency(Dependency{
+			assert.NoError(t, tsk.AddDependency(ctx, Dependency{
 				TaskId: tsk.Id,
 			}))
 
@@ -2919,6 +2922,9 @@ func getTaskThatNeedsContainerAllocation() Task {
 }
 
 func TestMarkUnattainableDependency(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	defer func() {
 		assert.NoError(t, db.Clear(Collection))
 	}()
@@ -2941,7 +2947,7 @@ func TestMarkUnattainableDependency(t *testing.T) {
 		}
 		require.NoError(t, dependentTask.Insert())
 
-		assert.NoError(t, dependentTask.MarkUnattainableDependency("t1", true))
+		assert.NoError(t, dependentTask.MarkUnattainableDependency(ctx, "t1", true))
 		assert.True(t, dependentTask.Blocked())
 		assert.True(t, dependentTask.UnattainableDependency)
 		require.Len(t, dependentTask.DependsOn, 2)
@@ -2975,7 +2981,7 @@ func TestMarkUnattainableDependency(t *testing.T) {
 		}
 		require.NoError(t, dependentTask.Insert())
 
-		assert.NoError(t, dependentTask.MarkUnattainableDependency("t3", true))
+		assert.NoError(t, dependentTask.MarkUnattainableDependency(ctx, "t3", true))
 		assert.False(t, dependentTask.Blocked())
 		assert.False(t, dependentTask.UnattainableDependency)
 		require.Len(t, dependentTask.DependsOn, 2)
@@ -3009,7 +3015,7 @@ func TestMarkUnattainableDependency(t *testing.T) {
 		}
 		require.NoError(t, dependentTask.Insert())
 
-		assert.NoError(t, dependentTask.MarkUnattainableDependency("t1", false))
+		assert.NoError(t, dependentTask.MarkUnattainableDependency(ctx, "t1", false))
 		assert.True(t, dependentTask.Blocked())
 		assert.True(t, dependentTask.UnattainableDependency)
 		require.Len(t, dependentTask.DependsOn, 2)
@@ -3043,7 +3049,7 @@ func TestMarkUnattainableDependency(t *testing.T) {
 		}
 		require.NoError(t, dependentTask.Insert())
 
-		assert.NoError(t, dependentTask.MarkUnattainableDependency("t1", false))
+		assert.NoError(t, dependentTask.MarkUnattainableDependency(ctx, "t1", false))
 		assert.False(t, dependentTask.Blocked())
 		assert.False(t, dependentTask.UnattainableDependency)
 		require.Len(t, dependentTask.DependsOn, 2)
@@ -3079,7 +3085,7 @@ func TestMarkUnattainableDependency(t *testing.T) {
 
 		dependentTask.DependsOn[1].Unattainable = true
 
-		assert.NoError(t, dependentTask.MarkUnattainableDependency("t1", false))
+		assert.NoError(t, dependentTask.MarkUnattainableDependency(ctx, "t1", false))
 
 		assert.False(t, dependentTask.Blocked())
 		assert.False(t, dependentTask.UnattainableDependency)
@@ -3194,6 +3200,9 @@ func TestGetLatestExecution(t *testing.T) {
 }
 
 func TestArchiveMany(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.ClearCollections(Collection, OldCollection))
 	t1 := Task{
 		Id:      "t1",
@@ -3225,7 +3234,7 @@ func TestArchiveMany(t *testing.T) {
 	assert.NoError(t, dt.Insert())
 
 	tasks := []Task{t1, t2, dt}
-	err := ArchiveMany(tasks)
+	err := ArchiveMany(ctx, tasks)
 	assert.NoError(t, err)
 	currentTasks, err := FindAll(db.Query(ByVersion("v")))
 	assert.NoError(t, err)
@@ -3244,6 +3253,9 @@ func TestArchiveMany(t *testing.T) {
 }
 
 func TestArchiveManyAfterFailedOnly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.ClearCollections(Collection, OldCollection))
 	et1 := Task{
 		Id:                    "et1",
@@ -3316,7 +3328,7 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 		Version:                 "v",
 	}
 	assert.NoError(t, t3.Insert())
-	assert.NoError(t, t3.Archive()) // Failed only is true
+	assert.NoError(t, t3.Archive(ctx)) // Failed only is true
 	currentTasks, err := FindAll(db.Query(ByVersion("v")))
 	assert.NoError(t, err)
 	for _, task := range currentTasks {
@@ -3354,7 +3366,7 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 	t3Pointer, err := FindByIdExecution(t3.Id, nil)
 	assert.NoError(t, err)
 	t3Pointer.ResetFailedWhenFinished = false
-	assert.NoError(t, ArchiveMany([]Task{t1, t2, *t3Pointer, t4}))
+	assert.NoError(t, ArchiveMany(ctx, []Task{t1, t2, *t3Pointer, t4}))
 
 	// Before ArchiveMany:
 	// t1: et1, et2 (execution 2)
@@ -3544,6 +3556,9 @@ func TestAbortVersionTasks(t *testing.T) {
 }
 
 func TestArchive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection, OldCollection, event.EventCollection))
 	}()
@@ -3584,7 +3599,7 @@ func TestArchive(t *testing.T) {
 			event.LogHostRunningTaskSet(hostID, tsk.Id, 0)
 			event.LogHostRunningTaskCleared(hostID, tsk.Id, 0)
 
-			require.NoError(t, tsk.Archive())
+			require.NoError(t, tsk.Archive(ctx))
 
 			checkTaskIsArchived(t, archivedTaskID)
 			checkEventLogHostTaskExecutions(t, hostID, archivedTaskID, archivedExecution)
@@ -3608,7 +3623,7 @@ func TestArchive(t *testing.T) {
 			archivedDisplayTaskID := MakeOldID(dt.Id, dt.Execution)
 			require.NoError(t, dt.Insert())
 
-			require.NoError(t, dt.Archive())
+			require.NoError(t, dt.Archive(ctx))
 
 			checkTaskIsArchived(t, archivedExecTaskID)
 			checkTaskIsArchived(t, archivedDisplayTaskID)
@@ -3620,7 +3635,7 @@ func TestArchive(t *testing.T) {
 			tsk.ExecutionPlatform = ExecutionPlatformContainer
 			require.NoError(t, tsk.Insert())
 
-			require.NoError(t, tsk.Archive())
+			require.NoError(t, tsk.Archive(ctx))
 			checkTaskIsArchived(t, archivedTaskID)
 		},
 	} {
@@ -3636,6 +3651,9 @@ func TestArchive(t *testing.T) {
 }
 
 func TestArchiveFailedOnly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection, OldCollection, event.EventCollection))
 	}()
@@ -3721,7 +3739,7 @@ func TestArchiveFailedOnly(t *testing.T) {
 		// Verifies the execution before and after calling Archive
 		archivedDisplayTaskID := MakeOldID(dt.Id, dt.Execution)
 		require.Equal(t, 0, dt.Execution)
-		require.NoError(t, dt.Archive())
+		require.NoError(t, dt.Archive(ctx))
 		dt, err = FindOneId(dt.Id)
 		require.NoError(t, err)
 		require.Equal(t, 1, dt.Execution)
@@ -3772,7 +3790,7 @@ func TestArchiveFailedOnly(t *testing.T) {
 
 		// Verifies the display task is archived after calling archive
 		archivedDisplayTaskID := MakeOldID(dt.Id, dt.Execution)
-		require.NoError(t, dt.Archive())
+		require.NoError(t, dt.Archive(ctx))
 		dt, err = FindOneId(dt.Id)
 		require.NoError(t, err)
 		require.Equal(t, 2, dt.Execution)
@@ -4013,6 +4031,9 @@ func (s *TaskConnectorFetchByIdSuite) TestFindById() {
 }
 
 func (s *TaskConnectorFetchByIdSuite) TestFindByIdAndExecution() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	s.Require().NoError(db.ClearCollections(Collection, OldCollection))
 	testTask1 := &Task{
 		Id:        "task_1",
@@ -4022,7 +4043,7 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByIdAndExecution() {
 	}
 	s.NoError(testTask1.Insert())
 	for i := 0; i < 10; i++ {
-		s.NoError(testTask1.Archive())
+		s.NoError(testTask1.Archive(ctx))
 		err := UpdateOne(
 			bson.M{IdKey: "task_1"},
 			bson.M{CanResetKey: false},
@@ -4112,6 +4133,9 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 }
 
 func (s *TaskConnectorFetchByIdSuite) TestFindOldTasksByIDWithDisplayTasks() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	s.Require().NoError(db.ClearCollections(Collection, OldCollection))
 	testTask1 := &Task{
 		Id:            "task_1",
@@ -4131,9 +4155,9 @@ func (s *TaskConnectorFetchByIdSuite) TestFindOldTasksByIDWithDisplayTasks() {
 	}
 	s.NoError(testTask2.Insert())
 	for i := 0; i < 10; i++ {
-		s.NoError(testTask1.Archive())
+		s.NoError(testTask1.Archive(ctx))
 		testTask1.Execution += 1
-		s.NoError(testTask2.Archive())
+		s.NoError(testTask2.Archive(ctx))
 		testTask2.Execution += 1
 	}
 	tasks, err := FindOldWithDisplayTasks(ByOldTaskID("task_1"))

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -390,7 +390,7 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 	if t.IsPartOfDisplay() {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
-	if err = t.Archive(); err != nil {
+	if err = t.Archive(ctx); err != nil {
 		return errors.Wrap(err, "can't restart task because it can't be archived")
 	}
 
@@ -727,7 +727,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		return errors.Wrap(err, "marking task finished")
 	}
 
-	if err = UpdateBlockedDependencies(t); err != nil {
+	if err = UpdateBlockedDependencies(ctx, t); err != nil {
 		return errors.Wrap(err, "updating blocked dependencies")
 	}
 
@@ -900,7 +900,7 @@ func logTaskEndStats(ctx context.Context, t *task.Task) error {
 // UpdateBlockedDependencies traverses the dependency graph and recursively sets
 // each parent dependency as unattainable in depending tasks. It updates the
 // status of builds as well, in case they change due to blocking dependencies.
-func UpdateBlockedDependencies(t *task.Task) error {
+func UpdateBlockedDependencies(ctx context.Context, t *task.Task) error {
 	dependentTasks, err := t.FindAllUnmarkedBlockedDependencies()
 	if err != nil {
 		return errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
@@ -908,10 +908,10 @@ func UpdateBlockedDependencies(t *task.Task) error {
 
 	buildIDsSet := make(map[string]struct{})
 	for _, dependentTask := range dependentTasks {
-		if err = dependentTask.MarkUnattainableDependency(t.Id, true); err != nil {
+		if err = dependentTask.MarkUnattainableDependency(ctx, t.Id, true); err != nil {
 			return errors.Wrap(err, "marking dependency unattainable")
 		}
-		if err = UpdateBlockedDependencies(&dependentTask); err != nil {
+		if err = UpdateBlockedDependencies(ctx, &dependentTask); err != nil {
 			return errors.Wrapf(err, "updating blocked dependencies for '%s'", t.Id)
 		}
 		buildIDsSet[dependentTask.BuildId] = struct{}{}
@@ -929,7 +929,7 @@ func UpdateBlockedDependencies(t *task.Task) error {
 }
 
 // UpdateUnblockedDependencies recursively marks all unattainable dependencies as attainable.
-func UpdateUnblockedDependencies(t *task.Task) error {
+func UpdateUnblockedDependencies(ctx context.Context, t *task.Task) error {
 	blockedTasks, err := t.FindAllMarkedUnattainableDependencies()
 	if err != nil {
 		return errors.Wrap(err, "getting dependencies marked unattainable")
@@ -937,11 +937,11 @@ func UpdateUnblockedDependencies(t *task.Task) error {
 
 	buildsToUpdate := make(map[string]bool)
 	for _, blockedTask := range blockedTasks {
-		if err = blockedTask.MarkUnattainableDependency(t.Id, false); err != nil {
+		if err = blockedTask.MarkUnattainableDependency(ctx, t.Id, false); err != nil {
 			return errors.Wrap(err, "marking dependency attainable")
 		}
 
-		if err := UpdateUnblockedDependencies(&blockedTask); err != nil {
+		if err := UpdateUnblockedDependencies(ctx, &blockedTask); err != nil {
 			return errors.WithStack(err)
 		}
 
@@ -1069,7 +1069,7 @@ func dequeueAndRestartItem(ctx context.Context, opts dequeueAndRestartOptions) (
 		return nil, errors.Errorf("patch '%s' not found", opts.itemVersionID)
 	}
 
-	removed, err := tryDequeueAndAbortCommitQueueItem(p, *opts.cq, opts.taskID, opts.mergeErrMsg, opts.caller)
+	removed, err := tryDequeueAndAbortCommitQueueItem(ctx, p, *opts.cq, opts.taskID, opts.mergeErrMsg, opts.caller)
 	if err != nil {
 		return nil, errors.Wrapf(err, "dequeueing and aborting commit queue item '%s'", opts.itemVersionID)
 	}
@@ -1167,9 +1167,9 @@ func dequeueAndRestartWithStepback(ctx context.Context, cq *commitqueue.CommitQu
 	return DequeueAndRestartForTask(ctx, cq, t, message.GithubStateFailure, caller, reason)
 }
 
-func tryDequeueAndAbortCommitQueueItem(p *patch.Patch, cq commitqueue.CommitQueue, taskID, mergeErrMsg string, caller string) (*commitqueue.CommitQueueItem, error) {
+func tryDequeueAndAbortCommitQueueItem(ctx context.Context, p *patch.Patch, cq commitqueue.CommitQueue, taskID, mergeErrMsg string, caller string) (*commitqueue.CommitQueueItem, error) {
 	issue := p.Id.Hex()
-	err := removeNextMergeTaskDependency(cq, issue)
+	err := removeNextMergeTaskDependency(ctx, cq, issue)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "error removing dependency",
 		"patch":   issue,
@@ -1201,7 +1201,7 @@ func tryDequeueAndAbortCommitQueueItem(p *patch.Patch, cq commitqueue.CommitQueu
 // removeNextMergeTaskDependency basically removes the given merge task from a linked list of
 // merge task dependencies. It makes the next merge not depend on the current one and also makes
 // the next merge depend on the previous one, if there is one
-func removeNextMergeTaskDependency(cq commitqueue.CommitQueue, currentIssue string) error {
+func removeNextMergeTaskDependency(ctx context.Context, cq commitqueue.CommitQueue, currentIssue string) error {
 	currentIndex := cq.FindItem(currentIssue)
 	if currentIndex < 0 {
 		return errors.New("commit queue item not found")
@@ -1242,7 +1242,7 @@ func removeNextMergeTaskDependency(cq commitqueue.CommitQueue, currentIssue stri
 			TaskId: prevMerge.Id,
 			Status: AllStatuses,
 		}
-		if err = nextMerge.AddDependency(d); err != nil {
+		if err = nextMerge.AddDependency(ctx, d); err != nil {
 			return errors.Wrap(err, "adding dependency")
 		}
 	}
@@ -1920,7 +1920,7 @@ func MarkOneTaskReset(ctx context.Context, t *task.Task) error {
 		return errors.Wrap(err, "resetting task in database")
 	}
 
-	if err := UpdateUnblockedDependencies(t); err != nil {
+	if err := UpdateUnblockedDependencies(ctx, t); err != nil {
 		return errors.Wrap(err, "clearing unattainable dependencies")
 	}
 
@@ -1949,7 +1949,7 @@ func MarkTasksReset(ctx context.Context, taskIds []string) error {
 
 	catcher := grip.NewBasicCatcher()
 	for _, t := range tasks {
-		catcher.Wrapf(UpdateUnblockedDependencies(&t), "clearing unattainable dependencies for task '%s'", t.Id)
+		catcher.Wrapf(UpdateUnblockedDependencies(ctx, &t), "clearing unattainable dependencies for task '%s'", t.Id)
 		catcher.Wrapf(t.MarkDependenciesFinished(ctx, false), "marking direct dependencies unfinished for task '%s'", t.Id)
 	}
 

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -278,9 +279,7 @@ func AddOrUpdateServiceUser(u DBUser) error {
 }
 
 // DeleteServiceUser deletes a service user by ID.
-func DeleteServiceUser(id string) error {
-	ctx, cancel := evergreen.GetEnvironment().Context()
-	defer cancel()
+func DeleteServiceUser(ctx context.Context, id string) error {
 	query := bson.M{
 		IdKey:      id,
 		OnlyAPIKey: true,

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -336,14 +337,11 @@ func (u *DBUser) RemoveRole(role string) error {
 }
 
 // GetViewableProjects returns the lists of projects/repos the user can view.
-func (u *DBUser) GetViewableProjectSettings() ([]string, error) {
+func (u *DBUser) GetViewableProjectSettings(ctx context.Context) ([]string, error) {
 	if evergreen.PermissionsDisabledForTests() {
 		return nil, nil
 	}
-	env := evergreen.GetEnvironment()
-	roleManager := env.RoleManager()
-	ctx, cancel := env.Context()
-	defer cancel()
+	roleManager := evergreen.GetEnvironment().RoleManager()
 
 	viewProjects, err := rolemanager.FindAllowedResources(ctx, roleManager, u.Roles(), evergreen.ProjectResourceType, evergreen.PermissionProjectSettings, evergreen.ProjectSettingsView.Value)
 	if err != nil {

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -748,7 +749,11 @@ func TestGeneralSubscriptionIDs(t *testing.T) {
 }
 
 func TestViewableProjectSettings(t *testing.T) {
-	rm := evergreen.GetEnvironment().RoleManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	env := testutil.NewEnvironment(ctx, t)
+	rm := env.RoleManager()
+
 	assert.NoError(t, db.ClearCollections(evergreen.RoleCollection, evergreen.ScopeCollection, Collection))
 	editScope := gimlet.Scope{
 		ID:        "edit_scope",
@@ -802,7 +807,7 @@ func TestViewableProjectSettings(t *testing.T) {
 	assert.NoError(t, myUser.AddRole(otherRole.ID))
 
 	// assert that viewable projects contains the edit projects and the view projects
-	projects, err := myUser.GetViewableProjectSettings()
+	projects, err := myUser.GetViewableProjectSettings(ctx)
 	assert.NoError(t, err)
 	assert.Len(t, projects, 3)
 	assert.Contains(t, projects, "edit1")

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -592,6 +592,9 @@ func (s *UserTestSuite) TestFindNeedsReauthorization() {
 }
 
 func TestServiceUserOperations(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.Clear(Collection))
 	u := DBUser{
 		Id:          "u",
@@ -623,9 +626,9 @@ func TestServiceUserOperations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, users, 1)
 
-	err = DeleteServiceUser("doesntexist")
+	err = DeleteServiceUser(ctx, "doesntexist")
 	assert.EqualError(t, err, "service user 'doesntexist' not found")
-	err = DeleteServiceUser(u.Id)
+	err = DeleteServiceUser(ctx, u.Id)
 	assert.NoError(t, err)
 	dbUser, err = FindOneById(u.Id)
 	assert.NoError(t, err)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -200,7 +200,7 @@ func TestMarkTaskForReset(t *testing.T) {
 			require.NoError(t, foundTask.MarkEnd(time.Now(), &apimodels.TaskEndDetail{
 				Status: evergreen.TaskFailed,
 			}))
-			require.NoError(t, foundTask.Archive())
+			require.NoError(t, foundTask.Archive(ctx))
 			require.NoError(t, foundTask.Reset(ctx))
 			resp = rh.Run(ctx)
 			require.NotZero(t, resp)

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -343,9 +343,6 @@ func TestAnnotationByTaskGetHandlerRun(t *testing.T) {
 }
 
 func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	assert.NoError(t, db.ClearCollections(annotations.Collection, task.Collection, task.OldCollection))
 	tasks := []task.Task{
 		{Id: "TaskFailedId", Execution: 1, Status: evergreen.TaskFailed},
@@ -363,6 +360,8 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		{Id: "t2_0", Execution: 0, Status: evergreen.TaskFailed},
 	}
 
+	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "test_annotation_user"})
+
 	for _, each := range tasks {
 		assert.NoError(t, each.Insert())
 	}
@@ -373,8 +372,6 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 	}
 
 	h := &annotationByTaskPutHandler{}
-
-	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "test_annotation_user"})
 
 	execution0 := 0
 	execution1 := 1

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -343,6 +343,9 @@ func TestAnnotationByTaskGetHandlerRun(t *testing.T) {
 }
 
 func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(annotations.Collection, task.Collection, task.OldCollection))
 	tasks := []task.Task{
 		{Id: "TaskFailedId", Execution: 1, Status: evergreen.TaskFailed},
@@ -366,7 +369,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 
 	for _, each := range old_tasks {
 		assert.NoError(t, each.Insert())
-		assert.NoError(t, each.Archive())
+		assert.NoError(t, each.Archive(ctx))
 	}
 
 	h := &annotationByTaskPutHandler{}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1313,7 +1313,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	// we should disable hosts and prevent them from performing
 	// more work if they appear to be in a bad state
 	// (e.g. encountered 5 consecutive system failures)
-	if event.AllRecentHostEventsMatchStatus(currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
+	if event.AllRecentHostEventsMatchStatus(ctx, currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
 		msg := "host encountered consecutive system failures"
 		if currentHost.Provider != evergreen.ProviderNameStatic {
 			grip.Error(message.WrapError(units.HandlePoisonedHost(ctx, h.env, currentHost, msg), message.Fields{

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -81,6 +81,9 @@ func (s *TaskAbortSuite) TestAbort() {
 }
 
 func TestFetchArtifacts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -91,7 +94,7 @@ func TestFetchArtifacts(t *testing.T) {
 		Execution: 0,
 	}
 	assert.NoError(task1.Insert())
-	assert.NoError(task1.Archive())
+	assert.NoError(task1.Archive(ctx))
 	entry := artifact.Entry{
 		TaskId:          task1.Id,
 		TaskDisplayName: "task",
@@ -119,7 +122,7 @@ func TestFetchArtifacts(t *testing.T) {
 		Status:      evergreen.TaskSucceeded,
 	}
 	assert.NoError(task2.Insert())
-	assert.NoError(task2.Archive())
+	assert.NoError(task2.Archive(ctx))
 
 	taskGet := taskGetHandler{taskID: task1.Id}
 	resp := taskGet.Run(context.Background())

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -707,7 +707,7 @@ func (h *serviceUserDeleteHandler) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (h *serviceUserDeleteHandler) Run(ctx context.Context) gimlet.Responder {
-	err := user.DeleteServiceUser(h.username)
+	err := user.DeleteServiceUser(ctx, h.username)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting service user '%s'", h.username))
 	}

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -61,7 +61,7 @@ func (j *checkBlockedTasksJob) Run(ctx context.Context) {
 	}
 	dependencyCache := map[string]task.Task{}
 	for _, t := range tasksToCheck {
-		j.AddError(errors.Wrapf(checkUnmarkedBlockingTasks(&t, dependencyCache), "checking task '%s'", t.Id))
+		j.AddError(errors.Wrapf(checkUnmarkedBlockingTasks(ctx, &t, dependencyCache), "checking task '%s'", t.Id))
 	}
 }
 
@@ -118,7 +118,7 @@ func (j *checkBlockedTasksJob) getContainerTasksToCheck() []task.Task {
 	return tasksToCheck
 }
 
-func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.Task) error {
+func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCaches map[string]task.Task) error {
 	catcher := grip.NewBasicCatcher()
 
 	dependenciesMet, err := t.DependenciesMet(dependencyCaches)
@@ -141,7 +141,7 @@ func checkUnmarkedBlockingTasks(t *task.Task, dependencyCaches map[string]task.T
 	if err == nil {
 		for _, blockingTask := range blockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			err = model.UpdateBlockedDependencies(&blockingTask)
+			err = model.UpdateBlockedDependencies(ctx, &blockingTask)
 			catcher.Wrapf(err, "updating blocked dependencies for '%s'", blockingTask.Id)
 		}
 	}

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -399,6 +399,9 @@ func (s *commitQueueSuite) TestUpdatePatch() {
 }
 
 func TestAddMergeTaskDependencies(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(task.Collection))
 	j := commitQueueJob{}
 	mergeTask1 := task.Task{
@@ -436,7 +439,7 @@ func TestAddMergeTaskDependencies(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, j.addMergeTaskDependencies(cq))
+	assert.NoError(t, j.addMergeTaskDependencies(ctx, cq))
 	dbTask1, err := task.FindOneId(mergeTask1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, dbTask1.NumDependents)

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -421,7 +421,7 @@ func (j *createHostJob) spawnAndReplaceHost(ctx context.Context, cloudMgr cloud.
 	if j.HostID == j.host.Id {
 		// Spawning the host did not change the ID, so we can replace the old
 		// host with the new one (e.g. for Docker containers).
-		if err = j.host.Replace(); err != nil {
+		if err = j.host.Replace(ctx); err != nil {
 			return false, errors.Wrapf(err, "replacing host '%s'", j.host.Id)
 		}
 		return true, nil


### PR DESCRIPTION
DEVPROD-810

### Description
Removed invocations of app-level context throughout the `model/` directory as indicated in the ticket.

Here were a few that proved too tricky to remove—let me know if they are crucial enough to revisit as part of this fix. I don't know much about how context is created in the application so apologies in advance.
- [`user.GetOrCreateUser`](https://github.com/evergreen-ci/evergreen/blob/812185e19e4e118b685086162c92f9e86ca8d6c6/model/user/db.go#L306) - function signature is defined as in [Gimlet](https://github.com/evergreen-ci/gimlet/blob/e7de42b0623c008a8eeca167a7190edcc364ac51/auth_interfaces.go#L72) so I couldn't add `ctx`
- [`model.GetFailedTests`](https://github.com/evergreen-ci/evergreen/blob/812185e19e4e118b685086162c92f9e86ca8d6c6/model/task_history.go#L236) - only used in `services/` directory for legacy UI
- [`task.PopulateTestResults`](https://github.com/evergreen-ci/evergreen/blob/812185e19e4e118b685086162c92f9e86ca8d6c6/model/task/task.go#L2710) - a huge cascade of changes were required to add context. I couldn't find exactly how GraphQL would call this function either.
- [`task.getExpectedDurationsForWindow`](https://github.com/evergreen-ci/evergreen/blob/812185e19e4e118b685086162c92f9e86ca8d6c6/model/task/expected_duration.go#L79) - `ExpectedDuration` seems to be used [only for legacy](https://github.com/evergreen-ci/evergreen/blob/812185e19e4e118b685086162c92f9e86ca8d6c6/model/task/task.go#L231-L233)

**Update:** Created DEVPROD-3925 to handle above issues

### Testing
- Updated lots of tests

### Documentation
N/A