### PR TITLE
DEVPROD-4768: bulk write updates when caching host data from EC2

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -757,7 +757,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 	}
 
 	// Cache instance information so we can make fewer calls to AWS's API.
-	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
+	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache...), message.Fields{
 		"message":   "error bulk updating cached host data",
 		"num_hosts": len(hostIDsToCache),
 		"host_ids":  hostIDsToCache,
@@ -796,7 +796,7 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 			host:     h,
 			instance: instance,
 		}
-		if err = cacheHostData(ctx, m.env, m.client, pair); err != nil {
+		if err = cacheAllHostData(ctx, m.env, m.client, pair); err != nil {
 			return status, errors.Wrapf(err, "caching EC2 host data for host '%s'", h.Id)
 		}
 	}
@@ -1027,7 +1027,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 		host:     h,
 		instance: instance,
 	}
-	if err = cacheHostData(ctx, m.env, m.client, pair); err != nil {
+	if err = cacheAllHostData(ctx, m.env, m.client, pair); err != nil {
 		return errors.Wrapf(err, "cache EC2 host data for host '%s'", h.Id)
 	}
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -742,7 +742,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		hostID := hostsToCheck[i]
 		instance, ok := reservationsMap[hostID]
 		if !ok {
-			hostToStatusMap[hostsToCheck[i]] = StatusNonExistent
+			hostToStatusMap[hostID] = StatusNonExistent
 			continue
 		}
 		status := ec2StatusToEvergreenStatus(instance.State.Name)
@@ -759,7 +759,7 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 	// Cache instance information so we can make fewer calls to AWS's API.
 	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
 		"message":   "error bulk updating cached host data",
-		"num_hosts": len(hostsToCache),
+		"num_hosts": len(hostIDsToCache),
 		"host_ids":  hostIDsToCache,
 	}))
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -709,7 +709,6 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 	defer m.client.Close()
 
 	instanceIdToHostMap := map[string]*host.Host{}
-	hostToStatusMap := map[string]CloudStatus{}
 	hostsToCheck := []string{}
 
 	for i := range hosts {
@@ -717,37 +716,46 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 		hostsToCheck = append(hostsToCheck, hosts[i].Id)
 	}
 
-	// Get host statuses
-	if len(hostsToCheck) > 0 {
-		out, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			InstanceIds: hostsToCheck,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "describing instances")
-		}
-		if err = validateEc2DescribeInstancesOutput(out); err != nil {
-			return nil, errors.Wrap(err, "invalid describe instances response")
-		}
-		reservationsMap := map[string]types.Instance{}
-		for i := range out.Reservations {
-			reservationsMap[*out.Reservations[i].Instances[0].InstanceId] = out.Reservations[i].Instances[0]
-		}
-		for i := range hostsToCheck {
-			instance, ok := reservationsMap[hostsToCheck[i]]
-			if !ok {
-				hostToStatusMap[hostsToCheck[i]] = StatusNonExistent
-				continue
-			}
-			status := ec2StatusToEvergreenStatus(instance.State.Name)
-			if status == StatusRunning {
-				// cache instance information so we can make fewer calls to AWS's API
-				if err = cacheHostData(ctx, m.env, instanceIdToHostMap[hostsToCheck[i]], &instance, m.client); err != nil {
-					return nil, errors.Wrapf(err, "caching EC2 host data for host '%s'", hostsToCheck[i])
-				}
-			}
-			hostToStatusMap[instanceIdToHostMap[hostsToCheck[i]].Id] = status
-		}
+	if len(hostsToCheck) == 0 {
+		return map[string]CloudStatus{}, nil
 	}
+
+	out, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: hostsToCheck,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "describing instances")
+	}
+	if err = validateEc2DescribeInstancesOutput(out); err != nil {
+		return nil, errors.Wrap(err, "invalid describe instances response")
+	}
+	reservationsMap := map[string]types.Instance{}
+	for i := range out.Reservations {
+		reservationsMap[*out.Reservations[i].Instances[0].InstanceId] = out.Reservations[i].Instances[0]
+	}
+	hostsToCache := make([]hostInstancePair, 0, len(hostsToCheck))
+	hostToStatusMap := map[string]CloudStatus{}
+	for i := range hostsToCheck {
+		instance, ok := reservationsMap[hostsToCheck[i]]
+		if !ok {
+			hostToStatusMap[hostsToCheck[i]] = StatusNonExistent
+			continue
+		}
+		status := ec2StatusToEvergreenStatus(instance.State.Name)
+		if status == StatusRunning {
+			hostsToCache = append(hostsToCache, hostInstancePair{
+				host:     instanceIdToHostMap[hostsToCheck[i]],
+				instance: &instance,
+			})
+		}
+		hostToStatusMap[instanceIdToHostMap[hostsToCheck[i]].Id] = status
+	}
+
+	// Cache instance information so we can make fewer calls to AWS's API.
+	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
+		"message":   "error bulk updating cached host data",
+		"num_hosts": len(hostsToCache),
+	}))
 
 	return hostToStatusMap, nil
 }
@@ -777,8 +785,12 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 	status = ec2StatusToEvergreenStatus(instance.State.Name)
 
 	if status == StatusRunning {
-		// cache instance information so we can make fewer calls to AWS's API
-		if err = cacheHostData(ctx, m.env, h, instance, m.client); err != nil {
+		// Cache instance information so we can make fewer calls to AWS's API.
+		pair := hostInstancePair{
+			host:     h,
+			instance: instance,
+		}
+		if err = cacheHostData(ctx, m.env, m.client, pair); err != nil {
 			return status, errors.Wrapf(err, "caching EC2 host data for host '%s'", h.Id)
 		}
 	}
@@ -1005,7 +1017,11 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 		return errors.Wrap(err, "checking if spawn host started")
 	}
 
