### PR TITLE
DEVPROD-5980 Add SetGithubAppCredentials to ProjectRef struct

### DIFF
--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -53,7 +53,7 @@ func HasGithubAppAuth(projectId string) (bool, error) {
 }
 
 // Upsert inserts or updates the app auth for the given project id in the database
-func (githubAppAuth GithubAppAuth) Upsert() error {
+func (githubAppAuth *GithubAppAuth) Upsert() error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -53,7 +53,7 @@ func HasGithubAppAuth(projectId string) (bool, error) {
 }
 
 // Upsert inserts or updates the app auth for the given project id in the database
-func (githubAppAuth *GithubAppAuth) Upsert() error {
+func (githubAppAuth GithubAppAuth) Upsert() error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -610,7 +610,7 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 // GithubAppAuth for the project ref. If the provided values
 // are empty, the entry is deleted.
 func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) error {
-	if appID == 0 || len(privateKey) == 0 {
+	if appID == 0 || privateKey == nil || len(privateKey) == 0 {
 		return RemoveGithubAppAuth(p.Id)
 	}
 	return GithubAppAuth{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -606,6 +606,20 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 	return err
 }
 
+// SetGitHubAppCredentials updates or creates an entry in
+// GithubAppAuth for the project ref. If the provided values
+// are empty, the entry is deleted.
+func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) error {
+	if appID == 0 || len(privateKey) == 0 {
+		return RemoveGithubAppAuth(p.Id)
+	}
+	return GithubAppAuth{
+		Id:         p.Id,
+		AppId:      appID,
+		PrivateKey: privateKey,
+	}.Upsert()
+}
+
 // AddToRepoScope validates that the branch can be attached to the matching repo,
 // adds the branch to the unrestricted branches under repo scope, and
 // adds repo view permission for branch admins, and adds branch edit access for repo admins.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -610,14 +610,18 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 // GithubAppAuth for the project ref. If the provided values
 // are empty, the entry is deleted.
 func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) error {
-	if appID == 0 || privateKey == nil || len(privateKey) == 0 {
-		return RemoveGithubAppAuth(p.Id)
+	if appID == 0 || len(privateKey) == 0 {
+		if appID == 0 && len(privateKey) == 0 {
+			return RemoveGithubAppAuth(p.Id)
+		}
+		return errors.New("both app ID and private key must be provided")
 	}
-	return GithubAppAuth{
+	auth := GithubAppAuth{
 		Id:         p.Id,
 		AppId:      appID,
 		PrivateKey: privateKey,
-	}.Upsert()
+	}
+	return auth.Upsert()
 }
 
 // AddToRepoScope validates that the branch can be attached to the matching repo,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -610,10 +610,11 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 // GithubAppAuth for the project ref. If the provided values
 // are empty, the entry is deleted.
 func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) error {
+	if appID == 0 && len(privateKey) == 0 {
+		return RemoveGithubAppAuth(p.Id)
+	}
+
 	if appID == 0 || len(privateKey) == 0 {
-		if appID == 0 && len(privateKey) == 0 {
-			return RemoveGithubAppAuth(p.Id)
-		}
 		return errors.New("both app ID and private key must be provided")
 	}
 	auth := GithubAppAuth{

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1374,7 +1374,7 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, hasApp)
 		},
-		"CredentialsCanBeRemovedByEmptyAppID": func(t *testing.T, p *ProjectRef) {
+		"CredentialsCanBeRemovedByEmptyAppIDAndEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
 			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
 			hasApp, err := HasGithubAppAuth(p.Id)
@@ -1382,12 +1382,25 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			assert.True(t, hasApp)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(0, []byte("private_key")))
+			require.NoError(t, p.SetGithubAppCredentials(0, []byte("")))
 			hasApp, err = HasGithubAppAuth(p.Id)
 			require.NoError(t, err)
 			assert.False(t, hasApp)
 		},
-		"CredentialsCanBeRemovedByEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
+		"CredentialsCanBeRemovedByEmptyAppIDAndNilPrivateKey": func(t *testing.T, p *ProjectRef) {
+			// Add credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.True(t, hasApp)
+
+			// Remove credentials.
+			require.NoError(t, p.SetGithubAppCredentials(0, nil))
+			hasApp, err = HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.False(t, hasApp)
+		},
+		"CredentialsCannotBeRemovedByOnlyEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
 			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
 			hasApp, err := HasGithubAppAuth(p.Id)
@@ -1397,10 +1410,10 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			// Remove credentials.
 			require.NoError(t, p.SetGithubAppCredentials(10, []byte("")))
 			hasApp, err = HasGithubAppAuth(p.Id)
-			require.NoError(t, err)
+			require.Error(t, err, "both app ID and private key must be provided")
 			assert.False(t, hasApp)
 		},
