### PR TITLE
DEVPROD-4989: use temporary AWS creds in project config

### DIFF
--- a/cmd/upload-s3/upload-s3.go
+++ b/cmd/upload-s3/upload-s3.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/pail"
@@ -32,15 +31,6 @@ func main() {
 		grip.EmergencyFatal("remote path is missing")
 	}
 
-	awsKey := os.Getenv("AWS_KEY")
-	if awsKey == "" {
-		grip.EmergencyFatal("AWS key is missing (env var: AWS_KEY)")
-	}
-	awsSecret := os.Getenv("AWS_SECRET")
-	if awsSecret == "" {
-		grip.EmergencyFatal("AWS secret is missing (env var: AWS_SECRET)")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -48,7 +38,6 @@ func main() {
 	defer utility.PutHTTPClient(client)
 
 	opts := pail.S3Options{
-		Credentials: pail.CreateAWSCredentials(awsKey, awsSecret, ""),
 		Region:      endpoints.UsEast1RegionID,
 		Name:        bucketName,
 		MaxRetries:  utility.ToIntPtr(10),

--- a/makefile
+++ b/makefile
@@ -155,8 +155,9 @@ set-project-var:$(buildDir)/set-project-var
 # commands such as s3.put. The agent revision must be set to the current version because the agent will have to exit
 # under the expectation that it will be redeployed if it's outdated (and the smoke test cannot deploy agents).
 set-smoke-vars:$(buildDir)/.load-smoke-data $(buildDir)/set-project-var $(buildDir)/set-var
-	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_key -value $(AWS_KEY)
-	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_secret -value $(AWS_SECRET)
+	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_key -value $(AWS_ACCESS_KEY_ID)
+	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_secret -value $(AWS_SECRET_ACCESS_KEY)
+	@$(buildDir)/set-project-var -dbName mci_smoke -key aws_token -value $(AWS_SESSION_TOKEN)
 	@$(buildDir)/set-var -dbName=mci_smoke -collection=hosts -id=localhost -key=agent_revision -value=$(agentVersion)
 	@$(buildDir)/set-var -dbName=mci_smoke -collection=pods -id=localhost -key=agent_version -value=$(agentVersion)
 

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -50,8 +50,6 @@ jira:
 providers:
   aws:
     parser_project:
-      key: "$AWS_KEY"
-      secret: "$AWS_SECRET"
       bucket: "evergreen-projects-testing"
       prefix: "$PARSER_PROJECT_S3_PREFIX"
       generated_json_prefix: $GENERATED_JSON_S3_PREFIX

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -5,33 +5,37 @@ ignore:
   - "*.mdx"
   - ".github/*" # github CODEOWNERS configuration
 
+pre_error_fails_task: true
+pre:
+  - func: assume-role
+
 post:
   - func: attach-test-results
   - command: s3.put
     display_name: Upload smoke test's app server logs to S3
     type: system
     params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
+      aws_key: ${AWS_ACCESS_KEY_ID}
+      aws_secret: ${AWS_SECRET_ACCESS_KEY}
+      aws_session_token: ${AWS_SESSION_TOKEN}
       local_file: evergreen/app_server.log
       remote_file: evergreen/${task_id}/app_server.log
       bucket: mciuploads
       content_type: text/plain
       permissions: private
-      visibility: signed
       display_name: Evergreen smoke test application server logs
   - command: s3.put
     display_name: Upload smoke test agent logs to S3
     type: system
     params:
-      aws_key: ${aws_key}
-      aws_secret: ${aws_secret}
+      aws_key: ${AWS_ACCESS_KEY_ID}
+      aws_secret: ${AWS_SECRET_ACCESS_KEY}
+      aws_session_token: ${AWS_SESSION_TOKEN}
       local_files_include_filter: evergreen/smoke*.log
       remote_file: evergreen/${task_id}/
       bucket: mciuploads
       content_type: text/plain
       permissions: private
-      visibility: signed
       display_name: (Evergreen smoke test agent logs)
 
 #######################################
@@ -50,8 +54,9 @@ variables:
         type: system
         params:
           optional: true
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_file: evergreen/bin/dist.tar.gz
           remote_file: evergreen/${build_id}-${build_variant}/evergreen-${task_name}-${revision}.tar.gz
           bucket: mciuploads
@@ -111,6 +116,7 @@ variables:
           timeout_secs: 900
       - func: get-project-and-modules
       - func: setup-mongodb
+      - func: setup-credentials
       - func: run-make
         vars: { target: "load-smoke-data" }
       - command: subprocess.exec
@@ -140,8 +146,9 @@ variables:
       - command: s3.put
         type: system
         params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_file: evergreen/bin/generate-lint.json
           remote_file: evergreen/${build_id}-${build_variant}/bin/generate-lint.json
           bucket: mciuploads
@@ -161,8 +168,9 @@ variables:
         vars: { target: "${task_name}" }
       - command: s3.put
         params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_files_include_filter_prefix: evergreen/clients
           local_files_include_filter: "*_*/evergreen*"
           remote_file: evergreen/clients/${version_id}/
@@ -196,6 +204,13 @@ functions:
             make mod-tidy;
             [[ $? -eq 0 ]] && break;
           done
+
+  assume-role:
+    - command: ec2.assume_role
+      type: setup
+      params:
+        role_arn: ${assume_role_arn}
+
   run-make:
     command: subprocess.exec
     params:
@@ -204,6 +219,9 @@ functions:
       args: ["${make_args|}", "${target}"]
       include_expansions_in_env:
         - GOROOT
+        - AWS_ACCESS_KEY_ID
+        - AWS_SECRET_ACCESS_KEY
+        - AWS_SESSION_TOKEN
         - MONGO_CREDS_FILE
         - RUN_TEST
         - RUN_EC2_SPECIFIC_TESTS
@@ -219,8 +237,6 @@ functions:
         - project_id
         - distro_id
       env:
-        AWS_KEY: ${aws_key}
-        AWS_SECRET: ${aws_secret}
         DEBUG_ENABLED: ${debug}
         DOCKER_HOST: ${docker_host}
         EVERGREEN_ALL: "true"
@@ -244,9 +260,6 @@ functions:
         OTEL_COLLECTOR_ENDPOINT: ${otel_collector_endpoint}
         OTEL_TRACE_ID: ${otel_trace_id}
         OTEL_PARENT_ID: ${otel_parent_id}
-        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-        AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
 
   setup-credentials:
     - command: ec2.assume_role
@@ -264,8 +277,6 @@ functions:
           GITHUB_APP_KEY: ${staging_github_app_key}
           JIRA_SERVER: ${jiraserver}
           CROWD_SERVER: ${crowdserver}
-          AWS_KEY: ${aws_key}
-          AWS_SECRET: ${aws_secret}
           PARSER_PROJECT_S3_PREFIX: ${task_id}/parser-projects
           GENERATED_JSON_S3_PREFIX: ${task_id}/generated-json
           JIRA_PRIVATE_KEY: ${jira_private_key}
@@ -590,10 +601,12 @@ tasks:
           binary: make
           args: ["upload-clis"]
           working_dir: evergreen
-          include_expansions_in_env: ["GOROOT"]
+          include_expansions_in_env:
+            - GOROOT
+            - AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY
+            - AWS_SESSION_TOKEN
           env:
-            AWS_KEY: ${aws_key}
-            AWS_SECRET: ${aws_secret}
             BUCKET_NAME: mciuploads
             LOCAL_PATH: clients
             EXCLUDE_PATTERN: .cache
@@ -664,8 +677,9 @@ tasks:
             $GOPATH/bin/swag init -g service/service.go
       - command: s3.put
         params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_file: evergreen/docs/swagger.json
           remote_file: evergreen/${task_id}/${execution}/swagger.json
           bucket: mciuploads
@@ -674,8 +688,9 @@ tasks:
           display_name: swagger.json
       - command: s3.put
         params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_file: evergreen/docs/swagger.json
           remote_file: evergreen/latest/swagger.json
           bucket: mciuploads
@@ -712,8 +727,9 @@ tasks:
         vars: { target: "bin/static_assets.tgz" }
       - command: s3.put
         params:
-          aws_key: ${aws_key}
-          aws_secret: ${aws_secret}
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
           local_file: evergreen/bin/static_assets.tgz
           remote_file: evergreen/clients/${version_id}/static_assets.tgz
           content_type: application/gzip
@@ -723,6 +739,9 @@ tasks:
 task_groups:
   - name: dist-and-upload-clis
     max_hosts: 1
+    setup_group_can_fail_task: true
+    setup_group:
+      - func: assume-role
     tasks:
       - dist
       - upload-clis

--- a/smoke/internal/testdata/project.yml
+++ b/smoke/internal/testdata/project.yml
@@ -190,6 +190,7 @@ tasks:
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
           local_file: upload/s3
           remote_file: evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}
           bucket: mciuploads
@@ -200,6 +201,7 @@ tasks:
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
           local_file: upload/s3
           remote_file: evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}
           bucket: mciuploads
@@ -210,6 +212,7 @@ tasks:
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
           remote_file: evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}
           bucket: mciuploads
           local_file: upload/s3-get
@@ -217,6 +220,7 @@ tasks:
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
           s3_copy_files:
             - source:
                 path: "evergreen/smoke/${build_id}-${build_variant}/evergreen-${task_name}-${revision}"


### PR DESCRIPTION
DEVPROD-4989

### Description
This will allow us to remove static AWS credentials from the Evergreen project variables.

- Update the existing AWS role for Evergreen integration tests to have S3 permissions for `mciuploads/evergreen`.
- Call `ec2.assume_role` at the beginning of tasks and pass around the temporary creds for S3 operations.

### Testing
Ran a full [patch build](https://spruce.mongodb.com/version/65de51c9c9ec44736b869649) including the `dist` and `build-and-push` tasks.

### Documentation
N/A