### PR TITLE
DEVPROD-4925: fix query for volume attached to terminated spawn host

### DIFF
--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -244,7 +244,7 @@ func (j *volumeMigrationJob) populateIfUnset(ctx context.Context) error {
 	if j.InitialHostID == "" {
 		// If volume was initially attached to a now-terminated host, query for this host by its home volume field.
 		if j.volume.Host == "" {
-			initialHost, err := host.FindLatestTerminatedHostWithHomeVolume(ctx, j.VolumeID, evergreen.User)
+			initialHost, err := host.FindLatestTerminatedHostWithHomeVolume(ctx, j.VolumeID, j.ModifyOptions.UserName)
 			if err != nil {
 				return errors.Wrapf(err, "getting host attached to volume '%s'", j.VolumeID)
 			}

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -260,10 +260,11 @@ func TestVolumeMigrateJob(t *testing.T) {
 				SpawnAllowed: true,
 			}
 
+			const username = "username"
 			h := &host.Host{
 				Id:           "h0",
 				UserHost:     true,
-				StartedBy:    evergreen.User,
+				StartedBy:    username,
 				Status:       evergreen.HostRunning,
 				Provider:     evergreen.ProviderNameMock,
 				Distro:       *d,
@@ -301,6 +302,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 			}
 
 			spawnOptions := cloud.SpawnOptions{
+				UserName:  username,
 				DistroId:  d.Id,
 				PublicKey: "ssh-rsa YWJjZDEyMzQK",
 				Region:    evergreen.DefaultEC2Region,


### PR DESCRIPTION
DEVPROD-4925

### Description
This changes the volume migration job to query for the user who spawned the host rather than the default "mci" user. This fixes a performance issue and a bug:
1. This query was looking through all terminated hosts owned by "mci", which is the default user for task hosts. Since the vast majority of the hosts collection is terminated task hosts, it was basically doing a collection scan.
2. Spawn hosts are always started by the real user, not by "mci", so the query would never find the right host.

### Testing
Updated unit test to more accurately reflect the user information the volume migration job would have.

### Documentation
N/A