-	if err = cacheHostData(ctx, m.env, h, instance, m.client); err != nil {
+	pair := hostInstancePair{
+		host:     h,
+		instance: instance,
+	}
+	if err = cacheHostData(ctx, m.env, m.client, pair); err != nil {
 		return errors.Wrapf(err, "cache EC2 host data for host '%s'", h.Id)
 	}
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1102,6 +1102,7 @@ func (c *awsClientMock) DescribeInstances(ctx context.Context, input *ec2.Descri
 							Name: types.InstanceStateNameRunning,
 						},
 						PublicDnsName:    aws.String("public_dns_name"),
+						PublicIpAddress:  aws.String("127.0.0.1"),
 						PrivateIpAddress: aws.String(MockIPV4),
 						NetworkInterfaces: []types.InstanceNetworkInterface{
 							{
@@ -1180,6 +1181,7 @@ func (c *awsClientMock) StartInstances(ctx context.Context, input *ec2.StartInst
 			AvailabilityZone: aws.String("us-east-1a"),
 		},
 		PublicDnsName:    aws.String("public_dns_name"),
+		PublicIpAddress:  aws.String("127.0.0.1"),
 		PrivateIpAddress: aws.String("12.34.56.78"),
 		LaunchTime:       aws.Time(time.Now()),
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -164,14 +164,8 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 	defer m.client.Close()
 
-	startAt := time.Now()
 	describeInstancesOutput, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		InstanceIds: instanceIDs,
-	})
-	grip.Debug(message.Fields{
-		"message":       "finished getting describe instances",
-		"num_hosts":     len(hosts),
-		"duration_secs": time.Since(startAt).Seconds(),
 	})
 
 	if err != nil {
@@ -210,7 +204,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	// Cache instance information so we can make fewer calls to AWS's API.
 	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
 		"message":   "error bulk updating cached host data",
-		"num_hosts": len(hostsToCache),
+		"num_hosts": len(hostIDsToCache),
 		"host_ids":  hostIDsToCache,
 	}))
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -193,6 +193,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 
 	hostsToCache := make([]hostInstancePair, 0, len(hosts))
+	hostIDsToCache := make([]string, 0, len(hosts))
 	for i := range hosts {
 		h := hosts[i]
 		status, ok := statuses[h.Id]
@@ -202,6 +203,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 		if status == StatusRunning {
 			pair := hostInstancePair{host: &h, instance: instanceMap[h.Id]}
 			hostsToCache = append(hostsToCache, pair)
+			hostIDsToCache = append(hostIDsToCache, h.Id)
 		}
 	}
 
@@ -209,6 +211,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
 		"message":   "error bulk updating cached host data",
 		"num_hosts": len(hostsToCache),
+		"host_ids":  hostIDsToCache,
 	}))
 
 	return statuses, nil

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -202,7 +202,7 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	}
 
 	// Cache instance information so we can make fewer calls to AWS's API.
-	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
+	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache...), message.Fields{
 		"message":   "error bulk updating cached host data",
 		"num_hosts": len(hostIDsToCache),
 		"host_ids":  hostIDsToCache,
@@ -243,7 +243,7 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 			host:     h,
 			instance: instance,
 		}
-		grip.Error(message.WrapError(cacheHostData(ctx, m.env, m.client, pair), message.Fields{
+		grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, pair), message.Fields{
 			"message": "can't update host cached data",
 			"host_id": h.Id,
 		}))

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -192,19 +192,24 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 		statuses[instanceID] = status
 	}
 
-	for _, h := range hosts {
+	hostsToCache := make([]hostInstancePair, 0, len(hosts))
+	for i := range hosts {
+		h := hosts[i]
 		status, ok := statuses[h.Id]
 		if !ok {
 			statuses[h.Id] = StatusNonExistent
 		}
 		if status == StatusRunning {
-			// cache instance information so we can make fewer calls to AWS's API
-			grip.Error(message.WrapError(cacheHostData(ctx, m.env, &h, instanceMap[h.Id], m.client), message.Fields{
-				"message": "can't update host cached data",
-				"host_id": h.Id,
-			}))
+			pair := hostInstancePair{host: &h, instance: instanceMap[h.Id]}
+			hostsToCache = append(hostsToCache, pair)
 		}
 	}
+
+	// Cache instance information so we can make fewer calls to AWS's API.
+	grip.Error(message.WrapError(cacheAllHostData(ctx, m.env, m.client, hostsToCache), message.Fields{
+		"message":   "error bulk updating cached host data",
+		"num_hosts": len(hostsToCache),
+	}))
 
 	return statuses, nil
 }
