### PR TITLE
DEVPROD-4494 add events to the sensitive collections

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1430,7 +1430,7 @@ var validKeyTypes = []string{
 	publicKeyECDSA,
 }
 
-var sensitiveCollections = []string{"project_vars"}
+var sensitiveCollections = []string{"project_vars", "events"}
 
 // ValidateSSHKey errors if the given key does not start with one of the allowed prefixes.
 func ValidateSSHKey(key string) error {


### PR DESCRIPTION
[DEVPROD-4494](https://jira.mongodb.org/browse/DEVPROD-4494)

### Description
We're sending db.statement for the events collection which could potentially contain a copy of updates to project vars.
The fastest way to address this is to add this to the hard coded slice of collections that have their `db.statement` redacted. In the future maybe we'd want to make it configurable. Or perhaps we want to rethink whether the `db.statement` attribute is worth the risk.

### Testing
If I get a chance I'll validate it on staging, but I don't think we really need to.
