### PR TITLE
DEVPROD-4767: support tenancy option for host.create

### DIFF
--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -36,7 +37,7 @@ func (s *createHostSuite) SetupSuite() {
 	s.conf = &internal.TaskConfig{
 		Expansions: util.Expansions{
 			"subnet_id": "subnet-123456",
-			"tenancy":   "dedicated",
+			"tenancy":   string(evergreen.EC2TenancyDedicated),
 		},
 		Task:    task.Task{Id: "mock_id", Secret: "mock_secret"},
 		Project: model.Project{}}
@@ -107,7 +108,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDistro", s.cmd.CreateHost.Distro)
 	s.Equal("task", s.cmd.CreateHost.Scope)
 	s.Equal("subnet-123456", s.cmd.CreateHost.Subnet)
-	s.Equal("dedicated", s.cmd.CreateHost.Tenancy)
+	s.Equal(evergreen.EC2TenancyDedicated, s.cmd.CreateHost.Tenancy)
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//parse from YAML file
@@ -125,7 +126,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDistro", s.cmd.CreateHost.Distro)
 	s.Equal("task", s.cmd.CreateHost.Scope)
 	s.Equal("subnet-123456", s.cmd.CreateHost.Subnet)
-	s.Equal("dedicated", s.cmd.CreateHost.Tenancy)
+	s.Equal(evergreen.EC2TenancyDedicated, s.cmd.CreateHost.Tenancy)
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//test with both file and other params

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -86,7 +86,6 @@ func (s *createHostSuite) TestParseFromFile() {
 		},
 	}
 	path := filepath.Join(tmpdir, "example.json")
