### PR TITLE
DEVPROD-6292: require matches for papertrail.trace

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -38,11 +38,7 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 	pclient := thirdparty.NewPapertrailClient(t.KeyID, t.SecretKey, "")
 
 	task := conf.Task
-
-	workdir := t.WorkDir
-	if workdir == "" {
-		workdir = conf.WorkDir
-	}
+	workdir := GetWorkingDirectory(conf, t.WorkDir)
 
 	const platform = "evergreen"
 
@@ -113,6 +109,10 @@ func getTraceFiles(workdir string, patterns []string) ([]papertrailTraceFile, er
 
 			files = append(files, f)
 		}
+	}
+
+	if len(files) == 0 {
+		return nil, errors.New("filenames did not match any files; papertrail.trace requires at least one matching filename on disk")
 	}
 
 	return files, nil

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-12"
+	AgentVersion = "2024-04-12-B"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -941,7 +941,7 @@ Parameters:
     the command will throw an error before any tracing occurs. Note that this
     means that each basename must be unique, regardless of their path on the
     filesystem. For example, `./build-a/file.zip` and `./build-b/file.zip` would
-    not be allowed as filenames in the same `papertrail.trace` command.
+    not be allowed as filenames in the same `papertrail.trace` command. If at least one file cannot be found while using wildcard globs, the command will return an error.
 
 ## perf.send
 


### PR DESCRIPTION
DEVPROD-6292

### Description
This commit makes a small change to papertrail.trace so it returns an error if none of the filename patterns in use match a file on disk.

Additionally, it fixes a bug and adds a test associated with working directory parsing. This bug is what prompted failing without matches, because it was very hard to debug without the error. The bug was fixed by switching to GetWorkingDirectory().

### Testing
I added two new tests and altered two others. The altered tests now ensure we're handling relative working directories correctly. One of the new tests checks to ensure that traces without the working directory set work correctly. The other new test checks that we error out if we don't trace at least one file.

### Documentation
I also added a note about the "traces at least one file" requirement to the command documentation.
