### PR TITLE
DEVPROD-5413 import tzdata package

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/api"


### PR DESCRIPTION
[DEVPROD-5413](https://jira.mongodb.org/browse/DEVPROD-5413)

### Description
Once we started shifting traffic to Kanopy we started seeing errors from [here](https://github.com/evergreen-ci/evergreen/blob/main/graphql/util.go#L135). [The docs](https://pkg.go.dev/time#LoadLocation) say it looks for timezone info in a bunch of places. The EC2 instances have this information at `/usr/share/zoneinfo` but it's missing on the ubuntu image.
Including this package will make go embed the data in the binary itself.

### Testing
I spun up an ubuntu:22.04 (our base image) container and ran the example from [here](https://pkg.go.dev/time#example-LoadLocation). Before I added [the tzdata package](https://pkg.go.dev/time/tzdata) it errored (once I uninstalled go so `$GOROOT/lib/time/zoneinfo.zip` was missing) and once I added it it succeeded.
