### PR TITLE
DEVPROD-5979 DB functions for the new collection to store github auth 

### DIFF
--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/mongodb/anser/bsonutil"
+	adb "github.com/mongodb/anser/db"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+var (
+	githubAppAuthIdKey      = bsonutil.MustHaveTag(GithubAppAuth{}, "Id")
+	githubAppAuthAppId      = bsonutil.MustHaveTag(GithubAppAuth{}, "AppId")
+	githubAppAuthPrivateKey = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKey")
+)
+
+const (
+	GitHubAppAuthCollection = "github_app_auth"
+)
+
+// GithubAppAuth hold the appId and privateKey for the github app associated with the project.
+// It will not be stored along with the project settings, instead it is fetched only when needed
+type GithubAppAuth struct {
+	//Should match the identifier of the project it refers to
+	Id string `bson:"_id" json:"_id"`
+
+	AppId      int64  `bson:"app_id" json:"app_id"`
+	PrivateKey []byte `bson:"private_key" json:"private_key"`
+}
+
+func FindOneGithubAppAuth(projectId string) (*GithubAppAuth, error) {
+	githubAppAuth := &GithubAppAuth{}
+	q := db.Query(bson.M{githubAppAuthIdKey: projectId})
+	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return githubAppAuth, nil
+}
+
+func HasGithubAppAuth(projectId string) (bool, error) {
+	githubAppAuth := &GithubAppAuth{}
+	q := db.Query(bson.M{githubAppAuthIdKey: projectId})
+	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
+	if adb.ResultsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (githubAppAuth *GithubAppAuth) Upsert() (*adb.ChangeInfo, error) {
+	return db.Upsert(
+		GitHubAppAuthCollection,
+		bson.M{
+			githubAppAuthIdKey: githubAppAuth.Id,
+		},
+		bson.M{
+			"$set": bson.M{
+				githubAppAuthAppId:      githubAppAuth.AppId,
+				githubAppAuthPrivateKey: githubAppAuth.PrivateKey,
+			},
+		},
+	)
+}
+
+// Remove deletes the app auth for the given project id from the database
+func Remove(id string) error {
+	return db.Remove(
+		GitHubAppAuthCollection,
+		bson.M{githubAppAuthIdKey: id},
+	)
+}

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -43,16 +43,13 @@ func FindOneGithubAppAuth(projectId string) (*GithubAppAuth, error) {
 
 // HasGithubAppAuth checks if the github app auth for the given project id exists
 func HasGithubAppAuth(projectId string) (bool, error) {
-	app, err := FindOneGithubAppAuth(projectId)
-	if err != nil {
+	var app *GithubAppAuth
+	var err error
+	if app, err = FindOneGithubAppAuth(projectId); err != nil {
 		return false, err
 	}
 
-	if app == nil {
-		return false, nil
-	}
-
-	return true, nil
+	return app != nil, nil
 }
 
 // Upsert inserts or updates the app auth for the given project id in the database

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindOneGithubAppAuth(t *testing.T) {
+	assert := assert.New(t)
+
+	require.NoError(t, db.Clear(GitHubAppAuthCollection),
+		"Error clearing collection")
+
+	key := []byte("I'm private!")
+	githubAppAuth := GithubAppAuth{
+		Id:         "mongodb",
+		AppId:      1234,
+		PrivateKey: key,
+	}
+	change, err := githubAppAuth.Upsert()
+	assert.NotNil(change)
+	assert.NoError(err)
+	assert.NotNil(change.UpsertedId)
+	assert.Equal(1, change.Updated, "%+v", change)
+
+	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
+	assert.NoError(err)
+
+	assert.Equal("mongodb", githubAppAuthFromDB.Id)
+	assert.Equal(int64(1234), githubAppAuthFromDB.AppId)
+	assert.Equal(key, githubAppAuthFromDB.PrivateKey)
+}
+
+func TestRemove(t *testing.T) {
+	assert := assert.New(t)
+	require.NoError(t, db.Clear(GitHubAppAuthCollection),
+		"Error clearing collection")
+
+	key := []byte("I'm private")
+	githubAppAuth := GithubAppAuth{
+		Id:         "mongodb",
+		AppId:      1234,
+		PrivateKey: key,
+	}
+	_, err := githubAppAuth.Upsert()
+	assert.NoError(err)
+
+	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
+	assert.NoError(err)
+	assert.NotNil(githubAppAuthFromDB)
+
+	err = Remove(githubAppAuthFromDB.Id)
+
+	assert.NoError(err)
+	githubAppAuthFromDB, err = FindOneGithubAppAuth("mongodb")
+	assert.NoError(err)
+	assert.Nil(githubAppAuthFromDB)
+}

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -20,21 +20,18 @@ func TestFindOneGithubAppAuth(t *testing.T) {
 		AppId:      1234,
 		PrivateKey: key,
 	}
-	change, err := githubAppAuth.Upsert()
-	assert.NotNil(change)
-	assert.NoError(err)
-	assert.NotNil(change.UpsertedId)
-	assert.Equal(1, change.Updated, "%+v", change)
+	err := githubAppAuth.Upsert()
 
+	require.NoError(t, err)
 	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assert.Equal("mongodb", githubAppAuthFromDB.Id)
 	assert.Equal(int64(1234), githubAppAuthFromDB.AppId)
 	assert.Equal(key, githubAppAuthFromDB.PrivateKey)
 }
 
-func TestRemove(t *testing.T) {
+func TestRemoveGithubAppAuth(t *testing.T) {
 	assert := assert.New(t)
 	require.NoError(t, db.Clear(GitHubAppAuthCollection),
 		"Error clearing collection")
@@ -45,17 +42,17 @@ func TestRemove(t *testing.T) {
 		AppId:      1234,
 		PrivateKey: key,
 	}
-	_, err := githubAppAuth.Upsert()
-	assert.NoError(err)
+	err := githubAppAuth.Upsert()
+	require.NoError(t, err)
 
 	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.NotNil(githubAppAuthFromDB)
 
-	err = Remove(githubAppAuthFromDB.Id)
+	err = RemoveGithubAppAuth(githubAppAuthFromDB.Id)
 
-	assert.NoError(err)
+	require.NoError(t, err)
 	githubAppAuthFromDB, err = FindOneGithubAppAuth("mongodb")
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Nil(githubAppAuthFromDB)
 }

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindOneAndHasApp(t *testing.T) {
+func TestFindOneGithubAppAuth(t *testing.T) {
 	assert := assert.New(t)
 
 	require.NoError(t, db.Clear(GitHubAppAuthCollection),

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindOneGithubAppAuth(t *testing.T) {
+func TestFindOneAndHasApp(t *testing.T) {
 	assert := assert.New(t)
 
 	require.NoError(t, db.Clear(GitHubAppAuthCollection),
@@ -45,14 +45,15 @@ func TestRemoveGithubAppAuth(t *testing.T) {
 	err := githubAppAuth.Upsert()
 	require.NoError(t, err)
 
-	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
+	hasGithubAppAuth, err := HasGithubAppAuth("mongodb")
 	require.NoError(t, err)
-	assert.NotNil(githubAppAuthFromDB)
+	assert.True(hasGithubAppAuth)
 
-	err = RemoveGithubAppAuth(githubAppAuthFromDB.Id)
+	err = RemoveGithubAppAuth(githubAppAuth.Id)
+	require.NoError(t, err)
 
+	hasGithubAppAuth, err = HasGithubAppAuth("mongodb")
 	require.NoError(t, err)
-	githubAppAuthFromDB, err = FindOneGithubAppAuth("mongodb")
-	require.NoError(t, err)
-	assert.Nil(githubAppAuthFromDB)
+	assert.False(hasGithubAppAuth)
+
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -20,6 +20,8 @@ type ProjectSettings struct {
 	Vars               ProjectVars          `bson:"vars" json:"vars"`
 	Aliases            []ProjectAlias       `bson:"aliases" json:"aliases"`
 	Subscriptions      []event.Subscription `bson:"subscriptions" json:"subscriptions"`
+	// HasGithubApp indicates if a user has saved an app key and secret for a github app
+	HasGitHubApp bool `bson:"has_github_app" json:"has_github_app"`
 }
 
 type ProjectSettingsEvent struct {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1815,7 +1815,7 @@ func GetProjectSettingsById(projectId string, isRepo bool) (*ProjectSettings, er
 func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 	// Don't error even if there is problem with verifying the GitHub app installation
 	// because a GitHub outage could cause project settings page to not load.
-	hasApp, _ := evergreen.GetEnvironment().Settings().HasGitHubApp(context.Background(), p.Owner, p.Repo)
+	hasEvergreenAppInstalled, _ := evergreen.GetEnvironment().Settings().HasGitHubApp(context.Background(), p.Owner, p.Repo)
 
 	projectVars, err := FindOneProjectVars(p.Id)
 	if err != nil {
@@ -1833,18 +1833,18 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 		return nil, errors.Wrapf(err, "finding subscription for project '%s'", p.Id)
 	}
 
-	hasGithubApp, err := HasGithubAppAuth(p.Id)
+	hasGithubAppAuth, err := HasGithubAppAuth(p.Id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding hadGithubApp for project '%s'", p.Id)
 	}
 
 	projectSettingsEvent := ProjectSettings{
 		ProjectRef:         *p,
-		GithubHooksEnabled: hasApp,
+		GithubHooksEnabled: hasEvergreenAppInstalled,
 		Vars:               *projectVars,
 		Aliases:            projectAliases,
 		Subscriptions:      subscriptions,
-		HasGitHubApp:       hasGithubApp,
+		HasGitHubApp:       hasGithubAppAuth,
 	}
 	return &projectSettingsEvent, nil
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1832,12 +1832,19 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding subscription for project '%s'", p.Id)
 	}
+
+	hasGithubApp, err := HasGithubAppAuth(p.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding hadGithubApp for project '%s'", p.Id)
+	}
+
 	projectSettingsEvent := ProjectSettings{
 		ProjectRef:         *p,
 		GithubHooksEnabled: hasApp,
 		Vars:               *projectVars,
 		Aliases:            projectAliases,
 		Subscriptions:      subscriptions,
+		HasGitHubApp:       hasGithubApp,
 	}
 	return &projectSettingsEvent, nil
 }


### PR DESCRIPTION
DEVPROD-5979

### Description
This adds the basic db functions for a new collection that will store the auth for github apps for users. It also adds a HasGitHubApp field on project settings and a HasGithubAppAuth() function and a call to it in getProjectSettings.

### Testing
unit tests 


