### PR TITLE
DEVPROD-3085 Check for copied include files

### DIFF
--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -637,8 +637,13 @@ func TestMakePatchedConfigRenamed(t *testing.T) {
 	assert.Equal(t, intermediateProject.BuildVariants[0].DisplayName, "Included variant!!!")
 }
 
-func TestParseRenamedFile(t *testing.T) {
+func TestParseRenamedOrCopiedFile(t *testing.T) {
 	patchContents := `
+diff --git a/include2.yml b/copiedInclude.yml
+similarity index 100%
+copy from include2.yml
+copy to copiedInclude.yml
+
 diff --git a/evergreen.yml b/evergreen.yml
 index a45dff8..83a8f81 100644
 --- a/evergreen.yml
@@ -657,7 +662,10 @@ similarity index 100%
 rename from include2.yml
 rename to rename2.yml
 `
-	renamedFile := parseRenamedFile(patchContents, "rename2.yml")
+	renamedFile := parseRenamedOrCopiedFile(patchContents, "rename2.yml")
+	assert.Equal(t, renamedFile, "include2.yml")
+
+	renamedFile = parseRenamedOrCopiedFile(patchContents, "copiedInclude.yml")
 	assert.Equal(t, renamedFile, "include2.yml")
 
 	patchContents = `
@@ -674,7 +682,7 @@ index 865a6ec..990824f 100644
      activate: true
      run_on:`
 
-	renamedFile = parseRenamedFile(patchContents, "include1.yml")
+	renamedFile = parseRenamedOrCopiedFile(patchContents, "include1.yml")
 	assert.Equal(t, renamedFile, "")
 
 	patchContents = `
@@ -707,7 +715,7 @@ index 748e345..7e70f15 100644
      activate: true
      run_on:`
 
-	renamedFile = parseRenamedFile(patchContents, "renamed.yml")
+	renamedFile = parseRenamedOrCopiedFile(patchContents, "renamed.yml")
 	assert.Equal(t, renamedFile, "include1.yml")
 }
 


### PR DESCRIPTION
DEVPROD-3085

### Description
#7452 fixed an issue where Evergreen couldn't process renamed include files because it was trying to fetch the newly renamed include file from git, which didn't yet exist.

As it turns out, if you set `diff.renames=copies` in your local git config, the created .patch file will not say "rename from <filename>", but "copy from <filename>". #7452 only checks for renamed files, so the above issue was still surfacing for a user who had `diff.renames=copies` set. They were able to workaround by unsetting the field, but we should be able to handle this case.

### Testing
Added some unit tests, and reproduced the issue with a locally created patch file. Confirmed I was able to submit a patch [successfully](https://evergreen-staging.corp.mongodb.com/filediff/65c67c009dbe324c21a0e67f/?patch_number=0) once this change was deployed to staging.

**_Note_**: This could also have just been resolved with a 1-line change, by prepending `args = append(args, "-c", "diff.renames=true")` on [this line](https://gist.github.com/hadjri/3cbe41c64504dff36e7185617e80d02d#file-patch_util-go-L891), which would unset copy detection automatically when running git diff commands locally, but I decided against this since it'd create a potential divergence between the git diff the user sees locally, and the git diff they find in the Evergreen UI. The solution in this PR prevents us from interfering with how users choose to locally configure their git.