### PR TITLE
DEVPROD-5232: Add mention of timeout configurations specific to CLI tools running on Evergreen 

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1536,4 +1536,6 @@ Parameters:
 Both parameters are optional. If not set, the task will use the
 definition from the project config.
 
+Note: CLI tools that run on Evergreen might have their own timeout configurations. For example, DSI has `expire-on-delta` and `no_output_ms`, which are documented on [this page](https://github.com/10gen/dsi/wiki/Configuration-Explained). Please check the documentation of the CLI tools you use for more details.
+
 Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files.md#timeout-handler).

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1536,6 +1536,6 @@ Parameters:
 Both parameters are optional. If not set, the task will use the
 definition from the project config.
 
-Note: CLI tools that run on Evergreen might have their own timeout configurations. For example, DSI has `expire-on-delta` and `no_output_ms`, which are documented on [this page](https://github.com/10gen/dsi/wiki/Configuration-Explained). Please check the documentation of the CLI tools you use for more details.
-
 Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files.md#timeout-handler).
+
+Note: CLI tools that run on Evergreen (such as DSI) might also have their own timeout configurations. Please check the documentation of the CLI tools you use for more details.


### PR DESCRIPTION
[DEVPROD-5232](https://jira.mongodb.org/browse/DEVPROD-5232)

### Description
Add mention of timeout configurations specific to CLI tools running on Evergreen (such as DSI), to help users who run performance tests avoid a common pitfall where they didn't know that they also have to set these DSI parameters for long-running tests.
