### PR TITLE
DEVPROD-4592 Check if task is last task to run in task group before restarting

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2111,6 +2111,11 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		})
 }
 
+// HasOrWillRun
+func (t *Task) HasOrWillRun() bool {
+	return t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.Status == evergreen.TaskStarted
+}
+
 // GetDisplayStatus finds and sets DisplayStatus to the task. It should reflect
 // the statuses assigned during the addDisplayStatus aggregation step.
 func (t *Task) GetDisplayStatus() string {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2111,7 +2111,7 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		})
 }
 
-// HasOrWillRun
+// HasOrWillRun returns whether the task has run or will run in the future.
 func (t *Task) HasOrWillRun() bool {
 	return t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.Status == evergreen.TaskStarted
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2111,11 +2111,6 @@ func (t *Task) MarkEnd(finishTime time.Time, detail *apimodels.TaskEndDetail) er
 		})
 }
 
-// HasOrWillRun returns whether the task has run or will run in the future.
-func (t *Task) HasOrWillRun() bool {
-	return t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.Status == evergreen.TaskStarted
-}
-
 // GetDisplayStatus finds and sets DisplayStatus to the task. It should reflect
 // the statuses assigned during the addDisplayStatus aggregation step.
 func (t *Task) GetDisplayStatus() string {

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -220,7 +220,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				// Check for the last task in the task group that we have activated, running, or completed.
 				var lastTaskGroupTask task.Task
 				for _, t := range tasks {
-					if t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.IsInProgress() {
+					if t.Activated {
 						lastTaskGroupTask = t
 					}
 				}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -217,9 +217,10 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 					j.AddError(errors.Errorf("no tasks found in task group for task '%s'", latestTask.Id))
 					return
 				}
+				// Check for the last task in the task group that we have activated, running, or completed.
 				var lastTaskGroupTask task.Task
 				for _, t := range tasks {
-					if t.HasOrWillRun() {
+					if t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.Status == evergreen.TaskStarted {
 						lastTaskGroupTask = t
 					}
 				}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -220,7 +220,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				// Check for the last task in the task group that we have activated, running, or completed.
 				var lastTaskGroupTask task.Task
 				for _, t := range tasks {
-					if t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.Status == evergreen.TaskStarted {
+					if t.Activated || evergreen.IsValidTaskEndStatus(t.Status) || t.IsInProgress() {
 						lastTaskGroupTask = t
 					}
 				}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -230,7 +230,6 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				}
 			}
 		}
-
 	}
 	// set host as decommissioned in DB so no new task will be assigned
 	prevStatus := j.host.Status

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -202,25 +202,31 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	} else {
 		// Consider if the host is in between running a single-host task group
 		if j.host.LastGroup != "" {
-			lastTask, err := task.FindOneId(j.host.LastTask)
+			latestTask, err := task.FindOneId(j.host.LastTask)
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "finding last task '%s'", j.host.LastTask))
 			}
 			// Only try to restart the task group if it was successful and should have continued executing.
