### PR TITLE
DEVPROD-4588 one less build for staging

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -656,7 +656,7 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-linux_arm64
-    tags: ["build", "build-staging"]
+    tags: ["build"]
   - <<: *build-and-push-client
     name: build-linux_ppc64le
     tags: ["build"]


### PR DESCRIPTION
[DEVPROD-4588](https://jira.mongodb.org/browse/DEVPROD-4588)

### Description
We no longer need the `linux_arm64` build for staging since the app servers will be running on `linux_amd64`
