### PR TITLE
DEVPROD-3947: add validation and calculate next stop/start time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20240129220701-28919e26f3a3
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b
-	github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d
+	github.com/evergreen-ci/utility v0.0.0-20240223193433-e2121cffbdfa
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b/go.mod h1:2f2M
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d h1:ayWz0PCzn61cGNFxWOux4yuyLWWSbKe9SMTjxFulLbk=
-github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
+github.com/evergreen-ci/utility v0.0.0-20240223193433-e2121cffbdfa h1:L/ABpQOmF8dIam4KpTjUnxBctxsZCAf+rU3EDyqZPrQ=
+github.com/evergreen-ci/utility v0.0.0-20240223193433-e2121cffbdfa/go.mod h1:/9mHqlcrKHRtK2qah6a+/r6xkDpNuOaAJyxNYNgmK6A=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3589,6 +3589,8 @@ func (h *Host) CalculateNextScheduledStopTime(now time.Time) (time.Time, error) 
 	return time.Time{}, errors.New("neither daily nor whole days off schedule could determine a next stop time")
 }
 
+// CalculateNextScheduledStopTime calculates the next time a host should be
+// started for its sleep schedule.
 // kim: NOTE: the algorithm for calculating the next start time is symmetrical
 // EXCEPT for the case of a whole day off segueing into a daily sleep (e.g.
 // Sunday off, then sleep 10pm - 4 am each day). This should only require a

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -369,7 +369,7 @@ type SleepScheduleInfo struct {
 }
 
 // Validate checks that the sleep schedule provided by the user is valid.
