### PR TITLE
Revert "DEVPROD-4556: use instance profile for AWS auth on the app servers (#7503)

### DIFF
--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -164,6 +164,15 @@ func (s *createHostSuite) TestParamValidation() {
 	s.NoError(s.cmd.ParseParams(s.params))
 	s.NoError(s.cmd.expandAndValidate(ctx, s.conf))
 
+	// having a key id but nothing else is an error
+	s.params["aws_access_key_id"] = "keyid"
+	s.NoError(s.cmd.ParseParams(s.params))
+	s.Contains(s.cmd.expandAndValidate(ctx, s.conf).Error(), "AWS access key ID, AWS secret access key, and key name must all be set or unset")
+	s.params["aws_secret_access_key"] = "secret"
+	s.params["key_name"] = "key"
+	s.NoError(s.cmd.ParseParams(s.params))
+	s.NoError(s.cmd.expandAndValidate(ctx, s.conf))
+
 	// verify errors for things controlled by the agent
 	s.params["num_hosts"] = "11"
 	s.NoError(s.cmd.ParseParams(s.params))

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -146,6 +146,9 @@ type CreateHost struct {
 	Subnet          string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
 	UserdataFile    string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
 	UserdataCommand string      `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`
+	AWSKeyID        string      `mapstructure:"aws_access_key_id" json:"aws_access_key_id" yaml:"aws_access_key_id" plugin:"expand"`
+	AWSSecret       string      `mapstructure:"aws_secret_access_key" json:"aws_secret_access_key" yaml:"aws_secret_access_key" plugin:"expand"`
+	KeyName         string      `mapstructure:"key_name" json:"key_name" yaml:"key_name" plugin:"expand"`
 
 	// docker-related settings
 	Image                    string           `mapstructure:"image" json:"image" yaml:"image" plugin:"expand"`
@@ -242,6 +245,11 @@ func (ch *CreateHost) validateEC2() error {
 		if ch.Subnet == "" {
 			catcher.New("subnet ID must be set if AMI is set")
 		}
+	}
+
+	if !(ch.AWSKeyID == "" && ch.AWSSecret == "" && ch.KeyName == "") &&
+		!(ch.AWSKeyID != "" && ch.AWSSecret != "" && ch.KeyName != "") {
+		catcher.New("AWS access key ID, AWS secret access key, and key name must all be set or unset")
 	}
 
 	return catcher.Resolve()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/evergreen-ci/birch"
@@ -30,6 +31,12 @@ type EC2ProviderSettings struct {
 
 	// AMI is the AMI ID.
 	AMI string `mapstructure:"ami" json:"ami,omitempty" bson:"ami,omitempty"`
+
+	// If set, overrides key from credentials
+	AWSKeyID string `mapstructure:"aws_access_key_id" json:"aws_access_key_id,omitempty" bson:"aws_access_key_id,omitempty"`
+
+	// If set, overrides secret from credentials
+	AWSSecret string `mapstructure:"aws_secret_access_key" json:"aws_access_key,omitempty" bson:"aws_secret_access_key,omitempty"`
 
 	// InstanceType is the EC2 instance type.
 	InstanceType string `mapstructure:"instance_type" json:"instance_type,omitempty" bson:"instance_type,omitempty"`
@@ -230,17 +237,29 @@ type EC2ManagerOptions struct {
 // ec2Manager starts and configures instances in EC2.
 type ec2Manager struct {
 	*EC2ManagerOptions
-	env      evergreen.Environment
-	settings *evergreen.Settings
+	credentials aws.CredentialsProvider
+	env         evergreen.Environment
+	settings    *evergreen.Settings
 }
 
-// Configure loads settings from the config file.
+// Configure loads credentials or other settings from the config file.
 func (m *ec2Manager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	m.settings = settings
 
 	if m.region == "" {
 		m.region = evergreen.DefaultEC2Region
 	}
+
+	var err error
+	m.providerKey, m.providerSecret, err = GetEC2Key(settings)
+	if err != nil {
+		return errors.Wrap(err, "getting EC2 keys")
+	}
+	if m.providerKey == "" || m.providerSecret == "" {
+		return errors.New("provider key/secret can't be empty")
+	}
+
+	m.credentials = credentials.NewStaticCredentialsProvider(m.providerKey, m.providerSecret, "")
 
 	return nil
 }
@@ -416,7 +435,7 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 			h.Distro.Id, h.Distro.Provider)
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -540,7 +559,7 @@ func (m *ec2Manager) setInstanceType(ctx context.Context, h *host.Host, instance
 }
 
 func (m *ec2Manager) CheckInstanceType(ctx context.Context, instanceType string) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -591,7 +610,7 @@ func (m *ec2Manager) extendExpiration(ctx context.Context, h *host.Host, extensi
 
 // ModifyHost modifies a spawn host according to the changes specified by a HostModifyOptions struct.
 func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, opts host.HostModifyOptions) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -660,7 +679,7 @@ func addPublicKey(ctx context.Context, h *host.Host, key string) error {
 
 // GetInstanceStatuses returns the current status of a slice of EC2 instances.
 func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host) (map[string]CloudStatus, error) {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -713,7 +732,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (CloudStatus, error) {
 	status := StatusUnknown
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return status, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -762,7 +781,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -849,7 +868,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		return errors.Errorf("cannot stop host '%s' because its status ('%s') is not a stoppable state", h.Id, h.Status)
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -926,7 +945,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 		return errors.Errorf("cannot start host '%s' because its status is '%s'", h.Id, h.Status)
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -978,7 +997,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 }
 
 func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment *host.VolumeAttachment) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1019,7 +1038,7 @@ func (m *ec2Manager) DetachVolume(ctx context.Context, h *host.Host, volumeID st
 		return errors.Errorf("volume '%s' not found", volumeID)
 	}
 
-	if err = m.client.Create(ctx, m.region); err != nil {
+	if err = m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1042,7 +1061,7 @@ func (m *ec2Manager) DetachVolume(ctx context.Context, h *host.Host, volumeID st
 }
 
 func (m *ec2Manager) CreateVolume(ctx context.Context, volume *host.Volume) (*host.Volume, error) {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1089,7 +1108,7 @@ func (m *ec2Manager) CreateVolume(ctx context.Context, volume *host.Volume) (*ho
 }
 
 func (m *ec2Manager) DeleteVolume(ctx context.Context, volume *host.Volume) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1105,7 +1124,7 @@ func (m *ec2Manager) DeleteVolume(ctx context.Context, volume *host.Volume) erro
 }
 
 func (m *ec2Manager) GetVolumeAttachment(ctx context.Context, volumeID string) (*VolumeAttachment, error) {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1161,7 +1180,7 @@ func (m *ec2Manager) modifyVolumeExpiration(ctx context.Context, volume *host.Vo
 }
 
 func (m *ec2Manager) ModifyVolume(ctx context.Context, volume *host.Volume, opts *model.VolumeModifyOptions) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1217,7 +1236,7 @@ func (m *ec2Manager) ModifyVolume(ctx context.Context, volume *host.Volume, opts
 
 // GetDNSName returns the DNS name for the host.
 func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return "", errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -1236,7 +1255,7 @@ func (m *ec2Manager) Cleanup(context.Context) error {
 }
 
 func (m *ec2Manager) AddSSHKey(ctx context.Context, pair evergreen.SSHKeyPair) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/evergreen-ci/evergreen"
@@ -86,8 +87,9 @@ type EC2FleetManagerOptions struct {
 
 type ec2FleetManager struct {
 	*EC2FleetManagerOptions
-	settings *evergreen.Settings
-	env      evergreen.Environment
+	credentials aws.CredentialsProvider
+	settings    *evergreen.Settings
+	env         evergreen.Environment
 }
 
 func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Settings) error {
@@ -97,6 +99,16 @@ func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Set
 		m.region = evergreen.DefaultEC2Region
 	}
 
+	var err error
+	m.providerKey, m.providerSecret, err = GetEC2Key(settings)
+	if err != nil {
+		return errors.Wrap(err, "getting EC2 keys")
+	}
+	if m.providerKey == "" || m.providerSecret == "" {
+		return errors.New("provider key/secret can't be empty")
+	}
+
+	m.credentials = credentials.NewStaticCredentialsProvider(m.providerKey, m.providerSecret, "")
 	return nil
 }
 
@@ -105,7 +117,7 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 		return nil, errors.Errorf("can't spawn instance for distro '%s': distro provider is '%s'", h.Distro.Id, h.Distro.Provider)
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -159,7 +171,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 		instanceIDs = append(instanceIDs, h.Id)
 	}
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -212,7 +224,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (CloudStatus, error) {
 	status := StatusUnknown
 
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return status, errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -251,7 +263,7 @@ func (m *ec2FleetManager) SetPortMappings(context.Context, *host.Host, *host.Hos
 }
 
 func (m *ec2FleetManager) CheckInstanceType(ctx context.Context, instanceType string) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -273,7 +285,7 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 	if h.Status == evergreen.HostTerminated {
 		return errors.Errorf("cannot terminate host '%s' because it's already marked as terminated", h.Id)
 	}
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -327,7 +339,7 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 }
 
 func (m *ec2FleetManager) Cleanup(ctx context.Context) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -388,7 +400,7 @@ func (m *ec2FleetManager) GetVolumeAttachment(context.Context, string) (*VolumeA
 }
 
 func (m *ec2FleetManager) GetDNSName(ctx context.Context, h *host.Host) (string, error) {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return "", errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()
@@ -562,7 +574,7 @@ func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2Pro
 }
 
 func (m *ec2FleetManager) AddSSHKey(ctx context.Context, pair evergreen.SSHKeyPair) error {
-	if err := m.client.Create(ctx, m.region); err != nil {
+	if err := m.client.Create(ctx, m.credentials, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
 	defer m.client.Close()

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
@@ -161,6 +162,7 @@ func TestFleet(t *testing.T) {
 				client: &awsClientMock{},
 				region: "test-region",
 			},
+			credentials: credentials.NewStaticCredentialsProvider("key", "secret", ""),
 			settings: &evergreen.Settings{
 				Providers: evergreen.CloudProviders{
 					AWS: evergreen.AWSConfig{

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -75,24 +75,13 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	m := &ec2Manager{env: env, EC2ManagerOptions: opts}
 	require.NoError(m.Configure(ctx, testConfig))
-	require.NoError(m.client.Create(ctx, evergreen.DefaultEC2Region))
+	require.NoError(m.client.Create(ctx, m.credentials, evergreen.DefaultEC2Region))
 
 	d := fetchTestDistro()
 	h := host.NewIntent(host.CreateOptions{
 		Distro:   d,
 		UserName: evergreen.User,
 		UserHost: false,
-		// The assumed role used for this integration test requires
-		// a specific resource tag to be set in order to perform
-		// certain actions (e.g., terminate a host). This means that
-		// the resource must have the tag or the action cannot be
-		// performed against it.
-		InstanceTags: []host.Tag{
-			{
-				Key:   "evergreen-integration-testing",
-				Value: "true",
-			},
-		},
 	})
 	h, err := m.SpawnHost(ctx, h)
 	assert.NoError(err)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -269,20 +269,28 @@ func (s *EC2Suite) TestConfigure() {
 	ctx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 
-	// No region specified.
-	s.Require().NoError(s.onDemandManager.Configure(ctx, settings))
-	ec2m, ok := s.onDemandManager.(*ec2Manager)
-	s.Require().True(ok)
-	s.Equal(evergreen.DefaultEC2Region, ec2m.region)
+	err := s.onDemandManager.Configure(ctx, settings)
+	s.Error(err)
 
-	// Region specified.
+	// No region specified
+	settings.Providers.AWS.EC2Keys = []evergreen.EC2Key{
+		{Key: "default-key", Secret: "default-secret"},
+	}
+	err = s.onDemandManager.Configure(ctx, settings)
+	s.NoError(err)
+	ec2m, ok := s.onDemandManager.(*ec2Manager)
+	s.True(ok)
+	creds, err := ec2m.credentials.Retrieve(ctx)
+	s.NoError(err)
+	s.Equal("default-key", creds.AccessKeyID)
+	s.Equal("default-secret", creds.SecretAccessKey)
+
+	// config missing key or secret
 	settings.Providers.AWS.EC2Keys = []evergreen.EC2Key{
 		{Key: "test-key", Secret: ""},
 	}
-	s.Require().NoError(s.onDemandWithRegionManager.Configure(ctx, settings))
-	ec2m, ok = s.onDemandWithRegionManager.(*ec2Manager)
-	s.Require().True(ok)
-	s.Equal(s.onDemandWithRegionOpts.region, ec2m.region)
+	err = s.onDemandWithRegionManager.Configure(ctx, settings)
+	s.Error(err)
 }
 
 func (s *EC2Suite) TestSpawnHostInvalidInput() {
@@ -1116,6 +1124,8 @@ func (s *EC2Suite) TestFromDistroSettings() {
 		InstanceType:          "other_instance",
 		SecurityGroupIDs:      []string{"ghijkl"},
 		IAMInstanceProfileARN: "a_beautiful_profile",
+		AWSKeyID:              "other_key_id",
+		KeyName:               "other_key",
 	}
 	bytes, err := bson.Marshal(ec2Settings)
 	s.NoError(err)
@@ -1147,6 +1157,28 @@ func (s *EC2Suite) TestGetEC2ManagerOptions() {
 	managerOpts, err := GetManagerOptions(d1)
 	s.NoError(err)
 	s.Equal(evergreen.DefaultEC2Region, managerOpts.Region)
+	s.Equal("key", managerOpts.ProviderKey)
+	s.Equal("secret", managerOpts.ProviderSecret)
+}
+
+func (s *EC2Suite) TestGetEC2Key() {
+	settings := &evergreen.Settings{
+		Providers: evergreen.CloudProviders{
+			AWS: evergreen.AWSConfig{},
+		},
+	}
+	key, secret, err := GetEC2Key(settings)
+	s.Empty(key)
+	s.Empty(secret)
+	s.EqualError(err, "no EC2 keys in config")
+
+	settings.Providers.AWS.EC2Keys = []evergreen.EC2Key{
+		{Key: "test-key", Secret: "test-secret"},
+	}
+	key, secret, err = GetEC2Key(settings)
+	s.Equal("test-key", key)
+	s.Equal("test-secret", secret)
+	s.NoError(err)
 }
 
 func (s *EC2Suite) TestSetNextSubnet() {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -594,14 +594,33 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2.DescribeI
 	return catcher.Resolve()
 }
 
+// Get EC2 key and secret from the AWS configuration
+func GetEC2Key(s *evergreen.Settings) (string, string, error) {
+	if len(s.Providers.AWS.EC2Keys) == 0 {
+		return "", "", errors.New("no EC2 keys in config")
+	}
+
+	key := s.Providers.AWS.EC2Keys[0].Key
+	secret := s.Providers.AWS.EC2Keys[0].Secret
+
+	// Error if key or secret are blank
+	if key == "" || secret == "" {
+		return "", "", errors.New("AWS key and secret must not be blank")
+	}
+
+	return key, secret, nil
+}
+
 func getEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
 	region := settings.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region
 	}
 	return ManagerOpts{
-		Provider: provider,
-		Region:   region,
+		Provider:       provider,
+		Region:         region,
+		ProviderKey:    settings.AWSKeyID,
+		ProviderSecret: settings.AWSSecret,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-09"
+	AgentVersion = "2024-02-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -586,6 +586,10 @@ EC2 Parameters:
 
 -   `ami` - For an `ec2` provider, the AMI to start. Must set `ami` or `distro`
     but must not set both.
+-   `aws_access_key_id` - AWS access key ID. May set to use a
+    non-default account. Must set if `aws_secret_access_key` is set.
+-   `aws_secret_access_key` - AWS secret key. May set to use a
+    non-default account. Must set if `aws_access_key_id` is set.
 -   `device_name` - name of EBS device
 -   `distro` - Evergreen distro to start. For the `ec2` provider, must set
     either `ami` only or `distro` but must not set both. For the `docker`
@@ -601,6 +605,8 @@ EC2 Parameters:
     distro configuration.
 -   `ipv6`- Set to true if instance should have _only_ an
     IPv6 address, rather than a public IPv4 address.
+-   `key_name` - EC2 Key name. Must set if `aws_access_key_id` or
+    `aws_secret_access_key` is set. Must not set otherwise.
 -   `region` - EC2 region. Default is the same as Evergreen's default.
 -   `security_group_ids` - List of security groups. Must set if `ami` is
     set. May set if `distro` is set, which will override the value from

--- a/environment.go
+++ b/environment.go
@@ -1213,6 +1213,11 @@ func (e *envState) populateS3ClientConfig(ctx context.Context, versionID string)
 	bucket, err := pail.NewS3Bucket(pail.S3Options{
 		Name:   e.settings.Providers.AWS.BinaryClient.Bucket,
 		Region: DefaultEC2Region,
+		Credentials: pail.CreateAWSCredentials(
+			e.settings.Providers.AWS.BinaryClient.Key,
+			e.settings.Providers.AWS.BinaryClient.Secret,
+			"",
+		),
 	})
 	if err != nil {
 		return errors.Wrap(err, "constructing pail bucket")

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.49.19
 	github.com/aws/aws-sdk-go-v2 v1.24.1
 	github.com/aws/aws-sdk-go-v2/config v1.26.6
-	github.com/aws/aws-sdk-go-v2/credentials v1.16.16 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.16.16
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.142.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.19.7

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
@@ -28,10 +29,15 @@ type ParserProjectS3Storage struct {
 func NewParserProjectS3Storage(ppConf evergreen.ParserProjectS3Config) (*ParserProjectS3Storage, error) {
 	c := utility.GetHTTPClient()
 
+	var creds *credentials.Credentials
+	if ppConf.Key != "" && ppConf.Secret != "" {
+		creds = pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, "")
+	}
 	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
-		Name:   ppConf.Bucket,
-		Prefix: ppConf.Prefix,
-		Region: endpoints.UsEast1RegionID,
+		Name:        ppConf.Bucket,
+		Prefix:      ppConf.Prefix,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: creds,
 	})
 	if err != nil {
 		utility.PutHTTPClient(c)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1972,8 +1972,9 @@ func TestParserProjectStorage(t *testing.T) {
 
 	ppConf := env.Settings().Providers.AWS.ParserProject
 	bucket, err := pail.NewS3BucketWithHTTPClient(c, pail.S3Options{
-		Name:   ppConf.Bucket,
-		Region: endpoints.UsEast1RegionID,
+		Name:        ppConf.Bucket,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
 	})
 	require.NoError(t, err)
 	defer func() {

--- a/model/task/generated_json_s3.go
+++ b/model/task/generated_json_s3.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
@@ -28,10 +29,15 @@ type generatedJSONS3Storage struct {
 func newGeneratedJSONS3Storage(ppConf evergreen.ParserProjectS3Config) (*generatedJSONS3Storage, error) {
 	c := utility.GetHTTPClient()
 
+	var creds *credentials.Credentials
+	if ppConf.Key != "" && ppConf.Secret != "" {
+		creds = pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, "")
+	}
 	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
-		Name:   ppConf.Bucket,
-		Prefix: ppConf.GeneratedJSONPrefix,
-		Region: endpoints.UsEast1RegionID,
+		Name:        ppConf.Bucket,
+		Prefix:      ppConf.GeneratedJSONPrefix,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: creds,
 	})
 	if err != nil {
 		utility.PutHTTPClient(c)

--- a/model/task/generated_json_storage_test.go
+++ b/model/task/generated_json_storage_test.go
@@ -31,8 +31,9 @@ func TestGeneratedJSONStorage(t *testing.T) {
 
 	ppConf := env.Settings().Providers.AWS.ParserProject
 	bucket, err := pail.NewS3BucketWithHTTPClient(c, pail.S3Options{
-		Name:   ppConf.Bucket,
-		Region: endpoints.UsEast1RegionID,
+		Name:        ppConf.Bucket,
+		Region:      endpoints.UsEast1RegionID,
+		Credentials: pail.CreateAWSCredentials(ppConf.Key, ppConf.Secret, ""),
 	})
 	require.NoError(t, err)
 	defer func() {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -345,6 +345,10 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 	if createHost.AMI != "" {
 		ec2Settings.AMI = createHost.AMI
 	}
+	if createHost.AWSKeyID != "" {
+		ec2Settings.AWSKeyID = createHost.AWSKeyID
+		ec2Settings.AWSSecret = createHost.AWSSecret
+	}
 
 	for _, mount := range createHost.EBSDevices {
 		ec2Settings.MountPoints = append(ec2Settings.MountPoints, cloud.MountPoint{
@@ -359,7 +363,7 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 		ec2Settings.InstanceType = createHost.InstanceType
 	}
 	if userID == "" {
-		ec2Settings.KeyName = "" // never use the distro's key
+		ec2Settings.KeyName = createHost.KeyName // never use the distro's key
 	}
 	if createHost.Subnet != "" {
 		ec2Settings.SubnetId = createHost.Subnet

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -75,6 +75,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -94,7 +95,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	// test roundtripping
@@ -105,7 +106,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
-	assert.Empty(ec2Settings2.KeyName)
+	assert.Equal("mock_key", ec2Settings2.KeyName)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// scope to build
@@ -122,6 +123,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "build",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -133,7 +135,7 @@ func TestMakeHost(t *testing.T) {
 	ec2Settings = &cloud.EC2ProviderSettings{}
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("build-id", h.SpawnOptions.BuildID)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -149,6 +151,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -168,7 +171,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	// override some evergreen distro settings
@@ -179,6 +182,8 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		AWSKeyID:            "my_aws_key",
+		AWSSecret:           "my_secret_key",
 		Subnet:              "subnet-123456",
 	}
 	handler.createHost = c
@@ -197,6 +202,8 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
+	assert.Equal("my_aws_key", ec2Settings.AWSKeyID)
+	assert.Equal("my_secret_key", ec2Settings.AWSSecret)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
 
@@ -204,6 +211,8 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
+	assert.Equal("my_aws_key", ec2Settings2.AWSKeyID)
+	assert.Equal("my_secret_key", ec2Settings2.AWSSecret)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
@@ -215,6 +224,8 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		AWSKeyID:            "my_aws_key",
+		AWSSecret:           "my_secret_key",
 		InstanceType:        "t1.micro",
 		Subnet:              "subnet-123456",
 		SecurityGroups:      []string{"1234"},
@@ -235,6 +246,8 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-654321", ec2Settings2.AMI)
+	assert.Equal("my_aws_key", ec2Settings2.AWSKeyID)
+	assert.Equal("my_secret_key", ec2Settings2.AWSSecret)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
@@ -250,6 +263,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -244,36 +244,28 @@ functions:
         OTEL_COLLECTOR_ENDPOINT: ${otel_collector_endpoint}
         OTEL_TRACE_ID: ${otel_trace_id}
         OTEL_PARENT_ID: ${otel_parent_id}
-        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-        AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
 
   setup-credentials:
-    - command: ec2.assume_role
-      type: setup
-      params:
-        role_arn: ${assume_role_arn}
-    - command: subprocess.exec
-      type: setup
-      params:
-        silent: true
-        working_dir: evergreen
-        env:
-          GITHUB_TOKEN: ${github_token}
-          GITHUB_APP_ID: ${staging_github_app_id}
-          GITHUB_APP_KEY: ${staging_github_app_key}
-          JIRA_SERVER: ${jiraserver}
-          CROWD_SERVER: ${crowdserver}
-          AWS_KEY: ${aws_key}
-          AWS_SECRET: ${aws_secret}
-          PARSER_PROJECT_S3_PREFIX: ${task_id}/parser-projects
-          GENERATED_JSON_S3_PREFIX: ${task_id}/generated-json
-          JIRA_PRIVATE_KEY: ${jira_private_key}
-          JIRA_ACCESS_TOKEN: ${jira_access_token}
-          JIRA_TOKEN_SECRET: ${jira_token_secret}
-          JIRA_CONSUMER_KEY: ${jira_consumer_key}
-        command: bash scripts/setup-credentials.sh
-
+    command: subprocess.exec
+    type: setup
+    params:
+      silent: true
+      working_dir: evergreen
+      env:
+        GITHUB_TOKEN: ${github_token}
+        GITHUB_APP_ID: ${staging_github_app_id}
+        GITHUB_APP_KEY: ${staging_github_app_key}
+        JIRA_SERVER: ${jiraserver}
+        CROWD_SERVER: ${crowdserver}
+        AWS_KEY: ${aws_key}
+        AWS_SECRET: ${aws_secret}
+        PARSER_PROJECT_S3_PREFIX: ${task_id}/parser-projects
+        GENERATED_JSON_S3_PREFIX: ${task_id}/generated-json
+        JIRA_PRIVATE_KEY: ${jira_private_key}
+        JIRA_ACCESS_TOKEN: ${jira_access_token}
+        JIRA_TOKEN_SECRET: ${jira_token_secret}
+        JIRA_CONSUMER_KEY: ${jira_consumer_key}
+      command: bash scripts/setup-credentials.sh
   setup-mongodb:
     - command: subprocess.exec
       type: setup

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -277,10 +277,14 @@ func MockConfig() *evergreen.Settings {
 				DefaultSecurityGroup: "test_security_group",
 				MaxVolumeSizePerUser: 200,
 				BinaryClient: evergreen.S3Credentials{
+					Key:    "client_key",
+					Secret: "client_secret",
 					Bucket: "client_bucket",
 				},
 				ParserProject: evergreen.ParserProjectS3Config{
 					S3Credentials: evergreen.S3Credentials{
+						Key:    "parser_project_key",
+						Secret: "parser_project_secret",
 						Bucket: "parser_project_bucket",
 					},
 					Prefix: "parser_project_prefix",


### PR DESCRIPTION
This reverts commit c21f9493dd9cdd6878d9a06d10aba95cbf994a42.

This was causing error rate alerts when it was deployed and PRs weren't processing. Will confirm that it passes compile and tests, then merge the revert.