### PR TITLE
DEVPROD-4947 Allow command in function to retry task on failure

### DIFF
--- a/agent/command.go
+++ b/agent/command.go
@@ -217,7 +217,7 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 			commandSpan.SetStatus(codes.Error, "running command")
 			commandSpan.RecordError(err, trace.WithAttributes(tc.taskConfig.TaskAttributes()...))
 			commandSpan.End()
-			if commandInfo.RetryOnFailure {
+			if commandInfo.RetryOnFailure || cmd.RetryOnFailure() {
 				logger.Task().Infof("Command is set to automatically restart on completion, this can be done %d total times per task.", evergreen.MaxAutomaticRestarts)
 				if restartErr := a.comm.MarkFailedTaskToRestart(ctx, tc.task); restartErr != nil {
 					logger.Task().Errorf("Encountered error marking task to restart upon completion: %s", restartErr)

--- a/agent/command.go
+++ b/agent/command.go
@@ -217,7 +217,7 @@ func (a *Agent) runCommandOrFunc(ctx context.Context, tc *taskContext, commandIn
 			commandSpan.SetStatus(codes.Error, "running command")
 			commandSpan.RecordError(err, trace.WithAttributes(tc.taskConfig.TaskAttributes()...))
 			commandSpan.End()
-			if commandInfo.RetryOnFailure || cmd.RetryOnFailure() {
+			if cmd.RetryOnFailure() {
 				logger.Task().Infof("Command is set to automatically restart on completion, this can be done %d total times per task.", evergreen.MaxAutomaticRestarts)
 				if restartErr := a.comm.MarkFailedTaskToRestart(ctx, tc.task); restartErr != nil {
 					logger.Task().Errorf("Encountered error marking task to restart upon completion: %s", restartErr)

--- a/agent/command/initial_setup.go
+++ b/agent/command/initial_setup.go
@@ -26,6 +26,8 @@ func (*initialSetup) IdleTimeout() time.Duration                      { return 0
 func (*initialSetup) ParseParams(params map[string]interface{}) error { return nil }
 func (*initialSetup) JasperManager() jasper.Manager                   { return nil }
 func (*initialSetup) SetJasperManager(_ jasper.Manager)               {}
+func (*initialSetup) RetryOnFailure() bool                            { return false }
+func (*initialSetup) SetRetryOnFailure(bool)                          {}
 func (*initialSetup) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -51,6 +51,9 @@ type Command interface {
 	// be used to run and manage processes that are started within commands.
 	JasperManager() jasper.Manager
 	SetJasperManager(jasper.Manager)
+
+	RetryOnFailure() bool
+	SetRetryOnFailure(bool)
 }
 
 // base contains a basic implementation of functionality that is
@@ -59,6 +62,7 @@ type base struct {
 	idleTimeout     time.Duration
 	typeName        string
 	fullDisplayName string
+	retryOnFailure  bool
 	jasper          jasper.Manager
 	mu              sync.RWMutex
 }
@@ -117,4 +121,18 @@ func (b *base) JasperManager() jasper.Manager {
 	defer b.mu.RUnlock()
 
 	return b.jasper
+}
+
+func (b *base) SetRetryOnFailure(retry bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.retryOnFailure = retry
+}
+
+func (b *base) RetryOnFailure() bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.retryOnFailure
 }

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -52,6 +52,7 @@ type Command interface {
 	JasperManager() jasper.Manager
 	SetJasperManager(jasper.Manager)
 
+	// RetryOnFailure indicates whether the entire task should be retried if this command fails.
 	RetryOnFailure() bool
 	SetRetryOnFailure(bool)
 }

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -191,6 +191,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmd.SetType(c.GetType(project))
 		cmd.SetFullDisplayName(c.DisplayName)
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
+		cmd.SetRetryOnFailure(c.RetryOnFailure)
 
 		out = append(out, cmd)
 	}

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -334,3 +334,29 @@ functions:
 	s.Equal("expansionVar3", key3Value, "key3 should be the original expansion value")
 	s.Empty(s.tc.taskConfig.DynamicExpansions)
 }
+
+func (s *CommandSuite) TestVarsUnsetPreserveExpansionUpdatesFromFile2() {
+	projYml := `
+functions:
+  should_retry:
+    command: shell.exec
+    retry_on_failure: true
+    params:
+      script: exit 1
+`
+	s.setUpConfigAndProject(projYml)
+
+	func1 := model.PluginCommandConf{
+		Function:    "should_retry",
+		DisplayName: "function",
+		Vars:        map[string]string{"key1": "newValue1", "key2": "newValue2", "key3": "newValue3"},
+	}
+
+	cmdBlock := commandBlock{
+		commands:    &model.YAMLCommandSet{SingleCommand: &func1},
+		canFailTask: true,
+	}
+	err := s.a.runCommandsInBlock(s.ctx, s.tc, cmdBlock)
+	s.Error(err)
+	s.True(s.mockCommunicator.TaskShouldRetryOnFail)
+}

--- a/agent/command_test.go
+++ b/agent/command_test.go
@@ -335,7 +335,7 @@ functions:
 	s.Empty(s.tc.taskConfig.DynamicExpansions)
 }
 
-func (s *CommandSuite) TestVarsUnsetPreserveExpansionUpdatesFromFile2() {
+func (s *CommandSuite) TestRetryOnFailureWorksForFunction() {
 	projYml := `
 functions:
   should_retry:

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-03-21"
+	AgentVersion = "2024-03-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1630,15 +1630,32 @@ This is only recommended for commands that are known to be flaky, or fail interm
 **In order to prevent overuse of this feature, the number of times a single
 task can be automatically restarted on failure is limited to 1 time.**
 
-An example is:
+In the example below, both `task1` and `task2` will retry automatically:
 
 ``` yaml
-- command: shell.exec
-  retry_on_failure: true
-  params:
-    working_dir: src
-    script: |
-      exit 1
+functions:
+  my_function:
+     - command: shell.exec
+       params:
+         script: echo "hello"
+     - command: shell.exec
+       retry_on_failure: true
+       params:
+         script: exit 1
+
+tasks:
+  - name: task1
+    commands:
+    - command: shell.exec
+      retry_on_failure: true
+      params:
+       working_dir: src
+       script: |
+        exit 1
+        
+  - name: task2
+    commands:
+    - func: my_function
 ```
 
 ### Customizing Logging


### PR DESCRIPTION
DEVPROD-4947

### Description
The `retry_on_failure` flag wasn't working for commands within a function, so I had to add the field to the actual rendered `Command` struct so we can case on it when a sub-command fails.
### Testing
Unit tests and [tested in staging](https://spruce-staging.corp.mongodb.com/task/test_trigger_sandbox_release_test_restart_on_fail_patch_200dd38a7144b884e67cf77fb705239e58fd5e11_65fdbb48872ffc0007e0524a_24_03_22_17_09_45/logs?execution=0&logtype=event).
### Documentation
Updated the docs to include an example that also uses a function.