### PR TITLE
DEVPROD-3875 Send email upon git tag unauthorized err

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -711,6 +711,9 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		catcher := grip.NewBasicCatcher()
 		for elem := range outputYAMLs {
 			catcher.Add(elem.err)
+			if thirdparty.IsFileNotFound(errors.Cause(elem.err)) {
+				return intermediateProject, errors.Wrap(elem.err, "getting includes")
+			}
 			if elem.yaml != nil {
 				yamlMap[elem.name] = elem.yaml
 			}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -711,9 +711,6 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		catcher := grip.NewBasicCatcher()
 		for elem := range outputYAMLs {
 			catcher.Add(elem.err)
-			if thirdparty.IsFileNotFound(errors.Cause(elem.err)) {
-				return intermediateProject, errors.Wrap(elem.err, "getting includes")
-			}
 			if elem.yaml != nil {
 				yamlMap[elem.name] = elem.yaml
 			}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -741,19 +741,6 @@ func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metada
 		if !ref.IsGitTagVersionsEnabled() {
 			return nil, errors.Errorf("git tag versions are not enabled for project '%s'", ref.Id)
 		}
-		settings, err := evergreen.GetConfig(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "error getting settings")
-		}
-		token, err := settings.GetGithubOauthToken()
-		if err != nil {
-			return nil, errors.Wrap(err, "error getting github token")
-		}
-
-		if !ref.AuthorizedForGitTag(ctx, metadata.GitTag.Pusher, token, ref.Owner, ref.Repo) {
-			return nil, errors.Errorf("user '%s' not authorized to create git tag versions for project '%s'",
-				metadata.GitTag.Pusher, ref.Id)
-		}
 		v.Id = makeVersionIdWithTag(ref.Identifier, metadata.GitTag.Tag, mgobson.NewObjectId().Hex())
 		v.Requester = evergreen.GitTagRequester
 		v.CreateTime = time.Now()

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -3,7 +3,6 @@ package route
 import (
 	"context"
 	"fmt"
-	"github.com/mongodb/grip/level"
 	"net/http"
 	"strings"
 	"time"
@@ -23,6 +22,7 @@ import (
 	"github.com/google/go-github/v52/github"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
DEVPROD-3875

### Description
Following up from [DEVPROD-781](https://jira.mongodb.org/browse/DEVPROD-781), this issue has surfaced again where a user was unauthorized to push a git tag which led to this ticket being created at a critical level as it was presumed to be a blocker.

Given that this has come up more frequently recently, this change aims to make this error more visible in the future by:
- creating a stub version for unauthorized git tag versions
- sending an email to the user's email associated with their github account
### Testing
Confirmed that an unauthorized git tag push results in a [stub version with the relevant error](https://spruce-staging.corp.mongodb.com/version/sandbox_testtag9_65b42ac59dbe32e18f3e268b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and that I got an email (see attached).

<img width="782" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/19805673/0dd4bac8-caca-4e74-a3f1-09204da95daa">
