### PR TITLE
DEVPROD-5482 client binaries redirect

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -50,12 +50,17 @@ func GetRouter(as *APIServer, uis *UIServer) (http.Handler, error) {
 	app.AddMiddleware(gimlet.NewStatic("", http.Dir(filepath.Join(uis.Home, "public"))))
 
 	clients := gimlet.NewApp()
-	clients.NoVersions = true
-	clients.AddPrefixRoute("/clients").Get().Head().Handler(func(w http.ResponseWriter, r *http.Request) {
-		path := strings.TrimPrefix(r.URL.Path, "/clients")
-		path = uis.env.ClientConfig().S3URLPrefix + path
-		http.Redirect(w, r, path, http.StatusTemporaryRedirect)
-	})
+	if !uis.env.Settings().ServiceFlags.S3BinaryDownloadsDisabled && uis.env.ClientConfig().S3URLPrefix != "" {
+		clients.NoVersions = true
+		clients.AddPrefixRoute("/clients").Get().Head().Handler(func(w http.ResponseWriter, r *http.Request) {
+			path := strings.TrimPrefix(r.URL.Path, "/clients")
+			path = uis.env.ClientConfig().S3URLPrefix + path
+			http.Redirect(w, r, path, http.StatusTemporaryRedirect)
+		})
+	} else {
+		clients.AddMiddleware(gimlet.NewGzipDefault())
+		clients.AddMiddleware(gimlet.NewStatic("/clients", http.Dir(filepath.Join(uis.Home, evergreen.ClientDirectory))))
+	}
 
 	// in the future, we'll make the gimlet app here, but we
 	// need/want to access and construct it separately.

--- a/service/service.go
+++ b/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -49,8 +50,12 @@ func GetRouter(as *APIServer, uis *UIServer) (http.Handler, error) {
 	app.AddMiddleware(gimlet.NewStatic("", http.Dir(filepath.Join(uis.Home, "public"))))
 
 	clients := gimlet.NewApp()
-	clients.AddMiddleware(gimlet.NewGzipDefault())
-	clients.AddMiddleware(gimlet.NewStatic("/clients", http.Dir(filepath.Join(uis.Home, evergreen.ClientDirectory))))
+	clients.NoVersions = true
+	clients.AddPrefixRoute("/clients").Get().Head().Handler(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/clients")
+		path = uis.env.ClientConfig().S3URLPrefix + path
+		http.Redirect(w, r, path, http.StatusTemporaryRedirect)
+	})
 
 	// in the future, we'll make the gimlet app here, but we
 	// need/want to access and construct it separately.


### PR DESCRIPTION
[DEVPROD-5482](https://jira.mongodb.org/browse/DEVPROD-5482)

### Description
I didn't anticipate users were downloading client binaries from this URL (without getting it from the UI first). Also it's good to have a stable URL for users to get the binary from.

This PR adds a redirect from the clients URLs to S3. It's a temporary redirect because the target URL will change with each subsequent evergreen deploy and we don't want browsers to cache an old URL.

### Testing
Works in staging™️ 
