### PR TITLE
DEVPROD-967 Return error so it doesn't log success 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1076,7 +1076,7 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 		checkRunOutput.Title = "Error getting check run output"
 		checkRunOutput.Summary = "Evergreen couldn't find the check run output file"
 		tc.logger.Task().Errorf("Attempting to create check run but file '%s' does not exist", fileName)
-		return &checkRunOutput, nil
+		return &checkRunOutput, errors.Wrap(err, "getting check run output")
 	}
 
 	err = utility.ReadJSONFile(fileName, &checkRunOutput)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-14"
+	AgentVersion = "2024-03-15"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-967

### Description
If a check run file is not found, return error so that it doesn't log the success message. 

<img width="606" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/13104717/9434575e-77aa-4dc6-8933-ab63e04c19a9">


