### PR TITLE
DEVPROD-6290 Error and do not update display task if no exec tasks are found

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2350,6 +2350,9 @@ func tryUpdateDisplayTaskAtomically(dt task.Task) (updated *task.Task, err error
 	if err != nil {
 		return &dt, errors.Wrap(err, "retrieving execution tasks")
 	}
+	if len(execTasks) == 0 {
+		return nil, errors.Errorf("display task '%s' has no execution tasks", dt.Id)
+	}
 
 	hasFinishedTasks := false
 	hasTasksToRun := false


### PR DESCRIPTION
DEVPROD-6290

### Description
This fixes a panic noticed & detailed in this ops thread.
