### PR TITLE
DEVPROD-1723: set log level and flush interval for evergreen task logger

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -481,8 +481,8 @@ func (c *baseCommunicator) makeSender(ctx context.Context, tsk *task.Task, opts 
 				Execution: tsk.Execution,
 			}
 			senderOpts := taskoutput.EvergreenSenderOptions{
-				MaxBufferSize: bufferSize,
-				FlushInterval: bufferDuration,
+				LevelInfo:     levelInfo,
+				FlushInterval: time.Minute,
 			}
 			sender, err = tsk.TaskOutputInfo.TaskLogs.NewSender(ctx, taskOpts, senderOpts, logType)
 			if err != nil {

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-12"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-18"
+	AgentVersion = "2024-01-18-b"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-12"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-18-b"
+	AgentVersion = "2024-01-18-a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-1723

### Description
This sets the log level and flush interval for the evergreen task logger.

The previous flush interval was set to 15 seconds and the max buffer size 1000 bytes. This uses the default evergreen log sender buffer size of 10MB.

### Testing
Tested in staging.

### Documentation
N/A
