### PR TITLE
DEVPROD-5597 Handle GitHub Suite Re-Run events

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -306,6 +306,9 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 		})
 		catcher.Add(errors.Wrapf(taskErr, "finding task '%s' for check run", checkRunTask))
 	}
+	if !utility.StringSliceContains(evergreen.TaskCompletedStatuses, taskToRestart.Status) {
+		return errors.Errorf("task '%s' is not in a completed state", checkRunTask)
+	}
 	githubUser, err := user.FindByGithubUID(uid)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -342,8 +342,9 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 		Summary: utility.ToStringPtr("Please wait for task to complete"),
 	}
 
-	// Get the task again to ensure we have the latest execution.
-	refreshedTask, taskErr := data.FindTask(taskIDFromCheckrun)
+	// Get the task again to ensure we have the latest execution for link to task.
+	// Should still update check run even if task isn't refreshed.
+	latestExecutionForTask, taskErr := data.FindTask(taskIDFromCheckrun)
 	if taskErr != nil {
 		grip.Error(message.Fields{
 			"source":  "GitHub hook",
@@ -354,9 +355,9 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 			"task":    taskIDFromCheckrun,
 			"message": "finding refreshed task",
 		})
-		refreshedTask = taskToRestart
+		latestExecutionForTask = taskToRestart
 	}
-	_, err = thirdparty.UpdateCheckRun(ctx, owner, repo, gh.settings.ApiUrl, checkRun.GetID(), refreshedTask, output)
+	_, err = thirdparty.UpdateCheckRun(ctx, owner, repo, gh.settings.ApiUrl, checkRun.GetID(), latestExecutionForTask, output)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":    "GitHub hook",


### PR DESCRIPTION
DEVPROD-5597

### Description
Re-run all was not being handled for suite events 

### Testing
on staging 
https://github.com/evergreen-ci/commit-queue-sandbox/pull/670/checks?check_run_id=22713199800

all check runs restarted in this pr