### PR TITLE
DEVPROD-4718 Fix email address for /admin/service_users route

### DIFF
--- a/model/user/db.go
+++ b/model/user/db.go
@@ -227,10 +227,11 @@ func AddOrUpdateServiceUser(u DBUser) error {
 	}
 	update := bson.M{
 		"$set": bson.M{
-			DispNameKey: u.DispName,
-			RolesKey:    u.SystemRoles,
-			OnlyAPIKey:  true,
-			APIKeyKey:   apiKey,
+			DispNameKey:     u.DispName,
+			RolesKey:        u.SystemRoles,
+			OnlyAPIKey:      true,
+			APIKeyKey:       apiKey,
+			EmailAddressKey: u.EmailAddress,
 		},
 	}
 	_, err := UpsertOne(query, update)

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -597,9 +597,10 @@ func TestServiceUserOperations(t *testing.T) {
 
 	require.NoError(t, db.Clear(Collection))
 	u := DBUser{
-		Id:          "u",
-		DispName:    "service_user",
-		SystemRoles: []string{"one"},
+		Id:           "u",
+		DispName:     "service_user",
+		SystemRoles:  []string{"one"},
+		EmailAddress: "myemail@mailplace.com",
 	}
 	assert.EqualError(t, AddOrUpdateServiceUser(u), "cannot update a non-service user")
 	u.OnlyAPI = true
@@ -621,6 +622,7 @@ func TestServiceUserOperations(t *testing.T) {
 	assert.Equal(t, u.DispName, dbUser.DispName)
 	assert.Equal(t, u.SystemRoles, dbUser.SystemRoles)
 	assert.Equal(t, u.APIKey, dbUser.APIKey)
+	assert.Equal(t, u.EmailAddress, dbUser.EmailAddress)
 
 	users, err := FindServiceUsers()
 	assert.NoError(t, err)

--- a/rest/model/generated.go
+++ b/rest/model/generated.go
@@ -92,6 +92,7 @@ func APIDBUserBuildFromService(t user.DBUser) *APIDBUser {
 	m.Roles = ArrstringArrstring(t.SystemRoles)
 	m.UserID = StringStringPtr(t.Id)
 	m.OnlyApi = BoolBool(t.OnlyAPI)
+	m.EmailAddress = StringStringPtr(t.EmailAddress)
 	return &m
 }
 
@@ -103,5 +104,6 @@ func APIDBUserToService(m APIDBUser) *user.DBUser {
 	out.Id = StringPtrString(m.UserID)
 	out.SystemRoles = ArrstringArrstring(m.Roles)
 	out.OnlyAPI = BoolBool(m.OnlyApi)
+	out.EmailAddress = StringPtrString(m.EmailAddress)
 	return out
 }

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -393,7 +393,7 @@ func TestServiceUserOperations(t *testing.T) {
 	defer cancel()
 	require.NoError(t, db.Clear(user.Collection))
 
-	body := `{ "user_id": "foo", "display_name": "service", "roles": ["one", "two"] }`
+	body := `{ "user_id": "foo", "display_name": "service", "roles": ["one", "two"], "email_address":"myemail@mailplace.com" }`
 	request, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer([]byte(body)))
 	require.NoError(t, err)
 	handler := makeUpdateServiceUser()
@@ -410,6 +410,7 @@ func TestServiceUserOperations(t *testing.T) {
 	assert.Equal(t, "foo", *users[0].UserID)
 	assert.Equal(t, "service", *users[0].DisplayName)
 	assert.Equal(t, []string{"one", "two"}, users[0].Roles)
+	assert.Equal(t, "myemail@mailplace.com", *users[0].EmailAddress)
 	assert.True(t, users[0].OnlyApi)
 
 	body = `{ "user_id": "foo", "display_name": "different" }`


### PR DESCRIPTION
DEVPROD-4718

### Description
Specifying an email address in the request body did nothing, despite being listed in the docs as a param. This fixes it. 

### Testing
Added to existing tests. 

### Documentation
This aligns the behavior with what's already documented. 
