### PR TITLE
DEVPROD-5232: Add mention of DSI's `expire-on-delta` & `no_output_ms` to documentation

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1513,3 +1513,5 @@ Both parameters are optional. If not set, the task will use the
 definition from the project config.
 
 Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files.md#timeout-handler).
+
+Note: CLI tools that run on Evergreen might have their own timeout configurations. For example, DSI has `expire-on-delta`, which is documented on [this page](https://github.com/10gen/dsi/wiki/Configuration-Explained). Please check the documentation of the CLI tools you use for more details.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1514,4 +1514,4 @@ definition from the project config.
 
 Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files.md#timeout-handler).
 
-Note: CLI tools that run on Evergreen might have their own timeout configurations. For example, DSI has `expire-on-delta`, which is documented on [this page](https://github.com/10gen/dsi/wiki/Configuration-Explained). Please check the documentation of the CLI tools you use for more details.
+Note: CLI tools that run on Evergreen might have their own timeout configurations. For example, DSI has `expire-on-delta` and `no_output_ms`, which are documented on [this page](https://github.com/10gen/dsi/wiki/Configuration-Explained). Please check the documentation of the CLI tools you use for more details.


### PR DESCRIPTION
DEVPROD-5232

### Description
Add mention of DSI's `expire-on-delta` & `no_output_ms`, to help users who run performance tests avoid a common pitfall where they didn't know that they also have to set these DSI parameters for long-running tests.
