### PR TITLE
DEVPROD-3944: create job to collect unexpirable host stats

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// User is the generic user representing the Evergreen application as a
+	// whole entity. If there's a more specific user performing an operation,
+	// prefer to use that instead.
 	User            = "mci"
 	GithubPatchUser = "github_pull_request"
 	GithubMergeUser = "github_merge_queue"

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1339,3 +1339,15 @@ func UnsafeReplace(ctx context.Context, env evergreen.Environment, idToRemove st
 
 	return nil
 }
+
+// FindUnexpirableRunning returns all unexpirable spawn hosts that are
+// currently running.
+func FindUnexpirableRunning() ([]Host, error) {
+	hosts := []Host{}
+	q := bson.M{
+		StatusKey:       evergreen.HostRunning,
+		StartedByKey:    bson.M{"$ne": evergreen.User},
+		NoExpirationKey: true,
+	}
+	return hosts, db.FindAllQ(Collection, db.Query(q), &hosts)
+}

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -1,0 +1,60 @@
+package host
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindUnexpirableRunning(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, h *Host){
+		"ReturnsUnexpirableRunningHost": func(ctx context.Context, t *testing.T, h *Host) {
+			require.NoError(t, h.Insert(ctx))
+			hosts, err := FindUnexpirableRunning()
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			assert.Equal(t, h.Id, hosts[0].Id)
+		},
+		"DoesNotReturnExpirableHost": func(ctx context.Context, t *testing.T, h *Host) {
+			h.NoExpiration = false
+			require.NoError(t, h.Insert(ctx))
+			hosts, err := FindUnexpirableRunning()
+			require.NoError(t, err)
+			assert.Empty(t, hosts)
+		},
+		"DoesNotReturnNonRunningHost": func(ctx context.Context, t *testing.T, h *Host) {
+			h.Status = evergreen.HostStopped
+			require.NoError(t, h.Insert(ctx))
+			hosts, err := FindUnexpirableRunning()
+			require.NoError(t, err)
+			assert.Empty(t, hosts)
+		},
+		"DoesNotReturnEvergreenOwnedHosts": func(ctx context.Context, t *testing.T, h *Host) {
+			h.StartedBy = evergreen.User
+			require.NoError(t, h.Insert(ctx))
+			hosts, err := FindUnexpirableRunning()
+			require.NoError(t, err)
+			assert.Empty(t, hosts)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(Collection))
+			h := Host{
+				Id:           "host_id",
+				Status:       evergreen.HostRunning,
+				StartedBy:    "myself",
+				NoExpiration: true,
+			}
+			tCase(ctx, t, &h)
+		})
+	}
+}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1231,7 +1231,7 @@ func PopulatePodResourceCleanupJobs() amboy.QueueOperation {
 // unexpirable spawn host usage.
 func PopulateUnexpirableSpawnHostStatsJob() amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		return amboy.EnqueueUniqueJob(ctx, queue, NewUnexpirableSpawnHostStatsJob(utility.RoundPartOfDay(0).Format(TSFormat)))
+		return amboy.EnqueueUniqueJob(ctx, queue, NewUnexpirableSpawnHostStatsJob(utility.RoundPartOfHour(0).Format(TSFormat)))
 	}
 }
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -1227,6 +1227,14 @@ func PopulatePodResourceCleanupJobs() amboy.QueueOperation {
 	}
 }
 
