### PR TITLE
DEVPROD-5758 special case mciuploads presigning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
 	github.com/evergreen-ci/gimlet v0.0.0-20240214172145-245537ea7b99
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
-	github.com/evergreen-ci/pail v0.0.0-20240319220903-6ca95a41e4c9
+	github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30
 	github.com/evergreen-ci/poplar v0.0.0-20240129220701-28919e26f3a3
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/evergreen-ci/pail v0.0.0-20211018155204-833e3187cfe7/go.mod h1:5gJ3sr
 github.com/evergreen-ci/pail v0.0.0-20220405154537-920afff49d92/go.mod h1:Vne1WBTeJaI2zRTv3forHzliSSQmr1zCogZIcpjFsUo=
 github.com/evergreen-ci/pail v0.0.0-20240319220903-6ca95a41e4c9 h1:ca6ZSiWSIuAA3vy5GaHThQjI3/WGkRqFXsOoUrBOUnY=
 github.com/evergreen-ci/pail v0.0.0-20240319220903-6ca95a41e4c9/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
+github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30 h1:qhQjz4osMb5A34PPtvu+oOYshFnNAhJ0fRt05Q8Mgnk=
+github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20211028170046-0999224b53df/go.mod h1:xiggfkrlxlu2C2e58tvk0WAYFetgNC7U9ONqcP29xZs=

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,6 @@ github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/s
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
 github.com/evergreen-ci/pail v0.0.0-20211018155204-833e3187cfe7/go.mod h1:5gJ3srLW+mTEtewtmEs5qdnFiKFtwoggc/U3oFCVAdc=
 github.com/evergreen-ci/pail v0.0.0-20220405154537-920afff49d92/go.mod h1:Vne1WBTeJaI2zRTv3forHzliSSQmr1zCogZIcpjFsUo=
-github.com/evergreen-ci/pail v0.0.0-20240319220903-6ca95a41e4c9 h1:ca6ZSiWSIuAA3vy5GaHThQjI3/WGkRqFXsOoUrBOUnY=
-github.com/evergreen-ci/pail v0.0.0-20240319220903-6ca95a41e4c9/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30 h1:qhQjz4osMb5A34PPtvu+oOYshFnNAhJ0fRt05Q8Mgnk=
 github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -92,7 +92,7 @@ func presignFile(file File) (string, error) {
 		return "", errors.New("AWS secret, AWS key, S3 bucket, or file key missing")
 	}
 
-	// TODO (DEVPROD-5758): remove this special casing once artifacts from the old
+	// TODO (DEVPROD-6193): remove this special casing once artifacts from the old
 	// AWS key have expired (after 3/1/2025).
 	// Empty creds will use the SDK's default credentials chain.
 	if file.Bucket == "mciuploads" {

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -74,20 +74,11 @@ func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
 		case (file.Visibility == Private || file.Visibility == Signed) && !hasUser:
 			continue
 		case file.Visibility == Signed && hasUser:
-			if !file.ContainsSigningParams() {
-				return nil, errors.New("AWS secret, AWS key, S3 bucket, or file key missing")
-			}
-			requestParams := pail.PreSignRequestParams{
-				Bucket:    file.Bucket,
-				FileKey:   file.FileKey,
-				AwsKey:    file.AwsKey,
-				AwsSecret: file.AwsSecret,
-			}
-			urlStr, err := pail.PreSign(requestParams)
+			link, err := presignFile(file)
 			if err != nil {
-				return nil, errors.Wrap(err, "presigning url")
+				return nil, errors.Wrapf(err, "presigning url for file '%s'", file.Name)
 			}
-			file.Link = urlStr
+			file.Link = link
 			publicFiles = append(publicFiles, file)
 		default:
 			publicFiles = append(publicFiles, file)
@@ -96,10 +87,26 @@ func StripHiddenFiles(files []File, hasUser bool) ([]File, error) {
 	return publicFiles, nil
 }
 
-// ContainsSigningParams returns true if all the params needed for
-// presigning a url are present
-func (f *File) ContainsSigningParams() bool {
-	return !(f.AwsSecret == "" || f.AwsKey == "" || f.Bucket == "" || f.FileKey == "")
+func presignFile(file File) (string, error) {
+	if file.AwsSecret == "" || file.AwsKey == "" || file.Bucket == "" || file.FileKey == "" {
+		return "", errors.New("AWS secret, AWS key, S3 bucket, or file key missing")
+	}
+
+	// TODO (DEVPROD-5758): remove this special casing once artifacts from the old
+	// AWS key have expired (after 3/1/2025).
+	// Empty creds will use the SDK's default credentials chain.
+	if file.Bucket == "mciuploads" {
+		file.AwsKey = ""
+		file.AwsSecret = ""
+	}
+
+	requestParams := pail.PreSignRequestParams{
+		Bucket:    file.Bucket,
+		FileKey:   file.FileKey,
+		AwsKey:    file.AwsKey,
+		AwsSecret: file.AwsSecret,
+	}
+	return pail.PreSign(requestParams)
 }
 
 func GetAllArtifacts(tasks []TaskIDAndExecution) ([]File, error) {


### PR DESCRIPTION
[DEVPROD-5758](https://jira.mongodb.org/browse/DEVPROD-5758)

### Description
There's a key we need to deactivate that was used to `s3.put` many, many artifacts. When the db-contrib-tool attempts to download these artifacts it requests a presigned download link from Evergreen and Evergreen uses the key that was provided in the original `s3.put` to presign the URLs. Since 3/1/24 we've been uploading them with the new key. For the future we won't cache the actual key ([DEVPROD-5286](https://jira.mongodb.org/browse/DEVPROD-5286)). For artifacts created prior to 3/1, however, we're going to continue using the old key to presign (since rotating the key in all the affected artifacts isn't feasible ([DEVPROD-5685](https://jira.mongodb.org/browse/DEVPROD-5685))). If we want to deactivate the old key we need a solution until the artifacts TTL in 11 months.

Since the problematic artifacts are all in the mciuploads bucket and the app servers have access to the bucket we can use the app's credentials to sign them.

An alternative could be to create a role for the db-contrib-tool to use to download from mciuploads. But then we'd need to work with the maintainers of the db-contrib tool to change the download logic, and all the teams that are using it to change their project configs to assume the role first. This special case seems more straightforward.

### Testing
Worked in staging.

