### PR TITLE
DEVPROD-5333 Improve post task logging in agent 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -829,8 +829,8 @@ func (a *Agent) runPostTaskCommands(ctx context.Context, tc *taskContext) error 
 	ctx, span := a.tracer.Start(ctx, "post-task-commands")
 	defer span.End()
 
-	a.killProcs(ctx, tc, false, "post task commands are starting")
-	defer a.killProcs(ctx, tc, false, "post task commands are finished")
+	a.killProcs(ctx, tc, false, "post-task commands are starting")
+	defer a.killProcs(ctx, tc, false, "post-task commands are finished")
 
 	post, err := tc.getPost()
 	if err != nil {
@@ -955,7 +955,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		a.handleTimeoutAndOOM(ctx, tc, status)
 		tc.logger.Task().Info("Task completed - SUCCESS.")
 		if err := a.runPostTaskCommands(ctx, tc); err != nil {
-			tc.logger.Task().Info("Post task completed - FAILURE. Overall task status changed to FAILED.")
+			tc.logger.Task().Info("Post-task completed - FAILURE. Overall task status changed to FAILED.")
 			setEndTaskFailureDetails(tc, detail, evergreen.TaskFailed, "", "")
 		}
 		a.runEndTaskSync(ctx, tc, detail)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -629,7 +629,7 @@ post:
 `
 	s.setupRunTask(projYml)
 
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -660,7 +660,7 @@ post:
 	s.setupRunTask(projYml)
 
 	startAt := time.Now()
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.Less(time.Since(startAt), 5*time.Second, "post command should have stopped early")
 	s.False(s.tc.hadTimedOut(), "should not record post timeout when post cannot fail task")
@@ -695,7 +695,7 @@ post:
 `
 	s.setupRunTask(projYml)
 
-	s.Error(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.Error(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, nil, []string{panicLog})
@@ -716,7 +716,7 @@ post:
 	s.setupRunTask(projYml)
 
 	startAt := time.Now()
-	err := s.a.runPostTaskCommands(s.ctx, s.tc)
+	err := s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc)
 	s.Error(err)
 	s.True(utility.IsContextError(errors.Cause(err)))
 
@@ -1120,7 +1120,7 @@ post:
 `
 	s.setupRunTask(projYml)
 
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -2057,7 +2057,7 @@ task_groups:
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
 	s.tc.taskConfig.TaskGroup = s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -2089,7 +2089,7 @@ task_groups:
 	s.tc.taskConfig.Task.TaskGroup = taskGroup
 	s.tc.taskConfig.TaskGroup = s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
-	s.Error(s.a.runPostTaskCommands(s.ctx, s.tc))
+	s.Error(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -2122,7 +2122,7 @@ task_groups:
 	s.tc.taskConfig.TaskGroup = s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
-	s.NoError(s.a.runPostTaskCommands(s.ctx, s.tc), "teardown task timeout should not fail task")
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc), "teardown task timeout should not fail task")
 
 	s.Less(time.Since(startAt), 5*time.Second, "timeout should have triggered after 1s")
 	s.False(s.tc.hadTimedOut(), "should not have hit task timeout")
@@ -2162,7 +2162,7 @@ task_groups:
 	s.tc.taskConfig.TaskGroup = s.tc.taskConfig.Project.FindTaskGroup(taskGroup)
 
 	startAt := time.Now()
-	err := s.a.runPostTaskCommands(s.ctx, s.tc)
+	err := s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc)
 	s.Error(err, "teardown task timeout should fail task")
 	s.True(utility.IsContextError(errors.Cause(err)))
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-04"
+	AgentVersion = "2024-03-05"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5333

### Description
Use consistant naming for post task: We sometimes refer to it as "post-task" and sometimes "post task" making searching logs harder. We should stick to one.

This also specifies that it can be a teardown task command. This helps because for task groups the post commands should not run, so the logs can look like a bug.  


