### PR TITLE
DEVPROD-6168 Retrieve OOM details only after it's been checked

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -942,7 +942,7 @@ func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status 
 	return false, errors.WithStack(err)
 }
 
-func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, status string) {
+func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail, status string) {
 	if tc.hadTimedOut() && ctx.Err() == nil {
 		status = evergreen.TaskFailed
 		a.runTaskTimeoutCommands(ctx, tc)
@@ -953,9 +953,13 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, status
 		oomCtx, oomCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer oomCancel()
 		tc.logger.Execution().Error(errors.Wrap(tc.oomTracker.Check(oomCtx), "checking for OOM killed processes"))
-		if lines, _ := tc.oomTracker.Report(); len(lines) > 0 {
+		if lines, pids := tc.oomTracker.Report(); len(lines) > 0 {
 			tc.logger.Execution().Debugf("Found an OOM kill (in %.3f seconds).", time.Since(startTime).Seconds())
 			tc.logger.Execution().Debug(strings.Join(lines, "\n"))
+			detail.OOMTracker = &apimodels.OOMTrackerInfo{
+				Detected: true,
+				Pids:     pids,
+			}
 		} else {
 			tc.logger.Execution().Debugf("Found no OOM kill (in %.3f seconds).", time.Since(startTime).Seconds())
 		}
@@ -968,7 +972,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	detail := a.endTaskResponse(ctx, tc, status, systemFailureDescription)
 	switch detail.Status {
 	case evergreen.TaskSucceeded:
-		a.handleTimeoutAndOOM(ctx, tc, status)
+		a.handleTimeoutAndOOM(ctx, tc, detail, status)
 		tc.logger.Task().Info("Task completed - SUCCESS.")
 		if err := a.runPostOrTeardownTaskCommands(ctx, tc); err != nil {
 			tc.logger.Task().Info("Post task completed - FAILURE. Overall task status changed to FAILED.")
@@ -977,7 +981,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		detail.PostErrored = tc.getPostErrored()
 		a.runEndTaskSync(ctx, tc, detail)
 	case evergreen.TaskFailed:
-		a.handleTimeoutAndOOM(ctx, tc, status)
+		a.handleTimeoutAndOOM(ctx, tc, detail, status)
 		tc.logger.Task().Info("Task completed - FAILURE.")
 		// If the post commands error, ignore the error. runCommandsInBlock
 		// already logged the error, and the post commands cannot cause the
@@ -1129,7 +1133,6 @@ func (a *Agent) endTaskResponse(ctx context.Context, tc *taskContext, status str
 	}
 
 	detail := &apimodels.TaskEndDetail{
-		OOMTracker:  tc.getOomTrackerInfo(),
 		TraceID:     tc.traceID,
 		DiskDevices: tc.diskDevices,
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1232,7 +1232,7 @@ tasks:
    commands: 
     - command: shell.exec
       params:
-        script: exit 0
+        script: exit 1
 post:
   - command: shell.exec
     params:
@@ -1253,7 +1253,7 @@ post:
 	}
 	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
 	s.NoError(err)
-	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
 	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
 	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
 }

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -153,18 +153,6 @@ func (tc *taskContext) hadTimedOut() bool {
 	return tc.timedOut()
 }
 
-func (tc *taskContext) getOomTrackerInfo() *apimodels.OOMTrackerInfo {
-	lines, pids := tc.oomTracker.Report()
-	if len(lines) == 0 {
-		return nil
-	}
-
-	return &apimodels.OOMTrackerInfo{
-		Detected: true,
-		Pids:     pids,
-	}
-}
-
 func (tc *taskContext) oomTrackerEnabled(cloudProvider string) bool {
 	return tc.taskConfig.Project.OomTracker && !utility.StringSliceContains(evergreen.ProviderContainer, cloudProvider)
 }

--- a/agent/task_context_test.go
+++ b/agent/task_context_test.go
@@ -13,16 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetOomTrackerInfo(t *testing.T) {
+func TestGetOomTrackerReport(t *testing.T) {
 	tc := taskContext{oomTracker: jasper.NewOOMTracker()}
-	info := tc.getOomTrackerInfo()
-	assert.Nil(t, info)
+	lines, pids := tc.oomTracker.Report()
+	assert.Empty(t, lines)
+	assert.Empty(t, pids)
 
 	tc.oomTracker = &mock.OOMTracker{Lines: []string{"line1", "line2", "line3"}, PIDs: []int{1, 2, 3}}
-	info = tc.getOomTrackerInfo()
-	assert.NotNil(t, info)
-	assert.True(t, info.Detected)
-	assert.Equal(t, []int{1, 2, 3}, info.Pids)
+	lines, pids = tc.oomTracker.Report()
+	assert.NotEmpty(t, lines)
+	assert.NotEmpty(t, pids)
+	assert.Equal(t, []int{1, 2, 3}, pids)
 }
 
 func TestGetDeviceNames(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-16"
+	AgentVersion = "2024-04-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-6168

### Description
The OOM tracker is currently broken because the oom tracker's [Check](https://github.com/mongodb/jasper/blob/main/oom_tracker_linux.go#L26) function must run before [Report](https://github.com/mongodb/jasper/blob/main/oom_tracker.go#L25) runs, and when we set it as part of the [end task details](https://github.com/evergreen-ci/evergreen/blob/main/agent/agent.go#L1132), this generates a Jasper report before check has a chance to run, meaning it's always empty. This PR sets the OOM details after the check for OOM lines and pids is run.
### Testing
Hard coded an OOM kill into Jasper, and confirmed that [before](https://spruce-staging.corp.mongodb.com/task/sandbox_git_env_test_test_restart_on_fail_6620152e4761ed0007f44d6e_24_04_17_18_30_06/logs?execution=1&logtype=agent) the change, no OOM shows up in the UI, and [after](https://spruce-staging.corp.mongodb.com/task/sandbox_git_env_test_test_restart_on_fail_6620152e4761ed0007f44d6e_24_04_17_18_30_06/logs?execution=2&logtype=agent) the change an OOM is set as expected.
