### PR TITLE
DEVPROD-4627 add local make target

### DIFF
--- a/makefile
+++ b/makefile
@@ -253,6 +253,7 @@ $(buildDir)/dist.tar.gz:$(buildDir)/make-tarball $(clientBinaries) $(uiFiles) $(
 	./$< --name $@ --prefix $(name) $(foreach item,$(distContents),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
 $(buildDir)/static_assets.tgz:$(buildDir)/make-tarball $(uiFiles)
 	./$< --name $@ --prefix static_assets $(foreach item,$(distArtifacts),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
+local: $(buildDir)/static_assets.tgz $(clientBinaries)
 # end main build
 
 # userfacing targets for basic build and development operations


### PR DESCRIPTION
[DEVPROD-4627](https://jira.mongodb.org/browse/DEVPROD-4627)

### Description
Add a `local` make target to build all the stuff you'll need to do a local build using https://github.com/10gen/kernel-tools/pull/428. Kind of like the `dist` target, just for Kanopy.

### Testing
It builds the stuff it's supposed to build.

### Documentation
I'll add it to the ops guide once https://github.com/10gen/kernel-tools/pull/428 merges.
