### PR TITLE
DEVPROD-5600 Log an error if a checkrun file does not exist 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1073,8 +1073,10 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
+		checkRunOutput.Title = "Error getting check run output"
+		checkRunOutput.Summary = "Evergreen couldn't find the check run output file"
 		tc.logger.Task().Errorf("Attempting to create check run but file '%s' does not exist", fileName)
-		return nil, errors.Errorf("file '%s' does not exist", fileName)
+		return &checkRunOutput, nil
 	}
 
 	err = utility.ReadJSONFile(fileName, &checkRunOutput)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1067,12 +1067,13 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 	fileName := utility.FromStringPtr(fileNamePointer)
 	checkRunOutput := apimodels.CheckRunOutput{}
 	if fileName == "" {
-		tc.logger.Task().Infof("Upserting checkRun with no output file specified.")
+		tc.logger.Task().Infof("Upserting check run with no output file specified.")
 		return &checkRunOutput, nil
 	}
 
 	_, err := os.Stat(fileName)
 	if os.IsNotExist(err) {
+		tc.logger.Task().Errorf("Attempting to create check run but file '%s' does not exist", fileName)
 		return nil, errors.Errorf("file '%s' does not exist", fileName)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2515,7 +2515,7 @@ func (s *AgentSuite) TestUpsertEmptyCheckRun() {
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Upserting checkRun with no output file specified.",
+		"Upserting check run with no output file specified.",
 	}, []string{panicLog})
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-07"
+	AgentVersion = "2024-03-14"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5600

### Description
If a check run output file is not found, log an error to the task. Also submit a checkrun to github with an output that contains the error. 

### Testing
https://github.com/evergreen-ci/commit-queue-sandbox/pull/670/checks?check_run_id=22683525279 