### PR TITLE
DEVPROD-978 Implement check run limit 

### DIFF
--- a/config_test/evg_settings.yml
+++ b/config_test/evg_settings.yml
@@ -175,3 +175,6 @@ shutdown_wait_seconds: 10
 project_creation:
   total_project_limit: 20
   repo_project_limit: 5
+
+github_check_run:
+  check_run_limit: 1

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -183,6 +183,15 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 			}
 		}
 	}
+
+	if p.IsGithubPRPatch() {
+		numCheckRuns := project.GetNumCheckRunsFromVariantTasks(p.VariantsTasks)
+		checkRunLimit := settings.GitHubCheckRun.CheckRunLimit
+		if numCheckRuns > checkRunLimit {
+			return http.StatusInternalServerError, errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
+		}
+	}
+
 	return http.StatusOK, nil
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -1528,6 +1528,42 @@ func (p *Project) findMatchingProjectTasks(tRegex *regexp.Regexp) []string {
 	return res
 }
 
+func (p *Project) GetNumCheckRunsFromVariantTasks(variantTasks []patch.VariantTasks) int {
+	numCheckRuns := 0
+	for _, variant := range variantTasks {
+		for _, t := range variant.Tasks {
+			numCheckRuns += p.getNumCheckRuns(t, variant.Variant)
+		}
+
+		for _, dt := range variant.DisplayTasks {
+			for _, t := range dt.ExecTasks {
+				numCheckRuns += p.getNumCheckRuns(t, variant.Variant)
+			}
+		}
+	}
+	return numCheckRuns
+}
+
+func (p *Project) GetNumCheckRunsFromTaskVariantPairs(variantTasks *TaskVariantPairs) int {
+	numCheckRuns := 0
+	for _, variant := range variantTasks.DisplayTasks {
+		numCheckRuns += p.getNumCheckRuns(variant.TaskName, variant.Variant)
+	}
+	for _, variant := range variantTasks.ExecTasks {
+		numCheckRuns += p.getNumCheckRuns(variant.TaskName, variant.Variant)
+	}
+	return numCheckRuns
+}
+
+func (p *Project) getNumCheckRuns(taskName, variantName string) int {
+	if bvtu := p.FindTaskForVariant(taskName, variantName); bvtu != nil {
+		if bvtu.HasCheckRun() {
+			return 1
+		}
+	}
+	return 0
+}
+
 func (p *Project) findProjectTasksWithTag(tags []string) []string {
 	var res []string
 	for _, t := range p.Tasks {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -841,6 +841,10 @@ func (s *projectSuite) TestCheckRunCount() {
 				Variant:  "bv_1",
 				TaskName: "a_task_2",
 			},
+			TVPair{
+				Variant:  "bv_1",
+				TaskName: "a_task_3",
+			},
 		},
 	}
 
@@ -850,7 +854,7 @@ func (s *projectSuite) TestCheckRunCount() {
 	variantTasks := []patch.VariantTasks{
 		{
 			Variant: "bv_1",
-			Tasks:   []string{"a_task_1", "a_task_2"},
+			Tasks:   []string{"a_task_1", "a_task_2", "a_task_3"},
 		},
 	}
 	checkRunCount = s.project.GetNumCheckRunsFromVariantTasks(variantTasks)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -582,10 +582,16 @@ func (s *projectSuite) SetupTest() {
 					{
 						Name:    "a_task_1",
 						Variant: "bv_1",
+						CreateCheckRun: &CheckRun{
+							PathToOutputs: "",
+						},
 					},
 					{
 						Name:    "a_task_2",
 						Variant: "bv_1",
+						CreateCheckRun: &CheckRun{
+							PathToOutputs: "",
+						},
 					},
 					{
 						Name:    "b_task_1",
@@ -824,6 +830,33 @@ func (s *projectSuite) TestAliasResolution() {
 	s.Empty(displayTaskPairs)
 }
 
+func (s *projectSuite) TestCheckRunCount() {
+	pairs := TaskVariantPairs{
+		ExecTasks: TVPairSet{
+			TVPair{
+				Variant:  "bv_1",
+				TaskName: "a_task_1",
+			},
+			TVPair{
+				Variant:  "bv_1",
+				TaskName: "a_task_2",
+			},
+		},
+	}
+
+	checkRunCount := s.project.GetNumCheckRunsFromTaskVariantPairs(&pairs)
+	s.Equal(2, checkRunCount)
+
+	variantTasks := []patch.VariantTasks{
+		{
+			Variant: "bv_1",
+			Tasks:   []string{"a_task_1", "a_task_2"},
+		},
+	}
+	checkRunCount = s.project.GetNumCheckRunsFromVariantTasks(variantTasks)
+	s.Equal(2, checkRunCount)
+
+}
 func (s *projectSuite) TestBuildProjectTVPairs() {
 	// test all expansions
 	patchDoc := patch.Patch{

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -289,6 +289,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	if errs := validator.CheckProjectSettings(ctx, j.env.Settings(), patchedProject, pref, false).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched config for current project settings: %s", validator.ValidationErrorsToString(errs))
 	}
+
 	if errs := validator.CheckPatchedProjectConfigErrors(patchedProjectConfig).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched project config syntax: %s", validator.ValidationErrorsToString(errs))
 	}
@@ -391,8 +392,14 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if patchDoc.IsGithubPRPatch() {
+		numCheckRuns := patchedProject.GetNumCheckRunsFromVariantTasks(patchDoc.VariantsTasks)
+		checkRunLimit := j.env.Settings().GitHubCheckRun.CheckRunLimit
+		if numCheckRuns > checkRunLimit {
+			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
+		}
 		catcher.Wrap(j.createGitHubSubscriptions(patchDoc), "creating GitHub PR patch subscriptions")
 	}
+
 	if patchDoc.IsGithubMergePatch() {
 		catcher.Wrap(j.createGitHubMergeSubscription(ctx, patchDoc), "creating GitHub merge queue subscriptions")
 	}


### PR DESCRIPTION
DEVPROD-978

### Description
Add checks that stops patches from creating more checkruns than the limit.

### Testing
Added a unit test and tested manually for schedule patch, configure patch, and generate patch. 
