### PR TITLE
DEVPROD-3861 distinct amboy connection string for Kanopy

### DIFF
--- a/config_amboy.go
+++ b/config_amboy.go
@@ -40,8 +40,9 @@ type AmboyConfig struct {
 
 // AmboyDBConfig configures Amboy's database connection.
 type AmboyDBConfig struct {
-	URL      string `bson:"url" json:"url" yaml:"url"`
-	Database string `bson:"database" json:"database" yaml:"database"`
+	URL       string `bson:"url" json:"url" yaml:"url"`
+	KanopyURL string `bson:"kanopy_url" json:"kanopy_url" yaml:"kanopy_url"`
+	Database  string `bson:"database" json:"database" yaml:"database"`
 }
 
 // AmboyRetryConfig represents configuration settings for Amboy's retryability

--- a/config_amboy.go
+++ b/config_amboy.go
@@ -40,7 +40,8 @@ type AmboyConfig struct {
 
 // AmboyDBConfig configures Amboy's database connection.
 type AmboyDBConfig struct {
-	URL       string `bson:"url" json:"url" yaml:"url"`
+	URL string `bson:"url" json:"url" yaml:"url"`
+	// TODO (DEVPROD-4163): remove KanopyURL after the cutover to Kanopy.
 	KanopyURL string `bson:"kanopy_url" json:"kanopy_url" yaml:"kanopy_url"`
 	Database  string `bson:"database" json:"database" yaml:"database"`
 }

--- a/config_test.go
+++ b/config_test.go
@@ -273,8 +273,9 @@ func (s *AdminSuite) TestAmboyConfig() {
 		Name:       "amboy",
 		SingleName: "single",
 		DBConnection: AmboyDBConfig{
-			URL:      "mongodb://localhost:27017",
-			Database: "db",
+			URL:       "mongodb://localhost:27017",
+			KanopyURL: "mongodb://localhost:27018",
+			Database:  "db",
 		},
 		PoolSizeLocal:                         10,
 		PoolSizeRemote:                        20,

--- a/environment.go
+++ b/environment.go
@@ -234,7 +234,7 @@ func NewEnvironment(ctx context.Context, confPath, versionID string, db *DBSetti
 	catcher.Add(e.initDepot(ctx))
 	catcher.Add(e.initThirdPartySenders(ctx))
 	catcher.Add(e.createLocalQueue(ctx))
-	catcher.Add(e.createRemoteQueues(ctx))
+	catcher.Add(e.createRemoteQueues(ctx, versionID != ""))
 	catcher.Add(e.createNotificationQueue(ctx))
 	catcher.Add(e.setupRoleManager())
 	catcher.Add(e.initTracer(ctx, versionID != ""))
@@ -376,8 +376,13 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings) error {
 	return nil
 }
 
-func (e *envState) createRemoteQueues(ctx context.Context) error {
-	url := e.settings.Amboy.DBConnection.URL
+func (e *envState) createRemoteQueues(ctx context.Context, inKanopy bool) error {
+	var url string
+	if inKanopy {
+		url = e.settings.Amboy.DBConnection.KanopyURL
+	} else {
+		url = e.settings.Amboy.DBConnection.URL
+	}
 	if url == "" {
 		url = DefaultAmboyDatabaseURL
 	}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -408,16 +408,18 @@ func (a *APIAmboyConfig) ToService() (interface{}, error) {
 }
 
 type APIAmboyDBConfig struct {
-	URL      *string `json:"url"`
-	Database *string `json:"database"`
-	Username *string `json:"username"`
-	Password *string `json:"password"`
+	URL       *string `json:"url"`
+	KanopyURL *string `json:"kanopy_url"`
+	Database  *string `json:"database"`
+	Username  *string `json:"username"`
+	Password  *string `json:"password"`
 }
 
 func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.AmboyDBConfig:
 		a.URL = utility.ToStringPtr(v.URL)
+		a.KanopyURL = utility.ToStringPtr(v.KanopyURL)
 		a.Database = utility.ToStringPtr(v.Database)
 		return nil
 	default:
@@ -427,8 +429,9 @@ func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
 
 func (a *APIAmboyDBConfig) ToService() (interface{}, error) {
 	return evergreen.AmboyDBConfig{
-		URL:      utility.FromStringPtr(a.URL),
-		Database: utility.FromStringPtr(a.Database),
+		URL:       utility.FromStringPtr(a.URL),
+		KanopyURL: utility.FromStringPtr(a.KanopyURL),
+		Database:  utility.FromStringPtr(a.Database),
 	}, nil
 }
 

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -91,6 +91,7 @@ func TestModelConversion(t *testing.T) {
 
 	assert.EqualValues(testSettings.Amboy.Name, utility.FromStringPtr(apiSettings.Amboy.Name))
 	assert.EqualValues(testSettings.Amboy.DBConnection.URL, utility.FromStringPtr(apiSettings.Amboy.DBConnection.URL))
+	assert.EqualValues(testSettings.Amboy.DBConnection.KanopyURL, utility.FromStringPtr(apiSettings.Amboy.DBConnection.KanopyURL))
 	assert.EqualValues(testSettings.Amboy.DBConnection.Database, utility.FromStringPtr(apiSettings.Amboy.DBConnection.Database))
 	assert.EqualValues(testSettings.Amboy.LocalStorage, apiSettings.Amboy.LocalStorage)
 	assert.EqualValues(testSettings.Amboy.GroupDefaultWorkers, apiSettings.Amboy.GroupDefaultWorkers)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1487,7 +1487,7 @@ Admin Settings
 										<label>Name</label>
 										<input type="text" ng-model="Settings.amboy.name">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Single Worker Name</label>
 										<input type="text" ng-model="Settings.amboy.single_name">
 									</md-input-container>
@@ -1495,23 +1495,27 @@ Admin Settings
 										<label>DB URL</label>
 										<input type="text" ng-model="Settings.amboy.db_connection.url">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
+										<label>Kanopy DB URL</label>
+										<input type="text" ng-model="Settings.amboy.db_connection.kanopy_url">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>DB name</label>
 										<input type="text" ng-model="Settings.amboy.db_connection.database">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%">
+									<md-input-container class="control" style="width:45%;">
 										<label>Local pool size</label>
 										<input type="number" ng-model="Settings.amboy.pool_size_local">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Remote pool size</label>
 										<input type="number" ng-model="Settings.amboy.pool_size_remote">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%">
+									<md-input-container class="control" style="width:45%;">
 										<label>Local storage size</label>
 										<input type="number" ng-model="Settings.amboy.local_storage_size">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<md-checkbox ng-model="Settings.amboy.remote_require_priority">Remote Require
 											Priority</md-checkbox>
 									</md-input-container>
@@ -1519,7 +1523,7 @@ Admin Settings
 										<label>Lock timeout (minutes)</label>
 										<input type="number" ng-model="Settings.amboy.lock_timeout_minutes">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Sample size</label>
 										<input type="number" ng-model="Settings.amboy.sample_size">
 									</md-input-container>
@@ -1527,7 +1531,7 @@ Admin Settings
 										<label>Retry Handler Workers</label>
 										<input type="number" ng-model="Settings.amboy.retry.num_workers">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Retry Handler Max Job Capacity</label>
 										<input type="number" ng-model="Settings.amboy.retry.max_capacity">
 									</md-input-container>
@@ -1535,7 +1539,7 @@ Admin Settings
 										<label>Max Retry Handler Attempts per Job</label>
 										<input type="number" ng-model="Settings.amboy.retry.max_retry_attempts">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Max Retry Handler Total Time per Job (Seconds)</label>
 										<input type="number" ng-model="Settings.amboy.retry.max_retry_time_seconds">
 									</md-input-container>
@@ -1543,7 +1547,7 @@ Admin Settings
 										<label>Retry Backoff per Job Attempt (Seconds)</label>
 										<input type="number" ng-model="Settings.amboy.retry.retry_backoff_seconds">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Frequency of Checking for Stale Retrying Jobs (Seconds)</label>
 										<input type="number" ng-model="Settings.amboy.retry.stale_retrying_monitor_interval_seconds">
 									</md-input-container>
@@ -1551,7 +1555,7 @@ Admin Settings
 										<label>Group default workers</label>
 										<input type="number" ng-model="Settings.amboy.group_default_workers">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Group background create frequency</label>
 										<input type="number"
 											ng-model="Settings.amboy.group_background_create_frequency">
@@ -1560,7 +1564,7 @@ Admin Settings
 										<label>Group prune frequency</label>
 										<input type="number" ng-model="Settings.amboy.group_prune_frequency">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left:50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Group TTL</label>
 										<input type="number" ng-model="Settings.amboy.group_ttl">
 									</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -89,8 +89,9 @@ func MockConfig() *evergreen.Settings {
 			Name:       "amboy",
 			SingleName: "single",
 			DBConnection: evergreen.AmboyDBConfig{
-				Database: "db",
-				URL:      "mongodb://localhost:27017",
+				Database:  "db",
+				URL:       "mongodb://localhost:27017",
+				KanopyURL: "mongodb://localhost:27018",
 			},
 			PoolSizeLocal:                         10,
 			PoolSizeRemote:                        20,


### PR DESCRIPTION
[DEVPROD-3861](https://jira.mongodb.org/browse/DEVPROD-3861)

### Description
Add another URL for connecting to amboy when the app is running inside Kanopy. This is necessary because it's a different private link and thus a different URL.

### Testing
It allowed us to set another URL for the instance of evergreen that was running in Kanopy staging.
