### PR TITLE
DEVPROD-1723: Pipe through agent AWS creds for task and test log buckets

### DIFF
--- a/agent/command/archive_auto_create_test.go
+++ b/agent/command/archive_auto_create_test.go
@@ -249,7 +249,7 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 			)
 			require.NoError(t, err)
 			comm := client.NewMock("url")
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 
 			tCase(ctx, t, &autoArchiveCreate{

--- a/agent/command/archive_auto_extract_test.go
+++ b/agent/command/archive_auto_extract_test.go
@@ -49,8 +49,8 @@ func (s *AutoExtractSuite) SetupTest() {
 		Project:    model.Project{},
 		WorkDir:    s.targetLocation,
 	}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 
 	s.cmd = &autoExtract{}
 	s.params = map[string]interface{}{}

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -87,8 +87,8 @@ func TestTarGzCommandMakeArchive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	comm := client.NewMock("http://localhost.com")
-	conf := &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{}, Project: model.Project{}}
-	logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	conf := &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{Id: "task"}, Project: model.Project{}}
+	logger, _ := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 
 	Convey("With a targz pack command", t, func() {
 		testDataDir := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "archive")

--- a/agent/command/archive_tarball_extract_test.go
+++ b/agent/command/archive_tarball_extract_test.go
@@ -45,8 +45,8 @@ func (s *TarballExtractSuite) SetupTest() {
 		Project:    model.Project{},
 		WorkDir:    s.targetLocation,
 	}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 
 	s.cmd = &tarballExtract{}
 	s.params = map[string]interface{}{}

--- a/agent/command/archive_zip_create_test.go
+++ b/agent/command/archive_zip_create_test.go
@@ -42,8 +42,8 @@ func (s *ZipCreateSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
 	s.conf = &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{}, Project: model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 
 	s.cmd = &zipArchiveCreate{}
 	s.params = map[string]interface{}{}

--- a/agent/command/archive_zip_extract_test.go
+++ b/agent/command/archive_zip_extract_test.go
@@ -45,7 +45,7 @@ func (s *ZipExtractSuite) SetupTest() {
 		Project:    model.Project{},
 		WorkDir:    s.targetLocation,
 	}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
 	s.NoError(err)
 
 	s.cmd = &zipExtract{}

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -42,10 +42,7 @@ func TestEc2AssumeRoleExecute(t *testing.T) {
 		},
 	}
 	comm := client.NewMock("localhost")
-	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
-		ID:     conf.Task.Id,
-		Secret: conf.Task.Secret,
-	}, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
 		"FailsWithNoARN": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {

--- a/agent/command/attach_artifacts_test.go
+++ b/agent/command/attach_artifacts_test.go
@@ -64,8 +64,8 @@ func (s *ArtifactsSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.comm = client.NewMock("http://localhost.com")
 	s.conf = &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{}, Project: model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 	s.cmd = attachArtifactsFactory().(*attachArtifacts)
 	s.conf.WorkDir = s.tmpdir
 	s.mock = s.comm.(*client.Mock)

--- a/agent/command/downstream_expansions_test.go
+++ b/agent/command/downstream_expansions_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDownstreamExpansions(t *testing.T) {
@@ -43,7 +44,8 @@ func TestDownstreamExpansions(t *testing.T) {
 				defer cancel()
 				comm := client.NewMock("http://localhost.com")
 				conf := &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{Requester: "patch_request"}, Project: model.Project{}}
-				logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+				logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+				require.NoError(t, err)
 				cwd := testutil.GetDirectoryOfFile()
 				path := filepath.Join(cwd, "testdata", "git", "test_expansions.yml")
 				testCase(t, ctx, comm, conf, logger, path)
@@ -55,7 +57,8 @@ func TestDownstreamExpansions(t *testing.T) {
 			defer cancel()
 			comm := client.NewMock("http://localhost.com")
 			conf := &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{Requester: "gitter_request"}, Project: model.Project{}}
-			logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+			require.NoError(t, err)
 			cwd := testutil.GetDirectoryOfFile()
 			path := filepath.Join(cwd, "testdata", "git", "test_expansions.yml")
 

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -53,8 +53,8 @@ func (s *execCmdSuite) SetupTest() {
 
 	s.comm = client.NewMock("http://localhost.com")
 	s.conf = &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{}, Project: model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 }
 
 func (s *execCmdSuite) TearDownTest() {

--- a/agent/command/generate_test.go
+++ b/agent/command/generate_test.go
@@ -41,8 +41,8 @@ func (s *generateSuite) SetupTest() {
 		Expansions: util.Expansions{},
 		Task:       task.Task{Id: "mock_id", Secret: "mock_secret"},
 		Project:    model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 	s.g = &generateTask{}
 	s.tmpDirName = s.T().TempDir()
 	s.conf.WorkDir = s.tmpDirName

--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -29,7 +29,8 @@ func TestPatchPluginAPI(t *testing.T) {
 	defer cancel()
 	comm := client.NewMock("http://localhost.com")
 	conf := &internal.TaskConfig{Expansions: util.Expansions{}, Task: task.Task{}, Project: model.Project{}}
-	logger, _ := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
 
 	cwd := testutil.GetDirectoryOfFile()
 
@@ -124,8 +125,8 @@ func TestPatchPlugin(t *testing.T) {
 		require.NoError(t, err)
 
 		comm := client.NewMock("http://localhost.com")
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: taskConfig.Task.Id, Secret: taskConfig.Task.Secret}, nil)
-		So(err, ShouldBeNil)
+		logger, err := comm.GetLoggerProducer(ctx, &taskConfig.Task, nil)
+		require.NoError(t, err)
 
 		Convey("all commands in test project should execute successfully", func() {
 			taskConfig.Task.Requester = evergreen.PatchVersionRequester

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -37,7 +37,7 @@ func TestGitPush(t *testing.T) {
 		ProjectRef: model.ProjectRef{Branch: "main"},
 		Expansions: util.Expansions{},
 	}
-	logger, err := comm.GetLoggerProducer(context.Background(), client.TaskData{}, nil)
+	logger, err := comm.GetLoggerProducer(context.Background(), &conf.Task, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, conf.GetCloneMethod(), evergreen.CloneMethodOAuth)

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -41,8 +41,8 @@ func (s *createHostSuite) SetupSuite() {
 		Expansions: util.Expansions{"subnet_id": "subnet-123456"},
 		Task:       task.Task{Id: "mock_id", Secret: "mock_secret"},
 		Project:    model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(context.Background(), client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(context.Background(), &s.conf.Task, nil)
+	s.Require().NoError(err)
 }
 
 func (s *createHostSuite) SetupTest() {

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -33,8 +33,8 @@ func (s *HostListSuite) SetupTest() {
 
 	s.comm = client.NewMock("http://localhost.com")
 	s.conf = &internal.TaskConfig{Expansions: util.Expansions{"foo": "3"}, Task: task.Task{}, Project: model.Project{}}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 	s.cmd = listHostFactory().(*listHosts)
 }
 

--- a/agent/command/keyval_test.go
+++ b/agent/command/keyval_test.go
@@ -35,8 +35,9 @@ func TestIncKey(t *testing.T) {
 		require.NoError(t, err)
 
 		Convey("Inc command should increment a key successfully", func() {
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-			So(err, ShouldBeNil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+			require.NoError(t, err)
+
 			for _, task := range conf.Project.Tasks {
 				So(len(task.Commands), ShouldNotEqual, 0)
 				for _, command := range task.Commands {

--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -38,8 +38,8 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 		require.NoError(t, err)
 		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-		So(err, ShouldBeNil)
+		logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+		require.NoError(t, err)
 
 		Convey("all commands in test project should execute successfully", func() {
 			curWD, err := os.Getwd()
@@ -100,8 +100,8 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 		require.NoError(t, err)
 		comm := client.NewMock("http://localhost.com")
 
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-		So(err, ShouldBeNil)
+		logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+		require.NoError(t, err)
 
 		Convey("all commands in test project should execute successfully", func() {
 			curWD, err := os.Getwd()

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -48,8 +48,8 @@ func TestAttachResults(t *testing.T) {
 		conf.WorkDir = "."
 
 		Convey("all commands in test project should execute successfully", func() {
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-			So(err, ShouldBeNil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+			require.NoError(t, err)
 
 			for _, projTask := range conf.Project.Tasks {
 				So(len(projTask.Commands), ShouldNotEqual, 0)
@@ -100,8 +100,8 @@ func TestAttachRawResults(t *testing.T) {
 		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		conf.WorkDir = "."
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-		So(err, ShouldBeNil)
+		logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+		require.NoError(t, err)
 
 		Convey("when attaching a raw log ", func() {
 			for _, projTask := range conf.Project.Tasks {

--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -52,7 +52,7 @@ func TestSendTestResults(t *testing.T) {
 	comm := client.NewMock("url")
 	displayTaskInfo, err := comm.GetDisplayTaskInfoFromExecution(ctx, td)
 	require.NoError(t, err)
-	logger, err := comm.GetLoggerProducer(ctx, td, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, logger.Close())

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -45,8 +45,8 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 		conf, err := agentutil.MakeTaskConfigFromModelData(ctx, testConfig, modelData)
 		require.NoError(t, err)
 		conf.WorkDir = "."
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
-		So(err, ShouldBeNil)
+		logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+		require.NoError(t, err)
 
 		Convey("all commands in test project should execute successfully", func() {
 			for _, projTask := range conf.Project.Tasks {
@@ -229,7 +229,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 			require.NoError(t, err)
 			conf.WorkDir = filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "xunit")
 
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 
 			tCase(tctx, t, cedarSrv, conf, logger)

--- a/agent/command/s3_copy_test.go
+++ b/agent/command/s3_copy_test.go
@@ -47,10 +47,7 @@ func TestS3CopyExecute(t *testing.T) {
 				},
 			}
 			comm := client.NewMock("localhost")
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
-				ID:     conf.Task.Id,
-				Secret: conf.Task.Secret,
-			}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 
 			c := &s3copy{S3CopyFiles: []*s3CopyFile{

--- a/agent/command/s3_pull_test.go
+++ b/agent/command/s3_pull_test.go
@@ -151,10 +151,7 @@ func TestS3PullExecute(t *testing.T) {
 				},
 			}
 			comm := client.NewMock("localhost")
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
-				ID:     conf.Task.Id,
-				Secret: conf.Task.Secret,
-			}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 			tmpDir := t.TempDir()
 			c := &s3Pull{Task: "task", FromBuildVariant: "from_build_variant"}

--- a/agent/command/s3_push_test.go
+++ b/agent/command/s3_push_test.go
@@ -150,10 +150,7 @@ func TestS3PushExecute(t *testing.T) {
 				},
 			}
 			comm := client.NewMock("localhost")
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{
-				ID:     conf.Task.Id,
-				Secret: conf.Task.Secret,
-			}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 			c := &s3Push{}
 			c.bucket, err = pail.NewLocalBucket(pail.LocalOptions{

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -352,7 +352,7 @@ func TestSignedUrlVisibility(t *testing.T) {
 			Project:      model.Project{},
 			BuildVariant: model.BuildVariant{},
 		}
-		logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+		logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 		require.NoError(t, err)
 
 		localFiles := []string{"file1", "file2"}
@@ -399,7 +399,7 @@ func TestContentTypeSaved(t *testing.T) {
 		BuildVariant: model.BuildVariant{},
 	}
 	s.taskdata = client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 
 	localFiles := []string{"file1", "file2"}
@@ -465,7 +465,7 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 				WorkDir:      dir,
 				BuildVariant: model.BuildVariant{},
 			}
-			logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 			require.NoError(t, err)
 
 			require.NoError(t, s.Execute(ctx, comm, logger, conf))
@@ -526,7 +526,7 @@ func TestFileUploadNaming(t *testing.T) {
 		WorkDir:      dir,
 		BuildVariant: model.BuildVariant{},
 	}
-	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, s.Execute(ctx, comm, logger, conf))
@@ -606,7 +606,7 @@ func TestPreservePath(t *testing.T) {
 		WorkDir:      dir,
 		BuildVariant: model.BuildVariant{},
 	}
-	logger, err := comm.GetLoggerProducer(ctx, client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}, nil)
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, s.Execute(ctx, comm, logger, conf))

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -56,8 +56,8 @@ func (s *shellExecuteCommandSuite) SetupTest() {
 		},
 		Project: model.Project{},
 	}
-	s.logger, err = s.comm.GetLoggerProducer(s.ctx, client.TaskData{ID: s.conf.Task.Id, Secret: s.conf.Task.Secret}, nil)
-	s.NoError(err)
+	s.logger, err = s.comm.GetLoggerProducer(s.ctx, &s.conf.Task, nil)
+	s.Require().NoError(err)
 }
 
 func (s *shellExecuteCommandSuite) TearDownTest() {

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -191,8 +191,7 @@ func TestEndTaskSyncCommands(t *testing.T) {
 				Id:            taskID,
 				SyncAtEndOpts: task.SyncAtEndOptions{Enabled: true},
 			}
-			td := client.TaskData{ID: taskID, Secret: "secret"}
-			logger, err := comm.GetLoggerProducer(ctx, td, nil)
+			logger, err := comm.GetLoggerProducer(ctx, &tsk, nil)
 			require.NoError(t, err)
 			tc := &taskContext{
 				taskConfig: &internal.TaskConfig{
@@ -226,7 +225,7 @@ func (s *CommandSuite) setUpConfigAndProject(projYml string) {
 	s.NoError(err)
 	s.tc.taskConfig.Project = p
 
-	s.tc.logger, err = s.mockCommunicator.GetLoggerProducer(s.ctx, s.tc.task, nil)
+	s.tc.logger, err = s.mockCommunicator.GetLoggerProducer(s.ctx, &config.Task, nil)
 	s.NoError(err)
 	s.tc.taskConfig.Project = p
 }

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model"
@@ -84,8 +85,9 @@ type SharedCommunicator interface {
 	// DisableHost signals to the app server that the host should be disabled.
 	DisableHost(context.Context, string, apimodels.DisableInfo) error
 
+	// TODO: Pass in task OR move this out.
 	// GetLoggerProducer constructs a new LogProducer instance for use by tasks.
-	GetLoggerProducer(context.Context, TaskData, *LoggerConfig) (LoggerProducer, error)
+	GetLoggerProducer(context.Context, *task.Task, *LoggerConfig) (LoggerProducer, error)
 	// GetLoggerMetadata() LoggerMetadata
 
 	// The following operations are used by task commands.
@@ -139,10 +141,12 @@ type LoggerConfig struct {
 	Agent              []LogOpts
 	Task               []LogOpts
 	SendToGlobalSender bool
+	AWSCredentials     *credentials.Credentials
 }
 
 type LogOpts struct {
 	Sender          string
+	AWSCredentials  *credentials.Credentials
 	SplunkServerURL string
 	SplunkToken     string
 	Filepath        string

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -167,9 +167,18 @@ func (c *Mock) GetTask(ctx context.Context, td TaskData) (*task.Task, error) {
 	if c.GetTaskResponse != nil {
 		return c.GetTaskResponse, nil
 	}
+
+	var id, secret string
+	if id = td.ID; id == "" {
+		id = "mock_task_id"
+	}
+	if secret = td.Secret; secret == "" {
+		secret = "mock_task_secret"
+	}
+
 	return &task.Task{
-		Id:             "mock_task_id",
-		Secret:         "mock_task_secret",
+		Id:             id,
+		Secret:         secret,
 		BuildVariant:   "mock_build_variant",
 		DisplayName:    "build",
 		Execution:      c.TaskExecution,

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -534,6 +532,11 @@ func (c *Mock) CreateInstallationToken(ctx context.Context, td TaskData, owner, 
 	return c.CreateInstallationTokenResult, nil
 }
 
+func (c *Mock) MarkFailedTaskToRestart(ctx context.Context, td TaskData) error {
+	c.TaskShouldRetryOnFail = true
+	return nil
+}
+
 type mockSender struct {
 	appendLine func(log.LogLine) error
 	lastErr    error
@@ -564,21 +567,3 @@ func (s *mockSender) Send(m message.Composer) {
 }
 
 func (s *mockSender) Flush(_ context.Context) error { return nil }
-
-type mockHandler struct {
-	serve func(http.ResponseWriter, *http.Request)
-}
-
-func (h *mockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { h.serve(w, r) }
-
-func newMockServer(serve func(http.ResponseWriter, *http.Request)) (*httptest.Server, *mockHandler) {
-	h := &mockHandler{
-		serve: serve,
-	}
-	return httptest.NewServer(h), h
-}
-
-func (c *Mock) MarkFailedTaskToRestart(ctx context.Context, td TaskData) error {
-	c.TaskShouldRetryOnFail = true
-	return nil
-}

--- a/agent/internal/client/timeout_sender_test.go
+++ b/agent/internal/client/timeout_sender_test.go
@@ -2,12 +2,9 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,9 +26,9 @@ import (
 
 func TestTimeoutSender(t *testing.T) {
 	comm := NewMock("url")
-	td := TaskData{ID: "task", Secret: "secret"}
+	tsk := &task.Task{Id: "task"}
 	ms := newMockSender("test_timeout_sender", func(line log.LogLine) error {
-		return comm.sendTaskLogLine(td, line)
+		return comm.sendTaskLogLine(tsk, line)
 	})
 	sender := makeTimeoutLogSender(ms, comm)
 
@@ -51,7 +48,6 @@ func TestTimeoutSender(t *testing.T) {
 
 type logSenderSuite struct {
 	suite.Suite
-	server            *httptest.Server
 	restClient        *hostCommunicator
 	tempDir           string
 	numMessages       int
@@ -65,35 +61,11 @@ func TestLogSenders(t *testing.T) {
 }
 
 func (s *logSenderSuite) SetupSuite() {
-	s.server, _ = newMockServer(func(w http.ResponseWriter, _ *http.Request) {
-		data, err := json.Marshal(&task.Task{
-			Id:      "task",
-			Project: "project",
-			TaskOutputInfo: &taskoutput.TaskOutput{
-				TaskLogs: taskoutput.TaskLogOutput{
-					Version: 1,
-					BucketConfig: evergreen.BucketConfig{
-						Name: s.T().TempDir(),
-						Type: "local",
-					},
-				},
-			},
-		})
-		s.Require().NoError(err)
-
-		_, err = w.Write(data)
-		s.Require().NoError(err)
-	})
-
-	s.restClient = NewHostCommunicator(s.server.URL, "hostID", "hostSecret").(*hostCommunicator)
+	s.restClient = NewHostCommunicator("url", "hostID", "hostSecret").(*hostCommunicator)
 	s.tempDir = s.T().TempDir()
 	s.numMessages = 1000
 	s.maxSleep = 10 * time.Millisecond
 	rand.Seed(time.Now().UnixNano())
-}
-
-func (s *logSenderSuite) TearDownSuite() {
-	s.server.Close()
 }
 
 func (s *logSenderSuite) SetupTest() {
@@ -113,8 +85,22 @@ func (s *logSenderSuite) randomSleep() {
 }
 
 func (s *logSenderSuite) TestFileLogger() {
+	tsk := &task.Task{
+		Id:      "task",
+		Project: "project",
+		TaskOutputInfo: &taskoutput.TaskOutput{
+			TaskLogs: taskoutput.TaskLogOutput{
+				Version: 1,
+				BucketConfig: evergreen.BucketConfig{
+					Name: s.T().TempDir(),
+					Type: evergreen.BucketTypeLocal,
+				},
+			},
+		},
+	}
+
 	logFileName := fmt.Sprintf("%s/log", s.tempDir)
-	fileSender, toClose, err := s.restClient.makeSender(context.Background(), TaskData{}, []LogOpts{{Sender: model.FileLogSender, Filepath: logFileName}}, false, taskoutput.TaskLogTypeAgent)
+	fileSender, toClose, err := s.restClient.makeSender(context.Background(), tsk, []LogOpts{{Sender: model.FileLogSender, Filepath: logFileName}}, false, taskoutput.TaskLogTypeAgent)
 	s.NoError(err)
 	s.underlyingSenders = append(s.underlyingSenders, toClose...)
 	s.NotNil(fileSender)
@@ -139,7 +125,7 @@ func (s *logSenderSuite) TestFileLogger() {
 
 	// No file logger for system logs.
 	path := filepath.Join(s.tempDir, "nothere")
-	defaultSender, toClose, err := s.restClient.makeSender(context.Background(), TaskData{Secret: "secret"}, []LogOpts{{Sender: model.FileLogSender, Filepath: path}}, false, taskoutput.TaskLogTypeSystem)
+	defaultSender, toClose, err := s.restClient.makeSender(context.Background(), tsk, []LogOpts{{Sender: model.FileLogSender, Filepath: path}}, false, taskoutput.TaskLogTypeSystem)
 	s.Require().NoError(err)
 	s.underlyingSenders = append(s.underlyingSenders, toClose...)
 	logger = logging.MakeGrip(defaultSender)
@@ -150,7 +136,20 @@ func (s *logSenderSuite) TestFileLogger() {
 }
 
 func (s *logSenderSuite) TestMisconfiguredSender() {
-	sender, toClose, err := s.restClient.makeSender(context.Background(), TaskData{}, []LogOpts{{Sender: model.EvergreenLogSender}}, false, taskoutput.TaskLogTypeAgent)
+	tsk := &task.Task{
+		Id:      "task",
+		Project: "project",
+		TaskOutputInfo: &taskoutput.TaskOutput{
+			TaskLogs: taskoutput.TaskLogOutput{
+				Version: 1,
+				BucketConfig: evergreen.BucketConfig{
+					Name: "misconfigured-invalid-bucket-type",
+					Type: "invalid",
+				},
+			},
+		},
+	}
+	sender, toClose, err := s.restClient.makeSender(context.Background(), tsk, []LogOpts{{Sender: model.EvergreenLogSender}}, false, taskoutput.TaskLogTypeAgent)
 	s.underlyingSenders = append(s.underlyingSenders, toClose...)
 	s.Error(err)
 	s.Nil(sender)

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -512,7 +512,7 @@ func setupTestTestLogDirectoryHandler(t *testing.T, comm *client.Mock) (*task.Ta
 			},
 		},
 	}
-	logger, err := comm.GetLoggerProducer(context.TODO(), client.TaskData{ID: tsk.Id}, nil)
+	logger, err := comm.GetLoggerProducer(context.TODO(), tsk, nil)
 	require.NoError(t, err)
 	h := newTestLogDirectoryHandler(tsk.TaskOutputInfo.TestLogs, taskoutput.TaskOptions{
 		ProjectID: tsk.Project,

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"
@@ -96,7 +97,7 @@ func (a *Agent) SetDefaultLogger(sender send.Sender) {
 func (a *Agent) makeLoggerProducer(ctx context.Context, tc *taskContext, c *model.LoggerConfig, commandName string) (client.LoggerProducer, error) {
 	config := a.prepLogger(tc, c, commandName)
 
-	logger, err := a.comm.GetLoggerProducer(ctx, tc.task, &config)
+	logger, err := a.comm.GetLoggerProducer(ctx, &tc.taskConfig.Task, &config)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +114,7 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 	}
 	config := client.LoggerConfig{
 		SendToGlobalSender: a.opts.SendTaskLogsToGlobalSender,
+		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskSync.Key, tc.taskConfig.TaskSync.Secret, ""),
 	}
 
 	defaultLogger := tc.taskConfig.ProjectRef.DefaultLogger

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper"
@@ -247,6 +248,11 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.Redacted = redacted
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
+
+	// Set AWS credentials for task output buckets.
+	awsCreds := pail.CreateAWSCredentials(taskConfig.TaskSync.Key, taskConfig.TaskSync.Secret, "")
+	taskConfig.Task.TaskOutputInfo.TaskLogs.AWSCredentials = awsCreds
+	taskConfig.Task.TaskOutputInfo.TestLogs.AWSCredentials = awsCreds
 
 	return taskConfig, nil
 }

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-11"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-16"
+	AgentVersion = "2024-01-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -547,7 +547,9 @@ func (h *getProjectRefHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	if p.DefaultLogger == "" {
+	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
+	// once we set the global default logger to "evergreen".
+	if p.DefaultLogger == "" && p.Id != "mci" {
 		// If the default logger is not set at the project level, use
 		// the global default logger.
 		p.DefaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -547,9 +547,7 @@ func (h *getProjectRefHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
-	// once we set the global default logger to "evergreen".
-	if p.DefaultLogger == "" && p.Id != "evergreen" {
+	if p.DefaultLogger == "" {
 		// If the default logger is not set at the project level, use
 		// the global default logger.
 		p.DefaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -549,7 +549,7 @@ func (h *getProjectRefHandler) Run(ctx context.Context) gimlet.Responder {
 
 	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
 	// once we set the global default logger to "evergreen".
-	if p.DefaultLogger == "" && p.Id != "mci" {
+	if p.DefaultLogger == "" && p.Id != "evergreen" {
 		// If the default logger is not set at the project level, use
 		// the global default logger.
 		p.DefaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger

--- a/taskoutput/evergreen_sender_test.go
+++ b/taskoutput/evergreen_sender_test.go
@@ -200,7 +200,7 @@ func TestSend(t *testing.T) {
 		mock.sender.mu.Lock()
 		require.NotEmpty(t, mock.sender.buffer)
 		mock.sender.mu.Unlock()
-		time.Sleep(3 * time.Second)
+		time.Sleep(5 * time.Second)
 		mock.sender.mu.Lock()
 		require.Empty(t, mock.sender.buffer)
 		mock.sender.mu.Unlock()

--- a/taskoutput/task_log.go
+++ b/taskoutput/task_log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/log"
@@ -41,6 +42,8 @@ func (t TaskLogType) Validate(writing bool) error {
 type TaskLogOutput struct {
 	Version      int                    `bson:"version" json:"version"`
 	BucketConfig evergreen.BucketConfig `bson:"bucket_config" json:"bucket_config"`
+
+	AWSCredentials *credentials.Credentials `bson:"-" json:"-"`
 }
 
 // ID returns the unique identifier of the task log output type.
@@ -144,7 +147,7 @@ func (o TaskLogOutput) getLogName(taskOpts TaskOptions, logType TaskLogType) str
 }
 
 func (o TaskLogOutput) getLogService(ctx context.Context) (log.LogService, error) {
-	b, err := newBucket(ctx, o.BucketConfig)
+	b, err := newBucket(ctx, o.BucketConfig, o.AWSCredentials)
 	if err != nil {
 		return nil, err
 	}

--- a/taskoutput/task_output.go
+++ b/taskoutput/task_output.go
@@ -25,10 +25,9 @@ func InitializeTaskOutput(env evergreen.Environment, opts TaskOptions) *TaskOutp
 	settings := env.Settings()
 
 	output := &TaskOutput{}
-	// TODO (DEVPROD-1723): Once Evergreen logging works for the evergreen
-	// project, remove this conditional logic here and turn it on for all
-	// projects.
-	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "evergreen" {
+	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
+	// once we set the global default logger to "evergreen".
+	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "mci" {
 		output.TaskLogs.Version = 1
 		output.TaskLogs.BucketConfig = settings.Buckets.LogBucket
 		output.TestLogs.Version = 1

--- a/taskoutput/task_output.go
+++ b/taskoutput/task_output.go
@@ -25,9 +25,7 @@ func InitializeTaskOutput(env evergreen.Environment, opts TaskOptions) *TaskOutp
 	settings := env.Settings()
 
 	output := &TaskOutput{}
-	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
-	// once we set the global default logger to "evergreen".
-	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "evergreen" {
+	if settings.LoggerConfig.DefaultLogger != "buildlogger" {
 		output.TaskLogs.Version = 1
 		output.TaskLogs.BucketConfig = settings.Buckets.LogBucket
 		output.TestLogs.Version = 1

--- a/taskoutput/task_output.go
+++ b/taskoutput/task_output.go
@@ -25,7 +25,10 @@ func InitializeTaskOutput(env evergreen.Environment, opts TaskOptions) *TaskOutp
 	settings := env.Settings()
 
 	output := &TaskOutput{}
-	if settings.LoggerConfig.DefaultLogger != "buildlogger" {
+	// TODO (DEVPROD-1723): Once Evergreen logging works for the evergreen
+	// project, remove this conditional logic here and turn it on for all
+	// projects.
+	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "evergreen" {
 		output.TaskLogs.Version = 1
 		output.TaskLogs.BucketConfig = settings.Buckets.LogBucket
 		output.TestLogs.Version = 1

--- a/taskoutput/task_output.go
+++ b/taskoutput/task_output.go
@@ -27,7 +27,7 @@ func InitializeTaskOutput(env evergreen.Environment, opts TaskOptions) *TaskOutp
 	output := &TaskOutput{}
 	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
 	// once we set the global default logger to "evergreen".
-	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "mci" {
+	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "evergreen" {
 		output.TaskLogs.Version = 1
 		output.TaskLogs.BucketConfig = settings.Buckets.LogBucket
 		output.TestLogs.Version = 1

--- a/taskoutput/test_log.go
+++ b/taskoutput/test_log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/log"
@@ -17,6 +18,8 @@ import (
 type TestLogOutput struct {
 	Version      int                    `bson:"version" json:"version"`
 	BucketConfig evergreen.BucketConfig `bson:"bucket_config" json:"bucket_config"`
+
+	AWSCredentials *credentials.Credentials `bson:"-" json:"-"`
 }
 
 // ID returns the unique identifier of the test log output type.
@@ -101,7 +104,7 @@ func (o TestLogOutput) getLogNames(taskOpts TaskOptions, logPaths []string) []st
 }
 
 func (o TestLogOutput) getLogService(ctx context.Context) (log.LogService, error) {
-	b, err := newBucket(ctx, o.BucketConfig)
+	b, err := newBucket(ctx, o.BucketConfig, o.AWSCredentials)
 	if err != nil {
 		return nil, err
 	}

--- a/taskoutput/util.go
+++ b/taskoutput/util.go
@@ -3,6 +3,7 @@ package taskoutput
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
@@ -10,11 +11,12 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func newBucket(ctx context.Context, config evergreen.BucketConfig) (pail.Bucket, error) {
+func newBucket(ctx context.Context, config evergreen.BucketConfig, creds *credentials.Credentials) (pail.Bucket, error) {
 	switch config.Type {
 	case evergreen.BucketTypeS3:
 		return pail.NewS3Bucket(pail.S3Options{
 			Name:        config.Name,
+			Credentials: creds,
 			Region:      evergreen.DefaultEC2Region,
 			Permissions: pail.S3PermissionsPrivate,
 			MaxRetries:  utility.ToIntPtr(10),


### PR DESCRIPTION
DEVPROD-1723

### Description
- Pipe through AWS credentials to the task log and test log output structs
- Set the AWS creds for task and test logging during task setup in the agent loop
- Update the `GetLoggerProducer` function in the agent's `Communicator` interface to take in a `Task` so we can cleanly pass in the AWS creds and avoid fetching the task again from the app servers (this required changing a bunch of test files)
- ~~Enable Evergreen logging for the "evergreen" project~~ (doing this in a subsequent PR just in case we need to revert it)

### Testing
Updated unit tests and tested in staging.

### Documentation
N/A