### PR TITLE
Revert "DEVPROD-3743: make it easier to trace event logging (#7407)"

### DIFF
--- a/trigger/process.go
+++ b/trigger/process.go
@@ -37,13 +37,13 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 
 	subscriptions, err := event.FindSubscriptionsByAttributes(e.ResourceType, h.Attributes())
 	msg := message.Fields{
-		"source":            "events-processing",
-		"message":           "processing event",
-		"event_id":          e.ID,
-		"event_type":        e.EventType,
-		"resource_id":       e.ResourceId,
-		"resource_type":     e.ResourceType,
-		"num_subscriptions": len(subscriptions),
+		"source":              "events-processing",
+		"message":             "processing event",
+		"event_id":            e.ID,
+		"event_type":          e.EventType,
+		"event_resource_type": e.ResourceType,
+		"event_resource":      e.ResourceId,
+		"num_subscriptions":   len(subscriptions),
 	}
 	if err != nil {
 		err = errors.Wrapf(err, "fetching subscriptions for event '%s' (resource type: '%s', event type: '%s')", e.ID, e.ResourceType, e.EventType)

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -132,8 +132,7 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 		"job_type":      j.Type().Name,
 		"operation":     "events-processing",
 		"message":       "event-stats",
-		"event_id":      e.ID,
-		"event_type":    e.EventType,
+		"event_id":      j.EventID,
 		"start_time":    startTime.String(),
 		"end_time":      endTime.String(),
 		"duration_secs": totalDuration.Seconds(),
@@ -154,13 +153,12 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 			n = nil
 			err = errors.Errorf("panicked while processing event '%s'", e.ID)
 			grip.Alert(message.WrapError(err, message.Fields{
-				"job_id":        j.ID(),
-				"job_type":      j.Type().Name,
-				"source":        "events-processing",
-				"event_id":      e.ID,
-				"event_type":    e.EventType,
-				"resource_id":   e.ResourceId,
-				"resource_type": e.ResourceType,
+				"job_id":      j.ID(),
+				"job_type":    j.Type().Name,
+				"source":      "events-processing",
+				"event_id":    e.ID,
+				"event_type":  e.ResourceType,
+				"panic_value": r,
 			}))
 		}
 	}()
@@ -173,35 +171,29 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 		"source":        "events-processing",
 		"message":       "event processed",
 		"event_id":      e.ID,
-		"event_type":    e.EventType,
-		"resource_id":   e.ResourceId,
-		"resource_type": e.ResourceType,
+		"event_type":    e.ResourceType,
 		"notifications": len(n),
 		"duration_secs": time.Since(startDebug).Seconds(),
 		"stat":          "notifications-from-event",
 	})
 
 	grip.Error(message.WrapError(err, message.Fields{
-		"job_id":        j.ID(),
-		"job_type":      j.Type().Name,
-		"source":        "events-processing",
-		"message":       "errors processing triggers for event",
-		"event_id":      e.ID,
-		"event_type":    e.EventType,
-		"resource_id":   e.ResourceId,
-		"resource_type": e.ResourceType,
+		"job_id":     j.ID(),
+		"job_type":   j.Type().Name,
+		"source":     "events-processing",
+		"message":    "errors processing triggers for event",
+		"event_id":   e.ID,
+		"event_type": e.ResourceType,
 	}))
 
 	v, err := trigger.EvalProjectTriggers(ctx, e, trigger.TriggerDownstreamVersion)
-	grip.InfoWhen(len(v) > 0, message.Fields{
+	grip.Info(message.Fields{
 		"job_id":        j.ID(),
 		"job_type":      j.Type().Name,
 		"source":        "events-processing",
 		"message":       "project triggers evaluated",
 		"event_id":      e.ID,
-		"event_type":    e.EventType,
-		"resource_id":   e.ResourceId,
-		"resource_type": e.ResourceType,
+		"event_type":    e.ResourceType,
 		"duration_secs": time.Since(startDebug).Seconds(),
 		"stat":          "eval-project-triggers",
 	})
@@ -210,15 +202,12 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 		versions = append(versions, version.Id)
 	}
 	grip.InfoWhen(len(versions) > 0, message.Fields{
-		"job_id":        j.ID(),
-		"job_type":      j.Type().Name,
-		"source":        "events-processing",
-		"message":       "triggering downstream builds",
-		"event_id":      e.ID,
-		"event_type":    e.EventType,
-		"resource_id":   e.ResourceId,
-		"resource_type": e.ResourceType,
-		"versions":      versions,
+		"job_id":   j.ID(),
+		"job_type": j.Type().Name,
+		"source":   "events-processing",
+		"message":  "triggering downstream builds",
+		"event_id": e.ID,
+		"versions": versions,
 	})
 
 	return n, err


### PR DESCRIPTION
This reverts commit 33d346851cdcb50c56a651275d5734e4efa29aa6.

Having Evergreen event log traceability in Splunk was cool and useful for debugging, but it produces a lot of Splunk events. Reverting to try putting us under the index limit.