### PR TITLE
DEVPROD-2450 Redirect host pages to spruce if spruce enabled

### DIFF
--- a/service/host.go
+++ b/service/host.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -51,7 +52,10 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id)) {
+	spruceLink := fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id)
+	// Redirect the user to spruce only if they aren't visiting this page from spruce already and have spruce enabled
+	if u.Settings.UseSpruceOptions.SpruceV1 && !strings.Contains(r.Referer(), uis.Settings.Ui.UIv2Url) {
+		http.Redirect(w, r, spruceLink, http.StatusTemporaryRedirect)
 		return
 	}
 
@@ -89,7 +93,6 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	spruceLink := fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, h.Id)
 	newUILink := ""
 	if len(uis.Settings.Ui.UIv2Url) > 0 {
 		newUILink = spruceLink

--- a/service/host.go
+++ b/service/host.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -53,9 +52,7 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	spruceLink := fmt.Sprintf("%s/host/%s", uis.Settings.Ui.UIv2Url, id)
-	// Redirect the user to spruce only if they aren't visiting this page from spruce already and have spruce enabled
-	if u.Settings.UseSpruceOptions.SpruceV1 && !strings.Contains(r.Referer(), uis.Settings.Ui.UIv2Url) {
-		http.Redirect(w, r, spruceLink, http.StatusTemporaryRedirect)
+	if RedirectIfSpruceSet(w, r, u, spruceLink, uis.Settings.Ui.UIv2Url) {
 		return
 	}
 

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -87,6 +88,15 @@ func RedirectSpruceUsers(w http.ResponseWriter, r *http.Request, redirect string
 
 	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
 	return true
+}
+
+// RedirectIfSpruceSet redirects the user to spruce only if they aren't visiting this page from spruce already and have spruce enabled
+func RedirectIfSpruceSet(w http.ResponseWriter, r *http.Request, u *user.DBUser, redirect, UIv2Url string) bool {
+	if u.Settings.UseSpruceOptions.SpruceV1 && !strings.Contains(r.Referer(), UIv2Url) {
+		http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
+		return true
+	}
+	return false
 }
 
 // ToPluginContext creates a UIContext from the projectContext data.

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -65,9 +64,7 @@ func (uis *UIServer) spawnPage(w http.ResponseWriter, r *http.Request) {
 	if hasQueryParams {
 		spruceLink += spruceQueryParams
 	}
-	// Redirect the user to spruce only if they aren't visiting this page from spruce already and have spruce enabled
-	if currentUser.Settings.UseSpruceOptions.SpruceV1 && !strings.Contains(r.Referer(), uis.Settings.Ui.UIv2Url) {
-		http.Redirect(w, r, spruceLink, http.StatusTemporaryRedirect)
+	if RedirectIfSpruceSet(w, r, currentUser, spruceLink, uis.Settings.Ui.UIv2Url) {
 		return
 	}
 


### PR DESCRIPTION
DEVPROD-2450

### Description
Host page will auto redirect to spruce just like spawn page does 

### Testing
Tested that host pages will auto redirect to spruce on staging
ie
https://evergreen-staging.corp.mongodb.com/host/i-00ab599007f7dd911 redirects to  https://spruce-staging.corp.mongodb.com/host/i-00ab599007f7dd911

