### PR TITLE
DEVPROD-4677 add a temporary Kanopy SSH key

### DIFF
--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -13,7 +13,6 @@ import (
 // underlying provider's implementation.
 type CloudHost struct {
 	Host     *host.Host
-	KeyPath  string
 	CloudMgr Manager
 }
 
@@ -28,12 +27,7 @@ func GetCloudHost(ctx context.Context, host *host.Host, env evergreen.Environmen
 	if err != nil {
 		return nil, err
 	}
-
-	keyPath := ""
-	if host.Distro.SSHKey != "" {
-		keyPath = env.Settings().Keys[host.Distro.SSHKey]
-	}
-	return &CloudHost{host, keyPath, mgr}, nil
+	return &CloudHost{Host: host, CloudMgr: mgr}, nil
 }
 
 func (cloudHost *CloudHost) ModifyHost(ctx context.Context, opts host.HostModifyOptions) error {

--- a/config.go
+++ b/config.go
@@ -57,60 +57,62 @@ type ConfigSection interface {
 // Settings contains all configuration settings for running Evergreen. Settings
 // with the "id" struct tag should implement the ConfigSection interface.
 type Settings struct {
-	Id                  string                  `bson:"_id" json:"id" yaml:"id"`
-	Amboy               AmboyConfig             `yaml:"amboy" bson:"amboy" json:"amboy" id:"amboy"`
-	Api                 APIConfig               `yaml:"api" bson:"api" json:"api" id:"api"`
-	ApiUrl              string                  `yaml:"api_url" bson:"api_url" json:"api_url"`
-	AuthConfig          AuthConfig              `yaml:"auth" bson:"auth" json:"auth" id:"auth"`
-	AWSInstanceRole     string                  `yaml:"aws_instance_role" bson:"aws_instance_role" json:"aws_instance_role"`
-	Banner              string                  `bson:"banner" json:"banner" yaml:"banner"`
-	BannerTheme         BannerTheme             `bson:"banner_theme" json:"banner_theme" yaml:"banner_theme"`
-	Buckets             BucketsConfig           `bson:"buckets" json:"buckets" yaml:"buckets" id:"buckets"`
-	Cedar               CedarConfig             `bson:"cedar" json:"cedar" yaml:"cedar" id:"cedar"`
-	ClientBinariesDir   string                  `yaml:"client_binaries_dir" bson:"client_binaries_dir" json:"client_binaries_dir"`
-	CommitQueue         CommitQueueConfig       `yaml:"commit_queue" bson:"commit_queue" json:"commit_queue" id:"commit_queue"`
-	ConfigDir           string                  `yaml:"configdir" bson:"configdir" json:"configdir"`
-	ContainerPools      ContainerPoolsConfig    `yaml:"container_pools" bson:"container_pools" json:"container_pools" id:"container_pools"`
-	Credentials         map[string]string       `yaml:"credentials" bson:"credentials" json:"credentials"`
-	CredentialsNew      util.KeyValuePairSlice  `yaml:"credentials_new" bson:"credentials_new" json:"credentials_new"`
-	Database            DBSettings              `yaml:"database" json:"database" bson:"database"`
-	DomainName          string                  `yaml:"domain_name" bson:"domain_name" json:"domain_name"`
-	Expansions          map[string]string       `yaml:"expansions" bson:"expansions" json:"expansions"`
-	ExpansionsNew       util.KeyValuePairSlice  `yaml:"expansions_new" bson:"expansions_new" json:"expansions_new"`
-	GithubPRCreatorOrg  string                  `yaml:"github_pr_creator_org" bson:"github_pr_creator_org" json:"github_pr_creator_org"`
-	GithubOrgs          []string                `yaml:"github_orgs" bson:"github_orgs" json:"github_orgs"`
-	DisabledGQLQueries  []string                `yaml:"disabled_gql_queries" bson:"disabled_gql_queries" json:"disabled_gql_queries"`
-	HostInit            HostInitConfig          `yaml:"hostinit" bson:"hostinit" json:"hostinit" id:"hostinit"`
-	HostJasper          HostJasperConfig        `yaml:"host_jasper" bson:"host_jasper" json:"host_jasper" id:"host_jasper"`
-	Jira                JiraConfig              `yaml:"jira" bson:"jira" json:"jira" id:"jira"`
-	JIRANotifications   JIRANotificationsConfig `yaml:"jira_notifications" json:"jira_notifications" bson:"jira_notifications" id:"jira_notifications"`
-	Keys                map[string]string       `yaml:"keys" bson:"keys" json:"keys"`
-	KeysNew             util.KeyValuePairSlice  `yaml:"keys_new" bson:"keys_new" json:"keys_new"`
-	LDAPRoleMap         LDAPRoleMap             `yaml:"ldap_role_map" bson:"ldap_role_map" json:"ldap_role_map"`
-	LoggerConfig        LoggerConfig            `yaml:"logger_config" bson:"logger_config" json:"logger_config" id:"logger_config"`
-	LogPath             string                  `yaml:"log_path" bson:"log_path" json:"log_path"`
-	NewRelic            NewRelicConfig          `yaml:"newrelic" bson:"newrelic" json:"newrelic" id:"newrelic"`
-	Notify              NotifyConfig            `yaml:"notify" bson:"notify" json:"notify" id:"notify"`
-	Plugins             PluginConfig            `yaml:"plugins" bson:"plugins" json:"plugins"`
-	PluginsNew          util.KeyValuePairSlice  `yaml:"plugins_new" bson:"plugins_new" json:"plugins_new"`
-	PodLifecycle        PodLifecycleConfig      `yaml:"pod_lifecycle" bson:"pod_lifecycle" json:"pod_lifecycle" id:"pod_lifecycle"`
-	PprofPort           string                  `yaml:"pprof_port" bson:"pprof_port" json:"pprof_port"`
-	ProjectCreation     ProjectCreationConfig   `yaml:"project_creation" bson:"project_creation" json:"project_creation" id:"project_creation"`
-	Providers           CloudProviders          `yaml:"providers" bson:"providers" json:"providers" id:"providers"`
-	RepoTracker         RepoTrackerConfig       `yaml:"repotracker" bson:"repotracker" json:"repotracker" id:"repotracker"`
-	Scheduler           SchedulerConfig         `yaml:"scheduler" bson:"scheduler" json:"scheduler" id:"scheduler"`
-	ServiceFlags        ServiceFlags            `bson:"service_flags" json:"service_flags" id:"service_flags" yaml:"service_flags"`
-	SSHKeyDirectory     string                  `yaml:"ssh_key_directory" bson:"ssh_key_directory" json:"ssh_key_directory"`
-	SSHKeyPairs         []SSHKeyPair            `yaml:"ssh_key_pairs" bson:"ssh_key_pairs" json:"ssh_key_pairs"`
-	Slack               SlackConfig             `yaml:"slack" bson:"slack" json:"slack" id:"slack"`
-	Splunk              SplunkConfig            `yaml:"splunk" bson:"splunk" json:"splunk" id:"splunk"`
-	TaskLimits          TaskLimitsConfig        `yaml:"task_limits" bson:"task_limits" json:"task_limits" id:"task_limits"`
-	Triggers            TriggerConfig           `yaml:"triggers" bson:"triggers" json:"triggers" id:"triggers"`
-	Ui                  UIConfig                `yaml:"ui" bson:"ui" json:"ui" id:"ui"`
-	Spawnhost           SpawnHostConfig         `yaml:"spawnhost" bson:"spawnhost" json:"spawnhost" id:"spawnhost"`
-	ShutdownWaitSeconds int                     `yaml:"shutdown_wait_seconds" bson:"shutdown_wait_seconds" json:"shutdown_wait_seconds"`
-	Tracer              TracerConfig            `yaml:"tracer" bson:"tracer" json:"tracer" id:"tracer"`
-	GitHubCheckRun      GitHubCheckRunConfig    `yaml:"github_check_run" bson:"github_check_run" json:"github_check_run" id:"github_check_run"`
+	Id                 string                  `bson:"_id" json:"id" yaml:"id"`
+	Amboy              AmboyConfig             `yaml:"amboy" bson:"amboy" json:"amboy" id:"amboy"`
+	Api                APIConfig               `yaml:"api" bson:"api" json:"api" id:"api"`
+	ApiUrl             string                  `yaml:"api_url" bson:"api_url" json:"api_url"`
+	AuthConfig         AuthConfig              `yaml:"auth" bson:"auth" json:"auth" id:"auth"`
+	AWSInstanceRole    string                  `yaml:"aws_instance_role" bson:"aws_instance_role" json:"aws_instance_role"`
+	Banner             string                  `bson:"banner" json:"banner" yaml:"banner"`
+	BannerTheme        BannerTheme             `bson:"banner_theme" json:"banner_theme" yaml:"banner_theme"`
+	Buckets            BucketsConfig           `bson:"buckets" json:"buckets" yaml:"buckets" id:"buckets"`
+	Cedar              CedarConfig             `bson:"cedar" json:"cedar" yaml:"cedar" id:"cedar"`
+	ClientBinariesDir  string                  `yaml:"client_binaries_dir" bson:"client_binaries_dir" json:"client_binaries_dir"`
+	CommitQueue        CommitQueueConfig       `yaml:"commit_queue" bson:"commit_queue" json:"commit_queue" id:"commit_queue"`
+	ConfigDir          string                  `yaml:"configdir" bson:"configdir" json:"configdir"`
+	ContainerPools     ContainerPoolsConfig    `yaml:"container_pools" bson:"container_pools" json:"container_pools" id:"container_pools"`
+	Credentials        map[string]string       `yaml:"credentials" bson:"credentials" json:"credentials"`
+	CredentialsNew     util.KeyValuePairSlice  `yaml:"credentials_new" bson:"credentials_new" json:"credentials_new"`
+	Database           DBSettings              `yaml:"database" json:"database" bson:"database"`
+	DomainName         string                  `yaml:"domain_name" bson:"domain_name" json:"domain_name"`
+	Expansions         map[string]string       `yaml:"expansions" bson:"expansions" json:"expansions"`
+	ExpansionsNew      util.KeyValuePairSlice  `yaml:"expansions_new" bson:"expansions_new" json:"expansions_new"`
+	GithubPRCreatorOrg string                  `yaml:"github_pr_creator_org" bson:"github_pr_creator_org" json:"github_pr_creator_org"`
+	GithubOrgs         []string                `yaml:"github_orgs" bson:"github_orgs" json:"github_orgs"`
+	DisabledGQLQueries []string                `yaml:"disabled_gql_queries" bson:"disabled_gql_queries" json:"disabled_gql_queries"`
+	HostInit           HostInitConfig          `yaml:"hostinit" bson:"hostinit" json:"hostinit" id:"hostinit"`
+	HostJasper         HostJasperConfig        `yaml:"host_jasper" bson:"host_jasper" json:"host_jasper" id:"host_jasper"`
+	Jira               JiraConfig              `yaml:"jira" bson:"jira" json:"jira" id:"jira"`
+	JIRANotifications  JIRANotificationsConfig `yaml:"jira_notifications" json:"jira_notifications" bson:"jira_notifications" id:"jira_notifications"`
+	Keys               map[string]string       `yaml:"keys" bson:"keys" json:"keys"`
+	// TODO (DEVPROD-4798): remove KanopySSHKeyPath after the cutover to Kanopy.
+	KanopySSHKeyPath    string                 `yaml:"kanopy_ssh_key_path" bson:"kanopy_ssh_key_path" json:"kanopy_ssh_key_path"`
+	KeysNew             util.KeyValuePairSlice `yaml:"keys_new" bson:"keys_new" json:"keys_new"`
+	LDAPRoleMap         LDAPRoleMap            `yaml:"ldap_role_map" bson:"ldap_role_map" json:"ldap_role_map"`
+	LoggerConfig        LoggerConfig           `yaml:"logger_config" bson:"logger_config" json:"logger_config" id:"logger_config"`
+	LogPath             string                 `yaml:"log_path" bson:"log_path" json:"log_path"`
+	NewRelic            NewRelicConfig         `yaml:"newrelic" bson:"newrelic" json:"newrelic" id:"newrelic"`
+	Notify              NotifyConfig           `yaml:"notify" bson:"notify" json:"notify" id:"notify"`
+	Plugins             PluginConfig           `yaml:"plugins" bson:"plugins" json:"plugins"`
+	PluginsNew          util.KeyValuePairSlice `yaml:"plugins_new" bson:"plugins_new" json:"plugins_new"`
+	PodLifecycle        PodLifecycleConfig     `yaml:"pod_lifecycle" bson:"pod_lifecycle" json:"pod_lifecycle" id:"pod_lifecycle"`
+	PprofPort           string                 `yaml:"pprof_port" bson:"pprof_port" json:"pprof_port"`
+	ProjectCreation     ProjectCreationConfig  `yaml:"project_creation" bson:"project_creation" json:"project_creation" id:"project_creation"`
+	Providers           CloudProviders         `yaml:"providers" bson:"providers" json:"providers" id:"providers"`
+	RepoTracker         RepoTrackerConfig      `yaml:"repotracker" bson:"repotracker" json:"repotracker" id:"repotracker"`
+	Scheduler           SchedulerConfig        `yaml:"scheduler" bson:"scheduler" json:"scheduler" id:"scheduler"`
+	ServiceFlags        ServiceFlags           `bson:"service_flags" json:"service_flags" id:"service_flags" yaml:"service_flags"`
+	SSHKeyDirectory     string                 `yaml:"ssh_key_directory" bson:"ssh_key_directory" json:"ssh_key_directory"`
+	SSHKeyPairs         []SSHKeyPair           `yaml:"ssh_key_pairs" bson:"ssh_key_pairs" json:"ssh_key_pairs"`
+	Slack               SlackConfig            `yaml:"slack" bson:"slack" json:"slack" id:"slack"`
+	Splunk              SplunkConfig           `yaml:"splunk" bson:"splunk" json:"splunk" id:"splunk"`
+	TaskLimits          TaskLimitsConfig       `yaml:"task_limits" bson:"task_limits" json:"task_limits" id:"task_limits"`
+	Triggers            TriggerConfig          `yaml:"triggers" bson:"triggers" json:"triggers" id:"triggers"`
+	Ui                  UIConfig               `yaml:"ui" bson:"ui" json:"ui" id:"ui"`
+	Spawnhost           SpawnHostConfig        `yaml:"spawnhost" bson:"spawnhost" json:"spawnhost" id:"spawnhost"`
+	ShutdownWaitSeconds int                    `yaml:"shutdown_wait_seconds" bson:"shutdown_wait_seconds" json:"shutdown_wait_seconds"`
+	Tracer              TracerConfig           `yaml:"tracer" bson:"tracer" json:"tracer" id:"tracer"`
+	GitHubCheckRun      GitHubCheckRunConfig   `yaml:"github_check_run" bson:"github_check_run" json:"github_check_run" id:"github_check_run"`
 }
 
 func (c *Settings) SectionId() string { return ConfigDocID }
@@ -152,6 +154,7 @@ func (c *Settings) Set(ctx context.Context) error {
 			githubOrgsKey:         c.GithubOrgs,
 			disabledGQLQueriesKey: c.DisabledGQLQueries,
 			keysKey:               c.Keys,
+			kanopySSHKeyPathKey:   c.KanopySSHKeyPath,
 			keysNewKey:            c.KeysNew,
 			ldapRoleMapKey:        c.LDAPRoleMap,
 			logPathKey:            c.LogPath,

--- a/config_db.go
+++ b/config_db.go
@@ -32,6 +32,7 @@ var (
 	slackKey              = bsonutil.MustHaveTag(Settings{}, "Slack")
 	providersKey          = bsonutil.MustHaveTag(Settings{}, "Providers")
 	keysKey               = bsonutil.MustHaveTag(Settings{}, "Keys")
+	kanopySSHKeyPathKey   = bsonutil.MustHaveTag(Settings{}, "KanopySSHKeyPath")
 	keysNewKey            = bsonutil.MustHaveTag(Settings{}, "KeysNew")
 	credentialsKey        = bsonutil.MustHaveTag(Settings{}, "Credentials")
 	credentialsNewKey     = bsonutil.MustHaveTag(Settings{}, "CredentialsNew")

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -151,7 +151,10 @@ func (h *Host) GetSSHOptions(settings *evergreen.Settings) ([]string, error) {
 			}))
 		}
 	}
-	if defaultKeyPath := settings.Keys[h.Distro.SSHKey]; defaultKeyPath != "" {
+
+	if _, err := os.Stat(settings.KanopySSHKeyPath); err == nil {
+		keyPaths = append(keyPaths, settings.KanopySSHKeyPath)
+	} else if defaultKeyPath := settings.Keys[h.Distro.SSHKey]; defaultKeyPath != "" {
 		keyPaths = append(keyPaths, defaultKeyPath)
 	}
 	if len(keyPaths) == 0 {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -74,6 +74,7 @@ type APIAdminSettings struct {
 	Jira                *APIJiraConfig                    `json:"jira,omitempty"`
 	JIRANotifications   *APIJIRANotificationsConfig       `json:"jira_notifications,omitempty"`
 	Keys                map[string]string                 `json:"keys,omitempty"`
+	KanopySSHKeyPath    *string                           `json:"kanopy_ssh_key_path,omitempty"`
 	LDAPRoleMap         *APILDAPRoleMap                   `json:"ldap_role_map,omitempty"`
 	LoggerConfig        *APILoggerConfig                  `json:"logger_config,omitempty"`
 	LogPath             *string                           `json:"log_path,omitempty"`
@@ -142,6 +143,7 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 		as.Credentials = v.Credentials
 		as.Expansions = v.Expansions
 		as.Keys = v.Keys
+		as.KanopySSHKeyPath = utility.ToStringPtr(v.KanopySSHKeyPath)
 		as.GithubOrgs = v.GithubOrgs
 		as.DisabledGQLQueries = v.DisabledGQLQueries
 		as.SSHKeyDirectory = utility.ToStringPtr(v.SSHKeyDirectory)
@@ -267,6 +269,7 @@ func (as *APIAdminSettings) ToService() (interface{}, error) {
 	for k, v := range as.Keys {
 		settings.Keys[k] = v
 	}
+	settings.KanopySSHKeyPath = utility.FromStringPtr(as.KanopySSHKeyPath)
 	for k, v := range as.Plugins {
 		settings.Plugins[k] = map[string]interface{}{}
 		for k2, v2 := range v {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2232,6 +2232,13 @@ Admin Settings
 											placeholder="Path where authorized SSH keys are stored on static hosts" />
 									</md-input-container>
 								</md-card-content>
+								<md-card-content>
+									<md-input-container class="control">
+										<label>Kanopy SSH Key</label>
+										<input type=text ng-model="Settings.kanopy_ssh_key_path"
+											placeholder="Path to the SSH key file when running in Kanopy" />
+									</md-input-container>
+								</md-card-content>
 
 							</md-card>
 


### PR DESCRIPTION
[DEVPROD-4677](https://jira.mongodb.org/browse/DEVPROD-4677)

### Description
The path to the key on Kanopy cannot be the same as it is on EC2 because the secret can't be mounted on an existing directory.
Add an extra SSH key path to use during the cutover. Once the cutover is done we'll remove this key and set the regular one to the new path ([DEVPROD-4798](https://jira.mongodb.org/browse/DEVPROD-4798)).

### Testing
Was able to kick off SSH provisioning on a host (that then failed for another reason)
