### PR TITLE
DEVPROD-4255: reduce noise in Splunk logs

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -318,13 +318,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		input.UserData = &userData
 	}
 
-	grip.Debug(message.Fields{
-		"message":       "starting on-demand instance",
-		"args":          input,
-		"host_id":       h.Id,
-		"host_provider": h.Distro.Provider,
-		"distro":        h.Distro.Id,
-	})
 	reservation, err := m.client.RunInstances(ctx, input)
 	if err != nil || reservation == nil {
 		if err == EC2InsufficientCapacityError {
@@ -393,12 +386,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 	}
 
 	instance := reservation.Instances[0]
-	grip.Debug(message.Fields{
-		"message":       "started ec2 instance",
-		"host_id":       *instance.InstanceId,
-		"distro":        h.Distro.Id,
-		"host_provider": h.Distro.Provider,
-	})
 	h.Id = *instance.InstanceId
 
 	return nil

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -555,17 +555,6 @@ func FindAllTaskQueues() ([]TaskQueue, error) {
 func FindDistroTaskQueue(distroID string) (TaskQueue, error) {
 	queue := TaskQueue{}
 	err := db.FindOneQ(TaskQueuesCollection, db.Query(bson.M{taskQueueDistroKey: distroID}), &queue)
-
-	grip.DebugWhen(err == nil, message.Fields{
-		"message":                              "fetched the distro's task queue items to create its task queue",
-		"distro":                               distroID,
-		"task_queue_generated_at":              queue.GeneratedAt,
-		"num_task_queue_items":                 len(queue.Queue),
-		"distro_queue_info_length":             queue.DistroQueueInfo.Length,
-		"distro_queue_info_expected_duration":  queue.DistroQueueInfo.ExpectedDuration,
-		"num_distro_queue_info_taskgroupinfos": len(queue.DistroQueueInfo.TaskGroupInfos),
-	})
-
 	return queue, errors.WithStack(err)
 }
 

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -47,18 +47,6 @@ func newDistroTaskDAGDispatchService(taskQueue TaskQueue, ttl time.Duration) (*b
 		}
 	}
 
-	grip.Debug(message.Fields{
-		"dispatcher":                DAGDispatcher,
-		"function":                  "newDistroTaskDAGDispatchService",
-		"message":                   "initializing new basicCachedDAGDispatcherImpl for a distro",
-		"distro_id":                 d.distroID,
-		"ttl":                       d.ttl,
-		"last_updated":              d.lastUpdated,
-		"num_task_groups":           len(d.taskGroups),
-		"num_taskqueueitems":        taskQueue.Length(),
-		"sorted_num_taskqueueitems": len(d.sorted),
-	})
-
 	return d, nil
 }
 
@@ -89,17 +77,6 @@ func (d *basicCachedDAGDispatcherImpl) Refresh() error {
 	if err := d.rebuild(taskQueueItems); err != nil {
 		return errors.Wrapf(err, "building the directed graph for distro '%s'", d.distroID)
 	}
-
-	grip.Debug(message.Fields{
-		"dispatcher":                 DAGDispatcher,
-		"function":                   "Refresh",
-		"message":                    "refresh was successful",
-		"distro_id":                  d.distroID,
-		"num_task_groups":            len(d.taskGroups),
-		"initial_num_taskqueueitems": len(taskQueueItems),
-		"sorted_num_taskqueueitems":  len(d.sorted),
-		"refreshed_at:":              time.Now(),
-	})
 
 	return nil
 }
@@ -272,19 +249,6 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 		}
 		// If the task group is not present in the TaskGroups map, then all its tasks are considered dispatched.
 		// Fall through to get a task that's not in this task group.
-
-		grip.Debug(message.Fields{
-			"dispatcher":               DAGDispatcher,
-			"function":                 "FindNextTask",
-			"message":                  "basicCachedDAGDispatcherImpl.taskGroupTasks[key] was not found - assuming it has been dispatched; falling through to try and get a task not in the current task group",
-			"key":                      taskGroupID,
-			"taskspec_group":           spec.Group,
-			"taskspec_build_variant":   spec.BuildVariant,
-			"taskspec_version":         spec.Version,
-			"taskspec_project":         spec.Project,
-			"taskspec_group_max_hosts": spec.GroupMaxHosts,
-			"distro_id":                d.distroID,
-		})
 	}
 
 	dependencyCaches := make(map[string]task.Task)

--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -67,9 +67,7 @@ func UtilizationBasedHostAllocator(ctx context.Context, hostAllocatorData *HostA
 	}
 
 	// split tasks/hosts by task group (including those with no group) and find # of hosts needed for each
-	taskGroupingBeginsAt := time.Now()
 	taskGroupDatas := groupByTaskGroup(hostAllocatorData.ExistingHosts, hostAllocatorData.DistroQueueInfo)
-	taskGroupingDuration := time.Since(taskGroupingBeginsAt)
 
 	numNewHostsRequired := 0
 	numFreeApprox := 0
@@ -127,7 +125,6 @@ func UtilizationBasedHostAllocator(ctx context.Context, hostAllocatorData *HostA
 // and dividing it by the target duration. Request however many hosts are needed to
 // achieve that minus the number of free hosts
 func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData TaskGroupData, futureHostFraction float64, containerPool *evergreen.ContainerPool, maxDurationThreshold time.Duration, maxHosts int) (int, int, error) {
-	evalStartAt := time.Now()
 	existingHosts := taskGroupData.Hosts
 	taskGroupInfo := taskGroupData.Info
 	numLongTasks := taskGroupInfo.CountDurationOverThreshold
@@ -155,12 +152,10 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 	}
 
 	// determine how many free hosts we have that are already up