+// PopulateUnexpirableSpawnHostStatsJob populates jobs to collect statistics on
+// unexpirable spawn host usage.
+func PopulateUnexpirableSpawnHostStatsJob() amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		return amboy.EnqueueUniqueJob(ctx, queue, NewUnexpirableSpawnHostStatsJob(utility.RoundPartOfDay(0).Format(TSFormat)))
+	}
+}
+
 func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGroupName string, factory cronJobFactory, ts time.Time) error {
 	appCtx, _ := env.Context()
 	queueGroup, err := env.RemoteQueueGroup().Get(appCtx, queueGroupName)

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -57,6 +57,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 		PopulateSSHKeyUpdates(j.env),
 		PopulateDuplicateTaskCheckJobs(),
 		PopulatePodResourceCleanupJobs(),
+		PopulateUnexpirableSpawnHostStatsJob(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -1,0 +1,120 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const (
+	unexpirableSpawnHostStatsJobName        = "unexpirable-spawnhost-stats"
+	unexpirableSpawnHostStatsJobMaxAttempts = 10
+)
+
+func init() {
+	registry.AddJobType(unexpirableSpawnHostStatsJobName, func() amboy.Job {
+		return makeUnexpirableSpawnHostStatsJob()
+	})
+}
+
+type unexpirableSpawnHostStatsJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+}
+
+func makeUnexpirableSpawnHostStatsJob() *unexpirableSpawnHostStatsJob {
+	j := &unexpirableSpawnHostStatsJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    podDefinitionCreationJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewUnexpirableSpawnHostStatsJob returns a job to collect estimated statistics
+// on unexpirable spawn host usage.
+func NewUnexpirableSpawnHostStatsJob(ts string) amboy.Job {
+	j := makeUnexpirableSpawnHostStatsJob()
+	j.SetID(fmt.Sprintf("%s.%s", unexpirableSpawnHostStatsJobName, ts))
+	j.SetScopes([]string{unexpirableSpawnHostStatsJobName})
+	j.SetEnqueueAllScopes(true)
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(unexpirableSpawnHostStatsJobMaxAttempts),
+	})
+	return j
+}
+
+func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	hosts, err := host.FindUnexpirableRunning()
+	if err != nil {
+		j.AddRetryableError(errors.Wrap(err, "finding unexpirable running hosts"))
+		return
+	}
+
+	stats := j.getStats(hosts)
+
+	grip.Info(message.Fields{
+		"message":                 "unexpirable spawn host stats",
+		"job_id":                  j.ID(),
+		"job_type":                j.Type(),
+		"total_uptime":            stats.totalUptime,
+		"uptime_by_distro":        stats.uptimeByDistro,
+		"uptime_by_instance_type": stats.uptimeByInstanceType,
+	})
+}
+
+type unexpirableSpawnHostStats struct {
+	totalUptime          time.Duration
+	uptimeByDistro       map[string]time.Duration
+	uptimeByInstanceType map[string]time.Duration
+}
+
+// getStats returns the estimated host uptime stats for the day. These are not
+// perfectly accurate, but give a sufficient ballpark estimate of spawn host
+// uptime. For example, it's assumed for simplicity that users don't stop their
+// hosts randomly throughout the day, so if the host is on, it's likely been on
+// the entire day.
+func (j *unexpirableSpawnHostStatsJob) getStats(hosts []host.Host) unexpirableSpawnHostStats {
+
+	var totalUptime time.Duration
+	uptimeByDistro := map[string]time.Duration{}
+	uptimeByInstanceType := map[string]time.Duration{}
+
+	for _, h := range hosts {
+		// Estimate that if the host is up now, it's been up all day.
+		const dailyUptimePerHost = 24 * time.Hour
+		totalUptime += dailyUptimePerHost
+		uptimeByDistro[h.Distro.Id] += dailyUptimePerHost
+		if evergreen.IsEc2Provider(h.Distro.Provider) {
+			if len(h.Distro.ProviderSettingsList) == 0 {
+				continue
+			}
+			instanceType, ok := h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK()
+			if !ok {
+				continue
+			}
+			uptimeByInstanceType[instanceType] += dailyUptimePerHost
+		}
+	}
+
+	return unexpirableSpawnHostStats{
+		totalUptime:          totalUptime,
+		uptimeByDistro:       uptimeByDistro,
+		uptimeByInstanceType: uptimeByInstanceType,
+	}
+}

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -99,11 +99,8 @@ func (j *unexpirableSpawnHostStatsJob) getStats(hosts []host.Host) unexpirableSp
 		totalUptime += dailyUptimePerHost
 		uptimeByDistro[h.Distro.Id] += int(dailyUptimePerHost.Seconds())
 		if evergreen.IsEc2Provider(h.Distro.Provider) {
-			if len(h.Distro.ProviderSettingsList) == 0 {
-				continue
-			}
-			instanceType, ok := h.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK()
-			if !ok {
+			instanceType := h.InstanceType
+			if instanceType == "" {
 				continue
 			}
 			uptimeByInstanceType[instanceType] += int(dailyUptimePerHost.Seconds())

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -69,7 +69,7 @@ func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 	stats := j.getStats(hosts)
 
 	grip.Info(message.Fields{
-		"message":                      "unexpirable spawn host stats total (in seconds)",
+		"message":                      "unexpirable spawn host stats",
 		"job_id":                       j.ID(),
 		"total_uptime_secs":            stats.totalUptime.Seconds(),
 		"uptime_secs_by_distro":        stats.uptimeSecsByDistro,

--- a/units/unexpirable_spawnhost_stats_test.go
+++ b/units/unexpirable_spawnhost_stats_test.go
@@ -102,15 +102,19 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 			}
 
 			stats := j.getStats(hosts)
+
+			const day = 24 * time.Hour
+			daySecs := int(day.Seconds())
 			assert.Equal(t, time.Duration(len(hosts))*24*time.Hour, stats.totalUptime)
+
 			assert.Len(t, stats.uptimeSecsByDistro, 3)
-			day := int(time.Duration(24 * time.Hour).Seconds())
-			assert.Equal(t, 4*day, stats.uptimeSecsByDistro["distro0"])
-			assert.Equal(t, day, stats.uptimeSecsByDistro["distro1"])
-			assert.Equal(t, day, stats.uptimeSecsByDistro["distro2"])
+			assert.Equal(t, 4*daySecs, stats.uptimeSecsByDistro["distro0"])
+			assert.Equal(t, daySecs, stats.uptimeSecsByDistro["distro1"])
+			assert.Equal(t, daySecs, stats.uptimeSecsByDistro["distro2"])
+
 			assert.Len(t, stats.uptimeSecsByInstanceType, 2)
-			assert.Equal(t, 5*day, stats.uptimeSecsByInstanceType["m5.xlarge"])
-			assert.Equal(t, day, stats.uptimeSecsByInstanceType["c5.xlarge"])
+			assert.Equal(t, 5*daySecs, stats.uptimeSecsByInstanceType["m5.xlarge"])
+			assert.Equal(t, daySecs, stats.uptimeSecsByInstanceType["c5.xlarge"])
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/units/unexpirable_spawnhost_stats_test.go
+++ b/units/unexpirable_spawnhost_stats_test.go
@@ -109,18 +109,17 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 
 			stats := j.getStats(hosts)
 
-			const day = 24 * time.Hour
-			daySecs := int(day.Seconds())
-			assert.Equal(t, time.Duration(len(hosts))*24*time.Hour, stats.totalUptime)
+			assert.Equal(t, time.Duration(len(hosts))*time.Hour, stats.totalUptime)
 
 			assert.Len(t, stats.uptimeSecsByDistro, 3)
-			assert.Equal(t, 4*daySecs, stats.uptimeSecsByDistro["distro0"])
-			assert.Equal(t, daySecs, stats.uptimeSecsByDistro["distro1"])
-			assert.Equal(t, daySecs, stats.uptimeSecsByDistro["distro2"])
+			hourSecs := int(time.Hour.Seconds())
+			assert.Equal(t, 4*hourSecs, stats.uptimeSecsByDistro["distro0"])
+			assert.Equal(t, hourSecs, stats.uptimeSecsByDistro["distro1"])
+			assert.Equal(t, hourSecs, stats.uptimeSecsByDistro["distro2"])
 
 			assert.Len(t, stats.uptimeSecsByInstanceType, 2)
-			assert.Equal(t, 5*daySecs, stats.uptimeSecsByInstanceType["m5.xlarge"])
-			assert.Equal(t, daySecs, stats.uptimeSecsByInstanceType["c5.xlarge"])
+			assert.Equal(t, 5*hourSecs, stats.uptimeSecsByInstanceType["m5.xlarge"])
+			assert.Equal(t, hourSecs, stats.uptimeSecsByInstanceType["c5.xlarge"])
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/units/unexpirable_spawnhost_stats_test.go
+++ b/units/unexpirable_spawnhost_stats_test.go
@@ -1,0 +1,124 @@
+package units
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/birch"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUnexpirableSpawnHostStatsJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	testutil.TestSpan(ctx, t)
+
+	j, ok := NewUnexpirableSpawnHostStatsJob(utility.RoundPartOfMinute(0).Format(TSFormat)).(*unexpirableSpawnHostStatsJob)
+	require.True(t, ok)
+
+	assert.NotZero(t, j.ID())
+}
+
+func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, j *unexpirableSpawnHostStatsJob){
+		"ReturnsZeroStatsForNoHosts": func(ctx context.Context, t *testing.T, j *unexpirableSpawnHostStatsJob) {
+			stats := j.getStats(nil)
+			assert.Zero(t, stats.totalUptime)
+			assert.Empty(t, stats.uptimeByDistro)
+			assert.Empty(t, stats.uptimeByInstanceType)
+		},
+		"ReturnsStatsForHosts": func(ctx context.Context, t *testing.T, j *unexpirableSpawnHostStatsJob) {
+			hosts := []host.Host{
+				{
+					Id: "h0",
+					Distro: distro.Distro{
+						Id:       "distro0",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
+						},
+					},
+				},
+				{
+					Id: "h1",
+					Distro: distro.Distro{
+						Id:       "distro0",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
+						},
+					},
+				},
+				{
+					Id: "h2",
+					Distro: distro.Distro{
+						Id:       "distro1",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
+						},
+					},
+				},
+				{
+					Id: "h3",
+					Distro: distro.Distro{
+						Id:       "distro2",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "c5.xlarge")),
+						},
+					},
+				},
+				{
+					Id: "h4",
+					Distro: distro.Distro{
+						Id:       "distro0",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
+						},
+					},
+				},
+				{
+					Id: "h5",
+					Distro: distro.Distro{
+						Id:       "distro0",
+						Provider: evergreen.ProviderNameEc2OnDemand,
+						ProviderSettingsList: []*birch.Document{
+							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
+						},
+					},
+				},
+			}
+
+			stats := j.getStats(hosts)
+			assert.Equal(t, time.Duration(len(hosts))*24*time.Hour, stats.totalUptime)
+			assert.Len(t, stats.uptimeByDistro, 3)
+			const day = 24 * time.Hour
+			assert.Equal(t, 4*day, stats.uptimeByDistro["distro0"])
+			assert.Equal(t, day, stats.uptimeByDistro["distro1"])
+			assert.Equal(t, day, stats.uptimeByDistro["distro2"])
+			assert.Len(t, stats.uptimeByInstanceType, 2)
+			assert.Equal(t, 5*day, stats.uptimeByInstanceType["m5.xlarge"])
+			assert.Equal(t, day, stats.uptimeByInstanceType["c5.xlarge"])
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			j, ok := NewUnexpirableSpawnHostStatsJob("").(*unexpirableSpawnHostStatsJob)
+			require.True(t, ok)
+			tCase(tctx, t, j)
+		})
+	}
+}

