### PR TITLE
DEVPROD-4196: Expose PersistentDNSName

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -441,6 +441,7 @@ type ComplexityRoot struct {
 		InstanceType          func(childComplexity int) int
 		LastCommunicationTime func(childComplexity int) int
 		NoExpiration          func(childComplexity int) int
+		PersistentDNSName     func(childComplexity int) int
 		Provider              func(childComplexity int) int
 		RunningTask           func(childComplexity int) int
 		StartedBy             func(childComplexity int) int
@@ -3405,6 +3406,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.NoExpiration(childComplexity), true
+
+	case "Host.persistentDnsName":
+		if e.complexity.Host.PersistentDNSName == nil {
+			break
+		}
+
+		return e.complexity.Host.PersistentDNSName(childComplexity), true
 
 	case "Host.provider":
 		if e.complexity.Host.Provider == nil {
@@ -21587,6 +21595,50 @@ func (ec *executionContext) fieldContext_Host_noExpiration(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Host_persistentDnsName(ctx context.Context, field graphql.CollectedField, obj *model.APIHost) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_persistentDnsName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PersistentDNSName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_persistentDnsName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Host_provider(ctx context.Context, field graphql.CollectedField, obj *model.APIHost) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Host_provider(ctx, field)
 	if err != nil {
@@ -23613,6 +23665,8 @@ func (ec *executionContext) fieldContext_HostsResponse_hosts(ctx context.Context
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -29820,6 +29874,8 @@ func (ec *executionContext) fieldContext_Mutation_editSpawnHost(ctx context.Cont
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -29980,6 +30036,8 @@ func (ec *executionContext) fieldContext_Mutation_spawnHost(ctx context.Context,
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -30195,6 +30253,8 @@ func (ec *executionContext) fieldContext_Mutation_updateSpawnHostStatus(ctx cont
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -42899,6 +42959,8 @@ func (ec *executionContext) fieldContext_Query_host(ctx context.Context, field g
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -43948,6 +44010,8 @@ func (ec *executionContext) fieldContext_Query_myHosts(ctx context.Context, fiel
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -63881,6 +63945,8 @@ func (ec *executionContext) fieldContext_Volume_host(ctx context.Context, field 
 				return ec.fieldContext_Host_lastCommunicationTime(ctx, field)
 			case "noExpiration":
 				return ec.fieldContext_Host_noExpiration(ctx, field)
+			case "persistentDnsName":
+				return ec.fieldContext_Host_persistentDnsName(ctx, field)
 			case "provider":
 				return ec.fieldContext_Host_provider(ctx, field)
 			case "runningTask":
@@ -73998,6 +74064,11 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = ec._Host_lastCommunicationTime(ctx, field, obj)
 		case "noExpiration":
 			out.Values[i] = ec._Host_noExpiration(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "persistentDnsName":
+			out.Values[i] = ec._Host_persistentDnsName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/graphql/schema/types/host.graphql
+++ b/graphql/schema/types/host.graphql
@@ -39,6 +39,7 @@ type Host {
   instanceTags: [InstanceTag!]!
   lastCommunicationTime: Time
   noExpiration: Boolean!
+  persistentDnsName: String!
   provider: String!
   runningTask: TaskInfo
   startedBy: String!

--- a/graphql/tests/query/myHosts/data.json
+++ b/graphql/tests/query/myHosts/data.json
@@ -18,6 +18,7 @@
       "display_name": "",
       "project": "",
       "zone": "us-east-1e",
+      "persistent_dns_name": "testuser-123.workstations.build.10gen.cc",
       "provisioned": true,
       "priv_attempts": 1,
       "last_task": "",

--- a/graphql/tests/query/myHosts/queries/my_hosts.graphql
+++ b/graphql/tests/query/myHosts/queries/my_hosts.graphql
@@ -6,6 +6,7 @@ query {
       workDir
       id
     }
+    persistentDnsName
     volumes {
       id
     }

--- a/graphql/tests/query/myHosts/results.json
+++ b/graphql/tests/query/myHosts/results.json
@@ -9,12 +9,14 @@
               "id": "i-06f80fa6e28f93b7d",
               "distroId": "ubuntu1604-small",
               "distro": { "workDir": "/data/mci", "id": "ubuntu1604-small" },
+              "persistentDnsName": "testuser-123.workstations.build.10gen.cc",
               "volumes": []
             },
             {
               "id": "i-0f81a2d39744003dd",
               "distroId": "ubuntu1604-large",
               "distro": { "workDir": "/data/mci", "id": "ubuntu1604-large" },
+              "persistentDnsName": "",
               "volumes": [
                 { "id": "vol-0b5ec54a106c6e976" },
                 { "id": "vol-015b745bb69a2a16b" }
@@ -27,12 +29,14 @@
                 "workDir": "/data/mci",
                 "id": "ubuntu1604-large"
               },
+              "persistentDnsName": "",
               "volumes": []
             },
             {
               "id": "recently-terminated-host",
               "distroId": "ubuntu1804-small",
               "distro": { "workDir": "/data/mci", "id": "ubuntu1804-small" },
+              "persistentDnsName": "",
               "volumes": []
             }
           ]

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -14,9 +14,10 @@ import (
 // APIHost is the model to be returned by the API whenever hosts are fetched.
 type APIHost struct {
 	// Unique identifier of a specific host
-	Id      *string `json:"host_id"`
-	HostURL *string `json:"host_url"`
-	Tag     *string `json:"tag"`
+	Id                *string `json:"host_id"`
+	HostURL           *string `json:"host_url"`
+	PersistentDNSName *string `json:"persistent_dns_name"`
+	Tag               *string `json:"tag"`
 	// Object containing information about the distro type of this host
 	Distro      DistroInfo `json:"distro"`
 	Provisioned bool       `json:"provisioned"`
@@ -116,6 +117,7 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 	}
 	apiHost.Id = utility.ToStringPtr(h.Id)
 	apiHost.HostURL = utility.ToStringPtr(h.Host)
+	apiHost.PersistentDNSName = utility.ToStringPtr(h.PersistentDNSName)
 	apiHost.Tag = utility.ToStringPtr(h.Tag)
 	apiHost.Provisioned = h.Provisioned
 	apiHost.StartedBy = utility.ToStringPtr(h.StartedBy)
@@ -164,6 +166,7 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 func (apiHost *APIHost) ToService() host.Host {
 	return host.Host{
 		Id:                    utility.FromStringPtr(apiHost.Id),
+		PersistentDNSName:     utility.FromStringPtr(apiHost.PersistentDNSName),
 		Tag:                   utility.FromStringPtr(apiHost.Tag),
 		Provisioned:           apiHost.Provisioned,
 		NoExpiration:          apiHost.NoExpiration,

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -98,8 +98,9 @@ func TestHostPaginator(t *testing.T) {
 						prefix = 0
 					}
 					nextModelHost := &model.APIHost{
-						Id:      utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
-						HostURL: utility.ToStringPtr(""),
+						Id:                utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
+						HostURL:           utility.ToStringPtr(""),
+						PersistentDNSName: utility.ToStringPtr(""),
 						Distro: model.DistroInfo{
 							Id:                   utility.ToStringPtr(""),
 							Provider:             utility.ToStringPtr(evergreen.ProviderNameMock),
@@ -151,8 +152,9 @@ func TestHostPaginator(t *testing.T) {
 						prefix = 0
 					}
 					nextModelHost := &model.APIHost{
-						Id:      utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
-						HostURL: utility.ToStringPtr(""),
+						Id:                utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
+						HostURL:           utility.ToStringPtr(""),
+						PersistentDNSName: utility.ToStringPtr(""),
 						Distro: model.DistroInfo{
 							Id:                   utility.ToStringPtr(""),
 							Provider:             utility.ToStringPtr(evergreen.ProviderNameMock),
@@ -205,8 +207,9 @@ func TestHostPaginator(t *testing.T) {
 						prefix = 0
 					}
 					nextModelHost := &model.APIHost{
-						Id:      utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
-						HostURL: utility.ToStringPtr(""),
+						Id:                utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
+						HostURL:           utility.ToStringPtr(""),
+						PersistentDNSName: utility.ToStringPtr(""),
 						Distro: model.DistroInfo{
 							Id:                   utility.ToStringPtr(""),
 							Provider:             utility.ToStringPtr(evergreen.ProviderNameMock),
@@ -258,8 +261,9 @@ func TestHostPaginator(t *testing.T) {
 						prefix = 0
 					}
 					nextModelHost := &model.APIHost{
-						Id:      utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
-						HostURL: utility.ToStringPtr(""),
+						Id:                utility.ToStringPtr(fmt.Sprintf("%dhost%d", prefix, i)),
+						HostURL:           utility.ToStringPtr(""),
+						PersistentDNSName: utility.ToStringPtr(""),
 						Distro: model.DistroInfo{
 							Id:                   utility.ToStringPtr(""),
 							Provider:             utility.ToStringPtr(evergreen.ProviderNameMock),


### PR DESCRIPTION
DEVPROD-4196 cc @Kimchelly 

### Description
- Expose hosts' persistent DNS name field to display to users

### Testing
- Add GraphQL unit tests
- Verified on staging

### Documentation
N/A