### PR TITLE
DEVPROD-6729: allow building hosts to request a next task

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1750,10 +1750,10 @@ func (h *Host) UpdateRunningTaskWithContext(ctx context.Context, env evergreen.E
 	}
 
 	statuses := []string{evergreen.HostRunning}
-	// User data can start anytime after the instance is created, so the app
-	// server may not have marked it as running yet.
+	// User data-provisioned hosts can start anytime after the instance is
+	// created, so the app server may not have marked it as running yet.
 	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData {
-		statuses = append(statuses, evergreen.HostStarting)
+		statuses = append(statuses, evergreen.StartedHostStatus...)
 	}
 	query := bson.M{
 		IdKey:          h.Id,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -392,7 +392,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 	}
 	var foundHost *host.Host
 	if h.hostID != "" {
-		foundHost, err = host.FindOneId(ctx, h.hostID)
+		foundHost, err = host.FindOneByIdOrTag(ctx, h.hostID)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting host '%s'", h.hostID))
 		}
@@ -600,7 +600,7 @@ func (h *getDistroViewHandler) Parse(ctx context.Context, r *http.Request) error
 }
 
 func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
-	host, err := host.FindOneId(ctx, h.hostID)
+	host, err := host.FindOneByIdOrTag(ctx, h.hostID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting host"))
 	}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -66,7 +66,7 @@ func (h *hostAgentNextTask) Parse(ctx context.Context, r *http.Request) error {
 	if h.hostID = gimlet.GetVars(r)["host_id"]; h.hostID == "" {
 		return errors.New("missing host ID")
 	}
-	host, err := host.FindOneId(ctx, h.hostID)
+	host, err := host.FindOneByIdOrTag(ctx, h.hostID)
 	if err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
@@ -881,9 +881,9 @@ func checkHostHealth(h *host.Host) bool {
 		return false
 	}
 
-	// User data can start anytime after the instance is created, so the app
-	// server may not have marked it as running yet.
-	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && h.Status == evergreen.HostStarting {
+	// User data-provisioned hosts can start anytime after the instance is
+	// created, so the app server may not have marked it as running yet.
+	if h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && utility.StringSliceContains(evergreen.StartedHostStatus, h.Status) {
 		return false
 	}
 

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
@@ -116,7 +117,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 	switch cloudStatus {
 	case cloud.StatusRunning:
-		userDataProvisioning := h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && h.Status == evergreen.HostStarting
+		userDataProvisioning := h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && utility.StringSliceContains(evergreen.StartedHostStatus, h.Status)
 		if h.Status != evergreen.HostRunning && !userDataProvisioning {
 			grip.Info(message.Fields{
 				"op_id":   id,


### PR DESCRIPTION
DEVPROD-6729

### Description
When deploying (or just restarting the apps), it's possible for there to be a race where the host creation job manages to create a host in EC2, but doesn't finish [the host replacement update](https://github.com/evergreen-ci/evergreen/blob/d00d9e168324aa0fe7a1d6e272ce8c006372f18b/model/host/db.go#L1370-L1418) that comes after starting the EC2 host. Later, that host comes up and asks for a next task, which causes some errors getting the next task because the next task route wasn't designed to let building hosts run tasks. I tweaked the queries to make it so that building hosts _can_ request a next task. The next task route already fixes the host in question, it just can't dispatch a task.

### Testing
Added unit tests.

### Documentation
N/A