@@ -236,8 +241,12 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	}
 	status = ec2StatusToEvergreenStatus(instance.State.Name)
 	if status == StatusRunning {
-		// cache instance information so we can make fewer calls to AWS's API
-		grip.Error(message.WrapError(cacheHostData(ctx, m.env, h, instance, m.client), message.Fields{
+		// Cache instance information so we can make fewer calls to AWS's API.
+		pair := hostInstancePair{
+			host:     h,
+			instance: instance,
+		}
+		grip.Error(message.WrapError(cacheHostData(ctx, m.env, m.client, pair), message.Fields{
 			"message": "can't update host cached data",
 			"host_id": h.Id,
 		}))

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/pkg/errors"
@@ -23,35 +24,196 @@ func TestFleet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var h *host.Host
-	var m *ec2FleetManager
-	for name, test := range map[string]func(*testing.T){
-		"SpawnHost": func(*testing.T) {
-			var err error
-			h, err = m.SpawnHost(context.Background(), h)
+	defer func() {
+		assert.NoError(t, db.Clear(host.Collection))
+	}()
+
+	for name, test := range map[string]func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host){
+		"SpawnHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h, err := m.SpawnHost(ctx, h)
 			assert.NoError(t, err)
 			assert.Equal(t, "i-12345", h.Id)
 		},
-		"GetInstanceStatuses": func(*testing.T) {
+		"GetInstanceStatusesReturnsMultipleHostStatusesAndCachesData": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h1 := h
+			h2 := host.Host{
+				Id:  "h2",
+				Tag: "ht_2",
+				Distro: distro.Distro{
+					ProviderSettingsList: []*birch.Document{birch.NewDocument(
+						birch.EC.String("ami", "ami"),
+						birch.EC.String("instance_type", "instance"),
+						birch.EC.String("key_name", "key"),
+						birch.EC.String("aws_access_key_id", "key_id"),
+						birch.EC.Double("bid_price", 0.001),
+						birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
+					)},
+					Provider: evergreen.ProviderNameEc2Fleet,
+				},
+			}
+			require.NoError(t, h2.Insert(ctx))
+
+			hosts := []host.Host{*h1, h2}
+
+			startedAt := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+			client.DescribeInstancesOutput = &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{
+						Instances: []types.Instance{
+							{
+								// h2
+								InstanceId:   aws.String(h2.Id),
+								InstanceType: "c4.4xlarge",
+								State: &types.InstanceState{
+									Name: types.InstanceStateNameRunning,
+								},
+								LaunchTime: aws.Time(startedAt),
+								Placement: &types.Placement{
+									AvailabilityZone: aws.String("us-east-1b"),
+								},
+								PublicDnsName:    aws.String("h2_public_dns_name"),
+								PrivateIpAddress: aws.String("127.0.0.1"),
+								PublicIpAddress:  aws.String("127.0.0.2"),
+								NetworkInterfaces: []types.InstanceNetworkInterface{
+									{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::1")}}},
+								},
+								BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+									{
+										DeviceName: aws.String("/dev/sda1"),
+										Ebs: &types.EbsInstanceBlockDevice{
+											VolumeId: aws.String("vol-12345"),
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Instances: []types.Instance{
+							{
+								// h1
+								InstanceId:   aws.String(h1.Id),
+								InstanceType: "m4.xlarge",
+								State: &types.InstanceState{
+									Name: types.InstanceStateNameRunning,
+								},
+								LaunchTime: aws.Time(startedAt),
+								Placement: &types.Placement{
+									AvailabilityZone: aws.String("us-east-1c"),
+								},
+								PublicDnsName:    aws.String("h1_public_dns_name"),
+								PrivateIpAddress: aws.String("127.0.0.3"),
+								PublicIpAddress:  aws.String("127.0.0.4"),
+								NetworkInterfaces: []types.InstanceNetworkInterface{
+									{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::1")}}},
+								},
+								BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+									{
+										DeviceName: aws.String("/dev/sdb1"),
+										Ebs: &types.EbsInstanceBlockDevice{
+											VolumeId: aws.String("vol-67890"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			statuses, err := m.GetInstanceStatuses(ctx, hosts)
+			assert.NoError(t, err)
+			assert.Len(t, statuses, len(hosts), "should return same number of statuses as there are hosts")
+			for hostID, status := range statuses {
+				assert.Equal(t, StatusRunning, status)
+				assert.Contains(t, []string{h1.Id, h2.Id}, hostID, "should return status for requested host")
+			}
+
+			dbHost1, err := host.FindOneId(ctx, h1.Id)
+			assert.NoError(t, err)
+			require.NotZero(t, dbHost1)
+			assert.Equal(t, "us-east-1c", dbHost1.Zone)
+			assert.WithinDuration(t, startedAt, dbHost1.StartTime, 0)
+			assert.Equal(t, "127.0.0.3", dbHost1.IPv4)
+			assert.Equal(t, "127.0.0.4", dbHost1.PublicIPv4)
+			assert.Equal(t, "::1", dbHost1.IP)
+			assert.Equal(t, "h1_public_dns_name", dbHost1.Host)
+			require.Len(t, dbHost1.Volumes, 1)
+			assert.Equal(t, "vol-67890", dbHost1.Volumes[0].VolumeID)
+			assert.Equal(t, "/dev/sdb1", dbHost1.Volumes[0].DeviceName)
+
+			dbHost2, err := host.FindOneId(ctx, h2.Id)
+			assert.NoError(t, err)
+			require.NotZero(t, dbHost2)
+			assert.Equal(t, "us-east-1b", dbHost2.Zone)
+			assert.WithinDuration(t, startedAt, dbHost2.StartTime, 0)
+			assert.Equal(t, "127.0.0.1", dbHost2.IPv4)
+			assert.Equal(t, "127.0.0.2", dbHost2.PublicIPv4)
+			assert.Equal(t, "::1", dbHost2.IP)
+			assert.Equal(t, "h2_public_dns_name", dbHost2.Host)
+			require.Len(t, dbHost2.Volumes, 1)
+			assert.Equal(t, "vol-12345", dbHost2.Volumes[0].VolumeID)
+			assert.Equal(t, "/dev/sda1", dbHost2.Volumes[0].DeviceName)
+		},
+		"GetInstanceStatusesReturnsSingleHostStatusAndCachesData": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			hosts := []host.Host{*h}
 
-			statuses, err := m.GetInstanceStatuses(context.Background(), hosts)
+			startedAt := time.Now().Round(time.Hour)
+			client.DescribeInstancesOutput = &ec2.DescribeInstancesOutput{
+				Reservations: []types.Reservation{
+					{
+						Instances: []types.Instance{
+							{
+								InstanceId:   aws.String(h.Id),
+								InstanceType: "m4.xlarge",
+								State: &types.InstanceState{
+									Name: types.InstanceStateNameRunning,
+								},
+								LaunchTime: aws.Time(startedAt),
+								Placement: &types.Placement{
+									AvailabilityZone: aws.String("us-east-1c"),
+								},
+								PublicDnsName:    aws.String("public_dns_name"),
+								PrivateIpAddress: aws.String("127.0.0.1"),
+								PublicIpAddress:  aws.String("127.0.0.2"),
+								NetworkInterfaces: []types.InstanceNetworkInterface{
+									{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::1")}}},
+								},
+								BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
+									{
+										DeviceName: aws.String("/dev/sda1"),
+										Ebs: &types.EbsInstanceBlockDevice{
+											VolumeId: aws.String("vol-12345"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			statuses, err := m.GetInstanceStatuses(ctx, hosts)
 			assert.NoError(t, err)
 			assert.Len(t, statuses, len(hosts), "should return same number of statuses as there are hosts")
 			for _, status := range statuses {
 				assert.Equal(t, StatusRunning, status)
 			}
 
-			mockClient := m.client.(*awsClientMock)
-			assert.Len(t, mockClient.DescribeInstancesInput.InstanceIds, 1)
-			assert.Equal(t, "h1", mockClient.DescribeInstancesInput.InstanceIds[0])
-
-			hDb, err := host.FindOneId(ctx, "h1")
+			dbHost, err := host.FindOneId(ctx, h.Id)
 			assert.NoError(t, err)
-			assert.Equal(t, "us-east-1a", hDb.Zone)
+			assert.Equal(t, "us-east-1c", dbHost.Zone)
+			assert.Equal(t, startedAt, dbHost.StartTime)
+			assert.Equal(t, "::1", dbHost.IP)
+			assert.Equal(t, "127.0.0.1", dbHost.IPv4)
+			assert.Equal(t, "127.0.0.2", dbHost.PublicIPv4)
+			assert.Equal(t, "public_dns_name", dbHost.Host)
+			require.Len(t, dbHost.Volumes, 1)
+			assert.Equal(t, "vol-12345", dbHost.Volumes[0].VolumeID)
+			assert.Equal(t, "/dev/sda1", dbHost.Volumes[0].DeviceName)
 		},
-		"GetInstanceStatus": func(*testing.T) {
-			status, err := m.GetInstanceStatus(context.Background(), h)
+		"GetInstanceStatus": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			status, err := m.GetInstanceStatus(ctx, h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusRunning, status)
 
@@ -60,64 +222,60 @@ func TestFleet(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "us-east-1a", hDb.Zone)
 		},
-		"GetInstanceStatusNonExistentInstance": func(*testing.T) {
+		"GetInstanceStatusNonExistentInstance": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			apiErr := &smithy.GenericAPIError{
 				Code:    EC2ErrorNotFound,
 				Message: "The instance ID 'test-id' does not exist",
 			}
 			wrappedAPIError := errors.Wrap(apiErr, "EC2 API returned error for DescribeInstances")
-			mockClient := m.client.(*awsClientMock)
-			mockClient.RequestGetInstanceInfoError = wrappedAPIError
-			status, err := m.GetInstanceStatus(context.Background(), h)
+			client.RequestGetInstanceInfoError = wrappedAPIError
+			status, err := m.GetInstanceStatus(ctx, h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)
 		},
-		"GetInstanceStatusNonExistentReservation": func(*testing.T) {
-			mockClient := m.client.(*awsClientMock)
-			mockClient.RequestGetInstanceInfoError = noReservationError
-			status, err := m.GetInstanceStatus(context.Background(), h)
+		"GetInstanceStatusNonExistentReservation": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			client.RequestGetInstanceInfoError = noReservationError
+			status, err := m.GetInstanceStatus(ctx, h)
 			assert.NoError(t, err)
 			assert.Equal(t, StatusNonExistent, status)
 		},
-		"TerminateInstance": func(*testing.T) {
-			assert.NoError(t, m.TerminateInstance(context.Background(), h, "evergreen", ""))
+		"TerminateInstance": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
 
-			mockClient := m.client.(*awsClientMock)
-			assert.Len(t, mockClient.TerminateInstancesInput.InstanceIds, 1)
-			assert.Equal(t, "h1", mockClient.TerminateInstancesInput.InstanceIds[0])
+			assert.Len(t, client.TerminateInstancesInput.InstanceIds, 1)
+			assert.Equal(t, "h1", client.TerminateInstancesInput.InstanceIds[0])
 
 			hDb, err := host.FindOneId(ctx, "h1")
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
 		},
-		"GetDNSName": func(*testing.T) {
-			dnsName, err := m.GetDNSName(context.Background(), h)
+		"GetDNSName": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			dnsName, err := m.GetDNSName(ctx, h)
 			assert.NoError(t, err)
 			assert.Equal(t, "public_dns_name", dnsName)
 		},
-		"SpawnFleetSpotHost": func(*testing.T) {
-			assert.NoError(t, m.spawnFleetSpotHost(context.Background(), &host.Host{Tag: "ht_1"}, &EC2ProviderSettings{}))
+		"SpawnFleetSpotHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			assert.NoError(t, m.spawnFleetSpotHost(ctx, &host.Host{Tag: "ht_1"}, &EC2ProviderSettings{}))
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Equal(t, "ht_1", *mockClient.DeleteLaunchTemplateInput.LaunchTemplateName)
 		},
-		"RequestFleet": func(*testing.T) {
+		"RequestFleet": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			ec2Settings := &EC2ProviderSettings{VpcName: "my_vpc", InstanceType: "instanceType0", IAMInstanceProfileARN: "my-profile"}
 
-			instanceID, err := m.requestFleet(context.Background(), h, ec2Settings)
+			instanceID, err := m.requestFleet(ctx, h, ec2Settings)
 			assert.NoError(t, err)
 			assert.Equal(t, "i-12345", instanceID)
 
-			mockClient := m.client.(*awsClientMock)
-			assert.Len(t, mockClient.CreateFleetInput.LaunchTemplateConfigs, 1)
-			assert.Equal(t, "ht_1", *mockClient.CreateFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName)
+			assert.Len(t, client.CreateFleetInput.LaunchTemplateConfigs, 1)
+			assert.Equal(t, "ht_1", *client.CreateFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName)
 		},
-		"MakeOverrides": func(*testing.T) {
+		"MakeOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			ec2Settings := &EC2ProviderSettings{
 				InstanceType:          "instanceType0",
 				IAMInstanceProfileARN: "my-profile",
 			}
-			overrides, err := m.makeOverrides(context.Background(), ec2Settings)
+			overrides, err := m.makeOverrides(ctx, ec2Settings)
 			assert.NoError(t, err)
 			require.Len(t, overrides, 1)
 			assert.Equal(t, "subnet-654321", *overrides[0].SubnetId)
@@ -125,7 +283,7 @@ func TestFleet(t *testing.T) {
 			ec2Settings = &EC2ProviderSettings{
 				InstanceType: "not_supported",
 			}
-			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
+			overrides, err = m.makeOverrides(ctx, ec2Settings)
 			assert.NoError(t, err)
 			assert.Nil(t, overrides)
 
@@ -134,46 +292,57 @@ func TestFleet(t *testing.T) {
 				IAMInstanceProfileARN: "my-profile",
 				SubnetId:              "subnet-654321",
 			}
-			overrides, err = m.makeOverrides(context.Background(), ec2Settings)
+			overrides, err = m.makeOverrides(ctx, ec2Settings)
 			assert.NoError(t, err)
 			assert.Nil(t, overrides)
 		},
 	} {
-		h = &host.Host{
-			Id:  "h1",
-			Tag: "ht_1",
-			Distro: distro.Distro{
-				ProviderSettingsList: []*birch.Document{birch.NewDocument(
-					birch.EC.String("ami", "ami"),
-					birch.EC.String("instance_type", "instance"),
-					birch.EC.String("key_name", "key"),
-					birch.EC.String("aws_access_key_id", "key_id"),
-					birch.EC.Double("bid_price", 0.001),
-					birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
-				)},
-				Provider: evergreen.ProviderNameEc2Fleet,
-			},
-		}
-		typeCache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{{SubnetID: "subnet-654321"}}
-		typeCache[instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{}
-		m = &ec2FleetManager{
-			EC2FleetManagerOptions: &EC2FleetManagerOptions{
-				client: &awsClientMock{},
-				region: "test-region",
-			},
-			settings: &evergreen.Settings{
-				Providers: evergreen.CloudProviders{
-					AWS: evergreen.AWSConfig{
-						DefaultSecurityGroup: "sg-default",
-						Subnets:              []evergreen.Subnet{{AZ: evergreen.DefaultEC2Region + "a", SubnetID: "subnet-654321"}},
+		t.Run(name, func(t *testing.T) {
+			tctx, tcancel := context.WithCancel(ctx)
+			defer tcancel()
+
+			h := &host.Host{
+				Id:  "h1",
+				Tag: "ht_1",
+				Distro: distro.Distro{
+					ProviderSettingsList: []*birch.Document{birch.NewDocument(
+						birch.EC.String("ami", "ami"),
+						birch.EC.String("instance_type", "instance"),
+						birch.EC.String("key_name", "key"),
+						birch.EC.String("aws_access_key_id", "key_id"),
+						birch.EC.Double("bid_price", 0.001),
+						birch.EC.SliceString("security_group_ids", []string{"abcdef"}),
+					)},
+					Provider: evergreen.ProviderNameEc2Fleet,
+				},
+			}
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, h.Insert(ctx))
+
+			typeCache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{{SubnetID: "subnet-654321"}}
+			typeCache[instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{}
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+			client := &awsClientMock{}
+			m := &ec2FleetManager{
+				EC2FleetManagerOptions: &EC2FleetManagerOptions{
+					client: client,
+					region: "test-region",
+				},
+				settings: &evergreen.Settings{
+					Providers: evergreen.CloudProviders{
+						AWS: evergreen.AWSConfig{
+							DefaultSecurityGroup: "sg-default",
+							Subnets:              []evergreen.Subnet{{AZ: evergreen.DefaultEC2Region + "a", SubnetID: "subnet-654321"}},
+						},
 					},
 				},
-			},
-		}
+				env: env,
+			}
 
-		require.NoError(t, db.Clear(host.Collection))
-		require.NoError(t, h.Insert(ctx))
-		t.Run(name, test)
+			test(tctx, t, m, client, h)
+		})
 	}
 }
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1082,7 +1082,8 @@ func (s *EC2Suite) TestCacheHostData() {
 	instance.PublicDnsName = aws.String("public_dns_name")
 	instance.PrivateIpAddress = aws.String("12.34.56.78")
 
-	s.NoError(cacheHostData(s.ctx, s.env, s.h, instance, ec2m.client))
+	pair := hostInstancePair{host: s.h, instance: instance}
+	s.NoError(cacheHostData(s.ctx, s.env, ec2m.client, pair))
 
 	s.Equal(*instance.Placement.AvailabilityZone, s.h.Zone)
 	s.True(instance.LaunchTime.Equal(s.h.StartTime))

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1120,7 +1120,7 @@ func (s *EC2Suite) TestCacheHostData() {
 	instance.PrivateIpAddress = aws.String("12.34.56.78")
 
 	pair := hostInstancePair{host: s.h, instance: instance}
-	s.NoError(cacheHostData(s.ctx, s.env, ec2m.client, pair))
+	s.NoError(cacheAllHostData(s.ctx, s.env, ec2m.client, pair))
 
 	s.Equal(*instance.Placement.AvailabilityZone, s.h.Zone)
 	s.True(instance.LaunchTime.Equal(s.h.StartTime))

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -702,11 +702,11 @@ func (s *EC2Suite) TestStartInstance() {
 	defer cancel()
 
 	hosts := []*host.Host{
-		&host.Host{
+		{
 			Id:     "host-running",
 			Status: evergreen.HostRunning,
 		},
-		&host.Host{
+		{
 			Id:     "host-stopped",
 			Status: evergreen.HostStopped,
 			Host:   "old_dns_name",
@@ -826,6 +826,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 							Name: types.InstanceStateNameRunning,
 						},
 						PublicDnsName:    aws.String("public_dns_name_3"),
+						PublicIpAddress:  aws.String("127.0.0.1"),
 						PrivateIpAddress: aws.String("3.3.3.3"),
 						Placement: &types.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
@@ -876,17 +877,22 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 							Name: types.InstanceStateNameRunning,
 						},
 						PublicDnsName:    aws.String("public_dns_name_3"),
+						PublicIpAddress:  aws.String("127.0.0.3"),
 						PrivateIpAddress: aws.String("3.3.3.3"),
 						Placement: &types.Placement{
-							AvailabilityZone: aws.String("us-east-1a"),
+							AvailabilityZone: aws.String("us-east-1c"),
 						},
 						LaunchTime: aws.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
 						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
 							{
 								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: aws.String("volume_id"),
+									VolumeId: aws.String("volume_id3"),
 								},
+								DeviceName: aws.String("/dev/sda3"),
 							},
+						},
+						NetworkInterfaces: []types.InstanceNetworkInterface{
+							{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::3")}}},
 						},
 					},
 				},
@@ -899,6 +905,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 							Name: types.InstanceStateNameRunning,
 						},
 						PublicDnsName:    aws.String("public_dns_name_1"),
+						PublicIpAddress:  aws.String("127.0.0.1"),
 						PrivateIpAddress: aws.String("1.1.1.1"),
 						Placement: &types.Placement{
 							AvailabilityZone: aws.String("us-east-1a"),
@@ -907,9 +914,13 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
 							{
 								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: aws.String("volume_id"),
+									VolumeId: aws.String("volume_id1"),
 								},
+								DeviceName: aws.String("/dev/sda1"),
 							},
+						},
+						NetworkInterfaces: []types.InstanceNetworkInterface{
+							{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::1")}}},
 						},
 					},
 				},
@@ -932,17 +943,22 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 							Name: types.InstanceStateNameRunning,
 						},
 						PublicDnsName:    aws.String("public_dns_name_2"),
+						PublicIpAddress:  aws.String("127.0.0.2"),
 						PrivateIpAddress: aws.String("2.2.2.2"),
 						Placement: &types.Placement{
-							AvailabilityZone: aws.String("us-east-1a"),
+							AvailabilityZone: aws.String("us-east-1b"),
 						},
 						LaunchTime: aws.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
 						BlockDeviceMappings: []types.InstanceBlockDeviceMapping{
 							{
 								Ebs: &types.EbsInstanceBlockDevice{
-									VolumeId: aws.String("volume_id"),
+									VolumeId: aws.String("volume_id2"),
 								},
+								DeviceName: aws.String("/dev/sda2"),
 							},
+						},
+						NetworkInterfaces: []types.InstanceNetworkInterface{
+							{Ipv6Addresses: []types.InstanceIpv6Address{{Ipv6Address: aws.String("::2")}}},
 						},
 					},
 				},
@@ -965,11 +981,31 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	}, statuses)
 
 	s.Equal("public_dns_name_1", hosts[0].Host)
+	s.Equal("127.0.0.1", hosts[0].PublicIPv4)
 	s.Equal("1.1.1.1", hosts[0].IPv4)
+	s.Equal("::1", hosts[0].IP)
+	s.Equal("us-east-1a", hosts[0].Zone)
+	s.Require().Len(hosts[0].Volumes, 1)
+	s.Equal("volume_id1", hosts[0].Volumes[0].VolumeID)
+	s.Equal("/dev/sda1", hosts[0].Volumes[0].DeviceName)
+
 	s.Equal("public_dns_name_2", hosts[1].Host)
+	s.Equal("127.0.0.2", hosts[1].PublicIPv4)
 	s.Equal("2.2.2.2", hosts[1].IPv4)
+	s.Equal("::2", hosts[1].IP)
+	s.Equal("us-east-1b", hosts[1].Zone)
+	s.Require().Len(hosts[1].Volumes, 1)
+	s.Equal("volume_id2", hosts[1].Volumes[0].VolumeID)
+	s.Equal("/dev/sda2", hosts[1].Volumes[0].DeviceName)
+
 	s.Equal("public_dns_name_3", hosts[2].Host)
+	s.Equal("127.0.0.3", hosts[2].PublicIPv4)
+	s.Equal("::3", hosts[2].IP)
 	s.Equal("3.3.3.3", hosts[2].IPv4)
+	s.Equal("us-east-1c", hosts[2].Zone)
+	s.Require().Len(hosts[2].Volumes, 1)
+	s.Equal("volume_id3", hosts[2].Volumes[0].VolumeID)
+	s.Equal("/dev/sda3", hosts[2].Volumes[0].DeviceName)
 }
 
 func (s *EC2Suite) TestGetInstanceStatusesForNonexistentInstances() {
@@ -1080,6 +1116,7 @@ func (s *EC2Suite) TestCacheHostData() {
 		},
 	}
 	instance.PublicDnsName = aws.String("public_dns_name")
+	instance.PublicIpAddress = aws.String("127.0.0.1")
 	instance.PrivateIpAddress = aws.String("12.34.56.78")
 
 	pair := hostInstancePair{host: s.h, instance: instance}
@@ -1088,6 +1125,9 @@ func (s *EC2Suite) TestCacheHostData() {
 	s.Equal(*instance.Placement.AvailabilityZone, s.h.Zone)
 	s.True(instance.LaunchTime.Equal(s.h.StartTime))
 	s.Equal("2001:0db8:85a3:0000:0000:8a2e:0370:7334", s.h.IP)
+	s.Equal("public_dns_name", s.h.Host)
+	s.Equal("127.0.0.1", s.h.PublicIPv4)
+	s.Equal("12.34.56.78", s.h.IPv4)
 	s.Equal([]host.VolumeAttachment{
 		{
 			VolumeID:   "volume_id",

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -302,12 +302,13 @@ func makeCloudProviderData(h *host.Host, instance *types.Instance) (*host.CloudP
 	}
 
 	return &host.CloudProviderData{
-		Zone:      utility.FromStringPtr(instance.Placement.AvailabilityZone),
-		StartedAt: utility.FromTimePtr(instance.LaunchTime),
-		PublicDNS: utility.FromStringPtr(instance.PublicDnsName),
-		Volumes:   makeVolumeAttachments(instance.BlockDeviceMappings),
-		IPv4:      utility.FromStringPtr(instance.PrivateIpAddress),
-		IPv6:      ipv6,
+		Zone:        utility.FromStringPtr(instance.Placement.AvailabilityZone),
+		StartedAt:   utility.FromTimePtr(instance.LaunchTime),
+		PublicDNS:   utility.FromStringPtr(instance.PublicDnsName),
+		Volumes:     makeVolumeAttachments(instance.BlockDeviceMappings),
+		PublicIPv4:  utility.FromStringPtr(instance.PublicIpAddress),
+		PrivateIPv4: utility.FromStringPtr(instance.PrivateIpAddress),
+		IPv6:        ipv6,
 	}, nil
 }
 
@@ -358,7 +359,7 @@ func cacheAllHostData(ctx context.Context, env evergreen.Environment, client AWS
 		h.Zone = data.Zone
 		h.StartTime = data.StartedAt
 		h.Host = data.PublicDNS
-		h.IPv4 = data.IPv4
+		h.IPv4 = data.PrivateIPv4
 		h.IP = data.IPv6
 		h.Volumes = data.Volumes
 
@@ -397,7 +398,7 @@ func validateInstanceDataToCache(instance *types.Instance) error {
 const persistentDNSRecordTTLSecs = 1
 
 // setHostPersistentDNSName sets a host's persistent DNS record with its
-// associated IP address and sets it on the host.
+// associated IP address and sets the persistent DNS name on the host.
 func setHostPersistentDNSName(ctx context.Context, env evergreen.Environment, h *host.Host, ipv4Addr string, client AWSClient) error {
 	if ipv4Addr == "" {
 		return errors.New("instance did not include an IP address")

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -340,7 +340,6 @@ func cacheHostData(ctx context.Context, env evergreen.Environment, client AWSCli
 
 // cacheAllHostData is the same as cacheHostData but optimized for updating many
 // hosts at once.
-// kim: TODO: add test
 func cacheAllHostData(ctx context.Context, env evergreen.Environment, client AWSClient, pairs []hostInstancePair) error {
 	catcher := grip.NewBasicCatcher()
 
@@ -359,6 +358,7 @@ func cacheAllHostData(ctx context.Context, env evergreen.Environment, client AWS
 		h.Zone = data.Zone
 		h.StartTime = data.StartedAt
 		h.Host = data.PublicDNS
+		h.PublicIPv4 = data.PublicIPv4
 		h.IPv4 = data.PrivateIPv4
 		h.IP = data.IPv6
 		h.Volumes = data.Volumes
@@ -376,7 +376,7 @@ func cacheAllHostData(ctx context.Context, env evergreen.Environment, client AWS
 		}
 	}
 
-	catcher.Wrap(host.CacheManyHostsCloudProviderData(ctx, env, hostsToCache), "bulk caching host data")
+	catcher.Wrap(host.CacheAllCloudProviderData(ctx, env, hostsToCache), "bulk caching host data")
 
 	return catcher.Resolve()
 }
@@ -388,6 +388,7 @@ func validateInstanceDataToCache(instance *types.Instance) error {
 	catcher.ErrorfWhen(instance.Placement == nil || instance.Placement.AvailabilityZone == nil, "instance missing availability zone")
 	catcher.ErrorfWhen(instance.LaunchTime == nil, "instance missing launch time")
 	catcher.ErrorfWhen(instance.PublicDnsName == nil, "instance missing public DNS name")
+	catcher.ErrorfWhen(instance.PublicIpAddress == nil, "instance missing public IP address")
 	catcher.ErrorfWhen(instance.PrivateIpAddress == nil, "instance missing private IP address")
 	return catcher.Resolve()
 }

--- a/cloud/userdata_test.go
+++ b/cloud/userdata_test.go
@@ -563,7 +563,7 @@ func TestWriteUserDataHeaders(t *testing.T) {
 }
 
 func TestWriteUserDataPart(t *testing.T) {
-	t.Run("SucceedsWIthValidUserData", func(t *testing.T) {
+	t.Run("SucceedsWithValidUserData", func(t *testing.T) {
 		buf := &bytes.Buffer{}
 		mimeWriter := multipart.NewWriter(buf)
 		boundary := "some_boundary"

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1153,27 +1153,6 @@ func (h *Host) SetDNSName(ctx context.Context, dnsName string) error {
 	return err
 }
 
-func (h *Host) SetIPv6Address(ctx context.Context, ipv6Address string) error {
-	err := UpdateOne(
-		ctx,
-		bson.M{
-			IdKey: h.Id,
-		},
-		bson.M{
-			"$set": bson.M{
-				IPKey: ipv6Address,
-			},
-		},
-	)
-
-	if err != nil {
-		return errors.Wrap(err, "updating IPv6 address")
-	}
-
-	h.IP = ipv6Address
-	return nil
-}
-
 // probably don't want to store the port mapping exactly this way
 func (h *Host) SetPortMapping(ctx context.Context, portsMap PortMap) error {
 	err := UpdateOne(

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1907,9 +1907,7 @@ type CloudProviderData struct {
 
 // CacheCloudProvider caches data about the host from its cloud provider.
 func (h *Host) CacheCloudProviderData(ctx context.Context, data CloudProviderData) error {
-	// kim: TODO: see if upsert can be converted to update without breaking
-	// tests.
-	if _, err := UpsertOne(
+	if err := UpdateOne(
 		ctx,
 		bson.M{
 			IdKey: h.Id,
@@ -1930,10 +1928,10 @@ func (h *Host) CacheCloudProviderData(ctx context.Context, data CloudProviderDat
 	return nil
 }
 
-// CacheManyHostsCloudProviderData performs the same updates as
+// CacheAllCloudProviderData performs the same updates as
 // (Host).CacheCloudProviderData but is optimized for updating many hosts at
 // once.
-func CacheManyHostsCloudProviderData(ctx context.Context, env evergreen.Environment, hosts map[string]CloudProviderData) error {
+func CacheAllCloudProviderData(ctx context.Context, env evergreen.Environment, hosts map[string]CloudProviderData) error {
 	updates := make([]mongo.WriteModel, 0, len(hosts))
 	for hostID, data := range hosts {
 		filter := bson.M{IdKey: hostID}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1884,29 +1884,6 @@ type CloudProviderData struct {
 	Volumes     []VolumeAttachment
 }
 
-// CacheCloudProvider caches data about the host from its cloud provider.
-func (h *Host) CacheCloudProviderData(ctx context.Context, data CloudProviderData) error {
-	if err := UpdateOne(
-		ctx,
-		bson.M{
-			IdKey: h.Id,
-		},
-		cacheCloudProviderDataUpdate(data),
-	); err != nil {
-		return err
-	}
-
-	h.Zone = data.Zone
-	h.StartTime = data.StartedAt
-	h.Host = data.PublicDNS
-	h.PublicIPv4 = data.PublicIPv4
-	h.IPv4 = data.PrivateIPv4
-	h.IP = data.IPv6
-	h.Volumes = data.Volumes
-
-	return nil
-}
-
 // CacheAllCloudProviderData performs the same updates as
 // (Host).CacheCloudProviderData but is optimized for updating many hosts at
 // once.

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -529,36 +529,6 @@ func TestHostSetDNSName(t *testing.T) {
 	})
 }
 
-func TestHostSetIPv6Address(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	assert := assert.New(t)
-	assert.NoError(db.ClearCollections(Collection))
-
-	host := &Host{
-		Id: "hostOne",
-	}
-	assert.NoError(host.Insert(ctx))
-
-	ipv6Address := "abcd:1234:459c:2d00:cfe4:843b:1d60:8e47"
-	ipv6Address2 := "aaaa:1f18:459c:2d00:cfe4:843b:1d60:9999"
-
-	assert.NoError(host.SetIPv6Address(ctx, ipv6Address))
-	assert.Equal(host.IP, ipv6Address)
-	host, err := FindOne(ctx, ById(host.Id))
-	assert.NoError(err)
-	assert.Equal(host.IP, ipv6Address)
-
-	// if the host is already updated, new updates should work
-	assert.NoError(host.SetIPv6Address(ctx, ipv6Address2))
-	assert.Equal(host.IP, ipv6Address2)
-
-	host, err = FindOne(ctx, ById(host.Id))
-	assert.NoError(err)
-	assert.Equal(host.IP, ipv6Address2)
-}
-
 func TestMarkAsProvisioned(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -43,7 +43,7 @@ func NewCloudHostReadyJob(env evergreen.Environment, id string) amboy.Job {
 	j.env = env
 	j.SetPriority(1)
 	j.SetScopes([]string{cloudHostReadyJobName})
-	// Jobs never appear to exceed 1 minute, but add a bunch of padding.
+	// Jobs never appear to exceed a few minutes, but add a bunch of padding.
 	j.UpdateTimeInfo(amboy.JobTimeInfo{MaxTime: 10 * time.Minute})
 	return j
 }


### PR DESCRIPTION
DEVPROD-4768

### Description
The host status job is responsible for polling host statuses so that Evergreen knows when they're up and running. When [getting the host status](https://github.com/evergreen-ci/evergreen/blob/99807e9b0813b44eb7c07958b8f1cbc4858f77e3/units/host_status.go#L104), it also [caches some of the information it gets](https://github.com/evergreen-ci/evergreen/blob/99807e9b0813b44eb7c07958b8f1cbc4858f77e3/cloud/ec2_util.go#L305-L327). This caching is done via many `UpdateOne` statements, so if the job checks `N` hosts and finds they're running, it will do approximately `2N` `UpdateOne`s sequentially.

Based on [Honeycomb stats](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/z5owHjDpkbH), the host status job occasionally takes several minutes to complete, and it looks like it's taking a long time to serially run the many `UpdateOne`s to cache the data. In [this example](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/z5owHjDpkbH/trace/RknW3hhoAn?fields[]=s_name&fields[]=s_serviceName&span=d331f3c4458fbff7), it took 1 second to get the statuses from EC2 but 5 minutes to finish all the `UpdateOne`s. During periods when Evergreen is starting up lots of hosts, this bottleneck means hosts may take a long time to get checked.

This PR reduces the amount of roundtrips to the DB by [bulk writing the updates to the hosts](https://www.mongodb.com/docs/manual/core/bulk-write-operations/#bulk-write-operations), which should speed things up when there's a lot of updates. So instead of doing `2N` individual trips to the DB to do the updates, it now sends all the cache updates in bulk to the DB in one trip.

I'm going to monitor the performance change after this is deployed. Depending on how much this speeds up the job, there may be a follow-up PR to further optimize it.

* Bulk write updates to cache EC2 instance data in host documents.
* Consolidate IPv6 and public IPv4 address updates so they get updated with the other EC2 instance data when caching.
* Refactor caching logic to consolidate common logic between caching 1 host vs. caching many.
* Simplify down some overly complicated logic in EC2 implementation for getting instance statuses.

### Testing
* Updated existing tests and added a couple more for better coverage.
* Tested in staging by spawning a spawn host and starting a fresh EC2 task host. Verified that both started up with all their EC2 instance data cached.

### Documentation
N/A