### PR TITLE
DEVPROD-6114 Update commit queue to allow merging with big diffs

### DIFF
--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -115,7 +115,7 @@ func (pc *DBCommitQueueConnector) AddPatchForPR(ctx context.Context, projectRef 
 
 func getPatchInfo(ctx context.Context, settings *evergreen.Settings, githubToken string, patchDoc *patch.Patch) (string, []thirdparty.Summary, *model.Project, *model.ParserProject, error) {
 	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(ctx, githubToken, patchDoc.GithubPatchData)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), thirdparty.PRDiffTooLargeErrorMessage) {
 		return "", nil, nil, nil, errors.Wrap(err, "getting GitHub PR diff")
 	}
 


### PR DESCRIPTION
DEVPROD-6114

### Description
Commit queue now does not error when the diff is too large for github to give a proper response 

### Testing
tested by forcing return nothing on the get diff function 
seen in this [version](https://spruce-staging.corp.mongodb.com/version/6614d053e489c80007ef292e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (no changes in the changes tab)

but you can see that the change in the pr is being used in the test (changed echo output)
and that the pr is merged correctly in the [repo](https://github.com/evergreen-ci/commit-queue-sandbox/commit/9c8b55eb25a3ade3b1009b60f82372729ae0687d) 