### PR TITLE
DEVPROD-4220 add auto-restart system failure service flag

### DIFF
--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -254,6 +254,17 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
+												<td>Auto-restart system failures</td>
+												<td colspan="2">
+													<md-radio-group
+															data-ng-model="Settings.service_flags.system_failed_task_restart_disabled"
+															layout="row">
+														<md-radio-button data-ng-value="false"></md-radio-button>
+														<md-radio-button data-ng-value="true"></md-radio-button>
+													</md-radio-group>
+												</td>
+											</tr>
+											<tr>
 												<td>Test GitHub pull requests</td>
 												<td colspan="2">
 													<md-radio-group


### PR DESCRIPTION
DEVPROD-4220
### Description
Forgot to actually add the service flag womp.
### Testing
Confirmed I could toggle the flag and save. 
![image](https://github.com/evergreen-ci/evergreen/assets/26798134/a8f84310-e656-47c2-be13-18f2068dee70)