### PR TITLE
DEVPROD-5257 Don't use command: attach.results as an example in teardown_group

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -244,7 +244,9 @@ buildvariants:
       share_processes: true
       max_hosts: 3
       teardown_group:
-      - command: attach.results
+      - command: shell.exec
+        params:
+          script: echo "tearing down group"
       tasks:
       - example_task_2
       - example_task_3


### PR DESCRIPTION
DEVPROD-5257

### Description
We should use a different example here because later on in the docs we say: 
"Some operations may not be permitted within the "teardown_group" phase, such as "attach.results" or "attach.artifacts"."

### Documentation
Indeed