### PR TITLE
DEVPROD-5783 use the sdk's default queue size

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -42,7 +42,6 @@ const (
 	packageName    = "github.com/evergreen-ci/evergreen/agent"
 	traceSuffix    = "build/OTelTraces"
 	maxLineSize    = 1024 * 1024
-	batchSize      = 1500
 
 	cpuTimeInstrumentPrefix = "system.cpu.time"
 	cpuUtilInstrument       = "system.cpu.utilization"
@@ -378,7 +377,7 @@ func (a *Agent) uploadTraces(ctx context.Context, taskDir string) error {
 			continue
 		}
 
-		spanBatches := batchSpans(resourceSpans, batchSize)
+		spanBatches := batchSpans(resourceSpans, sdktrace.DefaultMaxExportBatchSize)
 		for _, batch := range spanBatches {
 			if err = client.UploadTraces(ctx, batch); err != nil {
 				catcher.Wrapf(err, "uploading traces for '%s'", fileName)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-12-C"
+	AgentVersion = "2024-04-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[DEVPROD-5783](https://jira.mongodb.org/browse/DEVPROD-5783)

### Description
Even with batching we're still over the gRPC limit sometimes. Let's use the same batch size as the SDK batch processor.