### PR TITLE
DEVPROD-3670 Continue for display task error for stepback in markend

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -877,9 +877,10 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		if t.IsPartOfDisplay() {
 			_, err = t.GetDisplayTask()
 			if err != nil {
-				return errors.Wrap(err, "getting display task")
+				err = errors.Wrap(err, "getting display task")
+			} else {
+				err = evalStepback(ctx, t.DisplayTask, status)
 			}
-			err = evalStepback(ctx, t.DisplayTask, status)
 		} else {
 			err = evalStepback(ctx, t, status)
 		}


### PR DESCRIPTION
DEVPROD-3670

### Description
This ticket was to look in to continuing more in MarkEnd (I looked in to the Task's MarkEnd and the main MarkEnd we have for task lifecycle) to ensure core Evergreen behaviors, like setting status, get done more. I looked at our splunk logs for any of the errors that return kind of early, and it _never_ happens (in the last 6 months at least). The only improvement I could find is this straggler of a return inside of our stepback calls

### Testing
Existing unit tests