-	const tenancy = "dedicated"
 	fileContent := map[string]interface{}{
 		"distro":           "myDistro",
 		"scope":            "task",

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -136,16 +136,20 @@ type CreateHost struct {
 	Retries             int    `mapstructure:"retries" json:"retries" yaml:"retries"`
 
 	// EC2-related settings
-	AMI             string      `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
-	Distro          string      `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
-	EBSDevices      []EbsDevice `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
-	InstanceType    string      `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
-	IPv6            bool        `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
-	Region          string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
-	SecurityGroups  []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
-	Subnet          string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
-	UserdataFile    string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
-	UserdataCommand string      `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`
+	AMI            string      `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
+	Distro         string      `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
+	EBSDevices     []EbsDevice `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
+	InstanceType   string      `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
+	IPv6           bool        `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
+	Region         string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
+	SecurityGroups []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
+	Subnet         string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
+	// kim: TODO: test
+	Tenancy      string `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
+	UserdataFile string `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
+	// UserdataCommand is the content of the userdata file. Users can't actually
+	// set this directly, instead they pass in a userdata file.
+	UserdataCommand string `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`
 
 	// docker-related settings
 	Image                    string           `mapstructure:"image" json:"image" yaml:"image" plugin:"expand"`
@@ -242,6 +246,9 @@ func (ch *CreateHost) validateEC2() error {
 		if ch.Subnet == "" {
 			catcher.New("subnet ID must be set if AMI is set")
 		}
+	}
+	if ch.Tenancy != "" {
+		catcher.NewWhen(ch.Tenancy != "default" && ch.Tenancy != "dedicated" && ch.Tenancy != "host", "if set, tenancy must be 'default', 'shared', or dedicated'")
 	}
 
 	return catcher.Resolve()

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -144,9 +144,8 @@ type CreateHost struct {
 	Region         string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
 	SecurityGroups []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
 	Subnet         string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
-	// kim: TODO: test
-	Tenancy      string `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
-	UserdataFile string `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
+	Tenancy        string      `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
+	UserdataFile   string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
 	// UserdataCommand is the content of the userdata file. Users can't actually
 	// set this directly, instead they pass in a userdata file.
 	UserdataCommand string `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -136,16 +136,16 @@ type CreateHost struct {
 	Retries             int    `mapstructure:"retries" json:"retries" yaml:"retries"`
 
 	// EC2-related settings
-	AMI            string      `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
-	Distro         string      `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
-	EBSDevices     []EbsDevice `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
-	InstanceType   string      `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
-	IPv6           bool        `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
-	Region         string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
-	SecurityGroups []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
-	Subnet         string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
-	Tenancy        string      `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
-	UserdataFile   string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
+	AMI            string               `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
+	Distro         string               `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
+	EBSDevices     []EbsDevice          `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
+	InstanceType   string               `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
+	IPv6           bool                 `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
+	Region         string               `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
+	SecurityGroups []string             `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
+	Subnet         string               `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
+	Tenancy        evergreen.EC2Tenancy `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
+	UserdataFile   string               `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
 	// UserdataCommand is the content of the userdata file. Users can't actually
 	// set this directly, instead they pass in a userdata file.
 	UserdataCommand string `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`
@@ -247,7 +247,7 @@ func (ch *CreateHost) validateEC2() error {
 		}
 	}
 	if ch.Tenancy != "" {
-		catcher.NewWhen(ch.Tenancy != "default" && ch.Tenancy != "dedicated" && ch.Tenancy != "host", "if set, tenancy must be 'default', 'shared', or dedicated'")
+		catcher.ErrorfWhen(!evergreen.IsValidEC2Tenancy(ch.Tenancy), "invalid tenancy '%s', allowed values are: %s", ch.Tenancy, evergreen.ValidEC2Tenancies)
 	}
 
 	return catcher.Resolve()

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -54,7 +54,7 @@ type EC2ProviderSettings struct {
 
 	// Tenancy, if set, determines how EC2 instances are distributed across
 	// physical hardware.
-	Tenancy string `mapstructure:"tenancy" json:"tenancy,omitempty" bson:"tenancy,omitempty"`
+	Tenancy evergreen.EC2Tenancy `mapstructure:"tenancy" json:"tenancy,omitempty" bson:"tenancy,omitempty"`
 
 	// VpcName is used to get the subnet ID automatically. Either subnet id or vpc name must set.
 	VpcName string `mapstructure:"vpc_name" json:"vpc_name,omitempty" bson:"vpc_name,omitempty"`
@@ -97,7 +97,7 @@ func (s *EC2ProviderSettings) Validate() error {
 	}
 
 	if s.Tenancy != "" {
-		catcher.NewWhen(s.Tenancy != "default" && s.Tenancy != "dedicated" && s.Tenancy != "host", "if set, tenancy must be 'default', 'shared', or dedicated'")
+		catcher.ErrorfWhen(!evergreen.IsValidEC2Tenancy(s.Tenancy), "invalid tenancy '%s', allowed values are: %s", s.Tenancy, evergreen.ValidEC2Tenancies)
 	}
 
 	_, err := makeBlockDeviceMappings(s.MountPoints)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -52,6 +52,10 @@ type EC2ProviderSettings struct {
 	// SubnetId is only set in a VPC. Either subnet id or vpc name must set.
 	SubnetId string `mapstructure:"subnet_id" json:"subnet_id,omitempty" bson:"subnet_id,omitempty"`
 
+	// Tenancy, if set, determines how EC2 instances are distributed across
+	// physical hardware.
+	Tenancy string `mapstructure:"tenancy" json:"tenancy,omitempty" bson:"tenancy,omitempty"`
+
 	// VpcName is used to get the subnet ID automatically. Either subnet id or vpc name must set.
 	VpcName string `mapstructure:"vpc_name" json:"vpc_name,omitempty" bson:"vpc_name,omitempty"`
 
@@ -90,6 +94,10 @@ func (s *EC2ProviderSettings) Validate() error {
 
 	if s.IsVpc && s.SubnetId == "" {
 		catcher.New("must set a default subnet for a VPC")
+	}
+
+	if s.Tenancy != "" {
+		catcher.NewWhen(s.Tenancy != "default" && s.Tenancy != "dedicated" && s.Tenancy != "host", "if set, tenancy must be 'default', 'shared', or dedicated'")
 	}
 
 	_, err := makeBlockDeviceMappings(s.MountPoints)
@@ -275,6 +283,9 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		}
 	} else {
 		input.SecurityGroups = ec2Settings.SecurityGroupIDs
+	}
+	if ec2Settings.Tenancy != "" {
+		input.Placement = &types.Placement{Tenancy: types.Tenancy(ec2Settings.Tenancy)}
 	}
 
 	if ec2Settings.UserData != "" {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-12"
+	AgentVersion = "2024-02-15"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -607,7 +607,8 @@ EC2 Parameters:
     the distro configuration.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
 -   `tenancy` - If set, defines how the hosts are distributed across
-    physical hardware. Can be set to `default`, `dedicated`, or `host`.
+    physical hardware. Can be set to `default`, `dedicated`, or `host`. If not
+    set, it uses shared tenancy by default.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the
     distro configuration. May set if distro is not set.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -608,7 +608,7 @@ EC2 Parameters:
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
 -   `tenancy` - If set, defines how the hosts are distributed across
     physical hardware. Can be set to `default`, `dedicated`, or `host`. If not
-    set, it uses shared tenancy by default.
+    set, it uses the `default` (i.e. shared) tenancy.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the
     distro configuration. May set if distro is not set.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -606,7 +606,7 @@ EC2 Parameters:
     set. May set if `distro` is set, which will override the value from
     the distro configuration.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
--   `tenancy` - If set, defines how EC2 instances  are distributed across
+-   `tenancy` - If set, defines how the hosts are distributed across
     physical hardware. Can be set to `default`, `dedicated`, or `host`.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -606,6 +606,8 @@ EC2 Parameters:
     set. May set if `distro` is set, which will override the value from
     the distro configuration.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
+-   `tenancy` - If set, defines how EC2 instances  are distributed across
+    physical hardware. Can be set to `default`, `dedicated`, or `host`.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the
     distro configuration. May set if distro is not set.

--- a/globals.go
+++ b/globals.go
@@ -590,6 +590,23 @@ func IsDockerProvider(provider string) bool {
 		provider == ProviderNameDockerMock
 }
 
+// EC2Tenancy represents the physical hardware tenancy for EC2 hosts.
+type EC2Tenancy string
+
+const (
+	EC2TenancyDefault   EC2Tenancy = "default"
+	EC2TenancyDedicated EC2Tenancy = "dedicated"
+	EC2TenancyHost      EC2Tenancy = "host"
+)
+
+// ValidEC2Tenancies represents valid EC2 tenancy values.
+var ValidEC2Tenancies = []EC2Tenancy{EC2TenancyDefault, EC2TenancyDedicated, EC2TenancyHost}
+
+// IsValidEC2Tenancy returns if the given EC2 tenancy is valid.
+func IsValidEC2Tenancy(tenancy EC2Tenancy) bool {
+	return len(utility.FilterSlice(ValidEC2Tenancies, func(t EC2Tenancy) bool { return t == tenancy })) > 0
+}
+
 var (
 	// ProviderSpawnable includes all cloud provider types where hosts can be
 	// dynamically created and terminated according to need. This has no

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -375,6 +375,10 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, evergreen.GetEnvironment().Settings().Providers.AWS.DefaultSecurityGroup)
 	}
 
+	if createHost.Tenancy != "" {
+		ec2Settings.Tenancy = createHost.Tenancy
+	}
+
 	ec2Settings.IPv6 = createHost.IPv6
 	ec2Settings.IsVpc = true // task-spawned hosts do not support ec2 classic
 

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -180,7 +180,7 @@ func TestMakeHost(t *testing.T) {
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
 		Subnet:              "subnet-123456",
-		Tenancy:             "dedicated",
+		Tenancy:             evergreen.EC2TenancyDedicated,
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -198,7 +198,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Equal("dedicated", ec2Settings.Tenancy)
+	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings.Tenancy)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
 
@@ -207,7 +207,7 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
-	assert.Equal("dedicated", ec2Settings2.Tenancy)
+	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings2.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// bring your own ami
@@ -221,7 +221,7 @@ func TestMakeHost(t *testing.T) {
 		InstanceType:        "t1.micro",
 		Subnet:              "subnet-123456",
 		SecurityGroups:      []string{"1234"},
-		Tenancy:             "dedicated",
+		Tenancy:             evergreen.EC2TenancyDedicated,
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -240,7 +240,7 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-654321", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
-	assert.Equal("dedicated", ec2Settings.Tenancy)
+	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// with multiple regions

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -180,6 +180,7 @@ func TestMakeHost(t *testing.T) {
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
 		Subnet:              "subnet-123456",
+		Tenancy:             "dedicated",
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -197,6 +198,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
+	assert.Equal("dedicated", ec2Settings.Tenancy)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
 
@@ -205,6 +207,7 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
+	assert.Equal("dedicated", ec2Settings2.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// bring your own ami
@@ -218,6 +221,7 @@ func TestMakeHost(t *testing.T) {
 		InstanceType:        "t1.micro",
 		Subnet:              "subnet-123456",
 		SecurityGroups:      []string{"1234"},
+		Tenancy:             "dedicated",
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -236,6 +240,7 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-654321", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
+	assert.Equal("dedicated", ec2Settings.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// with multiple regions

--- a/util/expand_params_test.go
+++ b/util/expand_params_test.go
@@ -76,6 +76,21 @@ func TestExpandValues(t *testing.T) {
 
 		})
 
+		Convey("if any field of the input struct has a custom string type and has the appropriate tag, it should be expanded", func() {
+
+			type customType string
+			type s struct {
+				FieldOne customType `plugin:"expand"`
+			}
+
+			s1 := &s{
+				FieldOne: "yo ${exp2|yo}",
+			}
+
+			So(ExpandValues(s1, expansions), ShouldBeNil)
+			So(string(s1.FieldOne), ShouldEqual, "yo yo")
+		})
+
 		Convey("any nested structs tagged as expandable should have their"+
 			" fields expanded appropriately", func() {
 


### PR DESCRIPTION
DEVPROD-4767

### Description
Allow users to specify the EC2 host [tenancy option](https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-dedicated-instances.html) for host.create. Will add a follow-up PR in Shrub to add the new option once this is merged.

### Testing
* Added unit tests.
* Verified in staging that [a task could start an EC2 host.create host with tenancy set](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_kim_task_patch_3a552c8209cca308b80b52627897a8cec3000e2b_65ce55f7b8f8990007c8930c_24_02_15_18_20_39/logs?execution=1). I also double-checked that `aws ec2 describe-instances` for the instance shows its tenancy is `dedicated` (the custom value I set in the task) instead of `shared` (the default).

### Documentation
Updated docs.
