### PR TITLE
DEVPROD-2972: Stop populating trace ID for display tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2403,6 +2403,7 @@ func tryUpdateDisplayTaskAtomically(dt task.Task) (updated *task.Task, err error
 
 	dt.Status = statusTask.Status
 	dt.Details = statusTask.Details
+	dt.Details.TraceID = "" // Unset TraceID because display tasks don't have corresponding traces.
 	dt.TimeTaken = timeTaken
 
 	update := bson.M{


### PR DESCRIPTION
DEVPROD-2972

### Description
Display tasks should not have Honeycomb traces. Here is [an example of a display task](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_amazon_linux2_arm64_all_feature_flags_fuzzers_display_aggregation_optimization_fuzzer_ad1efe8f7f0413375649c50621251fcfca8cace8_24_02_28_11_11_20/execution-tasks?execution=0&sorts=STATUS%3AASC) on production that has a Honeycomb link. Jonathan pointed out that this Honeycomb link actually corresponds to one of its [execution tasks](https://spruce.mongodb.com/task/mongodb_mongo_master_enterprise_amazon_linux2_arm64_all_feature_flags_fuzzers_aggregation_optimization_fuzzer_03_linux_enterprise_ad1efe8f7f0413375649c50621251fcfca8cace8_24_02_28_11_11_20/tests?execution=0&sortBy=STATUS&sortDir=ASC). It seems like the current code just copies the trace ID from one of the execution tasks and assigns it to the display task.

### Testing
- On staging. 
  - Without my changes applied, you can see that this [display task](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu2004_display_display_task_patch_f95c79a17345e47ea7f3baee11d64a4223edd4e3_65df6e87d92c42000d93b7c3_24_02_28_17_34_20?execution=0&sorts=STATUS%3AASC) has a Honeycomb trace. If you check the staging DB or `/tasks` rest route, you can see the trace ID saved to the task details.
  - With my changes applied, you can see that this [display task](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu2004_display_display_task_patch_f95c79a17345e47ea7f3baee11d64a4223edd4e3_65df81ccda2fcf000edc32c3_24_02_28_18_56_20?execution=0&sorts=STATUS%3AASC) does not have a Honeycomb trace. If you check the staging DB or `/tasks` rest route, you can see there is no trace ID saved to the task details.
