### PR TITLE
DEVPROD-719 Update local aliases to use same tag logic as project aliases

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1460,10 +1460,11 @@ func (p *Project) findMatchingBuildVariants(bvRegex *regexp.Regexp) []string {
 func (p *Project) findBuildVariantsWithTag(tags []string) []string {
 	var res []string
 	for _, b := range p.BuildVariants {
-		if len(utility.StringSliceIntersection(b.Tags, tags)) > 0 {
+		if isValidRegexOrTag(b.Name, b.Tags, tags, nil) {
 			res = append(res, b.Name)
 		}
 	}
+
 	return res
 }
 
@@ -1547,7 +1548,7 @@ func (p *Project) getNumCheckRuns(taskName, variantName string) int {
 func (p *Project) findProjectTasksWithTag(tags []string) []string {
 	var res []string
 	for _, t := range p.Tasks {
-		if len(utility.StringSliceIntersection(t.Tags, tags)) > 0 {
+		if isValidRegexOrTag(t.Name, t.Tags, tags, nil) {
 			res = append(res, t.Name)
 		}
 	}


### PR DESCRIPTION

DEVPROD-719

### Description
negation tags weren't working with local aliases because it never checked for it 
now the logic for checking the tags is same for local and project aliases

### Testing
created a local alias with [ !smoke ] and ran this command and created a patch with tasks that don't have the smoke tag

`❯ evergreen patch -u -p mci -a testing
Banner: Please be careful about enabling staging projects that track real GitHub repositories
Set [.!smoke] as the default tasks for project 'mci'? (y/N) 
Enter a description for this patch (optional): 
 model/project.go         | 5 +++--
 operations/patch_util.go | 6 ++++++
 units/patch_intent.go    | 4 ++++
 3 files changed, 13 insertions(+), 2 deletions(-)
This is a summary of the patch to be submitted. Continue? (Y/n) 
Patch successfully created.

         ID : 65cd31e515df6c0007741ac3
    Project : evg
    Created : 2024-02-14 21:34:29.742 +0000 UTC
Description : DEVPROD-719: docs: provide better explanation for cron (#7528)
      Build : https://evergreen-staging.corp.mongodb.com/patch/65cd31e515df6c0007741ac3?redirect_spruce_users=true
     Status : created`