### PR TITLE
DEVPROD-4913: add back support for EC2 key in create.host

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -146,6 +146,7 @@ type CreateHost struct {
 	Subnet         string               `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
 	Tenancy        evergreen.EC2Tenancy `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
 	UserdataFile   string               `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
+	KeyName        string               `mapstructure:"key_name" json:"key_name" yaml:"key_name" plugin:"expand"`
 	// UserdataCommand is the content of the userdata file. Users can't actually
 	// set this directly, instead they pass in a userdata file.
 	UserdataCommand string `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-15"
+	AgentVersion = "2024-02-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -601,6 +601,7 @@ EC2 Parameters:
     distro configuration.
 -   `ipv6`- Set to true if instance should have _only_ an
     IPv6 address, rather than a public IPv4 address.
+-   `key_name` - EC2 key name.
 -   `region` - EC2 region. Default is the same as Evergreen's default.
 -   `security_group_ids` - List of security groups. Must set if `ami` is
     set. May set if `distro` is set, which will override the value from

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -359,7 +359,7 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 		ec2Settings.InstanceType = createHost.InstanceType
 	}
 	if userID == "" {
-		ec2Settings.KeyName = "" // never use the distro's key
+		ec2Settings.KeyName = createHost.KeyName // never use the distro's key
 	}
 	if createHost.Subnet != "" {
 		ec2Settings.SubnetId = createHost.Subnet

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -75,6 +75,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -94,7 +95,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	// test roundtripping
@@ -105,7 +106,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
-	assert.Empty(ec2Settings2.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// scope to build
@@ -122,6 +123,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "build",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -133,7 +135,7 @@ func TestMakeHost(t *testing.T) {
 	ec2Settings = &cloud.EC2ProviderSettings{}
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("build-id", h.SpawnOptions.BuildID)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	assert.Equal("archlinux-test", h.Distro.Id)
@@ -149,6 +151,7 @@ func TestMakeHost(t *testing.T) {
 		Scope:               "task",
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
+		KeyName:             "mock_key",
 	}
 	handler.createHost = c
 	handler.taskID = "task-id"
@@ -168,7 +171,7 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Empty(ec2Settings.KeyName)
+	assert.Equal("mock_key", ec2Settings.KeyName)
 	assert.Equal(true, ec2Settings.IsVpc)
 
 	// override some evergreen distro settings


### PR DESCRIPTION
DEVPROD-4913

### Description
We need to support this feature for the `buildhost-configuration` project. They do not need to pass in an AWS key/secret since the they are ultimately using the default AWS account.

### Testing
Updated unit tests. Ran a [patch in staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_test_cloud_patch_6e38484f356fbfb89f6627e970131afc3be49763_65cf87f8b2373662f5973933_24_02_16_16_06_56/logs?execution=1&logtype=task&sortBy=STATUS&sortDir=ASC) where I set the `key_name` field in the `host.create` command called in the `test-cloud` task. I verified via the AWS console that the spawn was launched with the `mcipacker` ssh key:

![Screenshot 2024-02-16 at 3 09 00 PM](https://github.com/evergreen-ci/evergreen/assets/16562432/984ef9cf-722b-4d76-a547-37117193c2f5)


### Documentation
Updated user-facing docs.
