### PR TITLE
DEVPROD-3949: check sleep schedule statuses when syncing permanent exemption

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1657,6 +1657,7 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 	if len(permanentlyExempt) > 0 {
 		res, err := coll.UpdateMany(ctx, isSleepScheduleApplicable(bson.M{
 			IdKey:                             bson.M{"$in": permanentlyExempt},
+			StatusKey:                         bson.M{"$in": evergreen.SleepScheduleStatuses},
 			sleepSchedulePermanentlyExemptKey: bson.M{"$ne": true},
 		}), bson.M{
 			"$set": bson.M{
@@ -1676,6 +1677,7 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 
 	res, err := coll.UpdateMany(ctx, isSleepScheduleApplicable(bson.M{
 		IdKey:                             bson.M{"$nin": permanentlyExempt},
+		StatusKey:                         bson.M{"$in": evergreen.SleepScheduleStatuses},
 		sleepSchedulePermanentlyExemptKey: true,
 	}), bson.M{
 		"$set": bson.M{


### PR DESCRIPTION
DEVPROD-3949

### Description
The query to remove hosts from permanent exemption used the `_id` index but didn't use it efficiently since it's a `$nin` query, which matches almost everything in the host collection. Tweaked the query to include the status so it can use a better index.

### Testing
Unit tests still pass.

### Documentation
N/A