### PR TITLE
DEVPROD-6729: reduce agent critical logs

### DIFF
--- a/agent/background.go
+++ b/agent/background.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/globals"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
 )
 
@@ -48,14 +46,6 @@ func (a *Agent) startHeartbeat(ctx context.Context, preAndMainCancel context.Can
 				timeoutOpts := tc.getHeartbeatTimeout()
 				timeout := timeoutOpts.getTimeout()
 				msg := fmt.Sprintf("Heartbeat has hit maximum allowed '%s' timeout of %s; task is at risk of timing out if it runs for much longer.", timeoutOpts.kind, timeout.String())
-				grip.Alert(message.Fields{
-					"message":        msg,
-					"task_id":        tc.taskConfig.Task.Id,
-					"task_execution": tc.taskConfig.Task.Execution,
-					"timeout_type":   timeoutOpts.kind,
-					"timeout_start":  timeoutOpts.startAt,
-					"timeout_secs":   timeout.Seconds(),
-				})
 				tc.logger.Task().Errorf(msg)
 				if !hasSentAbort {
 					preAndMainCancel()

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-19"
+	AgentVersion = "2024-04-22"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-6729

### Description
Remove critical log for heartbeat timeout due to a task exceeding its exec/idle timeout. Since this is typically caused by overusing the host's resources (like getting an OOM), it'll show up as a system failure to the user. It seems like this is an issue that can be diagnosed in the task itself and doesn't need to show up in our error alerting.

### Testing
N/A

### Documentation
N/A