### PR TITLE
DEVPROD-4695 remove #evergreen-users mentions (RIP)

### DIFF
--- a/docs/Containers/Container-Tasks.md
+++ b/docs/Containers/Container-Tasks.md
@@ -17,9 +17,7 @@ which should be considered if your goal is to port over a critical workflow to c
 
 If you have any questions about container tasks or are interested in
 exploring how this feature could benefit your project, we encourage you
-to reach out to us in ***#evergreen-users***. We'll discuss its
-potential applications and assist you in preparing for its broader
-release.
+to reach out for assistance.
 
 It's important to distinguish that this feature is entirely separate
 from the existing functionality Evergreen has to spin up docker containers

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -417,9 +417,8 @@ Notes:
     generate more than 100 variants or more than 1000 tasks.
 -   Because generate.tasks retries on errors that aren't known to us,
     it may appear that your generate.tasks is hanging until timeout.
-    There may be details of this in the task logs; please ask in
-    #evergreen-users if you aren't sure what to do with a hanging
-    generate.tasks.
+    There may be details of this in the task logs; please ask
+    if you aren't sure what to do with a hanging generate.tasks.
 
 ``` yaml
 - command: generate.tasks


### PR DESCRIPTION
DEVPROD-4695
### Description
Instead of replacing with #ask-devprod-evergreen I just left these general -- the implication if you need help for _any_ feature is to find our channel, I think it doesn't need to be hardcoded. Open to the argument it should be on the home page, although users have gotten by without that so far.
