### PR TITLE
DEVPROD-3943: add data model for host sleep schedule

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -345,9 +345,10 @@ type SleepScheduleInfo struct {
 	// NextStartTime is the next time that the host should start for its sleep
 	// schedule.
 	NextStartTime time.Time `bson:"next_start_time" json:"next_start_time"`
-	// TemporarilyExemptUntil stores when a user's temporary exemption ends. The
-	// sleep schedule will not take effect until this timestamp passes.
-	TemporarilyExemptUntil time.Time `bson:"temporarily_exempt_until" json:"temporarily_exempt_until"`
+	// TemporarilyExemptUntil stores when a user's temporary exemption ends, if
+	// any has been set. The sleep schedule will not take effect until
+	// this timestamp passes.
+	TemporarilyExemptUntil time.Time `bson:"temporarily_exempt_until,omitempty" json:"temporarily_exempt_until,omitempty"`
 }
 
 // IsZero implements the bsoncodec.Zeroer interface for the sake of defining the

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -155,6 +155,9 @@ type Host struct {
 	// HomeVolumeSize is the size of the home volume in GB
 	HomeVolumeSize int    `bson:"home_volume_size" json:"home_volume_size"`
 	HomeVolumeID   string `bson:"home_volume_id" json:"home_volume_id"`
+
+	// SleepSchedule stores host sleep schedule information.
+	SleepSchedule SleepScheduleInfo `bson:"sleep_schedule,omitempty" json:"sleep_schedule,omitempty"`
 }
 
 type Tag struct {
@@ -316,6 +319,48 @@ type SpawnOptions struct {
 
 	// SpawnedByTask indicates that this host has been spawned by a task.
 	SpawnedByTask bool `bson:"spawned_by_task,omitempty" json:"spawned_by_task,omitempty"`
+}
+
+// SleepScheduleInfo stores information about a host's sleep schedule and
+// related bookkeeping information.
+type SleepScheduleInfo struct {
+	// WholeWeekdaysOff represents whole weekdays for the host to sleep.
+	WholeWeekdaysOff []time.Weekday `bson:"whole_weekdays_off" json:"whole_weekdays_off"`
+	// DailyStartTime and DailyStopTime represent a daily schedule for when to
+	// start a stopped host back up. The format is HH:MM:SS.
+	DailyStartTime string `bson:"daily_sleep_start_time" json:"daily_sleep_start_time"`
+	// DailyStopTime represents a daily schedule for when to stop a host. The
+	// format is HH:MM:SS.
+	DailyStopTime string `bson:"daily_sleep_stop_time" json:"daily_sleep_stop_time"`
+	// TimeZone is the time zone for this host's sleep schedule.
+	TimeZone string `bson:"time_zone" json:"time_zone"`
+	// ShouldKeepOff indicates if the host should be kept off, regardless of the
+	// other sleep schedule settings. This exists to permit a host to remain off
+	// indefinitely until the host's owner is ready to turn it on and resume its
+	// usual sleep schedule.
+	ShouldKeepOff bool `bson:"should_keep_off" json:"should_keep_off"`
+	// NextStopTime is the next time that the host should stop for its sleep
+	// schedule.
+	NextStopTime time.Time `bson:"next_stop_time" json:"next_stop_time"`
+	// NextStartTime is the next time that the host should start for its sleep
+	// schedule.
+	NextStartTime time.Time `bson:"next_start_time" json:"next_start_time"`
+	// TemporarilyExemptUntil stores when a user's temporary exemption ends. The
+	// sleep schedule will not take effect until this timestamp passes.
+	TemporarilyExemptUntil time.Time `bson:"temporarily_exempt_until" json:"temporarily_exempt_until"`
+}
+
+// IsZero implements the bsoncodec.Zeroer interface for the sake of defining the
+// zero value for BSON marshalling.
+func (i SleepScheduleInfo) IsZero() bool {
+	return len(i.WholeWeekdaysOff) == 0 &&
+		i.DailyStartTime == "" &&
+		i.DailyStopTime == "" &&
+		i.TimeZone == "" &&
+		!i.ShouldKeepOff &&
+		utility.IsZeroTime(i.NextStopTime) &&
+		utility.IsZeroTime(i.NextStartTime) &&
+		utility.IsZeroTime(i.TemporarilyExemptUntil)
 }
 
 type newParentsNeededParams struct {


### PR DESCRIPTION
DEVPROD-3943

### Description
Add host fields for sleep schedule data model.

### Testing
These fields don't do anything, so there's nothing to test.

### Documentation
N/A