### PR TITLE
DEVPROD-4739: fix dependency inclusion for disabled tasks in task groups

### DIFF
--- a/model/dependency.go
+++ b/model/dependency.go
@@ -112,10 +112,10 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 	}
 
 	if bvt.SkipOnRequester(di.requester) {
-		// TODO (DEVPROD-XXX): it seems like this should not include the task,
+		// TODO (DEVPROD-4776): it seems like this should not include the task,
 		// but should not error either. When checking dependencies, it simply
-		// skips tasks whose requester doesn't apply, so tasks should be treated
-		// much the same.
+		// skips tasks whose requester doesn't apply, so it should probably just
+		// return false and no error here.
 		di.included[pair] = false
 		return false, errors.Errorf("task '%s' in variant '%s' cannot be run for a '%s'", pair.TaskName, pair.Variant, di.requester)
 	}

--- a/model/dependency.go
+++ b/model/dependency.go
@@ -89,19 +89,17 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 			// If there are some tasks in the task group that cannot be
 			// scheduled but others can, add only those tasks within task group
 			// that are schedulable.
-			di.included[TVPair{TaskName: t, Variant: pair.Variant}] = ok
-			if !ok {
-				// kim: TODO: verify that it's okay to not error out here for
-				// ok=false and no error.
-				di.included[pair] = false
-			}
+			// di.included[TVPair{TaskName: t, Variant: pair.Variant}] = ok
+			// if !ok {
+			//     di.included[pair] = false
+			// }
 			if err != nil {
 				return false, errors.Wrapf(err, "task group '%s' in variant '%s' contains unschedulable task '%s'", pair.TaskName, pair.Variant, t)
 			}
 			// TODO (DEVPROD-4739): delete this debug log after confirming that
 			// it doesn't cause issues.
 			grip.DebugWhen(!ok && err == nil, message.Fields{
-				"message":              "a task in a task group is disabled",
+				"message":              "not including a task in a task group that's disabled",
 				"ticket":               "DEVPROD-4739",
 				"task_group_task_name": t,
 				"build_variant":        pair.Variant,
@@ -132,14 +130,6 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 
 	if bvt.IsDisabled() {
 		di.included[pair] = false
-		// kim: NOTE: this is the error line because some of the tasks in the
-		// task group are disabled. This should be allowed, but we need to
-		// verify that returning no error here is okay. Need to make sure this
-		// isn't causing a conflict with something else.
-		// return false, errors.Errorf("task '%s' in variant '%s' has been disabled", pair.TaskName, pair.Variant)
-
-		// kim: NOTE: If a task is disabled, don't include it but it's also not
-		// an error.
 		return false, nil
 	}
 

--- a/model/dependency.go
+++ b/model/dependency.go
@@ -88,7 +88,7 @@ func (di *dependencyIncluder) handle(pair TVPair, activationInfo *specificActiva
 
 			// If there are some tasks in the task group that cannot be
 			// scheduled but others can, add only those tasks within task group
-			// that are schedulable (but not the entire task group).
+			// that are schedulable.
 			di.included[TVPair{TaskName: t, Variant: pair.Variant}] = ok
 			if !ok {
 				// kim: TODO: verify that it's okay to not error out here for

--- a/model/dependency_test.go
+++ b/model/dependency_test.go
@@ -63,10 +63,6 @@ func TestDependencyBSON(t *testing.T) {
 	})
 }
 
-// kim: TODO: add test for IncludeDependencies when a task group has a mix of
-// vanilla and disabled tasks.
-// kim: TODO: add test for IncludeDependencies when a task group has a mix of
-// vanilla and patch_only tasks.
 func TestIncludeDependencies(t *testing.T) {
 	Convey("With a project task config with cross-variant dependencies", t, func() {
 		parserProject := &ParserProject{
@@ -302,6 +298,7 @@ func TestIncludeDependencies(t *testing.T) {
 		pairs, _ := IncludeDependencies(p, []TVPair{initDep}, evergreen.PatchVersionRequester, nil)
 		So(pairs, ShouldHaveLength, 2)
 		So(initDep, ShouldBeIn, pairs)
+		So(TVPair{TaskName: "b", Variant: "variant-with-group"}, ShouldBeIn, pairs)
 	})
 	Convey("With a disabled task", t, func() {
 		parserProject := &ParserProject{
@@ -342,6 +339,7 @@ func TestIncludeDependencies(t *testing.T) {
 		pairs, _ := IncludeDependencies(p, []TVPair{tgTaskPair}, evergreen.PatchVersionRequester, nil)
 		So(pairs, ShouldHaveLength, 2)
 		So(pairs, ShouldNotContain, tgTaskPair)
+		So(pairs, ShouldNotContain, TVPair{TaskName: "c", Variant: "bv-with-group"})
 		So(pairs, ShouldEqual, []TVPair{{TaskName: "a", Variant: "bv-with-group"}, {TaskName: "b", Variant: "bv-with-group"}})
 	})
 }

--- a/model/dependency_test.go
+++ b/model/dependency_test.go
@@ -63,6 +63,10 @@ func TestDependencyBSON(t *testing.T) {
 	})
 }
 
+// kim: TODO: add test for IncludeDependencies when a task group has a mix of
+// vanilla and disabled tasks.
+// kim: TODO: add test for IncludeDependencies when a task group has a mix of
+// vanilla and patch_only tasks.
 func TestIncludeDependencies(t *testing.T) {
 	Convey("With a project task config with cross-variant dependencies", t, func() {
 		parserProject := &ParserProject{

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -148,9 +148,6 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 	}
 
 	patchVariantTasks := tasks.TVPairsToVariantTasks()
-	// kim: NOTE: e2e_nds_local_serverless_backup is missing from patch's stored
-	// variant tasks list, meaning the variant got lost somewhere along the way
-	// (in IncludeDependencies).
 	if len(patchVariantTasks) > 0 {
 		if err = p.SetVariantsTasks(patchVariantTasks); err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "setting description")

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -149,7 +149,8 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 
 	patchVariantTasks := tasks.TVPairsToVariantTasks()
 	// kim: NOTE: e2e_nds_local_serverless_backup is missing from patch's stored
-	// variant tasks list, meaning it got lost somewhere along the way.
+	// variant tasks list, meaning the variant got lost somewhere along the way
+	// (in IncludeDependencies).
 	if len(patchVariantTasks) > 0 {
 		if err = p.SetVariantsTasks(patchVariantTasks); err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "setting description")

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -148,6 +148,8 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 	}
 
 	patchVariantTasks := tasks.TVPairsToVariantTasks()
+	// kim: NOTE: e2e_nds_local_serverless_backup is missing from patch's stored
+	// variant tasks list, meaning it got lost somewhere along the way.
 	if len(patchVariantTasks) > 0 {
 		if err = p.SetVariantsTasks(patchVariantTasks); err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "setting description")

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -585,7 +585,7 @@ func TestMakePatchedConfigEmptyBase(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, project)
 
-	assert.Len(t, project.Tasks, 1)
+	require.Len(t, project.Tasks, 1)
 	assert.Equal(t, project.Tasks[0].Name, "hello")
 }
 


### PR DESCRIPTION
DEVPROD-4739

### Description
This fixes an issue where if you have a task within a task group that's disabled, then try to schedule it using the schedule patch REST route, it won't schedule the task group or return any error. This normally isn't a problem you encounter when you configure a patch in Spruce because it already auto-filters out disabled tasks from your selection choices.

* Allow task groups with some disabled tasks to be scheduled.
* Continue on error in more cases rather than exit early (to ensure later tasks in a list get scheduled even if there are errors for other tasks).
* Add a TODO for a similar bug (but for requesters instead of disable).

### Testing
* Add unit tests for patch configure route and dependency inclusion for partly-disabled task group tasks.
* Tested manually by submitting [a patch to prod](https://spruce.mongodb.com/patch/65ce36b05623432adc5c7d92/configure/tasks) and then [a patch to staging](https://spruce-staging.corp.mongodb.com/version/65ce37e1a7889000079fc418/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). I used the patch configure route on both to try to schedule the task group and it succeeded in staging once I applied my fix.

### Documentation
N/A