### PR TITLE
DEVPROD-4025: Configurable project var redactions

### DIFF
--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -33,11 +33,31 @@ func TestNewTaskConfig(t *testing.T) {
 	taskConfig, err := NewTaskConfig(curdir, &apimodels.DistroView{}, p, task, &model.ProjectRef{
 		Id:         "project_id",
 		Identifier: "project_identifier",
-	}, &patch.Patch{}, &apimodels.ExpansionsAndVars{})
+	}, &patch.Patch{}, &apimodels.ExpansionsAndVars{
+		Vars: map[string]string{
+			"num_hosts":      "",
+			"aws_token":      "",
+			"my_pass_secret": "",
+			"myPASSWORD":     "",
+			"mySecret":       "",
+			"git_token":      "",
+		},
+		PrivateVars: map[string]bool{
+			"aws_token": true,
+		},
+		RedactKeys: []string{"pass", "secret", "token"},
+	})
 	assert.NoError(t, err)
 
 	assert.Empty(t, taskConfig.DynamicExpansions)
 	assert.Empty(t, taskConfig.Expansions)
+	assert.Equal(t, map[string]bool{
+		"aws_token":      true,
+		"my_pass_secret": true,
+		"myPASSWORD":     true,
+		"mySecret":       true,
+		"git_token":      true,
+	}, taskConfig.Redacted)
 	assert.Equal(t, &apimodels.DistroView{}, taskConfig.Distro)
 	assert.Equal(t, p, &taskConfig.Project)
 	assert.Equal(t, task, &taskConfig.Task)

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -118,7 +118,7 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskSync.Key, tc.taskConfig.TaskSync.Secret, ""),
 	}
 	config.Expansions = tc.taskConfig.NewExpansions
-	config.ExpansionsToRedact = redactList(tc.taskConfig.Redacted)
+	config.ExpansionsToRedact = getExpansionsToRedact(tc.taskConfig.Redacted)
 
 	defaultLogger := tc.taskConfig.ProjectRef.DefaultLogger
 
@@ -171,12 +171,14 @@ func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, file
 	}
 }
 
-func redactList(redacted map[string]bool) []string {
-	var redactedKeys []string
+// getExpansionsToRedact returns the full list of expansion keys whose values
+// should get redacted from task logs.
+func getExpansionsToRedact(redacted map[string]bool) []string {
+	var expansionsToRedact []string
 	for key := range redacted {
-		redactedKeys = append(redactedKeys, key)
+		expansionsToRedact = append(expansionsToRedact, key)
 	}
-	redactedKeys = append(redactedKeys, command.ExpansionsToRedact...)
+	expansionsToRedact = append(expansionsToRedact, command.ExpansionsToRedact...)
 
-	return redactedKeys
+	return expansionsToRedact
 }

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/evergreen-ci/evergreen/agent/command"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -119,7 +118,7 @@ func (a *Agent) prepLogger(tc *taskContext, c *model.LoggerConfig, commandName s
 		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskSync.Key, tc.taskConfig.TaskSync.Secret, ""),
 	}
 	config.Expansions = tc.taskConfig.NewExpansions
-	config.ExpansionsToRedact = redactList(tc.taskConfig.ProjectVars, tc.taskConfig.Redacted)
+	config.ExpansionsToRedact = redactList(tc.taskConfig.Redacted)
 
 	defaultLogger := tc.taskConfig.ProjectRef.DefaultLogger
 
@@ -172,31 +171,8 @@ func (a *Agent) prepSingleLogger(tc *taskContext, in model.LogOpts, logDir, file
 	}
 }
 
