### PR TITLE
DEVPROD-970 Allow check runs to support multiple executions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1069,7 +1069,6 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 		return nil, errors.Wrap(err, "applying expansions")
 	}
 
-	tc.logger.Task().Infof("CheckRun built for task '%s'.", tc.task.ID)
 	return &checkRunOutput, nil
 
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1062,14 +1062,12 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 
 	err = utility.ReadJSONFile(fileName, &checkRunOutput)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "reading checkRun output file")
 	}
 
 	if err := util.ExpandValues(&checkRunOutput, &tc.taskConfig.Expansions); err != nil {
 		return nil, errors.Wrap(err, "applying expansions")
 	}
-
-	tc.logger.Task().Infof("Upserting checkRun: %s.", checkRunOutput.Title)
 
 	return &checkRunOutput, nil
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1069,6 +1069,7 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 		return nil, errors.Wrap(err, "applying expansions")
 	}
 
+	tc.logger.Task().Infof("CheckRun built for task '%s'.", tc.task.ID)
 	return &checkRunOutput, nil
 
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2483,7 +2483,7 @@ func (s *AgentSuite) TestUpsertCheckRun() {
 	s.tc.taskConfig.Task.Requester = evergreen.GithubPRRequester
 
 	s.tc.taskConfig.Expansions.Put("checkRun_key", "checkRun_value")
-	checkRunOutput, err := buildCheckRun(s.ctx, s.tc)
+	checkRunOutput, err := buildCheckRun(s.tc)
 	s.NoError(err)
 	s.NotNil(checkRunOutput)
 
@@ -2503,7 +2503,7 @@ func (s *AgentSuite) TestUpsertEmptyCheckRun() {
 	s.tc.taskConfig.Task.CheckRunPath = utility.ToStringPtr("")
 	s.tc.taskConfig.Task.Requester = evergreen.GithubPRRequester
 
-	checkRunOutput, err := buildCheckRun(s.ctx, s.tc)
+	checkRunOutput, err := buildCheckRun(s.tc)
 	s.NoError(err)
 	s.NotNil(checkRunOutput)
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2483,7 +2483,7 @@ func (s *AgentSuite) TestUpsertCheckRun() {
 	s.tc.taskConfig.Task.Requester = evergreen.GithubPRRequester
 
 	s.tc.taskConfig.Expansions.Put("checkRun_key", "checkRun_value")
-	checkRunOutput, err := buildCheckRun(s.tc)
+	checkRunOutput, err := buildCheckRun(s.ctx, s.tc)
 	s.NoError(err)
 	s.NotNil(checkRunOutput)
 
@@ -2503,7 +2503,7 @@ func (s *AgentSuite) TestUpsertEmptyCheckRun() {
 	s.tc.taskConfig.Task.CheckRunPath = utility.ToStringPtr("")
 	s.tc.taskConfig.Task.Requester = evergreen.GithubPRRequester
 
-	checkRunOutput, err := buildCheckRun(s.tc)
+	checkRunOutput, err := buildCheckRun(s.ctx, s.tc)
 	s.NoError(err)
 	s.NotNil(checkRunOutput)
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2486,11 +2486,17 @@ func (s *AgentSuite) TestUpsertCheckRun() {
 	checkRunOutput, err := buildCheckRun(s.ctx, s.tc)
 	s.NoError(err)
 	s.NotNil(checkRunOutput)
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Upserting checkRun: This is my report checkRun_value",
-	}, []string{panicLog})
+	s.Equal(checkRunOutput.Title, "This is my report checkRun_value")
+	s.Equal(checkRunOutput.Summary, "We found 6 failures and 2 warnings")
+	s.Equal(checkRunOutput.Text, "It looks like there are some errors on lines 2 and 4.")
+	s.Assert().Len(checkRunOutput.Annotations, 1)
+	s.Equal(checkRunOutput.Annotations[0].Path, "README.md")
+	s.Equal(checkRunOutput.Annotations[0].AnnotationLevel, "warning")
+	s.Equal(checkRunOutput.Annotations[0].Title, "Error Detector")
+	s.Equal(checkRunOutput.Annotations[0].Message, "message")
+	s.Equal(checkRunOutput.Annotations[0].RawDetails, "Do you mean this other thing?")
+	s.Equal(checkRunOutput.Annotations[0].StartLine, utility.ToIntPtr(2))
+	s.Equal(checkRunOutput.Annotations[0].EndLine, utility.ToIntPtr(4))
 }
 
 func (s *AgentSuite) TestUpsertEmptyCheckRun() {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-05"
+	AgentVersion = "2024-03-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -177,11 +177,11 @@ type Task struct {
 	IsGithubCheck bool `bson:"is_github_check,omitempty" json:"is_github_check,omitempty"`
 
 	// CheckRunPath is a local file path to an output json file for the checkrun.
-	CheckRunPath *string `bson:"check_run_path" json:"check_run_path"`
+	CheckRunPath *string `bson:"check_run_path,omitempty" json:"check_run_path,omitempty"`
 
 	// CheckRunId is the id for the checkrun that was created in github.
 	// This is used to update the checkrun for future executions of the task.
-	CheckRunId *int `bson:"check_run_id,omitempty" json:"check_run_id,omitempty"`
+	CheckRunId *int64 `bson:"check_run_id,omitempty" json:"check_run_id,omitempty"`
 
 	// CanReset indicates that the task has successfully archived and is in a valid state to be reset.
 	CanReset bool `bson:"can_reset,omitempty" json:"can_reset,omitempty"`
@@ -3464,7 +3464,7 @@ func (t *Task) SetDisplayTaskID(id string) error {
 }
 
 // SetCheckRunId sets the checkRunId for the task
-func (t *Task) SetCheckRunId(checkRunId int) error {
+func (t *Task) SetCheckRunId(checkRunId int64) error {
 	if err := UpdateOne(
 		bson.M{
 			IdKey: t.Id,
@@ -3477,7 +3477,7 @@ func (t *Task) SetCheckRunId(checkRunId int) error {
 	); err != nil {
 		return err
 	}
-	t.CheckRunId = utility.ToIntPtr(checkRunId)
+	t.CheckRunId = utility.ToInt64Ptr(checkRunId)
 	return nil
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3510,7 +3510,7 @@ func TestSetCheckRunId(t *testing.T) {
 	require.NotNil(t, t1)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 12345, utility.FromIntPtr(t1.CheckRunId))
+	assert.Equal(t, 12345, utility.FromInt64Ptr(t1.CheckRunId))
 
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3510,7 +3510,7 @@ func TestSetCheckRunId(t *testing.T) {
 	require.NotNil(t, t1)
 	assert.NoError(t, err)
 
-	assert.Equal(t, 12345, utility.FromInt64Ptr(t1.CheckRunId))
+	assert.Equal(t, int64(12345), utility.FromInt64Ptr(t1.CheckRunId))
 
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1416,7 +1416,7 @@ func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
 // POST /task/{task_id}/check_run
 type checkRunHandler struct {
 	taskID         string
-	checkRunOutput github.CheckRunOutput
+	checkRunOutput *github.CheckRunOutput
 	settings       *evergreen.Settings
 }
 
@@ -1435,7 +1435,8 @@ func (h *checkRunHandler) Parse(ctx context.Context, r *http.Request) error {
 		return errors.New("missing task ID")
 	}
 
-	err := utility.ReadJSON(r.Body, &h.checkRunOutput)
+	output := github.CheckRunOutput{}
+	err := utility.ReadJSON(r.Body, &output)
 	if err != nil {
 		errorMessage := fmt.Sprintf("reading checkRun for task '%s'", h.taskID)
 		grip.Error(message.Fields{
@@ -1445,12 +1446,19 @@ func (h *checkRunHandler) Parse(ctx context.Context, r *http.Request) error {
 		return errors.Wrapf(err, errorMessage)
 	}
 
-	err = thirdparty.ValidateCheckRun(&h.checkRunOutput)
+	// output is empty if it does not specify the three fields Evergreen processes.
+	if output.Title == nil && output.Summary == nil && len(output.Annotations) == 0 {
+		return nil
+	}
+
+	h.checkRunOutput = &output
+	err = thirdparty.ValidateCheckRunOutput(h.checkRunOutput)
 	if err != nil {
 		errorMessage := fmt.Sprintf("validating checkRun for task '%s'", h.taskID)
 		grip.Error(message.Fields{
 			"message": errorMessage,
 			"task_id": h.taskID,
+			"error":   err.Error(),
 		})
 		return errors.Wrapf(err, errorMessage)
 	}
@@ -1459,7 +1467,8 @@ func (h *checkRunHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
-	if h.settings.GitHubCheckRun.CheckRunLimit <= 0 {
+	env := evergreen.GetEnvironment()
+	if env.Settings().GitHubCheckRun.CheckRunLimit <= 0 {
 		return nil
 	}
 
@@ -1490,13 +1499,26 @@ func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	//todo: if it's the second execution of the same task, we should
-	// update the checkrun instead of creating a new one
 	gh := p.GithubPatchData
-	checkRun, err := thirdparty.CreateCheckRun(ctx, gh.HeadOwner, gh.HeadRepo, gh.HeadHash, h.settings.Ui.Url, t, &h.checkRunOutput)
+	if t.CheckRunId != nil {
+		_, err := thirdparty.UpdateCheckRun(ctx, gh.BaseOwner, gh.BaseRepo, env.Settings().ApiUrl, utility.FromInt64Ptr(t.CheckRunId), t, h.checkRunOutput)
+		if err != nil {
+			errorMessage := fmt.Sprintf("updating checkRun for task: '%s'", t.Id)
+			grip.Error(message.Fields{
+				"message":      errorMessage,
+				"error":        err.Error(),
+				"task_id":      t.Id,
+				"check_run_id": t.CheckRunId,
+			})
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "updating check run"))
+		}
+		return gimlet.NewJSONResponse(fmt.Sprintf("Successfully updated check run for  '%v'", t.Id))
+	}
+
+	checkRun, err := thirdparty.CreateCheckRun(ctx, gh.BaseOwner, gh.BaseRepo, gh.HeadHash, env.Settings().ApiUrl, t, h.checkRunOutput)
 
 	if err != nil {
-		errorMessage := fmt.Sprintf("creating checkRun for task: %s", t.Id)
+		errorMessage := fmt.Sprintf("creating checkRun for task: '%s'", t.Id)
 		grip.Error(message.Fields{
 			"message": errorMessage,
 			"error":   err.Error(),
@@ -1505,14 +1527,26 @@ func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating check run"))
 	}
 
-	checkRunInt := int(utility.FromInt64Ptr(checkRun.ID))
+	if checkRun == nil {
+		errorMessage := fmt.Sprintf("created checkRun not return for task: '%s'", t.Id)
+		grip.Error(message.Fields{
+			"message": errorMessage,
+			"error":   err.Error(),
+			"task_id": t.Id,
+		})
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating check run"))
+	}
+
+	checkRunInt := utility.FromInt64Ptr(checkRun.ID)
 	if err = t.SetCheckRunId(checkRunInt); err != nil {
 		err = errors.Wrap(err, "setting check run ID on task")
-		grip.Error(message.WrapError(err, message.Fields{
-			"task_id": t.Id}))
-
+		grip.Error(message.WrapError(err,
+			message.Fields{
+				"task_id":      t.Id,
+				"check_run_id": checkRunInt,
+			}))
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
-	return gimlet.NewJSONResponse(fmt.Sprintf("Successfully upserted checkRun for  %v ", t.Id))
+	return gimlet.NewJSONResponse(fmt.Sprintf("Successfully created check run for  '%v'", t.Id))
 }

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -343,14 +343,11 @@ func (gh *githubHookApi) handleCheckRunRerequested(ctx context.Context, event *g
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "resetting task"))
 	}
 
-	opts := &github.UpdateCheckRunOptions{
-		Name: checkRun.GetName(),
-		Output: &github.CheckRunOutput{
-			Title:   utility.ToStringPtr("Task restarted"),
-			Summary: utility.ToStringPtr("Please wait for task to complete"),
-		},
+	output := &github.CheckRunOutput{
+		Title:   utility.ToStringPtr("Task restarted"),
+		Summary: utility.ToStringPtr("Please wait for task to complete"),
 	}
-	_, err = thirdparty.UpdateCheckRun(ctx, owner, repo, checkRun.GetID(), opts)
+	_, err = thirdparty.UpdateCheckRun(ctx, owner, repo, gh.settings.ApiUrl, checkRun.GetID(), taskToRestart, output)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":    "GitHub hook",

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -2022,6 +2022,13 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	))
 	defer span.End()
 
+	if output == nil {
+		output = &github.CheckRunOutput{
+			Title:   utility.ToStringPtr("Task restarted with no output"),
+			Summary: utility.ToStringPtr(fmt.Sprintf("Task '%s' at execution %d was completed", task.DisplayName, task.Execution)),
+		}
+	}
+
 	updateOpts := github.UpdateCheckRunOptions{
 		Name:       makeCheckRunName(task),
 		Status:     utility.ToStringPtr(githubCheckRunCompleted),

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -2025,7 +2025,7 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	if output == nil {
 		output = &github.CheckRunOutput{
 			Title:   utility.ToStringPtr("Task restarted with no output"),
-			Summary: utility.ToStringPtr(fmt.Sprintf("Task '%s' at execution %d was completed", task.DisplayName, task.Execution)),
+			Summary: utility.ToStringPtr(fmt.Sprintf("Task '%s' at execution %d was completed", task.DisplayName, task.Execution+1)),
 		}
 	}
 

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -409,7 +409,7 @@ func TestGetGitHubSender(t *testing.T) {
 	assert.NotZero(t, sender.ErrorHandler, "fallback error handler should be set")
 }
 
-func TestValidateCheckRun(t *testing.T) {
+func TestValidateCheckRunOutput(t *testing.T) {
 	f, err := os.CreateTemp(os.TempDir(), "")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
@@ -439,7 +439,7 @@ func TestValidateCheckRun(t *testing.T) {
 
 	err = utility.ReadJSONFile(f.Name(), &checkRunOutput)
 	require.NoError(t, err)
-	err = ValidateCheckRun(checkRunOutput)
+	err = ValidateCheckRunOutput(checkRunOutput)
 
 	expectedError := "the checkRun 'This is my report' has no summary\n" +
 		"checkRun 'This is my report' specifies an annotation 'Error Detector' with no annotation level"

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -441,7 +441,7 @@ func TestValidateCheckRunOutput(t *testing.T) {
 	require.NoError(t, err)
 	err = ValidateCheckRunOutput(checkRunOutput)
 
-	expectedError := "the checkRun 'This is my report' has no summary\n" +
-		"checkRun 'This is my report' specifies an annotation 'Error Detector' with no annotation level"
+	expectedError := "the checkRun output 'This is my report' has no summary\n" +
+		"checkRun output 'This is my report' specifies an annotation 'Error Detector' with no annotation level"
 	assert.Equal(t, expectedError, err.Error())
 }


### PR DESCRIPTION
DEVPROD-970

### Description
Restarting a task from spruce will now update the check run instead of creating a task run

### Testing
on staging 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/617/checks?check_run_id=21350875510
this check run's URL has been updated to the latest execution of the task link 