### PR TITLE
DEVPROD-5626: add papertrail.trace command

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -1,0 +1,146 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mitchellh/mapstructure"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+type papertrailTrace struct {
+	Address   string   `mapstructure:"address" plugin:"expand"`
+	KeyID     string   `mapstructure:"key_id" plugin:"expand"`
+	SecretKey string   `mapstructure:"secret_key" plugin:"expand"`
+	Product   string   `mapstructure:"product" plugin:"expand"`
+	Version   string   `mapstructure:"version" plugin:"expand"`
+	Filenames []string `mapstructure:"filenames" plugin:"expand"`
+	WorkDir   string   `mapstructure:"work_dir" plugin:"expand"`
+	base
+}
+
+// This command is owned by the Dev Prod Release Infrastructure team
+func (t *papertrailTrace) Execute(ctx context.Context,
+	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+	if err := util.ExpandValues(t, &conf.Expansions); err != nil {
+		return errors.Wrap(err, "applying expansions")
+	}
+
+	pclient := thirdparty.NewPapertrailClient(t.KeyID, t.SecretKey, "")
+
+	task := conf.Task
+
+	workdir := t.WorkDir
+	if workdir == "" {
+		workdir = conf.WorkDir
+	}
+
+	const platform = "evergreen"
+
+	for _, file := range t.Filenames {
+		fullname := filepath.Join(workdir, file)
+
+		sha256sum, err := getSHA256(fullname)
+		if err != nil {
+			return errors.Wrap(err, "getting sha256")
+		}
+
+		papertrailBuildID := getPapertrailBuildID(task.Id, task.Execution)
+
+		// should already be the basename, but just in case
+		basename := filepath.Base(file)
+
+		args := thirdparty.TraceArgs{
+			Build:     papertrailBuildID,
+			Platform:  platform,
+			Filename:  basename,
+			Sha256:    sha256sum,
+			Product:   t.Product,
+			Version:   t.Version,
+			Submitter: task.ActivatedBy,
+		}
+
+		if err := pclient.Trace(ctx, args); err != nil {
+			return errors.Wrap(err, "running trace")
+		}
+
+		logger.Task().Infof("Successfully traced '%s' (sha256://%s)", fullname, sha256sum)
+	}
+
+	return nil
+}
+
+func getSHA256(filename string) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	sha256sum := fmt.Sprintf("%x", h.Sum(nil))
+
+	return sha256sum, nil
+}
+
+func (t *papertrailTrace) ParseParams(params map[string]any) error {
+	conf := &mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		Result:           t,
+	}
+
+	decoder, err := mapstructure.NewDecoder(conf)
+	if err != nil {
+		return errors.Wrap(err, "initializing new decoder")
+	}
+
+	if err := decoder.Decode(params); err != nil {
+		return errors.Wrap(err, "decoding params")
+	}
+
+	catcher := grip.NewSimpleCatcher()
+
+	if t.KeyID == "" {
+		catcher.New("must specify key_id")
+	}
+
+	if t.SecretKey == "" {
+		catcher.New("must specify secret_key")
+	}
+
+	if t.Product == "" {
+		catcher.New("must specify product")
+	}
+
+	if t.Version == "" {
+		catcher.New("must specify version")
+	}
+
+	if len(t.Filenames) == 0 {
+		catcher.New("must specify at least one filename")
+	}
+
+	return catcher.Resolve()
+}
+
+func getPapertrailBuildID(taskID string, execution int) string {
+	return fmt.Sprintf("%s_%d", taskID, execution)
+}
+
+func (t *papertrailTrace) Name() string { return "papertrail.trace" }
+
+func papertrailTraceFactory() Command { return &papertrailTrace{} }