-func redactList(projectVars map[string]string, redacted map[string]bool) []string {
-	suspiciousPatterns := []string{
-		"key",
-		"secret",
-		"auth",
-		"token",
-		"private",
-		"pass",
-		"pw",
-	}
-
+func redactList(redacted map[string]bool) []string {
 	var redactedKeys []string
-	for key := range projectVars {
-		if _, ok := redacted[key]; ok {
-			// Skip since the key is already in the redacted list.
-			continue
-		}
-
-		for _, pattern := range suspiciousPatterns {
-			if strings.Contains(strings.ToLower(key), pattern) {
-				redactedKeys = append(redactedKeys, key)
-				break
-			}
-		}
-	}
 	for key := range redacted {
 		redactedKeys = append(redactedKeys, key)
 	}

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -262,57 +262,15 @@ func TestTimberSender(t *testing.T) {
 
 func TestRedactList(t *testing.T) {
 	for _, test := range []struct {
-		name        string
-		projectVars map[string]string
-		redacted    map[string]bool
-		expected    []string
+		name     string
+		redacted map[string]bool
+		expected []string
 	}{
 		{
 			name: "Defaults",
 		},
 		{
-			name: "SuspiciousPatterns",
-			projectVars: map[string]string{
-				"not_suspicious":  "",
-				"num_hosts":       "",
-				"aws_key":         "",
-				"my_secret":       "",
-				"my_SECRET":       "",
-				"aws_token":       "",
-				"AWSTOKEN":        "",
-				"my_password":     "",
-				"servicePassword": "",
-				"srv_pass":        "",
-				"my_PASS":         "",
-				"mypw":            "",
-				"myPW":            "",
-				"private_key":     "",
-				"Some_Auth":       "",
-			},
-			expected: []string{
-				"aws_key",
-				"my_secret",
-				"my_SECRET",
-				"aws_token",
-				"AWSTOKEN",
-				"my_password",
-				"servicePassword",
-				"srv_pass",
-				"my_PASS",
-				"mypw",
-				"myPW",
-				"private_key",
-				"Some_Auth",
-			},
-		},
-		{
 			name: "Redacted",
-			projectVars: map[string]string{
-				"not_suspicious": "",
-				"num_hosts":      "",
-				"aws_token":      "",
-				"my_secret":      "",
-			},
 			redacted: map[string]bool{
 				"aws_token": true,
 				"my_secret": true,
@@ -320,32 +278,13 @@ func TestRedactList(t *testing.T) {
 			expected: []string{
 				"aws_token",
 				"my_secret",
-			},
-		},
-		{
-			name: "SuspiciousPatternsAndRedacted",
-			projectVars: map[string]string{
-				"not_suspicious": "",
-				"num_hosts":      "",
-				"aws_token":      "",
-				"my_secret":      "",
-				"svc_PASSWORD":   "",
-			},
-			redacted: map[string]bool{
-				"aws_token": true,
-				"my_secret": true,
-			},
-			expected: []string{
-				"aws_token",
-				"my_secret",
-				"svc_PASSWORD",
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			test.expected = append(test.expected, command.ExpansionsToRedact...)
 
-			actual := redactList(test.projectVars, test.redacted)
+			actual := redactList(test.redacted)
 			assert.ElementsMatch(t, test.expected, actual)
 		})
 	}

--- a/agent/logging_test.go
+++ b/agent/logging_test.go
@@ -260,7 +260,7 @@ func TestTimberSender(t *testing.T) {
 	assert.NoError(t, agt.startLogging(ctx, tc))
 }
 
-func TestRedactList(t *testing.T) {
+func TestGetExpansionsToRedact(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		redacted map[string]bool
@@ -284,7 +284,7 @@ func TestRedactList(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.expected = append(test.expected, command.ExpansionsToRedact...)
 
-			actual := redactList(test.redacted)
+			actual := getExpansionsToRedact(test.redacted)
 			assert.ElementsMatch(t, test.expected, actual)
 		})
 	}

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -345,4 +345,7 @@ type ExpansionsAndVars struct {
 	Vars map[string]string `json:"vars"`
 	// PrivateVars contain the project private variables.
 	PrivateVars map[string]bool `json:"private_vars"`
+	// Redact keys contain patterns to match against expansion keys for
+	// redaction in logs.
+	RedactKeys []string `json:"redact_keys"`
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-29"
+	AgentVersion = "2024-01-30"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config_logger.go
+++ b/config_logger.go
@@ -17,6 +17,7 @@ type LoggerConfig struct {
 	DefaultLevel   string       `bson:"default_level" json:"default_level" yaml:"default_level"`
 	ThresholdLevel string       `bson:"threshold_level" json:"threshold_level" yaml:"threshold_level"`
 	LogkeeperURL   string       `bson:"logkeeper_url" json:"logkeeper_url" yaml:"logkeeper_url"`
+	RedactKeys     []string     `bson:"redact_keys" json:"redact_keys" yaml:"redact_keys"`
 
 	// TODO (DEVPROD-3886): Remove these fields once we stop supporting
 	// sending logs to Cedar Buildlogger.

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -463,6 +463,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		Parameters:  map[string]string{},
 		Vars:        map[string]string{},
 		PrivateVars: map[string]bool{},
+		RedactKeys:  h.settings.LoggerConfig.RedactKeys,
 	}
 
 	projectVars, err := model.FindMergedProjectVars(t.Project)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -56,8 +56,9 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			data, ok := resp.Data().(apimodels.ExpansionsAndVars)
 			require.True(t, ok)
 			assert.Equal(t, rh.taskID, data.Expansions.Get("task_id"))
-			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
 			assert.Equal(t, data.Vars, map[string]string{"a": "1", "b": "3"})
+			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
+			assert.Equal(t, data.RedactKeys, []string{"pass", "secret"})
 		},
 		"RunSucceedsWithParamsSetOnVersion": func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler) {
 			rh.taskID = "t1"
@@ -66,8 +67,9 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 			data, ok := resp.Data().(apimodels.ExpansionsAndVars)
 			require.True(t, ok)
-			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
 			assert.Equal(t, data.Vars, map[string]string{"a": "4", "b": "3"})
+			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
+			assert.Equal(t, data.RedactKeys, []string{"pass", "secret"})
 		},
 		"RunSucceedsWithHostDistroExpansions": func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler) {
 			rh.taskID = "t1"
@@ -79,8 +81,9 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, rh.taskID, data.Expansions.Get("task_id"))
 			assert.Equal(t, "distro_expansion_value", data.Expansions.Get("distro_expansion_key"))
-			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
 			assert.Equal(t, data.Vars, map[string]string{"a": "4", "b": "3"})
+			assert.Equal(t, data.PrivateVars, map[string]bool{"b": true})
+			assert.Equal(t, data.RedactKeys, []string{"pass", "secret"})
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -89,6 +92,7 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
+			env.Settings().LoggerConfig.RedactKeys = []string{"pass", "secret"}
 
 			testutil.ConfigureIntegrationTest(t, env.Settings(), t.Name())
 


### PR DESCRIPTION
DEVPROD-4025

### Description
- Add a new logger config field `RedactKeys` to hold the patterns we want to look for for key redaction
- Send redact keys with expansions and vars in agent route
- Add any matching project var keys to the private vars list when setting up the task config
- Redact all private vars and selected default vars from logs

### Testing
Updated unit tests / [tested in staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_echo_variable_patch_f50345d4c091635680061fecb7f18af636a6bf08_65b7fec097b1d3897105fabe_24_01_29_19_39_01/logs?execution=2).

### Documentation
N/A
