### PR TITLE
DEVPROD-5432 disable go vulnerabilities task

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -640,7 +640,7 @@ tasks:
             - GOROOT
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
-    disable: true
+    disable: true # TODO: re-enable in DEVPROD-5453
     tags: ["linter", "skip-container"]
     commands:
       - func: get-project-and-modules

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -640,6 +640,7 @@ tasks:
             - GOROOT
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
+    disable: true
     tags: ["linter", "skip-container"]
     commands:
       - func: get-project-and-modules


### PR DESCRIPTION
DEVPROD-5432 

### Description
Disabling, from conversation.

### Testing
shouldn't run in PR testing , passed `evergreen validate` 
