### PR TITLE
DEVPROD-5372: use absolute path links instead of relative

### DIFF
--- a/docs/API/REST-V2-Usage.mdx
+++ b/docs/API/REST-V2-Usage.mdx
@@ -53,7 +53,7 @@ import ApiDocMdx from '@theme/ApiDocMdx';
 ## Deprecated endpoints
 
 ### TaskStats (DEPRECATED)
-**IMPORTANT: The task stats REST API has been deprecated, please use [Trino task stats](../Project-Configuration/Evergreen-Data-for-Analytics.md) instead.**
+**IMPORTANT: The task stats REST API has been deprecated, please use [Trino task stats](Project-Configuration/Evergreen-Data-for-Analytics) instead.**
 
 ### Notifications  (DEPRECATED)
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -333,7 +333,7 @@ Specify the optional `--dir` argument to choose the destination path where the d
 
 #### Pull
 
-The command `evergreen pull` can download the task directory contents of a synced task after an [s3.push](Project-Configuration/Project-Commands.md#s3push) command has finished or after a [patched task that has requested task sync](#task-sync) has completed.
+The command `evergreen pull` can download the task directory contents of a synced task after an [s3.push](Project-Configuration/Project-Commands#s3push) command has finished or after a [patched task that has requested task sync](#task-sync) has completed.
 
 Example that downloads the artifacts for the given task ID and cloning its source:
 ```
@@ -377,7 +377,7 @@ evergreen last-green -p mci -v ubuntu
 ```
 
 #### Commit Queue
-The command `evergreen commit-queue` contains subcommands for interacting with the commit queue. See [Commit Queue](Project-Configuration/Commit-Queue.md).
+The command `evergreen commit-queue` contains subcommands for interacting with the commit queue. See [Commit Queue](Project-Configuration/Commit-Queue).
 
 #### Buildlogger Fetch
 

--- a/docs/Hosts/Developer-Workstations.md
+++ b/docs/Hosts/Developer-Workstations.md
@@ -46,7 +46,7 @@ checked out and running on workstations, though this feature is not
 necessarily dependent on workstations, and could be used on local
 systems.
 
-Project settings include a ["Workstation Setup" section](../Project-Configuration/Project-and-Distro-Settings.md#virtual-workstation-commands)
+Project settings include a ["Workstation Setup" section](Project-Configuration/Project-and-Distro-Settings#virtual-workstation-commands)
 where administrators declare a number of simple commands (and directory
 contexts) that will run a project's setup. These commands are *not* shell
 interpolated, and are *not* meant to provision the development environment (e.g.

--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -38,13 +38,13 @@ Clicking it will pre-populate the spawn host page with a request to spawn a host
 
 ![spawn_host_modal.png](../images/spawn_host_modal.png)
 
-Fetching artifacts can also be performed manually; see [fetch](../CLI.md#fetch) in the Evergreen command line tool documentation.
+Fetching artifacts can also be performed manually; see [fetch](CLI#fetch) in the Evergreen command line tool documentation.
 
 Artifacts are placed in /data/mci. Note that you will likely be able to ssh into the host before the artifacts are finished fetching.
 
 If your project has a project setup script defined at the admin level, you can also check "Use project-specific setup script defined at ..." before creating the spawn host. You can check if there are errors fetching artifacts or running this script on the host page: `https://spruce.mongodb.com/host/<host_id>`.
 
-EC2 spawn hosts can be stopped/started and modified from the Spawn Host page, or via the command line, which is documented in [Basic Host Usage](../CLI.md#basic-host-usage) in the Evergreen command line tool documentation.
+EC2 spawn hosts can be stopped/started and modified from the Spawn Host page, or via the command line, which is documented in [Basic Host Usage](CLI#basic-host-usage) in the Evergreen command line tool documentation.
 
 ## Spawn Host Expiration
 
@@ -53,7 +53,7 @@ spawning the host or can be set later by pressing the "edit" button for the host
 lifetime up to 30 days past host creation.
 
 If you'd like to get a notification before a host expires, you can [set up a
-notification](../Project-Configuration/Notifications.md#spawn-host-expiration) for it.
+notification](Project-Configuration/Notifications#spawn-host-expiration) for it.
 
 ## Hosts Page
 

--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -13,7 +13,7 @@ Evergreen creates a temporary task directory for each task. Commands by default 
 
 ## subprocess.exec
 
-In general, use [subprocess.exec](Project-Commands.md#subprocessexec) instead of shell.exec.
+In general, use [subprocess.exec](Project-Commands#subprocessexec) instead of shell.exec.
 
 The reasons to prefer subprocess.exec include:
 1. Evergreen uses expansions with the same syntax as shell expansions.
@@ -25,7 +25,7 @@ You can pass environment variables to subprocess.exec if you'd like to pass expa
 
 ## Task Tags
 
-Use [task tags](Project-Configuration-Files.md#task-and-variant-tags) to reduce repetition in your Evergreen configuration file.
+Use [task tags](Project-Configuration-Files#task-and-variant-tags) to reduce repetition in your Evergreen configuration file.
 
 ## Expansions
 

--- a/docs/Project-Configuration/Commit-Queue.md
+++ b/docs/Project-Configuration/Commit-Queue.md
@@ -2,7 +2,7 @@
 
 Evergreen's commit queue merges changes after the code has passed a set of tests.
 
-Evergreen supports GitHub's [merge queue](Merge-Queue.md), and intends to deprecate the commit
+Evergreen supports GitHub's [merge queue](Merge-Queue), and intends to deprecate the commit
 queue feature in favor of GitHub's merge queue.
 
 ## Rationale 

--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -19,7 +19,7 @@ If "Automated Testing" is enabled, Evergreen will automatically create a patch f
 
 If you'd like the option of creating patches but wouldn't like it to happen automatically, you can enable "Manual Testing".
 
-You can read more about these options [here](../Project-Configuration/Project-and-Distro-Settings.md#github-pull-request-testing).
+You can read more about these options [here](Project-Configuration/Project-and-Distro-Settings#github-pull-request-testing).
 
 #### Retry a patch
 

--- a/docs/Project-Configuration/Notifications.md
+++ b/docs/Project-Configuration/Notifications.md
@@ -1,6 +1,6 @@
 # Notifications
 
-These are for setting up personal user notifications. For project-level notifications, see [project settings](Project-and-Distro-Settings.md#project-level-notifications).
+These are for setting up personal user notifications. For project-level notifications, see [project settings](Project-and-Distro-Settings#project-level-notifications).
 
 Evergreen has the ability to issue notifications based on events that happen in the system.
 

--- a/docs/Project-Configuration/Parameterized-Builds.md
+++ b/docs/Project-Configuration/Parameterized-Builds.md
@@ -68,7 +68,7 @@ foo       bar           this is a demonstration
 ```
 If testing local changes, you can use ``--path <path_to_file>`` instead of ``--project``.
 
-Parameters can also be retrieved with rest route [/projects/<project_id>/parameters](../API/REST-V2-Usage.md#get-current-parameters-for-a-project), although descriptions are not returned here.
+Parameters can also be retrieved with rest route [/projects/<project_id>/parameters](API/REST-V2-Usage#get-current-parameters-for-a-project), although descriptions are not returned here.
 
 #### Get Parameters for a Specific Patch
 

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -526,12 +526,12 @@ Parameters:
 
 -   `dir`: the directory to clone into
 -   `revisions`: For commit builds, each module should be passed as
-    `<module_name> : ${<module_name>_rev}` (these are loaded from the [manifest](../API/REST-V2-Usage.md#manifest) 
+    `<module_name> : ${<module_name>_rev}` (these are loaded from the [manifest](../API/REST-V2-Usage#manifest) 
     at the beginning of the command). 
     For patch builds, the hash
     must be passed directly as `<module_name> : <hash>`. Note that this
     means that for patch builds, editing the
-    ["modules"](Project-Configuration-Files.md#modules)
+    ["modules"](Project-Configuration-Files#modules)
     section of the project config will not change the checked out hash.
 -   `token`: Use a token to clone instead of the ssh key on the host.
     Since this is a secret, it should be provided as a project
@@ -1275,7 +1275,7 @@ s3.push is restarted, it will replace the existing one.
 Users also have the option to inspect the task working directory after
 it has finished pushing (e.g. for debugging a failed task). This can be
 achieved by either pulling the task working directory from S3 onto a
-spawn host (from the UI) or their local machines (using [evergreen pull](../CLI.md#pull)).
+spawn host (from the UI) or their local machines (using [evergreen pull](../CLI#pull)).
 
 The working directory is put in a private S3 bucket shared between all
 projects. Any other logged in user can pull and view the directory
@@ -1364,7 +1364,7 @@ Parameters:
 
 ## shell.exec
 
-This command runs a shell script. To follow [Evergreen best practices](Best-Practices.md#subprocessexec), we recommend using [subprocess.exec](#subprocess.exec).
+This command runs a shell script. To follow [Evergreen best practices](Best-Practices#subprocessexec), we recommend using [subprocess.exec](#subprocess.exec).
 
 ``` yaml
 - command: shell.exec
@@ -1536,6 +1536,6 @@ Parameters:
 Both parameters are optional. If not set, the task will use the
 definition from the project config.
 
-Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files.md#timeout-handler).
+Commands can also be configured to run if timeout occurs, as documented [here](Project-Configuration-Files#timeout-handler).
 
 Note: CLI tools that run on Evergreen (such as DSI) might also have their own timeout configurations. Please check the documentation of the CLI tools you use for more details.

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -301,7 +301,7 @@ Fields:
     will check that task once per day. If the most recent mainline commit is
     inactive, Evergreen will activate it. In this way, cron is tied more closely
     to project commit activity. To run something on a regular schedule
-    regardless of commit activity, consider using [periodic builds](Project-and-Distro-Settings.md#periodic-builds)
+    regardless of commit activity, consider using [periodic builds](Project-and-Distro-Settings#periodic-builds)
     instead.
 -   `task_group`: a [task
     group](#task-groups)
@@ -328,7 +328,7 @@ from larger, more powerful machines.
 ### Version Controlled Project Settings
 Project configurations can version control some select project settings (e.g. aliases, plugins) directly within the yaml
 rather than on the project page UI, for better accessibility and maintainability. Read more
-[here](Project-and-Distro-Settings.md#version-control).
+[here](Project-and-Distro-Settings#version-control).
 
 ## Advanced Features
 
@@ -343,7 +343,7 @@ includes. This will accept a list of filenames and module names. If the
 include isn't given, we will only use the main project configuration
 file.
 
-Note: included files do not support [version-controlled project settings configuration](Project-and-Distro-Settings.md#version-control)
+Note: included files do not support [version-controlled project settings configuration](Project-and-Distro-Settings#version-control)
 
 ``` yaml
 include: 
@@ -409,7 +409,7 @@ Manifest" will contain details on how the modules were parsed from YAML and
 which git revisions are being used. If no modules have been defined, the
 "Version Manifest" will not appear at all in the Spruce UI.
 
-For mainline commits and [trigger versions](Project-and-Distro-Settings.md#project-triggers), a new 
+For mainline commits and [trigger versions](Project-and-Distro-Settings#project-triggers), a new 
 manifest will be created that uses the latest revision available for each module.
 
 For manual patches and GitHub PRs, by default, the git revisions in the
@@ -421,7 +421,7 @@ latest revision available for a module. The full hierarchy of how
 module revisions are determined is available in the [git.get_project](Project-Commands/#module-hash-hierarchy)
 docs.
 
-Module fields support the expansion of variables defined in the [Variables](Project-and-Distro-Settings.md#variables)
+Module fields support the expansion of variables defined in the [Variables](Project-and-Distro-Settings#variables)
 tab of the Spruce project settings. These fields are expanded at the time of version creation, at which point 
 the "Version Manifest" shown in the Spruce UI should show module configurations including the expanded variables.
 
@@ -539,7 +539,7 @@ task commands; it does not apply to the `post`, `teardown_task`, and
 can only be set on the project or on a task as seen in below example. 
 It cannot be set on functions or build variant tasks.
 
-You can also set `exec_timeout_secs` using [timeout.update](Project-Commands.md#timeoutupdate).
+You can also set `exec_timeout_secs` using [timeout.update](Project-Commands#timeoutupdate).
 
 **Idle timeout: timeout_secs**
 You may also force a specific command to trigger a failure if it does not appear
@@ -553,7 +553,7 @@ commands; it does not apply to the `post`, `teardown_task`, and `teardown_group`
 blocks. This timeout defaults to 2 hours.
 
 You can also overwrite the default `timeout_secs` for all later commands using
-[timeout.update](Project-Commands.md#timeoutupdate).
+[timeout.update](Project-Commands#timeoutupdate).
 
 Example:
 
@@ -646,7 +646,7 @@ run for any requester. If you specify an empty `allowed_requesters` list (i.e.
 If `allowed_requesters` is specified and a conflicting project setting is also
 specified, `allowed_requesters` will take higher precedence. For example, if the
 project settings configure a [GitHub PR patch
-definition](Project-and-Distro-Settings.md#github-pull-request-testing) to run
+definition](Project-and-Distro-Settings#github-pull-request-testing) to run
 tasks A and B but task A has `allowed_requesters: ["commit"]`, then GitHub PR
 patches will only run task B.
 
@@ -790,11 +790,11 @@ Every task has some expansions available by default:
 -   `${otel_trace_id}` is the OTel trace ID this task is running under.
     Include the trace ID in your task's spans so they'll be hooked
     in under the task's trace.
-    See [Hooking tests into command spans](Task_Traces.md#hooking-tests-into-command-spans) for more information.
+    See [Hooking tests into command spans](Task_Traces#hooking-tests-into-command-spans) for more information.
 -   `${otel_parent_id}` is the OTel span ID of the current command.
     Include this ID in your test's root spans so it'll be hooked
     in under the command's trace.
-    See [Hooking tests into command spans](Task_Traces.md#hooking-tests-into-command-spans) for more information.
+    See [Hooking tests into command spans](Task_Traces#hooking-tests-into-command-spans) for more information.
 -   `${__project_aws_ssh_key_name}` is the unique key name for the ssh key 
     pair generated by Evergreen. 
 -   `${__project_aws_ssh_key_value}` is the unencrypted PEM encoded PKCS#1 private key 
@@ -832,7 +832,7 @@ given module
 -   `${<module_name>_owner}` is the Github repo owner for the evergreen
     module associated with this task
 
-In the [Github merge queue](Merge-Queue.md), a single additional expansion
+In the [Github merge queue](Merge-Queue), a single additional expansion
 called `${github_head_branch}` is available. This is the name of the temporary
 branch that GitHub creates for this merge group item. It looks something like
 "gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056". In the
@@ -1007,7 +1007,7 @@ oom_tracker: false
 ### Matrix Variant Definition
 
 The matrix syntax is deprecated in favor of the
-[generate.tasks](Project-Commands.md#generatetasks)
+[generate.tasks](Project-Commands#generatetasks)
 command. **Evergreen is unlikely to do further development on matrix
 variant definitions.** The documentation is here for completeness, but
 please do not add new matrix variant definitions. It is typically
@@ -1519,7 +1519,7 @@ parameters are available:
     not be automatically pulled in to the version.
 -   `omit_generated_tasks` - boolean (default: false). If true and the
     dependency is a generator task (i.e. it generates tasks via the
-    [`generate.tasks`](Project-Commands.md#generatetasks) command), then generated tasks will not be included
+    [`generate.tasks`](Project-Commands#generatetasks) command), then generated tasks will not be included
     as dependencies.
 
 So, for example:

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -73,7 +73,7 @@ Evergreen.
 
 Admins can also set the branch project to inherit values from a
 repo-level project settings configuration. This can be learned about at
-['Using Repo Level Settings'](Repo-Level-Settings.md).
+['Using Repo Level Settings'](Repo-Level-Settings).
 
 ### Project Flags
 
@@ -166,7 +166,7 @@ For example:
 - `["!cool !primary"]` would return all items that are not tagged "cool" AND not tagged
   with "primary". That means only items that don't have these tags will be included.
 
-Aliases can also be defined locally as shown [here](../CLI.md#local-aliases).
+Aliases can also be defined locally as shown [here](CLI#local-aliases).
 
 ### GitHub Pull Request Testing
 
@@ -364,7 +364,7 @@ child patch tracks the same project and branch as the parent patch, the
 child patch will also include the changes from the parent patch.
 
 To pass information from the upstream patch to the downstream patch use
-[downstream_expansions.set](Project-Commands.md#downstream_expansionsset)
+[downstream_expansions.set](Project-Commands#downstream_expansionsset)
 
 **Example**:  to allow testing Spruce tasks as part of patches for the Evergreen project,  
 a configuration like this could be added to **Evergreen's project page:**
@@ -432,10 +432,10 @@ Define default filters for your project. Users can access these filters in Parsl
 Enabling this feature allows users to push and pull their task working
 directory to and from a remote store (S3). This can be done either using
 the
-[s3.push](Project-Commands.md#s3push)
+[s3.push](Project-Commands#s3push)
 or
-[s3.pull](Project-Commands.md#s3pull)
-project commands, or using it from [the CLI](../CLI.md#task-sync).
+[s3.pull](Project-Commands#s3pull)
+project commands, or using it from [the CLI](CLI#task-sync).
 
 Options:
 
@@ -447,7 +447,7 @@ Options:
 ### Virtual Workstation Commands
 
 Users can specify custom commands to be run when setting up their
-virtual workstation. See more info [here](../Hosts/Developer-Workstations.md#project-setup).
+virtual workstation. See more info [here](Hosts/Developer-Workstations#project-setup).
 
 Options:
 
@@ -616,13 +616,13 @@ that all execute independently:
 
 ## Version Control
 
-A subset of the above project settings can also be specified in [config YAML](Project-Configuration-Files.md).
+A subset of the above project settings can also be specified in [config YAML](Project-Configuration-Files).
 To enable this feature, the "version control" flag must be enabled on the project settings page.
 ![container_metadata.png](../images/version_control.png)
 
 Once toggled, the settings specified [below](#available-fields) may be defined in YAML, rather than in the project or repo settings page.
 
-**Note**: [included files](Project-Configuration-Files.md#include) do not currently support version-controlled configurations. Version-controlled configuration must
+**Note**: [included files](Project-Configuration-Files#include) do not currently support version-controlled configurations. Version-controlled configuration must
 be defined in the main YAML file for it to take effect.
 
 ### Hierarchical Inheritance

--- a/docs/Project-Configuration/Task-Priority.md
+++ b/docs/Project-Configuration/Task-Priority.md
@@ -33,4 +33,4 @@ menu -> Set priority.
 ![set priority](../images/priority.png)
 
 It can also be set with the
-[API](../API/REST-V2-Usage.md).
+[API](API/REST-V2-Usage).

--- a/docs/Project-Configuration/Task-Runtime-Behavior.md
+++ b/docs/Project-Configuration/Task-Runtime-Behavior.md
@@ -3,8 +3,8 @@
 This article describes the detailed specification for how a task behaves once
 it's running. It also assumes you already have basic knowledge of task
 configuration. For more information on how to configure a task, see [project
-configuration](Project-Configuration-Files.md) or [project
-commands](Project-Commands.md).
+configuration](Project-Configuration-Files) or [project
+commands](Project-Commands).
 
 ## Initial Task Setup
 
@@ -21,12 +21,12 @@ are issues on Evergreen's end.
 Once the task is set up, the command blocks will run their commands. For a
 task that's not part of a task group, the blocks will run in this order:
 
-1. [`pre`](Project-Configuration-Files.md#pre-and-post)
+1. [`pre`](Project-Configuration-Files#pre-and-post)
 2. Main task commands (i.e. commands listed under the task definition)
-3. [`timeout`](Project-Configuration-Files.md#timeout-handler) (only runs if the task [hit a timeout](#task-timeouts))
-4. [`post`](Project-Configuration-Files.md#pre-and-post)
+3. [`timeout`](Project-Configuration-Files#timeout-handler) (only runs if the task [hit a timeout](#task-timeouts))
+4. [`post`](Project-Configuration-Files#pre-and-post)
 
-For a task that _is_ part of a [task group](Project-Configuration-Files.md#task-groups), the blocks will run in this
+For a task that _is_ part of a [task group](Project-Configuration-Files#task-groups), the blocks will run in this
 order:
 
 1. `setup_group` (only runs if it's the first task in this task group running on
@@ -66,7 +66,7 @@ If a command fails in `pre`, by default the task will continue on error, and
 will _not_ cause the task to fail. The `pre` block will simply log the failing
 command's error and continue running any remaining `pre` commands.
 
-However, if [`pre_error_fails_task`](Project-Configuration-Files.md#pre-and-post) is set to true and a `pre` command fails:
+However, if [`pre_error_fails_task`](Project-Configuration-Files#pre-and-post) is set to true and a `pre` command fails:
 
 ```yaml
 pre_error_fails_task: true
@@ -100,7 +100,7 @@ In between some command blocks, the task will try to clean up processes and
 Docker resources that were potentially created by commands. Process cleanup will
 stop any lingering processes and clean up Docker resources such as containers,
 images, and volumes. For example, if the task has a background `mongod` process
-started via [`subprocess.exec`](Project-Commands.md#subprocessexec) or if a `subprocess.exec` executable has also
+started via [`subprocess.exec`](Project-Commands#subprocessexec) or if a `subprocess.exec` executable has also
 started some child processes, the resource cleanup process will catch these
 processes and kill them.
 
@@ -228,7 +228,7 @@ is set.
 | Name            | Type    | Description                                                                                                                                                                                                                                                       |
 |-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | status          | string  | Required. The overall task status. This can be "success" or "failed". If this is configured incorrectly, the task will system fail.                                                                                                                               |
-| type            | string  | The failure type. This can be "setup", "system", or "test" (see [project configuration files](Project-Configuration-Files.md#command-failure-colors) for corresponding colors). If not specified, will default to the failure type of the last command that runs. |
+| type            | string  | The failure type. This can be "setup", "system", or "test" (see [project configuration files](Project-Configuration-Files#command-failure-colors) for corresponding colors). If not specified, will default to the failure type of the last command that runs. |
 | desc            | string  | Provide details on the task failure. This is limited to 500 characters. If not specified or the message is too long, it will default to the display name of the last command that runs.                                                                           |
 | should_continue | boolean | If set, the task will continue running commands, but the final status will be the one explicitly set. Defaults to false.                                                                                                                                          |
 

--- a/docs/Project-Configuration/Task_Traces.md
+++ b/docs/Project-Configuration/Task_Traces.md
@@ -10,16 +10,16 @@ encounters an error the error is recorded as a [span link](https://opentelemetry
 Evergreen provides two ways to send traces to the trace backend, 1) an [OTel collector](#otel-collector) and 2) [trace file parsing](#trace-file-parsing)
 
 ### OTel collector
-Evergreen provides an [OTel collector](https://opentelemetry.io/docs/collector/) to capture traces. The gRPC endpoint is exposed to tasks as the `${otel_collector_endpoint}` [default expansion](Project-Configuration-Files.md#default-expansions).
+Evergreen provides an [OTel collector](https://opentelemetry.io/docs/collector/) to capture traces. The gRPC endpoint is exposed to tasks as the `${otel_collector_endpoint}` [default expansion](Project-Configuration-Files#default-expansions).
 
 ### Trace file parsing
-When a task finishes Evergreen will check the task's [working directory](../Reference/Glossary.md) for any [encoded](#json-protobuf-encoding) trace files written to a `${workdir}/build/OTelTraces` directory, parse them, and send them to the collector. This can be useful if a test is running without a connection to the network. Only trace files are supported, and OTel metrics/logs files in the directory will be skipped.
+When a task finishes Evergreen will check the task's [working directory](Reference/Glossary) for any [encoded](#json-protobuf-encoding) trace files written to a `${workdir}/build/OTelTraces` directory, parse them, and send them to the collector. This can be useful if a test is running without a connection to the network. Only trace files are supported, and OTel metrics/logs files in the directory will be skipped.
 
 #### JSON protobuf encoding
 OTel defines [JSON protobuf encoding](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) for serializing traces to files. Some OTel SDKs support this natively (e.g. the Java SDK provides the [OtlpJsonLoggingSpanExporter exporter](https://javadoc.io/static/io.opentelemetry/opentelemetry-exporter-logging-otlp/1.10.0-rc.2/io/opentelemetry/exporter/logging/otlp/OtlpJsonLoggingSpanExporter.html)). If this isn't an option (e.g. the SDK for go doesn't provide a JSON protobuf exporter) another option is to configure the test to send its traces to a local collector running alongside the test and configure the collector to use the [file exporter](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter). The file exporter is only available in [the collector's "contrib" distribution](https://github.com/open-telemetry/opentelemetry-collector-contrib) (release builds for many OS/architectures are available [here](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)).
 
 ## Hooking tests into command spans
-Evergreen exposes every command's trace and span IDs to a running command as hex encoded strings in the `${otel_trace_id}` and `${otel_parent_id}` [default expansions](Project-Configuration-Files.md#default-expansions). To hook a test's spans into the command's span the trace id and parent id can be added to the current context.
+Evergreen exposes every command's trace and span IDs to a running command as hex encoded strings in the `${otel_trace_id}` and `${otel_parent_id}` [default expansions](Project-Configuration-Files#default-expansions). To hook a test's spans into the command's span the trace id and parent id can be added to the current context.
 
 ### Language specific examples
 The following examples illustrate how to inject the trace/span IDs into the context. They assume the script has the `${otel_trace_id}` and `${otel_parent_id}` expansions expanded.

--- a/docs/Reference/Comparison.md
+++ b/docs/Reference/Comparison.md
@@ -13,19 +13,19 @@
 | Variable | Variable | Expansion |
 | PR / Workflow Run | PR / Pipeline Run | Version (but you will also see people call these a Patch - see below for more details) |
 
-In Evergreen, all of the config for a Project lives in a single YAML file (but you can use [includes](../Project-Configuration/Project-Configuration-Files.md#include) to break things up). This is like a CircleCI Pipeline. With GitHub Actions (GHA), the project’s config is split into multiple files, one per workflow.
+In Evergreen, all of the config for a Project lives in a single YAML file (but you can use [includes](Project-Configuration/Project-Configuration-Files#include) to break things up). This is like a CircleCI Pipeline. With GitHub Actions (GHA), the project’s config is split into multiple files, one per workflow.
 
 An Evergreen Build Variant is like a single GHA or CircleCI Workflow or with no matrix.
 
-Like GHA and CircleCI do with Jobs, Evergreen runs Tasks in parallel by default. You can declare dependencies between Tasks using the [depends_on](../Project-Configuration/Project-Configuration-Files.md#task-dependencies) config key.
+Like GHA and CircleCI do with Jobs, Evergreen runs Tasks in parallel by default. You can declare dependencies between Tasks using the [depends_on](Project-Configuration/Project-Configuration-Files#task-dependencies) config key.
 
 In Evergreen, a Task consists of one or more Functions and Commands. A Command is a single operation, like running a shell script or uploading files to S3. A Function is a collection of multiple Commands that are run in sequence.
 
-The closest equivalent of a GHA Action or CircleCI Orb is a Function or Command. Evergreen provides a number of [built-in Commands](../Project-Configuration/Project-Commands.md). It’s also possible to define your own Functions in your project’s configuration. However, Evergreen **does not** have a mechanism for sharing Actions between config files in a way similar to Actions.
+The closest equivalent of a GHA Action or CircleCI Orb is a Function or Command. Evergreen provides a number of [built-in Commands](Project-Configuration/Project-Commands). It’s also possible to define your own Functions in your project’s configuration. However, Evergreen **does not** have a mechanism for sharing Actions between config files in a way similar to Actions.
 
 Evergreen does not have an equivalent of matrixes from GHA or CircleCI. However, there are a few different ways to generate config that can serve a similar purpose:
 
-- You can use the [generate.tasks](../Project-Configuration/Project-Commands.md#generatetasks) Command to generate Tasks, Build Variants, etc. dynamically during a run.
+- You can use the [generate.tasks](Project-Configuration/Project-Commands#generatetasks) Command to generate Tasks, Build Variants, etc. dynamically during a run.
 - You can write code that uses a shrub library to generate your project’s YAML config and then simply check that in:
   - [https://github.com/evergreen-ci/shrub](https://github.com/evergreen-ci/shrub) - Golang
   - [https://github.com/evergreen-ci/shrub.py](https://github.com/evergreen-ci/shrub.py) - Python
@@ -40,6 +40,6 @@ This is roughly equivalent to the set of GHA Workflows or CircleCI Pipelines run
 
 - Pushing a tag to a repo with an Evergreen project.
 - Scheduled version runs based on a cron schedule. This is configured in the Evergreen project settings.
-- Manually using the evergreen [CLI tool](../CLI.md)’s `evergreen patch` command. When you run this, the set of changes being tested is based on your **local checkout’s commits, not just a PR**. You can  even include uncommitted changes in the patch.
+- Manually using the evergreen [CLI tool](CLI)’s `evergreen patch` command. When you run this, the set of changes being tested is based on your **local checkout’s commits, not just a PR**. You can  even include uncommitted changes in the patch.
 - Triggered because of inter-project dependencies.
 - And several more.

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -15,4 +15,4 @@
 * **test**: A test is sent to Evergreen in a known format by a command during a task, parsed by Evergreen, and displayed on the task page.
 * **user configuration file**: The user configuration file is a file parsed by the Evergreen CLI. It contains the user’s API key and various settings.
 * **version**: A version, which corresponds to a vertical slice of tasks on the waterfall, is all tasks for a given commit or patch build.
-* **working directory**: The working directory is the temporary directory which Evergreen creates to run a task. It is available as [an expansion](../Project-Configuration/Project-Configuration-Files.md#default-expansions).
+* **working directory**: The working directory is the temporary directory which Evergreen creates to run a task. It is available as [an expansion](Project-Configuration/Project-Configuration-Files#default-expansions).

--- a/docs/UI/Patch-Configuration.md
+++ b/docs/UI/Patch-Configuration.md
@@ -1,7 +1,7 @@
 # Patch Configuration
 
 ## Overview
-The Patch Configure page is where you can configure your patch builds. It is accessible from the [My Patches page](./My-Patches.md) by clicking on a patch that has not yet been configured. The page is divided into several sections.
+The Patch Configure page is where you can configure your patch builds. It is accessible from the [My Patches page](My-Patches) by clicking on a patch that has not yet been configured. The page is divided into several sections.
 
 ### Build Variant Selector
 The left side panel contains the build variants that are available for the project. You can can select any combination of build variants using `Cmd` + click and `Shift` + click. If you have a task name that is reused across multiple build variants it will automatically be deduplicated in the task panel.
@@ -17,5 +17,5 @@ The left side panel contains the build variants that are available for the proje
  
 - **Configure:** the default which contains the tasks that are selectable for the variant, a search bar which allows you to search for tasks by name, a button to **Select All** visible tasks, and a button to **Deselect All** visible tasks.
 - **Changes** which shows the files that have been changed in the patch
-- **Parameters** which allows you to specify [custom parameters](../Project-Configuration/Parameterized-Builds.md) to pass into your patch build.
+- **Parameters** which allows you to specify [custom parameters](Project-Configuration/Parameterized-Builds) to pass into your patch build.
 

--- a/docs/UI/Version.md
+++ b/docs/UI/Version.md
@@ -12,7 +12,7 @@ The version page contains the run details for a given patch or mainline commit a
 The Tasks tab contains a table of all of the tasks that ran in the version. 
 
 The table is comprised of the following columns:
-* The Task name and a link to the [task page](./Task.md). 
+* The Task name and a link to the [task page](Task). 
 * The Task status. 
 * The Base Task status. For mainline commits this is the status of the task on the previous commit. For Patches this is the status of the task on the base commit.
 * The Build Variant the task ran on.
@@ -31,6 +31,6 @@ The Task Duration tab contains a list of all of the tasks that ran in the versio
 ![Changes table](../images/changes_table.png)
 
 #### Downstream Projects
-The Downstream Projects tab contains a list of all of the projects that were triggered by the version. Note: This tab is only visible if you have [project triggers configured](../Project-Configuration/Project-and-Distro-Settings.md#project-triggers).
+The Downstream Projects tab contains a list of all of the projects that were triggered by the version. Note: This tab is only visible if you have [project triggers configured](Project-Configuration/Project-and-Distro-Settings#project-triggers).
 
 ![Downstream Projects table](../images/downstream_projects.png)


### PR DESCRIPTION
DEVPROD-5372

I clicked a bunch of links in Pine and concluded that only some of the relative path links (e.g. `../API/REST-V2-Usage.md`) work, and I can't tell what causes some to work and others to not (some work, others don't, but they all are valid relative paths). My guess is that maybe the relative paths don't actually do anything, or that being able to render the link depends on the order that the files are processed by Docusaurus.

Anyways, I saw a couple links are using absolute paths starting from the docs root (i.e. https://docs.devprod.prod.corp.mongodb.com/evergreen/) and they seem to work, so I'm going to try switching all the relative path links to absolute paths to see if Docusaurus accepts them. If not, I can just revert it.

Will check the links once Pine deploys the latest docs.