### PR TITLE
DEVPROD-4234 Switch sha256sum to shasum available on macos by default

### DIFF
--- a/makefile
+++ b/makefile
@@ -202,7 +202,7 @@ $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 	@touch $@
 $(buildDir)/golangci-lint:
 	@curl $(curlRetryOpts) -o "$(buildDir)/install.sh" https://raw.githubusercontent.com/golangci/golangci-lint/$(goLintInstallerVersion)/install.sh
-	@echo "$(goLintInstallerChecksum) $(buildDir)/install.sh" | sha256sum --check
+	@echo "$(goLintInstallerChecksum) $(buildDir)/install.sh" | openssl dgst -sha256
 	@bash $(buildDir)/install.sh -b $(buildDir) $(goLintInstallerVersion) && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	$(gobin) build -ldflags "-w" -o $@ $<

--- a/makefile
+++ b/makefile
@@ -202,7 +202,7 @@ $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 	@touch $@
 $(buildDir)/golangci-lint:
 	@curl $(curlRetryOpts) -o "$(buildDir)/install.sh" https://raw.githubusercontent.com/golangci/golangci-lint/$(goLintInstallerVersion)/install.sh
-	@echo "$(goLintInstallerChecksum) $(buildDir)/install.sh" | openssl dgst -sha256
+	@echo "$(goLintInstallerChecksum) *$(buildDir)/install.sh" | shasum --check
 	@bash $(buildDir)/install.sh -b $(buildDir) $(goLintInstallerVersion) && touch $@
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup
 	$(gobin) build -ldflags "-w" -o $@ $<


### PR DESCRIPTION
DEVPROD-4234

### Description
Our `make lint-*` had a [security bump last March](https://github.com/evergreen-ci/evergreen/pull/6315#issue-1621703690) and added a package dependency `sha256sum`. The same thing can be done using `shasum` which is on every macos host (which most of the Evergreen team uses).

### Testing
Running make lint-graphql, make lint-model, and it passing the download/install step (I also made sure it is actually comparing the SHA by editing the `goLintINstallerChecksum` variable and it failing).