### PR TITLE
DEVPROD-741 Delete unnecessary validation for task config

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -134,24 +134,6 @@ func (c *TaskConfig) GetCloneMethod() string {
 	return evergreen.CloneMethodOAuth
 }
 
-// Validate validates that the task config is populated with the data required
-// for a task to run.
-// Note that this is here only as legacy code. These checks are not sufficient
-// to indicate that the TaskConfig has all the necessary information to run a
-// task.
-func (tc *TaskConfig) Validate() error {
-	if tc == nil {
-		return errors.New("unable to get task setup because task config is nil")
-	}
-	if tc.Task.Id == "" {
-		return errors.New("unable to get task setup because task ID is nil")
-	}
-	if tc.Task.Version == "" {
-		return errors.New("task has no version")
-	}
-	return nil
-}
-
 func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 	return map[string]string{
 		evergreen.TaskIDOtelAttribute:            tc.Task.Id,

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -263,10 +263,6 @@ type commandBlock struct {
 
 // getPre returns a command block containing the pre task commands.
 func (tc *taskContext) getPre() (*commandBlock, error) {
-	if err := tc.taskConfig.Validate(); err != nil {
-		return nil, err
-	}
-
 	tg := tc.taskConfig.TaskGroup
 	if tg == nil {
 		return &commandBlock{
@@ -289,10 +285,6 @@ func (tc *taskContext) getPre() (*commandBlock, error) {
 
 // getPost returns a command block containing the post task commands.
 func (tc *taskContext) getPost() (*commandBlock, error) {
-	if err := tc.taskConfig.Validate(); err != nil {
-		return nil, err
-	}
-
 	tg := tc.taskConfig.TaskGroup
 	if tg == nil {
 		return &commandBlock{
@@ -317,10 +309,6 @@ func (tc *taskContext) getPost() (*commandBlock, error) {
 
 // getSetupGroup returns the setup group for a task group task.
 func (tc *taskContext) getSetupGroup() (*commandBlock, error) {
-	if err := tc.taskConfig.Validate(); err != nil {
-		return nil, err
-	}
-
 	tg := tc.taskConfig.TaskGroup
 	if tg == nil {
 		return &commandBlock{}, nil
@@ -340,10 +328,6 @@ func (tc *taskContext) getSetupGroup() (*commandBlock, error) {
 
 // getTeardownGroup returns the teardown group for a task group task.
 func (tc *taskContext) getTeardownGroup() (*commandBlock, error) {
-	if err := tc.taskConfig.Validate(); err != nil {
-		return nil, err
-	}
-
 	tg := tc.taskConfig.TaskGroup
 	if tg == nil {
 		return &commandBlock{}, nil
@@ -363,10 +347,6 @@ func (tc *taskContext) getTeardownGroup() (*commandBlock, error) {
 
 // getTimeout returns a command block containing the timeout handler commands.
 func (tc *taskContext) getTimeout() (*commandBlock, error) {
-	if err := tc.taskConfig.Validate(); err != nil {
-		return nil, err
-	}
-
 	tg := tc.taskConfig.TaskGroup
 	if tg == nil {
 		return &commandBlock{

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-12"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-16"
+	AgentVersion = "2024-01-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-741

### Description
More details in ticket but we were validating task configs twice for no reason other than tests. Should be fine to delete if all tests pass

### Testing
all existing tests pass
staging works 