### PR TITLE
DEVPROD-5081 Update Deepcopy to use JSON copy method instead of gob.

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -1050,13 +1050,7 @@ func (e *envState) SaveConfig(ctx context.Context) error {
 	// this is a hacky workaround to any plugins that have fields that are maps, since
 	// deserializing these fields from yaml does not maintain the typing information
 	var copy Settings
-	registeredTypes := []interface{}{
-		map[interface{}]interface{}{},
-		map[string]interface{}{},
-		[]interface{}{},
-		[]util.KeyValuePair{},
-	}
-	err := util.DeepCopy(*e.settings, &copy, registeredTypes)
+	err := util.DeepCopy(*e.settings, &copy)
 	if err != nil {
 		return errors.Wrap(err, "copying settings")
 	}

--- a/environment.go
+++ b/environment.go
@@ -2,7 +2,6 @@ package evergreen
 
 import (
 	"context"
-	"encoding/gob"
 	"fmt"
 	"math"
 	"os"
@@ -19,7 +18,6 @@ import (
 	"github.com/evergreen-ci/gimlet/rolemanager"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
-	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/logger"
 	"github.com/mongodb/amboy/pool"
@@ -1053,22 +1051,6 @@ func (e *envState) SaveConfig(ctx context.Context) error {
 	err := util.DeepCopy(*e.settings, &copy)
 	if err != nil {
 		return errors.Wrap(err, "copying settings")
-	}
-
-	gob.Register(map[interface{}]interface{}{})
-	for pluginName, plugin := range copy.Plugins {
-		if pluginName == "buildbaron" {
-			for fieldName, field := range plugin {
-				if fieldName == "projects" {
-					var projects map[string]BuildBaronSettings
-					err := mapstructure.Decode(field, &projects)
-					if err != nil {
-						return errors.Wrap(err, "decoding buildbaron projects")
-					}
-					plugin[fieldName] = projects
-				}
-			}
-		}
 	}
 
 	return errors.WithStack(UpdateConfig(ctx, &copy))

--- a/graphql/redact_secrets_plugin.go
+++ b/graphql/redact_secrets_plugin.go
@@ -1,7 +1,6 @@
 package graphql
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
@@ -77,14 +76,7 @@ func isFieldRedacted(fieldName string, fieldsToRedact map[string]bool) bool {
 // Assumes map structure like map[string]interface{} where interface{} can be another map, a slice, or a basic datatype.
 func RedactFieldsInMap(data map[string]interface{}, fieldsToRedact map[string]bool) map[string]interface{} {
 	dataCopy := map[string]interface{}{}
-	registeredTypes := []interface{}{
-		map[interface{}]interface{}{},
-		map[string]interface{}{},
-		[]interface{}{},
-		[]util.KeyValuePair{},
-		json.Number(""),
-	}
-	if err := util.DeepCopy(data, &dataCopy, registeredTypes); err != nil {
+	if err := util.DeepCopy(data, &dataCopy); err != nil {
 		// If theres an error copying the data, log it and return an empty map.
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "failed to deep copy request variables",

--- a/util/copy.go
+++ b/util/copy.go
@@ -1,25 +1,20 @@
 package util
 
 import (
-	"bytes"
-	"encoding/gob"
+	"encoding/json"
 
 	"github.com/pkg/errors"
 )
 
 // DeepCopy makes a deep copy of the src value into the copy params
-// The registeredTypes param can be optionally used to register additional types
-// that need to be used by gob
-func DeepCopy(src, copy interface{}, registeredTypes []interface{}) error {
-	for _, t := range registeredTypes {
-		gob.Register(t)
-	}
-	var buff bytes.Buffer
-	enc := gob.NewEncoder(&buff)
-	dec := gob.NewDecoder(&buff)
-	err := enc.Encode(src)
+func DeepCopy(src, copy interface{}) error {
+	b, err := json.Marshal(src)
 	if err != nil {
-		return errors.Wrap(err, "encoding source")
+		return errors.Wrap(err, "marshalling source")
 	}
-	return errors.Wrap(dec.Decode(copy), "decoding copy")
+	err = json.Unmarshal(b, copy)
+	if err != nil {
+		return errors.Wrap(err, "unmarshalling copy")
+	}
+	return nil
 }

--- a/util/copy.go
+++ b/util/copy.go
@@ -7,6 +7,9 @@ import (
 )
 
 // DeepCopy makes a deep copy of the src value into the copy params
+// It uses json marshalling to do so, so the src and copy params must be
+// json encodable and decodable.
+// It only works with public fields.
 func DeepCopy(src, copy interface{}) error {
 	b, err := json.Marshal(src)
 	if err != nil {

--- a/util/copy_test.go
+++ b/util/copy_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dinner struct {
@@ -17,19 +17,29 @@ type drink struct {
 }
 
 func TestDeepCopy(t *testing.T) {
-	assert := assert.New(t)
-
-	myDinner := dinner{
-		Entree:  "gefilte fish",
-		Dessert: true,
-		Drink: &drink{
-			Sugars: 32,
-		},
-	}
-	var yourDinner dinner
-	err := DeepCopy(myDinner, &yourDinner)
-	assert.NoError(err)
-	assert.Equal(myDinner.Entree, yourDinner.Entree)
-	assert.Equal(myDinner.Drink.Sugars, yourDinner.Drink.Sugars)
-	assert.Equal(myDinner.Dessert, yourDinner.Dessert)
+	require := require.New(t)
+	t.Run("DeepCopy", func(t *testing.T) {
+		myDinner := dinner{
+			Entree:  "gefilte fish",
+			Dessert: true,
+			Drink: &drink{
+				Sugars: 32,
+			},
+		}
+		var yourDinner dinner
+		err := DeepCopy(myDinner, &yourDinner)
+		require.NoError(err)
+		require.Equal(myDinner.Entree, yourDinner.Entree)
+		require.Equal(myDinner.Drink.Sugars, yourDinner.Drink.Sugars)
+		require.Equal(myDinner.Dessert, yourDinner.Dessert)
+	})
+	t.Run("DeepCopyWithAStringMap", func(t *testing.T) {
+		myMap := map[string]string{
+			"foo": "bar",
+		}
+		var yourMap map[string]string
+		err := DeepCopy(myMap, &yourMap)
+		require.NoError(err)
+		require.Equal(myMap, yourMap)
+	})
 }

--- a/util/copy_test.go
+++ b/util/copy_test.go
@@ -33,6 +33,14 @@ func TestDeepCopy(t *testing.T) {
 		require.Equal(myDinner.Drink.Sugars, yourDinner.Drink.Sugars)
 		require.Equal(myDinner.Dessert, yourDinner.Dessert)
 	})
+	t.Run("DeepCopyWithAStringSlice", func(t *testing.T) {
+		mySlice := []string{"foo", "bar"}
+		var yourSlice []string
+		err := DeepCopy(mySlice, &yourSlice)
+		require.NoError(err)
+		require.Equal(mySlice, yourSlice)
+	})
+
 	t.Run("DeepCopyWithAStringMap", func(t *testing.T) {
 		myMap := map[string]string{
 			"foo": "bar",

--- a/util/copy_test.go
+++ b/util/copy_test.go
@@ -27,7 +27,7 @@ func TestDeepCopy(t *testing.T) {
 		},
 	}
 	var yourDinner dinner
-	err := DeepCopy(myDinner, &yourDinner, nil)
+	err := DeepCopy(myDinner, &yourDinner)
 	assert.NoError(err)
 	assert.Equal(myDinner.Entree, yourDinner.Entree)
 	assert.Equal(myDinner.Drink.Sugars, yourDinner.Drink.Sugars)


### PR DESCRIPTION
DEVPROD-5081

### Description
The `util.DeepCopy` method used [gob](https://pkg.go.dev/encoding/gob)  to encode/decode structs to allow for copying go structs. This however required each struct to be registered with the gob method in order for gob to be able to copy it. This unfortunately caused errors when used alongside the graphql request secret redaction since there were many different possibilities of structs that could be passed in that would need to be copied. This PR updates the `util.DeepCopy` method to use a more flexible json Marshall/Unmarshal method to copy structs.


