### PR TITLE
DEVPROD-3973: manage persistent DNS names

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -717,7 +717,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 			status := ec2StatusToEvergreenStatus(instance.State.Name)
 			if status == StatusRunning {
 				// cache instance information so we can make fewer calls to AWS's API
-				if err = cacheHostData(ctx, instanceIdToHostMap[hostsToCheck[i]], &instance, m.client); err != nil {
+				if err = cacheHostData(ctx, m.env, instanceIdToHostMap[hostsToCheck[i]], &instance, m.client); err != nil {
 					return nil, errors.Wrapf(err, "caching EC2 host data for host '%s'", hostsToCheck[i])
 				}
 			}
@@ -754,7 +754,7 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 
 	if status == StatusRunning {
 		// cache instance information so we can make fewer calls to AWS's API
-		if err = cacheHostData(ctx, h, instance, m.client); err != nil {
+		if err = cacheHostData(ctx, m.env, h, instance, m.client); err != nil {
 			return status, errors.Wrapf(err, "caching EC2 host data for host '%s'", h.Id)
 		}
 	}
@@ -792,7 +792,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 
 	if h.NoExpiration {
 		// Clean up remaining DNS records for unexpirable hosts.
-		grip.Error(message.WrapError(deleteHostPersistentDNSName(ctx, h, m.client), message.Fields{
+		grip.Error(message.WrapError(deleteHostPersistentDNSName(ctx, m.env, h, m.client), message.Fields{
 			"message":    "could not delete host's persistent DNS name",
 			"op":         "delete",
 			"dashboard":  "evergreen sleep schedule health",
@@ -981,7 +981,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 		return errors.Wrap(err, "checking if spawn host started")
 	}
 
-	if err = cacheHostData(ctx, h, instance, m.client); err != nil {
+	if err = cacheHostData(ctx, m.env, h, instance, m.client); err != nil {
 		return errors.Wrapf(err, "cache EC2 host data for host '%s'", h.Id)
 	}
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1010,6 +1010,9 @@ func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *rou
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))
+					if strings.Contains(apiErr.Error(), r53InvalidInput) {
+						return false, err
+					}
 				}
 				return true, err
 			}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1014,8 +1014,8 @@ func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *rou
 						return false, err
 					}
 					if strings.Contains(apiErr.Error(), r53InvalidChangeBatch) {
-						// Deleting a record that's already deleted means it
-						// already succeeded.
+						// This error means the record has already been deleted,
+						// so the delete operation was already successful.
 						return false, nil
 					}
 				}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1013,6 +1013,11 @@ func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *rou
 					if strings.Contains(apiErr.Error(), r53InvalidInput) {
 						return false, err
 					}
+					if strings.Contains(apiErr.Error(), r53InvalidChangeBatch) {
+						// Deleting a record that's already deleted means it
+						// already succeeded.
+						return false, nil
+					}
 				}
 				return true, err
 			}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/smithy-go"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -120,6 +121,9 @@ type AWSClient interface {
 	GetVolumeIDs(context.Context, *host.Host) ([]string, error)
 
 	GetPublicDNSName(ctx context.Context, h *host.Host) (string, error)
+
+	// ChangeResourceRecordSets is a wrapper for route53.ChangeResourceRecordSets.
+	ChangeResourceRecordSets(context.Context, *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error)
 }
 
 // awsClientImpl wraps ec2.EC2.
@@ -127,6 +131,7 @@ type awsClientImpl struct { //nolint:all
 	config     *aws.Config
 	httpClient *http.Client
 	client     *ec2.Client
+	r53Client  *route53.Client
 }
 
 type generateDeviceNameOptions struct {
@@ -169,6 +174,7 @@ func (c *awsClientImpl) Create(ctx context.Context, creds aws.CredentialsProvide
 		c.config = &config
 	}
 	c.client = ec2.NewFromConfig(*c.config)
+	c.r53Client = route53.NewFromConfig(*c.config)
 	return nil
 }
 
@@ -991,6 +997,31 @@ func (c *awsClientImpl) GetPublicDNSName(ctx context.Context, h *host.Host) (str
 	return *instance.PublicDnsName, nil
 }
 