-		"CredentialsCanBeRemovedByNilPrivateKey": func(t *testing.T, p *ProjectRef) {
+		"CredentialsCannotBeRemovedByOnlyNilPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
 			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
 			hasApp, err := HasGithubAppAuth(p.Id)
@@ -1410,7 +1423,20 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			// Remove credentials.
 			require.NoError(t, p.SetGithubAppCredentials(10, nil))
 			hasApp, err = HasGithubAppAuth(p.Id)
+			require.Error(t, err, "both app ID and private key must be provided")
+			assert.False(t, hasApp)
+		},
+		"CredentialsCannotBeRemovedByOnlyEmptyAppID": func(t *testing.T, p *ProjectRef) {
+			// Add credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
 			require.NoError(t, err)
+			assert.True(t, hasApp)
+
+			// Remove credentials.
+			require.NoError(t, p.SetGithubAppCredentials(0, []byte("private_key")))
+			hasApp, err = HasGithubAppAuth(p.Id)
+			require.Error(t, err, "both app ID and private key must be provided")
 			assert.False(t, hasApp)
 		},
 	} {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1408,10 +1408,7 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			assert.True(t, hasApp)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(10, []byte("")))
-			hasApp, err = HasGithubAppAuth(p.Id)
-			require.Error(t, err, "both app ID and private key must be provided")
-			assert.False(t, hasApp)
+			require.Error(t, p.SetGithubAppCredentials(10, []byte("")), "both app ID and private key must be provided")
 		},
 		"CredentialsCannotBeRemovedByOnlyNilPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
@@ -1421,10 +1418,7 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			assert.True(t, hasApp)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(10, nil))
-			hasApp, err = HasGithubAppAuth(p.Id)
-			require.Error(t, err, "both app ID and private key must be provided")
-			assert.False(t, hasApp)
+			require.Error(t, p.SetGithubAppCredentials(10, nil), "both app ID and private key must be provided")
 		},
 		"CredentialsCannotBeRemovedByOnlyEmptyAppID": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
@@ -1434,10 +1428,7 @@ func TestSetGithubAppCredentials(t *testing.T) {
 			assert.True(t, hasApp)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(0, []byte("private_key")))
-			hasApp, err = HasGithubAppAuth(p.Id)
-			require.Error(t, err, "both app ID and private key must be provided")
-			assert.False(t, hasApp)
+			require.Error(t, p.SetGithubAppCredentials(0, []byte("private_key")), "both app ID and private key must be provided")
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1361,6 +1361,70 @@ func TestFindProjectRefsByRepoAndBranch(t *testing.T) {
 	assert.Len(projectRefs, 2)
 }
 
+func TestSetGithubAppCredentials(t *testing.T) {
+	for name, test := range map[string]func(t *testing.T, p *ProjectRef){
+		"NoCredentialsWhenNoneExist": func(t *testing.T, p *ProjectRef) {
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.False(t, hasApp)
+		},
+		"CredentialsCanBeSet": func(t *testing.T, p *ProjectRef) {
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.True(t, hasApp)
+		},
+		"CredentialsCanBeRemovedByEmptyAppID": func(t *testing.T, p *ProjectRef) {
+			// Add credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.True(t, hasApp)
+
+			// Remove credentials.
+			require.NoError(t, p.SetGithubAppCredentials(0, []byte("private_key")))
+			hasApp, err = HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.False(t, hasApp)
+		},
+		"CredentialsCanBeRemovedByEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
+			// Add credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.True(t, hasApp)
+
+			// Remove credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("")))
+			hasApp, err = HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.False(t, hasApp)
+		},
+		"CredentialsCanBeRemovedByNilPrivateKey": func(t *testing.T, p *ProjectRef) {
+			// Add credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, []byte("private_key")))
+			hasApp, err := HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.True(t, hasApp)
+
+			// Remove credentials.
+			require.NoError(t, p.SetGithubAppCredentials(10, nil))
+			hasApp, err = HasGithubAppAuth(p.Id)
+			require.NoError(t, err)
+			assert.False(t, hasApp)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(ProjectRefCollection, GitHubAppAuthCollection))
+			p := &ProjectRef{
+				Id: "id1",
+			}
+			require.NoError(t, p.Insert())
+			test(t, p)
+		})
+	}
+}
+
 func TestCreateNewRepoRef(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, user.Collection,
 		evergreen.ScopeCollection, ProjectVarsCollection, ProjectAliasCollection, evergreen.GitHubAppCollection))


### PR DESCRIPTION
DEVPROD-5980

### Description
This adds a SetGithubAppCredentials method receiver to the ProjectRef. This is designed to remove the entry for empty arguments because when we test for existence, we specifically test if an entry is in the database- not it's values.

### Testing
Unit testing