### PR TITLE
DEVPROD-5173 Require build variant to select at least one task rather than each selector

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -883,7 +883,9 @@ buildvariants:
 ```
 
 Tags can be referenced in variant definitions to quickly include groups
-of tasks.
+of tasks. The build variant will only be considered invalid if _all_
+tag selectors and tasks are invalid/not found, if an individual tag
+selector has not tasks, it will be ignored.
 
 ``` yaml
 buildvariants:

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1305,6 +1305,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 	for _, t := range tasks {
 		tasksByName[t.Name] = t
 	}
+	var allNames []string
 	for _, pbvt := range pbv.Tasks {
 		// Evaluate each task against both the task and task group selectors
 		// only error if both selectors error because each task should only be found
@@ -1330,9 +1331,11 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 			}
 			if err1 != nil && err2 != nil {
 				evalErrs = append(evalErrs, err1, err2)
+				allNames = append(allNames, names...)
 				continue
 			}
 		}
+		allNames = append(allNames, names...)
 		// create new task definitions--duplicates must have the same status requirements
 		for _, name := range names {
 			parserTask := tasksByName[name]
@@ -1369,6 +1372,9 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 				}
 			}
 		}
+	}
+	if len(allNames) == 0 {
+		evalErrs = append(evalErrs, errors.Errorf("no tasks found for build variant '%s'", pbv.Name))
 	}
 	return ts, evalErrs
 }

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -172,9 +172,6 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
 			results = utility.StringSliceIntersection(results, names)
 		}
 	}
-	if len(results) == 0 {
-		return nil, errors.Errorf("nothing satisfies selector '%v'", s)
-	}
 	return results, nil
 }
 


### PR DESCRIPTION
DEVPROD-5173

### Description
Right now, our selectors validate at a per-line level, which means that if a selector results in 0 tasks -> validation error. This changes our validation to be a little more loose, allowing a single line to result in no tasks but not allowing a build variant to result in no tasks.

### Testing
Existing unit tests, added a unit test (running this against main it fails), and tested this small reproducable config:

```
buildvariants:
    - display_name: test this
      name: test-this
      run_on:
          - ubuntu2204-large
      tasks:
          - name: .release_critical .requires_large_host
          - name: .release_critical !.requires_large_host

tasks:
    - name: first-task
      tags: [release_critical, requires_large_host]
    - name: another-task
      tags: [release_critical, requires_large_host]
  ```

Running this against prod results in the `nothing satisfies selector '.release_critical !.requires_large_host'`, while running this against staging (and this is a CLI change, so building too) it does not result in an error.

If you comment out the first selector line (the one with .release_critical .requires_large_host) so that the build-variant will have no tasks, it will produce the error `ERROR: load project error(s): error translating project: no tasks found for build variant 'test-this'`

I also tested this with depends_on just to make sure existing functionality is not effected.

### Documentation
I added some docs explaining it but it might be convoluted, so please let me know if the wording can be improved!
