### PR TITLE
DEVPROD-4233 Set task ID as attribute

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -607,7 +607,6 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 
 	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
 	tskCtx, span := a.tracer.Start(tskCtx, "task")
-	span.SetAttributes(attribute.String("task.id", tc.task.ID))
 	defer span.End()
 	tc.traceID = span.SpanContext().TraceID().String()
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -606,7 +606,8 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 	})
 
 	tskCtx = utility.ContextWithAttributes(tskCtx, tc.taskConfig.TaskAttributes())
-	tskCtx, span := a.tracer.Start(tskCtx, fmt.Sprintf("task: '%s'", tc.taskConfig.Task.DisplayName))
+	tskCtx, span := a.tracer.Start(tskCtx, "task")
+	span.SetAttributes(attribute.String("task.id", tc.task.ID))
 	defer span.End()
 	tc.traceID = span.SpanContext().TraceID().String()
 

--- a/agent/command.go
+++ b/agent/command.go
@@ -185,7 +185,7 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 
 	if commandInfo.Function != "" {
 		var commandSetSpan trace.Span
-		ctx, commandSetSpan = a.tracer.Start(ctx, fmt.Sprintf("function: '%s'", commandInfo.Function), trace.WithAttributes(
+		ctx, commandSetSpan = a.tracer.Start(ctx, "function", trace.WithAttributes(
 			attribute.String(functionNameAttribute, commandInfo.Function),
 		))
 		defer commandSetSpan.End()

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-06"
+	AgentVersion = "2024-02-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-4233

### Description

Including the name of the task in the span makes it counintuitive to search for
the span, as typically the name of a span is the name of the function that it is
in, and is therefore static. This adds the task.id as an attribute instead of in
the span name.

We may wish to announce in Slack that this change is being made, as it may break
existing queries.

### Testing

None.

### Documentation

None.
