### PR TITLE
DEVPROD-6269: skip papertrail.trace testing on mac

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -33,6 +34,10 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if err := util.ExpandValues(t, &conf.Expansions); err != nil {
 		return errors.Wrap(err, "applying expansions")
+	}
+
+	if runtime.GOOS == "darwin" {
+		return errors.New("papertrail.trace is not supported on MacOS currently because these hosts do not always run in AWS with the necessary networking configuration")
 	}
 
 	pclient := thirdparty.NewPapertrailClient(t.KeyID, t.SecretKey, "")

--- a/agent/command/papertrail_trace_test.go
+++ b/agent/command/papertrail_trace_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -26,6 +27,10 @@ import (
 func TestPapertrailTrace(t *testing.T) {
 	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_INTEGRATION_TESTS")); skip {
 		t.Skip("SKIP_INTEGRATION_TESTS is set, skipping integration test")
+	}
+
+	if runtime.GOOS == "darwin" {
+		t.Skip("papertrail.trace is not supported on MacOS currently because these hosts do not always run in AWS with the necessary networking configuration")
 	}
 
 	settings := testutil.GetIntegrationFile(t)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-15"
+	AgentVersion = "2024-04-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -906,7 +906,10 @@ Parameters:
 
 This command traces artifact releases with the Papertrail service. It is owned
 by the Release Infrastructure team, and you may receive assistance with it in
-#ask-devprod-release-tools.
+#ask-devprod-release-tools. This command cannot run on Evergreen hosts outside
+of AWS, which includes most MacOS hosts, because of security requirements for
+the Papertrail service. In the future, MacOS hosts will not have this
+limitation.
 
 ``` yaml
 - command: papertrail.trace


### PR DESCRIPTION
DEVPROD-6269

### Description
This commit skips integration testing papertrail.trace on MacOS because all MacOS hosts currently run outside of AWS. Hosts running outside of AWS cannot bypass corpsecure when talking to Papertrail. This will change in the future when we migrate MacOS hosts to AWS, but for now we should skip testing there and document that this is unsupported.

### Testing
This commit has no functional changes

### Documentation
I updated the Project-Commands docs file with this information
