### PR TITLE
DEVPROD-2231 Change gopath to be specific to tasks rather than run-make

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -601,6 +601,8 @@ tasks:
           working_dir: evergreen
           env:
             GOPATH: ${workdir}/gopath
+          include_expansions_in_env:
+            - GOROOT
       - func: verify-swaggo-fmt
   - name: verify-agent-version-update
     tags: ["linter"]
@@ -640,6 +642,8 @@ tasks:
           working_dir: evergreen
           env:
             GOPATH: ${workdir}/gopath
+          include_expansions_in_env:
+            - GOROOT
       - command: shell.exec
         params:
           shell: bash

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -226,7 +226,6 @@ functions:
         EVERGREEN_ALL: "true"
         GOARCH: ${goarch}
         GOOS: ${goos}
-        GOPATH: ${workdir}/gopath
         KARMA_REPORTER: junit
         NODE_BIN_PATH: ${nodebin}
         RACE_DETECTOR: ${race_detector}
@@ -597,6 +596,9 @@ tasks:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "swaggo-install" }
+        params:
+          env: 
+            GOPATH: ${workdir}/gopath
       - func: verify-swaggo-fmt
   - name: verify-agent-version-update
     tags: ["linter"]
@@ -631,6 +633,9 @@ tasks:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "swaggo-install" }
+        params:
+          env: 
+            GOPATH: ${workdir}/gopath
       - command: shell.exec
         params:
           shell: bash

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -594,10 +594,12 @@ tasks:
     tags: ["linter"]
     commands:
       - func: get-project-and-modules
-      - func: run-make
-        vars: { target: "swaggo-install" }
+      - command: subprocess.exec
         params:
-          env: 
+          binary: make
+          args: ["swaggo-install"]
+          working_dir: evergreen
+          env:
             GOPATH: ${workdir}/gopath
       - func: verify-swaggo-fmt
   - name: verify-agent-version-update
@@ -631,10 +633,12 @@ tasks:
   - name: generate-api-docs
     commands: 
       - func: get-project-and-modules
-      - func: run-make
-        vars: { target: "swaggo-install" }
+      - command: subprocess.exec
         params:
-          env: 
+          binary: make
+          args: ["swaggo-install"]
+          working_dir: evergreen
+          env:
             GOPATH: ${workdir}/gopath
       - command: shell.exec
         params:


### PR DESCRIPTION
DEVPROD-2231

### Description
On windows machines, the gopath is being set incorrectly with run-make so this changes the responsibility of setting the gopath to the individual commands that use it rather than globally for run-make. Windows tests do not rely on any gopath being set- 

### Testing
Existing CI testing
