### PR TITLE
docs: add tag example to local aliases

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -173,6 +173,9 @@ projects:
   - alias: "alias_name"
     variant: ".*"
     task: "^compile$,tests$"
+  - alias: "alias_using_tags"
+    task_tags:  [ "test", "!smoke" ]
+    variant_tags: ["small"]
   tasks:
   - compile
   - unittests


### PR DESCRIPTION
From user thread:
https://mongodb.slack.com/archives/C0V896UV8/p1709049364840069