### PR TITLE
DEVPROD-5983 Edit getInstallationIDFromCache to work for user apps

### DIFF
--- a/github_app_test.go
+++ b/github_app_test.go
@@ -49,33 +49,39 @@ func (s *installationSuite) TestUpsert() {
 	s.Error(err)
 	s.Equal("Owner and repository must not be empty strings", err.Error())
 
-	installationWithInstallationID := GitHubAppInstallation{
+	installationWithInstallationAndAppID := GitHubAppInstallation{
 		Owner:          "evergreen-ci",
 		Repo:           "evergreen",
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
-	s.NoError(installationWithInstallationID.Upsert(s.ctx))
+	s.NoError(installationWithInstallationAndAppID.Upsert(s.ctx))
 }
 
 func (s *installationSuite) TestGetInstallationID() {
 	installation := GitHubAppInstallation{
 		Owner:          "evergreen-ci",
 		Repo:           "evergreen",
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 
 	s.NoError(installation.Upsert(s.ctx))
 
-	id, err := getInstallationID(s.ctx, nil, "evergreen-ci", "evergreen")
+	authFields := &githubAppAuth{
+		appId: 1234,
+	}
+
+	id, err := getInstallationID(s.ctx, authFields, "evergreen-ci", "evergreen")
 	s.NoError(err)
 	s.Equal(installation.InstallationID, id)
 
-	_, err = getInstallationID(s.ctx, nil, "evergreen-ci", "")
+	_, err = getInstallationID(s.ctx, authFields, "evergreen-ci", "")
 	s.Error(err)
 
-	_, err = getInstallationID(s.ctx, nil, "", "evergreen")
+	_, err = getInstallationID(s.ctx, authFields, "", "evergreen")
 	s.Error(err)
 
-	_, err = getInstallationID(s.ctx, nil, "", "")
+	_, err = getInstallationID(s.ctx, authFields, "", "")
 	s.Error(err)
 }

--- a/graphql/tests/projectSettings/projectRef/data.json
+++ b/graphql/tests/projectSettings/projectRef/data.json
@@ -126,7 +126,8 @@
     {
       "owner": "evergreen-ci",
       "repo": "commit-queue-sandbox",
-      "installation_id": 1234
+      "app_id": 1234,
+      "installation_id": 5678
     }
   ]
 }

--- a/graphql/tests/repoSettings/projectRef/data.json
+++ b/graphql/tests/repoSettings/projectRef/data.json
@@ -92,7 +92,8 @@
     {
       "owner": "evergreen-ci",
       "repo": "commit-queue-sandbox",
-      "installation_id": 1234
+      "app_id": 1234,
+      "installation_id": 5678
     }
   ]
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -529,7 +529,8 @@ func TestAttachToNewRepo(t *testing.T) {
 	installation := evergreen.GitHubAppInstallation{
 		Owner:          pRef.Owner,
 		Repo:           pRef.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 
@@ -542,7 +543,8 @@ func TestAttachToNewRepo(t *testing.T) {
 	newInstallation := evergreen.GitHubAppInstallation{
 		Owner:          pRef.Owner,
 		Repo:           pRef.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, newInstallation.Upsert(ctx))
 	assert.NoError(t, pRef.AttachToNewRepo(u))
@@ -642,7 +644,8 @@ func TestAttachToRepo(t *testing.T) {
 	installation := evergreen.GitHubAppInstallation{
 		Owner:          pRef.Owner,
 		Repo:           pRef.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 
@@ -1407,7 +1410,8 @@ func TestCreateNewRepoRef(t *testing.T) {
 	installation := evergreen.GitHubAppInstallation{
 		Owner:          "mongodb",
 		Repo:           "mongo",
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 

--- a/rest/route/repo_test.go
+++ b/rest/route/repo_test.go
@@ -95,7 +95,8 @@ func TestPatchRepoIDHandler(t *testing.T) {
 	installation := evergreen.GitHubAppInstallation{
 		Owner:          repoRef.Owner,
 		Repo:           repoRef.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 
@@ -231,7 +232,8 @@ func TestPatchRepoIDHandler(t *testing.T) {
 	installation = evergreen.GitHubAppInstallation{
 		Owner:          "10gen",
 		Repo:           repoRef.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 
@@ -284,7 +286,8 @@ func TestPatchHandlersWithRestricted(t *testing.T) {
 	installation := evergreen.GitHubAppInstallation{
 		Owner:          branchProject.Owner,
 		Repo:           branchProject.Repo,
-		InstallationID: 1234,
+		AppID:          1234,
+		InstallationID: 5678,
 	}
 	assert.NoError(t, installation.Upsert(ctx))
 

--- a/testdata/local/github_hooks.json
+++ b/testdata/local/github_hooks.json
@@ -1,2 +1,2 @@
-{"_id":{"$oid":"628ce40875c5071247ec564d"},"hook_id":0,"owner":"evergreen-ci","repo":"evergreen", "installation_id": 1234}
-{"_id":{"$oid":"628ce6d275c5071247ec564e"},"hook_id":1,"owner":"evergreen-ci","repo":"spruce", "installation_id": 1234}
+{"_id":{"$oid":"628ce40875c5071247ec564d"},"hook_id":0,"owner":"evergreen-ci","repo":"evergreen","app_id": 1234, "installation_id": 5678}
+{"_id":{"$oid":"628ce6d275c5071247ec564e"},"hook_id":1,"owner":"evergreen-ci","repo":"spruce","app_id": 1234,"installation_id": 5678}


### PR DESCRIPTION
[DEVPROD-5983](https://jira.mongodb.org/browse/DEVPROD-5983)

Description
Edit getInstallationIDFromCache to also search by appId when provided. After [DEVPROD-5982](https://jira.mongodb.org/browse/DEVPROD-5982) is done, we will edit validateOwnerRepo to also make sure appID isn't 0 and remove the check on it not being 0.

Testing
Edited existing unit tetst