### PR TITLE
DEVPROD-6683: allow papertrail.trace on macos

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -34,10 +33,6 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if err := util.ExpandValues(t, &conf.Expansions); err != nil {
 		return errors.Wrap(err, "applying expansions")
-	}
-
-	if runtime.GOOS == "darwin" {
-		return errors.New("papertrail.trace is not supported on MacOS currently because these hosts do not always run in AWS with the necessary networking configuration")
 	}
 
 	pclient := thirdparty.NewPapertrailClient(t.KeyID, t.SecretKey, "")

--- a/agent/command/papertrail_trace_test.go
+++ b/agent/command/papertrail_trace_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -27,10 +26,6 @@ import (
 func TestPapertrailTrace(t *testing.T) {
 	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_INTEGRATION_TESTS")); skip {
 		t.Skip("SKIP_INTEGRATION_TESTS is set, skipping integration test")
-	}
-
-	if runtime.GOOS == "darwin" {
-		t.Skip("papertrail.trace is not supported on MacOS currently because these hosts do not always run in AWS with the necessary networking configuration")
 	}
 
 	settings := testutil.GetIntegrationFile(t)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-17"
+	AgentVersion = "2024-04-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -906,10 +906,7 @@ Parameters:
 
 This command traces artifact releases with the Papertrail service. It is owned
 by the Release Infrastructure team, and you may receive assistance with it in
-#ask-devprod-release-tools. This command cannot run on Evergreen hosts outside
-of AWS, which includes most MacOS hosts, because of security requirements for
-the Papertrail service. In the future, MacOS hosts will not have this
-limitation.
+#ask-devprod-release-tools.
 
 ``` yaml
 - command: papertrail.trace


### PR DESCRIPTION
DEVPROD-6683

### Description
This commit removes the previous restrictions on papertrail.trace on MacOS. We have allow-listed the necessary IP addresses while we transition to AWS hosts, so there shouldn't be any more failures

### Testing
The existing tests should cover this!

### Documentation
Removed the note about this command not running on MacOS