### PR TITLE
DEVPROD-6070 Add limit for generate tasks JSON size

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -25,12 +25,16 @@ type TaskLimitsConfig struct {
 	// MaxPendingGeneratedTasks is the maximum number of tasks that can be created
 	// by all generated task at once.
 	MaxPendingGeneratedTasks int `bson:"max_pending_generated_tasks" json:"max_pending_generated_tasks" yaml:"max_pending_generated_tasks"`
+
+	// MaxGenerateTaskJSONSize is the maximum size of a JSON file in MB that can be specifed in the generate.tasks command.
+	MaxGenerateTaskJSONSize int `bson:"max_generate_task_json_size" json:"max_generate_task_json_size" yaml:"max_generate_task_json_size"`
 }
 
 var (
 	maxTasksPerVersionKey    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
 	maxIncludesPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
 	maxPendingGeneratedTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
+	maxGenerateTaskJSONSize  = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -58,6 +62,7 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			maxTasksPerVersionKey:    c.MaxTasksPerVersion,
 			maxIncludesPerVersionKey: c.MaxIncludesPerVersion,
 			maxPendingGeneratedTasks: c.MaxPendingGeneratedTasks,
+			maxGenerateTaskJSONSize:  c.MaxGenerateTaskJSONSize,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2820,6 +2820,7 @@ type APITaskLimitsConfig struct {
 	MaxTasksPerVersion       *int `json:"max_tasks_per_version"`
 	MaxIncludesPerVersion    *int `json:"max_includes_per_version"`
 	MaxPendingGeneratedTasks *int `json:"max_pending_generated_tasks"`
+	MaxGenerateTaskJSONSize  *int `json:"max_generate_task_json_size"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2828,6 +2829,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxTasksPerVersion = utility.ToIntPtr(v.MaxTasksPerVersion)
 		c.MaxIncludesPerVersion = utility.ToIntPtr(v.MaxIncludesPerVersion)
 		c.MaxPendingGeneratedTasks = utility.ToIntPtr(v.MaxPendingGeneratedTasks)
+		c.MaxGenerateTaskJSONSize = utility.ToIntPtr(v.MaxGenerateTaskJSONSize)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2839,5 +2841,6 @@ func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 		MaxTasksPerVersion:       utility.FromIntPtr(c.MaxTasksPerVersion),
 		MaxIncludesPerVersion:    utility.FromIntPtr(c.MaxIncludesPerVersion),
 		MaxPendingGeneratedTasks: utility.FromIntPtr(c.MaxPendingGeneratedTasks),
+		MaxGenerateTaskJSONSize:  utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
 	}, nil
 }

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -22,7 +22,7 @@ type Thing struct {
 	Thing string `json:"thing"`
 }
 
-func TestValidateJSON(t *testing.T) {
+func TestValidate(t *testing.T) {
 	assert := assert.New(t)
 	jsonBytes := []byte(`
 [
@@ -49,6 +49,8 @@ func TestValidateJSON(t *testing.T) {
 			assert.Equal("two", thing.Thing)
 		}
 	}
+
+	assert.NoError(validateFileSize(files, 1))
 }
 
 func TestGenerateExecute(t *testing.T) {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -610,6 +610,10 @@ Admin Settings
 										<label>Max Pending Generated Tasks</label>
 										<input type="number" ng-model="Settings.task_limits.max_pending_generated_tasks">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Generate Task JSON Limit (MB)</label>
+										<input type="number" ng-model="Settings.task_limits.max_generate_task_json_size">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>


### PR DESCRIPTION
DEVPROD-6070

### Description
Adds json limit to admin settings and generate tasks checks if the json is too big 
if the limit is not set, it is ignored

### Testing
unit test (didn't add failing case because i didn't want a 1MB file in test)