--- a/agent/command/papertrail_trace_test.go
+++ b/agent/command/papertrail_trace_test.go
@@ -1,0 +1,304 @@
+package command
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip/send"
+	"github.com/pkg/errors"
+)
+
+func TestPapertrailTrace(t *testing.T) {
+	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_INTEGRATION_TESTS")); skip {
+		t.Skip("SKIP_INTEGRATION_TESTS is set, skipping integration test")
+	}
+
+	settings := testutil.GetIntegrationFile(t)
+
+	keyID := settings.Expansions["papertrail_key_id"]
+	secretKey := settings.Expansions["papertrail_secret_key"]
+	product := "papertrail-evergreen-command-testing"
+
+	cases := map[string]struct {
+		keyID      string
+		secretKey  string
+		product    string
+		version    string
+		filenames  []string
+		author     string
+		taskID     string
+		execution  int
+		expansions map[string]string
+	}{
+		"basic-no-expansions": {
+			keyID:     keyID,
+			secretKey: secretKey,
+			product:   product,
+			version:   utility.RandomString(),
+			filenames: []string{
+				utility.RandomString(),
+				utility.RandomString(),
+			},
+			author:    "foo.bar",
+			taskID:    "abc123",
+			execution: 1,
+		},
+		"basic-expansions": {
+			keyID:     "${key_id}",
+			secretKey: "${secret_key}",
+			product:   "${product}",
+			version:   "${version}",
+			filenames: []string{
+				"${test-file-1}",
+				"${test-file-2}",
+			},
+			author:    "foo.bar",
+			taskID:    "abc123",
+			execution: 1,
+			expansions: map[string]string{
+				"key_id":      keyID,
+				"secret_key":  secretKey,
+				"product":     product,
+				"version":     utility.RandomString(),
+				"test-file-1": utility.RandomString(),
+				"test-file-2": utility.RandomString(),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	tempdir, err := os.MkdirTemp(os.TempDir(), "papertrail-test-*")
+	if err != nil {
+		t.Fatalf("make temp dir: %s", err)
+	}
+
+	t.Cleanup(func() { os.RemoveAll(tempdir) })
+
+	pclient := thirdparty.NewPapertrailClient(keyID, secretKey, "")
+
+	sender := send.MakeInternalLogger()
+	logger := client.NewSingleChannelLogHarness("test", sender)
+
+	for name, tc := range cases {
+		name, tc := name, tc
+
+		getExpandedValue := func(v string) string {
+			if strings.HasPrefix(v, "$") {
+				// trim '${}' from v
+				v = v[2 : len(v)-1]
+				return tc.expansions[v]
+			}
+
+			return v
+		}
+
+		t.Run(name, func(t *testing.T) {
+			filenames := make([]string, 0, len(tc.filenames))
+			checksums := make([]string, 0, len(tc.filenames))
+
+			for _, basename := range tc.filenames {
+				basename = getExpandedValue(basename)
+
+				data := utility.RandomString()
+
+				filename := filepath.Join(tempdir, basename)
+
+				if err := os.WriteFile(filename, []byte(data), 0755); err != nil {
+					t.Fatalf("write temp file: %s", err)
+				}
+
+				filenames = append(filenames, filepath.Base(filename))
+
+				h := sha256.New()
+				if _, err := io.Copy(h, strings.NewReader(data)); err != nil {
+					t.Fatalf("read file: %s", err)
+				}
+
+				sha256sum := fmt.Sprintf("%x", h.Sum(nil))
+
+				checksums = append(checksums, sha256sum)
+			}
+
+			params := map[string]any{
+				"key_id":     tc.keyID,
+				"secret_key": tc.secretKey,
+				"product":    tc.product,
+				"version":    tc.version,
+				"filenames":  filenames,
+				"work_dir":   tempdir,
+			}
+
+			cmd := papertrailTraceFactory()
+
+			if err := cmd.ParseParams(params); err != nil {
+				t.Fatalf("parse params: %s", err)
+			}
+
+			tconf := &internal.TaskConfig{
+				Expansions: util.Expansions(tc.expansions),
+				Task: task.Task{
+					Id:          tc.taskID,
+					Execution:   tc.execution,
+					ActivatedBy: tc.author,
+				},
+			}
+
+			if err := cmd.Execute(ctx, nil, logger, tconf); err != nil {
+				t.Fatalf("execute: %s", err)
+			}
+
+			product := getExpandedValue(tc.product)
+			version := getExpandedValue(tc.version)
+
+			pv, err := pclient.GetProductVersion(ctx, product, version)
+			if err != nil {
+				t.Fatalf("get product version: %s", err)
+			}
+
+			if len(pv.Spans) != len(filenames) {
+				t.Fatalf("got %d spans, expected %d", len(pv.Spans), len(filenames))
+			}
+
+			for i, got := range pv.Spans {
+
+				sum := checksums[i]
+				filename := filenames[i]
+
+				if got.SHA256sum != sum {
+					t.Fatalf("got checksum '%s', expected '%s'", got.SHA256sum, sum)
+				}
+
+				if got.Filename != filename {
+					t.Fatalf("got filename '%s', expected '%s'", got.Filename, filename)
+				}
+
+				build := getPapertrailBuildID(tc.taskID, tc.execution)
+
+				if got.Build != build {
+					t.Fatalf("got build '%s', expected '%s'", got.Build, build)
+				}
+
+				if got.Platform != "evergreen" {
+					t.Fatalf("got platform '%s', expected 'evergreen'", got.Platform)
+				}
+
+				if got.Product != product {
+					t.Fatalf("got product '%s', expected '%s'", got.Product, tc.product)
+				}
+
+				if got.Version != version {
+					t.Fatalf("got version '%s', expected '%s'", got.Version, tc.version)
+				}
+
+				if got.Submitter != tc.author {
+					t.Fatalf("got submitter '%s', expected '%s'", got.Submitter, tc.author)
+				}
+
+			}
+		})
+	}
+}
+
+func TestPapertrailParseParams(t *testing.T) {
+	cases := map[string]struct {
+		keyID     string
+		secretKey string
+		product   string
+		version   string
+		filenames []string
+		err       error
+	}{
+
+		"missing-key-id": {
+			keyID:     "",
+			secretKey: "test-secret-key",
+			product:   "test-product",
+			version:   "test-version",
+			filenames: []string{"test-filename"},
+			err:       errors.New("must specify key_id"),
+		},
+		"missing-secret-key": {
+			keyID:     "test-key",
+			secretKey: "",
+			product:   "test-product",
+			version:   "test-version",
+			filenames: []string{"test-filename"},
+			err:       errors.New("must specify secret_key"),
+		},
+		"missing-product": {
+			keyID:     "test-key",
+			secretKey: "test-secret-key",
+			product:   "",
+			version:   "test-version",
+			filenames: []string{"test-filename"},
+			err:       errors.New("must specify product"),
+		},
+		"missing-version": {
+			keyID:     "test-key",
+			secretKey: "test-secret-key",
+			product:   "test-product",
+			version:   "",
+			filenames: []string{"test-filename"},
+			err:       errors.New("must specify version"),
+		},
+		"missing-filename": {
+			keyID:     "test-key",
+			secretKey: "test-secret-key",
+			product:   "test-product",
+			version:   "test-version",
+			filenames: []string{},
+			err:       errors.New("must specify at least one filename"),
+		},
+	}
+
+	for name, tc := range cases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			params := map[string]any{
+				"key_id":     tc.keyID,
+				"secret_key": tc.secretKey,
+				"product":    tc.product,
+				"version":    tc.version,
+				"filenames":  tc.filenames,
+			}
+
+			cmd := papertrailTraceFactory()
+
+			err := cmd.ParseParams(params)
+			if err.Error() != tc.err.Error() {
+				t.Fatalf("expected error '%s', got '%s'", tc.err, err)
+			}
+		})
+	}
+
+	t.Run("no-errors", func(t *testing.T) {
+		params := map[string]any{
+			"key_id":     "test-key",
+			"secret_key": "test-secret-key",
+			"product":    "test-product",
+			"version":    "test-version",
+			"filenames":  "test-filename",
+		}
+
+		cmd := papertrailTraceFactory()
+
+		err := cmd.ParseParams(params)
+		if err != nil {
+			t.Fatalf("expected no error, got '%s'", err)
+		}
+	})
+}

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -39,6 +39,7 @@ func init() {
 		"gotest.parse_files":                    goTestFactory,
 		"keyval.inc":                            keyValIncFactory,
 		"manifest.load":                         manifestLoadFactory,
+		"papertrail.trace":                      papertrailTraceFactory,
 		"perf.send":                             perfSendFactory,
 		"downstream_expansions.set":             setExpansionsFactory,
 		"s3.get":                                s3GetFactory,

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-02"
+	AgentVersion = "2024-04-03"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -905,6 +905,38 @@ Parameters:
     internally.
 -   `destination`: expansion name to save the value to.
 
+## papertrail.trace
+
+This command traces artifact releases with the Papertrail service. It is owned
+by the Release Infrastructure team, and you may receive assistance with it in
+#ask-devprod-release-tools.
+
+``` yaml
+- command: papertrail.trace
+  params:
+    key_id: ${papertrail_key_id}
+    secret_key: ${papertrail_secret_key}
+    product: mongosh
+    version: 1.0.0
+    filenames:
+        - mongosh-linux-amd64.tar.gz
+        - mongosh-linux-arm64.tar.gz
+```
+
+Parameters:
+
+-   `key_id`: your Papertrail key ID (use private variables to keep this a
+    secret).
+-   `secret_key`: your Papertrail secret key (use private variables to keep this
+    a secret).
+-   `product`: The name of the product these filenames belong to (e.g. mongosh,
+    compass, java-driver).
+-   `version`: The version of the product these filenames belong to (e.g.
+    1.0.1).
+-   `filenames`: A list of filename paths to pass to the service. You may use
+    full filepaths in this parameter, the command will label the file with its
+    basename only when sent to the service.
+
 ## perf.send
 
 This command sends performance test data, as either JSON or YAML, to

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -71,8 +71,10 @@ auth:
 
 github_pr_creator_org: "10gen"
 
-# Do not edit below this line
 expansions:
+  papertrail_key_id: $PAPERTRAIL_KEY_ID
+  papertrail_secret_key: $PAPERTRAIL_SECRET_KEY
+  # Do not edit below this line
   github_app_key: |
 EOF
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -283,6 +283,8 @@ functions:
           JIRA_ACCESS_TOKEN: ${jira_access_token}
           JIRA_TOKEN_SECRET: ${jira_token_secret}
           JIRA_CONSUMER_KEY: ${jira_consumer_key}
+          PAPERTRAIL_KEY_ID: ${papertrail_key_id}
+          PAPERTRAIL_SECRET_KEY: ${papertrail_secret_key}
         command: bash scripts/setup-credentials.sh
 
   setup-mongodb:

--- a/thirdparty/papertrail.go
+++ b/thirdparty/papertrail.go
@@ -1,0 +1,169 @@
+package thirdparty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/pkg/errors"
+)
+
+const (
+	productionPapertrailAddress = "https://papertrail.devprod-infra.prod.corp.mongodb.com"
+)
+
+// PapertrailSpan represents a span in json form from Papertrail.
+type PapertrailSpan struct {
+	ID        string `json:"id"`
+	SHA256sum string `json:"sha256sum"`
+	Filename  string `json:"filename"`
+	Build     string `json:"build"`
+	Platform  string `json:"platform"`
+	Product   string `json:"product"`
+	Version   string `json:"version"`
+	Submitter string `json:"submitter"`
+	KeyID     string `json:"key_id"`
+	Time      uint64 `json:"time"`
+}
+
+// PapertrailProductVersion contains a particular product-version's complete
+// list of spans from Papertrail's /product-versions endpoint
+type PapertrailProductVersion struct {
+	Product string           `json:"product"`
+	Version string           `json:"version"`
+	Spans   []PapertrailSpan `json:"spans"`
+}
+
+// PapertrailClient is used to interact with the Papertrail service over HTTP.
+// It is recommended to use NewPapertrailClient to initialize this struct.
+type PapertrailClient struct {
+	*http.Client
+	Address   string
+	KeyID     string
+	SecretKey string
+}
+
+// NewPapertrailClient returns an initialized PapertrailClient. If address is
+// empty, the default production address is used
+func NewPapertrailClient(keyID, secretKey, address string) *PapertrailClient {
+	if address == "" {
+		address = productionPapertrailAddress
+	}
+
+	return &PapertrailClient{
+		Client:    &http.Client{},
+		Address:   address,
+		KeyID:     keyID,
+		SecretKey: secretKey,
+	}
+}
+
+// TraceArgs contain the list of items necessary to pass to Papertrail
+type TraceArgs struct {
+
+	// Build is the unique identifier for a particular job run in a CI system.
+	// For evergreen jobs, this is in the form "{task_id}_{execution}"
+	Build string
+
+	// Platform is the Papertrail-internal name for this CI service. It should
+	// always be set to Evergreen unless doing testing
+	Platform string
+
+	// Filename is the basename of the file that is being traced
+	Filename string
+
+	// Sha256 is the hex-encoded checksum of the file that is being traced
+	Sha256 string
+
+	// Product is the product name to associate this file with (e.g. compass)
+	Product string
+
+	// Version is the version name to associate this file with (e.g. 1.0.0)
+	Version string
+
+	// Submitter is the username in the CI system to associate this trace with.
+	Submitter string
+}
+
+// Trace calls the Papertrail /trace endpoint, associating a file and its
+// metadata with a product version.
+func (c *PapertrailClient) Trace(ctx context.Context, args TraceArgs) error {
+	params := url.Values{}
+
+	params.Set("build", args.Build)
+	params.Set("platform", args.Platform)
+	params.Set("filename", args.Filename)
+	params.Set("sha256", args.Sha256)
+	params.Set("product", args.Product)
+	params.Set("version", args.Version)
+	params.Set("submitter", args.Submitter)
+
+	addr := fmt.Sprintf("%s/trace?%s", c.Address, params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, addr, nil)
+	if err != nil {
+		return errors.Wrap(err, "getting new request")
+	}
+
+	req.Header.Set("X-PAPERTRAIL-KEY-ID", c.KeyID)
+	req.Header.Set("X-PAPERTRAIL-SECRET-KEY", c.SecretKey)
+
+	res, err := c.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "calling do")
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return util.RespErrorf(res, "running papertrail trace")
+	}
+
+	return nil
+}
+
+// GetProductVersion calls the Papertrail /product-version endpoint, returning
+// a PapertrailProductVersion with the collection of all spans associated with
+// the product and version passed in.
+func (c *PapertrailClient) GetProductVersion(ctx context.Context, product, version string) (*PapertrailProductVersion, error) {
+	params := url.Values{}
+
+	params.Set("product", product)
+	params.Set("version", version)
+	params.Set("format", "json")
+
+	addr := fmt.Sprintf("%s/product-version?%s", c.Address, params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting new request")
+	}
+
+	res, err := c.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "calling do")
+	}
+
+	defer res.Body.Close()
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading body")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, util.RespErrorf(res, "getting papertrail product version")
+	}
+
+	var v PapertrailProductVersion
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, errors.Errorf("unmarshal: %s: %s", err, string(b))
+	}
+
+	return &v, nil
+}


