### PR TITLE
DEVPROD-5983 Edit getInstallationIDFromCache to work for user apps

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -29,6 +29,7 @@ var (
 	ownerKey          = bsonutil.MustHaveTag(GitHubAppInstallation{}, "Owner")
 	repoKey           = bsonutil.MustHaveTag(GitHubAppInstallation{}, "Repo")
 	installationIDKey = bsonutil.MustHaveTag(GitHubAppInstallation{}, "InstallationID")
+	appIDKey          = bsonutil.MustHaveTag(GitHubAppInstallation{}, "AppID")
 )
 
 var (
@@ -41,6 +42,9 @@ type GitHubAppInstallation struct {
 
 	// InstallationID is the GitHub app's installation ID for the owner/repo.
 	InstallationID int64 `bson:"installation_id"`
+
+	// AppID is the id of the GitHub app that the installation ID is associated with
+	AppID int64 `bson:"app_id"`
 }
 
 type githubAppAuth struct {
@@ -112,7 +116,7 @@ func (s *Settings) CreateInstallationToken(ctx context.Context, owner, repo stri
 }
 
 func getInstallationID(ctx context.Context, authFields *githubAppAuth, owner, repo string) (int64, error) {
-	cachedID, err := getInstallationIDFromCache(ctx, owner, repo)
+	cachedID, err := getInstallationIDFromCache(ctx, authFields.appId, owner, repo)
 	if err != nil {
 		return 0, errors.Wrapf(err, "getting cached installation id for '%s/%s'", owner, repo)
 	}
@@ -129,6 +133,7 @@ func getInstallationID(ctx context.Context, authFields *githubAppAuth, owner, re
 		Owner:          owner,
 		Repo:           repo,
 		InstallationID: installationID,
+		AppID:          authFields.appId,
 	}
 	if err := cachedInstallation.Upsert(ctx); err != nil {
 		return 0, errors.Wrapf(err, "caching installation id for '%s/%s'", owner, repo)
@@ -138,10 +143,13 @@ func getInstallationID(ctx context.Context, authFields *githubAppAuth, owner, re
 
 }
 
-func byOwnerRepo(owner, repo string) bson.M {
+func byAppOwnerRepo(appId int64, owner, repo string) bson.M {
 	q := bson.M{
 		ownerKey: owner,
 		repoKey:  repo,
+	}
+	if appId != 0 {
+		q[appIDKey] = appId
 	}
 	return q
 }
@@ -161,7 +169,7 @@ func (h *GitHubAppInstallation) Upsert(ctx context.Context) error {
 
 	_, err := GetEnvironment().DB().Collection(GitHubAppCollection).UpdateOne(
 		ctx,
-		byOwnerRepo(h.Owner, h.Repo),
+		byAppOwnerRepo(h.AppID, h.Owner, h.Repo),
 		bson.M{
 			"$set": h,
 		},
@@ -173,13 +181,13 @@ func (h *GitHubAppInstallation) Upsert(ctx context.Context) error {
 }
 
 // getInstallationID returns the cached installation ID for GitHub app from the database.
-func getInstallationIDFromCache(ctx context.Context, owner, repo string) (int64, error) {
+func getInstallationIDFromCache(ctx context.Context, app int64, owner, repo string) (int64, error) {
 	if err := validateOwnerRepo(owner, repo); err != nil {
 		return 0, err
 	}
 
 	installation := &GitHubAppInstallation{}
-	res := GetEnvironment().DB().Collection(GitHubAppCollection).FindOne(ctx, byOwnerRepo(owner, repo))
+	res := GetEnvironment().DB().Collection(GitHubAppCollection).FindOne(ctx, byAppOwnerRepo(app, owner, repo))
 	if err := res.Err(); err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return 0, nil

--- a/github_app_test.go
+++ b/github_app_test.go
@@ -49,12 +49,13 @@ func (s *installationSuite) TestUpsert() {
 	s.Error(err)
 	s.Equal("Owner and repository must not be empty strings", err.Error())
 
-	installationWithInstallationID := GitHubAppInstallation{
+	installationWithInstallationAndAppID := GitHubAppInstallation{
 		Owner:          "evergreen-ci",
 		Repo:           "evergreen",
 		InstallationID: 1234,
+		AppID:          5678,
 	}
-	s.NoError(installationWithInstallationID.Upsert(s.ctx))
+	s.NoError(installationWithInstallationAndAppID.Upsert(s.ctx))
 }
 
 func (s *installationSuite) TestGetInstallationID() {
@@ -62,20 +63,25 @@ func (s *installationSuite) TestGetInstallationID() {
 		Owner:          "evergreen-ci",
 		Repo:           "evergreen",
 		InstallationID: 1234,
+		AppID:          5678,
 	}
 
 	s.NoError(installation.Upsert(s.ctx))
 
-	id, err := getInstallationID(s.ctx, nil, "evergreen-ci", "evergreen")
+	authFields := &githubAppAuth{
+		appId: 5678,
+	}
+
+	id, err := getInstallationID(s.ctx, authFields, "evergreen-ci", "evergreen")
 	s.NoError(err)
 	s.Equal(installation.InstallationID, id)
 
 	_, err = getInstallationID(s.ctx, nil, "evergreen-ci", "")
 	s.Error(err)
 
-	_, err = getInstallationID(s.ctx, nil, "", "evergreen")
+	_, err = getInstallationID(s.ctx, authFields, "", "evergreen")
 	s.Error(err)
 
-	_, err = getInstallationID(s.ctx, nil, "", "")
+	_, err = getInstallationID(s.ctx, authFields, "", "")
 	s.Error(err)
 }


### PR DESCRIPTION
DEVPROD-5983

### Description
Edit getInstallationIDFromCache to also search by appId when provided. After 
[DEVPROD-5982](https://jira.mongodb.org/browse/DEVPROD-5982) is done, we will edit validateOwnerRepo to also make sure appID isn't 0 and remove the check on it not being 0. 

### Testing
Edited existing unit tetst 
