### PR TITLE
DEVPROD-3137: Redirect to specific Spruce project page from legacy UI

### DIFF
--- a/service/project.go
+++ b/service/project.go
@@ -14,7 +14,8 @@ import (
 )
 
 func (uis *UIServer) projectsPage(w http.ResponseWriter, r *http.Request) {
-	newUIProjectsLink := fmt.Sprintf("%s/projects", uis.Settings.Ui.UIv2Url)
+	projectId := gimlet.GetVars(r)["project_id"]
+	newUIProjectsLink := fmt.Sprintf("%s/project/%s/settings", uis.Settings.Ui.UIv2Url, projectId)
 	http.Redirect(w, r, newUIProjectsLink, http.StatusPermanentRedirect)
 }
 

--- a/service/templates/menu.html
+++ b/service/templates/menu.html
@@ -64,7 +64,7 @@ window.NewUILink = {{.NewUILink}};
           </a>
           <ul class="dropdown-menu">
             <li><a ng-href="/distros">Distros</a></li>
-            <li><a ng-href="/projects##[[project]]">Projects</a></li>
+            <li><a ng-href="/projects/[[project]]">Projects</a></li>
             <li><a href="/spawn">Hosts</a></li>
             <li><a href="/patches/mine">Patches</a></li>
             <li class="divider"></li>

--- a/service/ui.go
+++ b/service/ui.go
@@ -405,7 +405,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/json/task_timing/{project_id}/{build_variant}/{request}").Wrap(needsLogin, needsContext, viewTasks).Handler(uis.taskTimingJSON).Get()
 
 	// Project routes
-	app.AddRoute("/projects").Wrap(needsLogin, needsContext).Handler(uis.projectsPage).Get()
+	app.AddRoute("/projects/{project_id}").Wrap(needsLogin, needsContext).Handler(uis.projectsPage).Get()
 	app.AddRoute("/project/{project_id}/events").Wrap(needsContext, viewProjectSettings).Handler(uis.projectEvents).Get()
 	app.AddRoute("/project/{project_id}/repo_revision").Wrap(needsContext, editProjectSettings).Handler(uis.setRevision).Put()
 


### PR DESCRIPTION
DEVPROD-3137

### Description
This PR makes the "Projects" option in the menu dropdown link to Spruce using the currently set project. In order to read the project ID variable from the URL, I changed the route to use a different format. (Couldn't find a way to read the project ID from the `##` format.)

### Testing
- On staging