### PR TITLE
DEVPROD-5634: add option to keep host off when stopped

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -45,7 +45,7 @@ type Manager interface {
 	TerminateInstance(context.Context, *host.Host, string, string) error
 
 	// StopInstance stops an instance.
-	StopInstance(context.Context, *host.Host, string) error
+	StopInstance(ctx context.Context, h *host.Host, shouldKeepOff bool, user string) error
 
 	// StartInstance starts a stopped instance.
 	StartInstance(context.Context, *host.Host, string) error

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -38,8 +38,8 @@ func (cloudHost *CloudHost) TerminateInstance(ctx context.Context, user, reason 
 	return cloudHost.CloudMgr.TerminateInstance(ctx, cloudHost.Host, user, reason)
 }
 
-func (cloudHost *CloudHost) StopInstance(ctx context.Context, user string) error {
-	return cloudHost.CloudMgr.StopInstance(ctx, cloudHost.Host, user)
+func (cloudHost *CloudHost) StopInstance(ctx context.Context, shouldKeepOff bool, user string) error {
+	return cloudHost.CloudMgr.StopInstance(ctx, cloudHost.Host, shouldKeepOff, user)
 }
 
 func (cloudHost *CloudHost) StartInstance(ctx context.Context, user string) error {

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -258,7 +258,7 @@ func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, use
 	return h.Terminate(ctx, user, reason)
 }
 
-func (m *dockerManager) StopInstance(ctx context.Context, host *host.Host, user string) error {
+func (m *dockerManager) StopInstance(ctx context.Context, host *host.Host, shouldKeepOff bool, user string) error {
 	return errors.New("StopInstance is not supported for Docker provider")
 }
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -903,7 +903,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 }
 
 // StopInstance stops a running EC2 instance.
-func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string) error {
+func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, shouldKeepOff bool, user string) error {
 	if !utility.StringSliceContains(evergreen.StoppableHostStatuses, h.Status) {
 		return errors.Errorf("host cannot be stopped because its status ('%s') is not a stoppable state", h.Status)
 	}
@@ -940,7 +940,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 				"host_id":       h.Id,
 				"distro":        h.Distro.Id,
 			})
-			return errors.Wrap(h.SetStopped(ctx, user), "marking DB host as stopped")
+			return errors.Wrap(h.SetStopped(ctx, shouldKeepOff, user), "marking DB host as stopped")
 		default:
 			return errors.Errorf("instance is in unexpected state '%s'", status)
 		}
@@ -983,7 +983,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, user string
 		"distro":        h.Distro.Id,
 	})
 
-	return errors.Wrap(h.SetStopped(ctx, user), "marking DB host as stopped")
+	return errors.Wrap(h.SetStopped(ctx, shouldKeepOff, user), "marking DB host as stopped")
 }
 
 // StartInstance starts a stopped EC2 instance.

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -323,7 +323,7 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 }
 
 // StopInstance should do nothing for EC2 Fleet.
