### PR TITLE
DEVPROD-3951: add sleep schedule-specific actions to start and stop jobs

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -195,9 +195,9 @@ const (
 )
 
 const (
-	checkSuccessAttempts   = 12
+	checkSuccessAttempts   = 10
 	checkSuccessInitPeriod = 2 * time.Second
-	checkSuccessMaxDelay   = 2 * time.Minute
+	checkSuccessMaxDelay   = time.Minute
 )
 
 const (
@@ -1020,6 +1020,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 		}, utility.RetryOptions{
 			MaxAttempts: checkSuccessAttempts,
 			MinDelay:    checkSuccessInitPeriod,
+			MaxDelay:    checkSuccessMaxDelay,
 		})
 
 	if err != nil {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1523,10 +1523,13 @@ func FindHostsScheduledToStop(ctx context.Context) ([]Host, error) {
 	})
 }
 
+// PreStartThreshold is how long in advance Evergreen can check for hosts that
+// are scheduled to start up soon.
+const PreStartThreshold = 5 * time.Minute
+
 // FindHostsToSleep finds all unexpirable hosts that are due to start soon due
 // to their sleep schedule settings.
 func FindHostsScheduledToStart(ctx context.Context) ([]Host, error) {
-	const preWakeThreshold = 5 * time.Minute
 	now := time.Now()
 	sleepScheduleNextStartKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
 	sleepSchedulePermanentlyExemptKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepSchedulePermanentlyExemptKey)
