### PR TITLE
DEVPROD-1008 Add oldest allowed merge base to resolvers

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -203,6 +203,11 @@ For security reasons, commits by users outside of your organization will
 not automatically be run. A patch will still be created and must be
 manually authorized to run by a logged-in user.
 
+#### Limiting when PR patches will run
+You can optionally specify the oldest commit SHA that is allowed to be a merge base
+for a PR, otherwise a PR patch will not be created. To do so, input the oldest SHA
+on your project's branch you want to accept as the merge base via the 'Oldest Allowed Merge Base' field.
+
 ### GitHub Commit Checks
 
 Definitions for this section exist under the "Github & Commit Queue" tab.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evergreen-ci/evergreen
 
-go 1.20
+go 1.19
 
 require (
 	github.com/99designs/gqlgen v0.17.42

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/evergreen-ci/evergreen
 
-go 1.19
+go 1.20
 
 require (
 	github.com/99designs/gqlgen v0.17.42

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -884,6 +884,7 @@ type ComplexityRoot struct {
 		IsFavorite               func(childComplexity int) int
 		ManualPRTestingEnabled   func(childComplexity int) int
 		NotifyOnBuildFailure     func(childComplexity int) int
+		OldestAllowedMergeBase   func(childComplexity int) int
 		Owner                    func(childComplexity int) int
 		PRTestingEnabled         func(childComplexity int) int
 		ParsleyFilters           func(childComplexity int) int
@@ -1050,6 +1051,7 @@ type ComplexityRoot struct {
 		Id                       func(childComplexity int) int
 		ManualPRTestingEnabled   func(childComplexity int) int
 		NotifyOnBuildFailure     func(childComplexity int) int
+		OldestAllowedMergeBase   func(childComplexity int) int
 		Owner                    func(childComplexity int) int
 		PRTestingEnabled         func(childComplexity int) int
 		ParsleyFilters           func(childComplexity int) int
@@ -5881,6 +5883,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Project.NotifyOnBuildFailure(childComplexity), true
 
+	case "Project.oldestAllowedMergeBase":
+		if e.complexity.Project.OldestAllowedMergeBase == nil {
+			break
+		}
+
+		return e.complexity.Project.OldestAllowedMergeBase(childComplexity), true
+
 	case "Project.owner":
 		if e.complexity.Project.Owner == nil {
 			break
@@ -6914,6 +6923,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.RepoRef.NotifyOnBuildFailure(childComplexity), true
+
+	case "RepoRef.oldestAllowedMergeBase":
+		if e.complexity.RepoRef.OldestAllowedMergeBase == nil {
+			break
+		}
+
+		return e.complexity.RepoRef.OldestAllowedMergeBase(childComplexity), true
 
 	case "RepoRef.owner":
 		if e.complexity.RepoRef.Owner == nil {
@@ -20652,6 +20668,8 @@ func (ec *executionContext) fieldContext_GroupedProjects_projects(ctx context.Co
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -20781,6 +20799,8 @@ func (ec *executionContext) fieldContext_GroupedProjects_repo(ctx context.Contex
 				return ec.fieldContext_RepoRef_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_RepoRef_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_RepoRef_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_RepoRef_owner(ctx, field)
 			case "parsleyFilters":
@@ -28334,6 +28354,8 @@ func (ec *executionContext) fieldContext_Mutation_addFavoriteProject(ctx context
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -28489,6 +28511,8 @@ func (ec *executionContext) fieldContext_Mutation_attachProjectToNewRepo(ctx con
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -28644,6 +28668,8 @@ func (ec *executionContext) fieldContext_Mutation_attachProjectToRepo(ctx contex
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -28799,6 +28825,8 @@ func (ec *executionContext) fieldContext_Mutation_createProject(ctx context.Cont
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -28954,6 +28982,8 @@ func (ec *executionContext) fieldContext_Mutation_copyProject(ctx context.Contex
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -29271,6 +29301,8 @@ func (ec *executionContext) fieldContext_Mutation_detachProjectFromRepo(ctx cont
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -29536,6 +29568,8 @@ func (ec *executionContext) fieldContext_Mutation_removeFavoriteProject(ctx cont
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -34504,6 +34538,8 @@ func (ec *executionContext) fieldContext_Patch_projectMetadata(ctx context.Conte
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -39227,6 +39263,50 @@ func (ec *executionContext) fieldContext_Project_notifyOnBuildFailure(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Project_oldestAllowedMergeBase(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OldestAllowedMergeBase, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_oldestAllowedMergeBase(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Project_owner(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Project_owner(ctx, field)
 	if err != nil {
@@ -41433,6 +41513,8 @@ func (ec *executionContext) fieldContext_ProjectEventSettings_projectRef(ctx con
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -41995,6 +42077,8 @@ func (ec *executionContext) fieldContext_ProjectSettings_projectRef(ctx context.
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -43731,6 +43815,8 @@ func (ec *executionContext) fieldContext_Query_project(ctx context.Context, fiel
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -46654,6 +46740,50 @@ func (ec *executionContext) fieldContext_RepoRef_notifyOnBuildFailure(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _RepoRef_oldestAllowedMergeBase(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RepoRef_oldestAllowedMergeBase(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OldestAllowedMergeBase, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RepoRef_oldestAllowedMergeBase(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RepoRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RepoRef_owner(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RepoRef_owner(ctx, field)
 	if err != nil {
@@ -47892,6 +48022,8 @@ func (ec *executionContext) fieldContext_RepoSettings_projectRef(ctx context.Con
 				return ec.fieldContext_RepoRef_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_RepoRef_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_RepoRef_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_RepoRef_owner(ctx, field)
 			case "parsleyFilters":
@@ -53656,6 +53788,8 @@ func (ec *executionContext) fieldContext_Task_project(ctx context.Context, field
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -62955,6 +63089,8 @@ func (ec *executionContext) fieldContext_Version_projectMetadata(ctx context.Con
 				return ec.fieldContext_Project_manualPrTestingEnabled(ctx, field)
 			case "notifyOnBuildFailure":
 				return ec.fieldContext_Project_notifyOnBuildFailure(ctx, field)
+			case "oldestAllowedMergeBase":
+				return ec.fieldContext_Project_oldestAllowedMergeBase(ctx, field)
 			case "owner":
 				return ec.fieldContext_Project_owner(ctx, field)
 			case "parsleyFilters":
@@ -69294,7 +69430,7 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "admins", "banner", "batchTime", "branch", "buildBaronSettings", "commitQueue", "containerSizeDefinitions", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "identifier", "manualPrTestingEnabled", "notifyOnBuildFailure", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "projectHealthView", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig"}
+	fieldsInOrder := [...]string{"id", "admins", "banner", "batchTime", "branch", "buildBaronSettings", "commitQueue", "containerSizeDefinitions", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "identifier", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "projectHealthView", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69474,6 +69610,13 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.NotifyOnBuildFailure = data
+		case "oldestAllowedMergeBase":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("oldestAllowedMergeBase"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OldestAllowedMergeBase = data
 		case "owner":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("owner"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -69813,7 +69956,7 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "admins", "batchTime", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig", "containerSizeDefinitions"}
+	fieldsInOrder := [...]string{"id", "admins", "batchTime", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "private", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "taskSync", "tracksPushEvents", "triggers", "versionControlEnabled", "workstationConfig", "containerSizeDefinitions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69965,6 +70108,13 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.NotifyOnBuildFailure = data
+		case "oldestAllowedMergeBase":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("oldestAllowedMergeBase"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OldestAllowedMergeBase = data
 		case "owner":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("owner"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -78426,6 +78576,11 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = ec._Project_manualPrTestingEnabled(ctx, field, obj)
 		case "notifyOnBuildFailure":
 			out.Values[i] = ec._Project_notifyOnBuildFailure(ctx, field, obj)
+		case "oldestAllowedMergeBase":
+			out.Values[i] = ec._Project_oldestAllowedMergeBase(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "owner":
 			out.Values[i] = ec._Project_owner(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -80296,6 +80451,11 @@ func (ec *executionContext) _RepoRef(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "notifyOnBuildFailure":
 			out.Values[i] = ec._RepoRef_notifyOnBuildFailure(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "oldestAllowedMergeBase":
+			out.Values[i] = ec._RepoRef_oldestAllowedMergeBase(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -231,6 +231,7 @@ type Project {
   isFavorite: Boolean!
   manualPrTestingEnabled: Boolean
   notifyOnBuildFailure: Boolean
+  oldestAllowedMergeBase: String!
   owner: String!
   parsleyFilters: [ParsleyFilter!]
   patches(patchesInput: PatchesInput!): Patches! # project patches

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -50,6 +50,7 @@ input ProjectInput {
   identifier: String
   manualPrTestingEnabled: Boolean
   notifyOnBuildFailure: Boolean
+  oldestAllowedMergeBase: String
   owner: String
   parsleyFilters: [ParsleyFilterInput!]
   patchingDisabled: Boolean

--- a/graphql/schema/types/repo_ref.graphql
+++ b/graphql/schema/types/repo_ref.graphql
@@ -18,6 +18,7 @@ input RepoRefInput {
   gitTagVersionsEnabled: Boolean
   manualPrTestingEnabled: Boolean
   notifyOnBuildFailure: Boolean
+  oldestAllowedMergeBase: String
   owner: String
   parsleyFilters: [ParsleyFilterInput!]
   patchingDisabled: Boolean
@@ -67,6 +68,7 @@ type RepoRef {
   gitTagVersionsEnabled: Boolean!
   manualPrTestingEnabled: Boolean!
   notifyOnBuildFailure: Boolean!
+  oldestAllowedMergeBase: String!
   owner: String!
   parsleyFilters: [ParsleyFilter!]
   patchingDisabled: Boolean!

--- a/graphql/tests/projectSettings/projectRef/data.json
+++ b/graphql/tests/projectSettings/projectRef/data.json
@@ -95,6 +95,7 @@
           "exact_match": true
         }
       ],
+      "oldest_allowed_merge_base": "abc",
       "git_tag_authorized_users": ["ablack12"],
       "workstation_config": {
         "setup_commands": null,

--- a/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
+++ b/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
@@ -28,6 +28,7 @@
       }
       gitTagAuthorizedUsers
       gitTagAuthorizedTeams
+      oldestAllowedMergeBase
       triggers {
         project
         level

--- a/graphql/tests/projectSettings/projectRef/results.json
+++ b/graphql/tests/projectSettings/projectRef/results.json
@@ -37,6 +37,7 @@
               ],
               "gitTagAuthorizedUsers": ["ablack12"],
               "gitTagAuthorizedTeams": null,
+              "oldestAllowedMergeBase": "abc",
               "triggers": [
                 {
                   "project": "spruce",

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -582,6 +582,8 @@ type APIProjectRef struct {
 	BatchTime int `json:"batch_time"`
 	// Path to config file in repo.
 	RemotePath *string `json:"remote_path"`
+	// Oldest allowed merge base for PR patches
+	OldestAllowedMergeBase *string `json:"oldest_allowed_merge_base"`
 	// File path to script that users can run on spawn hosts loaded with task
 	// data.
 	SpawnHostScriptPath *string `json:"spawn_host_script_path"`
@@ -724,6 +726,7 @@ func (p *APIProjectRef) ToService() (*model.ProjectRef, error) {
 		DisabledStatsCache:     utility.BoolPtrCopy(p.DisabledStatsCache),
 		NotifyOnBuildFailure:   utility.BoolPtrCopy(p.NotifyOnBuildFailure),
 		SpawnHostScriptPath:    utility.FromStringPtr(p.SpawnHostScriptPath),
+		OldestAllowedMergeBase: utility.FromStringPtr(p.OldestAllowedMergeBase),
 		Admins:                 utility.FromStringPtrSlice(p.Admins),
 		GitTagAuthorizedUsers:  utility.FromStringPtrSlice(p.GitTagAuthorizedUsers),
 		GitTagAuthorizedTeams:  utility.FromStringPtrSlice(p.GitTagAuthorizedTeams),
@@ -833,6 +836,7 @@ func (p *APIProjectRef) BuildPublicFields(projectRef model.ProjectRef) error {
 	p.DisabledStatsCache = utility.BoolPtrCopy(projectRef.DisabledStatsCache)
 	p.NotifyOnBuildFailure = utility.BoolPtrCopy(projectRef.NotifyOnBuildFailure)
 	p.SpawnHostScriptPath = utility.ToStringPtr(projectRef.SpawnHostScriptPath)
+	p.OldestAllowedMergeBase = utility.ToStringPtr(projectRef.OldestAllowedMergeBase)
 	p.GitTagAuthorizedUsers = utility.ToStringPtrSlice(projectRef.GitTagAuthorizedUsers)
 	p.GitTagAuthorizedTeams = utility.ToStringPtrSlice(projectRef.GitTagAuthorizedTeams)
 	p.GithubTriggerAliases = utility.ToStringPtrSlice(projectRef.GithubTriggerAliases)


### PR DESCRIPTION
DEVPROD-1008

### Description
This adds the new field to our resolvers so it can be set via Spruce.
### Testing
Unit test.
### Documentation
Added doc section for the feature