### PR TITLE
DEVPROD-956: treat different task group execution as new task group

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -498,18 +498,27 @@ func (a *Agent) handleSetupError(ctx context.Context, tc *taskContext, err error
 	return tc, shouldExit, catcher.Resolve()
 }
 
+// shouldRunSetupGroup determines if the next task that's about to run is part
+// of a new task group or is a standalone task.
+// If so, then the task or task group is new to the host and should therefore
+// perform task initialization, including setting up a new task directory and
+// running setup group (for task groups only).
+// If not, then the task is part of a task group, and it shares the task
+// directory with the previous task in the task group that the agent ran.
 func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) bool {
 	var previousTaskGroup string
 	if tc.taskConfig != nil && tc.taskConfig.TaskGroup != nil {
 		previousTaskGroup = tc.taskConfig.TaskGroup.Name
 	}
-	if !tc.ranSetupGroup { // we didn't run setup group yet
+	if !tc.ranSetupGroup { // The agent hasn't run setup group before.
 		return true
-	} else if tc.taskConfig == nil ||
-		nextTask.TaskGroup == "" ||
-		nextTask.Build != tc.taskConfig.Task.BuildId { // next task has a standalone task or a new build
+	} else if tc.taskConfig == nil || // The agent hasn't run any task previously.
+		nextTask.TaskGroup == "" || // The agent's previous task wasn't part of a task group.
+		nextTask.Build != tc.taskConfig.Task.BuildId { // The next task is in a different build.
 		return true
-	} else if nextTask.TaskGroup != previousTaskGroup { // next task has a different task group
+	} else if nextTask.TaskGroup != previousTaskGroup { // The next task has a different task group.
+		return true
+	} else if nextTask.TaskExecution != tc.taskConfig.Task.Execution { // The previous and next task are in the same task group but the next task has a different execution number.
 		return true
 	}
 	return false

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -113,6 +113,7 @@ type AgentSetupData struct {
 // NextTaskResponse represents the response sent back when an agent asks for a next task
 type NextTaskResponse struct {
 	TaskId              string `json:"task_id,omitempty"`
+	TaskExecution       int    `json:"task_execution,omitempty"`
 	TaskSecret          string `json:"task_secret,omitempty"`
 	TaskGroup           string `json:"task_group,omitempty"`
 	Version             string `json:"version,omitempty"`

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-02-29"
+	AgentVersion = "2024-03-01"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1349,7 +1349,6 @@ into their resulting variants client-side. Run
 evaluated version of the project.
 
 ### Task Groups
-
 Task groups pin groups of tasks to sets of hosts. When tasks run in a
 task group, the task directory is not removed between tasks, which
 allows tasks in the same task group to share state, which can be useful
@@ -1474,6 +1473,30 @@ The following constraints apply:
 Tasks in a group will be displayed as
 separate tasks. Users can use display tasks if they wish to group the
 task group tasks.
+
+#### Task Group Restarts
+If a task in a single-host task group is restarted:
+
+- The entire task group is restarted. All the tasks in the task group will
+  restart to a new execution.
+- Additionally, if a task in the task group is restarted while some tasks in the
+  task group are still running or waiting to run, it will wait until all of the
+  tasks in the task group finish before restarting all of them.
+- The task directory and setup group commands are not shared across task
+  executions. If the restarted tasks are assigned to the same host as the
+  previous execution, it's treated like a new task group, so it will clear the
+  task directory and re-run the setup group commands.
+
+If a task in a multi-host task group is restarted:
+
+- Only the selected tasks will be restarted.
+- The restarted task can begin running at any time. It won't wait until other
+  tasks in the task group finish.
+- The task directory and setup group commands are not shared across task
+  executions. If the restarted task is assigned to a host that is already
+  running the task group but with a different task execution, it's treated like
+  a new task group, so it will clear the task directory and re-run the setup
+  group commands.
 
 ### Task Dependencies
 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1484,8 +1484,9 @@ If a task in a single-host task group is restarted:
   tasks in the task group finish before restarting all of them.
 - The task directory and setup group commands are not shared across task
   executions. If the restarted tasks are assigned to the same host as the
-  previous execution, it's treated like a new task group, so it will clear the
-  task directory and re-run the setup group commands.
+  previous execution, it's treated like a new task group, so it will run the
+  teardown group commands, clear the task directory, and re-run the setup group
+  commands.
 
 If a task in a multi-host task group is restarted:
 
@@ -1495,8 +1496,8 @@ If a task in a multi-host task group is restarted:
 - The task directory and setup group commands are not shared across task
   executions. If the restarted task is assigned to a host that is already
   running the task group but with a different task execution, it's treated like
-  a new task group, so it will clear the task directory and re-run the setup
-  group commands.
+  a new task group, so it will run the teardown group commands, clear the task
+  directory, and re-run the setup group commands.
 
 ### Task Dependencies
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1095,6 +1095,8 @@ func sendBackRunningTask(ctx context.Context, env evergreen.Environment, h *host
 	}
 	if t == nil {
 		grip.Notice(getMessage("clearing host's running task because it does not exist"))
+		// Need to store the running task and execution here because
+		// ClearRunningTask will unset them.
 		runningTask := h.RunningTask
 		runningTaskExec := h.RunningTaskExecution
 		if err := h.ClearRunningTask(ctx); err != nil {

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1095,11 +1095,13 @@ func sendBackRunningTask(ctx context.Context, env evergreen.Environment, h *host
 	}
 	if t == nil {
 		grip.Notice(getMessage("clearing host's running task because it does not exist"))
+		runningTask := h.RunningTask
+		runningTaskExec := h.RunningTaskExecution
 		if err := h.ClearRunningTask(ctx); err != nil {
 			grip.Error(message.WrapError(err, getMessage("could not clear host's nonexistent running task")))
 			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
-		err := errors.Errorf("host's running task '%s' execution '%d' not found", h.RunningTask, h.RunningTaskExecution)
+		err := errors.Errorf("host's running task '%s' execution '%d' not found", runningTask, runningTaskExec)
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
@@ -1172,6 +1174,7 @@ func sendBackRunningTask(ctx context.Context, env evergreen.Environment, h *host
 // setNextTask constructs a NextTaskResponse from a task that has been assigned to run next.
 func setNextTask(t *task.Task, response *apimodels.NextTaskResponse) {
 	response.TaskId = t.Id
+	response.TaskExecution = t.Execution
 	response.TaskSecret = t.Secret
 	response.TaskGroup = t.TaskGroup
 	response.Version = t.Version


### PR DESCRIPTION
DEVPROD-956

### Description
Per the user request, when task groups are restarted, the restart is treated like it's a brand new task group running on the host. Previously, restarted tasks would be treated as part of the same task group, so the host would retain all the state from previous executions. This works with both single-host and multi-host task groups.

* Handle running a next tasks in the same task group but with a different execution as if it's a brand new task group.
* Fix a tiny bug that I noticed where one error message has the wrong info because the running task is cleared before the error message is created.

### Testing
* Updated unit tests for next task behavior.
* Tested in a patch in staging with single-host and multi-host task groups.
* Slightly modernize some of the (very old) tests for the next task route by adding more panic checks and fixing order of expected/actual assertion parameters.

### Documentation
Updated docs to cover task group behavior when tasks are restarted.