### PR TITLE
DEVPROD-3911: fix data race in agent tests

### DIFF
--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -85,10 +85,8 @@ type SharedCommunicator interface {
 	// DisableHost signals to the app server that the host should be disabled.
 	DisableHost(context.Context, string, apimodels.DisableInfo) error
 
-	// TODO: Pass in task OR move this out.
 	// GetLoggerProducer constructs a new LogProducer instance for use by tasks.
 	GetLoggerProducer(context.Context, *task.Task, *LoggerConfig) (LoggerProducer, error)
-	// GetLoggerMetadata() LoggerMetadata
 
 	// The following operations are used by task commands.
 	SendTestLog(context.Context, TaskData, *testlog.TestLog) (string, error)

--- a/agent/internal/client/timeout_sender_test.go
+++ b/agent/internal/client/timeout_sender_test.go
@@ -28,7 +28,7 @@ func TestTimeoutSender(t *testing.T) {
 	comm := NewMock("url")
 	tsk := &task.Task{Id: "task"}
 	ms := newMockSender("test_timeout_sender", func(line log.LogLine) error {
-		return comm.sendTaskLogLine(tsk, line)
+		return comm.sendTaskLogLine(tsk.Id, line)
 	})
 	sender := makeTimeoutLogSender(ms, comm)
 

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 	ClientVersion = "2024-01-12"
 
 	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-18-a"
+	AgentVersion = "2024-01-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-3911

### Description
This data race was caused because the mock implementation for `Communicator.GetLoggerProducer` was passing the task pointer into the append line function (after my changes in #7420), which is called to add lines to the in-memory task logs cache by the underlying sender. The agent test suite stores a task and agent struct which are reset on every call to `SetupTest`. If an async agent process is running that accesses the logger producer while the next test is getting set up, the append line function reads the task pointer that has since been written to, hence the data race.

I fixed this by setting a variable with the task's ID and using that in the append line function which, while a safer implementation, masks that these tests are likely leaking goroutines if they are not properly signaling exits (cc @evergreen-ci/evg-app).

### Testing
[Patch with data race variant](https://spruce.mongodb.com/version/65abf63ac9ec44ca5f3dbb61/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Documentation
N/A