-	startAt := time.Now()
 	numFreeHosts, err := calcExistingFreeHosts(existingHosts, futureHostFraction, maxDurationThreshold)
 	if err != nil {
 		return numNewHosts, numFreeHosts, err
 	}
-	freeHostDur := time.Since(startAt)
 
 	roundDown := true
 	if d.HostAllocatorSettings.RoundingRule == evergreen.HostAllocatorRoundUp {

--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -120,19 +120,6 @@ func UtilizationBasedHostAllocator(ctx context.Context, hostAllocatorData *HostA
 	}
 	numNewHostsToRequest := numNewHostsRequired + numAdditionalHostsToMeetMinimum
 
-	grip.Info(message.Fields{
-		"runner":                               RunnerName,
-		"message":                              "requesting new hosts",
-		"distro":                               distro.Id,
-		"group_dur_secs":                       taskGroupingDuration.Seconds(),
-		"group_num":                            len(taskGroupDatas),
-		"minimum_hosts_for_distro":             minimumHostsThreshold,
-		"num_existing_hosts":                   numExistingHosts,
-		"num_new_hosts_required:":              numNewHostsRequired,
-		"num_additional_hosts_to_meet_minimum": numAdditionalHostsToMeetMinimum,
-		"total_new_hosts_to_request":           numNewHostsToRequest,
-	})
-
 	return numNewHostsToRequest, numFreeApprox, nil
 }
 
@@ -217,23 +204,6 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 	}
 	avgMakespan := scheduledDuration / time.Duration(maxHosts)
 	grip.AlertWhen(avgMakespan > dynamicDistroRuntimeAlertThreshold, underWaterAlert)
-
-	grip.Info(message.Fields{
-		"message":                      "queue state report",
-		"runner":                       RunnerName,
-		"provider":                     d.Provider,
-		"distro":                       d.Id,
-		"pool_size":                    d.HostAllocatorSettings.MaximumHosts,
-		"new_hosts_needed":             numNewHosts,
-		"num_existing_hosts":           len(existingHosts),
-		"num_free_hosts_approx":        numFreeHosts,
-		"queue_length":                 taskGroupInfo.Count,
-		"long_tasks":                   numLongTasks,
-		"scheduled_tasks_runtime":      int64(scheduledDuration),
-		"scheduled_tasks_runtime_span": scheduledDuration.String(),
-		"op_dur_free_host_secs":        freeHostDur.Seconds(),
-		"op_dur_total_secs":            time.Since(evalStartAt).Seconds(),
-	})
 
 	return numNewHosts, numFreeHosts, nil
 }

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -36,6 +36,10 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 	}
 
 	subscriptions, err := event.FindSubscriptionsByAttributes(e.ResourceType, h.Attributes())
+	subIDs := make([]string, 0, len(subscriptions))
+	for _, sub := range subscriptions {
+		subIDs = append(subIDs, sub.ID)
+	}
 	msg := message.Fields{
 		"source":            "events-processing",
 		"message":           "processing event",
@@ -44,6 +48,7 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 		"resource_id":       e.ResourceId,
 		"resource_type":     e.ResourceType,
 		"num_subscriptions": len(subscriptions),
+		"subscription_ids":  subIDs,
 	}
 	if err != nil {
 		err = errors.Wrapf(err, "fetching subscriptions for event '%s' (resource type: '%s', event type: '%s')", e.ID, e.ResourceType, e.EventType)

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -50,10 +50,10 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 		grip.Error(message.WrapError(err, msg))
 		return nil, err
 	}
-	grip.Info(msg)
 	if len(subscriptions) == 0 {
 		return nil, nil
 	}
+	grip.Info(msg)
 
 	notifications := make([]notification.Notification, 0, len(subscriptions))
 
@@ -62,23 +62,22 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 		n, err := h.Process(&subscriptions[i])
 		msg := message.Fields{
 			"source":              "events-processing",
-			"message":             "processing subscription",
+			"message":             "processed subscription and created notifications",
 			"event_id":            e.ID,
 			"event_type":          e.EventType,
 			"event_resource_type": e.ResourceType,
 			"event_resource":      e.ResourceId,
 			"subscription_id":     subscriptions[i].ID,
-			"notification_is_nil": n == nil,
 		}
 		if n != nil {
 			msg["notification_id"] = n.ID
 		}
 		catcher.Add(err)
 		grip.Error(message.WrapError(err, msg))
-		grip.InfoWhen(err == nil, msg)
 		if n == nil {
 			continue
 		}
+		grip.Info(msg)
 
 		notifications = append(notifications, *n)
 	}

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -167,11 +167,11 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 
 	startDebug := time.Now()
 	n, err = trigger.NotificationsFromEvent(ctx, e)
-	grip.Info(message.Fields{
+	grip.InfoWhen(len(n) > 0, message.Fields{
 		"job_id":        j.ID(),
 		"job_type":      j.Type().Name,
 		"source":        "events-processing",
-		"message":       "event processed",
+		"message":       "event processed and created notifications",
 		"event_id":      e.ID,
 		"event_type":    e.EventType,
 		"resource_id":   e.ResourceId,


### PR DESCRIPTION
DEVPROD-4255

### Description
I pruned some of the biggest contributors to the Splunk log size. I don't think any of these are controversial since they don't drastically change traceability of code, but I addressed each one in a comment.

Post-deploy, will continue monitoring to see if it's still too much logging for Splunk. Will also verify that the Evergreen Splunk dashboard still renders properly.

### Testing
N/A

### Documentation
N/A