### PR TITLE
DEVPROD-3949: handle special cases in sleep schedule

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -78,8 +78,10 @@ func (c instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen
 }
 
 type EC2FleetManagerOptions struct {
-	client         AWSClient
-	region         string
+	client AWSClient
+	region string
+	// kim: TODO: remove providerKey and providerSecret because both are dead
+	// fields.
 	providerKey    string
 	providerSecret string
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -78,10 +78,8 @@ func (c instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen
 }
 
 type EC2FleetManagerOptions struct {
-	client AWSClient
-	region string
-	// kim: TODO: remove providerKey and providerSecret because both are dead
-	// fields.
+	client         AWSClient
+	region         string
 	providerKey    string
 	providerSecret string
 }

--- a/globals.go
+++ b/globals.go
@@ -971,6 +971,15 @@ var (
 		HostStopped,
 	}
 
+	// SleepScheduleStatuses are all host statuses for which the sleep schedule
+	// can take effect. If it's not in one of these states, the sleep schedule
+	// does not apply.
+	SleepScheduleStatuses = []string{
+		HostRunning,
+		HostStopped,
+		HostStopping,
+	}
+
 	// Set of host status values that can be user set via the API
 	ValidUserSetHostStatus = []string{
 		HostRunning,

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1520,7 +1520,9 @@ func isSleepScheduleEnabledQuery(q bson.M, now time.Time) bson.M {
 	sleepScheduleShouldKeepOff := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleShouldKeepOffKey)
 
 	if _, ok := q[StatusKey]; !ok {
-		q[StatusKey] = bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopped, evergreen.HostStopping}}
+		// Use all sleep schedule statuses if the query hasn't already specified
+		// a more specific set of statuses.
+		q[StatusKey] = bson.M{"$in": evergreen.SleepScheduleStatuses}
 	}
 
 	q[sleepSchedulePermanentlyExemptKey] = bson.M{"$ne": true}
@@ -1622,7 +1624,6 @@ func FindExceedsSleepScheduleTimeout(ctx context.Context) ([]Host, error) {
 	sleepScheduleNextStartKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
 	sleepScheduleNextStopKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
 	q := isSleepScheduleEnabledQuery(bson.M{
-		StatusKey: bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopped, evergreen.HostStopping}},
 		"$or": []bson.M{
 			{
 				sleepScheduleNextStartKey: bson.M{"$lte": now.Add(-SleepScheduleActionTimeout)},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1496,31 +1496,71 @@ func FindUnexpirableRunningWithoutPersistentDNSName(ctx context.Context, limit i
 	}, options.Find().SetLimit(int64(limit)))
 }
 
-// FindHostsScheduledToStop finds all unepxirable hosts that are due to stop due to their sleep
-// schedule settings.
-func FindHostsScheduledToStop(ctx context.Context) ([]Host, error) {
-	now := time.Now()
-	sleepScheduleNextStopKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
+// isSleepScheduleApplicable returns a query that finds hosts which can use a
+// sleep schedule.
+func isSleepScheduleApplicable(q bson.M) bson.M {
+	if q == nil {
+		q = bson.M{}
+	}
+	q[StartedByKey] = bson.M{"$ne": evergreen.User}
+	q[NoExpirationKey] = true
+	return q
+}
+
+// isSleepScheduleEnabledQuery returns a query that finds unexpirable hosts for
+// which the sleep schedule should take effect.
+func isSleepScheduleEnabledQuery(q bson.M, now time.Time) bson.M {
+	if q == nil {
+		q = bson.M{}
+	}
+
+	q = isSleepScheduleApplicable(q)
 	sleepSchedulePermanentlyExemptKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepSchedulePermanentlyExemptKey)
 	sleepScheduleTemporarilyExemptUntil := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
 	sleepScheduleShouldKeepOff := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleShouldKeepOffKey)
 
-	return Find(ctx, bson.M{
-		StatusKey:                         bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopping}},
-		StartedByKey:                      bson.M{"$ne": evergreen.User},
-		NoExpirationKey:                   true,
-		sleepScheduleNextStopKey:          bson.M{"$lte": now},
-		sleepSchedulePermanentlyExemptKey: bson.M{"$ne": true},
-		"$or": []bson.M{
-			{
-				sleepScheduleTemporarilyExemptUntil: nil,
-			},
-			{
-				sleepScheduleTemporarilyExemptUntil: bson.M{"$lte": now},
-			},
+	if _, ok := q[StatusKey]; !ok {
+		q[StatusKey] = bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopped, evergreen.HostStopping}}
+	}
+
+	q[sleepSchedulePermanentlyExemptKey] = bson.M{"$ne": true}
+
+	notTemporarilyExempt := []bson.M{
+		{
+			sleepScheduleTemporarilyExemptUntil: nil,
 		},
-		sleepScheduleShouldKeepOff: bson.M{"$ne": true},
-	})
+		{
+			sleepScheduleTemporarilyExemptUntil: bson.M{"$lte": now},
+		},
+	}
+	if orClause, ok := q["$or"]; ok {
+		// Combine $or clauses in case there's multiple.
+		q["$and"] = []interface{}{
+			orClause,
+			bson.M{
+				"$or": notTemporarilyExempt,
+			},
+		}
+	} else {
+		q["$or"] = notTemporarilyExempt
+	}
+	q[sleepScheduleShouldKeepOff] = bson.M{"$ne": true}
+
+	return q
+}
+
+// FindHostsScheduledToStop finds all unepxirable hosts that are due to stop due to their sleep
+// schedule settings.
+func FindHostsScheduledToStop(ctx context.Context) ([]Host, error) {
+	now := time.Now()
+	sleepScheduleNextStopTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
+
+	q := isSleepScheduleEnabledQuery(bson.M{
+		StatusKey:                    bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopping}},
+		sleepScheduleNextStopTimeKey: bson.M{"$lte": now},
+	}, now)
+
+	return Find(ctx, q)
 }
 
 // PreStartThreshold is how long in advance Evergreen can check for hosts that
