### PR TITLE
DEVPROD-2299 Remove govulncheck from container tasks

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -627,7 +627,7 @@ tasks:
             - GOROOT
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
-    tags: ["linter", "no-container"]
+    tags: ["linter", "skip-container"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec
@@ -819,7 +819,7 @@ buildvariants:
       - name: ".smoke"
       - name: ".test"
       - name: "js-test"
-      - name: ".linter !.no-container"
+      - name: ".linter !.skip-container"
       - name: "dist-staging"
 
   - name: lint

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -627,7 +627,7 @@ tasks:
             - GOROOT
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
-    tags: ["linter"]
+    tags: ["linter", "no-container"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec
@@ -819,7 +819,7 @@ buildvariants:
       - name: ".smoke"
       - name: ".test"
       - name: "js-test"
-      - name: ".linter"
+      - name: ".linter !.no-container"
       - name: "dist-staging"
 
   - name: lint


### PR DESCRIPTION
DEVPROD-2299

### Description
Adds a new tag that excludes tasks tagged with "no-container" for linter tasks.

I was thinking of expanding this to the other tags but I think that should be done on an "as-needed" basis. This solution seems like the most self-documenting.

### Testing
Configured a patch and it no longer shows up in the container ubuntu distro, only in the ubuntu distro