--- a/units/unexpirable_spawnhost_stats_test.go
+++ b/units/unexpirable_spawnhost_stats_test.go
@@ -34,8 +34,8 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 		"ReturnsZeroStatsForNoHosts": func(ctx context.Context, t *testing.T, j *unexpirableSpawnHostStatsJob) {
 			stats := j.getStats(nil)
 			assert.Zero(t, stats.totalUptime)
-			assert.Empty(t, stats.uptimeByDistro)
-			assert.Empty(t, stats.uptimeByInstanceType)
+			assert.Empty(t, stats.uptimeSecsByDistro)
+			assert.Empty(t, stats.uptimeSecsByInstanceType)
 		},
 		"ReturnsStatsForHosts": func(ctx context.Context, t *testing.T, j *unexpirableSpawnHostStatsJob) {
 			hosts := []host.Host{
@@ -103,14 +103,14 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 
 			stats := j.getStats(hosts)
 			assert.Equal(t, time.Duration(len(hosts))*24*time.Hour, stats.totalUptime)
-			assert.Len(t, stats.uptimeByDistro, 3)
-			const day = 24 * time.Hour
-			assert.Equal(t, 4*day, stats.uptimeByDistro["distro0"])
-			assert.Equal(t, day, stats.uptimeByDistro["distro1"])
-			assert.Equal(t, day, stats.uptimeByDistro["distro2"])
-			assert.Len(t, stats.uptimeByInstanceType, 2)
-			assert.Equal(t, 5*day, stats.uptimeByInstanceType["m5.xlarge"])
-			assert.Equal(t, day, stats.uptimeByInstanceType["c5.xlarge"])
+			assert.Len(t, stats.uptimeSecsByDistro, 3)
+			day := int(time.Duration(24 * time.Hour).Seconds())
+			assert.Equal(t, 4*day, stats.uptimeSecsByDistro["distro0"])
+			assert.Equal(t, day, stats.uptimeSecsByDistro["distro1"])
+			assert.Equal(t, day, stats.uptimeSecsByDistro["distro2"])
+			assert.Len(t, stats.uptimeSecsByInstanceType, 2)
+			assert.Equal(t, 5*day, stats.uptimeSecsByInstanceType["m5.xlarge"])
+			assert.Equal(t, day, stats.uptimeSecsByInstanceType["c5.xlarge"])
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/units/unexpirable_spawnhost_stats_test.go
+++ b/units/unexpirable_spawnhost_stats_test.go
@@ -48,6 +48,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
 						},
 					},
