### PR TITLE
DEVPROD-5336 Allow projects not tracking repos to be deletable

### DIFF
--- a/graphql/tests/mutation/deleteProject/results.json
+++ b/graphql/tests/mutation/deleteProject/results.json
@@ -19,20 +19,7 @@
     },
     {
       "query_file": "not_attached_to_repo.graphql",
-      "result": { 
-        "data": null,
-        "errors": [
-          {
-            "message": "400 (Bad Request): project 'evergreen_id' must be attached to a repo to be eligible for deletion",
-            "path": [
-              "deleteProject"
-            ],
-            "extensions": {
-              "code": "INPUT_VALIDATION_ERROR"
-            }
-          }
-        ]
-      }
+      "result": { "data": { "deleteProject": true } }
     },
     {
       "query_file": "success.graphql",

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -430,13 +430,6 @@ func HideBranch(projectID string) error {
 		}
 	}
 
-	if !pRef.UseRepoSettings() {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    errors.Errorf("project '%s' must be attached to a repo to be eligible for deletion", pRef.Id).Error(),
-		}
-	}
-
 	skeletonProj := model.ProjectRef{
 		Id:        pRef.Id,
 		Owner:     pRef.Owner,

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1141,12 +1141,12 @@ func TestDeleteProject(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.Status())
 
 	// Project with UseRepoSettings == false
-	badProject := serviceModel.ProjectRef{
+	nonTrackingProject := serviceModel.ProjectRef{
 		Id:        "non_tracking_project",
 		RepoRefId: "",
 	}
-	require.NoError(t, badProject.Insert())
-	pdh.projectName = badProject.Id
+	require.NoError(t, nonTrackingProject.Insert())
+	pdh.projectName = nonTrackingProject.Id
 	resp = pdh.Run(ctx)
 	assert.Equal(t, http.StatusOK, resp.Status())
 }

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1142,7 +1142,7 @@ func TestDeleteProject(t *testing.T) {
 
 	// Project with UseRepoSettings == false
 	badProject := serviceModel.ProjectRef{
-		Id:        "bad_project",
+		Id:        "non_tracking_project",
 		RepoRefId: "",
 	}
 	require.NoError(t, badProject.Insert())

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1148,7 +1148,7 @@ func TestDeleteProject(t *testing.T) {
 	require.NoError(t, badProject.Insert())
 	pdh.projectName = badProject.Id
 	resp = pdh.Run(ctx)
-	assert.Equal(t, http.StatusBadRequest, resp.Status())
+	assert.Equal(t, http.StatusOK, resp.Status())
 }
 
 func TestAttachProjectToRepo(t *testing.T) {


### PR DESCRIPTION
[DEVPROD-5336](https://jira.mongodb.org/browse/DEVPROD-5336)

### Description
Originally, there is no way to make projects deletable/hidden- then when we added multi-tracking branch projects and repo ref, we made those deletable/hiddenable. This was out of scope and at the time, seen as not required. Most of the changes need to be done via the frontend.

### Testing
Manual testing via staging. Some CI testing edited

I made two projects:

https://evergreen-staging.corp.mongodb.com/rest/v2/projects/DeleteMe
https://evergreen-staging.corp.mongodb.com/rest/v2/projects/deleteme

The 2nd one I successfully deleted when I deployed. The 1st is unable to delete. The 2nd is successfully hidden from UI as well.