### PR TITLE
DEVPROD-2719: Move execution task filter earlier in getTasksByVersion pipeline

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2602,7 +2602,16 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		{"$project": projectOut},
 		{"$match": match},
 	}
-
+	if !opts.IncludeExecutionTasks {
+		pipeline = append(pipeline, bson.M{
+			"$match": bson.M{
+				"$or": []bson.M{
+					{DisplayTaskIdKey: ""},
+					{DisplayOnlyKey: true},
+				},
+			},
+		})
+	}
 	// Filter on Build Variants matching on display name or variant name if it exists
 	nonEmptyVariants := utility.FilterSlice(opts.Variants, func(s string) bool { return s != "" })
 	if len(nonEmptyVariants) > 0 {
@@ -2617,16 +2626,6 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 		pipeline = append(pipeline, bson.M{"$match": match})
 	}
 
-	if !opts.IncludeExecutionTasks {
-		pipeline = append(pipeline, bson.M{
-			"$match": bson.M{
-				"$or": []bson.M{
-					{DisplayTaskIdKey: ""},
-					{DisplayOnlyKey: true},
-				},
-			},
-		})
-	}
 	// TODO: DEVPROD-3994 Remove this conditional and annotation lookup pipelines
 	// Pull one task, any task associated with this versionID. A task's CreateTime is
 	// derived from the version commit time or the patch creation time, allowing us to treat it


### PR DESCRIPTION
DEVPROD-2719

### Description
These code changes move execution task filtering to the beginning of the getTasksByVersion pipeline. The idea is to reduce the amount of data processed early in the pipeline to ensure subsequent stages operate on a smaller dataset. 
I used this [query](https://evergreen-staging.corp.mongodb.com/graphql?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAGr4DOAlhEgCoCG5A1uQBQA6SRRAJAG4VqSAJJh0RAMoo8lJAHMAhJ248UjJgDFKAGxT4A8gAcUQ8uIbMtug8dNKkASiLBlRAXio1WlMb3eeRMCcXLm4iH1duNWY2CFsaM15ozR09PCMTBODIsKgIGFQc7jB6NWcisLBKckNtegIAOXpECu4EAA8EWEykVqIOrpgeixYNGG1tctCwmaIAI0YEEanZ1f7O7qE%2BmYjpte5yNRQYcm2iAF8zqpq6xuaEM4HNmjPd-cu9nbAKj5nfi84HxA5yAA) in the EVG staging GQL playground to test my changes. The resolution times for the patch are 5.08s, 5.12s, 5.10s. 4.99s, 5.55s (**avg 5.168s**). The resolution times for the base branch are 6.33s, 4.93s, 6.48s. 4.95s, 6.24s (**avg 5.786s**). 
I investigated if it's possible to always include the display tasks in the query in order to omit the filter step completely. The main obstacle with the current implementation is that execution tasks will then be included in the pagination / limit constraints making it simpler to query execution tasks in ExecutionTasksFull, a separate conditional resolver.