### PR TITLE
DEVPROD-777: document missing archive commands

### DIFF
--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -18,9 +18,6 @@ type autoExtract struct {
 
 	TargetDirectory string `mapstructure:"destination" plugin:"expand"`
 
-	// a list of filename blobs to exclude when extracting
-	ExcludeFiles []string `mapstructure:"exclude_files" plugin:"expand"`
-
 	base
 }
 
@@ -29,10 +26,6 @@ func (e *autoExtract) Name() string { return "archive.auto_extract" }
 func (e *autoExtract) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, e); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
-	}
-
-	if len(e.ExcludeFiles) != 0 {
-		return errors.New("auto extraction does not support excluded files")
 	}
 
 	if e.ArchivePath == "" {

--- a/agent/command/archive_auto_extract_test.go
+++ b/agent/command/archive_auto_extract_test.go
@@ -65,21 +65,14 @@ func (s *AutoExtractSuite) TestNilArguments() {
 	s.Error(s.cmd.ParseParams(s.params))
 }
 
-func (s *AutoExtractSuite) TestMalformedParams() {
-	s.params["exclude_files"] = 1
-	s.params["path"] = "foo"
+func (s *AutoExtractSuite) TestMissingParams() {
+	s.params["path"] = ""
 	s.Error(s.cmd.ParseParams(s.params))
 }
 
 func (s *AutoExtractSuite) TestCorrectParams() {
 	s.params["path"] = "foo"
 	s.NoError(s.cmd.ParseParams(s.params))
-}
-
-func (s *AutoExtractSuite) TestErrorWhenExcludeFilesExist() {
-	s.cmd.ExcludeFiles = []string{"foo"}
-	s.cmd.ArchivePath = "bar"
-	s.Error(s.cmd.ParseParams(s.params))
 }
 
 func (s *AutoExtractSuite) TestErrorsWithMalformedExpansions() {

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -18,9 +18,6 @@ type zipExtract struct {
 
 	TargetDirectory string `mapstructure:"destination" plugin:"expand"`
 
-	// a list of filename blobs to exclude when extracting
-	ExcludeFiles []string `mapstructure:"exclude_files" plugin:"expand"`
-
 	base
 }
 
@@ -29,10 +26,6 @@ func (e *zipExtract) Name() string { return "archive.zip_extract" }
 func (e *zipExtract) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, e); err != nil {
 		return errors.Wrapf(err, "decoding mapstructure params")
-	}
-
-	if len(e.ExcludeFiles) != 0 {
-		return errors.New("zip extraction does not support excluded files")
 	}
 
 	if e.ArchivePath == "" {

--- a/agent/command/archive_zip_extract_test.go
+++ b/agent/command/archive_zip_extract_test.go
@@ -61,21 +61,14 @@ func (s *ZipExtractSuite) TestNilArguments() {
 	s.Error(s.cmd.ParseParams(s.params))
 }
 
-func (s *ZipExtractSuite) TestMalformedParams() {
-	s.params["exclude_files"] = 1
-	s.params["path"] = "foo"
+func (s *ZipExtractSuite) TestMissingParams() {
+	s.params["path"] = ""
 	s.Error(s.cmd.ParseParams(s.params))
 }
 
 func (s *ZipExtractSuite) TestCorrectParams() {
 	s.params["path"] = "foo"
 	s.NoError(s.cmd.ParseParams(s.params))
-}
-
-func (s *ZipExtractSuite) TestErrorWhenExcludeFilesExist() {
-	s.cmd.ExcludeFiles = []string{"foo"}
-	s.cmd.ArchivePath = "bar"
-	s.Error(s.cmd.ParseParams(s.params))
 }
 
 func (s *ZipExtractSuite) TestErrorsWithMalformedExpansions() {

--- a/config.go
+++ b/config.go
@@ -35,8 +35,9 @@ var (
 	// ClientVersion is the commandline version string used to control auto-updating.
 	ClientVersion = "2024-01-18"
 
-	// Agent version to control agent rollover.
-	AgentVersion = "2024-01-22"
+	// Agent version to control agent rollover. The format is the calendar date
+	// (YYYY-MM-DD).
+	AgentVersion = "2024-01-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -32,7 +32,8 @@ var (
 	// BuildRevision should be specified with -ldflags at build time
 	BuildRevision = ""
 
-	// ClientVersion is the commandline version string used to control auto-updating.
+	// ClientVersion is the commandline version string used to control updating
+	// the CLI. The format is the calendar date (YYYY-MM-DD).
 	ClientVersion = "2024-01-18"
 
 	// Agent version to control agent rollover. The format is the calendar date

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -50,6 +50,23 @@ In addition to the
 it should recurse into subdirectories. With only `*`, it
 will not recurse.
 
+## archive.auto_extract
+
+`archive.auto_extract` extracts an archived/compressed file with an arbitrary
+format based on its file extension.
+
+``` yaml
+- command: archive.targz_extract
+  params:
+    path: "jstests.tgz"
+    destination: "src/jstestfuzz"
+```
+
+Parameters:
+
+-   `path`: the path to the file to extract.
+-   `destination`: the target directory.
+
 ## archive.auto_pack
 
 `archive.auto_pack` creates an archived/compressed file with an arbitrary
@@ -95,6 +112,52 @@ Parameters:
 In addition to the
 [filepath.Match](https://golang.org/pkg/path/filepath/#Match) syntax,
 `archive.auto_pack` supports using `**` to indicate that
+it should recurse into subdirectories. With only `*`, it
+will not recurse.
+
+## archive.zip_extract
+
+`archive.zip_extract` extracts files from a zip file.
+
+``` yaml
+- command: archive.targz_extract
+  params:
+    path: "jstests.zip"
+    destination: "src/jstestfuzz"
+```
+
+Parameters:
+
+-   `path`: the path to the zip file.
+-   `destination`: the target directory.
+
+## archive.zip_pack
+
+`archive.zip_pack` creates a zip file.
+
+``` yaml
+- command: archive.zip_pack
+  params:
+    target: "jstests.zip"
+    source_dir: "src/jstestfuzz"
+    include:
+      - "out/*.js"
+```
+
+Parameters:
+
+-   `target`: the zip file that will be created.
+-   `source_dir`: the directory to archive/compress.
+-   `include`: a list of filename
+    [blobs](https://golang.org/pkg/path/filepath/#Match) to include from the
+    source directory.
+-   `exclude_files`: a list of filename
+    [blobs](https://golang.org/pkg/path/filepath/#Match) to exclude from the
+    source directory.
+
+In addition to the
+[filepath.Match](https://golang.org/pkg/path/filepath/#Match) syntax,
+`archive.zip_pack` supports using `**` to indicate that
 it should recurse into subdirectories. With only `*`, it
 will not recurse.
 


### PR DESCRIPTION
DEVPROD-777

### Description
* Document `archive.auto_extract`, `archive.zip_create`, and `archive.zip_extract` commands.
* Remove some random dead/non-working parameters from the newly-documented archive functions. It looks like they were never implemented, so it's not worth keeping them around.

### Testing
Smoke test already tests these commands, and it still passes.
