### PR TITLE
DEVPROD-4040: use a smaller set of characters for persistent DNS names

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3396,7 +3396,7 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 	}
 	user := strings.Join(cleanedParts, "-")
 
-	const maxRandLen = 5
+	const maxRandLen = 3
 
 	// Since each user can own multiple unexpirable hosts, just using their
 	// username is not sufficient to make a unique persistent DNS name. Try

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3376,8 +3376,8 @@ func (h *Host) ClearDockerStdinData(ctx context.Context) error {
 // character ([0-9A-Za-z]).
 var nonAlphanumericRegexp = regexp.MustCompile("[[:^alnum:]]+")
 
-// alphanumericChars contains all alphanumeric characters (case-insensitive).
-const alphanumericChars = "abcdefghijklmnopqrstuvwxyz0123456789"
+// hexadecimalChars contains all hexademical characters (case-insensitive).
+const hexadecimalChars = "abcdef0123456789"
 
 // GeneratePersistentDNSName returns the host's persistent DNS name, or
 // generates a new one if it doesn't have one currently assigned.
@@ -3404,9 +3404,9 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 	// 1. contains only alphanumeric characters so it's more memorable, and
 	// 2. is derived from the host ID.
 	//
-	// This is slightly preferable to a random alphanumeric string, because a
-	// host with a particular ID will have a more short and memorable
-	// alphabet-only string.
+	// This is slightly preferable compared to a random alphanumeric string,
+	// because a host with a particular ID will always map to the same ID and
+	// will have a more short and memorable string.
 
 	idBasedHash := sha256.Sum256([]byte(h.Id))
 	encoder := base64.RawURLEncoding
@@ -3417,7 +3417,7 @@ func (h *Host) GeneratePersistentDNSName(ctx context.Context, domain string) (st
 	// more memorable.
 	idBasedRandom := make([]byte, maxRandLen)
 	for i := range idBasedRandom {
-		idBasedRandom[i] = alphanumericChars[idBasedEncoding[i]%byte(len(alphanumericChars))]
+		idBasedRandom[i] = hexadecimalChars[idBasedEncoding[i]%byte(len(hexadecimalChars))]
 	}
 	candidate := fmt.Sprintf("%s-%s.%s", user, string(idBasedRandom), strings.TrimPrefix(domain, "."))
 	conflicting, _ := FindOneByPersistentDNSName(ctx, candidate)

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6028,7 +6028,7 @@ func TestGeneratePersistentDNSName(t *testing.T) {
 		// If working properly, the generated DNS name output should always be
 		// the same when given the same inputs (i.e. same host ID and host
 		// owner) no matter how many times this test runs.
-		assert.Equal(t, fmt.Sprintf("itsa-memario-gf6pd.%s", domain), dnsName, "should produce DNS name deterministically if there's no other host with the same DNS name")
+		assert.Equal(t, fmt.Sprintf("itsa-memario-87ed9.%s", domain), dnsName, "should produce DNS name deterministically if there's no other host with the same DNS name")
 	})
 	t.Run("AlwaysReturnsSameStringForSameHostID", func(t *testing.T) {
 		h := Host{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6028,7 +6028,7 @@ func TestGeneratePersistentDNSName(t *testing.T) {
 		// If working properly, the generated DNS name output should always be
 		// the same when given the same inputs (i.e. same host ID and host
 		// owner) no matter how many times this test runs.
-		assert.Equal(t, fmt.Sprintf("itsa-memario-87ed9.%s", domain), dnsName, "should produce DNS name deterministically if there's no other host with the same DNS name")
+		assert.Equal(t, fmt.Sprintf("itsa-memario-87e.%s", domain), dnsName, "should produce DNS name deterministically if there's no other host with the same DNS name")
 	})
 	t.Run("AlwaysReturnsSameStringForSameHostID", func(t *testing.T) {
 		h := Host{


### PR DESCRIPTION
DEVPROD-4040

### Description
This is a small amendment to #7557. I looked at some of the generated DNS names after the job finished and a couple of them look like real words (for example, I saw one that had randomly generated `firstname-lastname-labs1`). Ideally, the DNS name that users see should only contain meaningless unique strings, so to avoid that confusion, I cut down the letter set down to just hexademical characters and reduced the length of the random portion. I don't think you can make many words with 3 hexademical-only characters.

After this is deployed, I'm also gonna clear the existing persistent DNS names so that the persistent DNS assignment job from #7557 can automatically regenerate them.

### Testing
Updated existing tests.

### Documentation
N/A