@@ -1539,7 +1542,7 @@ func FindHostsScheduledToStart(ctx context.Context) ([]Host, error) {
 		NoExpirationKey: true,
 		// Include hosts that are imminently about to reach their wakeup time to
 		// better ensure the host is running at the scheduled time.
-		sleepScheduleNextStartKey:         bson.M{"$lte": now.Add(preWakeThreshold)},
+		sleepScheduleNextStartKey:         bson.M{"$lte": now.Add(PreStartThreshold)},
 		sleepSchedulePermanentlyExemptKey: bson.M{"$ne": true},
 		"$or": []bson.M{
 			{

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -830,9 +830,9 @@ func TestCountRunningStatusHosts(t *testing.T) {
 
 	assert.NoError(t, db.InsertMany(Collection, h1, h2, h3, h4, h5, h6, h7, h8))
 
-	ctx := context.TODO()
-	count, err := CountRunningStatusHosts(ctx, "d1")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	count, err := CountRunningStatusHosts(ctx, d1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
-
 }

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -830,9 +830,9 @@ func TestCountRunningStatusHosts(t *testing.T) {
 
 	assert.NoError(t, db.InsertMany(Collection, h1, h2, h3, h4, h5, h6, h7, h8))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	count, err := CountRunningStatusHosts(ctx, d1.Id)
+	ctx := context.TODO()
+	count, err := CountRunningStatusHosts(ctx, "d1")
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
+
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -356,10 +356,10 @@ type SleepScheduleInfo struct {
 	WholeWeekdaysOff []time.Weekday `bson:"whole_weekdays_off" json:"whole_weekdays_off"`
 	// DailyStartTime and DailyStopTime represent a daily schedule for when to
 	// start a stopped host back up. The format is "HH:MM".
-	DailyStartTime string `bson:"daily_sleep_start_time" json:"daily_sleep_start_time"`
+	DailyStartTime string `bson:"daily_start_time" json:"daily_start_time"`
 	// DailyStopTime represents a daily schedule for when to stop a host. The
 	// format is "HH:MM".
-	DailyStopTime string `bson:"daily_sleep_stop_time" json:"daily_sleep_stop_time"`
+	DailyStopTime string `bson:"daily_stop_time" json:"daily_stop_time"`
 	// TimeZone is the time zone for this host's sleep schedule.
 	TimeZone string `bson:"time_zone" json:"time_zone"`
 	// TemporarilyExemptUntil stores when a user's temporary exemption ends, if

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3840,3 +3840,37 @@ func getNextScheduledTime(after time.Time, spec string) (time.Time, error) {
 	}
 	return nextTriggerAt, nil
 }
+
+// SetNextScheduledStart sets the next time the host is planned to start for its
+// sleep schedule.
+func (h *Host) SetNextScheduledStart(ctx context.Context, t time.Time) error {
+	// kim: NOTE: needs merge.
+	sleepScheduleStartKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
+	if err := UpdateOne(ctx,
+		bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{sleepScheduleStartKey: t}},
+	); err != nil {
+		return err
+	}
+
+	h.SleepSchedule.NextStartTime = t
+
+	return nil
+}
+
+// SetNextScheduledStop sets the next time the host is planned to stop for its
+// sleep schedule.
+func (h *Host) SetNextScheduledStop(ctx context.Context, t time.Time) error {
+	// kim: NOTE: needs merge.
+	sleepScheduleStopKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
+	if err := UpdateOne(ctx,
+		bson.M{IdKey: h.Id},
+		bson.M{"$set": bson.M{sleepScheduleStopKey: t}},
+	); err != nil {
+		return err
+	}
+
+	h.SleepSchedule.NextStopTime = t
+
+	return nil
+}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3844,7 +3844,6 @@ func getNextScheduledTime(after time.Time, spec string) (time.Time, error) {
 // SetNextScheduledStart sets the next time the host is planned to start for its
 // sleep schedule.
 func (h *Host) SetNextScheduledStart(ctx context.Context, t time.Time) error {
-	// kim: NOTE: needs merge.
 	sleepScheduleStartKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
 	if err := UpdateOne(ctx,
 		bson.M{IdKey: h.Id},
@@ -3861,7 +3860,6 @@ func (h *Host) SetNextScheduledStart(ctx context.Context, t time.Time) error {
 // SetNextScheduledStop sets the next time the host is planned to stop for its
 // sleep schedule.
 func (h *Host) SetNextScheduledStop(ctx context.Context, t time.Time) error {
-	// kim: NOTE: needs merge.
 	sleepScheduleStopKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
 	if err := UpdateOne(ctx,
 		bson.M{IdKey: h.Id},

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -181,7 +181,7 @@ func StopSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUse
 	}
 
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	stopJob := units.NewSpawnhostStopJob(h, shouldKeepOff, u.Id, ts)
+	stopJob := units.NewSpawnhostStopJob(h, shouldKeepOff, evergreen.ModifySpawnHostManual, u.Id, ts)
 	if err := units.EnqueueSpawnHostModificationJob(ctx, env, stopJob); err != nil {
 		if amboy.IsDuplicateJobScopeError(err) {
 			err = errHostStatusChangeConflict
@@ -199,7 +199,7 @@ func StartSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUs
 	}
 
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	startJob := units.NewSpawnhostStartJob(h, u.Id, ts)
+	startJob := units.NewSpawnhostStartJob(h, evergreen.ModifySpawnHostManual, u.Id, ts)
 	if err := units.EnqueueSpawnHostModificationJob(ctx, env, startJob); err != nil {
 		if amboy.IsDuplicateJobScopeError(err) {
 			err = errHostStatusChangeConflict

--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -151,7 +151,7 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 // stopInitialHost inspects the initial host's status and stops it if the host is still running.
 func (j *volumeMigrationJob) stopInitialHost(ctx context.Context) {
 	ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-	stopJob := NewSpawnhostStopJob(j.initialHost, false, evergreen.User, ts)
+	stopJob := NewSpawnhostStopJob(j.initialHost, false, evergreen.ModifySpawnHostManual, evergreen.User, ts)
 	err := amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), stopJob)
 	if err != nil {
 		j.AddRetryableError(err)

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -100,9 +100,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 			// until the spawn host stop job finishes once (with an error).
 			var foundFinishedSpawnHostStopJob bool
 			for {
-				if ctx.Err() != nil {
-					require.FailNow(t, "context timed out looking for finished spawn host stop job in the queue")
-				}
+				require.NoError(t, ctx.Err(), "context timed out looking for finished jobs in the queue")
 				for ji := range env.RemoteQueue().JobInfo(ctx) {
 					if ji.ID == j.ID() && ji.Status.Completed {
 						foundFinishedVolumeMigrationJob = true

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -90,19 +90,37 @@ func TestVolumeMigrateJob(t *testing.T) {
 
 			j := NewVolumeMigrationJob(env, v.ID, spawnOptions, "123")
 			j.UpdateRetryInfo(amboy.JobRetryOptions{
-				WaitUntil:   utility.ToTimeDurationPtr(100 * time.Millisecond),
-				MaxAttempts: utility.ToIntPtr(3),
+				Retryable: utility.FalsePtr(),
 			})
 			require.NoError(t, env.RemoteQueue().Start(ctx))
 			require.NoError(t, env.RemoteQueue().Put(ctx, j))
 
-			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
-			assert.Error(t, j.Error())
-			assert.Contains(t, j.Error().Error(), "not yet stopped")
-			// Second attempt fails to stop initial host
-			j, ok := env.RemoteQueue().Get(ctx, j.ID())
-			assert.True(t, ok)
-			assert.Error(t, j.Error())
+			var foundFinishedVolumeMigrationJob bool
+			// The spawn host start job should fail but may also retry, so wait
+			// until the spawn host stop job finishes once (with an error).
+			var foundFinishedSpawnHostStopJob bool
+			for {
+				if ctx.Err() != nil {
+					require.FailNow(t, "context timed out looking for finished spawn host stop job in the queue")
+				}
+				for ji := range env.RemoteQueue().JobInfo(ctx) {
+					if ji.ID == j.ID() && ji.Status.Completed {
+						foundFinishedVolumeMigrationJob = true
+						assert.NotZero(t, ji.Status.ErrorCount, "volume migration job should have errored")
+					}
+					if ji.Type.Name == spawnhostStopName && ji.Status.Completed {
+						foundFinishedSpawnHostStopJob = true
+						assert.NotZero(t, ji.Status.ErrorCount, "spawn host stop job should have errored")
+					}
+				}
+				if foundFinishedSpawnHostStopJob && foundFinishedVolumeMigrationJob {
+					break
+				}
+			}
+			assert.True(t, foundFinishedSpawnHostStopJob, "should have found a finished spawn host stop job in the queue")
+			assert.True(t, foundFinishedVolumeMigrationJob, "should have found a finished volume migration job in the queue")
+
+			require.Error(t, j.Error())
 			assert.Contains(t, j.Error().Error(), "not yet stopped")
 
 			// Verify volume remains attached to initial host

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -72,6 +72,8 @@ func (j *sleepSchedulerJob) populateIfUnset() error {
 	return nil
 }
 
+const sleepScheduleUser = "sleep_schedule"
+
 func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
@@ -95,7 +97,7 @@ func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergree
 		hostIDsToStop = make([]string, 0, len(hostsToStop))
 		for i := range hostsToStop {
 			h := hostsToStop[i]
-			stopJobs = append(stopJobs, NewSpawnhostStopJob(&h, false, evergreen.User, ts.Format(TSFormat)))
+			stopJobs = append(stopJobs, NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts.Format(TSFormat)))
 			hostIDsToStop = append(hostIDsToStop, h.Id)
 		}
 	}
@@ -108,7 +110,7 @@ func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergree
 	hostIDsToStart := make([]string, 0, len(hostsToStart))
 	for i := range hostsToStart {
 		h := hostsToStart[i]
-		startJobs = append(startJobs, NewSpawnhostStartJob(&h, evergreen.User, ts.Format(TSFormat)))
+		startJobs = append(startJobs, NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts.Format(TSFormat)))
 		hostIDsToStart = append(hostIDsToStart, h.Id)
 	}
 

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -125,7 +125,7 @@ func (j *spawnhostStartJob) setNextScheduledStart(ctx context.Context, h *host.H
 		return errors.Wrap(err, "calculating next scheduled start")
 	}
 	if err := h.SetNextScheduledStart(ctx, nextStart); err != nil {
-		return errors.Wrapf(err, "setting next scheduled stop to '%s'", nextStart)
+		return errors.Wrapf(err, "setting next scheduled start to '%s'", nextStart)
 	}
 	return nil
 }

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -120,7 +120,7 @@ func (j *spawnhostStartJob) setNextScheduledStart(ctx context.Context, h *host.H
 	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
 		return nil
 	}
-	nextStart, err := h.GetNextScheduledStartTime(h.SleepSchedule.NextStartTime)
+	nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(h.SleepSchedule.NextStartTime)
 	if err != nil {
 		return errors.Wrap(err, "calculating next scheduled start")
 	}

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -120,7 +120,7 @@ func (j *spawnhostStartJob) setNextScheduledStart(ctx context.Context, h *host.H
 	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
 		return nil
 	}
-	nextStart, err := h.GetNextScheduledStartTime(time.Now())
+	nextStart, err := h.GetNextScheduledStartTime(h.SleepSchedule.NextStartTime)
 	if err != nil {
 		return errors.Wrap(err, "calculating next scheduled start")
 	}

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -63,13 +63,11 @@ func NewSpawnhostStartJob(h *host.Host, source evergreen.ModifySpawnHostSource, 
 	return j
 }
 
-// kim: TODO: test for sleep schedule next start time.
 func (j *spawnhostStartJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	startCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
-		// kim: TODO: account for few minutes of padding to pre-emptive start.
-		if j.Source == evergreen.ModifySpawnHostSleepSchedule && h.SleepSchedule.NextStartTime.After(time.Now()) {
+		if j.Source == evergreen.ModifySpawnHostSleepSchedule && h.SleepSchedule.NextStartTime.After(time.Now().Add(host.PreStartThreshold)) {
 			grip.Info(message.Fields{
 				"message":         "no-oping because host is not scheduled to start yet",
 				"host_id":         h.Id,

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	spawnHostStartRetryLimit = 10
+	spawnHostStartRetryLimit = 3
 	spawnhostStartName       = "spawnhost-start"
 )
 
@@ -92,7 +92,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 	}
 
 	if err := j.CloudHostModification.modifyHost(ctx, startCloudHost); err != nil {
-		j.AddError(err)
+		j.AddRetryableError(err)
 		return
 	}
 }

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -33,7 +33,7 @@ func TestSpawnhostStartJob(t *testing.T) {
 				Provider: evergreen.ProviderNameMock,
 				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
 			}
-			j, ok := NewSpawnhostStartJob(&h, "user", ts).(*spawnhostStartJob)
+			j, ok := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts).(*spawnhostStartJob)
 			require.True(t, ok)
 
 			assert.NotZero(t, j.RetryInfo().GetMaxAttempts(), "job should retry")
@@ -54,7 +54,7 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, "user", ts)
+			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -110,7 +110,7 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, "user", ts)
+			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -135,7 +135,7 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, "user", ts)
+			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())
@@ -147,6 +147,10 @@ func TestSpawnhostStartJob(t *testing.T) {
 
 			checkSpawnHostModificationEvent(t, h.Id, event.EventHostStarted, false)
 		},
+		// "RunSchedulesNextStartTime": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
+		// },
+		// "RunNoopsIfNotScheduledToStart": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
+		// },
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tctx := testutil.TestSpan(ctx, t)

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -84,7 +84,7 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, "user", ts)
+			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -224,10 +224,6 @@ func TestSpawnhostStartJob(t *testing.T) {
 
 			assert.True(t, dbHost.SleepSchedule.NextStartTime.Equal(nextStart), "next start time should be the same as original")
 		},
-		// "RunSchedulesNextStartTime": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
-		// },
-		// "RunNoopsIfNotScheduledToStart": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
-		// },
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tctx := testutil.TestSpan(ctx, t)

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -48,15 +48,15 @@ func makeSpawnhostStopJob() *spawnhostStopJob {
 }
 
 // NewSpawnhostStopJob returns a job to stop a running spawn host.
-func NewSpawnhostStopJob(h *host.Host, shouldKeepOff bool, user, ts string) amboy.Job {
+func NewSpawnhostStopJob(h *host.Host, shouldKeepOff bool, source evergreen.ModifySpawnHostSource, user, ts string) amboy.Job {
 	j := makeSpawnhostStopJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s.%s", spawnhostStopName, user, h.Id, ts))
 	j.SetScopes([]string{fmt.Sprintf("%s.%s", spawnHostStatusChangeScopeName, h.Id)})
 	j.SetEnqueueAllScopes(true)
 	j.CloudHostModification.HostID = h.Id
 	j.CloudHostModification.UserID = user
-	j.CloudHostModification.Source = evergreen.ModifySpawnHostManual
 	j.ShouldKeepOff = shouldKeepOff
+	j.CloudHostModification.Source = source
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),
 		MaxAttempts: utility.ToIntPtr(spawnHostStopRetryLimit),
@@ -65,10 +65,21 @@ func NewSpawnhostStopJob(h *host.Host, shouldKeepOff bool, user, ts string) ambo
 	return j
 }
 
+// kim: TODO: test for sleep schedule next start time.
 func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
+		if j.Source == evergreen.ModifySpawnHostSleepSchedule && h.SleepSchedule.NextStopTime.After(time.Now()) {
+			grip.Info(message.Fields{
+				"message":        "no-oping because host is not scheduled to stop yet",
+				"host_id":        h.Id,
+				"next_stop_time": h.SleepSchedule.NextStopTime,
+				"job":            j.ID(),
+			})
+			return nil
+		}
+
 		if err := mgr.StopInstance(ctx, h, j.ShouldKeepOff, user); err != nil {
 			event.LogHostStopError(h.Id, err.Error())
 			grip.Error(message.WrapError(err, message.Fields{
@@ -76,19 +87,30 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 				"host_id":  h.Id,
 				"host_tag": h.Tag,
 				"distro":   h.Distro.Id,
-				"user":     user,
+				"job":      j.ID(),
 			}))
 			return errors.Wrap(err, "stopping spawn host")
 		}
 
 		event.LogHostStopSucceeded(h.Id)
 		grip.Info(message.Fields{
-			"message":  "stopped spawn host",
-			"host_id":  h.Id,
-			"host_tag": h.Tag,
-			"distro":   h.Distro.Id,
-			"user":     user,
+			"message":    "stopped spawn host",
+			"host_id":    h.Id,
+			"started_by": h.StartedBy,
+			"host_tag":   h.Tag,
+			"distro":     h.Distro.Id,
+			"job":        j.ID(),
 		})
+
+		if j.Source == evergreen.ModifySpawnHostSleepSchedule {
+			grip.Warning(message.WrapError(j.setNextScheduledStop(ctx, h), message.Fields{
+				"message":        "successfully stopped host for sleep schedule but could not set next scheduled stop time",
+				"host_id":        h.Id,
+				"started_by":     h.StartedBy,
+				"sleep_schedule": fmt.Sprintf("%#v", h.SleepSchedule),
+				"job":            j.ID(),
+			}))
+		}
 
 		return nil
 	}
@@ -97,4 +119,18 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 		j.AddRetryableError(err)
 		return
 	}
+}
+
+func (j *spawnhostStopJob) setNextScheduledStop(ctx context.Context, h *host.Host) error {
+	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
+		return nil
+	}
+	nextStop, err := h.GetNextScheduledStopTime(time.Now())
+	if err != nil {
+		return errors.Wrap(err, "calculating next scheduled stop time")
+	}
+	if err := h.SetNextScheduledStop(ctx, nextStop); err != nil {
+		return errors.Wrapf(err, "setting next scheduled stop to '%s'", nextStop)
+	}
+	return nil
 }

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -124,7 +124,7 @@ func (j *spawnhostStopJob) setNextScheduledStop(ctx context.Context, h *host.Hos
 	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
 		return nil
 	}
-	nextStop, err := h.GetNextScheduledStopTime(time.Now())
+	nextStop, err := h.GetNextScheduledStopTime(h.SleepSchedule.NextStopTime)
 	if err != nil {
 		return errors.Wrap(err, "calculating next scheduled stop time")
 	}

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -124,7 +124,7 @@ func (j *spawnhostStopJob) setNextScheduledStop(ctx context.Context, h *host.Hos
 	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
 		return nil
 	}
-	nextStop, err := h.GetNextScheduledStopTime(h.SleepSchedule.NextStopTime)
+	nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(h.SleepSchedule.NextStopTime)
 	if err != nil {
 		return errors.Wrap(err, "calculating next scheduled stop time")
 	}

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -65,7 +65,6 @@ func NewSpawnhostStopJob(h *host.Host, shouldKeepOff bool, source evergreen.Modi
 	return j
 }
 
-// kim: TODO: test for sleep schedule next start time.
 func (j *spawnhostStopJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	spawnHostStopRetryLimit = 10
+	spawnHostStopRetryLimit = 3
 	spawnhostStopName       = "spawnhost-stop"
 )
 
@@ -94,7 +94,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 	}
 
 	if err := j.CloudHostModification.modifyHost(ctx, stopCloudHost); err != nil {
-		j.AddError(err)
+		j.AddRetryableError(err)
 		return
 	}
 }

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -124,7 +124,8 @@ func (j *spawnhostStopJob) setNextScheduledStop(ctx context.Context, h *host.Hos
 	if j.Source != evergreen.ModifySpawnHostSleepSchedule {
 		return nil
 	}
-	nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(h.SleepSchedule.NextStopTime)
+	scheduleAfter := time.Now()
+	nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(scheduleAfter)
 	if err != nil {
 		return errors.Wrap(err, "calculating next scheduled stop time")
 	}

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -82,7 +82,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, true, "user", ts)
+			j := NewSpawnhostStopJob(&h, true, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -169,7 +169,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -211,7 +211,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -33,7 +33,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 				Provider: evergreen.ProviderNameMock,
 				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
 			}
-			j, ok := NewSpawnhostStopJob(&h, false, "user", ts).(*spawnhostStopJob)
+			j, ok := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts).(*spawnhostStopJob)
 			require.True(t, ok)
 
 			assert.NotZero(t, j.RetryInfo().GetMaxAttempts(), "job should retry")
@@ -54,7 +54,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, "user", ts)
+			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -109,7 +109,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, "user", ts)
+			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -134,7 +134,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, "user", ts)
+			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())
@@ -146,6 +146,10 @@ func TestSpawnhostStopJob(t *testing.T) {
 
 			checkSpawnHostModificationEvent(t, h.Id, event.EventHostStarted, false)
 		},
+		// "RunSchedulesNextStopTime": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
+		// },
+		// "RunNoopsIfNotScheduledToStopYet": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
+		// },
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tctx := testutil.TestSpan(ctx, t)


### PR DESCRIPTION
DEVPROD-3951

### Description
This does a couple of things to make the spawn host stop/start jobs work with sleep schedules:
* When the host is stopped/started successfully, the next stop/start time is scheduled.
* Retry on error when stopping/starting the host, but reduce the max wait time spent in exponential backoff. Before, it could wait up to 2 minutes between checks when polling AWS for the host status, and the jobs didn't retry failed attempts. Now, it waits at most 1 minute between host status checks and the job retries properly.
* No-op the stop/start if it's not scheduled to stop/start. This could happen if the host is taking too long to stop/start.
* Fixed a trivial issue where I noticed the BSON tags in the sleep schedule data model were wrong.

### Testing
* Added unit tests.
* Tested in staging that the sleep schedule correctly schedules the host to stop/start, and sets the next stop/start times.

### Documentation
N/A