### PR TITLE
DEVPROD-3888 Use custom context for GitHub webhook route

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -44,6 +44,9 @@ const (
 	// skipCIDescriptionCharLimit is the maximum number of characters that will
 	// be scanned in the PR description for a skip CI label.
 	skipCIDescriptionCharLimit = 100
+
+	// githubWebhookTimeout is the maximum timeout for processing a GitHub webhook.
+	githubWebhookTimeout = 60 * time.Second
 )
 
 // skipCILabels are a set of labels which will skip creating PR patch if part of
@@ -118,6 +121,9 @@ func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo stri
 }
 
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
+	ctx, cancel := context.WithTimeout(context.Background(), githubWebhookTimeout)
+	defer cancel()
+
 	switch event := gh.event.(type) {
 	case *github.PingEvent:
 		fromApp := event.GetInstallation() != nil

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -121,6 +121,9 @@ func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo stri
 }
 
 func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
+	// GitHub occasionally aborts requests early before we are able to complete the full operation
+	// (for example enqueueing a PR to the commit queue). We therefore want to use a custom context
+	// instead of using the request context.
 	ctx, cancel := context.WithTimeout(context.Background(), githubWebhookTimeout)
 	defer cancel()
 


### PR DESCRIPTION
DEVPROD-3888

### Description
We ran into some issues that seemed to be caused by the request cancelling which most likely happened due to a client-side timeout. 

This will ignore the request context passed into Run for the GitHub webhook route and instead use a custom context with a 60 second timeout. That will ensure that webhook requests are not affected by the original webhook request context cancelling.

