### PR TITLE
DEVPROD-5047: Fix conversion to APIDuration for TargetTime and AcceptableHostIdleTime

### DIFF
--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -345,7 +345,7 @@ func (r *finderSettingsInputResolver) Version(ctx context.Context, obj *model.AP
 
 // AcceptableHostIdleTime is the resolver for the acceptableHostIdleTime field.
 func (r *hostAllocatorSettingsInputResolver) AcceptableHostIdleTime(ctx context.Context, obj *model.APIHostAllocatorSettings, data int) error {
-	obj.AcceptableHostIdleTime = model.NewAPIDuration(time.Duration(data))
+	obj.AcceptableHostIdleTime = model.NewAPIDuration(time.Duration(data) * time.Millisecond)
 	return nil
 }
 
@@ -407,7 +407,7 @@ func (r *hostAllocatorSettingsInputResolver) Version(ctx context.Context, obj *m
 
 // TargetTime is the resolver for the targetTime field.
 func (r *plannerSettingsInputResolver) TargetTime(ctx context.Context, obj *model.APIPlannerSettings, data int) error {
-	obj.TargetTime = model.NewAPIDuration(time.Duration(data))
+	obj.TargetTime = model.NewAPIDuration(time.Duration(data) * time.Millisecond)
 	return nil
 }
 

--- a/graphql/redacted_fields_gen.go
+++ b/graphql/redacted_fields_gen.go
@@ -7,4 +7,3 @@ var redactedFields = map[string]bool{
 	"servicePassword": true,
 	"vars": true,
 }
-

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -74,7 +74,7 @@ mutation {
         }
         dispatcherSettings: { version: REVISED_WITH_DEPENDENCIES }
         hostAllocatorSettings: {
-          acceptableHostIdleTime: 5407399999
+          acceptableHostIdleTime: 5400
           feedbackRule: DEFAULT
           futureHostFraction: 0
           hostsOverallocatedRule: DEFAULT

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -69,12 +69,12 @@ mutation {
           mainlineTimeInQueueFactor: 0
           patchFactor: 0
           patchTimeInQueueFactor: 0
-          targetTime: 0
+          targetTime: 5000
           version: TUNABLE
         }
         dispatcherSettings: { version: REVISED_WITH_DEPENDENCIES }
         hostAllocatorSettings: {
-          acceptableHostIdleTime: 30000000000
+          acceptableHostIdleTime: 30000
           feedbackRule: DEFAULT
           futureHostFraction: 0
           hostsOverallocatedRule: DEFAULT
@@ -103,6 +103,12 @@ mutation {
       isCluster
       name
       note
+      plannerSettings {
+        targetTime
+      }
+      hostAllocatorSettings {
+        acceptableHostIdleTime
+      }
     }
     hostCount
   }

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -3,7 +3,7 @@ mutation {
     opts: {
       distro: {
         name: "rhel71-power8-large"
-        adminOnly: false,
+        adminOnly: false
         workDir: ""
         mountpoints: ["/"]
         aliases: ["new-alias"]
@@ -74,7 +74,7 @@ mutation {
         }
         dispatcherSettings: { version: REVISED_WITH_DEPENDENCIES }
         hostAllocatorSettings: {
-          acceptableHostIdleTime: 30000000000
+          acceptableHostIdleTime: 30000
           feedbackRule: DEFAULT
           futureHostFraction: 0
           hostsOverallocatedRule: DEFAULT

--- a/graphql/tests/mutation/saveDistro/results.json
+++ b/graphql/tests/mutation/saveDistro/results.json
@@ -11,7 +11,13 @@
               "disableShallowClone": true,
               "isCluster": true,
               "name": "rhel71-power8-large",
-              "note": "This is an updated note"
+              "note": "This is an updated note",
+              "plannerSettings": {
+                "targetTime": 5000
+              },
+              "hostAllocatorSettings": {
+                "acceptableHostIdleTime": 30000
+              }
             },
             "hostCount": 2
           }


### PR DESCRIPTION
DEVPROD-5047

### Description
On Spruce we expect these values to be entered as milliseconds:
<img width="425" alt="Screenshot 2024-03-06 at 4 36 52 PM" src="https://github.com/evergreen-ci/evergreen/assets/47064971/d50b43dc-8134-44f9-aabf-a401ebf522d9">

But the function `NewAPIDuration` expects the input to be nanoseconds, causing the values to be incorrectly parsed as 0 (e.g. 5000 sent from frontend -> 5000 is divided by 1000000 to get 0.005).

### Testing
- Updated GraphQL tests
- Locally on my machine
