### PR TITLE
DEVPROD-5576 include source and patch alias name in validation

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-02-26"
+	ClientVersion = "2024-04-19"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -536,7 +536,15 @@ func constructAliasWarnings(aliasMap map[string]model.ProjectAlias, aliasNeedsVa
 		case evergreen.GithubChecksAlias:
 			msgComponents = append(msgComponents, "GitHub check alias")
 		default:
-			msgComponents = append(msgComponents, "Patch alias")
+			msgComponents = append(msgComponents, fmt.Sprintf("Patch alias '%s'", a.Alias))
+		}
+		switch a.Source {
+		case model.AliasSourceConfig:
+			msgComponents = append(msgComponents, "(from the yaml)")
+		case model.AliasSourceProject:
+			msgComponents = append(msgComponents, "(from the project page)")
+		case model.AliasSourceRepo:
+			msgComponents = append(msgComponents, "(from the repo page)")
 		}
 		if len(a.VariantTags) > 0 {
 			msgComponents = append(msgComponents, fmt.Sprintf("matching variant tags '%v'", a.VariantTags))

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2059,12 +2059,14 @@ func TestValidateAliasCoverage(t *testing.T) {
 				Alias:       evergreen.CommitQueueAlias,
 				VariantTags: []string{"notTheVariantTag"},
 				TaskTags:    []string{"taskTag1", "taskTag2"},
+				Source:      model.AliasSourceConfig,
 			}
 			alias2 := model.ProjectAlias{
 				ID:      mgobson.NewObjectId(),
 				Alias:   evergreen.CommitQueueAlias,
 				Variant: "nonsense",
 				Task:    ".*",
+				Source:  model.AliasSourceConfig,
 			}
 			aliasMap := map[string]model.ProjectAlias{
 				"alias1": alias1,
@@ -2084,8 +2086,10 @@ func TestValidateAliasCoverage(t *testing.T) {
 			errs := validateAliasCoverage(p, model.ProjectAliases{alias1, alias2})
 			require.Len(t, errs, 2)
 			assert.Contains(t, errs[0].Message, "Commit queue alias")
+			assert.Contains(t, errs[0].Message, "(from the yaml)")
 			assert.Contains(t, errs[0].Message, "has no matching variants")
 			assert.Contains(t, errs[1].Message, "Commit queue alias")
+			assert.Contains(t, errs[1].Message, "(from the yaml)")
 			assert.Contains(t, errs[1].Message, "has no matching variants")
 			assert.NotContains(t, errs[0].Message, "tasks")
 			assert.NotContains(t, errs[1].Message, "tasks")
@@ -2127,11 +2131,13 @@ func TestValidateAliasCoverage(t *testing.T) {
 				ID:          mgobson.NewObjectId(),
 				Alias:       evergreen.CommitQueueAlias,
 				VariantTags: []string{"variantTag"},
+				Source:      model.AliasSourceProject,
 			}
 			alias2 := model.ProjectAlias{
 				ID:      mgobson.NewObjectId(),
 				Alias:   evergreen.CommitQueueAlias,
 				Variant: "badRegex",
+				Source:  model.AliasSourceProject,
 			}
 			aliasMap := map[string]model.ProjectAlias{
 				"alias1": alias1,
@@ -2150,9 +2156,11 @@ func TestValidateAliasCoverage(t *testing.T) {
 			errs := validateAliasCoverage(p, model.ProjectAliases{alias1, alias2})
 			require.Len(t, errs, 2)
 			assert.Contains(t, errs[0].Message, "Commit queue alias")
+			assert.Contains(t, errs[0].Message, "(from the project page)")
 			assert.Contains(t, errs[0].Message, "has no matching variants")
 			assert.NotContains(t, errs[0].Message, "matching task regexp")
 			assert.Contains(t, errs[1].Message, "Commit queue alias")
+			assert.Contains(t, errs[1].Message, "(from the project page)")
 			assert.Contains(t, errs[1].Message, "has no matching tasks")
 			assert.Contains(t, errs[1].Message, "variant tags")
 			assert.Contains(t, errs[1].Message, "matching task regexp")
@@ -2264,6 +2272,7 @@ func TestValidateAliasCoverage(t *testing.T) {
 				Alias:    "alias",
 				Variant:  "bvWithTag",
 				TaskTags: []string{"taskTag1 taskTag2 nonexistent"},
+				Source:   model.AliasSourceRepo,
 			}
 			aliases := map[string]model.ProjectAlias{a.Alias: a}
 			needsVariants, needsTasks, err := getAliasCoverage(p, aliases)
@@ -2278,6 +2287,8 @@ func TestValidateAliasCoverage(t *testing.T) {
 			}
 			errs := validateAliasCoverage(p, model.ProjectAliases{a})
 			assert.Len(t, errs, 1)
+			assert.Contains(t, errs[0].Message, "(from the repo page)")
+			assert.Contains(t, errs[0].Message, "Patch alias 'alias'")
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-5576
### Description
Added a tiny change to include the patch alias name and source in validation; this should be helpful for the server especially now as they're migrating aliases around.

### Testing
Added to unit test.