-			if lastTask != nil && lastTask.IsPartOfSingleHostTaskGroup() && lastTask.Status == evergreen.TaskSucceeded {
-				tasks, err := task.FindTaskGroupFromBuild(lastTask.BuildId, lastTask.TaskGroup)
+			if latestTask != nil && latestTask.IsPartOfSingleHostTaskGroup() && latestTask.Status == evergreen.TaskSucceeded {
+				tasks, err := task.FindTaskGroupFromBuild(latestTask.BuildId, latestTask.TaskGroup)
 				if err != nil {
-					j.AddError(errors.Wrapf(err, "getting task group for task '%s'", lastTask.Id))
+					j.AddError(errors.Wrapf(err, "getting task group for task '%s'", latestTask.Id))
 					return
 				}
 				if len(tasks) == 0 {
-					j.AddError(errors.Errorf("no tasks found in task group for task '%s'", lastTask.Id))
+					j.AddError(errors.Errorf("no tasks found in task group for task '%s'", latestTask.Id))
 					return
 				}
-				if tasks[len(tasks)-1].Id != lastTask.Id {
+				var lastTaskGroupTask task.Task
+				for _, t := range tasks {
+					if t.HasOrWillRun() {
+						lastTaskGroupTask = t
+					}
+				}
+				if lastTaskGroupTask.Id != latestTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,
 					// because later tasks in the group need to run on the same host as the earlier ones.
-					j.AddError(errors.Wrapf(model.TryResetTask(ctx, j.env.Settings(), lastTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", lastTask.Id))
+					j.AddError(errors.Wrapf(model.TryResetTask(ctx, j.env.Settings(), latestTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", latestTask.Id))
 				}
 			}
 		}

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -296,7 +296,6 @@ func TestHostTerminationJob(t *testing.T) {
 			// Check if task1 has been reset
 			resetTask, err := task.FindOneId("task2")
 			require.NoError(t, err)
-			assert.Equal(t, "i-12345", resetTask.HostId)
 			assert.Equal(t, evergreen.TaskSucceeded, resetTask.Status)
 		},
 	} {

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -7,9 +7,11 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -237,9 +239,69 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
+		"TaskInTaskGroupDoesNotRestartIfFinished": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
+			h.LastGroup = "taskgroup"
+			h.LastTask = "task2"
+			require.NoError(t, h.Insert(ctx))
+
+			task1 := task.Task{
+				Id:                "task1",
+				Status:            evergreen.TaskSucceeded,
+				Activated:         true,
+				BuildId:           "b1",
+				Project:           "exists",
+				HostId:            h.Id,
+				TaskGroup:         "taskgroup",
+				TaskGroupMaxHosts: 1,
+			}
+			require.NoError(t, task1.Insert())
+			task2 := task.Task{
+				Id:                "task2",
+				Status:            evergreen.TaskSucceeded,
+				Activated:         true,
+				BuildId:           "b1",
+				Project:           "exists",
+				TaskGroup:         "taskgroup",
+				TaskGroupMaxHosts: 1,
+			}
+			require.NoError(t, task2.Insert())
+			pref := &model.ProjectRef{
+				Id:      "exists",
+				Enabled: true,
+			}
+			require.NoError(t, pref.Insert())
+			mcp.Set(h.Id, cloud.MockInstance{
+				Status: cloud.StatusRunning,
+			})
+
+			const reason = "some termination message"
+			j := NewHostTerminationJob(env, h, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: reason,
+			})
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			dbHost, err := host.FindOne(ctx, host.ById(h.Id))
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
+
+			checkTerminationEvent(t, h.Id, reason)
+
+			cloudHost := mcp.Get(h.Id)
+			require.NotZero(t, cloudHost)
+			assert.Equal(t, cloud.StatusTerminated, cloudHost.Status)
+
+			// Check if task1 has been reset
+			resetTask, err := task.FindOneId("task2")
+			require.NoError(t, err)
+			assert.Equal(t, "i-12345", resetTask.HostId)
+			assert.Equal(t, evergreen.TaskSucceeded, resetTask.Status)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(host.Collection, event.EventCollection))
+			require.NoError(t, db.ClearCollections(host.Collection, event.EventCollection, task.Collection, model.ProjectRefCollection))
 			tctx := testutil.TestSpan(ctx, t)
 
 			env := testutil.NewEnvironment(tctx, t)
@@ -247,7 +309,7 @@ func TestHostTerminationJob(t *testing.T) {
 			h := &host.Host{
 				Id:          "i-12345",
 				Status:      evergreen.HostRunning,
-				Distro:      distro.Distro{Provider: evergreen.ProviderNameMock},
+				Distro:      distro.Distro{Id: "d1", Provider: evergreen.ProviderNameMock},
 				Provider:    evergreen.ProviderNameMock,
 				Provisioned: true,
 			}


### PR DESCRIPTION
DEVPROD-4592

### Description
This checks instead of the last task in a task group, the last task that is will or scheduled to run. The issue with checking the rigid last task in a task group is that they can be partially scheduled.

### Testing
Add CI test and ran it against the old codebase and it failed

(PR patch shows the current code, [here](https://spruce.mongodb.com/task/evergreen_ubuntu2204_test_units_patch_2a81f2c4cfdcb3766b0b8c95738ac6a7392f58b6_65df4e5a2fbabec589804010_24_02_28_15_16_50?execution=0&sortBy=STATUS&sortDir=ASC) is a manual patch with the new test but the old implementation)