### PR TITLE
DEVPROD-4025 fix redacting sender panic

### DIFF
--- a/agent/internal/client/redacting_sender.go
+++ b/agent/internal/client/redacting_sender.go
@@ -20,6 +20,10 @@ type redactingSender struct {
 }
 
 func (r *redactingSender) Send(m message.Composer) {
+	if !m.Loggable() {
+		return
+	}
+
 	msg := m.String()
 	for _, expansion := range r.expansionsToRedact {
 		if val := r.expansions.Get(expansion); val != "" {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-30-a"
+	AgentVersion = "2024-01-31"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[DEVPROD-4025](https://jira.mongodb.org/browse/DEVPROD-4025)

### Description
https://github.com/evergreen-ci/evergreen/pull/7453 caused a panic when a wrapped nil error is logged. We should check the message is loggable, like [other senders do](https://github.com/evergreen-ci/timber/blob/819ca602876e1ee91c6f7cc73885ab94ed80d841/buildlogger/basic_sender.go#L276-L278), before accessing the message string, which tries to [dereference the error](https://github.com/mongodb/grip/blob/dfee190b28366aa88b31c2386cf97ec1af7bde6b/message/error_message.go#L60).

### Testing
With HEAD in staging [the error was logged](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3Devergreen-staging%20%22encountered%20issue%20in%20stats%20collector%22&earliest=1706732970&latest=1706733870&workload_pool=standard_perf&sid=1706733882.16199623). With this deployed [there were no errors on staging](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3Devergreen-staging%20%22encountered%20issue%20in%20stats%20collector%22&earliest=1706733926&latest=1706734226&workload_pool=standard_perf&sid=1706734238.16200602).