### PR DESCRIPTION
DEVPROD-5626

Description

This commit adds the papertrail.trace Evergreen command. Projects will
use this command to simplify their interaction with the Papertrail
service when tracking artifact publishing. The command takes the
following parameters:

  key_id:      The Papertrail Key ID for authentication
  secret_key:  The Papertrail Secret Key for authentication
  product:     The procut name to associate with each trace
  version:     The product version to associate with each trace
  filenames:   A list of files present locally to trace
  work_dir:    An optional working directory to search for files in


Testing
In addition to the automated tests I've added, I also tested this in staging here: https://spruce-staging.corp.mongodb.com/task/evg_test_simple_bv_test_simple_task_patch_5e5de0e49ae51c658e12c6bcb93d76d112dd780d_6605afc7df21fd0007ce45c5_24_03_28_17_58_42/logs?execution=0

The tests are currently red because I need to add variables to the production Evergreen project in order for them to pass. I ran a test in staging with the variables set and they pass: https://parsley-staging.corp.mongodb.com/evergreen/evg_ubuntu2204_test_agent_command_patch_b8eeb3950a989b4aada521dff8e10d7543cc7636_6606dd7cfb2a0900076c97a8_24_03_29_15_26_33/0/task?bookmarks=0,1362&shareLine=1063

Documentation

The documentation for this new command is included in this PR under the "Project Commands" page.