### PR TITLE
DEVPROD-4536: Use $limit instead of $count in HasMatchingTasks

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2532,7 +2532,7 @@ func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTas
 	if err != nil {
 		return false, errors.Wrap(err, "getting tasks by version pipeline")
 	}
-	pipeline = append(pipeline, bson.M{"$count": "count"})
+	pipeline = append(pipeline, bson.M{"$limit": 1})
 	env := evergreen.GetEnvironment()
 	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
 	if err != nil {
@@ -2544,18 +2544,17 @@ func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTas
 		return false, err
 	}
 
-	type Count struct {
-		Count int `bson:"count"`
+	type hasMatchingTasksResult struct {
+		Task Task `bson:"task"`
 	}
-	count := []*Count{}
-	err = cursor.All(ctx, &count)
+	result := []*hasMatchingTasksResult{}
+	err = cursor.All(ctx, &result)
+
 	if err != nil {
 		return false, err
 	}
-	if len(count) == 0 {
-		return false, nil
-	}
-	return count[0].Count > 0, nil
+
+	return len(result) > 0, nil
 }
 
 type GetTasksByVersionOptions struct {


### PR DESCRIPTION
DEVPROD-4536

### Description
Mohamed and I were talking and noticed that it would be possible to use `$limit` instead of `$count` in HasMatchingTasks since we only care if a single matching task exists. I think logically this should be faster since I believe our usage of `$count` will scan all of the results to get the total number. ([docs](https://www.mongodb.com/docs/manual/reference/method/cursor.count/#index-use))

### Testing
Tested on Compass Production against a server patch.

Here is the explain for the aggregation with  `$count` on a server patch with filters `[{ taskName: /s/ }, { buildVariant: /a/ }]`:
<img width="500" alt="Screenshot 2024-02-06 at 2 49 18 PM" src="https://github.com/evergreen-ci/evergreen/assets/47064971/6103603f-903a-407e-9803-36abbc60d0b6">

Here is the explain for the aggregation with `$limit` on a server patch with filters `[{ taskName: /s/ }, { buildVariant: /a/ }]`:
<img width="500" alt="Screenshot 2024-02-06 at 2 49 31 PM" src="https://github.com/evergreen-ci/evergreen/assets/47064971/55a94675-6770-45f4-bb96-7c6f35be7ba8">


