### PR TITLE
DEVPROD-4739: fix flaky dependency test

### DIFF
--- a/model/dependency_test.go
+++ b/model/dependency_test.go
@@ -340,6 +340,7 @@ func TestIncludeDependencies(t *testing.T) {
 		So(pairs, ShouldHaveLength, 2)
 		So(pairs, ShouldNotContain, tgTaskPair)
 		So(pairs, ShouldNotContain, TVPair{TaskName: "c", Variant: "bv-with-group"})
-		So(pairs, ShouldEqual, []TVPair{{TaskName: "a", Variant: "bv-with-group"}, {TaskName: "b", Variant: "bv-with-group"}})
+		So(pairs, ShouldContain, TVPair{TaskName: "a", Variant: "bv-with-group"})
+		So(pairs, ShouldContain, TVPair{TaskName: "b", Variant: "bv-with-group"})
 	})
 }


### PR DESCRIPTION
DEVPROD-4739

This test is flaky because goconvey needs the order of slice elements to match exactly. I fixed the test to not depend on the order of the elements in the slice.