### PR TITLE
DEVPROD-3871 Add tracing for when the agent exits because it was told to 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -383,7 +383,7 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 		msg := "run task indicates agent should exit"
 		span.SetStatus(codes.Error, msg)
 		span.RecordError(errors.New(msg), trace.WithAttributes(
-			attribute.Bool(shouldExitAttribute, nt.ShouldExit),
+			attribute.Bool(shouldExitAttribute, shouldExit),
 		))
 		return processNextResponse{
 			shouldExit: true,

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-05"
+	AgentVersion = "2024-03-07"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-3871

### Description
There is currently no way to tell if the agent exited because it received "shouldExit". This will help debug things. 

### Testing
I can't think of a good way to test it. I think it's simple enough to not need it. 
