### PR TITLE
DEVPROD-4163 remove Kanopy amboy url

### DIFF
--- a/config_amboy.go
+++ b/config_amboy.go
@@ -40,10 +40,8 @@ type AmboyConfig struct {
 
 // AmboyDBConfig configures Amboy's database connection.
 type AmboyDBConfig struct {
-	URL string `bson:"url" json:"url" yaml:"url"`
-	// TODO (DEVPROD-4163): remove KanopyURL after the cutover to Kanopy.
-	KanopyURL string `bson:"kanopy_url" json:"kanopy_url" yaml:"kanopy_url"`
-	Database  string `bson:"database" json:"database" yaml:"database"`
+	URL      string `bson:"url" json:"url" yaml:"url"`
+	Database string `bson:"database" json:"database" yaml:"database"`
 }
 
 // AmboyRetryConfig represents configuration settings for Amboy's retryability

--- a/config_test.go
+++ b/config_test.go
@@ -274,9 +274,8 @@ func (s *AdminSuite) TestAmboyConfig() {
 		Name:       "amboy",
 		SingleName: "single",
 		DBConnection: AmboyDBConfig{
-			URL:       "mongodb://localhost:27017",
-			KanopyURL: "mongodb://localhost:27018",
-			Database:  "db",
+			URL:      "mongodb://localhost:27017",
+			Database: "db",
 		},
 		PoolSizeLocal:                         10,
 		PoolSizeRemote:                        20,

--- a/environment.go
+++ b/environment.go
@@ -242,7 +242,7 @@ func NewEnvironment(ctx context.Context, confPath, versionID string, db *DBSetti
 	catcher.Add(e.initDepot(ctx, tracer))
 	catcher.Add(e.initThirdPartySenders(ctx, tracer))
 	catcher.Add(e.createLocalQueue(ctx, tracer))
-	catcher.Add(e.createRemoteQueues(ctx, versionID != "", tracer))
+	catcher.Add(e.createRemoteQueues(ctx, tracer))
 	catcher.Add(e.createNotificationQueue(ctx, tracer))
 	catcher.Add(e.setupRoleManager(ctx, tracer))
 	catcher.Add(e.initTracer(ctx, versionID != "", tracer))
@@ -389,16 +389,11 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings, tracer trace
 	return nil
 }
 
-func (e *envState) createRemoteQueues(ctx context.Context, inKanopy bool, tracer trace.Tracer) error {
+func (e *envState) createRemoteQueues(ctx context.Context, tracer trace.Tracer) error {
 	ctx, span := tracer.Start(ctx, "CreateRemoteQueues")
 	defer span.End()
 
-	var url string
-	if inKanopy {
-		url = e.settings.Amboy.DBConnection.KanopyURL
-	} else {
-		url = e.settings.Amboy.DBConnection.URL
-	}
+	url := e.settings.Amboy.DBConnection.URL
 	if url == "" {
 		url = DefaultAmboyDatabaseURL
 	}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -413,18 +413,16 @@ func (a *APIAmboyConfig) ToService() (interface{}, error) {
 }
 
 type APIAmboyDBConfig struct {
-	URL       *string `json:"url"`
-	KanopyURL *string `json:"kanopy_url"`
-	Database  *string `json:"database"`
-	Username  *string `json:"username"`
-	Password  *string `json:"password"`
+	URL      *string `json:"url"`
+	Database *string `json:"database"`
+	Username *string `json:"username"`
+	Password *string `json:"password"`
 }
 
 func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.AmboyDBConfig:
 		a.URL = utility.ToStringPtr(v.URL)
-		a.KanopyURL = utility.ToStringPtr(v.KanopyURL)
 		a.Database = utility.ToStringPtr(v.Database)
 		return nil
 	default:
@@ -434,9 +432,8 @@ func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
 
 func (a *APIAmboyDBConfig) ToService() (interface{}, error) {
 	return evergreen.AmboyDBConfig{
-		URL:       utility.FromStringPtr(a.URL),
-		KanopyURL: utility.FromStringPtr(a.KanopyURL),
-		Database:  utility.FromStringPtr(a.Database),
+		URL:      utility.FromStringPtr(a.URL),
+		Database: utility.FromStringPtr(a.Database),
 	}, nil
 }
 

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -91,7 +91,6 @@ func TestModelConversion(t *testing.T) {
 
 	assert.EqualValues(testSettings.Amboy.Name, utility.FromStringPtr(apiSettings.Amboy.Name))
 	assert.EqualValues(testSettings.Amboy.DBConnection.URL, utility.FromStringPtr(apiSettings.Amboy.DBConnection.URL))
-	assert.EqualValues(testSettings.Amboy.DBConnection.KanopyURL, utility.FromStringPtr(apiSettings.Amboy.DBConnection.KanopyURL))
 	assert.EqualValues(testSettings.Amboy.DBConnection.Database, utility.FromStringPtr(apiSettings.Amboy.DBConnection.Database))
 	assert.EqualValues(testSettings.Amboy.LocalStorage, apiSettings.Amboy.LocalStorage)
 	assert.EqualValues(testSettings.Amboy.GroupDefaultWorkers, apiSettings.Amboy.GroupDefaultWorkers)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1465,10 +1465,6 @@ Admin Settings
 										<input type="text" ng-model="Settings.amboy.db_connection.url">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Kanopy DB URL</label>
-										<input type="text" ng-model="Settings.amboy.db_connection.kanopy_url">
-									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
 										<label>DB name</label>
 										<input type="text" ng-model="Settings.amboy.db_connection.database">
 									</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -90,9 +90,8 @@ func MockConfig() *evergreen.Settings {
 			Name:       "amboy",
 			SingleName: "single",
 			DBConnection: evergreen.AmboyDBConfig{
-				Database:  "db",
-				URL:       "mongodb://localhost:27017",
-				KanopyURL: "mongodb://localhost:27018",
+				Database: "db",
+				URL:      "mongodb://localhost:27017",
 			},
 			PoolSizeLocal:                         10,
 			PoolSizeRemote:                        20,


### PR DESCRIPTION
[DEVPROD-4163](https://jira.mongodb.org/browse/DEVPROD-4163)

### Description
Now that we're completely in Kanopy we don't need two separate URLs for the amboy db.
Just use the original URL field.

### Testing
In staging we can still connect to the amboy db.
