### PR TITLE
DEVPROD-1723: enable evergreen logger for a single project

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -547,7 +547,9 @@ func (h *getProjectRefHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	if p.DefaultLogger == "" {
+	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
+	// once we set the global default logger to "evergreen".
+	if p.DefaultLogger == "" && p.Id != "evergreen" {
 		// If the default logger is not set at the project level, use
 		// the global default logger.
 		p.DefaultLogger = evergreen.GetEnvironment().Settings().LoggerConfig.DefaultLogger

--- a/taskoutput/task_output.go
+++ b/taskoutput/task_output.go
@@ -25,7 +25,9 @@ func InitializeTaskOutput(env evergreen.Environment, opts TaskOptions) *TaskOutp
 	settings := env.Settings()
 
 	output := &TaskOutput{}
-	if settings.LoggerConfig.DefaultLogger != "buildlogger" {
+	// TODO (DEVPROD-1723): Remove special logic for the evergreen project
+	// once we set the global default logger to "evergreen".
+	if settings.LoggerConfig.DefaultLogger != "buildlogger" || opts.ProjectID == "evergreen" {
 		output.TaskLogs.Version = 1
 		output.TaskLogs.BucketConfig = settings.Buckets.LogBucket
 		output.TestLogs.Version = 1


### PR DESCRIPTION
DEVPROD-1723

### Description
Add temporary logic to enable the evergreen logger for a single project (evergreen) while the global default logger is set to "buidlogger". Once we are confident that the evergreen logger works in prod, we can set the global default logger to "evergreen" and remove the logic introduced here.

### Testing
Tested in staging with the mci project.

### Documentation
N/A
