### PR TITLE
DEVPROD-915 Remove unnecessary https from url

### DIFF
--- a/graphql/tests/task/taskLogs/results.json
+++ b/graphql/tests/task/taskLogs/results.json
@@ -35,7 +35,7 @@
                   "data": {
                     "hostId": "hostid",
                     "jiraIssue": "an_issue",
-                    "jiraLink": "https://https://jira.mongodb.org/browse/an_issue",
+                    "jiraLink": "https://jira.mongodb.org/browse/an_issue",
                     "priority": 55,
                     "status": "success",
                     "timestamp": "2020-03-03T10:45:27.83-05:00",

--- a/rest/model/event.go
+++ b/rest/model/event.go
@@ -90,7 +90,7 @@ func (el *TaskEventData) BuildFromService(ctx context.Context, v *event.TaskEven
 	jiraHost := settings.Jira.GetHostURL()
 	jiraLink := ""
 	if len(v.JiraIssue) != 0 {
-		jiraLink = "https://" + jiraHost + "/browse/" + v.JiraIssue
+		jiraLink = jiraHost + "/browse/" + v.JiraIssue
 	}
 	el.Execution = v.Execution
 	el.HostId = utility.ToStringPtr(v.HostId)


### PR DESCRIPTION
DEVPROD-915

### Description
Event log jira ticket urls were being returned with an additional `https://` which is unnecessary since the jiraHost URL already has an `https://`

