### PR TITLE
DEVPROD-774: allow AWS session tokens for S3 commands

### DIFF
--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -31,8 +31,9 @@ const (
 type s3copy struct {
 	// AwsKey and AwsSecret are the user's credentials for
 	// authenticating interactions with s3.
-	AwsKey    string `mapstructure:"aws_key" plugin:"expand"`
-	AwsSecret string `mapstructure:"aws_secret" plugin:"expand"`
+	AwsKey          string `mapstructure:"aws_key" plugin:"expand"`
+	AwsSecret       string `mapstructure:"aws_secret" plugin:"expand"`
+	AwsSessionToken string `mapstructure:"aws_session_token" plugin:"expand"`
 	// An array of file copy configurations
 	S3CopyFiles []*s3CopyFile `mapstructure:"s3_copy_files" plugin:"expand"`
 
@@ -229,11 +230,8 @@ func (c *s3copy) copyWithRetry(ctx context.Context,
 			continue
 		}
 
-		s3CopyReq.AwsKey = c.AwsKey
-		s3CopyReq.AwsSecret = c.AwsSecret
-
 		srcOpts := pail.S3Options{
-			Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
+			Credentials: pail.CreateAWSCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken),
 			Region:      s3CopyReq.S3SourceRegion,
 			Name:        s3CopyReq.S3SourceBucket,
 			Permissions: pail.S3Permissions(s3CopyReq.S3Permissions),
@@ -260,7 +258,7 @@ func (c *s3copy) copyWithRetry(ctx context.Context,
 			return catcher.Resolve()
 		}
 		destOpts := pail.S3Options{
-			Credentials: pail.CreateAWSCredentials(s3CopyReq.AwsKey, s3CopyReq.AwsSecret, ""),
+			Credentials: pail.CreateAWSCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken),
 			Region:      s3CopyReq.S3DestinationRegion,
 			Name:        s3CopyReq.S3DestinationBucket,
 			Permissions: pail.S3Permissions(s3CopyReq.S3Permissions),

--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -29,7 +29,7 @@ const (
 // The S3CopyPlugin consists of zero or more files that are to be copied
 // from one location in S3 to the other.
 type s3copy struct {
-	// AwsKey and AwsSecret are the user's credentials for
+	// AwsKey, AwsSecret, and AwsSessionToken are the user's credentials for
 	// authenticating interactions with s3.
 	AwsKey          string `mapstructure:"aws_key" plugin:"expand"`
 	AwsSecret       string `mapstructure:"aws_secret" plugin:"expand"`

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -21,10 +21,11 @@ import (
 // s3get is a command to fetch a resource from an S3 bucket and download it to
 // the local machine.
 type s3get struct {
-	// AwsKey and AwsSecret are the user's credentials for
+	// AwsKey, AwsSecret, and AwsSessionToken are the user's credentials for
 	// authenticating interactions with s3.
-	AwsKey    string `mapstructure:"aws_key" plugin:"expand"`
-	AwsSecret string `mapstructure:"aws_secret" plugin:"expand"`
+	AwsKey          string `mapstructure:"aws_key" plugin:"expand"`
+	AwsSecret       string `mapstructure:"aws_secret" plugin:"expand"`
+	AwsSessionToken string `mapstructure:"aws_session_token" plugin:"expand"`
 
 	// RemoteFile is the file path of the file to get, within its bucket.
 	RemoteFile string `mapstructure:"remote_file" plugin:"expand"`
@@ -283,7 +284,7 @@ func (c *s3get) get(ctx context.Context) error {
 
 func (c *s3get) createPailBucket(httpClient *http.Client) error {
 	opts := pail.S3Options{
-		Credentials: pail.CreateAWSCredentials(c.AwsKey, c.AwsSecret, ""),
+		Credentials: pail.CreateAWSCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken),
 		Region:      c.Region,
 		Name:        c.Bucket,
 	}

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -244,6 +244,24 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(cmd.Permissions, ShouldEqual, params["permissions"])
 				So(cmd.ResourceDisplayName, ShouldEqual, params["display_name"])
 			})
+
+			Convey("combining temporary credentials with signed visibility should cause an error", func() {
+				params := map[string]interface{}{
+					"aws_key":           "key",
+					"aws_secret":        "secret",
+					"aws_session_token": "temporary_token",
+					"local_file":        "local",
+					"remote_file":       "remote",
+					"bucket":            "bck",
+					"permissions":       "public-read",
+					"content_type":      "application/x-tar",
+					"display_name":      "test_file",
+					"visibility":        "signed",
+				}
+				err := cmd.ParseParams(params)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "cannot use temporary AWS credentials with signed link visibility")
+			})
 		})
 
 	})

