### PR TITLE
DEVPROD-4117: Treat missing include files as FileNotFoundError

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -711,6 +711,9 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, ide
 		catcher := grip.NewBasicCatcher()
 		for elem := range outputYAMLs {
 			catcher.Add(elem.err)
+			if thirdparty.IsFileNotFound(errors.Cause(elem.err)) {
+				return intermediateProject, errors.Wrap(elem.err, "getting includes")
+			}
 			if elem.yaml != nil {
 				yamlMap[elem.name] = elem.yaml
 			}


### PR DESCRIPTION
DEVPROD-4117

### Description
this will cause the repotracker job to error on that revision, [error out early](https://gist.github.com/hadjri/6064931f12c55e28d11c945b76a94d96#file-repotracker-go-L287) instead of continuing as it should, thereby preventing any later mainline commit versions from being created.

If a production project were to do this, it would create a fire. 
### Testing
add a description of how you tested it

### Documentation
remember to add or edit docs in the docs/ directory if relevant
