### PR TITLE
DEVPROD-3346 Include command display name in honeycomb trace

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -29,8 +29,9 @@ const (
 )
 
 var (
-	commandNameAttribute  = fmt.Sprintf("%s.command_name", commandsAttribute)
-	functionNameAttribute = fmt.Sprintf("%s.function_name", commandsAttribute)
+	commandNameAttribute        = fmt.Sprintf("%s.command_name", commandsAttribute)
+	commandDisplayNameAttribute = fmt.Sprintf("%s.command_display_name", commandsAttribute)
+	functionNameAttribute       = fmt.Sprintf("%s.function_name", commandsAttribute)
 )
 
 type runCommandsOptions struct {
@@ -204,6 +205,7 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 
 		ctx, commandSpan := a.tracer.Start(ctx, cmd.Name(), trace.WithAttributes(
 			attribute.String(commandNameAttribute, cmd.Name()),
+			attribute.String(commandDisplayNameAttribute, cmd.FullDisplayName()),
 		))
 		tc.taskConfig.NewExpansions.Put(otelTraceIDExpansion, commandSpan.SpanContext().TraceID().String())
 		tc.taskConfig.NewExpansions.Put(otelParentIDExpansion, commandSpan.SpanContext().SpanID().String())

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-05"
+	AgentVersion = "2024-02-06"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-3346

### Description
The display name will include additional relevant context like the function and block the command runs in. This context will be helpful to have in honeycomb, and the display name can be queried for in honeycomb with `evergreen.command.command_display_name contains <displayName>`. 

