### PR TITLE
DEVPROD-5339 Respect private variables in event logs for project vars rotate route

### DIFF
--- a/model/project_event.go
+++ b/model/project_event.go
@@ -111,11 +111,13 @@ func (p *ProjectChangeEvents) RedactPrivateVars() {
 		modifiedPrivateVarKeys := findModifiedPrivateVars(changeEvent)
 		changeEvent.After.Vars = *changeEvent.After.Vars.RedactPrivateVars()
 		changeEvent.Before.Vars = *changeEvent.Before.Vars.RedactPrivateVars()
-		// If a private variable has been changed, change the before value of the
-		// variable to {REDACTED} so the event log will show that the private variable
-		// has been changed in the UI.
+		// Here we need to change the after value of modified private variables to
+		// {REDACTED} so the event log will show that the private variable
+		// has been changed in the UI. This is necessary because the above RedactPrivateVars
+		// function redacts private variables to an empty string, which will not get picked up
+		// by the UI as it relies on the before / after diff.
 		for _, privateVarKey := range modifiedPrivateVarKeys {
-			changeEvent.Before.Vars.Vars[privateVarKey] = "{REDACTED}"
+			changeEvent.After.Vars.Vars[privateVarKey] = "{REDACTED}"
 		}
 		event.EventLogEntry.Data = changeEvent
 	}

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -117,7 +117,8 @@ func (p *ProjectChangeEvents) RedactPrivateVars() {
 		// function redacts private variables to an empty string, which will not get picked up
 		// by the UI as it relies on the before / after diff.
 		for _, privateVarKey := range modifiedPrivateVarKeys {
-			changeEvent.After.Vars.Vars[privateVarKey] = "{REDACTED}"
+			changeEvent.After.Vars.Vars[privateVarKey] = "{REDACTED_AFTER}"
+			changeEvent.Before.Vars.Vars[privateVarKey] = "{REDACTED_BEFORE}"
 		}
 		event.EventLogEntry.Data = changeEvent
 	}

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -153,12 +153,10 @@ func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun bo
 }
 
 func (projectVars *ProjectVars) updateSingleVar(key, val string) error {
-	setUpdate := bson.M{}
 	if len(projectVars.Vars) == 0 && len(projectVars.PrivateVars) == 0 &&
 		len(projectVars.AdminOnlyVars) == 0 {
 		return nil
 	}
-	setUpdate[bsonutil.GetDottedKeyName(projectVarsMapKey, key)] = val
 
 	return db.Update(
 		ProjectVarsCollection,

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -226,19 +226,19 @@ func TestGetVarsByValue(t *testing.T) {
 	require.NoError(t, projectVars2.Insert())
 	require.NoError(t, projectVars3.Insert())
 
-	newVars, err := GetVarsByValue("1")
+	newVars, err := getVarsByValue("1")
 	assert.NoError(err)
 	assert.Equal(2, len(newVars))
 
-	newVars, err = GetVarsByValue("2")
+	newVars, err = getVarsByValue("2")
 	assert.NoError(err)
 	assert.Equal(3, len(newVars))
 
-	newVars, err = GetVarsByValue("3")
+	newVars, err = getVarsByValue("3")
 	assert.NoError(err)
 	assert.Equal(1, len(newVars))
 
-	newVars, err = GetVarsByValue("0")
+	newVars, err = getVarsByValue("0")
 	assert.NoError(err)
 	assert.Equal(0, len(newVars))
 }

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -331,7 +331,7 @@ func TestUpdateProjectVarsByValue(t *testing.T) {
 
 	projectEvents, err := model.MostRecentProjectEvents(projectId, 5)
 	assert.NoError(t, err)
-	require.Len(t, 2, len(projectEvents))
+	require.Len(t, projectEvents, 2)
 
 	assert.NotNil(t, projectEvents[0].Data)
 	eventData := projectEvents[0].Data.(*model.ProjectChangeEvent)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -211,8 +211,8 @@ func (s *ProjectConnectorGetSuite) TestGetProjectEvents() {
 		s.Len(eventLog.After.ProjectRef.WorkstationConfig.SetupCommands, 0)
 		s.Equal(eventLog.Before.Vars.Vars["hello"], "world")
 		s.Equal(eventLog.After.Vars.Vars["hello"], "another_world")
-		s.Equal(eventLog.After.Vars.Vars["world"], "{REDACTED}")
-		s.Equal(eventLog.Before.Vars.Vars["world"], "")
+		s.Equal(eventLog.After.Vars.Vars["world"], "{REDACTED_AFTER}")
+		s.Equal(eventLog.Before.Vars.Vars["world"], "{REDACTED_BEFORE}")
 	}
 
 	// No error for empty events

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -211,8 +211,8 @@ func (s *ProjectConnectorGetSuite) TestGetProjectEvents() {
 		s.Len(eventLog.After.ProjectRef.WorkstationConfig.SetupCommands, 0)
 		s.Equal(eventLog.Before.Vars.Vars["hello"], "world")
 		s.Equal(eventLog.After.Vars.Vars["hello"], "another_world")
-		s.Equal(eventLog.Before.Vars.Vars["world"], "{REDACTED}")
-		s.Equal(eventLog.After.Vars.Vars["world"], "")
+		s.Equal(eventLog.After.Vars.Vars["world"], "{REDACTED}")
+		s.Equal(eventLog.Before.Vars.Vars["world"], "")
 	}
 
 	// No error for empty events
@@ -331,7 +331,7 @@ func TestUpdateProjectVarsByValue(t *testing.T) {
 
 	projectEvents, err := model.MostRecentProjectEvents(projectId, 5)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(projectEvents))
+	require.Len(t, 2, len(projectEvents))
 
 	assert.NotNil(t, projectEvents[0].Data)
 	eventData := projectEvents[0].Data.(*model.ProjectChangeEvent)
@@ -342,7 +342,7 @@ func TestUpdateProjectVarsByValue(t *testing.T) {
 	assert.Equal(t, "33", eventData.After.Vars.Vars["b"])
 	assert.True(t, eventData.After.Vars.PrivateVars["b"])
 
-	assert.NotNil(t, projectEvents[1].Data)
+	require.NotNil(t, projectEvents[1].Data)
 	eventData = projectEvents[1].Data.(*model.ProjectChangeEvent)
 
 	assert.Equal(t, username, eventData.User)


### PR DESCRIPTION
DEVPROD-5339

### Description
Changed `UpdateProjectVarsByValue` to include the full project vars struct when creating project event logs. The absence of private vars previously is what led to the event logs revealing private vars in the UI.

A side effect of this fix was that modifying private variables would no longer show any event log at all in the UI because the UI analyzes before/after diffs which are not picked up when the before and after value of a private var are both redacted to `""`. To fix this, if a private variable has been modified, I've changed to show {REDACTED} in the before field so that it will show up in the UI as an event log.

### Testing
Tested in staging and confirmed the project variable rotation route will not lead to event logs showing the private variable's value. Added unit tests.