### PR TITLE
DEVPROD-5419 Add check in assignNextAvailableTask for teardown needed when queue is empty

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-04"
+	AgentVersion = "2024-04-11"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -696,11 +696,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 	if taskQueue.Length() == 0 && details.TaskGroup != "" {
 		// if we have reached the end of the queue and the previous task was part of a task group,
 		// the current task group is finished and needs to be torn down.
-		grip.Info(message.Fields{
-			"message":   "no tasks on queue but task group needs teardown",
-			"host_id":   currentHost.Id,
-			"taskGroup": details.TaskGroup,
-		})
 		return nil, true, nil
 
 	}

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1084,6 +1084,17 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			So(currentTq.Length(), ShouldEqual, 2)
 			details.TaskGroup = ""
 		})
+		Convey("a completed task group and an empty queue should return true for teardown", func() {
+			taskQueue.Queue = []model.TaskQueueItem{}
+			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Length(), ShouldEqual, 0)
+
+			details.TaskGroup = "my-task-group"
+			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)
+			So(err, ShouldBeNil)
+			So(t, ShouldBeNil)
+			So(shouldTeardown, ShouldBeTrue)
+		})
 		Convey("a task that is not undispatched should not be updated in the host", func() {
 			taskQueue.Queue = []model.TaskQueueItem{
 				{Id: "undispatchedTask"},


### PR DESCRIPTION
DEVPROD-5419

### Description
If the task queue is empty, assignNextAvailableTask won't hit [this line](https://github.com/evergreen-ci/evergreen/blob/49a0c6894aa286e65db45b2ea016be8b9a6320ba/rest/route/host_agent.go#L605) to check if it should return true to indicate shouldRunTeardown. 

This adds a check when taskQueue.Length is 0 to see if teardown is needed and return true if it is. 

### Testing
Added a unit test and tested on staging to make sure [this](https://github.com/evergreen-ci/evergreen/commit/81a155b822cf8d26df15ff2d67cf173b7d1bebe5) is logged in splunk. 