@@ -1531,29 +1571,16 @@ const PreStartThreshold = 5 * time.Minute
 // to their sleep schedule settings.
 func FindHostsScheduledToStart(ctx context.Context) ([]Host, error) {
 	now := time.Now()
-	sleepScheduleNextStartKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
-	sleepSchedulePermanentlyExemptKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepSchedulePermanentlyExemptKey)
-	sleepScheduleTemporarilyExemptUntil := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
-	sleepScheduleShouldKeepOff := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleShouldKeepOffKey)
+	sleepScheduleNextStartTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
 
-	return Find(ctx, bson.M{
-		StatusKey:       bson.M{"$in": []string{evergreen.HostStopped, evergreen.HostStopping}},
-		StartedByKey:    bson.M{"$ne": evergreen.User},
-		NoExpirationKey: true,
+	q := isSleepScheduleEnabledQuery(bson.M{
+		StatusKey: bson.M{"$in": []string{evergreen.HostStopped, evergreen.HostStopping}},
 		// Include hosts that are imminently about to reach their wakeup time to
 		// better ensure the host is running at the scheduled time.
-		sleepScheduleNextStartKey:         bson.M{"$lte": now.Add(PreStartThreshold)},
-		sleepSchedulePermanentlyExemptKey: bson.M{"$ne": true},
-		"$or": []bson.M{
-			{
-				sleepScheduleTemporarilyExemptUntil: nil,
-			},
-			{
-				sleepScheduleTemporarilyExemptUntil: bson.M{"$lte": now},
-			},
-		},
-		sleepScheduleShouldKeepOff: bson.M{"$ne": true},
-	})
+		sleepScheduleNextStartTimeKey: bson.M{"$lte": now.Add(PreStartThreshold)},
+	}, now)
+
+	return Find(ctx, q)
 }
 
 // setSleepSchedule sets the sleep schedule for a given host
@@ -1568,4 +1595,82 @@ func setSleepSchedule(ctx context.Context, hostId string, schedule SleepSchedule
 		return err
 	}
 	return nil
+}
+
+// kim: TODO: add tests
+// FindMissingNextSleepScheduleTime finds hosts that are subject to the sleep
+// schedule but are missing a next scheduled stop/start time.
+func FindMissingNextSleepScheduleTime(ctx context.Context) ([]Host, error) {
+	now := time.Now()
+	sleepScheduleNextStartTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
+	sleepScheduleNextStopTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
+	q := isSleepScheduleEnabledQuery(bson.M{
+		StatusKey: bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopped, evergreen.HostStopping}},
+		"$or": []bson.M{
+			{
+				sleepScheduleNextStartTimeKey: nil,
+			},
+			{
+				sleepScheduleNextStopTimeKey: nil,
+			},
+		},
+	}, now)
+	return Find(ctx, q)
+}
+
+const SleepScheduleActionTimeout = 30 * time.Minute
+
+// kim: TODO: add tests
+// FindMissingNextSleepScheduleTime finds hosts that are subject to the sleep
+// schedule and are scheduled to stop/start, but have taken too long to do so.
+func FindExceedsSleepScheduleActionTimeout(ctx context.Context) ([]Host, error) {
+	now := time.Now()
+	sleepScheduleNextStartTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
+	sleepScheduleNextStopTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
+	q := isSleepScheduleEnabledQuery(bson.M{
+		StatusKey: bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStopped, evergreen.HostStopping}},
+		"$or": []bson.M{
+			{
+				sleepScheduleNextStartTimeKey: bson.M{"$lte": now.Add(-SleepScheduleActionTimeout)},
+			},
+			{
+				sleepScheduleNextStopTimeKey: bson.M{"$lte": now.Add(-SleepScheduleActionTimeout)},
+			},
+		},
+	}, now)
+	return Find(ctx, q)
+}
+
+// kim: TODO: test
+// FindPermanentlyExemptSetDifference finds two sets of unexpirable hosts based
+// on the authoritative list of permanently exempt hosts. The function returns:
+//  1. Hosts that are on the list of permanent exemptions but are not marked as
+//     permanently exempt (i.e. should be marked as permanently exempt).
+//  2. Hosts that are marked as permanentl yexempt but are not on the list of
+//     permanent exemptions (i.e. should be marked as not permanently exempt).
+func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) error {
+	sleepSchedulePermanentlyExemptKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepSchedulePermanentlyExemptKey)
+
+	catcher := grip.NewBasicCatcher()
+	err := UpdateAll(ctx, isSleepScheduleApplicable(bson.M{
+		IdKey:                             bson.M{"$in": permanentlyExempt},
+		sleepSchedulePermanentlyExemptKey: bson.M{"$ne": true},
+	}), bson.M{
+		"$set": bson.M{
+			sleepSchedulePermanentlyExemptKey: true,
+		},
+	})
+	catcher.Wrap(err, "marking newly-added hosts as permanently exempt")
+
+	err = UpdateAll(ctx, isSleepScheduleApplicable(bson.M{
+		IdKey:                             bson.M{"$nin": permanentlyExempt},
+		sleepSchedulePermanentlyExemptKey: true,
+	}), bson.M{
+		"$set": bson.M{
+			sleepSchedulePermanentlyExemptKey: false,
+		},
+	})
+	catcher.Wrap(err, "marking newly-removed hosts as no longer permanently exempt")
+
+	return catcher.Resolve()
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -888,7 +888,13 @@ func (h *Host) SetStopped(ctx context.Context, shouldKeepOff bool, user string) 
 	}
 	if shouldKeepOff {
 		shouldKeepOffKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleShouldKeepOffKey)
