### PR TITLE
DEVPROD-6213: return on error fetching service flags

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -253,7 +253,7 @@ functions:
         XC_BUILD: ${xc_build}
         NOTARY_CLIENT_URL: ${notary_client_url}
         NOTARY_SERVER_URL: ${notary_server_url}
-        MACOS_NOTARY_KEY: ${notary_server_key}
+        MACOS_NOTARY_KEY: ${notary_server_id}
         MACOS_NOTARY_SECRET: ${notary_server_secret}
         EVERGREEN_BUNDLE_ID: ${evergreen_bundle_id}
         SIGN_MACOS: ${sign_macos}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -253,7 +253,7 @@ functions:
         XC_BUILD: ${xc_build}
         NOTARY_CLIENT_URL: ${notary_client_url}
         NOTARY_SERVER_URL: ${notary_server_url}
-        MACOS_NOTARY_KEY: ${notary_server_id}
+        MACOS_NOTARY_KEY: ${notary_server_key}
         MACOS_NOTARY_SECRET: ${notary_server_secret}
         EVERGREEN_BUNDLE_ID: ${evergreen_bundle_id}
         SIGN_MACOS: ${sign_macos}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -93,6 +93,7 @@ func (j *createHostJob) Run(ctx context.Context) {
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		j.AddError(err)
+		return
 	}
 
 	if flags.HostInitDisabled {


### PR DESCRIPTION
DEVPROD-6213

### Description
The host creation job didn't return if the DB errored fetching the service flags, meaning the flags could be nil and cause a panic when checking them.

### Testing
Didn't seem worth adding an explicit test for something so minor.