--- a/apimodels/s3copy.go
+++ b/apimodels/s3copy.go
@@ -4,8 +4,6 @@ package apimodels
 // complete an S3 copy request; namely, an S3 key/secret, a source and
 // a destination path
 type S3CopyRequest struct {
-	AwsKey              string `json:"aws_key"`
-	AwsSecret           string `json:"aws_secret"`
 	S3SourceRegion      string `json:"s3_source_region"`
 	S3SourceBucket      string `json:"s3_source_bucket"`
 	S3SourcePath        string `json:"s3_source_path"`

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-23"
+	AgentVersion = "2024-01-25"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1105,6 +1105,7 @@ Parameters:
   params:
     aws_key: ${aws_key}
     aws_secret: ${aws_secret}
+    aws_session_token: ${aws_session_token}
     remote_file: ${mongo_binaries}
     bucket: mciuploads
     local_file: src/mongo-binaries.tgz
@@ -1112,8 +1113,9 @@ Parameters:
 
 Parameters:
 
--   `aws_key`: your AWS key (use expansions to keep this a secret)
--   `aws_secret`: your AWS secret (use expansions to keep this a secret)
+-   `aws_key`: your AWS key (use expansions to keep this a secret).
+-   `aws_secret`: your AWS secret (use expansions to keep this a secret).
+-   `aws_session_token`: your temporary AWS session token (use expansions to keep this a secret).
 -   `local_file`: the local file to save, do not use with `extract_to`
 -   `extract_to`: the local directory to extract to, do not use with
     `local_file`
@@ -1133,6 +1135,7 @@ distribution. Files uploaded with this command will also be viewable within the 
   params:
     aws_key: ${aws_key}
     aws_secret: ${aws_secret}
+    aws_session_token: ${aws_session_token}
     local_file: src/mongodb-binaries.tgz
     remote_file: mongodb-mongo-master/${build_variant}/${revision}/binaries/mongo-${build_id}.${ext|tgz}
     bucket: mciuploads
@@ -1143,8 +1146,10 @@ distribution. Files uploaded with this command will also be viewable within the 
 
 Parameters:
 
--   `aws_key`: your AWS key (use expansions to keep this a secret)
--   `aws_secret`: your AWS secret (use expansions to keep this a secret)
+-   `aws_key`: your AWS key (use expansions to keep this a secret).
+-   `aws_secret`: your AWS secret (use expansions to keep this a secret).
+-   `aws_session_token`: your temporary AWS session token (use expansions to keep this a secret). This cannot be used
+    with `visibility: signed`.
 -   `local_file`: the local file to post
 -   `remote_file`: the S3 path to post the file to
 -   `bucket`: the S3 bucket to use. Note: buckets created after Sept.
@@ -1190,6 +1195,7 @@ Using the s3.put command in this uploads multiple files to an s3 bucket.
   params:
     aws_key: ${aws_key}
     aws_secret: ${aws_secret}
+    aws_session_token: ${aws_session_token}
     local_files_include_filter:
       - slow_tests/coverage/*.tgz
       - fast_tests/coverage/*.tgz
@@ -1295,6 +1301,7 @@ Parameters:
   params:
     aws_key: ${aws_key}
     aws_secret: ${aws_secret}
+    aws_session_token: ${aws_session_token}
     s3_copy_files:
         - {'optional': true, 'source': {'path': '${push_path}-STAGE/${push_name}/mongodb-${push_name}-${push_arch}-${suffix}-${task_id}.${ext|tgz}', 'bucket': 'build-push-testing'},
            'destination': {'path': '${push_path}/mongodb-${push_name}-${push_arch}-${suffix}.${ext|tgz}', 'bucket': '${push_bucket}'}}
@@ -1302,8 +1309,9 @@ Parameters:
 
 Parameters:
 
--   `aws_key`: your AWS key (use expansions to keep this a secret)
--   `aws_secret`: your AWS secret (use expansions to keep this a secret)
+-   `aws_key`: your AWS key (use expansions to keep this a secret).
+-   `aws_secret`: your AWS secret (use expansions to keep this a secret).
+-   `aws_session_token`: your temporary AWS session token (use expansions to keep this a secret).
 -   `s3_copy_files`: a map of `source` (`bucket` and `path`),
     `destination`, `build_variants` (a list of strings), `display_name`,
     and `optional` (suppresses errors). Note: destination buckets

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
 	github.com/evergreen-ci/gimlet v0.0.0-20231108203524-e7de42b0623c
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
-	github.com/evergreen-ci/pail v0.0.0-20240112202407-5e294ada6b3e
+	github.com/evergreen-ci/pail v0.0.0-20240125155701-e60f20da397e
 	github.com/evergreen-ci/poplar v0.0.0-20220908212406-a5e2aa799def
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:p
 github.com/evergreen-ci/pail v0.0.0-20211018155204-833e3187cfe7/go.mod h1:5gJ3srLW+mTEtewtmEs5qdnFiKFtwoggc/U3oFCVAdc=
 github.com/evergreen-ci/pail v0.0.0-20211028170419-8efd623fd305/go.mod h1:ch0TKjI+NK2GewovamMpY9tqoe0Fal71c/4x+4x1+Io=
 github.com/evergreen-ci/pail v0.0.0-20220908201135-8a2090a672b7/go.mod h1:Ten0LDyKy6zFGFtu4DwTdOa+KGpiivkwJZmXEa024mw=
-github.com/evergreen-ci/pail v0.0.0-20240112202407-5e294ada6b3e h1:1OzmqPeNgKhQoNnf685GvA53iY5pSK0KqNFVNPutWhQ=
-github.com/evergreen-ci/pail v0.0.0-20240112202407-5e294ada6b3e/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
+github.com/evergreen-ci/pail v0.0.0-20240125155701-e60f20da397e h1:ZVUMRfqAEIv4xArRkbCCiBAszrI2E59HIvWiRbCSguE=
+github.com/evergreen-ci/pail v0.0.0-20240125155701-e60f20da397e/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20211028170046-0999224b53df/go.mod h1:xiggfkrlxlu2C2e58tvk0WAYFetgNC7U9ONqcP29xZs=

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -12,7 +12,6 @@ import (
 )
 
 const Collection = "artifact_files"
-const PresignExpireTime = 24 * time.Hour
 
 const (
 	// strings for setting visibility


### PR DESCRIPTION
DEVPROD-774

### Description
This adds support for passing temporary AWS credentials to S3 commands. I also chose to not allow combining temporary credentials with pre-signed URLs - this is because artifacts with `visibility: signed` can only work if the credentials live forever. URLs are lazily signed only when the user clicks the link in the task artifacts, and the link is only valid for one day. Therefore, if the user tries to click the link after the temporary credentials have already expired, the signing will fail and the user won't be able to access the artifact.

There will be a follow-up PR to add this parameter to Shrub.

* Upgrade Pail to support AWS session tokens.
* Allow temporary AWS session tokens for S3 commands.
* Remove some dead code from pre-signed URL functionality.

### Testing
* Added unit test for error case.
* Tested temporary credentials work in [a staging patch](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_test_util_patch_871b5ef7e755f60e7025e3fbff7aa183aa1e50c5_65b2972db237360ae7e12192_24_01_25_17_15_25/logs?execution=0).

### Documentation
Updated command docs.