-func (i SleepScheduleInfo) Validate() error {
+func (i *SleepScheduleInfo) Validate() error {
 	if i.PermanentlyExempt {
 		return nil
 	}
@@ -408,9 +408,10 @@ func (i SleepScheduleInfo) Validate() error {
 	if i.DailyStopTime != "" && i.DailyStartTime != "" {
 		// Add up how much time is hypothetically spent sleeping for the daily
 		// sleep schedule.
-		sampleStart, err := time.Parse("15:04", i.DailyStartTime)
+		const hoursMinsFmt = "15:04"
+		sampleStart, err := time.Parse(hoursMinsFmt, i.DailyStartTime)
 		catcher.Wrapf(err, "parsing daily start time as a timestamp")
-		sampleStop, err := time.Parse("15:04", i.DailyStopTime)
+		sampleStop, err := time.Parse(hoursMinsFmt, i.DailyStopTime)
 		catcher.Wrapf(err, "parsing daily stop time as a timestamp")
 		if !utility.IsZeroTime(sampleStart) && !utility.IsZeroTime(sampleStop) {
 			var dailySleep time.Duration

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -419,6 +419,7 @@ func (i SleepScheduleInfo) Validate() error {
 			} else {
 				dailySleep = sampleStart.Sub(sampleStop)
 			}
+			catcher.ErrorfWhen(dailySleep < time.Hour, "daily sleep schedule runs for %s per day, which is less than the minimum of 1 hour", dailySleep.String())
 			weeklySleep += dailySleep * time.Duration(7-len(i.WholeWeekdaysOff))
 		}
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6236,6 +6236,14 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
+	t.Run("FailsWithDailyScheduleUnderOneHourPerDay", func(t *testing.T) {
+		assert.Error(t, (SleepScheduleInfo{
+			DailyStartTime:   "00:10",
+			DailyStopTime:    "00:00",
+			WholeWeekdaysOff: []time.Weekday{time.Sunday},
+			TimeZone:         "America/New_York",
+		}).Validate())
+	})
 	t.Run("SucceedsWithDailyOvernightScheduleUnderMinimumHoursPerWeek", func(t *testing.T) {
 		assert.Error(t, (SleepScheduleInfo{
 			DailyStartTime: "01:00",

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6218,6 +6218,12 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
+	t.Run("FailsWithNonexistentTimezone", func(t *testing.T) {
+		assert.Error(t, (SleepScheduleInfo{
+			WholeWeekdaysOff: []time.Weekday{time.Sunday},
+			TimeZone:         "foobar",
+		}).Validate())
+	})
 	t.Run("FailsWithoutTimeZone", func(t *testing.T) {
 		assert.Error(t, (SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
@@ -6284,7 +6290,7 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 	})
 }
 
-func TestCalculateNextScheduledStopTime(t *testing.T) {
+func TestGetNextScheduledStopTime(t *testing.T) {
 	const easternTZ = "America/New_York"
 	easternTZLoc, err := time.LoadLocation(easternTZ)
 	require.NoError(t, err)
@@ -6297,7 +6303,7 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 			}
 			now := time.Now()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			assert.True(t, nextStop.After(now), "next stop time should be in the future")
@@ -6314,48 +6320,48 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				TimeZone:         easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at 3:00 PM EST
+			// Wednesday February 21, 2024 at 15:00 EST
 			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 15:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
-			// Thursday February 22 at midnight EST
+			// Thursday February 22, 2024 at 00:00 EST
 			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-22 00:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 
-			// The next stop time should be:
-			// Thursday February 22 at 00:00 EST
+			// The next stop time should be equivalent to:
+			// Thursday February 22, 2024 at 05:00 UTC
 			expectedNextStopUTC, err := time.ParseInLocation(time.DateTime, "2024-02-22 05:00:00", time.UTC)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStopUTC, nextStop, 0)
-			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 		},
 		"ReturnsNextStopTimeCorrectlyWithTimeZoneDifferenceBetweenUserTimeAndEvergreenTime": func(t *testing.T, h *Host) {
 			h.SleepSchedule = SleepScheduleInfo{
-				WholeWeekdaysOff: []time.Weekday{time.Wednesday, time.Thursday},
+				WholeWeekdaysOff: []time.Weekday{time.Wednesday},
 				TimeZone:         easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at midnight UTC
+			// Wednesday February 21, 2024 at 00:00 UTC
 			// Note that the user time zone is in EST, which is 5 hours behind
-			// UTC, so in the user's time zone, it's Tuesday February 20, 2024
-			// at 7:00 PM EST.
+			// UTC, so in the user's time zone, it's Wednesday February 21, 2024
+			// at 19:00 EST.
 			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 00:00:00", time.UTC)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
 			// Wednesday February 21, 2024 at 00:00 EST
 			// This is because the current time is still Tuesday
-			// 19:00 in EST (the user's time zone).
+			// 19:00 in EST.
 			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-21 00:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
@@ -6368,12 +6374,12 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				TimeZone:       easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at 10:00 UTC
-			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 10:00:00", easternTZLoc)
+			// Wednesday February 21, 2024 at 01:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 01:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
@@ -6390,96 +6396,68 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				TimeZone:       easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at 22:00 UTC
+			// Wednesday February 21, 2024 at 17:00 EST
 			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 17:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
-			// Wednesday February 22, 2024 at 20:00 EST
+			// Thursday February 22, 2024 at 17:00 EST
 			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-22 17:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
 			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 		},
-		"ReturnsNextStopTimeAsWholeWeekdayOffForMixOfWholeWeekdaysOffAndDailySchedule": func(t *testing.T, h *Host) {
+		"ReturnsNextStopTimeAsWholeWeekdayOffAfterDailyStop": func(t *testing.T, h *Host) {
 			h.SleepSchedule = SleepScheduleInfo{
-				WholeWeekdaysOff: []time.Weekday{time.Thursday, time.Friday},
+				WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
 				DailyStartTime:   "06:00",
-				DailyStopTime:    "17:00",
+				DailyStopTime:    "01:00",
 				TimeZone:         easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at 23:00 UTC
-			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 18:00:00", easternTZLoc)
+			// Friday February 23, 2024 at 19:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 19:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
-			// Thursday February 22, 2024 at midnight EST
-			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-22 00:00:00", easternTZLoc)
+			// Saturday February 24, 2024 at 00:00 EST
+			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-24 00:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
 			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 		},
-		"ReturnsNextStopTimeAsDailyStopTimeForMixOfWholeWeekdaysOffAndDailySchedule": func(t *testing.T, h *Host) {
+		"ReturnsNextStopTimeAsDailyStopTimeForOvernightDailyScheduleLeadingIntoWholeWeekdaysOff": func(t *testing.T, h *Host) {
 			h.SleepSchedule = SleepScheduleInfo{
-				WholeWeekdaysOff: []time.Weekday{time.Thursday, time.Friday},
+				WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
 				DailyStartTime:   "06:00",
-				DailyStopTime:    "17:00",
+				DailyStopTime:    "22:00",
 				TimeZone:         easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Wednesday February 21, 2024 at 23:00 UTC
-			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 18:00:00", easternTZLoc)
+			// Friday February 23, 2024 at 21:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 21:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
-			// Thursday February 22, 2024 at midnight EST
-			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-22 00:00:00", easternTZLoc)
+			// Friday February 23, 2024 at 22:00 EST
+			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-23 22:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
 			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 		},
 		"ReturnsNextStopTimeAfterNextStartTime": func(t *testing.T, h *Host) {
-			// Simulate the next start time, which is:
-			// Monday February 26, 2024 at 06:00 EST.
-			nextStart, err := time.ParseInLocation(time.DateTime, "2024-02-26 06:00:00", easternTZLoc)
-			require.NoError(t, err)
-			h.SleepSchedule = SleepScheduleInfo{
-				WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
-				DailyStartTime:   "06:00",
-				DailyStopTime:    "01:00",
-				NextStartTime:    nextStart,
-				TimeZone:         easternTZ,
-			}
-			// Simulate the current time, which is:
-			// Saturday February 24, 2024 at 00:00 UTC
-			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 19:00:00", easternTZLoc)
-			require.NoError(t, err)
-			now = now.UTC()
-
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
-			assert.NoError(t, err)
-
-			// The next stop time should be:
-			// Tuesday February 27, 2024 at 01:00 EST
-			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-27 01:00:00", easternTZLoc)
-			require.NoError(t, err)
-			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
-			assert.Equal(t, h.SleepSchedule.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
-		},
-		"ReturnsNextStopTimeAfterNextStartTimeForOvernightDailySchedule": func(t *testing.T, h *Host) {
 			// Simulate the next start time, which is:
 			// Monday February 26, 2024 at 06:00 EST
 			nextStart, err := time.ParseInLocation(time.DateTime, "2024-02-26 06:00:00", easternTZLoc)
@@ -6492,16 +6470,16 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				TimeZone:         easternTZ,
 			}
 			// Simulate the current time, which is:
-			// Friday February 23, 2024 at 22:00 UTC
-			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 17:00:00", easternTZLoc)
+			// Friday February 23, 2024 at 22:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 22:00:00", easternTZLoc)
 			require.NoError(t, err)
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
-			// Monday February 26, 2024 at 22:00 EST
+			// Monday February 26, 2024 at 22:00
 			expectedNextStop, err := time.ParseInLocation(time.DateTime, "2024-02-26 22:00:00", easternTZLoc)
 			require.NoError(t, err)
 			assert.WithinDuration(t, expectedNextStop, nextStop, 0)
@@ -6523,7 +6501,7 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 			assert.Equal(t, expectedOffsetSecs, tzOffset, "current time should be EST")
 			now = now.UTC()
 
-			nextStop, err := h.CalculateNextScheduledStopTime(now)
+			nextStop, err := h.GetNextScheduledStopTime(now)
 			assert.NoError(t, err)
 
 			// The next stop time should be:
@@ -6544,7 +6522,7 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				WholeWeekdaysOff:  []time.Weekday{time.Sunday},
 				PermanentlyExempt: true,
 			}
-			nextStop, err := h.CalculateNextScheduledStopTime(time.Now())
+			nextStop, err := h.GetNextScheduledStopTime(time.Now())
 			assert.NoError(t, err)
 			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
 		},
@@ -6553,12 +6531,12 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				WholeWeekdaysOff: []time.Weekday{time.Sunday},
 				ShouldKeepOff:    true,
 			}
-			nextStop, err := h.CalculateNextScheduledStopTime(time.Now())
+			nextStop, err := h.GetNextScheduledStopTime(time.Now())
 			assert.NoError(t, err)
 			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
 		},
 		"ReturnsErrorForZeroSleepSchedule": func(t *testing.T, h *Host) {
-			_, err := h.CalculateNextScheduledStopTime(time.Now())
+			_, err := h.GetNextScheduledStopTime(time.Now())
 			assert.Error(t, err)
 		},
 		"ReturnsErrorForInvalidTimeZone": func(t *testing.T, h *Host) {
@@ -6566,7 +6544,243 @@ func TestCalculateNextScheduledStopTime(t *testing.T) {
 				WholeWeekdaysOff: []time.Weekday{time.Sunday},
 				TimeZone:         "foobar",
 			}
-			_, err := h.CalculateNextScheduledStopTime(time.Now())
+			_, err := h.GetNextScheduledStopTime(time.Now())
+			assert.Error(t, err)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tCase(t, &Host{Id: "host_id"})
+		})
+	}
+}
+
+func TestGetNextScheduledStartTime(t *testing.T) {
+	const easternTZ = "America/New_York"
+	easternTZLoc, err := time.LoadLocation(easternTZ)
+	require.NoError(t, err)
+
+	for tName, tCase := range map[string]func(t *testing.T, h *Host){
+		"ReturnsNextStartTimeForWholeDayOff": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Sunday},
+				TimeZone:         easternTZ,
+			}
+			now := time.Now()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			assert.True(t, nextStart.After(now), "next start time should be in the future")
+			assert.True(t, nextStart.Compare(now.AddDate(0, 0, 7)) <= 0, "next start time should within the next week")
+			assert.Equal(t, time.Monday, nextStart.Weekday(), "next start time should be on Monday")
+			assert.Zero(t, nextStart.Hour(), "next start time should be at midnight")
+			assert.Zero(t, nextStart.Minute(), "next start time should be at midnight")
+			assert.Zero(t, nextStart.Second(), "next start time should be at midnight")
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeBasedOnCurrentTimestamp": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Sunday, time.Tuesday, time.Thursday},
+				TimeZone:         easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Wednesday February 21, 2024 at 15:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 15:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Friday February 23, 2024 at 00:00 EST
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-23 00:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+
+			// The next start time should be equivalent to:
+			// Friday February 23, 2024 at 05:00 UTC
+			expectedNextStartUTC, err := time.ParseInLocation(time.DateTime, "2024-02-23 05:00:00", time.UTC)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStartUTC, nextStart, 0)
+		},
+		"ReturnsNextStartTimeCorrectlyWithTimeZoneDifferenceBetweenUserTimeAndEvergreenTime": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Wednesday},
+				TimeZone:         easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Thursday February 22, 2024 at 00:00 UTC
+			// Note that the user time zone is in EST, which is 5 hours behind
+			// UTC, so in the user's time zone, it's Wednesday February 21, 2024
+			// at 19:00 EST.
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 00:00:00", time.UTC)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Thursday February 21, 2024 at 00:00 EST
+			// This is because the current time is still Wednesday
+			// 19:00 in EST.
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-22 00:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeForDailySchedule": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				DailyStartTime: "06:00",
+				DailyStopTime:  "17:00",
+				TimeZone:       easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Wednesday February 21, 2024 at 01:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 01:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Wednesday February 22, 2024 at 06:00 EST
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-21 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeForDailyScheduleAfterStartTime": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				DailyStartTime: "06:00",
+				DailyStopTime:  "17:00",
+				TimeZone:       easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Wednesday February 21, 2024 at 10:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Thursday February 22, 2024 at 06:00 EST
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-22 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeAsMidnightAfterWholeWeekdayOffAfterDailyStart": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
+				DailyStartTime:   "06:00",
+				DailyStopTime:    "22:00",
+				TimeZone:         easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Friday February 23, 2024 at 07:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 07:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Monday February 26, 2024 at 07:00 EST
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-26 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeAsDailyStartTimeForWholeWeekdaysOffLeadingIntoOvernightDailySchedule": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
+				DailyStartTime:   "06:00",
+				DailyStopTime:    "22:00",
+				TimeZone:         easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Friday February 23, 2024 at 21:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-23 21:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Monday February 26, 2024 at 06:00 EST
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-02-26 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsNextStartTimeWithAccountingForDaylightSavingsTime": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				DailyStartTime: "06:00",
+				DailyStopTime:  "22:00",
+				TimeZone:       easternTZ,
+			}
+			// Simulate the current time, which is:
+			// Saturday March 9, 2024 at 22:00 EST (AKA Sunday March 10, 2024 at
+			// 03:00 UTC)
+			now, err := time.ParseInLocation(time.DateTime, "2024-03-09 22:00:00", easternTZLoc)
+			require.NoError(t, err)
+			_, tzOffset := now.Zone()
+			expectedOffsetSecs := int((-5 * time.Hour).Seconds())
+			assert.Equal(t, expectedOffsetSecs, tzOffset, "current time should be EST")
+			now = now.UTC()
+
+			nextStart, err := h.GetNextScheduledStartTime(now)
+			assert.NoError(t, err)
+
+			// The next start time should be:
+			// Sunday March 10, 2024 at 02:30 EDT
+			// Note that daylight savings time begins on March 10 at 2 AM,
+			// meaning that the next start time is in EDT rather than EST.
+			expectedNextStart, err := time.ParseInLocation(time.DateTime, "2024-03-10 06:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStart, nextStart, 0)
+
+			_, tzOffset = nextStart.Zone()
+			expectedOffsetSecs = int((-4 * time.Hour).Seconds())
+			assert.Equal(t, expectedOffsetSecs, tzOffset, "next start time should be in EDT rather than EST")
+			assert.Equal(t, h.SleepSchedule.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
+		},
+		"ReturnsSentinelTimeForPermanentlyExemptHost": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff:  []time.Weekday{time.Sunday},
+				PermanentlyExempt: true,
+			}
+			nextStop, err := h.GetNextScheduledStartTime(time.Now())
+			assert.NoError(t, err)
+			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+		},
+		"ReturnsSentinelTimeForIndefinitelyOffHost": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Sunday},
+				ShouldKeepOff:    true,
+			}
+			nextStop, err := h.GetNextScheduledStartTime(time.Now())
+			assert.NoError(t, err)
+			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+		},
+		"ReturnsErrorForZeroSleepSchedule": func(t *testing.T, h *Host) {
+			_, err := h.GetNextScheduledStartTime(time.Now())
+			assert.Error(t, err)
+		},
+		"ReturnsErrorForInvalidTimeZone": func(t *testing.T, h *Host) {
+			h.SleepSchedule = SleepScheduleInfo{
+				WholeWeekdaysOff: []time.Weekday{time.Sunday},
+				TimeZone:         "foobar",
+			}
+			_, err := h.GetNextScheduledStartTime(time.Now())
 			assert.Error(t, err)
 		},
 	} {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6179,32 +6179,32 @@ func TestUnsetPersistentDNSInfo(t *testing.T) {
 
 func TestSleepScheduleInfoValidate(t *testing.T) {
 	t.Run("FailsWithZeroOptions", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{}).Validate())
+		assert.Error(t, (&SleepScheduleInfo{}).Validate())
 	})
 	t.Run("SucceedsWithPermanentExemption", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{PermanentlyExempt: true}).Validate())
