### PR TITLE
DEVPROD-1008 Add setting to define oldest allowed merge base for PR patches

### DIFF
--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -1,7 +1,6 @@
 package patch
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -118,7 +117,7 @@ var (
 
 // NewGithubIntent creates an Intent from a google/go-github PullRequestEvent,
 // or returns an error if the some part of the struct is invalid
-func NewGithubIntent(msgDeliveryID, patchOwner, calledBy string, pr *github.PullRequest) (Intent, error) {
+func NewGithubIntent(msgDeliveryID, patchOwner, calledBy, mergeBase string, pr *github.PullRequest) (Intent, error) {
 	if pr == nil ||
 		pr.Base == nil || pr.Base.Repo == nil ||
 		pr.Head == nil || pr.Head.Repo == nil ||
@@ -164,13 +163,6 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy string, pr *github.Pull
 	repeat, err := getRepeatPatchId(pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName(), pr.GetNumber())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting patch to repeat definitions from")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
-	mergeBase, err := thirdparty.GetGithubMergeBaseRevision(ctx, "", baseOwnerAndRepo[0], baseOwnerAndRepo[1], pr.Base.GetRef(), pr.Head.GetRef())
-	if err != nil {
-		return nil, errors.Wrapf(err, "getting merge base between branches '%s' and '%s'", pr.Base.GetRef(), pr.Head.GetRef())
 	}
 
 	return &githubIntent{

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -304,6 +304,7 @@ func (g *githubIntent) NewPatch() *Patch {
 			HeadOwner:  headRepo[0],
 			HeadRepo:   headRepo[1],
 			HeadHash:   g.HeadHash,
+			MergeBase:  g.MergeBase,
 			Author:     g.User,
 			AuthorUID:  g.UID,
 		},

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -127,8 +127,7 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy, mergeBase string, pr *
 	if msgDeliveryID == "" {
 		return nil, errors.New("unique msg ID cannot be empty")
 	}
-	baseOwnerAndRepo := strings.Split(pr.Base.Repo.GetFullName(), "/")
-	if len(baseOwnerAndRepo) != 2 {
+	if len(strings.Split(pr.Base.Repo.GetFullName(), "/")) != 2 {
 		return nil, errors.New("base repo name is invalid (expected [owner]/[repo])")
 	}
 	if pr.Base.GetRef() == "" {

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -49,45 +49,45 @@ func (s *GithubSuite) SetupTest() {
 }
 
 func (s *GithubSuite) TestNewGithubIntent() {
-	intent, err := NewGithubIntent("1", "", "", testutil.NewGithubPR(0, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", "", "", testutil.NewGithubPR(0, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, "", s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, "", s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, "", s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, "", s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, "", s.user, s.title))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, "", s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
 	// Creates new intent with callers
-	intent, err = NewGithubIntent("2", "", AutomatedCaller, testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent("2", "", AutomatedCaller, "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", ManualCaller, testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent("2", "", ManualCaller, "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
 	// PRs can't have an empty title
-	intent, err = NewGithubIntent("2", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, ""))
+	intent, err = NewGithubIntent("2", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, ""))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("4", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("4", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.Implements((*Intent)(nil), intent)
@@ -130,7 +130,7 @@ func (s *GithubSuite) TestNewGithubIntent() {
 		},
 	}
 	s.NoError(patch.Insert())
-	intent, err = NewGithubIntent("4", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent("4", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.Implements((*Intent)(nil), intent)
@@ -140,7 +140,7 @@ func (s *GithubSuite) TestNewGithubIntent() {
 }
 
 func (s *GithubSuite) TestInsert() {
-	intent, err := NewGithubIntent("1", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -160,7 +160,7 @@ func (s *GithubSuite) TestInsert() {
 }
 
 func (s *GithubSuite) TestFindIntentSpecifically() {
-	intent, err := NewGithubIntent("300", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("300", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -179,7 +179,7 @@ func (s *GithubSuite) TestFindIntentSpecifically() {
 }
 
 func (s *GithubSuite) TestSetProcessed() {
-	intent, err := NewGithubIntent("1", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("1", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -250,7 +250,7 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 
 func (s *GithubSuite) TestNewPatch() {
 	s.NoError(db.Clear(IntentCollection))
-	intent, err := NewGithubIntent("4", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent("4", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -339,6 +339,7 @@ var (
 	projectRefPatchTriggerAliasesKey      = bsonutil.MustHaveTag(ProjectRef{}, "PatchTriggerAliases")
 	projectRefGithubTriggerAliasesKey     = bsonutil.MustHaveTag(ProjectRef{}, "GithubTriggerAliases")
 	projectRefPeriodicBuildsKey           = bsonutil.MustHaveTag(ProjectRef{}, "PeriodicBuilds")
+	projectRefOldestAllowedMergeBaseKey   = bsonutil.MustHaveTag(ProjectRef{}, "OldestAllowedMergeBase")
 	projectRefWorkstationConfigKey        = bsonutil.MustHaveTag(ProjectRef{}, "WorkstationConfig")
 	projectRefTaskAnnotationSettingsKey   = bsonutil.MustHaveTag(ProjectRef{}, "TaskAnnotationSettings")
 	projectRefBuildBaronSettingsKey       = bsonutil.MustHaveTag(ProjectRef{}, "BuildBaronSettings")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2065,6 +2065,7 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 					ProjectRefGitTagAuthorizedUsersKey:  p.GitTagAuthorizedUsers,
 					ProjectRefGitTagAuthorizedTeamsKey:  p.GitTagAuthorizedTeams,
 					projectRefCommitQueueKey:            p.CommitQueue,
+					projectRefOldestAllowedMergeBaseKey: p.OldestAllowedMergeBase,
 				},
 			})
 	case ProjectPageNotificationsSection:

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -73,9 +73,12 @@ type ProjectRef struct {
 	// all aliases defined for the project
 	PatchTriggerAliases []patch.PatchTriggerDefinition `bson:"patch_trigger_aliases" json:"patch_trigger_aliases"`
 	// all PatchTriggerAliases applied to github patch intents
-	GithubTriggerAliases []string                  `bson:"github_trigger_aliases" json:"github_trigger_aliases"`
-	PeriodicBuilds       []PeriodicBuildDefinition `bson:"periodic_builds" json:"periodic_builds"`
-	CommitQueue          CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
+	GithubTriggerAliases []string `bson:"github_trigger_aliases" json:"github_trigger_aliases"`
+	// OldestAllowedMergeBase is the commit hash of the oldest merge base on the target branch
+	// that PR patches can be created from.
+	OldestAllowedMergeBase string                    `bson:"oldest_allowed_merge_base" json:"oldest_allowed_merge_base"`
+	PeriodicBuilds         []PeriodicBuildDefinition `bson:"periodic_builds" json:"periodic_builds"`
+	CommitQueue            CommitQueueParams         `bson:"commit_queue" json:"commit_queue" yaml:"commit_queue"`
 
 	// Admins contain a list of users who are able to access the projects page.
 	Admins []string `bson:"admins" json:"admins"`

--- a/rest/data/patch_intent.go
+++ b/rest/data/patch_intent.go
@@ -16,22 +16,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AddPatchIntent inserts the intent and adds it to the queue if PR testing is enabled for the branch.
-func AddPatchIntent(intent patch.Intent, queue amboy.Queue) error {
-	// Verify that the owner/repo uses PR testing before inserting the intent.
-	patchDoc := intent.NewPatch()
-	projectRef, err := model.FindOneProjectRefByRepoAndBranchWithPRTesting(patchDoc.GithubPatchData.BaseOwner,
-		patchDoc.GithubPatchData.BaseRepo, patchDoc.GithubPatchData.BaseBranch, intent.GetCalledBy())
-	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "finding project ref for patch").Error(),
-		}
-	}
-	if projectRef == nil {
-		return nil
-	}
-
+// AddPRPatchIntent inserts the intent and adds it to the queue if PR testing is enabled for the branch.
+func AddPRPatchIntent(intent patch.Intent, queue amboy.Queue) error {
 	if err := intent.Insert(); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "couldn't insert patch intent",

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -723,9 +723,8 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 	conflictingPatches, err := getOtherPatchesWithHash(pr.Head.GetSHA(), pr.GetNumber())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": "error getting same hash patches",
-			"owner":   pr.Base.User.GetLogin(),
-
+			"message":           "error getting same hash patches",
+			"owner":             pr.Base.User.GetLogin(),
 			"repo":              pr.Base.Repo.GetName(),
 			"ref":               pr.Head.GetRef(),
 			"pr_num":            pr.GetNumber(),

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -712,6 +712,9 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		defer cancel()
 		baseOwnerAndRepo := strings.Split(pr.Base.Repo.GetFullName(), "/")
+		if len(baseOwnerAndRepo) != 2 {
+			return errors.New("PR base repo name is invalid (expected [owner]/[repo])")
+		}
 		mergeBase, err = thirdparty.GetGithubMergeBaseRevision(ctx, "", baseOwnerAndRepo[0], baseOwnerAndRepo[1], pr.Base.GetRef(), pr.Head.GetRef())
 		if err != nil {
 			return errors.Wrapf(err, "getting merge base between branches '%s' and '%s'", pr.Base.GetRef(), pr.Head.GetRef())

--- a/testutil/github.go
+++ b/testutil/github.go
@@ -11,6 +11,7 @@ func NewGithubPR(prNumber int, baseRepoName, baseHash, headRepoName, headHash, u
 		Title:  github.String(title),
 		Number: github.Int(prNumber),
 		Head: &github.PullRequestBranch{
+			Ref: github.String("DEVPROD-123"),
 			SHA: github.String(headHash),
 			Repo: &github.Repository{
 				FullName: github.String(headRepoName),

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -655,7 +655,7 @@ func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, 
 		apiErr := errors.Errorf("nil response from merge base commit response for '%s/%s'@%s..%s: %v", owner, repo, baseRevision, currentCommitHash, err)
 		grip.Error(message.WrapError(apiErr, message.Fields{
 			"message":             "failed to compare commits to determine order of commits",
-			"op":                  "IsMergeBaseAllowed",
+			"op":                  "getCommitComparison",
 			"github_error":        fmt.Sprint(err),
 			"repo":                repo,
 			"base_revision":       baseRevision,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -602,12 +602,41 @@ func getMergeBaseRevision(ctx context.Context, token, owner, repo, baseRevision,
 		attribute.String(githubRepoAttribute, repo),
 	))
 	defer span.End()
+	compare, err := getCommitComparison(ctx, token, owner, repo, baseRevision, currentCommitHash, caller)
+	if err != nil {
+		return "", errors.Wrapf(err, "retreiving comparison between commit hashses '%s' and '%s'", baseRevision, currentCommitHash)
+	}
+	return *compare.MergeBaseCommit.SHA, nil
+}
 
+// IsMergeBaseAllowed will return true if the input merge base is newer than the oldest allowed merge base
+// configured in the project settings.
+func IsMergeBaseAllowed(ctx context.Context, token, owner, repo, oldestAllowedMergeBase, mergeBase string) (bool, error) {
+	caller := "IsMergeBaseAllowed"
+	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
+		attribute.String(githubEndpointAttribute, caller),
+		attribute.String(githubOwnerAttribute, owner),
+		attribute.String(githubRepoAttribute, repo),
+	))
+	defer span.End()
+	compare, err := getCommitComparison(ctx, token, owner, repo, oldestAllowedMergeBase, mergeBase, caller)
+	if err != nil {
+		return false, errors.Wrapf(err, "retreiving comparison between commit hashses '%s' and '%s'", oldestAllowedMergeBase, mergeBase)
+	}
+	status := compare.GetStatus()
+
+	// Per the API docs: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits
+	// Valid statuses are within the enum of "diverged", "ahead", "behind", "identical"
+	return status != "ahead", nil
+}
+
+func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, currentCommitHash, caller string) (*github.CommitsComparison, error) {
+	span := trace.SpanFromContext(ctx)
 	if token == "" {
 		var err error
 		token, err = getInstallationToken(ctx, owner, repo, nil)
 		if err != nil {
-			return "", errors.Wrap(err, "getting installation token")
+			return nil, errors.Wrap(err, "getting installation token")
 		}
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
@@ -618,26 +647,24 @@ func getMergeBaseRevision(ctx context.Context, token, owner, repo, baseRevision,
 		defer resp.Body.Close()
 		span.SetAttributes(attribute.Bool(githubCachedAttribute, respFromCache(resp.Response)))
 		if err != nil {
-			return "", parseGithubErrorResponse(resp)
+			return nil, parseGithubErrorResponse(resp)
 		}
 	} else {
 		apiErr := errors.Errorf("nil response from merge base commit response for '%s/%s'@%s..%s: %v", owner, repo, baseRevision, currentCommitHash, err)
 		grip.Error(message.WrapError(apiErr, message.Fields{
-			"message":             "failed to compare commits to find merge base commit",
-			"op":                  "GetGithubMergeBaseRevision",
+			"message":             "failed to compare commits to determine order of commits",
+			"op":                  "IsMergeBaseAllowed",
 			"github_error":        fmt.Sprint(err),
 			"repo":                repo,
 			"base_revision":       baseRevision,
 			"current_commit_hash": currentCommitHash,
 		}))
-		return "", APIResponseError{apiErr.Error()}
+		return nil, APIResponseError{apiErr.Error()}
 	}
-
 	if compare == nil || compare.MergeBaseCommit == nil || compare.MergeBaseCommit.SHA == nil {
-		return "", APIRequestError{Message: "missing data from GitHub compare response"}
+		return nil, APIRequestError{Message: "missing data from GitHub compare response"}
 	}
-
-	return *compare.MergeBaseCommit.SHA, nil
+	return compare, nil
 }
 
 func GetCommitEvent(ctx context.Context, token, owner, repo, githash string) (*github.RepositoryCommit, error) {

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -50,6 +50,7 @@ const (
 	EmptyConfig                 = "config file was empty"
 	ProjectFailsValidation      = "Project fails validation"
 	OtherErrors                 = "Evergreen error"
+	MergeBaseTooOld             = "merge base is too old"
 )
 
 func init() {

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -168,7 +168,7 @@ func (s *githubStatusUpdateSuite) TestForDeleteFromCommitQueue() {
 }
 
 func (s *githubStatusUpdateSuite) TestForProcessingError() {
-	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(448,
+	intent, err := patch.NewGithubIntent("1", "", "", "", testutil.NewGithubPR(448,
 		"evergreen-ci/evergreen", "7c38f3f63c05675329518c148d3a176e1da6ec2d", "tychoish/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "tychoish", "Title"))
 	s.NoError(err)
 	s.NotNil(intent)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -282,8 +282,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if j.IntentType == patch.GithubIntentType && pref.OldestAllowedMergeBase != "" {
-		isMergeBaseAllowed, err := thirdparty.IsMergeBaseAllowed(ctx, token, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, pref.OldestAllowedMergeBase, j.intent.GetType())
-		// TODO change above
+		isMergeBaseAllowed, err := thirdparty.IsMergeBaseAllowed(ctx, token, patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo, pref.OldestAllowedMergeBase, patchDoc.GithubPatchData.MergeBase)
 		if err != nil {
 			return errors.Wrap(err, "checking if merge base is allowed")
 		}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1275,7 +1275,7 @@ func (s *PatchIntentUnitsSuite) TestRunInDegradedModeWithGithubIntent() {
 	}
 	s.NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
-	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.baseHash, s.headRepo, s.hash, "tychoish", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.baseHash, s.headRepo, s.hash, "tychoish", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
@@ -1306,7 +1306,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	}
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
-	intent, err := patch.NewGithubIntent("1", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent("1", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert())


### PR DESCRIPTION
DEVPROD-1008

### Description
This introduces a new optional project ref setting field that defines the oldest allowed commit hash that can be the merge base for PR patches. If the field is set for the project and the PR patch's merge base is older than the defined commit sha, the patch will not run.

In order to make it such that the git commit comparison check API only hits for projects that have this new field set, I had to refactor the github PR intent logic a bit to move the project ref query earlier in the logic.

This will require a followup Spruce PR.
### Testing
Tested in staging by setting an oldest allowed merge base on a sandbox project, and confirmed that PRs opened with merge bases before the merge base [ran tasks](https://github.com/evergreen-ci/commit-queue-sandbox/pull/680), and a PR opened with a merge base older than the oldest allowed base failed with ["merge base is too old"](https://github.com/evergreen-ci/commit-queue-sandbox/pull/681)

