### PR TITLE
DEVPROD-2961: stop sending perf results to the Data-Pipes service

### DIFF
--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/util"
@@ -86,7 +87,7 @@ func (c *perfSend) addEvgData(report *poplar.Report, conf *internal.TaskConfig) 
 	report.TaskName = conf.Task.DisplayName
 	report.TaskID = conf.Task.Id
 	report.Execution = conf.Task.Execution
-	report.Requester = conf.Task.Requester
+	report.Mainline = conf.Task.Requester == evergreen.RepotrackerVersionRequester
 
 	report.BucketConf.APIKey = c.AWSKey
 	report.BucketConf.APISecret = c.AWSSecret

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/util"
@@ -87,7 +86,6 @@ func (c *perfSend) addEvgData(report *poplar.Report, conf *internal.TaskConfig) 
 	report.TaskName = conf.Task.DisplayName
 	report.TaskID = conf.Task.Id
 	report.Execution = conf.Task.Execution
-	report.Mainline = conf.Task.Requester == evergreen.RepotrackerVersionRequester
 	report.Requester = conf.Task.Requester
 
 	report.BucketConf.APIKey = c.AWSKey

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/poplar"
 	"github.com/evergreen-ci/poplar/rpc"
-	"github.com/evergreen-ci/utility"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -68,26 +67,14 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 	}
 	c.addEvgData(report, conf)
 
-	// Send data to the Cedar and Data-Pipes services.
+	// Send data to the Cedar performance results service.
 	conn, err := comm.GetCedarGRPCConn(ctx)
 	if err != nil {
 		return errors.Wrap(err, "connecting to Cedar")
 	}
-	dataPipes, err := comm.GetDataPipesConfig(ctx)
-	if err != nil {
-		return errors.Wrap(err, "getting the Data-Pipes config")
-	}
-	httpClient := utility.GetDefaultHTTPRetryableClient()
-	defer utility.PutHTTPClient(httpClient)
 	opts := rpc.UploadReportOptions{
-		Report:              report,
-		ClientConn:          conn,
-		DataPipesHost:       dataPipes.Host,
-		DataPipesRegion:     dataPipes.Region,
-		AWSAccessKey:        dataPipes.AWSAccessKey,
-		AWSSecretKey:        dataPipes.AWSSecretKey,
-		AWSToken:            dataPipes.AWSToken,
-		DataPipesHTTPClient: httpClient,
+		Report:     report,
+		ClientConn: conn,
 	}
 	return errors.Wrap(rpc.UploadReport(ctx, opts), "uploading report to Cedar")
 }

--- a/agent/command/perf_send_test.go
+++ b/agent/command/perf_send_test.go
@@ -69,7 +69,6 @@ func TestPerfSendAddEvgData(t *testing.T) {
 		TaskID:    conf.Task.Id,
 		Execution: conf.Task.Execution,
 		Mainline:  true,
-		Requester: evergreen.RepotrackerVersionRequester,
 		BucketConf: poplar.BucketConfiguration{
 			APIKey:    cmd.AWSKey,
 			APISecret: cmd.AWSSecret,

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -592,26 +592,6 @@ func (c *baseCommunicator) GetAgentSetupData(ctx context.Context) (*apimodels.Ag
 	return &data, nil
 }
 
-// GetDataPipesConfig returns the Data-Pipes service configuration.
-func (c *baseCommunicator) GetDataPipesConfig(ctx context.Context) (*apimodels.DataPipesConfig, error) {
-	info := requestInfo{
-		method: http.MethodGet,
-		path:   "agent/data_pipes_config",
-	}
-
-	resp, err := c.retryRequest(ctx, info, nil)
-	if err != nil {
-		return nil, util.RespErrorf(resp, errors.Wrap(err, "getting the Data-Pipes config").Error())
-	}
-
-	config := &apimodels.DataPipesConfig{}
-	if err := utility.ReadJSON(resp.Body, config); err != nil {
-		return nil, errors.Wrap(err, "reading the Data-Pipes config from response")
-	}
-
-	return config, nil
-}
-
 // GetPatchFiles is used by the git.get_project plugin and fetches
 // patches from the database, used in patch builds.
 func (c *baseCommunicator) GetPatchFile(ctx context.Context, taskData TaskData, patchFileID string) (string, error) {

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -76,8 +76,6 @@ type SharedCommunicator interface {
 	GetCedarGRPCConn(context.Context) (*grpc.ClientConn, error)
 	// SetResultsInfo sets the test results information in the task.
 	SetResultsInfo(context.Context, TaskData, string, bool) error
-	// GetDataPipesConfig returns the Data-Pipes service configuration.
-	GetDataPipesConfig(context.Context) (*apimodels.DataPipesConfig, error)
 
 	// GetPullRequestInfo takes in a PR number, owner, and repo and returns information from the corresponding pull request.
 	GetPullRequestInfo(context.Context, TaskData, int, string, string, bool) (*apimodels.PullRequestInfo, error)

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -330,16 +330,6 @@ func (c *Mock) GetCedarGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
 	return c.CedarGRPCConn, nil
 }
 
-// GetDataPipesConfig returns a mock Data-Pipes service configuration.
-func (c *Mock) GetDataPipesConfig(ctx context.Context) (*apimodels.DataPipesConfig, error) {
-	return &apimodels.DataPipesConfig{
-		Host:         "url",
-		Region:       "us-east-1",
-		AWSAccessKey: "access",
-		AWSSecretKey: "secret",
-	}, nil
-}
-
 // GetLoggerProducer constructs a single channel log producer.
 func (c *Mock) GetLoggerProducer(ctx context.Context, tsk *task.Task, _ *LoggerConfig) (LoggerProducer, error) {
 	if c.GetLoggerProducerShouldFail {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-25"
+	AgentVersion = "2024-01-29"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-2961

### Description
Stop sending performance results to the Data-Pipes service from the agent.

This needs to be done before we remove support for Data-Pipes on the Evergreen app (https://github.com/evergreen-ci/evergreen/pull/7456) to avoid breaking running performance tasks after a deploy.

### Testing
Updated relevant unit tests.

### Documentation
N/A
