### PR TITLE
DEVPROD-3025 Update evaluate command to output sorted build variants

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-01-18"
+	ClientVersion = "2024-02-08"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -61,7 +61,10 @@ func Evaluate() cli.Command {
 				sortTasksByName := model.ProjectTasksByName(p.Tasks)
 				sort.Sort(sortTasksByName)
 				p.Tasks = sortTasksByName
-				sort.Sort(p.BuildVariants)
+
+				sortBuildVariantsByName := model.BuildVariantsByName(p.BuildVariants)
+				sort.Sort(sortBuildVariantsByName)
+				p.BuildVariants = model.BuildVariants(sortBuildVariantsByName)
 			}
 
 			var out interface{}

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/pkg/errors"
@@ -50,6 +51,7 @@ func Evaluate() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading project")
 			}
+			sort.Sort(p.BuildVariants)
 
 			var out interface{}
 			if showTasks || showVariants {


### PR DESCRIPTION
DEVPROD-3025

### Description
evaluate has a --diffable flag that will alphabetize tasks and bvs 

### Testing
tested locally 
![image](https://github.com/evergreen-ci/evergreen/assets/26491602/d1522338-1b64-43ba-a313-2534ba4c14cf)
