### PR TITLE
DEVPROD-3946: add Honeycomb attributes for spawn host modification jobs

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -486,13 +486,13 @@ type ModifySpawnHostSource string
 const (
 	// ModifySpawnHostManual means the spawn host is being modified manually
 	// because a user requested it.
-	ModifySpawnHostManual = "manual"
+	ModifySpawnHostManual ModifySpawnHostSource = "manual"
 	// ModifySpawnHostManual means the spawn host is being modified by the
 	// automatic sleep schedule.
-	ModifySpawnHostSleepSchedule = "sleep_schedule"
+	ModifySpawnHostSleepSchedule ModifySpawnHostSource = "sleep_schedule"
 	// ModifySpawnHostManual means the spawn host is being modified by a
 	// user-owned sleep script.
-	ModifySpawnHostScript = "script"
+	ModifySpawnHostScript ModifySpawnHostSource = "script"
 )
 
 // Common OTEL constants and attribute keys

--- a/globals.go
+++ b/globals.go
@@ -479,6 +479,16 @@ func IsSuccessfulVersionStatus(status string) bool {
 
 type ModificationAction string
 
+// ModifySpawnHostSource determines the originating source of a spawn host
+// modification.
+type ModifySpawnHostSource string
+
+const (
+	ModifySpawnHostManual        = "manual"
+	ModifySpawnHostSleepSchedule = "sleep_schedule"
+	ModifySpawnHostScript        = "script"
+)
+
 // Common OTEL constants and attribute keys
 const (
 	PackageName = "github.com/evergreen-ci/evergreen"
@@ -497,6 +507,9 @@ const (
 	ProjectIDOtelAttribute         = "evergreen.project.id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
 	HostIDOtelAttribute            = "evergreen.host.id"
+	HostStartedByOtelAttribute     = "evergreen.host.started_by"
+	HostNoExpirationOtelAttribute  = "evergreen.host.no_expiration"
+	HostInstanceTypeOtelAttribute  = "evergreen.host.instance_type"
 	AggregationNameOtelAttribute   = "db.aggregationName"
 )
 

--- a/globals.go
+++ b/globals.go
@@ -484,9 +484,15 @@ type ModificationAction string
 type ModifySpawnHostSource string
 
 const (
-	ModifySpawnHostManual        = "manual"
+	// ModifySpawnHostManual means the spawn host is being modified manually
+	// because a user requested it.
+	ModifySpawnHostManual = "manual"
+	// ModifySpawnHostManual means the spawn host is being modified by the
+	// automatic sleep schedule.
 	ModifySpawnHostSleepSchedule = "sleep_schedule"
-	ModifySpawnHostScript        = "script"
+	// ModifySpawnHostManual means the spawn host is being modified by a
+	// user-owned sleep script.
+	ModifySpawnHostScript = "script"
 )
 
 // Common OTEL constants and attribute keys

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -112,7 +112,8 @@ type Host struct {
 	// for non-legacy hosts.
 	JasperCredentialsID string `bson:"jasper_credentials_id" json:"jasper_credentials_id"`
 
-	// for ec2 dynamic hosts, the instance type requested
+	// InstanceType is the EC2 host's requested instance type. This is kept
+	// up-to-date even if the instance type is changed.
 	InstanceType string `bson:"instance_type" json:"instance_type,omitempty"`
 	// The volumeID and device name for each volume attached to the host
 	Volumes []VolumeAttachment `bson:"volumes,omitempty" json:"volumes,omitempty"`

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -67,8 +67,12 @@ func (s *PatchIntentUnitsSuite) TearDownSuite() {
 }
 
 func (s *PatchIntentUnitsSuite) TearDownTest() {
-	evergreen.SetEnvironment(s.originalEnv)
-	s.NoError(evergreen.UpdateConfig(s.ctx, s.originalConfig))
+	if s.originalEnv != nil {
+		evergreen.SetEnvironment(s.originalEnv)
+	}
+	if s.originalConfig != nil {
+		s.NoError(evergreen.UpdateConfig(s.ctx, s.originalConfig))
+	}
 }
 
 func (s *PatchIntentUnitsSuite) SetupTest() {

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -15,8 +16,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -55,6 +54,7 @@ func NewSpawnhostStartJob(h *host.Host, user, ts string) amboy.Job {
 	j.SetEnqueueAllScopes(true)
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
+	j.CloudHostModification.Source = evergreen.ModifySpawnHostManual
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),
 		MaxAttempts: utility.ToIntPtr(spawnHostStartRetryLimit),
@@ -67,17 +67,8 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	startCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
-		// kim: TODO: figure out if span has naming conventions (e.g. snake case)
-		// kim: TODO: test
-		ctx, span := tracer.Start(ctx, "start-spawn-host")
-		defer span.End()
-
 		if err := mgr.StartInstance(ctx, h, user); err != nil {
 			event.LogHostStartError(h.Id, err.Error())
-			span.SetStatus(codes.Error, "error starting host")
-			// kim: TODO: figure out if these host attributes end up in the
-			// exception, and what that actually entails
-			span.RecordError(err, trace.WithAttributes(j.hostAttributes(h)...), trace.WithStackTrace(true))
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error starting spawn host",
 				"host_id":  h.Id,
@@ -99,6 +90,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 		return nil
 	}
+
 	if err := j.CloudHostModification.modifyHost(ctx, startCloudHost); err != nil {
 		j.AddError(err)
 		return

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpawnhostStartJob(t *testing.T) {
@@ -22,6 +23,22 @@ func TestSpawnhostStartJob(t *testing.T) {
 
 	assert.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
 	mock := cloud.GetMockProvider()
+	t.Run("NewSpawnhostStartJobSetsExpectedFields", func(t *testing.T) {
+		ts := utility.RoundPartOfMinute(1).Format(TSFormat)
+		h := host.Host{
+			Id:       "host_id",
+			Status:   evergreen.HostRunning,
+			Provider: evergreen.ProviderNameMock,
+			Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+		}
+		j, ok := NewSpawnhostStartJob(&h, "user", ts).(*spawnhostStartJob)
+		require.True(t, ok)
+
+		assert.NotZero(t, j.RetryInfo().GetMaxAttempts(), "job should retry")
+		assert.Equal(t, h.Id, j.HostID)
+		assert.Equal(t, "user", j.UserID)
+		assert.Equal(t, evergreen.ModifySpawnHostManual, j.Source)
+	})
 	t.Run("NewSpawnhostStartJobHostNotStopped", func(t *testing.T) {
 		tctx := testutil.TestSpan(ctx, t)
 		h := host.Host{

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -15,6 +15,8 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -64,9 +66,14 @@ func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
 func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	stopCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
+	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
+		ctx, span := tracer.Start(ctx, "stop-spawn-host")
+		defer span.End()
+
 		if err := mgr.StopInstance(ctx, h, user); err != nil {
 			event.LogHostStopError(h.Id, err.Error())
+			span.SetStatus(codes.Error, "error stopping host")
+			span.RecordError(err, trace.WithAttributes(j.hostAttributes(h)...), trace.WithStackTrace(true))
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error stopping spawn host",
 				"host_id":  h.Id,

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -15,8 +16,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -55,6 +54,7 @@ func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
 	j.SetEnqueueAllScopes(true)
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
+	j.CloudHostModification.Source = evergreen.ModifySpawnHostManual
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),
 		MaxAttempts: utility.ToIntPtr(spawnHostStopRetryLimit),
@@ -67,13 +67,8 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
-		ctx, span := tracer.Start(ctx, "stop-spawn-host")
-		defer span.End()
-
 		if err := mgr.StopInstance(ctx, h, user); err != nil {
 			event.LogHostStopError(h.Id, err.Error())
-			span.SetStatus(codes.Error, "error stopping host")
-			span.RecordError(err, trace.WithAttributes(j.hostAttributes(h)...), trace.WithStackTrace(true))
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error stopping spawn host",
 				"host_id":  h.Id,
@@ -95,6 +90,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 		return nil
 	}
+
 	if err := j.CloudHostModification.modifyHost(ctx, stopCloudHost); err != nil {
 		j.AddError(err)
 		return

--- a/units/spawnhost_terminate.go
+++ b/units/spawnhost_terminate.go
@@ -50,7 +50,7 @@ func NewSpawnHostTerminationJob(h *host.Host, user, ts string) amboy.Job {
 func (j *spawnHostTerminationJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	terminateCloudHost := func(mgr cloud.Manager, h *host.Host, user string) error {
+	terminateCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.TerminateInstance(ctx, h, user, "user requested spawn host termination"); err != nil {
 			return err
 		}

--- a/units/spawnhost_terminate.go
+++ b/units/spawnhost_terminate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
@@ -44,6 +45,7 @@ func NewSpawnHostTerminationJob(h *host.Host, user, ts string) amboy.Job {
 	j.SetEnqueueAllScopes(true)
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
+	j.CloudHostModification.Source = evergreen.ModifySpawnHostManual
 	return j
 }
 

--- a/units/spawnhost_terminate_test.go
+++ b/units/spawnhost_terminate_test.go
@@ -1,0 +1,30 @@
+package units
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpawnHostTerminationJob(t *testing.T) {
+	t.Run("NewSpawnHostTerminateJobSetsExpectedFields", func(t *testing.T) {
+		ts := utility.RoundPartOfMinute(1).Format(TSFormat)
+		h := host.Host{
+			Id:       "host_id",
+			Status:   evergreen.HostRunning,
+			Provider: evergreen.ProviderNameMock,
+			Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+		}
+		j, ok := NewSpawnHostTerminationJob(&h, "user", ts).(*spawnHostTerminationJob)
+		require.True(t, ok)
+
+		assert.Equal(t, h.Id, j.HostID)
+		assert.Equal(t, "user", j.UserID)
+		assert.Equal(t, evergreen.ModifySpawnHostManual, j.Source)
+	})
+}


### PR DESCRIPTION
DEVPROD-3946

### Description
Attach more spawn host attributes to the Amboy job Honeycomb spans (specifically for for spawn host modification jobs). This lets us do things like set up Honeycomb dashboards for stops/starts and filter by host fields like whether it's stopping an unexpirable host, the instance type, the source of the stop/start action (a user pressing the button vs. the sleep schedule), etc.

If the job errors (e.g. because AWS returns an error while stopping the host), Amboy's Honeycomb setup already records those errors and stack traces for us. They're also already logged to Splunk.

### Testing
Stopped/starting a spawn host in staging and verified that [the Honeycomb data is being sent](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/cSoZWBv2MFb) and is queryable.

### Documentation
N/A