### PR TITLE
DEVPROD-4025: remove `key` as a suspicious expansion pattern

### DIFF
--- a/agent/logging.go
+++ b/agent/logging.go
@@ -174,13 +174,12 @@ func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, file
 
 func redactList(projectVars map[string]string, redacted map[string]bool) []string {
 	suspiciousPatterns := []string{
-		"key",
-		"secret",
 		"auth",
-		"token",
-		"private",
 		"pass",
+		"private",
 		"pw",
+		"secret",
+		"token",
 	}
 
 	var redactedKeys []string

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -273,9 +273,9 @@ func TestRedactList(t *testing.T) {
 		{
 			name: "SuspiciousPatterns",
 			projectVars: map[string]string{
-				"not_suspicious":  "",
 				"num_hosts":       "",
 				"aws_key":         "",
+				"aws_secret_key":  "",
 				"my_secret":       "",
 				"my_SECRET":       "",
 				"aws_token":       "",
@@ -290,7 +290,7 @@ func TestRedactList(t *testing.T) {
 				"Some_Auth":       "",
 			},
 			expected: []string{
-				"aws_key",
+				"aws_secret_key",
 				"my_secret",
 				"my_SECRET",
 				"aws_token",
@@ -308,10 +308,10 @@ func TestRedactList(t *testing.T) {
 		{
 			name: "Redacted",
 			projectVars: map[string]string{
-				"not_suspicious": "",
-				"num_hosts":      "",
-				"aws_token":      "",
-				"my_secret":      "",
+				"num_hosts": "",
+				"aws_key":   "",
+				"aws_token": "",
+				"my_secret": "",
 			},
 			redacted: map[string]bool{
 				"aws_token": true,
@@ -325,11 +325,11 @@ func TestRedactList(t *testing.T) {
 		{
 			name: "SuspiciousPatternsAndRedacted",
 			projectVars: map[string]string{
-				"not_suspicious": "",
-				"num_hosts":      "",
-				"aws_token":      "",
-				"my_secret":      "",
-				"svc_PASSWORD":   "",
+				"num_hosts":    "",
+				"aws_key":      "",
+				"aws_token":    "",
+				"my_secret":    "",
+				"svc_PASSWORD": "",
 			},
 			redacted: map[string]bool{
 				"aws_token": true,

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-29"
+	AgentVersion = "2024-01-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -652,7 +652,7 @@ task logs and replaced with `<REDACTED:expansion_key>` if they meet one of the
 following criteria:
 - the project variable is marked as private
 - the project variable key contains any of the following case-insensitive
-  patterns: `auth`, `key`, `pass`, `private`, `pw`, `token`
+  patterns: `auth`, `pass`, `private`, `pw`, `token`
 
 Please note that this is the last line of defense against leaking secrets and
 task workflows should always follow best practices for securing sensitive


### PR DESCRIPTION
DEVPROD-4025

### Description
This was too aggressive since users often use `key` for user names that are not sensitive and may collide with common strings such as `evergreen`. See [these logs](https://parsley-staging.corp.mongodb.com/evergreen/evg_ubuntu2204_test_cloud_userdata_29a1f4e2b3ac38e396bb705e807867433c893309_24_01_30_00_19_35/1/all?bookmarks=0,569) for an example.

### Testing
Updated unit tests. Tested in [staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_echo_variable_patch_f50345d4c091635680061fecb7f18af636a6bf08_65b7fec097b1d3897105fabe_24_01_29_19_39_01/logs?execution=1&logtype=task).

### Documentation
Updated expansions documentation to remove `key` from the suspicious pattern list.
