### PR TITLE
DEVPROD-67: Ingest and test ship test logs at end of task

### DIFF
--- a/agent/internal/taskoutput/directory.go
+++ b/agent/internal/taskoutput/directory.go
@@ -108,10 +108,10 @@ type directoryHandler interface {
 
 type Directory struct {
 	root     string
-	handlers map[string]directoryHandler
+	handlers []directoryHandler
 }
 
-func NewDirectory(root string, tsk *task.Task, logger client.LoggerProducer) *Directory {
+func NewDirectory(root string, tsk *task.Task, logger client.LoggerProducer) (*Directory, error) {
 	output := tsk.TaskOutputInfo
 	taskOpts := taskoutput.TaskOptions{
 		ProjectID: tsk.Project,
@@ -121,8 +121,8 @@ func NewDirectory(root string, tsk *task.Task, logger client.LoggerProducer) *Di
 
 	return &Directory{
 		root: root,
-		handlers: map[string]directoryHandler{
-			output.TestLogs.ID(): newTestLogDirectoryHandler(output.TestLogs, taskOpts, logger),
+		handlers: []directoryHandler{
+			newTestLogDirectoryHandler(output.TestLogs, taskOpts, logger),
 		},
 	}
 }

--- a/agent/internal/taskoutput/test_log.go
+++ b/agent/internal/taskoutput/test_log.go
@@ -1,7 +1,9 @@
 package taskoutput
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -20,7 +22,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/grip/send"
-	"github.com/nxadm/tail"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -88,25 +89,23 @@ func sendTestLogToCedar(ctx context.Context, comm client.Communicator, tsk *task
 	return nil
 }
 
-// testLogDirectoryHandler implements automatic and asynchronous task output
-// handling for the reserved test log directory.
+// testLogDirectoryHandler implements automatic task output handling for the
+// reserved test log directory.
 type testLogDirectoryHandler struct {
-	dir             string
 	logger          client.LoggerProducer
 	spec            testLogSpec
 	maxBufferSize   int
 	createSender    func(context.Context, string) (send.Sender, error)
-	cancel          context.CancelFunc
 	followFileCount int
-
-	once sync.Once
-	wg   sync.WaitGroup
 }
 
 // newTestLogDirectoryHandler returns a new test log directory handler for the
 // specified task.
 func newTestLogDirectoryHandler(output taskoutput.TestLogOutput, taskOpts taskoutput.TaskOptions, logger client.LoggerProducer) *testLogDirectoryHandler {
-	h := &testLogDirectoryHandler{logger: logger}
+	h := &testLogDirectoryHandler{
+		dir:    dir,
+		logger: logger,
+	}
 	h.createSender = func(ctx context.Context, logPath string) (send.Sender, error) {
 		return output.NewSender(ctx, taskOpts, taskoutput.EvergreenSenderOptions{
 			Local:         logger.Task().GetSender(),
@@ -118,75 +117,49 @@ func newTestLogDirectoryHandler(output taskoutput.TestLogOutput, taskOpts taskou
 	return h
 }
 
-func (h *testLogDirectoryHandler) start(ctx context.Context, dir string) error {
-	h.dir = dir
+func (h *testLogDirectoryHandler) sweep(ctx context.Context, dir string) error {
+	h.getSpecFile()
 
-	watcherCtx, cancel := context.WithCancel(ctx)
-	h.cancel = cancel
-	go h.watch(watcherCtx)
-
-	return nil
-}
-
-// watch recursively watches the reserved test log directory for newly created
-// log files. When a new file is detected, an asynchronous file follower is
-// created to ingest the log data as it is written for the duration of the
-// task.
-func (h *testLogDirectoryHandler) watch(ctx context.Context) {
-	defer func() {
-		h.logger.Execution().Critical(recovery.HandlePanicWithError(recover(), nil, "test log directory watcher"))
-	}()
-
-	timer := time.NewTimer(0)
-	defer timer.Stop()
+	var wg sync.WaitGroup
 	ignore := filepath.Join(h.dir, testLogSpecFilename)
-	seenFiles := map[string]bool{}
-	for {
-		select {
-		case <-timer.C:
-			err := filepath.WalkDir(h.dir, func(path string, info fs.DirEntry, err error) error {
-				if err != nil {
-					h.logger.Execution().Warning(errors.Wrap(err, "watching the test log directory, continuing watching"))
-					return nil
-				}
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				if info.IsDir() {
-					return nil
-				}
-				if path == ignore {
-					return nil
-				}
-
-				if !seenFiles[path] {
-					seenFiles[path] = true
-					h.followFileCount++
-					h.wg.Add(1)
-					go h.followFile(ctx, path)
-				}
-
-				return nil
-			})
-			if err != nil {
-				h.logger.Execution().Debug("context canceled, exiting test log directory watcher")
-				return
-			}
-
-			timer.Reset(time.Millisecond)
-		case <-ctx.Done():
-			h.logger.Execution().Debug("context canceled, exiting test log directory watcher")
-			return
+	err := filepath.WalkDir(h.dir, func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			h.logger.Execution().Warning(errors.Wrap(err, "sweeping"))
+			return nil
 		}
-	}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if path == ignore {
+			return nil
+		}
+
+		h.followFileCount++
+		wg.Add(1)
+		go func() {
+			defer func() {
+				h.logger.Task().Critical(recovery.HandlePanicWithError(recover(), nil, "ingesting test log"))
+			}()
+			defer wg.Done()
+
+			h.ingest(ctx, path)
+		}()
+
+		return nil
+	})
+	wg.Wait()
+
+	return err
 }
 
 // getSpecFile looks for the test log specification file in the top level of
 // the reserved test log directory. If the spec file cannot be read for any
 // reason, an error is logged and the handler uses the default spec.
 //
-// Called once per task run immediately after the first log file is detected
-// and before any data is ingested.
+// Called once per task run before sweeping the directory for test log files.
 func (h *testLogDirectoryHandler) getSpecFile() {
 	h.logger.Task().Infof("detected first test log file, getting test log spec file")
 
@@ -205,16 +178,8 @@ func (h *testLogDirectoryHandler) getSpecFile() {
 	}
 }
 
-// followFile tails a test log file for the duration of a task, ingesting and
-// persisting log lines as they are written.
-func (h *testLogDirectoryHandler) followFile(ctx context.Context, path string) {
-	defer func() {
-		h.logger.Task().Critical(recovery.HandlePanicWithError(recover(), nil, "test log file follower"))
-	}()
-	defer h.wg.Done()
-
-	h.once.Do(h.getSpecFile)
-
+// ingest reads and ships a test log file.
+func (h *testLogDirectoryHandler) ingest(ctx context.Context, path string) {
 	h.logger.Task().Infof("new test log file '%s' found, initiating automated ingestion", path)
 
 	// The persisted log path should be relative to the reserved directory
@@ -226,27 +191,14 @@ func (h *testLogDirectoryHandler) followFile(ctx context.Context, path string) {
 	}
 	logPath = filepath.ToSlash(logPath)
 
-	t, err := tail.TailFile(path, tail.Config{
-		ReOpen:    true,
-		MustExist: true,
-		Poll:      true,
-		Follow:    true,
-		// Setting this field may lead to some data loss in the case of
-		// non-atomic line writes: if the last read line does not
-		// terminate with a newline character (e.g., the follower
-		// exits early or the test process crashes), it will not get
-		// returned. This is ok because the complete line must be read
-		// to guarantee proper line format for the parser (assumming
-		// the complete line has the expected format).
-		CompleteLines: true,
-	})
+	f, err := os.Open(path)
 	if err != nil {
-		h.logger.Task().Error(errors.Wrapf(err, "creating follower for test log file '%s'", path))
+		h.logger.Task().Error(errors.Wrapf(err, "opening test log file '%s'", path))
 		return
 	}
 	defer func() {
-		if err := t.Stop(); err != nil {
-			h.logger.Task().Error(errors.Wrapf(err, "following test log file '%s'", path))
+		if err := f.Close(); err != nil {
+			h.logger.Task().Error(errors.Wrapf(err, "closing test log file '%s'", path))
 		}
 	}()
 
@@ -255,39 +207,23 @@ func (h *testLogDirectoryHandler) followFile(ctx context.Context, path string) {
 		h.logger.Task().Error(errors.Wrapf(err, "creating Sender for test log '%s'", path))
 		return
 	}
-	defer func() {
-		if err = t.Err(); err != nil {
-			h.logger.Task().Error(errors.Wrapf(err, "following test log file '%s'", path))
-		}
-		if err = sender.Close(); err != nil {
-			h.logger.Task().Error(errors.Wrapf(err, "closing Sender for test log '%s'", path))
-		}
-	}()
 
+	r := bufio.NewReader(f)
 	for {
-		select {
-		case <-ctx.Done():
-			return
-		case line := <-t.Lines:
-			if line.Err != nil {
-				// If there is a line error it is safe to
-				// continue because the follower maintains the
-				// seek position and will pick up where it left
-				// off. These errors usually occur when rate
-				// limiting is configured and a cool down
-				// period is taking place.
-				h.logger.Task().Debug(errors.Wrapf(err, "reading lines from test log file '%s'", path))
-			} else {
-				sender.Send(message.NewDefaultMessage(level.Info, line.Text))
-			}
+		line, err := r.ReadString('\n')
+		if err == io.EOF {
+			break
 		}
-	}
-}
-func (h *testLogDirectoryHandler) close(_ context.Context) error {
-	h.cancel()
-	h.wg.Wait()
+		if err != nil {
+			h.logger.Task().Error(errors.Wrapf(err, "reading test log '%s'", path))
+			return
+		}
 
-	return nil
+		sender.Send(message.NewDefaultMessage(level.Info, line))
+	}
+	if err = sender.Close(); err != nil {
+		h.logger.Task().Error(errors.Wrapf(err, "closing Sender for test log '%s'", path))
+	}
 }
 
 // testLogSpec represents the test log specification file written at the top

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/evergreen-ci/timber/buildlogger"
 	timberutil "github.com/evergreen-ci/timber/testutil"
 	"github.com/evergreen-ci/utility"
-	"github.com/fortytw2/leaktest"
 	"github.com/mongodb/grip/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,18 +135,11 @@ func TestAppendTestLog(t *testing.T) {
 	})
 }
 
-func TestTestLogDirectoryHandler(t *testing.T) {
-	// Check for leaked goroutines.
-	defer leaktest.Check(t)()
-
+func TestTestLogDirectoryHandlerRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	comm := client.NewMock("url")
-	tsk, h := setupTestTestLogDirectoryHandler(t, comm)
-	// Set a small buffer so lines are flushed to the
-	// underlying log service quickly.
-	h.maxBufferSize = 100
 
 	type logInfo struct {
 		logPath       string
@@ -157,145 +148,64 @@ func TestTestLogDirectoryHandler(t *testing.T) {
 
 	for _, test := range []struct {
 		name string
-		run  func(*testing.T) []logInfo
+		logs []logInfo
 	}{
 		{
-			name: "NestedFile",
-			run: func(t *testing.T) []logInfo {
-				info := logInfo{
-					logPath: "nested/log.log",
+			name: "RecursiveDirectoryWalk",
+			logs: []logInfo{
+				{
+					logPath: "log0.log",
 					expectedLines: []string{
 						"This is a small test log.",
 						"With only a few lines.",
-						"In a nested directory.",
 					},
-				}
-
-				require.NoError(t, os.Mkdir(filepath.Join(h.dir, filepath.Dir(info.logPath)), 0777))
-				require.NoError(t, os.WriteFile(filepath.Join(h.dir, info.logPath), []byte(strings.Join(info.expectedLines, "\n")+"\n"), 0777))
-
-				return []logInfo{info}
-			},
-		},
-		{
-			name: "NonAtomicLineWrite",
-			run: func(t *testing.T) []logInfo {
-				info := logInfo{
-					logPath: "non_atomic_line_writes.log",
-				}
-
-				f, err := os.Create(filepath.Join(h.dir, info.logPath))
-				require.NoError(t, err)
-				defer f.Close()
-
-				firstPart := "This is the first part of the line, "
-				_, err = f.WriteString(firstPart)
-				require.NoError(t, err)
-				time.Sleep(time.Second)
-				secondPart := "this is the second part of the line."
-				_, err = f.WriteString(secondPart + "\n")
-				require.NoError(t, err)
-				info.expectedLines = append(info.expectedLines, firstPart+secondPart)
-
-				return []logInfo{info}
-			},
-		},
-		{
-			name: "IgnorePartialLines",
-			run: func(t *testing.T) []logInfo {
-				rawLines := []string{
-					"This is a small test log.",
-					"The last line should get ignored.",
-					"Because it does not end in a newline character...",
-				}
-				info := logInfo{
-					logPath:       "parital_line.log",
-					expectedLines: rawLines[:len(rawLines)-1],
-				}
-				require.NoError(t, os.WriteFile(filepath.Join(h.dir, info.logPath), []byte(strings.Join(rawLines, "\n")), 0777))
-
-				return []logInfo{info}
-			},
-		},
-		{
-			name: "ReadLinesContinuously",
-			run: func(t *testing.T) []logInfo {
-				var (
-					logs  []logInfo
-					files []*os.File
-				)
-				for i := 0; i < 2; i++ {
-					logs = append(logs, logInfo{logPath: utility.RandomString()})
-
-					f, err := os.Create(filepath.Join(h.dir, logs[len(logs)-1].logPath))
-					require.NoError(t, err)
-					files = append(files, f)
-				}
-
-				// Set up asynchronous test log file writing.
-				writerCtx, writerCancel := context.WithCancel(ctx)
-				var (
-					mu sync.Mutex
-					wg sync.WaitGroup
-				)
-				wg.Add(1)
-				go func() {
-					defer func() {
-						for _, f := range files {
-							f.Close()
-						}
-						wg.Done()
-					}()
-
-					for {
-						select {
-						case <-writerCtx.Done():
-							return
-						default:
-							mu.Lock()
-							for i := range files {
-								line := fmt.Sprintf("%s %s.", utility.RandomString(), utility.RandomString())
-
-								_, err := files[i].WriteString(line + "\n")
-								require.NoError(t, err)
-
-								logs[i].expectedLines = append(logs[i].expectedLines, line)
-							}
-							mu.Unlock()
-
-							time.Sleep(time.Second)
-						}
-					}
-				}()
-
-				// Check that logs are ingested continuously.
-				time.Sleep(5 * time.Second)
-				mu.Lock()
-				for _, l := range logs {
-					it, err := tsk.GetTestLogs(ctx, taskoutput.TestLogGetOptions{LogPaths: []string{l.logPath}})
-					require.NoError(t, err)
-					assert.True(t, it.Next())
-					assert.NoError(t, it.Close())
-				}
-				mu.Unlock()
-
-				// Wait for async writing to exit cleanly and
-				// close the test log directory handler.
-				writerCancel()
-				wg.Wait()
-
-				return logs
+				},
+				{
+					logPath: "log1.log",
+					expectedLines: []string{
+						"This is a another small test log.",
+						"With only a few lines.",
+						"But it should get there.",
+					},
+				},
+				{
+					logPath: "nested/log2.log",
+					expectedLines: []string{
+						"This is a another small test log.",
+						"With only a few lines.",
+						"But this time it is in nested directory.",
+					},
+				},
+				{
+					logPath: "nested/nested/log3.log",
+					expectedLines: []string{
+						"This is a small test log, again.",
+						"In an an even more nested directory.",
+						"With some a friend!",
+					},
+				},
+				{
+					logPath: "nested/nested/log4.log",
+					expectedLines: []string{
+						"This is the last test log.",
+						"Blah blah blah blah.",
+						"Something something something.",
+						"We are done here.",
+					},
+				},
 			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			require.NoError(t, h.start(ctx, t.TempDir()))
-			logs := test.run(t)
-			time.Sleep(5 * time.Second)
-			require.NoError(t, h.close(ctx))
+			tsk, h := setupTestTestLogDirectoryHandler(t, comm)
+			for _, li := range test.logs {
+				require.NoError(t, os.MkdirAll(filepath.Join(h.dir, filepath.Dir(li.logPath)), 0777))
+				require.NoError(t, os.WriteFile(filepath.Join(h.dir, li.logPath), []byte(strings.Join(li.expectedLines, "\n")+"\n"), 0777))
+			}
 
-			for _, l := range logs {
-				it, err := tsk.GetTestLogs(ctx, taskoutput.TestLogGetOptions{LogPaths: []string{l.logPath}})
+			require.NoError(t, h.run(ctx))
+			for _, li := range test.logs {
+				it, err := tsk.GetTestLogs(ctx, taskoutput.TestLogGetOptions{LogPaths: []string{li.logPath}})
 				require.NoError(t, err)
 				var persistedRawLines []string
 				for it.Next() {
@@ -303,7 +213,7 @@ func TestTestLogDirectoryHandler(t *testing.T) {
 				}
 				assert.NoError(t, it.Close())
 				require.NoError(t, it.Err())
-				assert.Equal(t, l.expectedLines, persistedRawLines)
+				assert.Equal(t, li.expectedLines, persistedRawLines)
 			}
 		})
 	}
@@ -357,7 +267,6 @@ func TestTestLogDirectoryHandlerGetSpecFile(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			tsk, h := setupTestTestLogDirectoryHandler(t, comm)
-			require.NoError(t, h.start(ctx, t.TempDir()))
 
 			// Set the expected test log spec and write spec file
 			// if spec data exists.
@@ -383,15 +292,12 @@ func TestTestLogDirectoryHandlerGetSpecFile(t *testing.T) {
 			rawLines, formatLine := getRawLinesAndFormatter(expectedSpec.Format)
 			logPath := utility.RandomString()
 			require.NoError(t, os.WriteFile(filepath.Join(h.dir, logPath), []byte(strings.Join(rawLines, "\n")+"\n"), 0777))
+			require.NoError(t, h.run(ctx))
 
-			// Sleep before continuing to avoid racing to detect
-			// the new file.
-			time.Sleep(time.Second)
-			require.NoError(t, h.close(ctx))
 			assert.Equal(t, expectedSpec, h.spec)
 
-			// Check that only log files are followed.
-			assert.Equal(t, 1, h.followFileCount)
+			// Check that only log files are handled.
+			assert.Equal(t, 1, h.logFileCount)
 
 			// Check that raw log lines were correctly parsed in
 			// accordance with their format.
@@ -515,13 +421,13 @@ func setupTestTestLogDirectoryHandler(t *testing.T, comm *client.Mock) (*task.Ta
 	}
 	logger, err := comm.GetLoggerProducer(context.TODO(), tsk, nil)
 	require.NoError(t, err)
-	h := newTestLogDirectoryHandler(tsk.TaskOutputInfo.TestLogs, taskoutput.TaskOptions{
+	h := newTestLogDirectoryHandler(t.TempDir(), tsk.TaskOutputInfo, taskoutput.TaskOptions{
 		ProjectID: tsk.Project,
 		TaskID:    tsk.Id,
 		Execution: tsk.Execution,
 	}, logger)
 
-	return tsk, h
+	return tsk, h.(*testLogDirectoryHandler)
 }
 
 func setupCedarServer(ctx context.Context, t *testing.T, comm *client.Mock) *timberutil.MockCedarServer {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-01-29"
+	AgentVersion = "2024-02-04"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-67

### Description
Ingest and ship test logs at the end of task instead of tailing files.

### Testing
Updated unit tests and tested in staging.

### Documentation
N/A