### PR TITLE
DEVPROD-1735: make Slack alert logging optional

### DIFF
--- a/config.go
+++ b/config.go
@@ -506,7 +506,7 @@ func (s *Settings) GetSender(ctx context.Context, env Environment) (send.Sender,
 	}
 
 	// the slack logging service is only for logging very high level alerts.
-	if s.Slack.Token != "" {
+	if s.Slack.Token != "" && level.FromString(s.Slack.Level).IsValid() {
 		sender, err = send.NewSlackLogger(s.Slack.Options, s.Slack.Token,
 			send.LevelInfo{Default: level.Critical, Threshold: level.FromString(s.Slack.Level)})
 		if err == nil {

--- a/config_slack.go
+++ b/config_slack.go
@@ -68,7 +68,7 @@ func (c *SlackConfig) ValidateAndDefault() error {
 			return errors.Wrap(err, "with a non-empty token, you must specify a valid Slack configuration")
 		}
 
-		if !level.FromString(c.Level).IsValid() {
+		if c.Level != "" && !level.FromString(c.Level).IsValid() {
 			return errors.Errorf("%s is not a valid priority", c.Level)
 		}
 	}


### PR DESCRIPTION
DEVPROD-1735

### Description
Apparently, the Slack token is used for the new Slack app, but it's also used to determine whether or not we log to ops alerts. Since the level settings and other Slack admin settings only apply to ops alerting, I'm going to make them optional so that when the app starts, it'll still set up the Slack app but not the ops alerting.

### Testing
Deployed staging with just the token set, bounced the app, and then verified that I still got a Slack notification for a finished task.

### Documentation
N/A