### PR TITLE
DEVPROD-6548: set author for periodic builds

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-22"
+	AgentVersion = "2024-04-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/globals.go
+++ b/globals.go
@@ -384,6 +384,10 @@ const (
 	// HostServicePasswordExpansion is the expansion for the service password that is stored on the host,
 	// and is meant to be set as a private variable so that it will be redacted in all logs.
 	HostServicePasswordExpansion = "host_service_password"
+
+	// PeriodicBuildAuthor is the revision author name to use when a periodic
+	// build selects a version without an author already assigned
+	PeriodicBuildAuthor = "Evergreen Periodic Build"
 )
 
 var VersionSucceededStatuses = []string{

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -97,20 +97,21 @@ func byLatestProjectVersion(projectId string) bson.M {
 	}
 }
 
-// FindLatestRevisionForProject returns the latest revision for the project, and returns an error if it's not found.
-func FindLatestRevisionForProject(projectId string) (string, error) {
+// FindLatestRevisionAndauthorForProject returns the latest revision for the project, and returns an error if it's not found.
+func FindLatestRevisionAndAuthorForProject(projectId string) (string, string, error) {
 	v, err := VersionFindOne(db.Query(byLatestProjectVersion(projectId)).
-		Sort([]string{"-" + VersionRevisionOrderNumberKey}).WithFields(VersionRevisionKey))
+		Sort([]string{"-" + VersionRevisionOrderNumberKey}).WithFields(VersionRevisionKey, VersionAuthorKey))
 	if err != nil {
-		return "", errors.Wrapf(err, "finding most recent version for project '%s'", projectId)
+		return "", "", errors.Wrapf(err, "finding most recent version for project '%s'", projectId)
 	}
 	if v == nil {
-		return "", errors.Errorf("no recent version found for project '%s'", projectId)
+		return "", "", errors.Errorf("no recent version found for project '%s'", projectId)
 	}
 	if v.Revision == "" {
-		return "", errors.Errorf("latest version '%s' has no revision", v.Id)
+		return "", "", errors.Errorf("latest version '%s' has no revision", v.Id)
 	}
-	return v.Revision, nil
+
+	return v.Revision, v.Author, nil
 }
 
 // BaseVersionByProjectIdAndRevision finds a base version for the given project and revision.

--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -49,6 +49,7 @@ func TestPeriodicBuildsJob(t *testing.T) {
 		Identifier: sampleProject.Id,
 		Requester:  evergreen.RepotrackerVersionRequester,
 		Revision:   "88dcc12106a40cb4917f552deab7574ececd9a3e",
+		Author:     "test author",
 	}
 	assert.NoError(prevVersion.Insert())
 
@@ -59,9 +60,11 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.AdHocRequester, createdVersion.Requester)
 	assert.Equal(prevVersion.Revision, createdVersion.Revision)
+	assert.Equal(prevVersion.Author, createdVersion.Author)
 	tasks, err := task.Find(task.ByVersion(createdVersion.Id))
 	assert.NoError(err)
 	assert.True(tasks[0].Activated)
+	assert.Equal(tasks[0].ActivatedBy, prevVersion.Author)
 	dbProject, err := model.FindBranchProjectRef(sampleProject.Id)
 	assert.NoError(err)
 	assert.True(sampleProject.PeriodicBuilds[0].NextRunTime.Add(time.Hour).Equal(dbProject.PeriodicBuilds[0].NextRunTime))


### PR DESCRIPTION
DEVPROD-6548

### Description
This commit ensures that the author is set when tasks are created via a periodic build. Right now, the VersionMetadata field is initialized with only the most recent revision we fetched from the database. This commit changes the behavior so that we also fetch the author and populate the metadata with the author of the same commit. All versions should have an author associated with them.

Someone else is free to use this PR as a starting point if there is another approach you'd like to take for fixing this.

### Testing
I added a new test for the function I changed, and made additional assertions in the existing job test that I think should cover this change?

### Documentation
No need for documentation changes as this is mostly just fixing an oversight.