+		assert.NoError(t, (&SleepScheduleInfo{PermanentlyExempt: true}).Validate())
 	})
 	t.Run("SucceedsWithOneWholeDayOff", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{
+		assert.NoError(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
 			TimeZone:         "America/New_York",
 		}).Validate())
 	})
 	t.Run("SucceedsWithMultipleWholeDayOff", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{
+		assert.NoError(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday, time.Wednesday, time.Friday, time.Saturday},
 			TimeZone:         "America/New_York",
 		}).Validate())
 	})
 	t.Run("SucceedsWithDailyScheduleMeetingMinimumHoursPerWeek", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{
+		assert.NoError(t, (&SleepScheduleInfo{
 			DailyStartTime: "04:00",
 			DailyStopTime:  "00:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("SucceedsWithCombinationOfDailyScheduleAndWholeDaysOff", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{
+		assert.NoError(t, (&SleepScheduleInfo{
 			DailyStartTime:   "05:00",
 			DailyStopTime:    "06:00",
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
@@ -6212,32 +6212,32 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 		}).Validate())
 	})
 	t.Run("SucceedsWithDailyOvernightScheduleMeetingMinimumHoursPerWeek", func(t *testing.T) {
-		assert.NoError(t, (SleepScheduleInfo{
+		assert.NoError(t, (&SleepScheduleInfo{
 			DailyStartTime: "05:00",
 			DailyStopTime:  "20:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithNonexistentTimezone", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
 			TimeZone:         "foobar",
 		}).Validate())
 	})
 	t.Run("FailsWithoutTimeZone", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
 		}).Validate())
 	})
 	t.Run("FailsWithDailyScheduleUnderMinimumHoursPerWeek", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "01:00",
 			DailyStopTime:  "00:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithDailyScheduleUnderOneHourPerDay", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime:   "00:10",
 			DailyStopTime:    "00:00",
 			WholeWeekdaysOff: []time.Weekday{time.Sunday},
@@ -6245,53 +6245,53 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 		}).Validate())
 	})
 	t.Run("SucceedsWithDailyOvernightScheduleUnderMinimumHoursPerWeek", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "01:00",
 			DailyStopTime:  "23:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithOnlyDailyStopTimeAndNoDailyStartTime", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStopTime: "00:00",
 			TimeZone:      "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithOnlyDailyStartTimeAndNoDailyStopTime", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "00:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithInvalidDailyStartTime", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "05:00:00",
 			DailyStopTime:  "20:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithInvalidDailyStopTime", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "00:00",
 			DailyStopTime:  "20:00:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithSameDailyStopAndStartTimes", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			DailyStartTime: "00:00",
 			DailyStopTime:  "00:00",
 			TimeZone:       "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithDuplicateWholeWeekdaysOff", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{time.Sunday, time.Sunday, time.Monday},
 			TimeZone:         "America/New_York",
 		}).Validate())
 	})
 	t.Run("FailsWithInvalidWeekdays", func(t *testing.T) {
-		assert.Error(t, (SleepScheduleInfo{
+		assert.Error(t, (&SleepScheduleInfo{
 			WholeWeekdaysOff: []time.Weekday{12345},
 			TimeZone:         "America/New_York",
 		}).Validate())


### PR DESCRIPTION
DEVPROD-3947

### Description
I apologize in advance, the code change itself isn't actually that long (most of the diff is tests) but the algorithm is kind of tricky. Feel free to read the test cases or ask questions if you need clarification.

* Add validation function to ensure sleep schedule provided by user is sensible and follows the basic requirements.
* Add helper functions to calculate the next scheduled stop/start times. This uses [the same cron library](https://pkg.go.dev/github.com/robfig/cron) that we use for implementing the `cron` YAML field to help with the future time calculations.

### Testing
Added lots of unit tests for validation and calculation correctness.

### Documentation
N/A