### PR TITLE
DEVPROD-3973: manage DNS when host expirability changes

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -587,7 +587,7 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 			Resources: resources,
 			Tags: []types.Tag{
 				{
-					Key:   aws.String("expire-on"),
+					Key:   aws.String(evergreen.TagExpireOn),
 					Value: aws.String(expireOnValue),
 				},
 			},
@@ -607,11 +607,12 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 		}))
 		if instance != nil {
 			grip.Error(message.WrapError(setHostPersistentDNSName(ctx, m.env, h, utility.FromStringPtr(instance.PublicIpAddress), m.client), message.Fields{
-				"message":    "could not update host's persistent DNS name",
-				"op":         "upsert",
-				"dashboard":  "evergreen sleep schedule health",
-				"host_id":    h.Id,
-				"started_by": h.StartedBy,
+				"message":         "could not update host's persistent DNS name",
+				"op":              "upsert",
+				"dashboard":       "evergreen sleep schedule health",
+				"host_id":         h.Id,
+				"started_by":      h.StartedBy,
+				"instance_status": ec2StatusToEvergreenStatus(instance.State.Name),
 			}))
 		}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -598,8 +598,34 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 	}
 
 	if noExpiration {
+		instance, err := m.client.GetInstanceInfo(ctx, h.Id)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":    "could not get instance info for assigning persistent DNS name",
+			"dashboard":  "evergreen sleep schedule health",
+			"host_id":    h.Id,
+			"started_by": h.StartedBy,
+		}))
+		if instance != nil {
+			grip.Error(message.WrapError(setHostPersistentDNSName(ctx, m.env, h, utility.FromStringPtr(instance.PublicIpAddress), m.client), message.Fields{
+				"message":    "could not update host's persistent DNS name",
+				"op":         "upsert",
+				"dashboard":  "evergreen sleep schedule health",
+				"host_id":    h.Id,
+				"started_by": h.StartedBy,
+			}))
+		}
+
 		return errors.Wrapf(h.MarkShouldNotExpire(ctx, expireOnValue), "marking host should not expire in DB for host '%s'", h.Id)
 	}
