### PR TITLE
DEVPROD-4510 Log script before expanding expansions

### DIFF
--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -117,6 +117,15 @@ func (c *shellExec) ParseParams(params map[string]interface{}) error {
 func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	logger.Execution().Debug("Preparing script...")
 
+	// We do this before expanding expansions so that expansions are not logged.
+	if c.Silent {
+		logger.Execution().Infof("Executing script with shell '%s' (source hidden)...",
+			c.Shell)
+	} else {
+		logger.Execution().Infof("Executing script with shell '%s':\n%s",
+			c.Shell, c.Script)
+	}
+
 	var err error
 	if err = c.doExpansions(&conf.Expansions); err != nil {
 		return errors.WithStack(err)
@@ -211,14 +220,6 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		} else {
 			cmd.SetErrorSender(level.Error, logger.Task().GetSender())
 		}
-	}
-
-	if c.Silent {
-		logger.Execution().Infof("Executing script with shell '%s' (source hidden)...",
-			c.Shell)
-	} else {
-		logger.Execution().Infof("Executing script with shell '%s':\n%s",
-			c.Shell, c.Script)
 	}
 
 	err = cmd.Run(ctx)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-07"
+	AgentVersion = "2024-02-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-4510

### Description

This prints the script for troubleshooting before expansions are expanded.

### Testing

This should be covered by existing tests, and we should validate that a task runs in staging.

### Documentation

None.