+func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	var output *route53.ChangeResourceRecordSetsOutput
+	var err error
+
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("ChangeResourceRecordSets", fmt.Sprintf("%T", c), input)
+			output, err = c.r53Client.ChangeResourceRecordSets(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
 // awsClientMock mocks ec2.EC2.
 type awsClientMock struct { //nolint
 	*ec2.RunInstancesInput
@@ -1023,6 +1054,9 @@ type awsClientMock struct { //nolint
 	*ec2.DescribeInstanceTypeOfferingsOutput
 
 	launchTemplates []types.LaunchTemplate
+
+	*route53.ChangeResourceRecordSetsInput
+	*route53.ChangeResourceRecordSetsOutput
 }
 
 // Create a new mock client.
@@ -1376,6 +1410,11 @@ func (c *awsClientMock) GetPublicDNSName(ctx context.Context, h *host.Host) (str
 	}
 
 	return "public_dns_name", nil
+}
+
+func (c *awsClientMock) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	c.ChangeResourceRecordSetsInput = input
+	return c.ChangeResourceRecordSetsOutput, nil
 }
 
 func makeAWSLogMessage(name, client string, args interface{}) message.Fields {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -211,7 +211,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 		}
 		if status == StatusRunning {
 			// cache instance information so we can make fewer calls to AWS's API
-			grip.Error(message.WrapError(cacheHostData(ctx, &h, instanceMap[h.Id], m.client), message.Fields{
+			grip.Error(message.WrapError(cacheHostData(ctx, m.env, &h, instanceMap[h.Id], m.client), message.Fields{
 				"message": "can't update host cached data",
 				"host_id": h.Id,
 			}))
@@ -249,7 +249,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	status = ec2StatusToEvergreenStatus(instance.State.Name)
 	if status == StatusRunning {
 		// cache instance information so we can make fewer calls to AWS's API
-		grip.Error(message.WrapError(cacheHostData(ctx, h, instance, m.client), message.Fields{
+		grip.Error(message.WrapError(cacheHostData(ctx, m.env, h, instance, m.client), message.Fields{
 			"message": "can't update host cached data",
 			"host_id": h.Id,
 		}))

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1066,7 +1066,7 @@ func (s *EC2Suite) TestCacheHostData() {
 	instance.PublicDnsName = aws.String("public_dns_name")
 	instance.PrivateIpAddress = aws.String("12.34.56.78")
 
-	s.NoError(cacheHostData(s.ctx, s.h, instance, ec2m.client))
+	s.NoError(cacheHostData(s.ctx, s.env, s.h, instance, ec2m.client))
 
 	s.Equal(*instance.Placement.AvailabilityZone, s.h.Zone)
 	s.True(instance.LaunchTime.Equal(s.h.StartTime))

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -35,6 +35,8 @@ const (
 	EC2VolumeNotFound       = "InvalidVolume.NotFound"
 	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
 	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
+
+	r53InvalidInput = "InvalidInput"
 )
 
 var (

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -36,7 +36,8 @@ const (
 	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
 	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
 
-	r53InvalidInput = "InvalidInput"
+	r53InvalidInput       = "InvalidInput"
+	r53InvalidChangeBatch = "InvalidChangeBatch"
 )
 
 var (
@@ -403,6 +404,9 @@ func deleteHostPersistentDNSName(ctx context.Context, env evergreen.Environment,
 				{
 					Action: r53Types.ChangeActionDelete,
 					ResourceRecordSet: &r53Types.ResourceRecordSet{
+						// The record name, value, type, and TTL must match the
+						// one in Route 53 exactly or else this will not be able
+						// to delete.
 						Name: aws.String(h.PersistentDNSName),
 						Type: r53Types.RRTypeA,
 						ResourceRecords: []r53Types.ResourceRecord{

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -335,7 +335,6 @@ const persistentDNSRecordTTLSecs = 1
 
 // setHostPersistentDNSName sets a host's persistent DNS record with its
 // associated IP address and sets it on the host.
-// kim: TODO: test with mock AWS client
 func setHostPersistentDNSName(ctx context.Context, env evergreen.Environment, h *host.Host, instance *types.Instance, client AWSClient) error {
 	ipAddr := utility.FromStringPtr(instance.PublicIpAddress)
 	if ipAddr == "" {
@@ -384,7 +383,6 @@ func setHostPersistentDNSName(ctx context.Context, env evergreen.Environment, h 
 
 // deleteHostPersistentDNSName deletes a host's persistent DNS record and unsets
 // it from the host.
-// kim: TODO: test with mock AWS client
 func deleteHostPersistentDNSName(ctx context.Context, env evergreen.Environment, h *host.Host, client AWSClient) error {
 	if h.PersistentDNSName == "" || h.PublicIPv4 == "" {
 		return nil

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -343,7 +343,10 @@ func setHostPersistentDNSName(ctx context.Context, h *host.Host, instance *types
 		return nil
 	}
 
-	dnsName := h.GetPersistentDNSName(settings.Providers.AWS.PersistentDNS.Domain)
+	dnsName, err := h.GeneratePersistentDNSName(ctx, settings.Providers.AWS.PersistentDNS.Domain)
+	if err != nil {
+		return errors.Wrap(err, "getting host's persistent DNS name")
+	}
 	in := route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(settings.Providers.AWS.PersistentDNS.HostedZoneID),
 		ChangeBatch: &r53Types.ChangeBatch{

--- a/cloud/ec2_util_test.go
+++ b/cloud/ec2_util_test.go
@@ -1,10 +1,21 @@
 package cloud
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	r53Types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanLaunchTemplateName(t *testing.T) {
@@ -67,6 +78,151 @@ func TestUsesHourlyBilling(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, UsesHourlyBilling(&testCase.distro), testCase.hourly)
+		})
+	}
+}
+
+func TestSetHostPersistentDNSName(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(host.Collection))
+	}()
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, instance *types.Instance, client *awsClientMock){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, instance *types.Instance, client *awsClientMock) {
+			require.NoError(t, h.Insert(ctx))
+			require.NoError(t, setHostPersistentDNSName(ctx, env, h, instance, client))
+
+			assert.NotZero(t, h.PersistentDNSName)
+			assert.True(t, strings.HasSuffix(h.PersistentDNSName, env.Settings().Providers.AWS.PersistentDNS.Domain))
+			assert.Equal(t, utility.FromStringPtr(instance.PublicIpAddress), h.PublicIPv4)
+
+			require.NotZero(t, client.ChangeResourceRecordSetsInput)
+			require.NotZero(t, client.ChangeResourceRecordSetsInput.ChangeBatch)
+			require.Len(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes, 1)
+			require.NotZero(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet)
+			require.Len(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords, 1)
+			assert.Equal(t, env.Settings().Providers.AWS.PersistentDNS.HostedZoneID, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.HostedZoneId))
+			assert.Equal(t, r53Types.ChangeActionUpsert, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].Action)
+			assert.Equal(t, h.PersistentDNSName, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.Name), "DNS record name should match host's persistent DNS name")
+			assert.Equal(t, h.PublicIPv4, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0].Value), "DNS record IP address should match host's IP address")
+
+			dbHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, h.PersistentDNSName, dbHost.PersistentDNSName)
+			assert.Equal(t, h.PublicIPv4, dbHost.PublicIPv4)
+		},
+		"FailsForInstanceWithoutIPv4Address": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, instance *types.Instance, client *awsClientMock) {
+			instance.PublicIpAddress = nil
+			require.NoError(t, h.Insert(ctx))
+			assert.Error(t, setHostPersistentDNSName(ctx, env, h, instance, client))
+
+			assert.Zero(t, h.PersistentDNSName)
+			assert.Zero(t, h.PublicIPv4)
+
+			assert.Zero(t, client.ChangeResourceRecordSetsInput)
+
+			dbHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Zero(t, dbHost.PersistentDNSName)
+			assert.Zero(t, dbHost.PublicIPv4)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, db.ClearCollections(host.Collection))
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+			env.EvergreenSettings.Providers.AWS.PersistentDNS = evergreen.PersistentDNSConfig{
+				HostedZoneID: "hosted_zone_id",
+				Domain:       "example.com",
+			}
+			const hostID = "host_id"
+			h := &host.Host{
+				Id:        hostID,
+				StartedBy: "some.user",
+			}
+			instance := &types.Instance{
+				InstanceId:      aws.String(hostID),
+				PublicIpAddress: aws.String("127.0.0.1"),
+			}
+
+			tCase(ctx, t, env, h, instance, &awsClientMock{})
+		})
+	}
+}
+
+func TestDeleteHostPersistentDNSName(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(host.Collection))
+	}()
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, client *awsClientMock){
+		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, client *awsClientMock) {
+			persistentDNS := h.PersistentDNSName
+			ipv4Addr := h.PublicIPv4
+			require.NoError(t, h.Insert(ctx))
+			require.NoError(t, deleteHostPersistentDNSName(ctx, env, h, client))
+
+			assert.Zero(t, h.PersistentDNSName)
+			assert.Zero(t, h.PublicIPv4)
+
+			require.NotZero(t, client.ChangeResourceRecordSetsInput)
+			require.NotZero(t, client.ChangeResourceRecordSetsInput.ChangeBatch)
+			require.Len(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes, 1)
+			require.NotZero(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet)
+			require.Len(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords, 1)
+			assert.Equal(t, env.Settings().Providers.AWS.PersistentDNS.HostedZoneID, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.HostedZoneId))
+			assert.Equal(t, r53Types.ChangeActionDelete, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].Action)
+			assert.Equal(t, persistentDNS, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.Name), "DNS record to delete should match host's persistent DNS name")
+			assert.Equal(t, ipv4Addr, utility.FromStringPtr(client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.ResourceRecords[0].Value), "DNS record IP address to delete should match host's IP address")
+
+			dbHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Zero(t, dbHost.PersistentDNSName)
+			assert.Zero(t, dbHost.PublicIPv4)
+		},
+		"NoopsForInstanceWithoutIPv4AddressOrPersistentDNSName": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, client *awsClientMock) {
+			h.PublicIPv4 = ""
+			h.PersistentDNSName = ""
+			require.NoError(t, h.Insert(ctx))
+			assert.NoError(t, deleteHostPersistentDNSName(ctx, env, h, client))
+
+			assert.NotZero(t, h.PersistentDNSName)
+			assert.Zero(t, h.PublicIPv4)
+
+			assert.Zero(t, client.ChangeResourceRecordSetsInput)
+
+			dbHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.NotZero(t, dbHost.PersistentDNSName)
+			assert.Zero(t, dbHost.PublicIPv4)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, db.ClearCollections(host.Collection))
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+			env.EvergreenSettings.Providers.AWS.PersistentDNS = evergreen.PersistentDNSConfig{
+				HostedZoneID: "hosted_zone_id",
+				Domain:       "example.com",
+			}
+			h := &host.Host{
+				Id:                "host_id",
+				StartedBy:         "some.user",
+				PersistentDNSName: "somebody-abc12.example.com",
+				PublicIPv4:        "127.0.0.1",
+			}
+
+			tCase(ctx, t, env, h, &awsClientMock{})
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.37.1
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
 	github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1
