### PR TITLE
DEVPROD-5822 Prevent setup group from running for tasks with smaller executions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -534,7 +534,7 @@ func shouldRunSetupGroup(nextTask *apimodels.NextTaskResponse, tc *taskContext) 
 		return true
 	} else if nextTask.TaskGroup != previousTaskGroup { // The next task has a different task group.
 		return true
-	} else if nextTask.TaskExecution != tc.taskConfig.Task.Execution { // The previous and next task are in the same task group but the next task has a different execution number.
+	} else if nextTask.TaskExecution > tc.taskConfig.Task.Execution { // The previous and next task are in the same task group but the next task has a higher execution number.
 		return true
 	}
 	return false

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-01a"
+	AgentVersion = "2024-04-03"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5822

### Description
Server has been getting non-matching directories for task groups because they sometimes have different executions if the first task was aborted/restarted and the rest of the tasks didn't. 

ie 
task group: 
  task1: execution 1
  task2: execution 0

and we ran setup group if executions did not match
we updated this logic to no longer run setup group if the execution of the next task in the same task group is smaller or equal to the execution in the current task.

### Testing
unit tests
staging 
https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu2204_print_banana_patch_dc47177f87c5d979e74ae5cc4649c54474f55a3c_660dbc39aa78030007b6059f_24_04_03_20_29_51/logs?execution=1

print_banana task execution 2 does not have the set up message while running with print_apple execution 3 which does have a set up message
