### PR TITLE
DEVPROD-5317 Add otel tracing for host agent end task

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -771,6 +771,8 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status
 func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
 	deactivatePrevious bool) error {
+	ctx, span := tracer.Start(ctx, "mark-end")
+	defer span.End()
 
 	const slowThreshold = time.Second
 
@@ -1003,6 +1005,9 @@ func logTaskEndStats(ctx context.Context, t *task.Task) error {
 // each parent dependency as unattainable in depending tasks. It updates the
 // status of builds as well, in case they change due to blocking dependencies.
 func UpdateBlockedDependencies(ctx context.Context, t *task.Task) error {
+	ctx, span := tracer.Start(ctx, "update-blocked-dependencies")
+	defer span.End()
+
 	dependentTasks, err := t.FindAllUnmarkedBlockedDependencies()
 	if err != nil {
 		return errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
@@ -1561,6 +1566,9 @@ func updateBuildGithubStatus(b *build.Build, buildTasks []task.Task) error {
 // checkUpdateBuildPRStatusPending checks if the build is coming from a PR, and if so
 // sends a pending status to GitHub to reflect the status of the build.
 func checkUpdateBuildPRStatusPending(ctx context.Context, b *build.Build) error {
+	ctx, span := tracer.Start(ctx, "check-update-build-pr-status-pending")
+	defer span.End()
+
 	if !evergreen.IsGitHubPatchRequester(b.Requester) {
 		return nil
 	}
@@ -1834,6 +1842,9 @@ func UpdatePatchStatus(p *patch.Patch, status string) error {
 // and the task's version based on all the builds in the version.
 // Also update build and version Github statuses based on the subset of tasks and builds included in github checks
 func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error {
+	ctx, span := tracer.Start(ctx, "save-builds-and-tasks")
+	defer span.End()
+
 	taskBuild, err := build.FindOneId(t.BuildId)
 	if err != nil {
 		return errors.Wrapf(err, "getting build for task '%s'", t.Id)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -23,8 +23,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 type StatusChanges struct {
@@ -773,9 +771,7 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status
 func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
 	deactivatePrevious bool) error {
-	ctx, span := tracer.Start(ctx, "mark-end", trace.WithAttributes(
-		attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution),
-	))
+	ctx, span := tracer.Start(ctx, "mark-end")
 	defer span.End()
 
 	const slowThreshold = time.Second

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -23,6 +23,8 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type StatusChanges struct {
@@ -771,7 +773,9 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 // MarkEnd updates the task as being finished, performs a stepback if necessary, and updates the build status
 func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, caller string, finishTime time.Time, detail *apimodels.TaskEndDetail,
 	deactivatePrevious bool) error {
-	ctx, span := tracer.Start(ctx, "mark-end")
+	ctx, span := tracer.Start(ctx, "mark-end", trace.WithAttributes(
+		attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution),
+	))
 	defer span.End()
 
 	const slowThreshold = time.Second

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1262,6 +1262,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
+	span.SetAttributes(attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution))
 	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{
 		attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution),
 	})

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1262,7 +1262,9 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
-	span.SetAttributes(attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution))
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{
+		attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution),
+	})
 
 	currentHost, err := host.FindOneId(ctx, h.hostID)
 	if err != nil {

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1262,6 +1262,8 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
+	span.SetAttributes(attribute.Int(evergreen.TaskExecutionOtelAttribute, t.Execution))
+
 	currentHost, err := host.FindOneId(ctx, h.hostID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting host"))

--- a/rest/route/otel.go
+++ b/rest/route/otel.go
@@ -1,0 +1,12 @@
+package route
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/route")
+
+var tracer = otel.GetTracerProvider().Tracer(packageName)

--- a/rest/route/otel.go
+++ b/rest/route/otel.go
@@ -7,6 +7,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/route")
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/rest/route")
 
 var tracer = otel.GetTracerProvider().Tracer(packageName)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -520,6 +520,9 @@ func getFile(ctx context.Context, token, owner, repo, path, ref string) (*github
 // SendPendingStatusToGithub sends a pending status to a Github PR patch
 // associated with a given version.
 func SendPendingStatusToGithub(ctx context.Context, input SendGithubStatusInput, urlBase string) error {
+	ctx, span := tracer.Start(ctx, "send-pending-status-to-github")
+	defer span.End()
+
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving admin settings")


### PR DESCRIPTION
DEVPROD-5317

### Description
add tracing for host agent end task

### Testing
https://ui.honeycomb.io/mongodb-4b/environments/staging/result/tC3ag9ShgWA/trace/hBoQnTFVri6?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&source=query&span=86644ab9b12567ab

tested on honeycomb