### PR TITLE
DEVPROD-3873 Allow container image to use project variable

### DIFF
--- a/docs/Containers/Container-Tasks.md
+++ b/docs/Containers/Container-Tasks.md
@@ -191,7 +191,7 @@ containers:
       
   - name: example-small-container
     working_dir: /
-    image: "557821124784.dkr.ecr.us-east-1.amazonaws.com/evergreen/other_repo:&lt;hash&gt;"
+    image: ${image_project_variable}
     size: small-container
     system:
       cpu_architecture: x86_64
@@ -212,7 +212,7 @@ Fields:
     build them into a container registry. Defining arbitrary
     Dockerfiles will be unsupported to start as we need to vet them as
     we scope out the best image-building primitives that are both
-    sustainable and secure.
+    sustainable and secure. (**_note_**: this field can be expanded by project variables)
 
 -   **resources**: the resources allocated to the container: cpu and
     memory_mb set the CPU units and the memory (in MB), respectively,

--- a/model/project.go
+++ b/model/project.go
@@ -431,7 +431,7 @@ type ParameterInfo struct {
 type Container struct {
 	Name       string              `yaml:"name" bson:"name"`
 	WorkingDir string              `yaml:"working_dir,omitempty" bson:"working_dir"`
-	Image      string              `yaml:"image" bson:"image"`
+	Image      string              `yaml:"image" bson:"image" plugin:"expand"`
 	Size       string              `yaml:"size,omitempty" bson:"size"`
 	Credential string              `yaml:"credential,omitempty" bson:"credential"`
 	Resources  *ContainerResources `yaml:"resources,omitempty" bson:"resources"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1006,7 +1006,7 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 	buildVariants, errs := GetVariantsWithMatrices(ase, pp.Axes, pp.BuildVariants)
 	catcher.Extend(errs)
 	vse := NewVariantSelectorEvaluator(buildVariants, ase)
-	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups, pp.Containers)
+	proj.Tasks, proj.TaskGroups, errs = evaluateTaskUnits(tse, tgse, vse, pp.Tasks, pp.TaskGroups)
 	catcher.Extend(errs)
 
 	proj.BuildVariants, errs = evaluateBuildVariants(tse, tgse, vse, buildVariants, pp.Tasks, proj.TaskGroups)
@@ -1070,7 +1070,7 @@ func sieveMatrixVariants(bvs []parserBV) (regular []parserBV, matrices []matrix)
 // evaluateTaskUnits translates intermediate tasks into true ProjectTask types,
 // evaluating any selectors in the DependsOn field.
 func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
-	pts []parserTask, tgs []parserTaskGroup, containers []Container) ([]ProjectTask, []TaskGroup, []error) {
+	pts []parserTask, tgs []parserTaskGroup) ([]ProjectTask, []TaskGroup, []error) {
 	tasks := []ProjectTask{}
 	groups := []TaskGroup{}
 	var evalErrs, errs []error

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2884,7 +2884,7 @@ func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, container
 		image := container.Image
 		if expansions != nil {
 			image, err = expansions.ExpandString(container.Image)
-			catcher.Add(errors.Wrap(err, "expanding container image"))
+			catcher.Wrap(err, "expanding container image")
 		}
 		catcher.Add(container.System.Validate())
 		if container.Resources != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2870,7 +2870,22 @@ func GetMessageForPatch(patchID string) (string, error) {
 // on the project admin page.
 func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, containers []Container) error {
 	catcher := grip.NewSimpleCatcher()
+
+	projVars, err := FindMergedProjectVars(pRef.Id)
+	if err != nil {
+		return errors.Wrapf(err, "getting project vars for project '%s'", pRef.Id)
+	}
+	var expansions *util.Expansions
+	if projVars != nil {
+		expansions = util.NewExpansions(projVars.Vars)
+	}
+
 	for _, container := range containers {
+		image := container.Image
+		if expansions != nil {
+			image, err = expansions.ExpandString(container.Image)
+			catcher.Add(errors.Wrap(err, "expanding container image"))
+		}
 		catcher.Add(container.System.Validate())
 		if container.Resources != nil {
 			catcher.Add(container.Resources.Validate(ecsConf))
@@ -2903,7 +2918,7 @@ func ValidateContainers(ecsConf evergreen.ECSConfig, pRef *ProjectRef, container
 		catcher.NewWhen(container.Image == "", "image must be defined")
 		catcher.NewWhen(container.WorkingDir == "", "working directory must be defined")
 		catcher.NewWhen(container.Name == "", "name must be defined")
-		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !util.HasAllowedImageAsPrefix(container.Image, ecsConf.AllowedImages), "image '%s' not allowed", container.Image)
+		catcher.ErrorfWhen(len(ecsConf.AllowedImages) > 0 && !util.HasAllowedImageAsPrefix(image, ecsConf.AllowedImages), "image '%s' not allowed", image)
 	}
 	return catcher.Resolve()
 }

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -898,7 +898,7 @@ buildvariants:
 containers:
   - name: evg-container
     working_dir: /
-    image: "557821124784.dkr.ecr.us-east-1.amazonaws.com/evergreen/production-ecs:1635b8ecdd264fb4f5fde38d88931b4e9a677b06"
+    image: ${container_image}
     resources:
       cpu: 4096
       memory_mb: 8192

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4378,19 +4378,24 @@ func TestValidateContainers(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.Clear(model.ProjectRefCollection))
+			require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
 
 			p := &model.Project{
 				Identifier: "proj",
 				Containers: []model.Container{
 					{
 						Name:       "c1",
-						Image:      "hadjri/evg-container-self-tests",
+						Image:      "${image}",
 						WorkingDir: "/root",
 						Size:       "s1",
 						Credential: "c1",
 					},
 				},
+			}
+
+			projVars := model.ProjectVars{
+				Id:   "proj",
+				Vars: map[string]string{"image": "hadjri/evg-container-self-tests"},
 			}
 
 			ref := &model.ProjectRef{
@@ -4418,6 +4423,7 @@ func TestValidateContainers(t *testing.T) {
 			}
 
 			require.NoError(t, ref.Upsert())
+			require.NoError(t, projVars.Insert())
 			tCase(t, p, ref)
 		})
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4291,7 +4291,7 @@ func TestValidateContainers(t *testing.T) {
 	}
 	assert.NoError(t, evergreen.UpdateConfig(ctx, testutil.TestConfig()))
 	defer func() {
-		assert.NoError(t, db.Clear(model.ProjectRefCollection))
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
 	}()
 	for tName, tCase := range map[string]func(t *testing.T, p *model.Project, ref *model.ProjectRef){
 		"SucceedsWithValidProjectAndRef": func(t *testing.T, p *model.Project, ref *model.ProjectRef) {
@@ -4394,6 +4394,7 @@ func TestValidateContainers(t *testing.T) {
 			}
 
 			ref := &model.ProjectRef{
+				Id:         "proj",
 				Identifier: "proj",
 				ContainerSizeDefinitions: []model.ContainerResources{
 					{
@@ -4416,6 +4417,7 @@ func TestValidateContainers(t *testing.T) {
 				},
 			}
 
+			require.NoError(t, ref.Upsert())
 			tCase(t, p, ref)
 		})
 	}


### PR DESCRIPTION
DEVPROD-3873

### Description
Allow container image URIs to be expanded from project variables. This will allow staging and prod to reference their own ECR repositories and get the staging container variant green again.
### Testing
Tested in staging. The PR checks here can't run, so I scheduled [this patch](https://spruce.mongodb.com/version/65d7b8989ccd4eb556cbb23a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) in prod to represent the build state
