### PR TITLE
DEVPROD-5223 Pass caller to restarted task's ActivatedBy field

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -404,7 +404,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	}
 
 	// Set all the task fields to indicate restarted
-	if err := MarkTasksReset(ctx, restartIds); err != nil {
+	if err := MarkTasksReset(ctx, restartIds, caller); err != nil {
 		return errors.WithStack(err)
 	}
 	for _, t := range allFinishedTasks {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2209,6 +2209,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	for _, dbTask := range tasks {
 		assert.Equal(evergreen.TaskUndispatched, dbTask.Status, dbTask.Id)
 		assert.True(dbTask.Activated, dbTask.Id)
+		assert.Equal(dbTask.ActivatedBy, "test")
 	}
 
 	// test restarting a build
@@ -2220,6 +2221,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	for _, dbTask := range tasks {
 		assert.Equal(evergreen.TaskUndispatched, dbTask.Status, dbTask.Id)
 		assert.True(dbTask.Activated, dbTask.Id)
+		assert.Equal(dbTask.ActivatedBy, "test")
 	}
 
 	// test that restarting a task correctly resets the task and archives it
@@ -2241,6 +2243,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	for _, dbTask := range tasks {
 		assert.Equal(evergreen.TaskUndispatched, dbTask.Status, dbTask.Id)
 		assert.True(dbTask.Activated, dbTask.Id)
+		assert.Equal(dbTask.ActivatedBy, "caller")
 	}
 
 	// Test that restarting a display task with restartFailed correctly resets failed tasks.

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4874,7 +4874,7 @@ func TestResetTasks(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, ResetTasks([]Task{t0}, ""))
+		assert.NoError(t, ResetTasks([]Task{t0}, "user"))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4766,7 +4766,7 @@ func TestReset(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, t0.Reset(ctx))
+		assert.NoError(t, t0.Reset(ctx, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
@@ -4786,7 +4786,7 @@ func TestReset(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, t0.Reset(ctx))
+		assert.NoError(t, t0.Reset(ctx, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.True(t, dbTask.UnattainableDependency)
@@ -4806,7 +4806,7 @@ func TestReset(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, t0.Reset(ctx))
+		assert.NoError(t, t0.Reset(ctx, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
@@ -4836,7 +4836,7 @@ func TestReset(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, t0.Reset(ctx))
+		assert.NoError(t, t0.Reset(ctx, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.ResultsFailed)
@@ -4873,7 +4873,7 @@ func TestResetTasks(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, ResetTasks([]Task{t0}))
+		assert.NoError(t, ResetTasks([]Task{t0}, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
@@ -4893,7 +4893,7 @@ func TestResetTasks(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, ResetTasks([]Task{t0}))
+		assert.NoError(t, ResetTasks([]Task{t0}, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.True(t, dbTask.UnattainableDependency)
@@ -4913,7 +4913,7 @@ func TestResetTasks(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, ResetTasks([]Task{t0}))
+		assert.NoError(t, ResetTasks([]Task{t0}, ""))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4766,10 +4766,11 @@ func TestReset(t *testing.T) {
 		}
 		assert.NoError(t, t0.Insert())
 
-		assert.NoError(t, t0.Reset(ctx, ""))
+		assert.NoError(t, t0.Reset(ctx, "user"))
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
+		assert.Equal(t, dbTask.ActivatedBy, "user")
 	})
 
 	t.Run("UnattainableDependency", func(t *testing.T) {
@@ -4877,6 +4878,7 @@ func TestResetTasks(t *testing.T) {
 		dbTask, err := FindOneId(t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
+		assert.Equal(t, dbTask.ActivatedBy, "user")
 	})
 
 	t.Run("UnattainableDependency", func(t *testing.T) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -390,7 +390,7 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 		return errors.Wrap(err, "can't restart task because it can't be archived")
 	}
 
-	if err = MarkOneTaskReset(ctx, t); err != nil {
+	if err = MarkOneTaskReset(ctx, t, caller); err != nil {
 		return errors.WithStack(err)
 	}
 	event.LogTaskRestarted(t.Id, t.Execution, caller)
@@ -1897,10 +1897,10 @@ func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 	return nil
 }
 
-func MarkOneTaskReset(ctx context.Context, t *task.Task) error {
+func MarkOneTaskReset(ctx context.Context, t *task.Task, caller string) error {
 	if t.DisplayOnly {
 		if !t.ResetFailedWhenFinished {
-			if err := MarkTasksReset(ctx, t.ExecutionTasks); err != nil {
+			if err := MarkTasksReset(ctx, t.ExecutionTasks, caller); err != nil {
 				return errors.Wrap(err, "resetting execution tasks")
 			}
 		} else {
@@ -1912,13 +1912,13 @@ func MarkOneTaskReset(ctx context.Context, t *task.Task) error {
 			for _, et := range failedExecTasks {
 				failedExecTaskIds = append(failedExecTaskIds, et.Id)
 			}
-			if err := MarkTasksReset(ctx, failedExecTaskIds); err != nil {
+			if err := MarkTasksReset(ctx, failedExecTaskIds, caller); err != nil {
 				return errors.Wrap(err, "resetting failed execution tasks")
 			}
 		}
 	}
 
-	if err := t.Reset(ctx); err != nil && !adb.ResultsNotFound(err) {
+	if err := t.Reset(ctx, caller); err != nil && !adb.ResultsNotFound(err) {
 		return errors.Wrap(err, "resetting task in database")
 	}
 
@@ -1935,7 +1935,7 @@ func MarkOneTaskReset(ctx context.Context, t *task.Task) error {
 
 // MarkTasksReset resets many tasks by their IDs. For execution tasks, this also
 // resets their parent display tasks.
-func MarkTasksReset(ctx context.Context, taskIds []string) error {
+func MarkTasksReset(ctx context.Context, taskIds []string, caller string) error {
 	tasks, err := task.FindAll(db.Query(task.ByIds(taskIds)))
 	if err != nil {
 		return errors.WithStack(err)
@@ -1945,7 +1945,7 @@ func MarkTasksReset(ctx context.Context, taskIds []string) error {
 		return errors.WithStack(err)
 	}
 
-	if err = task.ResetTasks(tasks); err != nil {
+	if err = task.ResetTasks(tasks, caller); err != nil {
 		return errors.Wrap(err, "resetting tasks in database")
 	}
 

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -216,7 +216,7 @@ func TestMarkTaskForReset(t *testing.T) {
 				Status: evergreen.TaskFailed,
 			}))
 			require.NoError(t, foundTask.Archive(ctx))
-			require.NoError(t, foundTask.Reset(ctx))
+			require.NoError(t, foundTask.Reset(ctx, ""))
 			resp = rh.Run(ctx)
 			require.NotZero(t, resp)
 			assert.Equal(t, http.StatusBadRequest, resp.Status())


### PR DESCRIPTION
DEVPROD-5223

### Description
This makes it such that when a task is restarted, the `activated_by` field changes to the user / caller that restarted it rather than always keeping the field equal to the person who initially created the task.
### Testing
Existing tests.