### PR TITLE
DEVPROD-1648 Use HTTP cloning for host configure CLI command

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2627,8 +2627,7 @@ func (p *ProjectRef) GetProjectSetupCommands(opts apimodels.WorkstationSetupComm
 	cmds := []*jasper.Command{}
 
 	if p.WorkstationConfig.ShouldGitClone() {
-		args := []string{"git", "clone", "-b", p.Branch, fmt.Sprintf("git@github.com:%s/%s.git", p.Owner, p.Repo), opts.Directory}
-
+		args := []string{"git", "clone", "-b", p.Branch, fmt.Sprintf("https://github.com/%s/%s.git", p.Owner, p.Repo), opts.Directory}
 		cmd := jasper.NewCommand().Add(args).
 			SetErrorWriter(utility.NopWriteCloser(os.Stderr)).
 			Prerequisite(func() bool {


### PR DESCRIPTION
DEVPROD-1648

### Description
Updating the host configure command to use HTTP cloning 
Upon investigation, this is the command what server uses to set up their virtual workstations. 
In theory, having this command use ssh cloning was okay because server setup workflow dictates that they add their own SSH keys before running this command since other workflows may be relying on this, we decided to update this command 

### Testing 
staging 

<img width="801" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/944eaf8f-e79f-4cd3-b370-10a06d43c33d">
