### PR TITLE
DEVPROD-4588 turn on the build-and-push task

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -819,9 +819,9 @@ buildvariants:
     display_name: Build and Push
     run_on:
       - ubuntu2204-small
-    activate: false
     tasks:
       - name: ".build"
+        priority: 100
     expansions:
       GOROOT: /opt/golang/go1.20
       sign_macos: true

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -821,7 +821,6 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: ".build"
-        priority: 100
     expansions:
       GOROOT: /opt/golang/go1.20
       sign_macos: true
@@ -838,6 +837,7 @@ buildvariants:
     activate: false
     tasks:
       - name: ".build-staging"
+        priority: 100
     expansions:
       GOROOT: /opt/golang/go1.20
     display_tasks:


### PR DESCRIPTION
[DEVPROD-4588](https://jira.mongodb.org/browse/DEVPROD-4588)

### Description
We're going to start turning on the Kanopy cluster soon. Let's turn this on now so we have a bit of history.

### Testing
We should see it running on the project health when we merge.
