### PR TITLE
DEVPROD-6216: rename notary_server_key project var

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -253,7 +253,7 @@ functions:
         XC_BUILD: ${xc_build}
         NOTARY_CLIENT_URL: ${notary_client_url}
         NOTARY_SERVER_URL: ${notary_server_url}
-        MACOS_NOTARY_KEY: ${notary_server_key}
+        MACOS_NOTARY_KEY: ${notary_server_id}
         MACOS_NOTARY_SECRET: ${notary_server_secret}
         EVERGREEN_BUNDLE_ID: ${evergreen_bundle_id}
         SIGN_MACOS: ${sign_macos}


### PR DESCRIPTION
DEVPROD-6216

### Description
Rename the `notary_server_key` project variable in Evergreen's self-tests to not have the string `key` in it because it falsely redacts all the time in the self-test task logs (it's just the string "evergreen"). I'll rename the project variable itself once this is merged.