### PR TITLE
DEVPROD-6198: add wildcards to papertrail.trace

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -46,24 +46,19 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 
 	const platform = "evergreen"
 
-	for _, file := range t.Filenames {
-		fullname := filepath.Join(workdir, file)
+	papertrailBuildID := getPapertrailBuildID(task.Id, task.Execution)
 
-		sha256sum, err := getSHA256(fullname)
-		if err != nil {
-			return errors.Wrap(err, "getting sha256")
-		}
+	files, err := getTraceFiles(workdir, t.Filenames)
+	if err != nil {
+		return errors.Wrap(err, "getting trace files")
+	}
 
-		papertrailBuildID := getPapertrailBuildID(task.Id, task.Execution)
-
-		// should already be the basename, but just in case
-		basename := filepath.Base(file)
-
+	for _, f := range files {
 		args := thirdparty.TraceArgs{
 			Build:     papertrailBuildID,
 			Platform:  platform,
-			Filename:  basename,
-			Sha256:    sha256sum,
+			Filename:  f.filename,
+			Sha256:    f.sha256,
 			Product:   t.Product,
 			Version:   t.Version,
 			Submitter: task.ActivatedBy,
@@ -73,10 +68,54 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 			return errors.Wrap(err, "running trace")
 		}
 
-		logger.Task().Infof("Successfully traced '%s' (sha256://%s)", fullname, sha256sum)
+		logger.Task().Infof("Successfully traced '%s' (sha256://%s)", f.filename, f.sha256)
 	}
 
 	return nil
+}
+
+type papertrailTraceFile struct {
+	filename string
+	sha256   string
+}
+
+func getTraceFiles(workdir string, patterns []string) ([]papertrailTraceFile, error) {
+	files := make([]papertrailTraceFile, 0, len(patterns))
+
+	seen := make(map[string]string)
+
+	for _, path := range patterns {
+		patternpath := filepath.Join(workdir, path)
+
+		matches, err := filepath.Glob(patternpath)
+		if err != nil {
+			return nil, errors.Wrap(err, "globbing filepath")
+		}
+
+		for _, matchpath := range matches {
+			sha256sum, err := getSHA256(matchpath)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting sha256")
+			}
+
+			basename := filepath.Base(matchpath)
+
+			if v, ok := seen[basename]; ok {
+				return nil, errors.Errorf("file '%s' matched multiple filename patterns ('%s' and '%s'); papertrail.trace requires uploaded filenames to be unique regardless of their path, please provide only unique file names", basename, path, v)
+			}
+
+			seen[basename] = path
+
+			f := papertrailTraceFile{
+				filename: basename,
+				sha256:   sha256sum,
+			}
+
+			files = append(files, f)
+		}
+	}
+
+	return files, nil
 }
 
 func getSHA256(filename string) (string, error) {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-04"
+	AgentVersion = "2024-04-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -921,6 +921,7 @@ by the Release Infrastructure team, and you may receive assistance with it in
     filenames:
         - mongosh-linux-amd64.tar.gz
         - mongosh-linux-arm64.tar.gz
+        - *.zip
 ```
 
 Parameters:
@@ -935,7 +936,15 @@ Parameters:
     1.0.1).
 -   `filenames`: A list of filename paths to pass to the service. You may use
     full filepaths in this parameter, the command will label the file with its
-    basename only when sent to the service.
+    basename only when sent to the service. Wildcard globs are supported within
+    a single directory path. For example, the filename `dist/*.zip` would
+    locate each zip file within the `dist` directory and individually trace
+    those files. Double star globs like `dist/**/*.zip` are not supported. If
+    a filename is matched multiple times in the same call to `papertrail.trace`,
+    the command will throw an error before any tracing occurs. Note that this
+    means that each basename must be unique, regardless of their path on the
+    filesystem. For example, `./build-a/file.zip` and `./build-b/file.zip` would
+    not be allowed as filenames in the same `papertrail.trace` command.
 
 ## perf.send
 


### PR DESCRIPTION
DEVPROD-6198

### Description
This commit changes papertrail.trace to support wildcard globs in the filename parameter. Users may specify a path like "\*.tar.gz" and the command will trace all files that match. Arbitrary recursion sometimes implemented as double star globs (/foo/bar/**/*.tar.gz) is not supported.

Additionally, some checks have been added for duplicate filenames being traced in the same execution. While this was possible before, with wildcards it becomes quite a bit more likely to accidentally do. While it is possible some users have legitimate needs to trace the same filename twice, it's safer to have those users run multiple trace commands as a workaround.

### Testing
I have new unit tests for these cases.

### Documentation
I've updated the command docs to describe this feature.