-func (m *ec2FleetManager) StopInstance(context.Context, *host.Host, string) error {
+func (m *ec2FleetManager) StopInstance(context.Context, *host.Host, bool, string) error {
 	return errors.New("can't stop instances for EC2 fleet provider")
 }
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -667,7 +667,7 @@ func (s *EC2Suite) TestStopInstance() {
 		s.Require().NoError(h.Insert(ctx))
 	}
 	for _, h := range unstoppableHosts {
-		s.Error(s.onDemandManager.StopInstance(ctx, h, evergreen.User))
+		s.Error(s.onDemandManager.StopInstance(ctx, h, false, evergreen.User))
 	}
 
 	stoppableHosts := []*host.Host{
@@ -690,10 +690,42 @@ func (s *EC2Suite) TestStopInstance() {
 	}
 
 	for _, h := range stoppableHosts {
-		s.NoError(s.onDemandManager.StopInstance(ctx, h, evergreen.User))
+		s.NoError(s.onDemandManager.StopInstance(ctx, h, false, evergreen.User))
 		found, err := host.FindOne(ctx, host.ById(h.Id))
 		s.NoError(err)
 		s.Equal(evergreen.HostStopped, found.Status)
+	}
+}
+
+func (s *EC2Suite) TestStopInstanceAndShouldKeepOff() {
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	stoppableHosts := []*host.Host{
+		{
+			Id:     "host-stopping",
+			Status: evergreen.HostStopping,
+		},
+		{
+			Id:     "host-running",
+			Status: evergreen.HostRunning,
+		},
+		{
+			Id:     "host-stopped",
+			Status: evergreen.HostStopped,
+		},
+	}
+	for _, h := range stoppableHosts {
+		h.Distro = s.distro
+		s.Require().NoError(h.Insert(ctx))
+	}
+
+	for _, h := range stoppableHosts {
+		s.NoError(s.onDemandManager.StopInstance(ctx, h, true, evergreen.User))
+		found, err := host.FindOne(ctx, host.ById(h.Id))
+		s.NoError(err)
+		s.Equal(evergreen.HostStopped, found.Status)
+		s.True(found.SleepSchedule.ShouldKeepOff)
 	}
 }
 
@@ -727,10 +759,11 @@ func (s *EC2Suite) TestStartInstance() {
 			Status: evergreen.HostRunning,
 		},
 		{
-			Id:     "host-stopped",
-			Status: evergreen.HostStopped,
-			Host:   "old_dns_name",
-			IPv4:   "1.1.1.1",
+			Id:            "host-stopped",
+			Status:        evergreen.HostStopped,
+			Host:          "old_dns_name",
+			IPv4:          "1.1.1.1",
+			SleepSchedule: host.SleepScheduleInfo{ShouldKeepOff: true},
 		},
 	}
 	for _, h := range startableHosts {
@@ -745,6 +778,7 @@ func (s *EC2Suite) TestStartInstance() {
 		s.Equal(evergreen.HostRunning, found.Status)
 		s.Equal("public_dns_name", found.Host)
 		s.Equal("12.34.56.78", found.IPv4)
+		s.False(found.SleepSchedule.ShouldKeepOff)
 	}
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -266,7 +266,7 @@ func (m *mockManager) TerminateInstance(ctx context.Context, host *host.Host, us
 	return errors.WithStack(host.Terminate(ctx, user, reason))
 }
 
-func (m *mockManager) StopInstance(ctx context.Context, host *host.Host, user string) error {
+func (m *mockManager) StopInstance(ctx context.Context, host *host.Host, shouldKeepOff bool, user string) error {
 	if !utility.StringSliceContains(evergreen.StoppableHostStatuses, host.Status) {
 		return errors.Errorf("cannot stop host '%s' because the host status is '%s' which is not a stoppable state", host.Id, host.Status)
 	}
@@ -281,7 +281,7 @@ func (m *mockManager) StopInstance(ctx context.Context, host *host.Host, user st
 	instance.Status = StatusStopped
 	m.Instances[host.Id] = instance
 
-	return errors.WithStack(host.SetStopped(ctx, user))
+	return errors.WithStack(host.SetStopped(ctx, shouldKeepOff, user))
 
 }
 

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -109,7 +109,7 @@ func (staticMgr *staticManager) TerminateInstance(ctx context.Context, host *hos
 	return nil
 }
 
-func (staticMgr *staticManager) StopInstance(ctx context.Context, host *host.Host, user string) error {
+func (staticMgr *staticManager) StopInstance(ctx context.Context, host *host.Host, shouldKeepOff bool, user string) error {
 	return errors.New("StopInstance is not supported for static provider")
 }
 

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -964,7 +964,7 @@ func (r *mutationResolver) UpdateSpawnHostStatus(ctx context.Context, hostID str
 	case SpawnHostStatusActionsStart:
 		httpStatus, err = data.StartSpawnHost(ctx, env, usr, h)
 	case SpawnHostStatusActionsStop:
-		httpStatus, err = data.StopSpawnHost(ctx, env, usr, h)
+		httpStatus, err = data.StopSpawnHost(ctx, env, usr, h, false)
 	case SpawnHostStatusActionsTerminate:
 		httpStatus, err = data.TerminateSpawnHost(ctx, env, usr, h)
 	default:

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -97,6 +97,7 @@ var (
 	HomeVolumeIDKey                    = bsonutil.MustHaveTag(Host{}, "HomeVolumeID")
 	PortBindingsKey                    = bsonutil.MustHaveTag(Host{}, "PortBindings")
 	IsVirtualWorkstationKey            = bsonutil.MustHaveTag(Host{}, "IsVirtualWorkstation")
+	SleepScheduleKey                   = bsonutil.MustHaveTag(Host{}, "SleepSchedule")
 	SpawnOptionsTaskIDKey              = bsonutil.MustHaveTag(SpawnOptions{}, "TaskID")
 	SpawnOptionsTaskExecutionNumberKey = bsonutil.MustHaveTag(SpawnOptions{}, "TaskExecutionNumber")
 	SpawnOptionsBuildIDKey             = bsonutil.MustHaveTag(SpawnOptions{}, "BuildID")
@@ -114,6 +115,7 @@ var (
 	VolumeAttachmentIDKey              = bsonutil.MustHaveTag(VolumeAttachment{}, "VolumeID")
 	VolumeDeviceNameKey                = bsonutil.MustHaveTag(VolumeAttachment{}, "DeviceName")
 	DockerOptionsStdinDataKey          = bsonutil.MustHaveTag(DockerOptions{}, "StdinData")
+	SleepScheduleShouldKeepOffKey      = bsonutil.MustHaveTag(SleepScheduleInfo{}, "ShouldKeepOff")
 )
 
 var (

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -896,6 +896,7 @@ func (h *Host) SetStopped(ctx context.Context, shouldKeepOff bool, user string) 
 	h.Status = evergreen.HostStopped
 	h.Host = ""
 	h.StartTime = utility.ZeroTime
+	h.SleepSchedule.ShouldKeepOff = shouldKeepOff
 
 	return nil
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -175,13 +175,13 @@ func TerminateSpawnHost(ctx context.Context, env evergreen.Environment, u *user.
 }
 
 // StopSpawnHost enqueues a job to stop a running spawn host.
-func StopSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUser, h *host.Host) (int, error) {
+func StopSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUser, h *host.Host, shouldKeepOff bool) (int, error) {
 	if !utility.StringSliceContains(evergreen.StoppableHostStatuses, h.Status) {
 		return http.StatusBadRequest, errors.Errorf("host '%s' cannot be stopped because because its status ('%s') is not a stoppable state", h.Id, h.Status)
 	}
 
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	stopJob := units.NewSpawnhostStopJob(h, u.Id, ts)
+	stopJob := units.NewSpawnhostStopJob(h, shouldKeepOff, u.Id, ts)
 	if err := units.EnqueueSpawnHostModificationJob(ctx, env, stopJob); err != nil {
 		if amboy.IsDuplicateJobScopeError(err) {
 			err = errHostStatusChangeConflict

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -235,6 +235,7 @@ func checkVolumeLimitExceeded(user string, newSize int, maxSize int) error {
 
 type hostStopHandler struct {
 	hostID           string
+	shouldKeepOff    bool
 	subscriptionType string
 	env              evergreen.Environment
 }
@@ -253,7 +254,7 @@ func makeHostStopManager(env evergreen.Environment) gimlet.RouteHandler {
 //	@Router			/hosts/{host_id}/stop [post]
 //	@Security		Api-User || Api-Key
 //	@Param			host_id		path	string					true	"the host ID"
-//	@Param			{object}	body	hostSubscriptionInfo	false	"subscription_type"
+//	@Param			{object}	body	hostSubscriptionInfo	false "subscription_type"
 //	@Success		200
 func (h *hostStopHandler) Factory() gimlet.RouteHandler {
 	return &hostStopHandler{
@@ -292,7 +293,7 @@ func (h *hostStopHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding host '%s' with owner '%s'", h.hostID, user.Id))
 	}
 
-	statusCode, err := data.StopSpawnHost(ctx, h.env, user, host)
+	statusCode, err := data.StopSpawnHost(ctx, h.env, user, host, false)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: statusCode,

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -235,8 +235,8 @@ func checkVolumeLimitExceeded(user string, newSize int, maxSize int) error {
 
 type hostStopHandler struct {
 	hostID           string
-	shouldKeepOff    bool
 	subscriptionType string
+	shouldKeepOff    bool
 	env              evergreen.Environment
 }
 
@@ -253,8 +253,8 @@ func makeHostStopManager(env evergreen.Environment) gimlet.RouteHandler {
 //	@Tags			hosts
 //	@Router			/hosts/{host_id}/stop [post]
 //	@Security		Api-User || Api-Key
-//	@Param			host_id		path	string					true	"the host ID"
-//	@Param			{object}	body	hostSubscriptionInfo	false "subscription_type"
+//	@Param			host_id		path	string			true	"the host ID"
+//	@Param			{object}	body	hostStopOptions	false	"subscription type and whether an unexpirable host should be kept off"
 //	@Success		200
 func (h *hostStopHandler) Factory() gimlet.RouteHandler {
 	return &hostStopHandler{
@@ -262,9 +262,13 @@ func (h *hostStopHandler) Factory() gimlet.RouteHandler {
 	}
 }
 
-type hostSubscriptionInfo struct {
+type hostStopOptions struct {
 	// The type of subscription to send when the host is stopped ("slack" or "email")
 	SubscriptionType string `json:"subscription_type"`
+	// If this host is an unexpirable host with a sleep schedule, setting this
+	// to true will keep the host off (and ignore the sleep schedule) until it's
+	// started back up manually.
+	ShouldKeepOff bool `json:"should_keep_off"`
 }
 
 func (h *hostStopHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -277,11 +281,12 @@ func (h *hostStopHandler) Parse(ctx context.Context, r *http.Request) error {
 	body := utility.NewRequestReader(r)
 	defer body.Close()
 
-	options := hostSubscriptionInfo{}
+	options := hostStopOptions{}
 	if err := utility.ReadJSON(body, &options); err != nil {
 		h.subscriptionType = ""
 	}
 	h.subscriptionType = options.SubscriptionType
+	h.shouldKeepOff = options.ShouldKeepOff
 
 	return nil
 }
@@ -293,7 +298,7 @@ func (h *hostStopHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding host '%s' with owner '%s'", h.hostID, user.Id))
 	}
 
-	statusCode, err := data.StopSpawnHost(ctx, h.env, user, host, false)
+	statusCode, err := data.StopSpawnHost(ctx, h.env, user, host, h.shouldKeepOff)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: statusCode,
@@ -344,6 +349,11 @@ func (h *hostStartHandler) Factory() gimlet.RouteHandler {
 	return &hostStartHandler{
 		env: h.env,
 	}
+}
+
+type hostSubscriptionInfo struct {
+	// The type of subscription to send when the host is running ("slack" or "email")
+	SubscriptionType string `json:"subscription_type"`
 }
 
 func (h *hostStartHandler) Parse(ctx context.Context, r *http.Request) error {

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -373,7 +373,7 @@ func (uis *UIServer) modifySpawnHost(w http.ResponseWriter, r *http.Request) {
 		return
 
 	case HostStop:
-		_, err = data.StopSpawnHost(ctx, evergreen.GetEnvironment(), u, h)
+		_, err = data.StopSpawnHost(ctx, evergreen.GetEnvironment(), u, h, false)
 		if err != nil {
 			gimlet.WriteJSONError(w, err)
 		}

--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -151,7 +151,7 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 // stopInitialHost inspects the initial host's status and stops it if the host is still running.
 func (j *volumeMigrationJob) stopInitialHost(ctx context.Context) {
 	ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-	stopJob := NewSpawnhostStopJob(j.initialHost, evergreen.User, ts)
+	stopJob := NewSpawnhostStopJob(j.initialHost, false, evergreen.User, ts)
 	err := amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), stopJob)
 	if err != nil {
 		j.AddRetryableError(err)

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -31,6 +31,7 @@ func init() {
 
 type spawnhostStopJob struct {
 	CloudHostModification `bson:"cloud_host_modification" json:"cloud_host_modification" yaml:"cloud_host_modification"`
+	ShouldKeepOff         bool `bson:"should_keep_off" json:"should_keep_off" yaml:"should_keep_off"`
 	job.Base              `bson:"job_base" json:"job_base" yaml:"job_base"`
 }
 
@@ -47,7 +48,7 @@ func makeSpawnhostStopJob() *spawnhostStopJob {
 }
 
 // NewSpawnhostStopJob returns a job to stop a running spawn host.
-func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
+func NewSpawnhostStopJob(h *host.Host, shouldKeepOff bool, user, ts string) amboy.Job {
 	j := makeSpawnhostStopJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s.%s", spawnhostStopName, user, h.Id, ts))
 	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnHostStatusChangeScopeName, h.Id)})
@@ -55,6 +56,7 @@ func NewSpawnhostStopJob(h *host.Host, user, ts string) amboy.Job {
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
 	j.CloudHostModification.Source = evergreen.ModifySpawnHostManual
+	j.ShouldKeepOff = shouldKeepOff
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),
 		MaxAttempts: utility.ToIntPtr(spawnHostStopRetryLimit),
@@ -67,7 +69,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
-		if err := mgr.StopInstance(ctx, h, user); err != nil {
+		if err := mgr.StopInstance(ctx, h, j.ShouldKeepOff, user); err != nil {
 			event.LogHostStopError(h.Id, err.Error())
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error stopping spawn host",


### PR DESCRIPTION
DEVPROD-5634

### Description
DEVPROD-4198 will update Spruce to have an extra option for unexpirable hosts on a sleep schedule to keep their host off indefinitely when they press the stop button. If they enable this, Evergreen should ignore the host's sleep schedule and just let the host stay stopped. Once the user starts their host back up, it'll resume its regular sleep schedule again.

cc @sophstad 

### Testing
Updated unit tests for stop/start.

### Documentation
N/A