### PR TITLE
DEVPROD-4040: no-op persistent DNS assignment job

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -1248,11 +1248,3 @@ func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGro
 
 	return errors.Wrapf(amboy.EnqueueManyUniqueJobs(ctx, queueGroup, jobs), "populating '%s' queue", queueGroupName)
 }
-
-// PopulatePersistentDNSAssignment populates jobs to assign persistent DNS names
-// to running unexpirable hosts that don't already have one assigned.
-func PopulatePersistentDNSAssignment() amboy.QueueOperation {
-	return func(ctx context.Context, queue amboy.Queue) error {
-		return amboy.EnqueueUniqueJob(ctx, queue, NewPersistentDNSAssignmentJob(utility.RoundPartOfHour(15).Format(TSFormat)))
-	}
-}

--- a/units/crons_remote_fifteen_minute.go
+++ b/units/crons_remote_fifteen_minute.go
@@ -50,7 +50,6 @@ func (j *cronsRemoteFifteenMinuteJob) Run(ctx context.Context) {
 		PopulatePeriodicBuilds(),
 		PopulateReauthorizeUserJobs(j.env),
 		PopulateCheckUnmarkedBlockedTasks(),
-		PopulatePersistentDNSAssignment(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/persistent_dns_assignment.go
+++ b/units/persistent_dns_assignment.go
@@ -5,14 +5,9 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/cloud"
-	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -52,47 +47,4 @@ func NewPersistentDNSAssignmentJob(ts string) amboy.Job {
 
 func (j *persistentDNSAssignmentJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
-	}
-
-	hosts, err := host.FindUnexpirableRunningWithoutPersistentDNSName(ctx, persistentDNSAssignmentBatchSize)
-	if err != nil {
-		j.AddError(err)
-		return
-	}
-	if len(hosts) == 0 {
-		// TODO (DEVPROD-4040): remove this job once all existing unexpirable
-		// hosts have been assigned a persistent DNS name.
-		grip.Info(message.Fields{
-			"message": "all unexpirable hosts have an assigned persistent DNS name",
-			"job_id":  j.ID(),
-		})
-		return
-	}
-
-	for _, h := range hosts {
-		cloudHost, err := cloud.GetCloudHost(ctx, &h, j.env)
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "getting cloud host for host '%s'", h.Id))
-			continue
-		}
-
-		// GetInstanceStatus implicitly refreshes the host's cached data to
-		// include its public IPv4 address and persistent DNS name.
-		cloudStatus, err := cloudHost.GetInstanceStatus(ctx)
-		if err != nil {
-			j.AddError(errors.Wrapf(err, "getting instance status for host '%s'", h.Id))
-			continue
-		}
-
-		grip.InfoWhen(cloudStatus == cloud.StatusRunning, message.Fields{
-			"message":             "successfully assigned persistent DNS name to unexpirable host",
-			"ipv4_address":        h.PublicIPv4,
-			"persistent_dns_name": h.PersistentDNSName,
-			"host_id":             h.Id,
-			"job_id":              j.ID(),
-		})
-	}
 }

--- a/units/persistent_dns_assignment.go
+++ b/units/persistent_dns_assignment.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 )
 
 const (
-	persistentDNSAssignmentJobName   = "persistent-dns-assignment"
-	persistentDNSAssignmentBatchSize = 10
+	persistentDNSAssignmentJobName = "persistent-dns-assignment"
 )
 
 func init() {
@@ -23,8 +21,6 @@ func init() {
 
 type persistentDNSAssignmentJob struct {
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
-
-	env evergreen.Environment
 }
 
 func makePersistentDNSAssignment() *persistentDNSAssignmentJob {


### PR DESCRIPTION
DEVPROD-4040

### Description
Follow-up to #7587 - now that the job has finished assigning persistent DNS names to existing hosts, the job can be removed. To delete the job gracefully, we have to first let any remaining persistent DNS jobs drain out of the Amboy queue (to avoid an issue where the Amboy queue might still have a job in the queue from before the deploy and doesn't know what to do with it because the code is gone). After this is deployed, then the remaining code will be deleted in a follow-up PR.

### Testing
N/A

### Documentation
N/A