@@ -209,7 +210,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.37.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/google/go-github/v29 v29.0.2 // indirect
 	github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 // indirect

--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.37.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/google/go-github/v29 v29.0.2 // indirect
 	github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 h1:DBYTXwIG
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10/go.mod h1:wohMUQiFdzo0NtxbBg0mSRGZ4vL3n0dKjLTINdcIino=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.19.7 h1:7eUbCh7rEJ0Me/1D5UyT5ksz4nWASR9R1/DMCxrQ3qE=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.19.7/go.mod h1:p4y72CeHo5Xf7dCO73Df90qPGMVl8gfurPkSllLjrpo=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.37.1 h1:U7OksynDSIFScG+7sGqOuJh+fP1USMkNtjxzGFZYG34=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.37.1/go.mod h1:8qqfpG4mug2JLlEyWPSFhEGvJiaZ9iPmMDDMYc5Xtas=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.26.1 h1:Sn3MAV9YeACCULaxNWWYFH1a6G4wYFwBn3/TA5MwE2Q=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.26.1/go.mod h1:qutL00aW8GSo2D0I6UEOqMvRS3ZyuBrOC1BLe5D2jPc=
 github.com/aws/aws-sdk-go-v2/service/ses v1.19.6 h1:2WWiQwUVU39kD8EGYw/sTGU+REd5Q+BFarTccU00Asc=

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -31,7 +31,6 @@ const (
 var (
 	IdKey                              = bsonutil.MustHaveTag(Host{}, "Id")
 	DNSKey                             = bsonutil.MustHaveTag(Host{}, "Host")
-	PersistentDNSNameKey               = bsonutil.MustHaveTag(Host{}, "PersistentDNSName")
 	SecretKey                          = bsonutil.MustHaveTag(Host{}, "Secret")
 	UserKey                            = bsonutil.MustHaveTag(Host{}, "User")
 	ServicePasswordKey                 = bsonutil.MustHaveTag(Host{}, "ServicePassword")
@@ -40,6 +39,8 @@ var (
 	ProviderKey                        = bsonutil.MustHaveTag(Host{}, "Provider")
 	IPKey                              = bsonutil.MustHaveTag(Host{}, "IP")
 	IPv4Key                            = bsonutil.MustHaveTag(Host{}, "IPv4")
+	PersistentDNSNameKey               = bsonutil.MustHaveTag(Host{}, "PersistentDNSName")
+	PublicIPv4Key                      = bsonutil.MustHaveTag(Host{}, "PublicIPv4")
 	ProvisionedKey                     = bsonutil.MustHaveTag(Host{}, "Provisioned")
 	ProvisionTimeKey                   = bsonutil.MustHaveTag(Host{}, "ProvisionTime")
 	ExtIdKey                           = bsonutil.MustHaveTag(Host{}, "ExternalIdentifier")

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -31,6 +31,7 @@ const (
 var (
 	IdKey                              = bsonutil.MustHaveTag(Host{}, "Id")
 	DNSKey                             = bsonutil.MustHaveTag(Host{}, "Host")
+	PersistentDNSNameKey               = bsonutil.MustHaveTag(Host{}, "PersistentDNSName")
 	SecretKey                          = bsonutil.MustHaveTag(Host{}, "Secret")
 	UserKey                            = bsonutil.MustHaveTag(Host{}, "User")
 	ServicePasswordKey                 = bsonutil.MustHaveTag(Host{}, "ServicePassword")
@@ -1350,4 +1351,12 @@ func FindUnexpirableRunning() ([]Host, error) {
 		NoExpirationKey: true,
 	}
 	return hosts, db.FindAllQ(Collection, db.Query(q), &hosts)
+}
+
+// FindOneByPersistentDNSName returns hosts that have a matching persistent DNS
+// name.
+func FindOneByPersistentDNSName(ctx context.Context, dnsName string) (*Host, error) {
+	return FindOne(ctx, bson.M{
+		PersistentDNSNameKey: dnsName,
+	})
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3248,7 +3248,7 @@ func (h *Host) ClearDockerStdinData(ctx context.Context) error {
 }
 
 // nonAlphanumericRegexp matches any character that is not an alphanumeric
-// character ([0-9A-Za-z]) or a dash ("-").
+// character ([0-9A-Za-z]).
 var nonAlphanumericRegexp = regexp.MustCompile("[[:^alnum:]]+")
 
 // GeneratePersistentDNSName returns the host's persistent DNS name, or

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3284,6 +3284,7 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 }
 
 // SetPersistentDNSName sets the host's persistent DNS name.
+// kim: TODO: test
 func (h *Host) SetPersistentDNSName(ctx context.Context, dnsName string) error {
 	return UpdateOne(ctx, bson.M{
 		IdKey: h.Id,

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -16,9 +16,7 @@ type APIHost struct {
 	// Unique identifier of a specific host
 	Id      *string `json:"host_id"`
 	HostURL *string `json:"host_url"`
-	// kim: TODO: test round trip between service-API models
-	PersistentDNSName *string `json:"persistent_dns_name"`
-	Tag               *string `json:"tag"`
+	Tag     *string `json:"tag"`
 	// Object containing information about the distro type of this host
 	Distro      DistroInfo `json:"distro"`
 	Provisioned bool       `json:"provisioned"`
@@ -118,7 +116,6 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 	}
 	apiHost.Id = utility.ToStringPtr(h.Id)
 	apiHost.HostURL = utility.ToStringPtr(h.Host)
-	apiHost.PersistentDNSName = utility.ToStringPtr(h.PersistentDNSName)
 	apiHost.Tag = utility.ToStringPtr(h.Tag)
 	apiHost.Provisioned = h.Provisioned
 	apiHost.StartedBy = utility.ToStringPtr(h.StartedBy)
@@ -167,7 +164,6 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 func (apiHost *APIHost) ToService() host.Host {
 	return host.Host{
 		Id:                    utility.FromStringPtr(apiHost.Id),
-		PersistentDNSName:     utility.FromStringPtr(apiHost.PersistentDNSName),
 		Tag:                   utility.FromStringPtr(apiHost.Tag),
 		Provisioned:           apiHost.Provisioned,
 		NoExpiration:          apiHost.NoExpiration,

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -16,7 +16,9 @@ type APIHost struct {
 	// Unique identifier of a specific host
 	Id      *string `json:"host_id"`
 	HostURL *string `json:"host_url"`
-	Tag     *string `json:"tag"`
+	// kim: TODO: test round trip between service-API models
+	PersistentDNSName *string `json:"persistent_dns_name"`
+	Tag               *string `json:"tag"`
 	// Object containing information about the distro type of this host
 	Distro      DistroInfo `json:"distro"`
 	Provisioned bool       `json:"provisioned"`
@@ -116,6 +118,7 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 	}
 	apiHost.Id = utility.ToStringPtr(h.Id)
 	apiHost.HostURL = utility.ToStringPtr(h.Host)
+	apiHost.PersistentDNSName = utility.ToStringPtr(h.PersistentDNSName)
 	apiHost.Tag = utility.ToStringPtr(h.Tag)
 	apiHost.Provisioned = h.Provisioned
 	apiHost.StartedBy = utility.ToStringPtr(h.StartedBy)
@@ -164,6 +167,7 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 func (apiHost *APIHost) ToService() host.Host {
 	return host.Host{
 		Id:                    utility.FromStringPtr(apiHost.Id),
+		PersistentDNSName:     utility.FromStringPtr(apiHost.PersistentDNSName),
 		Tag:                   utility.FromStringPtr(apiHost.Tag),
 		Provisioned:           apiHost.Provisioned,
 		NoExpiration:          apiHost.NoExpiration,


### PR DESCRIPTION
DEVPROD-3973

### Description
This PR 1. assigns persistent DNS records to unexpirable hosts whenever they start up (the first time they're created and every time a stopped one is started) and 2. deletes those records when the host is terminated. Those DNS records can be used to resolve the host's IP address, which makes it more resilient to IP address changes whenever the host reboots.

To reduce the size of this PR, I'm splitting this ticket into two PRs because it still doesn't handle some cases. For example, if a host starts out expirable and is later edited to be unexpirable, that's not handled yet - it'll be handled in the follow-up PR. Furthermore, unexpirable hosts that already exist and don't have a persistent DNS name won't have a persistent DNS name assigned unless they stop/start their host - these existing hosts will all be assigned persistent DNS names in DEVPROD-4040.

It only applies if the required admin settings have been set, so this won't take effect in prod until those admin settings are set.

### Testing
* Added unit tests for new logic.
* Tested with unexpirable hosts in staging to ensure that I could SSH using the persistent DNS name and could also `dig +short` the persistent DNS name and it resolved into the correct IP address, even after rebooting the host.

### Documentation
N/A - this currently isn't visible in the UI nor is it rolled out for all unexpirable hosts yet. Documentation of persistent DNS names will come out with sleep schedule documentation in DEVPROD-4055.