+
+	grip.Error(message.WrapError(deleteHostPersistentDNSName(ctx, m.env, h, m.client), message.Fields{
+		"message":    "could not delete host's persistent DNS name",
+		"op":         "delete",
+		"dashboard":  "evergreen sleep schedule health",
+		"host_id":    h.Id,
+		"started_by": h.StartedBy,
+	}))
+
 	return errors.Wrapf(h.MarkShouldExpire(ctx, expireOnValue), "marking host should in DB for host '%s'", h.Id)
 }
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1278,6 +1278,7 @@ func (c *awsClientMock) GetInstanceInfo(ctx context.Context, id string) (*types.
 	instance.InstanceType = "m3.4xlarge"
 	instance.LaunchTime = aws.Time(time.Now())
 	instance.PublicDnsName = aws.String("public_dns_name")
+	instance.PublicIpAddress = aws.String("127.0.0.1")
 	instance.PrivateIpAddress = aws.String(MockIPV4)
 	ipv6 := types.InstanceIpv6Address{}
 	ipv6.Ipv6Address = aws.String(MockIPV6)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"net"
@@ -3251,6 +3253,9 @@ func (h *Host) ClearDockerStdinData(ctx context.Context) error {
 // character ([0-9A-Za-z]).
 var nonAlphanumericRegexp = regexp.MustCompile("[[:^alnum:]]+")
 
+// alphanumericChars contains all alphanumeric characters.
+const alphanumericChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
 // GeneratePersistentDNSName returns the host's persistent DNS name, or
 // generates a new one if it doesn't have one currently assigned.
 func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (string, error) {
@@ -3268,9 +3273,39 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 	}
 	user := strings.Join(cleanedParts, "-")
 
+	const maxRandLen = 5
+
+	// Since each user can own multiple unexpirable hosts, just using their
+	// username is not sufficient to make a unique persistent DNS name. Try
+	// first generating a persistent DNS name that:
+	// 1. contains only alphanumeric characters so it's more memorable, and
+	// 2. is derived from the host ID.
+	//
+	// This is slightly preferable to a random alphanumeric string, because a
+	// host with a particular ID will have a more short and memorable
+	// alphabet-only string.
+
+	idBasedHash := sha256.Sum256([]byte(h.Id))
+	encoder := base64.RawURLEncoding
+	idBasedEncoding := make([]byte, encoder.EncodedLen(len(idBasedHash[:])))
+	encoder.Encode(idBasedEncoding, idBasedHash[:])
+
+	// Shorten the string and map encoding to only alphabet characters so it's
+	// more memorable.
+	idBasedRandom := make([]byte, maxRandLen)
+	for i := range idBasedRandom {
+		idBasedRandom[i] = alphanumericChars[idBasedEncoding[i]%byte(len(alphanumericChars))]
+	}
+	candidate := fmt.Sprintf("%s-%s.%s", user, string(idBasedRandom), strings.TrimPrefix(domain, "."))
+	conflicting, _ := FindOneByPersistentDNSName(ctx, candidate)
+	if conflicting == nil || conflicting.Id == h.Id {
+		return candidate, nil
+	}
+
+	// If that can't produce a unique ID, then fall back to using a random
+	// string to produce a unique DNS name.
 	const numAttempts = 5
 	for i := 0; i < numAttempts; i++ {
-		const maxRandLen = 5
 		random := utility.RandomString()[:maxRandLen]
 		candidate := fmt.Sprintf("%s-%s.%s", user, random, strings.TrimPrefix(domain, "."))
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3302,8 +3302,11 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 		return candidate, nil
 	}
 
-	// If that can't produce a unique ID, then fall back to using a random
-	// string to produce a unique DNS name.
+	// If the host ID can't be mapped to a unique DNS name, then fall back to
+	// using a random string to produce a unique DNS name. This is less
+	// preferable because it's randomly-generated, but it does handle the very
+	// tiny edge case where the DNS name generated above conflicts with an
+	// existing one.
 	const numAttempts = 5
 	for i := 0; i < numAttempts; i++ {
 		random := utility.RandomString()[:maxRandLen]

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -62,6 +62,9 @@ func TestSpawnhostModifyJob(t *testing.T) {
 		assert.Equal(t, j.ModifyOptions, modifyOpts)
 		assert.Equal(t, evergreen.ModifySpawnHostManual, j.Source)
 	})
+	// kim: TODO: add tests for:
+	// * expirable -> unexpirable
+	// * unexpirable -> expirable
 	t.Run("ModifiesHost", func(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
 		mock := cloud.GetMockProvider()

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -44,6 +44,10 @@ func TestSpawnhostModifyJob(t *testing.T) {
 	defer cancel()
 	ctx = testutil.TestSpan(ctx, t)
 
+	defer func() {
+		assert.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
+	}()
+
 	t.Run("NewSpawnhostModifyJobSetsExpectedFields", func(t *testing.T) {
 		ts := utility.RoundPartOfMinute(1).Format(TSFormat)
 		h := host.Host{
@@ -62,62 +66,61 @@ func TestSpawnhostModifyJob(t *testing.T) {
 		assert.Equal(t, j.ModifyOptions, modifyOpts)
 		assert.Equal(t, evergreen.ModifySpawnHostManual, j.Source)
 	})
-	// kim: TODO: add tests for:
-	// * expirable -> unexpirable
-	// * unexpirable -> expirable
-	t.Run("ModifiesHost", func(t *testing.T) {
-		assert.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
-		mock := cloud.GetMockProvider()
-		h := host.Host{
-			Id:       "hostID",
-			Provider: evergreen.ProviderNameMock,
-			InstanceTags: []host.Tag{
-				{
-					Key:           "key1",
-					Value:         "value1",
-					CanBeModified: true,
+
+	for tName, tCase := range map[string]func(ctx context.Context, h *host.Host, mock cloud.MockProvider){
+		"RunModifiesInstanceType": func(ctx context.Context, h *host.Host, mock cloud.MockProvider) {
+			require.NoError(t, h.Insert(ctx))
+			mock.Set(h.Id, cloud.MockInstance{
+				Status: cloud.StatusRunning,
+				Tags: []host.Tag{
+					{
+						Key:           "key1",
+						Value:         "value1",
+						CanBeModified: true,
+					},
 				},
-			},
-			InstanceType: "instance-type-1",
-			Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
-		}
-		assert.NoError(t, h.Insert(ctx))
-		mock.Set(h.Id, cloud.MockInstance{
-			Status: cloud.StatusRunning,
-			Tags: []host.Tag{
-				{
-					Key:           "key1",
-					Value:         "value1",
-					CanBeModified: true,
+				Type: "instance-type-1",
+			})
+			changes := host.HostModifyOptions{
+				AddInstanceTags: []host.Tag{
+					{
+						Key:           "key2",
+						Value:         "value2",
+						CanBeModified: true,
+					},
 				},
-			},
-			Type: "instance-type-1",
+				DeleteInstanceTags: []string{"key1"},
+				InstanceType:       "instance-type-2",
+			}
+
+			j := NewSpawnhostModifyJob(h, changes, "")
+			j.Run(ctx)
+			assert.NoError(t, j.Error())
+			assert.True(t, j.Status().Completed)
+
+			modifiedHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, modifiedHost)
+			assert.Equal(t, []host.Tag{{Key: "key2", Value: "value2", CanBeModified: true}}, modifiedHost.InstanceTags)
+			assert.Equal(t, "instance-type-2", modifiedHost.InstanceType)
+
+			checkSpawnHostModificationEvent(t, h.Id, event.EventHostModified, true)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			require.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
+
+			mock := cloud.GetMockProvider()
+			h := host.Host{
+				Id:       "host_id",
+				Status:   evergreen.HostRunning,
+				Provider: evergreen.ProviderNameMock,
+				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+			}
+
+			tCase(ctx, &h, mock)
 		})
-
-		changes := host.HostModifyOptions{
-			AddInstanceTags: []host.Tag{
-				{
-					Key:           "key2",
-					Value:         "value2",
-					CanBeModified: true,
-				},
-			},
-			DeleteInstanceTags: []string{"key1"},
-			InstanceType:       "instance-type-2",
-		}
-
-		ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-		j := NewSpawnhostModifyJob(&h, changes, ts)
-
-		j.Run(context.Background())
-		assert.NoError(t, j.Error())
-		assert.True(t, j.Status().Completed)
-
-		modifiedHost, err := host.FindOneId(ctx, h.Id)
-		assert.NoError(t, err)
-		assert.Equal(t, []host.Tag{{Key: "key2", Value: "value2", CanBeModified: true}}, modifiedHost.InstanceTags)
-		assert.Equal(t, "instance-type-2", modifiedHost.InstanceType)
-
-		checkSpawnHostModificationEvent(t, h.Id, event.EventHostModified, true)
-	})
+	}
 }


### PR DESCRIPTION
DEVPROD-3973

### Description
Follow-up to #7520. #7520 already handles the common case where users will just spawn an unexpirable host and then will never make it expirable again (they could just terminate it if they want it gone). This handles some less-common scenarios where a user decides to change their host's expirability setting later on.

* When switching an expirable host to be unexpirable, assign it a persistent DNS name.
* When switching an unexpirable host back to an expirable one, remove its persistent DNS name (Evergreen only manages persistent DNS names for long-lived spawn hosts).
* Remove the "random" aspect of the persistent DNS name generation so that, if given a host and user, it'll always generate the same DNS name no matter how many times it's called. The only time this wouldn't be true is in extreme edge cases where another host coincidentally has the exact same persistent DNS name.
    * This is a nice-to-have for users because it helps ensure that, once a host has a persistent DNS name, that persistent DNS name is always the same for the lifetime of the host, even if you do something unusual like toggle expirability on/off. With the old logic, you'd get a new randomized persistent DNS name every time you toggled expirability on/off, but now your host will always be re-assigned to the same persistent DNS name.

### Testing
* Added unit tests for toggling expirability.
* Tested in staging by editing a host a bunch of times to toggle "Never expire" on and off again. I verified that the DNS record was correctly updated and that furthermore, the same host always got re-assigned the same DNS name no matter how many times I toggled it.

### Documentation
N/A