### PR TITLE
DEVPROD-3085 Check for renamed includes when creating diff patch

### DIFF
--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -531,7 +531,7 @@ func TestMakePatchedConfig(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			projectData, err := MakePatchedConfig(ctx, env, p, remoteConfigPath, string(projectBytes))
+			projectData, err := MakePatchedConfig(ctx, GetProjectOpts{}, env, p, remoteConfigPath, string(projectBytes))
 			assert.NoError(t, err)
 			assert.NotNil(t, projectData)
 			project := &Project{}
@@ -563,7 +563,7 @@ func TestMakePatchedConfigEmptyBase(t *testing.T) {
 		}},
 	}
 
-	projectData, err := MakePatchedConfig(ctx, env, p, remoteConfigPath, "")
+	projectData, err := MakePatchedConfig(ctx, GetProjectOpts{}, env, p, remoteConfigPath, "")
 	assert.NoError(t, err)
 
 	project := &Project{}
@@ -573,6 +573,30 @@ func TestMakePatchedConfigEmptyBase(t *testing.T) {
 
 	assert.Len(t, project.Tasks, 1)
 	assert.Equal(t, project.Tasks[0].Name, "hello")
+}
+
+func TestParseRenamedFile(t *testing.T) {
+	patchContents := `
+diff --git a/evergreen.yml b/evergreen.yml
+index a45dff8..83a8f81 100644
+--- a/evergreen.yml
++++ b/evergreen.yml
+@@ -5,7 +5,7 @@ stepback: true
+ 
+ include:
+   - filename: include1.yml
+-  - filename: include2.yml
++  - filename: rename2.yml
+   - filename: include3.yml
+   - filename: include4.yml
+   - filename: include5.yml
+diff --git a/include2.yml b/rename2.yml
+similarity index 100%
+rename from include2.yml
+rename to rename2.yml
+`
+	renamedFile := parseRenamedFile(patchContents, "rename2.yml")
+	assert.Equal(t, renamedFile, "include2.yml")
 }
 
 // shouldContainPair returns a blank string if its arguments resemble each other, and returns a

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -810,7 +810,7 @@ func retrieveFile(ctx context.Context, opts GetProjectOpts) ([]byte, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching remote configuration file")
 		}
-		fileContents, err := MakePatchedConfig(ctx, opts.PatchOpts.env, opts.PatchOpts.patch, opts.RemotePath, string(originalConfig))
+		fileContents, err := MakePatchedConfig(ctx, opts, opts.PatchOpts.env, opts.PatchOpts.patch, opts.RemotePath, string(originalConfig))
 		if err != nil {
 			return nil, errors.Wrap(err, "patching remote configuration file")
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -810,7 +810,7 @@ func retrieveFile(ctx context.Context, opts GetProjectOpts) ([]byte, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching remote configuration file")
 		}
-		fileContents, err := MakePatchedConfig(ctx, opts, opts.PatchOpts.env, opts.PatchOpts.patch, opts.RemotePath, string(originalConfig))
+		fileContents, err := MakePatchedConfig(ctx, opts, string(originalConfig))
 		if err != nil {
 			return nil, errors.Wrap(err, "patching remote configuration file")
 		}

--- a/model/testdata/include1.yml
+++ b/model/testdata/include1.yml
@@ -1,0 +1,9 @@
+buildvariants:
+  - name: included-variant
+    display_name: "Included variant"
+    batchtime: 0
+    activate: true
+    run_on:
+      - ubuntu2004
+    tasks:
+      - name: unit_tests

--- a/model/testdata/renamed_patch.diff
+++ b/model/testdata/renamed_patch.diff
@@ -1,0 +1,28 @@
+diff --git a/evergreen.yml b/evergreen.yml
+index bd66c6e..b671f40 100644
+--- a/evergreen.yml
++++ b/evergreen.yml
+@@ -4,7 +4,7 @@ ignore:
+ stepback: true
+ 
+ includes:
+-  - include1.yml
++  - renamed.yml
+ 
+ pre_error_fails_task: true
+ pre: &pre
+diff --git a/include1.yml b/renamed.yml
+similarity index 65%
+rename from include1.yml
+rename to renamed.yml
+index 748e345..7e70f15 100644
+--- a/include1.yml
++++ b/renamed.yml
+@@ -1,6 +1,6 @@
+ buildvariants:
+   - name: included-variant
+-    display_name: "Included variant"
++    display_name: "Included variant!!!"
+     batchtime: 0
+     activate: true
+     run_on:


### PR DESCRIPTION
DEVPROD-3085

### Description
Currently if you try to submit a CLI patch that changes the name of an included config file, the patch will fail to be created because Evergreen is trying to apply a patch to a file that does not yet exist remotely (because it was just renamed to something else).

Modified the `MakePatchedConfig` logic to detect if the patch includes a rename for the remote file in question, and if so, retrieve the old file name remote config, and apply the patch to that instead.
### Testing
Added unit tests and test files.

Tested in staging and confirmed that without this change, if I submit a patch with include file name changes I get the following error: `retrieving file for include 'renamed.yml': patching remote configuration file: running patch command (possibly due to merge conflict on evergreen configuration file):`

Confirmed that after the change the patch goes through with the correct diff, and that the /tmp/evergreen directory on the staging host is clean ([link](https://spruce-staging.corp.mongodb.com/patch/65b2a53d97b1d3630c3f9cc9/configure/changes))
