### PR TITLE
DEVPROD-5308: call assume role for each task in the `dist-and-upload-clis` task group

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -767,8 +767,8 @@ tasks:
 task_groups:
   - name: dist-and-upload-clis
     max_hosts: 1
-    setup_group_can_fail_task: true
-    setup_group:
+    setup_task_can_fail_task: true
+    setup_task:
       - func: assume-role
     tasks:
       - dist


### PR DESCRIPTION
DEVPROD-5308

### Description
Assume role state is not passed between tasks in a task group. Need to call this before each task rather than once for the entire group.

### Testing
N/A

### Documentation
N/A
