### PR TITLE
DEVPROD-6045 Make generator/generated tasks track properly for bisect stepback

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-01a"
+	AgentVersion = "2024-04-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-10"
+	AgentVersion = "2024-04-01a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -130,6 +130,17 @@ var (
 	LastPassingStepbackTaskIdKey = bsonutil.MustHaveTag(StepbackInfo{}, "LastPassingStepbackTaskId")
 	NextStepbackTaskIdKey        = bsonutil.MustHaveTag(StepbackInfo{}, "NextStepbackTaskId")
 	PreviousStepbackTaskIdKey    = bsonutil.MustHaveTag(StepbackInfo{}, "PreviousStepbackTaskId")
+	GeneratedStepbackInfoKey     = bsonutil.MustHaveTag(StepbackInfo{}, "GeneratedStepbackInfo")
+)
+
+var (
+	// BSON fields for generated stepback info
+	GeneratedLastFailingStepbackTaskIdKey = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "LastFailingStepbackTaskId")
+	GeneratedLastPassingStepbackTaskIdKey = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "LastPassingStepbackTaskId")
+	GeneratedNextStepbackTaskIdKey        = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "NextStepbackTaskId")
+	GeneratedPreviousStepbackTaskIdKey    = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "PreviousStepbackTaskId")
+	GeneratedDisplayNameKey               = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "DisplayName")
+	GeneratedBuildVariantKey              = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "BuildVariant")
 )
 
 var (

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -131,16 +131,8 @@ var (
 	NextStepbackTaskIdKey        = bsonutil.MustHaveTag(StepbackInfo{}, "NextStepbackTaskId")
 	PreviousStepbackTaskIdKey    = bsonutil.MustHaveTag(StepbackInfo{}, "PreviousStepbackTaskId")
 	GeneratedStepbackInfoKey     = bsonutil.MustHaveTag(StepbackInfo{}, "GeneratedStepbackInfo")
-)
-
-var (
-	// BSON fields for generated stepback info
-	GeneratedLastFailingStepbackTaskIdKey = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "LastFailingStepbackTaskId")
-	GeneratedLastPassingStepbackTaskIdKey = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "LastPassingStepbackTaskId")
-	GeneratedNextStepbackTaskIdKey        = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "NextStepbackTaskId")
-	GeneratedPreviousStepbackTaskIdKey    = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "PreviousStepbackTaskId")
-	GeneratedDisplayNameKey               = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "DisplayName")
-	GeneratedBuildVariantKey              = bsonutil.MustHaveTag(GeneratedStepbackInfo{}, "BuildVariant")
+	StepbackInfoDisplayNameKey   = bsonutil.MustHaveTag(StepbackInfo{}, "DisplayName")
+	StepbackInfoBuildVariantKey  = bsonutil.MustHaveTag(StepbackInfo{}, "BuildVariant")
 )
 
 var (

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -338,14 +338,13 @@ type StepbackInfo struct {
 }
 
 // IsZero returns true if the StepbackInfo is empty or nil.
+// It does not include GeneratedStepbackInfo in the check because
+// those do not cause a generator to stepback.
 func (s *StepbackInfo) IsZero() bool {
 	if s == nil {
 		return true
 	}
 	if s.LastFailingStepbackTaskId != "" && s.LastPassingStepbackTaskId != "" {
-		return false
-	}
-	if len(s.GeneratedStepbackInfo) > 0 {
 		return false
 	}
 	// If the other fields are set but not the ones above, the struct should be considered empty.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -351,18 +351,9 @@ func (s *StepbackInfo) IsZero() bool {
 	return true
 }
 
-// HasGeneratedStepbackInfo returns true if the StepbackInfo has generated stepback info.
-// This means the task with this stepback info is a generator task and a generated task
-// of it is being stepbacked.
-func (s *StepbackInfo) HasGeneratedStepbackInfo() bool {
-	if s == nil {
-		return false
-	}
-	return len(s.GeneratedStepbackInfo) > 0
-}
-
-// GetGeneratedStepbackInfo returns the generated stepback info for the given display name and build variant.
-func (s *StepbackInfo) GetGeneratedStepbackInfo(displayName string, buildVariant string) *StepbackInfo {
+// GetStepbackInfoForGeneratedTask returns the StepbackInfo for a generated task that's
+// on a generator task.
+func (s *StepbackInfo) GetStepbackInfoForGeneratedTask(displayName string, buildVariant string) *StepbackInfo {
 	if s == nil {
 		return nil
 	}
@@ -1598,8 +1589,8 @@ func SetLastAndPreviousStepbackIds(taskId string, s StepbackInfo) error {
 	)
 }
 
-// AddGeneratedStepbackInfoForGenerator appends a new GeneratedStepbackInfo to the
-// task's StepbackInfo.
+// AddGeneratedStepbackInfoForGenerator appends a new StepbackInfo to the
+// task's GeneratedStepbackInfo.
 func AddGeneratedStepbackInfoForGenerator(taskId string, s StepbackInfo) error {
 	return UpdateOne(
 		bson.M{
@@ -1613,8 +1604,8 @@ func AddGeneratedStepbackInfoForGenerator(taskId string, s StepbackInfo) error {
 	)
 }
 
-// SetGeneratedStepbackInfoForGenerator sets the StepbackInfo that already
-// exists on that task's StepbackInfo (by DisplayName and BuildVariant).
+// SetGeneratedStepbackInfoForGenerator sets the StepbackInfo's GeneratedStepbackInfo
+// element with the same DisplayName and BuildVariant as the input StepbackInfo.
 func SetGeneratedStepbackInfoForGenerator(ctx context.Context, taskId string, s StepbackInfo) error {
 	r, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateOne(ctx,
 		bson.M{

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -890,7 +890,9 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 
 	// Deactivate previous occurrences of the same task if this one passed on mainline commits.
 	if t.Status == evergreen.TaskSucceeded && deactivatePrevious && t.Requester == evergreen.RepotrackerVersionRequester && t.ActivatedBy != evergreen.StepbackTaskActivator {
-		return errors.Wrap(DeactivatePreviousTasks(ctx, t, caller), "deactivating previous tasks")
+		grip.Error(message.WrapError(DeactivatePreviousTasks(ctx, t, caller), message.Fields{
+			"message": "deactivating previous tasks",
+		}))
 	}
 
 	if err = UpdateBuildAndVersionStatusForTask(ctx, t); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -752,13 +752,6 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 	}); err != nil {
 		return errors.Wrapf(err, "could not set stepback info for generated task '%s'", generated.Id)
 	}
-	if nextTask.GeneratedTasks {
-		// TODO: Get generated task's next task.
-		// If the next task has finished, negative priority, or already activated, no-op.
-		if nextTask.IsFinished() || nextTask.Priority < 0 || nextTask.Activated {
-			return nil
-		}
-	}
 	// Store our last and previous stepback tasks in our upcoming/next task.
 	if err = task.AddGeneraterStepbackInfo(nextTask.Id, s); err != nil {
 		return errors.Wrapf(err, "setting stepback info for task '%s'", nextTask.Id)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1426,7 +1426,7 @@ func evalBisectStepback(ctx context.Context, t *task.Task, newStepback, shouldSt
 	if generator == nil {
 		return errors.Errorf("nil generator '%s'", t.GeneratedBy)
 	}
-	// Test if the task is in stepback.
+	// Check if the task is in stepback.
 	if generator.StepbackInfo.GetStepbackInfoForGeneratedTask(t.DisplayName, t.BuildVariant) == nil {
 		return nil
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1426,8 +1426,8 @@ func evalBisectStepback(ctx context.Context, t *task.Task, newStepback, shouldSt
 	if generator == nil {
 		return errors.Errorf("nil generator '%s'", t.GeneratedBy)
 	}
-	// Check if the task is in stepback.
-	if generator.StepbackInfo.GetStepbackInfoForGeneratedTask(t.DisplayName, t.BuildVariant) == nil {
+	// Check if the task is in stepback (if it is not a new one).
+	if generator.StepbackInfo.GetStepbackInfoForGeneratedTask(t.DisplayName, t.BuildVariant) == nil && !newStepback {
 		return nil
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1411,7 +1411,7 @@ func evalBisectStepback(ctx context.Context, t *task.Task, newStepback, shouldSt
 	}
 
 	existingStepback := !t.StepbackInfo.IsZero() && t.ActivatedBy == evergreen.StepbackTaskActivator
-	if newStepback || existingStepback {
+	if (newStepback || existingStepback) && t.GeneratedBy == "" {
 		return errors.Wrap(doBisectStepback(ctx, t), "performing bisect stepback")
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1411,8 +1411,7 @@ func evalBisectStepback(ctx context.Context, t *task.Task, newStepback, shouldSt
 	}
 
 	existingStepback := !t.StepbackInfo.IsZero() && t.ActivatedBy == evergreen.StepbackTaskActivator
-	generatedTaskStepback := t.GeneratedBy != ""
-	if newStepback || existingStepback || generatedTaskStepback {
+	if newStepback || existingStepback {
 		return errors.Wrap(doBisectStepback(ctx, t), "performing bisect stepback")
 	}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6255,13 +6255,13 @@ func TestEvalStepbackDeactivatePrevious(t *testing.T) {
 	assert.NoError(b3.Insert())
 
 	// Should not unschedule previous tasks if the requester is not repotracker.
-	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskSucceeded, true))
+	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskSucceeded))
 	checkTask, err := task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.True(checkTask.Activated)
 
 	finishedTask.Requester = evergreen.RepotrackerVersionRequester
-	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskSucceeded, true))
+	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskSucceeded))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.False(checkTask.Activated)
@@ -6282,13 +6282,13 @@ func TestEvalBisectStepback(t *testing.T) {
 			// Set the first task to failed status.
 			require.NoError(task.UpdateOne(bson.M{"_id": "t1"},
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
-			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed))
 			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
 			require.NoError(err)
 			assert.False(midTask.Activated)
 		},
 		"FailedTaskInStepback": func(t *testing.T, t10 task.Task) {
-			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed))
 			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
 			prevTask := *midTask
 			require.NoError(err)
@@ -6318,7 +6318,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.UpdateOne(bson.M{"_id": midTask.Id},
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
 			// Activate next stepback
-			require.NoError(evalStepback(ctx, &prevTask, "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &prevTask, "", evergreen.TaskFailed))
 			midTask, err = task.FindMidwayTaskFromIds("t1", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -6342,7 +6342,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.Nil(lastPassing.StepbackInfo)
 		},
 		"PassedTaskInStepback": func(t *testing.T, t10 task.Task) {
-			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &t10, "", evergreen.TaskFailed))
 			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -6372,7 +6372,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.UpdateOne(bson.M{"_id": midTask.Id},
 				bson.M{"$set": bson.M{"status": evergreen.TaskSucceeded}}))
 			// Activate next stepback
-			require.NoError(evalStepback(ctx, midTask, "", evergreen.TaskSucceeded, false))
+			require.NoError(evalStepback(ctx, midTask, "", evergreen.TaskSucceeded))
 			midTask, err = task.FindMidwayTaskFromIds("t10", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -6453,8 +6453,8 @@ func TestEvalBisectStepback(t *testing.T) {
 			generated2Tasks[9].Status = evergreen.TaskFailed
 			require.NoError(task.UpdateOne(bson.M{"_id": generated2Tasks[9].Id},
 				bson.M{"$set": bson.M{"status": generated2Tasks[9].Status}}))
-			require.NoError(evalStepback(ctx, &generated1Tasks[9], "", evergreen.TaskFailed, false))
-			require.NoError(evalStepback(ctx, &generated2Tasks[9], "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &generated1Tasks[9], "", evergreen.TaskFailed))
+			require.NoError(evalStepback(ctx, &generated2Tasks[9], "", evergreen.TaskFailed))
 			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -6520,8 +6520,8 @@ func TestEvalBisectStepback(t *testing.T) {
 
 			prevTask := *midTask
 			// Activate g1 next stepback
-			require.NoError(evalStepback(ctx, midTaskG1, "", evergreen.TaskSucceeded, false))
-			require.NoError(evalStepback(ctx, midTaskG2, "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, midTaskG1, "", evergreen.TaskSucceeded))
+			require.NoError(evalStepback(ctx, midTaskG2, "", evergreen.TaskFailed))
 
 			// Check mid task stepback info relating to generated task 1.
 			midTask, err = task.FindMidwayTaskFromIds("t10", prevTask.Id)
@@ -6748,7 +6748,7 @@ tasks:
 	assert.NoError(b3.Insert())
 
 	// should not step back if there was never a successful task
-	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskFailed, false))
+	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskFailed))
 	checkTask, err := task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.False(checkTask.Activated)
@@ -6772,7 +6772,7 @@ tasks:
 		BuildVariant: "bv",
 	}
 	assert.NoError(b1.Insert())
-	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskFailed, false))
+	assert.NoError(evalStepback(ctx, &finishedTask, "", evergreen.TaskFailed))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	require.NoError(t, err)
 	assert.True(checkTask.Activated)
@@ -6845,14 +6845,14 @@ tasks:
 	}
 	assert.NoError(b5.Insert())
 	// Ensure system failure doesn't cause a stepback unless we're already stepping back.
-	assert.NoError(evalStepback(ctx, &generated, "", evergreen.TaskSystemFailed, false))
+	assert.NoError(evalStepback(ctx, &generated, "", evergreen.TaskSystemFailed))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.False(checkTask.Activated)
 
 	// System failure steps back since activated by stepback (and steps back generator).
 	generated.ActivatedBy = evergreen.StepbackTaskActivator
-	assert.NoError(evalStepback(ctx, &generated, "", evergreen.TaskSystemFailed, false))
+	assert.NoError(evalStepback(ctx, &generated, "", evergreen.TaskSystemFailed))
 	checkTask, err = task.FindOneId(stepbackTask.Id)
 	assert.NoError(err)
 	assert.True(checkTask.Activated)
@@ -7017,7 +7017,7 @@ func TestEvalStepbackTaskGroup(t *testing.T) {
 		RevisionOrderNumber: 1,
 	}
 	assert.NoError(t, db.InsertMany(task.Collection, t1, t2, t3, prevT1, prevT2, prevT3, prevSuccessT1, prevSuccessT2, prevSuccessT3))
-	assert.NoError(t, evalStepback(ctx, &t2, "", evergreen.TaskFailed, false))
+	assert.NoError(t, evalStepback(ctx, &t2, "", evergreen.TaskFailed))
 
 	// verify only the previous t1 and t2 are stepped back
 	prevT1FromDb, err := task.FindOneId(prevT1.Id)
@@ -7031,7 +7031,7 @@ func TestEvalStepbackTaskGroup(t *testing.T) {
 	assert.False(t, prevT3FromDb.Activated)
 
 	// stepping back t3 should now also stepback t3 and not error on earlier activated tasks
-	assert.NoError(t, evalStepback(ctx, &t3, "", evergreen.TaskFailed, false))
+	assert.NoError(t, evalStepback(ctx, &t3, "", evergreen.TaskFailed))
 	prevT3FromDb, err = task.FindOneId(prevT3.Id)
 	assert.NoError(t, err)
 	assert.True(t, prevT3FromDb.Activated)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6400,49 +6400,172 @@ func TestEvalBisectStepback(t *testing.T) {
 			assert.Equal("t10", lastPassing.StepbackInfo.PreviousStepbackTaskId)
 		},
 		"GeneratedTasksStepbackGenerator": func(t *testing.T, t10 task.Task) {
-			generatedTasks := []task.Task{}
+			// Make all generator tasks pass.
 			for i := 1; i <= 10; i++ {
-				generated := task.Task{
-					Id:                  fmt.Sprintf("g%d", i),
+				require.NoError(task.UpdateOne(bson.M{"_id": fmt.Sprintf("t%d", i)},
+					bson.M{"$set": bson.M{"status": evergreen.TaskSucceeded}}))
+			}
+			generated1Tasks := []task.Task{}
+			generated2Tasks := []task.Task{}
+			for i := 1; i <= 10; i++ {
+				generated1 := task.Task{
+					Id:                  fmt.Sprintf("g1-%d", i),
 					BuildId:             fmt.Sprintf("b%d", i),
 					GeneratedBy:         fmt.Sprintf("t%d", i),
-					Status:              evergreen.TaskFailed,
+					Status:              evergreen.TaskUndispatched,
 					BuildVariant:        "bv",
-					DisplayName:         "generated",
+					DisplayName:         "generated1",
 					Project:             "proj",
 					Activated:           false,
 					RevisionOrderNumber: i,
 					Requester:           evergreen.RepotrackerVersionRequester,
 					Version:             fmt.Sprintf("v%d", i),
 				}
-				assert.NoError(generated.Insert())
-				generatedTasks = append(generatedTasks, generated)
+				assert.NoError(generated1.Insert())
+				generated1Tasks = append(generated1Tasks, generated1)
+
+				generated2 := task.Task{
+					Id:                  fmt.Sprintf("g2-%d", i),
+					BuildId:             fmt.Sprintf("b%d", i),
+					GeneratedBy:         fmt.Sprintf("t%d", i),
+					Status:              evergreen.TaskUndispatched,
+					BuildVariant:        "bv",
+					DisplayName:         "generated2",
+					Project:             "proj",
+					Activated:           false,
+					RevisionOrderNumber: i,
+					Requester:           evergreen.RepotrackerVersionRequester,
+					Version:             fmt.Sprintf("v%d", i),
+				}
+				assert.NoError(generated2.Insert())
+				generated2Tasks = append(generated2Tasks, generated2)
 			}
-			t10Generated := generatedTasks[9]
-			require.NoError(evalStepback(ctx, &t10Generated, "", evergreen.TaskFailed, false))
+			// Make the first generated tasks fail and the last pass.
+			generated1Tasks[0].Status = evergreen.TaskSucceeded
+			require.NoError(task.UpdateOne(bson.M{"_id": generated1Tasks[0].Id},
+				bson.M{"$set": bson.M{"status": generated1Tasks[0].Status}}))
+			generated2Tasks[0].Status = evergreen.TaskSucceeded
+			require.NoError(task.UpdateOne(bson.M{"_id": generated2Tasks[0].Id},
+				bson.M{"$set": bson.M{"status": generated2Tasks[0].Status}}))
+			generated1Tasks[9].Status = evergreen.TaskFailed
+			require.NoError(task.UpdateOne(bson.M{"_id": generated1Tasks[9].Id},
+				bson.M{"$set": bson.M{"status": generated1Tasks[9].Status}}))
+			generated2Tasks[9].Status = evergreen.TaskFailed
+			require.NoError(task.UpdateOne(bson.M{"_id": generated2Tasks[9].Id},
+				bson.M{"$set": bson.M{"status": generated2Tasks[9].Status}}))
+			require.NoError(evalStepback(ctx, &generated1Tasks[9], "", evergreen.TaskFailed, false))
+			require.NoError(evalStepback(ctx, &generated2Tasks[9], "", evergreen.TaskFailed, false))
 			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
 			require.NoError(err)
 			assert.True(midTask.Activated)
-			// See if the mid task properly has it's last passing, last failing,
-			// and previous but not next stepback task.
 			require.NotNil(midTask.StepbackInfo)
-			assert.Equal("t10", midTask.StepbackInfo.LastFailingStepbackTaskId)
-			assert.Equal("t1", midTask.StepbackInfo.LastPassingStepbackTaskId)
-			assert.Empty(midTask.StepbackInfo.NextStepbackTaskId)
-			assert.Equal("t10", midTask.StepbackInfo.PreviousStepbackTaskId)
-			// See if the last failing, last passing, and previous correctly
-			// point to the midway task id.
+			// The task itself should have no stepback info, only for its generated tasks.
+			require.Empty(midTask.StepbackInfo.LastFailingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.LastPassingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.NextStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.PreviousStepbackTaskId)
+			// For generated task 1.
+			g1Info := midTask.StepbackInfo.GetGeneratedStepbackInfo("generated1", "bv")
+			require.NotNil(g1Info)
+			assert.Equal("t10", g1Info.LastFailingStepbackTaskId)
+			assert.Equal("t1", g1Info.LastPassingStepbackTaskId)
+			assert.Equal("t5", g1Info.NextStepbackTaskId)
+			assert.Equal("t10", g1Info.PreviousStepbackTaskId)
+			// For generated task 2.
+			g2Info := midTask.StepbackInfo.GetGeneratedStepbackInfo("generated2", "bv")
+			require.NotNil(g2Info)
+			assert.Equal("t10", g2Info.LastFailingStepbackTaskId)
+			assert.Equal("t1", g2Info.LastPassingStepbackTaskId)
+			assert.Equal("t5", g2Info.NextStepbackTaskId)
+			assert.Equal("t10", g2Info.PreviousStepbackTaskId)
+			// For last failing.
 			lastFailing, err := task.FindOneId("t10")
 			require.NoError(err)
 			require.NotNil(lastFailing.StepbackInfo)
-			assert.Empty(lastFailing.StepbackInfo.LastFailingStepbackTaskId)
-			assert.Empty(lastFailing.StepbackInfo.LastPassingStepbackTaskId)
-			assert.Equal(midTask.Id, lastFailing.StepbackInfo.NextStepbackTaskId)
-			assert.Empty(lastFailing.StepbackInfo.PreviousStepbackTaskId)
-
+			// For generator's generated task info 1.
+			g1Info = lastFailing.StepbackInfo.GetGeneratedStepbackInfo("generated1", "bv")
+			require.NotNil(g1Info)
+			assert.Equal("t10", g1Info.LastFailingStepbackTaskId)
+			assert.Equal("t1", g1Info.LastPassingStepbackTaskId)
+			assert.Equal(midTask.Id, g1Info.NextStepbackTaskId)
+			assert.Equal("t10", g1Info.PreviousStepbackTaskId)
+			assert.Equal(generated1Tasks[0].DisplayName, g1Info.DisplayName)
+			assert.Equal(generated1Tasks[0].BuildVariant, g1Info.BuildVariant)
+			// For generator's generated task info 2.
+			g2Info = lastFailing.StepbackInfo.GetGeneratedStepbackInfo("generated2", "bv")
+			require.NotNil(g2Info)
+			assert.Equal("t10", g2Info.LastFailingStepbackTaskId)
+			assert.Equal("t1", g2Info.LastPassingStepbackTaskId)
+			assert.Equal(midTask.Id, g2Info.NextStepbackTaskId)
+			assert.Equal("t10", g2Info.PreviousStepbackTaskId)
+			assert.Equal(generated2Tasks[0].DisplayName, g2Info.DisplayName)
+			assert.Equal(generated2Tasks[0].BuildVariant, g2Info.BuildVariant)
+			// Last passing should be empty.
 			lastPassing, err := task.FindOneId("t1")
 			require.NoError(err)
 			require.Nil(lastPassing.StepbackInfo)
+
+			// 2nd Iteration. Generated Task 1 passed, moving last passing stepback to midtask.
+			// Generated Task 2 failed, moving last failing to midtask.
+			midTaskG1, err := task.FindOneId("g1-5")
+			require.NoError(err)
+			midTaskG1.Status = evergreen.TaskSucceeded
+			require.NoError(task.UpdateOne(bson.M{"_id": midTaskG1.Id},
+				bson.M{"$set": bson.M{"status": midTaskG1.Status}}))
+			midTaskG2, err := task.FindOneId("g2-5")
+			require.NoError(err)
+			midTaskG2.Status = evergreen.TaskFailed
+			require.NoError(task.UpdateOne(bson.M{"_id": midTaskG2.Id},
+				bson.M{"$set": bson.M{"status": midTaskG2.Status}}))
+
+			prevTask := *midTask
+			// Activate g1 next stepback
+			require.NoError(evalStepback(ctx, midTaskG1, "", evergreen.TaskSucceeded, false))
+			require.NoError(evalStepback(ctx, midTaskG2, "", evergreen.TaskFailed, false))
+
+			// Check mid task stepback info relating to generated task 1.
+			midTask, err = task.FindMidwayTaskFromIds("t10", prevTask.Id)
+			require.NoError(err)
+			assert.True(midTask.Activated)
+			require.NotNil(midTask.StepbackInfo)
+			// The mid task is the generator task and should have no stepback info.
+			// (It should only be in the generated task's stepback info.)
+			require.Empty(midTask.StepbackInfo.LastFailingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.LastPassingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.NextStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.PreviousStepbackTaskId)
+			// For generated task 1.
+			g1Info = midTask.StepbackInfo.GetGeneratedStepbackInfo("generated1", "bv")
+			require.NotNil(g1Info)
+			assert.Equal("t10", g1Info.LastFailingStepbackTaskId)
+			assert.Equal(prevTask.Id, g1Info.LastPassingStepbackTaskId)
+			assert.Equal("t7", g1Info.NextStepbackTaskId)
+			assert.Equal(prevTask.Id, g1Info.PreviousStepbackTaskId)
+			// For generated task 2 (this mid task should not have data on it).
+			g2Info = midTask.StepbackInfo.GetGeneratedStepbackInfo("generated2", "bv")
+			require.Nil(g2Info)
+
+			// Check mid task stepback info relating to generated task 2.
+			midTask, err = task.FindMidwayTaskFromIds("t1", prevTask.Id)
+			require.NoError(err)
+			assert.True(midTask.Activated)
+			require.NotNil(midTask.StepbackInfo)
+			// The mid task is the generator task and should have no stepback info.
+			// (It should only be in the generated task's stepback info.)
+			require.Empty(midTask.StepbackInfo.LastFailingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.LastPassingStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.NextStepbackTaskId)
+			require.Empty(midTask.StepbackInfo.PreviousStepbackTaskId)
+			// For generated task 1 (this mid task should not have data on it).
+			g1Info = midTask.StepbackInfo.GetGeneratedStepbackInfo("generated1", "bv")
+			require.Nil(g1Info)
+			// For generated task 2.
+			g2Info = midTask.StepbackInfo.GetGeneratedStepbackInfo("generated2", "bv")
+			require.NotNil(g2Info)
+			assert.Equal(prevTask.Id, g2Info.LastFailingStepbackTaskId)
+			assert.Equal("t1", g2Info.LastPassingStepbackTaskId)
+			assert.Equal("t3", g2Info.NextStepbackTaskId)
+			assert.Equal(prevTask.Id, g2Info.PreviousStepbackTaskId)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-6045

### Description
This adds a subfield on the `StepbackInfo` field for the Task struct that are for generator's only. The field holds information for each generated task *going through bisect stepback*. As well, the generated tasks also get set with `StepbackInfo` for the UI to show the corresponding fields (the values are not used in the UI and won't be).

### Testing
Add an extensive unit test and did a lot of staging tests. Here is a short video

#### Early Stepback example
![Screenshot 2024-04-04 at 10 00 02 AM](https://github.com/evergreen-ci/evergreen/assets/64446617/5b3301ad-8c68-47b8-98e5-c196610b6e81)


#### Video
https://github.com/evergreen-ci/evergreen/assets/64446617/13eef201-bfef-4cd0-a34a-a5d34544a2b9


### Documentation
Should I add documentation around generator tasks working now? I think the expectation is that they just work- so I'm not sure.