### PR TITLE
DEVPROD-5349: send otel traces before cleaning up task output dir

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -635,8 +635,8 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 	}
 
 	defer func() {
-		tc.logger.Execution().Error(errors.Wrap(tc.taskConfig.TaskOutputDir.Run(tskCtx), "ingesting task output"))
 		tc.logger.Execution().Error(errors.Wrap(a.uploadTraces(tskCtx, tc.taskConfig.WorkDir), "uploading traces"))
+		tc.logger.Execution().Error(errors.Wrap(tc.taskConfig.TaskOutputDir.Run(tskCtx), "ingesting task output"))
 	}()
 
 	tc.setHeartbeatTimeout(heartbeatTimeoutOptions{})

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-04"
+	AgentVersion = "2024-03-04-a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5349

### Description
This needs to happen before we handle task directory output in the reserved directory because the `Run` function blows up the reserved `build` dir.

### Testing
N/A

### Documentation
N/A