### PR TITLE
DEVPROD-5244: fix broken agent test

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2466,7 +2466,12 @@ tasks:
     commands:
       - command: shell.exec
         params:
-          script: echo "I am test log.\nI should get ingested automatically by the agent.\n" > ${workdir}/build/TestLogs/test.log
+          script: |
+            cat >> build/TestLogs/test.log <<EOF
+            I am test log.
+            I should get ingested automatically by the agent.
+            And stored as well.
+            EOF
 `
 	s.setupRunTask(projYml)
 	nextTask := &apimodels.NextTaskResponse{
@@ -2483,7 +2488,7 @@ tasks:
 	for it.Next() {
 		actualLines += it.Item().Data + "\n"
 	}
-	expectedLines := "I am test log.\nI should get ingested automatically by the agent.\n"
+	expectedLines := "I am test log.\nI should get ingested automatically by the agent.\nAnd stored as well.\n"
 	s.Equal(expectedLines, actualLines)
 }
 


### PR DESCRIPTION
DEVPROD-5244

### Description
Just cygwin weirdness...

### Testing
[patch build with passing task on windows
](https://spruce.mongodb.com/task/evergreen_windows_test_agent_patch_6107b5deeeb8b6f9d0b0563dcebf8ec7b2085685_65e0fb603066153a34e89302_24_02_29_21_47_27/logs?execution=0&logtype=task&sortBy=STATUS&sortDir=ASC)

### Documentation
N/A
