### PR TITLE
DEVPROD-4517 Add idle lock to host

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -97,6 +97,7 @@ var (
 	HomeVolumeIDKey                    = bsonutil.MustHaveTag(Host{}, "HomeVolumeID")
 	PortBindingsKey                    = bsonutil.MustHaveTag(Host{}, "PortBindings")
 	IsVirtualWorkstationKey            = bsonutil.MustHaveTag(Host{}, "IsVirtualWorkstation")
+	IsIdleKey                          = bsonutil.MustHaveTag(Host{}, "IsIdle")
 	SpawnOptionsTaskIDKey              = bsonutil.MustHaveTag(SpawnOptions{}, "TaskID")
 	SpawnOptionsTaskExecutionNumberKey = bsonutil.MustHaveTag(SpawnOptions{}, "TaskExecutionNumber")
 	SpawnOptionsBuildIDKey             = bsonutil.MustHaveTag(SpawnOptions{}, "BuildID")
@@ -175,6 +176,7 @@ func IdleEphemeralGroupedByDistroID(ctx context.Context, env evergreen.Environme
 				StartedByKey:     evergreen.User,
 				ProviderKey:      bson.M{"$in": evergreen.ProviderSpawnable},
 				HasContainersKey: bson.M{"$ne": true},
+				IsIdleKey:        bson.M{"$ne": false},
 				"$or": []bson.M{
 					{
 						StatusKey: evergreen.HostRunning,
@@ -577,6 +579,7 @@ var IsIdle = bson.M{
 	RunningTaskKey: bson.M{"$exists": false},
 	StatusKey:      evergreen.HostRunning,
 	StartedByKey:   evergreen.User,
+	IsIdleKey:      bson.M{"$ne": false},
 }
 
 // ByNotMonitoredSince produces a query that returns all hosts whose

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -847,7 +847,7 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 			" and task dispatch time fields from both the in-memory and"+
 			" database copies of the host", func() {
 
-			So(host.ClearRunningAndSetLastTask(ctx, &task.Task{Id: "prevTask"}), ShouldBeNil)
+			So(host.ClearRunningAndSetLastTask(ctx, &task.Task{Id: "prevTask"}, true), ShouldBeNil)
 			So(host.RunningTask, ShouldEqual, "")
 			So(host.LastTask, ShouldEqual, "prevTask")
 
@@ -857,10 +857,17 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 			So(host.RunningTask, ShouldEqual, "")
 			So(host.LastTask, ShouldEqual, "prevTask")
 
-			Convey("the count of idle hosts should go up", func() {
+			Convey("the count of idle hosts should not go up", func() {
 				count, err := Count(ctx, IsIdle)
 				So(err, ShouldBeNil)
-				So(count, ShouldEqual, 1)
+				So(count, ShouldEqual, 0)
+
+				Convey("the count of idle hosts should go up after unsetting idle", func() {
+					host.UnsetIsIdle(ctx)
+					count, err := Count(ctx, IsIdle)
+					So(err, ShouldBeNil)
+					So(count, ShouldEqual, 1)
+				})
 
 				Convey("but the active host count should remain the same", func() {
 					count, err = Count(ctx, IsActive)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -863,7 +863,7 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 				So(count, ShouldEqual, 0)
 
 				Convey("the count of idle hosts should go up after unsetting idle", func() {
-					host.UnsetIsIdle(ctx)
+					So(host.UnsetIsIdle(ctx), ShouldBeNil)
 					count, err := Count(ctx, IsIdle)
 					So(err, ShouldBeNil)
 					So(count, ShouldEqual, 1)

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1267,11 +1267,12 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	// This is a more difficult check because it will require cross-referencing
 	// the host's state against the task's state. Doing the former order of
 	// operations avoids this expensive check.
-	if err = currentHost.ClearRunningAndSetLastTask(ctx, t); err != nil {
+	if err = currentHost.ClearRunningAndSetLastTask(ctx, t, true); err != nil {
 		err = errors.Wrapf(err, "clearing running task '%s' for host '%s'", t.Id, currentHost.Id)
 		grip.Errorf(err.Error())
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
+	defer currentHost.UnsetIsIdle(ctx)
 
 	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
 	details := &h.details

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1272,8 +1272,13 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		grip.Errorf(err.Error())
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
-	defer currentHost.UnsetIsIdle(ctx)
-
+	defer func() {
+		err := currentHost.UnsetIsIdle(ctx)
+		if err != nil {
+			err = errors.Wrapf(err, "unsetting IsIdle for host '%s'", currentHost.Id)
+			grip.Errorf(err.Error())
+		}
+	}()
 	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
 	details := &h.details
 	if t.Aborted {

--- a/units/task_monitor_execution_timeout.go
+++ b/units/task_monitor_execution_timeout.go
@@ -202,7 +202,7 @@ func (j *taskExecutionTimeoutJob) cleanUpTimedOutTask(ctx context.Context) error
 			// fixing the stranded task.
 			return nil
 		}
-		if err = host.ClearRunningAndSetLastTask(ctx, j.task); err != nil {
+		if err = host.ClearRunningAndSetLastTask(ctx, j.task, false); err != nil {
 			return errors.Wrapf(err, "clearing running task '%s' from host '%s'", j.task.Id, host.Id)
 		}
 	}


### PR DESCRIPTION
DEVPROD-4517

### Description
To prevent race conditions where the idle host monitor picks up a host while it is in the process of clearing and ending the task it was running, I added a field called "IsIdle" that is set to false when we want to lock the host while we do something that could potentially be slow (like ending a task) 

### Testing
unit test
added sleep 40 seconds to task end to emulate what would happen if it took a long time and it was not picked up by idle host monitor job