+		sleepScheduleNextStartTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
+		sleepScheduleNextStopTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
 		setFields[shouldKeepOffKey] = true
+		// Zero out the next stop/start times because the sleep schedule should
+		// not take effect until the user starts the host again.
+		setFields[sleepScheduleNextStartTimeKey] = time.Time{}
+		setFields[sleepScheduleNextStopTimeKey] = time.Time{}
 	}
 	err := UpdateOne(
 		ctx,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -891,8 +891,6 @@ func (h *Host) SetStopped(ctx context.Context, shouldKeepOff bool, user string) 
 		sleepScheduleNextStartTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStartTimeKey)
 		sleepScheduleNextStopTimeKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleNextStopTimeKey)
 		setFields[shouldKeepOffKey] = true
-		// Zero out the next stop/start times because the sleep schedule should
-		// not take effect until the user starts the host again.
 		setFields[sleepScheduleNextStartTimeKey] = time.Time{}
 		setFields[sleepScheduleNextStopTimeKey] = time.Time{}
 	}
@@ -921,6 +919,10 @@ func (h *Host) SetStopped(ctx context.Context, shouldKeepOff bool, user string) 
 	h.Host = ""
 	h.StartTime = utility.ZeroTime
 	h.SleepSchedule.ShouldKeepOff = shouldKeepOff
+	if shouldKeepOff {
+		h.SleepSchedule.NextStartTime = time.Time{}
+		h.SleepSchedule.NextStopTime = time.Time{}
+	}
 
 	return nil
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -451,8 +451,10 @@ func TestSetStopped(t *testing.T) {
 			assert.Empty(t, dbHost.Host)
 			assert.True(t, utility.IsZeroTime(dbHost.StartTime))
 			assert.False(t, h.SleepSchedule.ShouldKeepOff)
+			assert.NotZero(t, h.SleepSchedule.NextStopTime, "next stop time should remain set on the host")
+			assert.NotZero(t, h.SleepSchedule.NextStartTime, "next start time should remain set on the host")
 		},
