### PR TITLE
DEVPROD-5990 Add RevokeInstallationToken and call it for internal functions that use a one time use token

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -353,9 +353,9 @@ func RevokeInstallationToken(ctx context.Context, token string) error {
 	defer span.End()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
-	_, err := githubClient.Apps.RevokeInstallationToken(ctx)
+	resp, err := githubClient.Apps.RevokeInstallationToken(ctx)
 
-	span.SetAttributes(attribute.Bool("success", err == nil))
+	span.SetAttributes(attribute.Int("status", resp.StatusCode))
 	if err != nil {
 		span.SetAttributes(attribute.String("err", err.Error()))
 	}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -344,6 +344,25 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 	return token, nil
 }
 
+// revokeInstallationToken revokes an installation token.
+func RevokeInstallationToken(ctx context.Context, token string) error {
+	caller := "RevokeInstallationToken"
+	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
+		attribute.String(githubEndpointAttribute, caller),
+	))
+	defer span.End()
+
+	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	_, err := githubClient.Apps.RevokeInstallationToken(ctx)
+
+	span.SetAttributes(attribute.Bool("success", err == nil))
+	if err != nil {
+		span.SetAttributes(attribute.String("err", err.Error()))
+	}
+
+	return err
+}
+
 func getInstallationTokenWithDefaultOwnerRepo(ctx context.Context, opts *github.InstallationTokenOptions) (string, error) {
 	settings, err := evergreen.GetConfig(ctx)
 	if err != nil {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -420,6 +420,7 @@ func getCommits(ctx context.Context, token, owner, repo, ref string, until time.
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -503,6 +504,7 @@ func getFile(ctx context.Context, token, owner, repo, path, ref string) (*github
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -663,6 +665,7 @@ func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, 
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -725,6 +728,7 @@ func commitEvent(ctx context.Context, token, owner, repo, githash string) (*gith
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -805,6 +809,7 @@ func commitDiff(ctx context.Context, token, owner, repo, sha string) (string, er
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -864,6 +869,7 @@ func branchEvent(ctx context.Context, token, owner, repo, branch string) (*githu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1059,6 +1065,7 @@ func taggedCommit(ctx context.Context, token, owner, repo, tag string) (string, 
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	ref, resp, err := githubClient.Git.GetRef(ctx, owner, repo, tag)
@@ -1112,6 +1119,7 @@ func getObjectTag(ctx context.Context, token, owner, repo, sha string) (*github.
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1164,6 +1172,7 @@ func userInTeam(ctx context.Context, token string, teams []string, org, user, ow
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1272,6 +1281,7 @@ func apiLimit(ctx context.Context, token string) (int64, error) {
 		if err != nil {
 			return 0, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1325,6 +1335,7 @@ func getUser(ctx context.Context, token, loginName string) (*github.User, error)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1377,6 +1388,7 @@ func userInOrganization(ctx context.Context, token, requiredOrganization, userna
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1421,6 +1433,7 @@ func authorizedForOrg(ctx context.Context, token, requiredOrganization, name str
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1491,6 +1504,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1545,6 +1559,7 @@ func getPRMergeBase(ctx context.Context, token string, data GithubPatch) (string
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1594,6 +1609,7 @@ func getCommit(ctx context.Context, token, owner, repo, sha string) (*github.Rep
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1646,6 +1662,7 @@ func getPullRequest(ctx context.Context, token, baseOwner, baseRepo string, prNu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1695,6 +1712,7 @@ func pullRequestDiff(ctx context.Context, token string, gh GithubPatch) (string,
 		if err != nil {
 			return "", nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1922,6 +1940,7 @@ func postComment(ctx context.Context, token, owner, repo string, prNum int, comm
 		if err != nil {
 			return errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 
@@ -1978,6 +1997,7 @@ func GetBranchProtectionRules(ctx context.Context, token, owner, repo, branch st
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
+		defer RevokeInstallationToken(ctx, token)
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 
@@ -2036,6 +2056,7 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
+	defer RevokeInstallationToken(ctx, token)
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -2093,6 +2114,7 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
+	defer RevokeInstallationToken(ctx, token)
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	checkRun, resp, err := githubClient.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, updateOpts)
@@ -2158,6 +2180,7 @@ func ListCheckRunCheckSuite(ctx context.Context, owner, repo string, checkSuiteI
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
+	defer RevokeInstallationToken(ctx, token)
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	listCheckRunsResult, resp, err := githubClient.Checks.ListCheckRunsCheckSuite(ctx, owner, repo, checkSuiteID, nil)
@@ -2189,6 +2212,7 @@ func GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*gi
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
+	defer RevokeInstallationToken(ctx, token)
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	checkRun, resp, err := githubClient.Checks.GetCheckRun(ctx, owner, repo, checkRunID)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -420,7 +420,7 @@ func getCommits(ctx context.Context, token, owner, repo, ref string, until time.
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -504,7 +504,7 @@ func getFile(ctx context.Context, token, owner, repo, path, ref string) (*github
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -665,7 +665,7 @@ func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, 
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -728,7 +728,7 @@ func commitEvent(ctx context.Context, token, owner, repo, githash string) (*gith
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -809,7 +809,7 @@ func commitDiff(ctx context.Context, token, owner, repo, sha string) (string, er
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -869,7 +869,7 @@ func branchEvent(ctx context.Context, token, owner, repo, branch string) (*githu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1065,7 +1065,7 @@ func taggedCommit(ctx context.Context, token, owner, repo, tag string) (string, 
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	ref, resp, err := githubClient.Git.GetRef(ctx, owner, repo, tag)
@@ -1119,7 +1119,7 @@ func getObjectTag(ctx context.Context, token, owner, repo, sha string) (*github.
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1172,7 +1172,7 @@ func userInTeam(ctx context.Context, token string, teams []string, org, user, ow
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1281,7 +1281,7 @@ func apiLimit(ctx context.Context, token string) (int64, error) {
 		if err != nil {
 			return 0, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1335,7 +1335,7 @@ func getUser(ctx context.Context, token, loginName string) (*github.User, error)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1388,7 +1388,7 @@ func userInOrganization(ctx context.Context, token, requiredOrganization, userna
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1433,7 +1433,7 @@ func authorizedForOrg(ctx context.Context, token, requiredOrganization, name str
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -1504,7 +1504,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1559,7 +1559,7 @@ func getPRMergeBase(ctx context.Context, token string, data GithubPatch) (string
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1609,7 +1609,7 @@ func getCommit(ctx context.Context, token, owner, repo, sha string) (*github.Rep
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1662,7 +1662,7 @@ func getPullRequest(ctx context.Context, token, baseOwner, baseRepo string, prNu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1712,7 +1712,7 @@ func pullRequestDiff(ctx context.Context, token string, gh GithubPatch) (string,
 		if err != nil {
 			return "", nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 
@@ -1940,7 +1940,7 @@ func postComment(ctx context.Context, token, owner, repo string, prNum int, comm
 		if err != nil {
 			return errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 
@@ -1997,7 +1997,7 @@ func GetBranchProtectionRules(ctx context.Context, token, owner, repo, branch st
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer RevokeInstallationToken(ctx, token)
+		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 
@@ -2056,7 +2056,7 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer RevokeInstallationToken(ctx, token)
+	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 
@@ -2114,7 +2114,7 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer RevokeInstallationToken(ctx, token)
+	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	checkRun, resp, err := githubClient.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, updateOpts)
@@ -2180,7 +2180,7 @@ func ListCheckRunCheckSuite(ctx context.Context, owner, repo string, checkSuiteI
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer RevokeInstallationToken(ctx, token)
+	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	listCheckRunsResult, resp, err := githubClient.Checks.ListCheckRunsCheckSuite(ctx, owner, repo, checkSuiteID, nil)
@@ -2212,7 +2212,7 @@ func GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*gi
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer RevokeInstallationToken(ctx, token)
+	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	checkRun, resp, err := githubClient.Checks.GetCheckRun(ctx, owner, repo, checkRunID)

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -163,6 +163,20 @@ func (s *githubSuite) TestGetGithubCommitsUntil() {
 	s.Len(githubCommits, 4)
 }
 
+func (s *githubSuite) TestRevokeInstallationToken() {
+	token, err := getInstallationToken(s.ctx, "evergreen-ci", "evergreen", nil)
+	s.NoError(err)
+	s.NotEmpty(token)
+
+	// Revoking the first time should succeed.
+	err = RevokeInstallationToken(s.ctx, token)
+	s.NoError(err)
+
+	// Revoking the second time should fail.
+	err = RevokeInstallationToken(s.ctx, token)
+	s.Error(err)
+}
+
 func (s *githubSuite) TestGetTaggedCommitFromGithub() {
 	s.Run("AnnotatedTag", func() {
 		commit, err := GetTaggedCommitFromGithub(s.ctx, s.token, "evergreen-ci", "spruce", "refs/tags/v3.0.97")

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -164,7 +164,7 @@ func (s *githubSuite) TestGetGithubCommitsUntil() {
 }
 
 func (s *githubSuite) TestRevokeInstallationToken() {
-	token, err := getInstallationToken(s.ctx, "evergreen-ci", "evergreen", nil)
+	token, err := getInstallationToken(s.ctx, "evergreen-ci", "sample", nil)
 	s.NoError(err)
 	s.NotEmpty(token)
 


### PR DESCRIPTION
DEVPROD-5990

### Description
This adds a `RevokeInstallationToken` which has some basic honeycomb tracking. As well, makes other functions that generate a token and use it only through the lifetime of that function, to also call and revoke those tokens as an added security measure. The error returned in this instance is ignored since it's not _vital_ we revoke it but a nice to have- the honeycomb span also tracks if it was actually revoked but only so that we can maybe later query for success rate.

### Testing
Unit testing