+					InstanceType: "m5.xlarge",
 				},
 				{
 					Id: "h1",
@@ -58,6 +59,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
 						},
 					},
+					InstanceType: "m5.xlarge",
 				},
 				{
 					Id: "h2",
@@ -68,6 +70,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
 						},
 					},
+					InstanceType: "m5.xlarge",
 				},
 				{
 					Id: "h3",
@@ -78,6 +81,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "c5.xlarge")),
 						},
 					},
+					InstanceType: "c5.xlarge",
 				},
 				{
 					Id: "h4",
@@ -88,6 +92,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
 						},
 					},
+					InstanceType: "m5.xlarge",
 				},
 				{
 					Id: "h5",
@@ -98,6 +103,7 @@ func TestUnexpirableSpawnHostStatsJob(t *testing.T) {
 							birch.NewDocument(birch.EC.String("instance_type", "m5.xlarge")),
 						},
 					},
+					InstanceType: "m5.xlarge",
 				},
 			}
 


### PR DESCRIPTION
DEVPROD-3944

### Description
Create a daily job that will collect estimated uptime stats on unexpirable hosts. This will help diff the cost savings before/after the sleep schedule is rolled out. It intentionally logs to Splunk rather than Honeycomb because Honeycomb's 60 day TTL is too short of a time period.

### Testing
* Added unit tests.
* Tested in staging that it outputted the stats in the expected format.

### Documentation
N/A