-		"SetsShouldKeepOff": func(ctx context.Context, t *testing.T, h *Host) {
+		"SetsShouldKeepOffAndClearsNextSleepScheduleTimes": func(ctx context.Context, t *testing.T, h *Host) {
 			require.NoError(t, h.Insert(ctx))
 
 			assert.NoError(t, h.SetStopped(ctx, true, ""))
@@ -467,6 +469,8 @@ func TestSetStopped(t *testing.T) {
 			assert.Empty(t, dbHost.Host)
 			assert.True(t, utility.IsZeroTime(dbHost.StartTime))
 			assert.True(t, dbHost.SleepSchedule.ShouldKeepOff)
+			assert.Zero(t, h.SleepSchedule.NextStopTime, "next stop time should be cleared on a host being kept off")
+			assert.Zero(t, h.SleepSchedule.NextStartTime, "next start time should be cleared on a host being kept off")
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -479,6 +483,10 @@ func TestSetStopped(t *testing.T) {
 				Status:    evergreen.HostRunning,
 				StartTime: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 				Host:      "host.mongodb.com",
+				SleepSchedule: SleepScheduleInfo{
+					NextStartTime: time.Now(),
+					NextStopTime:  time.Now(),
+				},
 			}
 			tCase(ctx, t, h)
 		})

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6601,23 +6601,23 @@ func TestGetNextScheduledStopTime(t *testing.T) {
 			assert.Equal(t, expectedOffsetSecs, tzOffset, "next stop time should be in EDT rather than EST")
 			assert.Equal(t, s.TimeZone, nextStop.Location().String(), "next stop time should be specified in the user's time zone")
 		},
-		"ReturnsSentinelTimeForPermanentlyExemptHost": func(t *testing.T) {
+		"ReturnsZeroTimeForPermanentlyExemptHost": func(t *testing.T) {
 			s := SleepScheduleInfo{
 				WholeWeekdaysOff:  []time.Weekday{time.Sunday},
 				PermanentlyExempt: true,
 			}
 			nextStop, err := s.GetNextScheduledStopTime(time.Now())
 			assert.NoError(t, err)
-			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+			assert.Zero(t, nextStop)
 		},
-		"ReturnsSentinelTimeForIndefinitelyOffHost": func(t *testing.T) {
+		"ReturnsZeroTimeForIndefinitelyOffHost": func(t *testing.T) {
 			s := SleepScheduleInfo{
 				WholeWeekdaysOff: []time.Weekday{time.Sunday},
 				ShouldKeepOff:    true,
 			}
 			nextStop, err := s.GetNextScheduledStopTime(time.Now())
 			assert.NoError(t, err)
-			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+			assert.Zero(t, nextStop)
 		},
 		"ReturnsErrorForZeroSleepSchedule": func(t *testing.T) {
 			s := SleepScheduleInfo{}
@@ -6836,23 +6836,23 @@ func TestGetNextScheduledStartTime(t *testing.T) {
 			assert.Equal(t, expectedOffsetSecs, tzOffset, "next start time should be in EDT rather than EST")
 			assert.Equal(t, s.TimeZone, nextStart.Location().String(), "next start time should be specified in the user's time zone")
 		},
-		"ReturnsSentinelTimeForPermanentlyExemptHost": func(t *testing.T, h *Host) {
+		"ReturnsZeroTimeForPermanentlyExemptHost": func(t *testing.T, h *Host) {
 			s := SleepScheduleInfo{
 				WholeWeekdaysOff:  []time.Weekday{time.Sunday},
 				PermanentlyExempt: true,
 			}
 			nextStop, err := s.GetNextScheduledStartTime(time.Now())
 			assert.NoError(t, err)
-			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+			assert.Zero(t, nextStop)
 		},
-		"ReturnsSentinelTimeForIndefinitelyOffHost": func(t *testing.T, h *Host) {
+		"ReturnsZeroTimeForIndefinitelyOffHost": func(t *testing.T, h *Host) {
 			s := SleepScheduleInfo{
 				WholeWeekdaysOff: []time.Weekday{time.Sunday},
 				ShouldKeepOff:    true,
 			}
 			nextStop, err := s.GetNextScheduledStartTime(time.Now())
 			assert.NoError(t, err)
-			assert.Equal(t, SleepScheduleSentinelTime, nextStop)
+			assert.Zero(t, nextStop)
 		},
 		"ReturnsErrorForZeroSleepSchedule": func(t *testing.T, h *Host) {
 			s := SleepScheduleInfo{}

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -287,15 +287,15 @@ func (s *cronsEventSuite) TestEndToEnd() {
 
 	go httpServer(ln, handler)
 
-	q := evergreen.GetEnvironment().RemoteQueue()
+	q := s.env.RemoteQueue()
 	jobs, err := eventNotifierJobs(s.ctx, s.env, time.Time{})
 	s.NoError(err)
 	s.NoError(q.PutMany(s.ctx, jobs))
 
 	// Wait for event notifier to finish.
-	amboy.WaitInterval(s.ctx, q, 10*time.Millisecond)
+	s.Require().True(amboy.WaitInterval(s.ctx, q, 10*time.Millisecond))
 	// Wait for event send to finish.
-	amboy.WaitInterval(s.ctx, q, 10*time.Millisecond)
+	s.Require().True(amboy.WaitInterval(s.ctx, q, 10*time.Millisecond))
 
 	out := []notification.Notification{}
 	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -58,7 +58,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		"periodic notification":      periodicNotificationJobs,
 		"user data done":             userDataDoneJobs,
 		"pod termination":            podTerminationJobs,
-		"sleep scheduler":            sleepSchedulerJobs,
 	}
 
 	var allJobs []amboy.Job
@@ -83,6 +82,7 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	catcher.Add(populateQueueGroup(ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, spawnHostModificationQueueGroup, sleepSchedulerJobs, ts))
 
 	// Add generate tasks fallbacks to their versions' queues.
 	catcher.Add(enqueueFallbackGenerateTasksJobs(ctx, j.env, ts))

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -76,7 +76,9 @@ func (j *sleepSchedulerJob) populateIfUnset() error {
 const sleepScheduleUser = "sleep_schedule"
 
 // fixMissingNextScheduleTimes finds and fixes hosts that are subject to the
-// sleep schedule but are missing next stop/start times.
+// sleep schedule but are missing next stop/start times. For example, a host
+// that was kept off but is now back on should be put back on its regular sleep
+// schedule.
 func (j *sleepSchedulerJob) fixMissingNextScheduleTimes(ctx context.Context) error {
 	hosts, err := host.FindMissingNextSleepScheduleTime(ctx)
 	if err != nil {

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -59,7 +59,7 @@ func (j *sleepSchedulerJob) Run(ctx context.Context) {
 	}
 
 	j.AddError(errors.Wrap(j.syncPermanentlyExemptHosts(ctx), "syncing permanently exempt hosts"))
-	j.AddError(errors.Wrap(j.fixMissingNextScheduleTimes(ctx), "fixing hosts that are missing next schedule times"))
+	j.AddError(errors.Wrap(j.fixMissingNextScheduleTimes(ctx), "fixing hosts that are missing next scheduled start/stop times"))
 	j.AddError(errors.Wrap(j.fixHostsExceedingTimeout(ctx), "fixing hosts that are exceeding the scheduled stop/start timeout"))
 
 	ts := utility.RoundPartOfMinute(0)
@@ -98,7 +98,7 @@ func (j *sleepSchedulerJob) fixMissingNextScheduleTimes(ctx context.Context) err
 			}
 
 			grip.Notice(message.Fields{
-				"message":             "host has exceeded scheduled start timeout, re-scheduled to next available start time",
+				"message":             "host is missing next start time, re-scheduled to next available start time",
 				"host_id":             h.Id,
 				"started_by":          h.StartedBy,
 				"old_next_start_time": oldNextStart,
@@ -119,7 +119,7 @@ func (j *sleepSchedulerJob) fixMissingNextScheduleTimes(ctx context.Context) err
 			}
 
 			grip.Notice(message.Fields{
-				"message":            "host has exceeded scheduled stop timeout, re-scheduled to next available stop time",
+				"message":            "host is missing next stop time, re-scheduled to next available stop time",
 				"host_id":            h.Id,
 				"started_by":         h.StartedBy,
 				"old_next_stop_time": oldNextStop,
@@ -154,7 +154,7 @@ func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error 
 				continue
 			}
 
-			grip.Notice(message.Fields{
+			grip.Warning(message.Fields{
 				"message":             "host has exceeded scheduled start timeout, re-scheduled to next available start time",
 				"host_id":             h.Id,
 				"started_by":          h.StartedBy,
@@ -175,7 +175,7 @@ func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error 
 				continue
 			}
 
-			grip.Notice(message.Fields{
+			grip.Warning(message.Fields{
 				"message":            "host has exceeded scheduled stop timeout, re-scheduling to next available stop time",
 				"host_id":            h.Id,
 				"started_by":         h.StartedBy,

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -82,42 +82,48 @@ func (j *sleepSchedulerJob) fixMissingNextScheduleTimes(ctx context.Context) err
 	if err != nil {
 		return errors.Wrap(err, "finding hosts with missing next stop/start times")
 	}
-	// now := time.Now()
+	now := time.Now()
 	catcher := grip.NewBasicCatcher()
 	for _, h := range hosts {
 		if utility.IsZeroTime(h.SleepSchedule.NextStartTime) {
 			oldNextStart := h.SleepSchedule.NextStartTime
-			// nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
-			// if err != nil {
-			//     catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
-			//     continue
-			// }
-			// // kim: TODO: needs DEVPROD-3951
-			// h.SetNextScheduledStartTime(ctx, nextStart)
+			nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
+			if err != nil {
+				catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
+				continue
+			}
+			if err := h.SetNextScheduledStart(ctx, nextStart); err != nil {
+				catcher.Wrapf(err, "setting next start time for host '%s'", h.Id)
+				continue
+			}
+
 			grip.Notice(message.Fields{
-				"message":             "host has exceeded scheduled start timeout, re-scheduling to next available start time",
+				"message":             "host has exceeded scheduled start timeout, re-scheduled to next available start time",
 				"host_id":             h.Id,
 				"started_by":          h.StartedBy,
 				"old_next_start_time": oldNextStart,
-				"new_next_start_time": "kim: TODO: fill in",
+				"new_next_start_time": nextStart,
 				"job":                 j.ID(),
 			})
 		}
 		if utility.IsZeroTime(h.SleepSchedule.NextStopTime) {
 			oldNextStop := h.SleepSchedule.NextStopTime
-			// nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
-			// if err != nil {
-			//     catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
-			//     continue
-			// }
-			// // kim: TODO: needs DEVPROD-3951
-			// h.SetNextScheduledStopTime(ctx, nextStop)
+			nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
+			if err != nil {
+				catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
+				continue
+			}
+			if err := h.SetNextScheduledStop(ctx, nextStop); err != nil {
+				catcher.Wrapf(err, "setting next stop time for host '%s'", h.Id)
+				continue
+			}
+
 			grip.Notice(message.Fields{
-				"message":            "host has exceeded scheduled stop timeout, re-scheduling to next available stop time",
+				"message":            "host has exceeded scheduled stop timeout, re-scheduled to next available stop time",
 				"host_id":            h.Id,
 				"started_by":         h.StartedBy,
 				"old_next_stop_time": oldNextStop,
-				"new_next_stop_time": "kim: TODO: fill in",
+				"new_next_stop_time": nextStop,
 				"job":                j.ID(),
 			})
 		}
@@ -138,38 +144,44 @@ func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error 
 	for _, h := range hosts {
 		if now.Sub(h.SleepSchedule.NextStartTime) > host.SleepScheduleActionTimeout {
 			oldNextStart := h.SleepSchedule.NextStartTime
-			// nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
-			// if err != nil {
-			//     catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
-			//     continue
-			// }
-			// // kim: TODO: needs DEVPROD-3951
-			// h.SetNextScheduledStartTime(ctx, nextStart)
+			nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
+			if err != nil {
+				catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
+				continue
+			}
+			if err := h.SetNextScheduledStart(ctx, nextStart); err != nil {
+				catcher.Wrapf(err, "setting next start time for host '%s'", h.Id)
+				continue
+			}
+
 			grip.Notice(message.Fields{
-				"message":             "host has exceeded scheduled start timeout, re-scheduling to next available start time",
+				"message":             "host has exceeded scheduled start timeout, re-scheduled to next available start time",
 				"host_id":             h.Id,
 				"started_by":          h.StartedBy,
 				"job":                 j.ID(),
 				"old_next_start_time": oldNextStart,
-				"new_next_start_time": "kim: TODO: fill in",
+				"new_next_start_time": nextStart,
 			})
 		}
 		if now.Sub(h.SleepSchedule.NextStopTime) > host.SleepScheduleActionTimeout {
 			oldNextStop := h.SleepSchedule.NextStopTime
-			// nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
-			// if err != nil {
-			//     catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
-			//     continue
-			// }
-			// // kim: TODO: needs DEVPROD-3951
-			// h.SetNextScheduledStopTime(ctx, nextStop)
+			nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
+			if err != nil {
+				catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
+				continue
+			}
+			if err := h.SetNextScheduledStop(ctx, nextStop); err != nil {
+				catcher.Wrapf(err, "setting next stop time for host '%s'", h.Id)
+				continue
+			}
+
 			grip.Notice(message.Fields{
 				"message":            "host has exceeded scheduled stop timeout, re-scheduling to next available stop time",
 				"host_id":            h.Id,
 				"started_by":         h.StartedBy,
 				"job":                j.ID(),
 				"old_next_stop_time": oldNextStop,
-				"new_next_stop_time": "kim: TODO: fill in",
+				"new_next_stop_time": nextStop,
 			})
 		}
 	}

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -192,7 +192,10 @@ func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error 
 // permanently exempt are consistent with the most up-to-date list of
 // permanently exempt hosts.
 func (j *sleepSchedulerJob) syncPermanentlyExemptHosts(ctx context.Context) error {
-	settings := j.env.Settings()
+	settings, err := evergreen.GetConfig(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting admin settings")
+	}
 	return host.SyncPermanentExemptions(ctx, settings.SleepSchedule.PermanentlyExemptHosts)
 }
 

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -58,11 +58,12 @@ func (j *sleepSchedulerJob) Run(ctx context.Context) {
 		return
 	}
 
+	j.AddError(errors.Wrap(j.syncPermanentlyExemptHosts(ctx), "syncing permanently exempt hosts"))
+	j.AddError(errors.Wrap(j.fixMissingNextScheduleTimes(ctx), "fixing hosts that are missing next schedule times"))
+	j.AddError(errors.Wrap(j.fixHostsExceedingTimeout(ctx), "fixing hosts that are exceeding the scheduled stop/start timeout"))
+
 	ts := utility.RoundPartOfMinute(0)
-	if err := populateQueueGroup(ctx, j.env, spawnHostModificationQueueGroup, j.makeStopAndStartJobs, ts); err != nil {
-		j.AddError(errors.Wrap(err, "enqueuing stop and start jobs"))
-		return
-	}
+	j.AddError(errors.Wrap(populateQueueGroup(ctx, j.env, spawnHostModificationQueueGroup, j.makeStopAndStartJobs, ts), "enqueueing stop and start jobs"))
 }
 
 func (j *sleepSchedulerJob) populateIfUnset() error {
@@ -74,9 +75,9 @@ func (j *sleepSchedulerJob) populateIfUnset() error {
 
 const sleepScheduleUser = "sleep_schedule"
 
-// fixMissingNextScheduledTimes finds and fixes hosts that are subject to the
+// fixMissingNextScheduleTimes finds and fixes hosts that are subject to the
 // sleep schedule but are missing next stop/start times.
-func (j *sleepSchedulerJob) fixMissingNextScheduledTimes(ctx context.Context) error {
+func (j *sleepSchedulerJob) fixMissingNextScheduleTimes(ctx context.Context) error {
 	hosts, err := host.FindMissingNextSleepScheduleTime(ctx)
 	if err != nil {
 		return errors.Wrap(err, "finding hosts with missing next stop/start times")
@@ -85,6 +86,7 @@ func (j *sleepSchedulerJob) fixMissingNextScheduledTimes(ctx context.Context) er
 	catcher := grip.NewBasicCatcher()
 	for _, h := range hosts {
 		if utility.IsZeroTime(h.SleepSchedule.NextStartTime) {
+			oldNextStart := h.SleepSchedule.NextStartTime
 			// nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
 			// if err != nil {
 			//     catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
@@ -92,8 +94,17 @@ func (j *sleepSchedulerJob) fixMissingNextScheduledTimes(ctx context.Context) er
 			// }
 			// // kim: TODO: needs DEVPROD-3951
 			// h.SetNextScheduledStartTime(ctx, nextStart)
+			grip.Notice(message.Fields{
+				"message":             "host has exceeded scheduled start timeout, re-scheduling to next available start time",
+				"host_id":             h.Id,
+				"started_by":          h.StartedBy,
+				"old_next_start_time": oldNextStart,
+				"new_next_start_time": "kim: TODO: fill in",
+				"job":                 j.ID(),
+			})
 		}
 		if utility.IsZeroTime(h.SleepSchedule.NextStopTime) {
+			oldNextStop := h.SleepSchedule.NextStopTime
 			// nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
 			// if err != nil {
 			//     catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
@@ -101,6 +112,14 @@ func (j *sleepSchedulerJob) fixMissingNextScheduledTimes(ctx context.Context) er
 			// }
 			// // kim: TODO: needs DEVPROD-3951
 			// h.SetNextScheduledStopTime(ctx, nextStop)
+			grip.Notice(message.Fields{
+				"message":            "host has exceeded scheduled stop timeout, re-scheduling to next available stop time",
+				"host_id":            h.Id,
+				"started_by":         h.StartedBy,
+				"old_next_stop_time": oldNextStop,
+				"new_next_stop_time": "kim: TODO: fill in",
+				"job":                j.ID(),
+			})
 		}
 	}
 	return catcher.Resolve()
@@ -109,24 +128,16 @@ func (j *sleepSchedulerJob) fixMissingNextScheduledTimes(ctx context.Context) er
 // fixHostsExceedingScheduledTimeout finds and reschedules the next stop/start
 // time for hosts that need to stop/start for their sleep schedule but have
 // taken too long while attempting to stop/start.
-func (j *sleepSchedulerJob) fixHostsExceedingScheduledTimeout(ctx context.Context) error {
-	hosts, err := host.FindExceedsSleepScheduleActionTimeout(ctx)
+func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error {
+	hosts, err := host.FindExceedsSleepScheduleTimeout(ctx)
 	if err != nil {
-		return errors.Wrap(err, "finding hosts exceeding scheduled threshold")
+		return errors.Wrap(err, "finding hosts exceeding sleep schedule timeout")
 	}
 	now := time.Now()
 	catcher := grip.NewBasicCatcher()
 	for _, h := range hosts {
-		if h.SleepSchedule.NextStopTime.Before(now.Add(-host.SleepScheduleActionTimeout)) {
-			// nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
-			// if err != nil {
-			//     catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
-			//     continue
-			// }
-			// // kim: TODO: needs DEVPROD-3951
-			// h.SetNextScheduledStopTime(ctx, nextStop)
-		}
-		if h.SleepSchedule.NextStartTime.Before(now.Add(-host.SleepScheduleActionTimeout)) {
+		if now.Sub(h.SleepSchedule.NextStartTime) > host.SleepScheduleActionTimeout {
+			oldNextStart := h.SleepSchedule.NextStartTime
 			// nextStart, err := h.SleepSchedule.GetNextScheduledStartTime(now)
 			// if err != nil {
 			//     catcher.Wrapf(err, "getting next start time for host '%s'", h.Id)
@@ -134,6 +145,32 @@ func (j *sleepSchedulerJob) fixHostsExceedingScheduledTimeout(ctx context.Contex
 			// }
 			// // kim: TODO: needs DEVPROD-3951
 			// h.SetNextScheduledStartTime(ctx, nextStart)
+			grip.Notice(message.Fields{
+				"message":             "host has exceeded scheduled start timeout, re-scheduling to next available start time",
+				"host_id":             h.Id,
+				"started_by":          h.StartedBy,
+				"job":                 j.ID(),
+				"old_next_start_time": oldNextStart,
+				"new_next_start_time": "kim: TODO: fill in",
+			})
+		}
+		if now.Sub(h.SleepSchedule.NextStopTime) > host.SleepScheduleActionTimeout {
+			oldNextStop := h.SleepSchedule.NextStopTime
+			// nextStop, err := h.SleepSchedule.GetNextScheduledStopTime(now)
+			// if err != nil {
+			//     catcher.Wrapf(err, "getting next stop time for host '%s'", h.Id)
+			//     continue
+			// }
+			// // kim: TODO: needs DEVPROD-3951
+			// h.SetNextScheduledStopTime(ctx, nextStop)
+			grip.Notice(message.Fields{
+				"message":            "host has exceeded scheduled stop timeout, re-scheduling to next available stop time",
+				"host_id":            h.Id,
+				"started_by":         h.StartedBy,
+				"job":                j.ID(),
+				"old_next_stop_time": oldNextStop,
+				"new_next_stop_time": "kim: TODO: fill in",
+			})
 		}
 	}
 	return catcher.Resolve()
@@ -142,6 +179,8 @@ func (j *sleepSchedulerJob) fixHostsExceedingScheduledTimeout(ctx context.Contex
 // syncPermanentlyExemptHosts ensures that the hosts that are marked as
 // permanently exempt are consistent with the most up-to-date list of
 // permanently exempt hosts.
+// kim: NOTE: this is first step in fixes because permanent exemption syncing is
+// important to get right before other fixes.
 func (j *sleepSchedulerJob) syncPermanentlyExemptHosts(ctx context.Context) error {
 	settings := j.env.Settings()
 	return host.SyncPermanentExemptions(ctx, settings.SleepSchedule.PermanentlyExemptHosts)

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -34,8 +34,8 @@ type sleepSchedulerJob struct {
 func NewSleepSchedulerJob(env evergreen.Environment, ts string) amboy.Job {
 	j := makeSleepSchedulerJob()
 	j.SetID(fmt.Sprintf("%s.%s", sleepSchedulerJobName, ts))
+	j.SetEnqueueScopes(sleepSchedulerJobName)
 	j.env = env
-	j.SetScopes([]string{sleepSchedulerJobName})
 	return j
 }
 
@@ -179,8 +179,6 @@ func (j *sleepSchedulerJob) fixHostsExceedingTimeout(ctx context.Context) error 
 // syncPermanentlyExemptHosts ensures that the hosts that are marked as
 // permanently exempt are consistent with the most up-to-date list of
 // permanently exempt hosts.
-// kim: NOTE: this is first step in fixes because permanent exemption syncing is
-// important to get right before other fixes.
 func (j *sleepSchedulerJob) syncPermanentlyExemptHosts(ctx context.Context) error {
 	settings := j.env.Settings()
 	return host.SyncPermanentExemptions(ctx, settings.SleepSchedule.PermanentlyExemptHosts)

--- a/units/sleep_scheduler_test.go
+++ b/units/sleep_scheduler_test.go
@@ -294,7 +294,6 @@ func TestSleepSchedulerJob(t *testing.T) {
 			assert.True(t, dbHost.SleepSchedule.NextStartTime.Equal(now), "next start time should be unchanged")
 			assert.True(t, dbHost.SleepSchedule.NextStopTime.After(now), "next stop time should be re-scheduled to be in the future")
 		},
-		// kim: NOTE; tests won't pass until DEVPROD-3951 is merged
 		"ReschedulesNextStartForHostExceedingAttemptTimeout": func(ctx context.Context, t *testing.T, env *mock.Environment, j *sleepSchedulerJob) {
 			now := utility.BSONTime(time.Now())
 			h := host.Host{

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -68,7 +68,6 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 	startCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule && !h.IsSleepScheduleEnabled() {
-			// kim: TODO: test
 			grip.Info(message.Fields{
 				"message":             "no-oping scheduled start because sleep schedule is not enabled for this host",
 				"host_id":             j.HostID,

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -86,6 +86,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 				"next_start_time": h.SleepSchedule.NextStartTime,
 				"job":             j.ID(),
 			})
+			return nil
 		}
 
 		if err := mgr.StartInstance(ctx, h, user); err != nil {

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -68,6 +68,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 	startCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule && !h.IsSleepScheduleEnabled() {
+			// kim: TODO: test
 			grip.Info(message.Fields{
 				"message":             "no-oping scheduled start because sleep schedule is not enabled for this host",
 				"host_id":             j.HostID,

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -67,6 +67,17 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	startCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
+		if j.Source == evergreen.ModifySpawnHostSleepSchedule && !h.IsSleepScheduleEnabled() {
+			grip.Info(message.Fields{
+				"message":             "no-oping scheduled start because sleep schedule is not enabled for this host",
+				"host_id":             j.HostID,
+				"host_status":         h.Status,
+				"host_sleep_schedule": h.SleepSchedule,
+				"user":                j.UserID,
+				"job":                 j.ID(),
+			})
+			return nil
+		}
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule && h.SleepSchedule.NextStartTime.After(time.Now().Add(host.PreStartThreshold)) {
 			grip.Info(message.Fields{
 				"message":         "no-oping because host is not scheduled to start yet",
@@ -74,7 +85,6 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 				"next_start_time": h.SleepSchedule.NextStartTime,
 				"job":             j.ID(),
 			})
-			return nil
 		}
 
 		if err := mgr.StartInstance(ctx, h, user); err != nil {

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -153,10 +153,11 @@ func TestSpawnhostStartJob(t *testing.T) {
 			require.NoError(t, err)
 			now := utility.BSONTime(time.Now())
 			h := host.Host{
-				Id:       "host-stopped",
-				Status:   evergreen.HostStopped,
-				Provider: evergreen.ProviderNameMock,
-				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+				Id:           "host-stopped",
+				Status:       evergreen.HostStopped,
+				Provider:     evergreen.ProviderNameMock,
+				Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+				NoExpiration: true,
 				SleepSchedule: host.SleepScheduleInfo{
 					DailyStartTime: "10:00",
 					DailyStopTime:  "18:00",
@@ -193,12 +194,13 @@ func TestSpawnhostStartJob(t *testing.T) {
 			userTZ, err := time.LoadLocation("Antarctica/South_Pole")
 			require.NoError(t, err)
 			now := utility.BSONTime(time.Now())
-			nextStart := now.Add(time.Hour)
+			nextStart := utility.BSONTime(now.Add(time.Hour))
 			h := host.Host{
-				Id:       "host-running",
-				Status:   evergreen.HostRunning,
-				Provider: evergreen.ProviderNameMock,
-				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+				Id:           "host-running",
+				Status:       evergreen.HostRunning,
+				Provider:     evergreen.ProviderNameMock,
+				Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+				NoExpiration: true,
 				SleepSchedule: host.SleepScheduleInfo{
 					DailyStartTime: "10:00",
 					DailyStopTime:  "18:00",

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -74,7 +74,6 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 		return
 	}
 	if j.Source == evergreen.ModifySpawnHostSleepSchedule && flags.SleepScheduleDisabled {
-		// kim: TODO: test
 		grip.Notice(message.Fields{
 			"message": "no-oping scheduled stop because sleep schedule service flag is disabled",
 			"host_id": j.HostID,

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -86,6 +86,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule && !h.IsSleepScheduleEnabled() {
+			// kim: TODO: test
 			grip.Info(message.Fields{
 				"message":             "no-oping scheduled stop because sleep schedule is not enabled for this host",
 				"host_id":             j.HostID,

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -86,7 +86,6 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 	stopCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule && !h.IsSleepScheduleEnabled() {
-			// kim: TODO: test
 			grip.Info(message.Fields{
 				"message":             "no-oping scheduled stop because sleep schedule is not enabled for this host",
 				"host_id":             j.HostID,

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -152,10 +152,11 @@ func TestSpawnhostStopJob(t *testing.T) {
 			require.NoError(t, err)
 			now := utility.BSONTime(time.Now())
 			h := host.Host{
-				Id:       "host-running",
-				Status:   evergreen.HostRunning,
-				Provider: evergreen.ProviderNameMock,
-				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+				Id:           "host-running",
+				Status:       evergreen.HostRunning,
+				Provider:     evergreen.ProviderNameMock,
+				Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+				NoExpiration: true,
 				SleepSchedule: host.SleepScheduleInfo{
 					DailyStartTime: "10:00",
 					DailyStopTime:  "18:00",
@@ -192,12 +193,13 @@ func TestSpawnhostStopJob(t *testing.T) {
 			userTZ, err := time.LoadLocation("Antarctica/South_Pole")
 			require.NoError(t, err)
 			now := utility.BSONTime(time.Now())
-			nextStop := now.Add(time.Hour)
+			nextStop := utility.BSONTime(now.Add(time.Hour))
 			h := host.Host{
-				Id:       "host-running",
-				Status:   evergreen.HostRunning,
-				Provider: evergreen.ProviderNameMock,
-				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
+				Id:           "host-running",
+				Status:       evergreen.HostRunning,
+				Provider:     evergreen.ProviderNameMock,
+				Distro:       distro.Distro{Provider: evergreen.ProviderNameMock},
+				NoExpiration: true,
 				SleepSchedule: host.SleepScheduleInfo{
 					DailyStartTime: "10:00",
 					DailyStopTime:  "18:00",


### PR DESCRIPTION
DEVPROD-3949

### Description
Handle special cases, namely:
* Handle updates to the permanent exemption list. Hosts should have their permanent exemption field synced to the official list in the admin settings.
* Add next start/stop times for hosts that are on the sleep schedule but don't have them set. This could happen in cases like being removed from the permanent exemption list, at which point we need to put it back on the sleep schedule.
* Eventually give up on scheduled stop/start attempts if they're clearly taking a long time (30+ minutes) and the host is not reaching the goal state. This is an extra safety precaution against trying to stop/start a host forever unsuccessfully. For example, if AWS has an outage that prevents us from stopping/starting the host, we should eventually give up and just try again tomorrow.
* Do a last second check to see if the sleep schedule applies before stopping/starting the host for its schedule. (as an extra safety measure)

Also had to make some other changes to make the special case logic tidy:
* Change the data model to allow hosts to have an empty next start/stop time. I found this to be slightly easier/neater to deal with in terms of query, rather than requiring the fields and setting a special "invalid" time to indicate that a host is exempt from the sleep schedule.
* Refactor some queries to use common sleep schedule queries and reduce copy-pasting.

### Testing
* Tested these special cases in staging.
* Added unit tests.

### Documentation
N/A