### PR TITLE
DEVPROD-6014 Surface check run creation errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1024,9 +1024,8 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 
 	err = a.upsertCheckRun(ctx, tc)
 	if err != nil {
-		err = errors.Wrap(err, "upserting checkrun")
-		grip.Error(err)
-		tc.logger.Task().Error(err.Error())
+		grip.Error(errors.Wrap(err, "upserting check run"))
+		tc.logger.Task().Errorf("Error upserting check run: '%s'", err.Error())
 	}
 
 	span := trace.SpanFromContext(ctx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1050,6 +1050,7 @@ func (a *Agent) upsertCheckRun(ctx context.Context, tc *taskContext) error {
 	}
 
 	if err = a.comm.UpsertCheckRun(ctx, tc.task, *checkRunOutput); err != nil {
+		tc.logger.Task().Debugf("Error upserting checkRun: '%s'", err.Error())
 		return err
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1075,7 +1075,7 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 
 	fileName, err := tc.taskConfig.Expansions.ExpandString(fileName)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.New("Error expanding check run output file")
 	}
 
 	fileName = command.GetWorkingDirectory(tc.taskConfig, fileName)
@@ -1094,7 +1094,7 @@ func buildCheckRun(ctx context.Context, tc *taskContext) (*apimodels.CheckRunOut
 	}
 
 	if err := util.ExpandValues(&checkRunOutput, &tc.taskConfig.Expansions); err != nil {
-		return nil, errors.Wrap(err, "applying expansions")
+		return nil, errors.New("Error expanding values for check run output")
 	}
 
 	return &checkRunOutput, nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1024,7 +1024,9 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 
 	err = a.upsertCheckRun(ctx, tc)
 	if err != nil {
-		grip.Error(errors.Wrap(err, "upserting checkrun"))
+		err = errors.Wrap(err, "upserting checkrun")
+		grip.Error(err)
+		tc.logger.Task().Error(err.Error())
 	}
 
 	span := trace.SpanFromContext(ctx)
@@ -1050,7 +1052,6 @@ func (a *Agent) upsertCheckRun(ctx context.Context, tc *taskContext) error {
 	}
 
 	if err = a.comm.UpsertCheckRun(ctx, tc.task, *checkRunOutput); err != nil {
-		tc.logger.Task().Debugf("Error upserting checkRun: '%s'", err.Error())
 		return err
 	}
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-01"
+	AgentVersion = "2024-04-01a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-6014

### Description
print error for check run in log 

### Testing
[error in task log](https://parsley-staging.corp.mongodb.com/evergreen/sandbox_ubuntu2204_print_banana_patch_75296bc001a22600252f2d4e8f35d47c9b31221b_660b29c1f77c0d00075e57db_24_04_01_21_40_21/0/task?bookmarks=0,49&shareLine=48)
