### PR TITLE
DEVPROD-2239 Fix bug that causes variants to not activate

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2288,8 +2288,9 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 		if buildStatus.BuildVariant != variant.Name || !buildStatus.Activated {
 			continue
 		}
-
-		return buildStatus.ActivateAt.Add(time.Minute * time.Duration(p.getBatchTimeForVariant(variant))), nil
+		if !buildStatus.ActivateAt.IsZero() {
+			return buildStatus.ActivateAt.Add(time.Minute * time.Duration(p.getBatchTimeForVariant(variant))), nil
+		}
 	}
 
 	return defaultRes, nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3383,3 +3383,44 @@ func TestSetContainerSecrets(t *testing.T) {
 		assert.Empty(t, dbProjRef.RepotrackerError)
 	})
 }
+
+func TestGetActivationTimeForVariant(t *testing.T) {
+	assert := assert.New(t)
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, VersionCollection))
+	projectRef := &ProjectRef{
+		Owner:      "mongodb",
+		Repo:       "mci",
+		Branch:     "main",
+		Enabled:    true,
+		Id:         "ident",
+		Identifier: "identifier",
+	}
+	assert.Nil(projectRef.Insert())
+
+	// set based on last activation time when no version is found
+	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
+	assert.NoError(err)
+	assert.NotZero(activationTime)
+
+	// set based on last activation time with a version
+	version := &Version{
+		Id:                  "v1",
+		Identifier:          "ident",
+		RevisionOrderNumber: 10,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		BuildVariants: []VersionBuildStatus{
+			{
+				BuildVariant: "bv",
+				BuildId:      "build",
+				ActivationStatus: ActivationStatus{
+					Activated: true,
+				},
+			},
+		},
+	}
+	assert.Nil(version.Insert())
+
+	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
+	assert.NoError(err)
+	assert.NotZero(activationTime)
+}


### PR DESCRIPTION
DEVPROD-2239

### Description
There is a bug in GetActivationTimeForVariant that causes variants to not activate if the last version that had that variant activated did not have activate_at set. It ends up setting it to zero time when trying to add a zero batch size to zero time and then activating it.  

### Testing
added a unit test

This being the cause of 112 versions not being activated can be verified by searching for the build variant name [here](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1706128126&latest=1706300926.001&q=search%20index%3Devergreen%20created%20build%20%7C%20spath%20project_identifier%20%7C%20search%20project_identifier%3D%22atlasproxy%22%7C%20spath%20version%20%7C%20search%20version%3Datlasproxy_d31ea2aa83fef051b0e3b91ad9c70c2bd42aeb21&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=standard_perf&sid=1713299482.14193881) 
![image](https://github.com/evergreen-ci/evergreen/assets/13104717/3d3c3b06-f08d-4ff0-a25f-7b84d36f66cb)

 
and by searching the db for the version corresponding with VersionByLastVariantActivation for one of the versions that didn't activate the buildvariant: activate_at is omitted. 