### PR TITLE
DEVPROD-4199 Spruce up docs for patch alias tag selection and add a test. 

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -139,19 +139,32 @@ GitHub checks, git tag triggers, project triggers, and patch triggers.
 For most aliases, you must define a variant regex or tags, and a task
 regex or tags to match. The matching variants/tasks will be included for the
 alias. If matching by tags, alias tags support a limited set of the [tag
-selector syntax](Project-Configuration-Files.md#task-and-variant-tags).
+selector syntax](../Project-Configuration-Files/#task-and-variant-tags).
 In particular, it supports tag negation and multiple tag criteria separated by
-spaces to get the set intersection of those tags. For example, when defining
-task tags:
+spaces to get the set intersection of those tags. Unlike the project tag selector
+syntax linked above, alias tags should not be prefixed by a period. 
+
+For example, when defining task tags:
 
 - `primary` would return all tasks with the tag `primary`.
 - `!primary` would return all tasks that are NOT tagged with "primary".
 - `cool !primary` would return all items that are tagged "cool" and NOT tagged
   with "primary".
+- `!cool !primary` would return all items that are NOT tagged "cool" and NOT tagged
+  with "primary".
+- `!.cool !.primary` is invalid and will not work as expected. Alias tags should not 
+  be prefixed by a period.
 
-Each tag definition is considered independently, so as long as a task fully
-matches one tag definition, it will be included. In other words, the matching
+Important note: Each tag definition is considered independently, so as long as a task 
+fully matches one tag definition, it will be included. In other words, the matching 
 variants/tasks are the set union of all the individual tag definitions.
+
+For example: 
+- `["!cool", "!primary"]` would return all items that are not tagged "cool" OR not tagged
+  "primary". That means that something with the tag "cool" (because it's !primary)
+  and something with the tag "primary" (because it's !cool) will still be included.
+- `["!cool !primary"]` would return all items that are not tagged "cool" AND not tagged
+  with "primary". That means only items that don't have these tags will be included.
 
 Aliases can also be defined locally as shown [here](../CLI.md#local-aliases).
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2767,3 +2767,83 @@ tasks:
 		})
 	}
 }
+func (s *projectSuite) TestTagNegation() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	const projYml = `
+tasks:
+  - name: performance-test
+    commands:
+      - command: shell.exec
+        params:
+          script: echo "performance test"
+  - name: other
+    commands:
+      - command: shell.exec
+        params:
+          script: echo "other"
+  - name: print
+    commands:
+      - command: shell.exec
+        params:
+          script: echo "print"
+buildvariants:
+  - name: performance-variant
+    tags: ["performance"]
+    display_name: performance-variant
+    run_on:
+      - ubuntu1604-small
+    tasks:
+      - name: performance-test
+  - name: other-variant
+    tags: ["other"]
+    display_name: other-variant
+    run_on:
+      - ubuntu1604-small
+    tasks:
+      - name: other
+  - name: print-variant
+    tags: ["print"]
+    display_name: print-variant
+    run_on:
+      - ubuntu1604-small
+    tasks:
+      - name: print
+
+patch_aliases:
+  - alias: "my alias"
+    # Do not run variants tagged with performance or other
+    variant_tags: ["!performance !other"]
+    task: ".*"
+`
+
+	p := &Project{}
+	_, err := LoadProjectInto(ctx, []byte(projYml), nil, "", p)
+	s.Require().NoError(err)
+
+	pc, err := CreateProjectConfig([]byte(projYml), "")
+	s.NoError(err)
+	s.NotNil(pc)
+
+	alias := pc.PatchAliases[0]
+	pairs, _, err := p.BuildProjectTVPairsWithAlias([]ProjectAlias{alias}, evergreen.PatchVersionRequester)
+	s.NoError(err)
+	s.Len(pairs, 1)
+	for _, pair := range pairs {
+		a := pair.Variant
+		b := pair.TaskName
+		print(a, b)
+	}
+
+	pairStrs := make([]string, len(pairs))
+	for i, p := range pairs {
+		pairStrs[i] = p.String()
+	}
+
+	s.Contains(pairStrs, "print-variant/print")
+
+	for _, pair := range pairs {
+		s.NotEqual("performance-variant", pair.Variant)
+		s.NotEqual("other-variant", pair.Variant)
+	}
+}


### PR DESCRIPTION
DEVPROD-4199

### Description
A user ran into issues excluding build variants with one of two tags in patch aliases. This verifies that it works and spruces up the docs. Troubleshooting was also done with the user. I couldn't reproduce the bug but verified that it now works as expected for them. 

### Testing
Added. 

### Documentation
Included
