### PR TITLE
DEVPROD-6348: only set persistent DNS for running unexpirable hosts

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -599,8 +599,9 @@ func (m *ec2Manager) setNoExpiration(ctx context.Context, h *host.Host, noExpira
 			return errors.Wrapf(err, "marking host should not expire in DB for host '%s'", h.Id)
 		}
 
-		// Add/update the persistent DNS name if the unexpirable host is
-		// running.
+		// Use GetInstanceStatus to add/update the cached host data (including
+		// unexpirable host information like persistent DNS names and IP
+		// addrseses) if the unexpirable host is running.
 		_, err := m.GetInstanceStatus(ctx, h)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":    "could not get instance info to assign persistent DNS name",

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -777,12 +777,6 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 		if isEC2InstanceNotFound(err) {
 			return StatusNonExistent, nil
 		}
-		grip.Error(message.WrapError(err, message.Fields{
-			"message":       "error getting instance info",
-			"host_id":       h.Id,
-			"host_provider": h.Distro.Provider,
-			"distro":        h.Distro.Id,
-		}))
 		return status, err
 	}
 	status = ec2StatusToEvergreenStatus(instance.State.Name)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -580,6 +580,17 @@ func (s *EC2Suite) TestModifyHost() {
 	s.Zero(found.PersistentDNSName, "persistent DNS name should be removed once host is expirable")
 	s.Zero(found.PublicIPv4)
 
+	// modifying host to have no expiration when it's currently stopped
+	s.NoError(s.h.SetStatus(ctx, evergreen.HostStopped, "user", ""))
+	changes = host.HostModifyOptions{NoExpiration: utility.TruePtr()}
+	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
+	found, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(err)
+	s.Require().NotZero(found)
+	s.True(found.NoExpiration)
+	s.NotZero(found.PersistentDNSName, "persistent DNS name should not be assigned to stopped host")
+	s.NotZero(found.PublicIPv4)
+
 	// attaching a volume to host
 	volumeToMount := host.Volume{
 		ID:               "thang",


### PR DESCRIPTION
DEVPROD-6348

### Description
There's a job that periodically bumps the expiration time for unexpirable hosts to make sure they don't get terminated by the AWS reaper. However, it can also bump the expiration for stopped unexpirable hosts, which don't have any IP address. Only update the persistent DNS + IP address for running unexpirable hosts.

### Testing
Updated unit tests.

### Documentation
N/A