### PR TITLE
DEVPROD-739 Remove hidden projects from permissions response

### DIFF
--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -496,7 +496,7 @@ func removeHiddenProjects(permissions []rolemanager.PermissionSummary) error {
 	for _, permission := range permissions {
 		if permission.Type == evergreen.ProjectResourceType {
 			projectPermissions = permission.Permissions
-			for projectID, _ := range permission.Permissions {
+			for projectID := range permission.Permissions {
 				projectIDs = append(projectIDs, projectID)
 			}
 		}

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -493,10 +493,10 @@ func (h *userPermissionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 func removeHiddenProjects(permissions []rolemanager.PermissionSummary) error {
 	var projectIDs []string
-	var projectPermissions rolemanager.PermissionsForResources
-	for _, permission := range permissions {
+	var projectResourceIndex int
+	for i, permission := range permissions {
 		if permission.Type == evergreen.ProjectResourceType {
-			projectPermissions = permission.Permissions
+			projectResourceIndex = i
 			for projectID := range permission.Permissions {
 				projectIDs = append(projectIDs, projectID)
 			}
@@ -508,7 +508,7 @@ func removeHiddenProjects(permissions []rolemanager.PermissionSummary) error {
 	}
 	for _, projectRef := range projectRefs {
 		if utility.FromBoolPtr(projectRef.Hidden) {
-			delete(projectPermissions, projectRef.Id)
+			delete(permissions[projectResourceIndex].Permissions, projectRef.Id)
 		}
 	}
 	return nil

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -479,11 +479,12 @@ func (h *userPermissionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if !h.includeAll {
 		rolesToSearch, _ = utility.StringSliceSymmetricDifference(u.SystemRoles, evergreen.GeneralAccessRoles)
 	}
-	// filter out the roles that everybody has automatically
+	// Filter out the roles that everybody has automatically
 	permissions, err := rolemanager.PermissionSummaryForRoles(ctx, rolesToSearch, h.rm)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "getting permissions for user '%s'", h.userID))
 	}
+	// Hidden projects are not meant to be exposed to the user, so we remove them from the response here.
 	if err = removeHiddenProjects(permissions); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -554,10 +554,18 @@ func TestRemoveHiddenProjects(t *testing.T) {
 				},
 			},
 		},
+		{
+			Type: evergreen.DistroResourceType,
+			Permissions: rolemanager.PermissionsForResources{
+				"distro1": gimlet.Permissions{
+					"distro_settings": 10,
+				},
+			},
+		},
 	}
 
 	assert.NoError(t, removeHiddenProjects(permissions))
-	require.Len(t, permissions, 1)
+	require.Len(t, permissions, 2)
 	require.Len(t, permissions[0].Permissions, 2)
 	require.Nil(t, permissions[0].Permissions["project1"])
 	require.NotNil(t, permissions[0].Permissions["project2"])

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func init() { testutil.Setup() }
-
 type UserRouteSuite struct {
 	suite.Suite
 	postHandler gimlet.RouteHandler


### PR DESCRIPTION
DEVPROD-739

### Description
This removes hidden project ref IDs from the /permissions route response.
### Testing
Unit tests and tested in staging
