### PR TITLE
DEVPROD-6601 Get task before midway task if midway task is not found

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1419,14 +1419,14 @@ func findMidwayTask(t1, t2 Task) (*Task, error) {
 	return FindOne(db.Query(ByRevisionOrderNumber(t1.BuildVariant, t1.DisplayName, t1.Project, t1.Requester, mid)))
 }
 
-// FindMidwayTaskFromIds gets the task between two tasks given that they are
-// from the same project, requester, build variant, and display name. If the tasks
-// passed cannot have a middle (i.e. it is sequential tasks or the same task)
-// it will return the first task given.
-func FindMidwayTaskFromIds(t1Id, t2Id string) (*Task, error) {
-	if t1Id == "" || t2Id == "" {
-		return nil, nil
-	}
+// ByBeforeMidwayTaskFromIds gets the task before the midway task between two tasks.
+// It checks that the tasks are from the same project, requester,
+// build variant, and display name.
+// It looks between the order revision number of the two tasks
+// and returns the task in the middle. If that version does not
+// have the task, it will look before that version for one that
+// matches. If it cannot find a task, it returns the second task.
+func ByBeforeMidwayTaskFromIds(t1Id, t2Id string) (*Task, error) {
 	t1, err := FindOneId(t1Id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding task id '%s'", t1Id)
@@ -1436,12 +1436,67 @@ func FindMidwayTaskFromIds(t1Id, t2Id string) (*Task, error) {
 	}
 	t2, err := FindOneId(t2Id)
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding task id %s", t2Id)
+		return nil, errors.Wrapf(err, "finding task id '%s'", t2Id)
 	}
 	if t2 == nil {
 		return nil, errors.Errorf("could not find task id '%s'", t2Id)
 	}
-	return findMidwayTask(*t1, *t2)
+
+	// The tasks should be the same build variant, display name, project, and requester.
+	catcher := grip.NewBasicCatcher() // Makes an error accumulator
+	catcher.ErrorfWhen(t1.BuildVariant != t2.BuildVariant, "given tasks have differing build variants '%s' and '%s'", t1.BuildVariant, t2.BuildVariant)
+	catcher.ErrorfWhen(t1.DisplayName != t2.DisplayName, "given tasks have differing display name '%s' and '%s'", t1.DisplayName, t2.DisplayName)
+	catcher.ErrorfWhen(t1.Project != t2.Project, "given tasks have differing project '%s' and '%s'", t1.Project, t2.Project)
+	catcher.ErrorfWhen(t1.Requester != t2.Requester, "given tasks have differing requester '%s' and '%s'", t1.Requester, t2.Requester)
+	if catcher.HasErrors() {
+		return nil, catcher.Resolve()
+	}
+
+	middleOrderNumber := (t1.RevisionOrderNumber + t2.RevisionOrderNumber) / 2
+	filter, sort := ByBeforeRevision(middleOrderNumber+1, t1.BuildVariant, t1.DisplayName, t1.Project, t1.Requester)
+	query := db.Query(filter).Sort(sort)
+
+	task, err := FindOne(query)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding task between '%s' and '%s'", t1Id, t2Id)
+	}
+	if task == nil {
+		return nil, errors.Errorf("could not find task between '%s' and '%s'", t1Id, t2Id)
+	}
+
+	// If t1 is before t2, t1 is our lower bound and t2 is our upper bound.
+	if t1.RevisionOrderNumber <= t2.RevisionOrderNumber {
+		if task.RevisionOrderNumber >= t2.RevisionOrderNumber || task.RevisionOrderNumber <= t1.RevisionOrderNumber {
+			grip.Info(message.Fields{
+				"message":                 "found midway task is out of bounds",
+				"t1_id":                   t1Id,
+				"t1_order_number":         t1.RevisionOrderNumber,
+				"t2_id":                   t2Id,
+				"t2_order_number":         t2.RevisionOrderNumber,
+				"found_task":              task.Id,
+				"found_task_order_number": task.RevisionOrderNumber,
+			})
+			// We return the lower bound task if the found task is out of bounds.
+			return t1, nil
+		}
+	} else {
+		// If t2 is before t1, t2 is our lower bound and t1 is our upper bound.
+		if task.RevisionOrderNumber >= t1.RevisionOrderNumber || task.RevisionOrderNumber <= t2.RevisionOrderNumber {
+			grip.Info(message.Fields{
+				"message":                 "found midway task is out of bounds",
+				"t1_id":                   t1Id,
+				"t1_order_number":         t1.RevisionOrderNumber,
+				"t2_id":                   t2Id,
+				"t2_order_number":         t2.RevisionOrderNumber,
+				"found_task":              task.Id,
+				"found_task_order_number": task.RevisionOrderNumber,
+			})
+			// We return the lower bound task if the found task is out of bounds.
+			return t2, nil
+		}
+	}
+
+	return task, nil
 }
 
 // UnscheduleStaleUnderwaterHostTasks Removes host tasks older than the unscheduable threshold (e.g. one week) from

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1388,13 +1388,13 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	return nil
 }
 
-// ByBeforeMidwayTaskFromIds gets the task before the midway task between two tasks.
-// It checks that the tasks are from the same project, requester,
+// ByBeforeMidwayTaskFromIds tries to get the midway task between two tasks
+// but if it does not find it (i.e. periodic builds), it gets the closest task
+// (with lower order number). If there are no matching tasks, or the task it
+// gets is out of bounds, it returns the given lower order revision task.
+//
+// It verifies that the tasks are from the same project, requester,
 // build variant, and display name.
-// It looks between the order revision number of the two tasks
-// and returns the task in the middle. If that version does not
-// have the task, it will look before that version for one that
-// matches. If it cannot find a task, it returns the second task.
 func ByBeforeMidwayTaskFromIds(t1Id, t2Id string) (*Task, error) {
 	t1, err := FindOneId(t1Id)
 	if err != nil {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1306,7 +1306,7 @@ func TestBulkInsert(t *testing.T) {
 	}
 }
 
-func TestFindMidwayTask(t *testing.T) {
+func TestByBeforeMidwayTaskFromIds(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 	displayName := "cool-task-9000"
@@ -1326,88 +1326,138 @@ func TestFindMidwayTask(t *testing.T) {
 		assert.NoError(task.Insert())
 		tasks = append(tasks, task)
 	}
-	t10, err := findMidwayTask(tasks[0], tasks[19])
+	t10, err := ByBeforeMidwayTaskFromIds(tasks[0].Id, tasks[19].Id)
 	assert.NoError(err)
 	require.NotNil(t, t10)
 	assert.Equal(10, t10.RevisionOrderNumber)
 
-	t5, err := findMidwayTask(tasks[0], tasks[9])
+	t5, err := ByBeforeMidwayTaskFromIds(tasks[0].Id, tasks[9].Id)
 	assert.NoError(err)
 	require.NotNil(t, t5)
 	assert.Equal(5, t5.RevisionOrderNumber, 5)
 
-	t15, err := findMidwayTask(tasks[10], tasks[19])
+	t15, err := ByBeforeMidwayTaskFromIds(tasks[10].Id, tasks[19].Id)
 	assert.NoError(err)
 	require.NotNil(t, t15)
 	assert.Equal(15, t15.RevisionOrderNumber)
 
-	t19, err := findMidwayTask(tasks[17], tasks[19])
+	t19, err := ByBeforeMidwayTaskFromIds(tasks[17].Id, tasks[19].Id)
 	assert.NoError(err)
 	require.NotNil(t, t19)
 	assert.Equal(19, t19.RevisionOrderNumber)
 
-	t4, err := findMidwayTask(tasks[6], tasks[0])
+	t4, err := ByBeforeMidwayTaskFromIds(tasks[6].Id, tasks[0].Id)
 	assert.NoError(err)
 	require.NotNil(t, t4)
 	assert.Equal(4, t4.RevisionOrderNumber)
 
-	t12, err := findMidwayTask(tasks[11], tasks[11])
+	t12, err := ByBeforeMidwayTaskFromIds(tasks[11].Id, tasks[11].Id)
 	assert.NoError(err)
 	require.NotNil(t, t12)
 	assert.Equal(12, t12.RevisionOrderNumber)
 
-	t16, err := findMidwayTask(tasks[15], tasks[16])
+	t16, err := ByBeforeMidwayTaskFromIds(tasks[15].Id, tasks[16].Id)
 	assert.NoError(err)
 	require.NotNil(t, t16)
 	assert.Equal(16, t16.RevisionOrderNumber)
 
-	otherDisplayName := Task{
-		Id:           "otherTaskDisplayName",
-		DisplayName:  "Other display name",
-		BuildVariant: buildVarient,
-		Requester:    requester,
-		Project:      project,
-	}
-	assert.NoError(otherDisplayName.Insert())
-	task, err := findMidwayTask(tasks[0], otherDisplayName)
-	assert.Error(err)
-	assert.Nil(task)
+	t.Run("IncompatibleTasks", func(t *testing.T) {
+		otherDisplayName := Task{
+			Id:           "otherTaskDisplayName",
+			DisplayName:  "Other display name",
+			BuildVariant: buildVarient,
+			Requester:    requester,
+			Project:      project,
+		}
+		assert.NoError(otherDisplayName.Insert())
+		task, err := ByBeforeMidwayTaskFromIds(tasks[0].Id, otherDisplayName.Id)
+		assert.Error(err)
+		assert.Nil(task)
 
-	otherBuildVariant := Task{
-		Id:           "otherTaskBuildVariant",
-		DisplayName:  displayName,
-		BuildVariant: "Other Build Variant",
-		Requester:    requester,
-		Project:      project,
-	}
-	assert.NoError(otherBuildVariant.Insert())
-	task, err = findMidwayTask(tasks[0], otherBuildVariant)
-	assert.Error(err)
-	assert.Nil(task)
+		otherBuildVariant := Task{
+			Id:           "otherTaskBuildVariant",
+			DisplayName:  displayName,
+			BuildVariant: "Other Build Variant",
+			Requester:    requester,
+			Project:      project,
+		}
+		assert.NoError(otherBuildVariant.Insert())
+		task, err = ByBeforeMidwayTaskFromIds(tasks[0].Id, otherBuildVariant.Id)
+		assert.Error(err)
+		assert.Nil(task)
 
-	otherRequester := Task{
-		Id:           "otherTaskRequester",
-		DisplayName:  displayName,
-		BuildVariant: buildVarient,
-		Requester:    "Other Requester",
-		Project:      project,
-	}
-	assert.NoError(otherRequester.Insert())
-	task, err = findMidwayTask(tasks[0], otherRequester)
-	assert.Error(err)
-	assert.Nil(task)
+		otherRequester := Task{
+			Id:           "otherTaskRequester",
+			DisplayName:  displayName,
+			BuildVariant: buildVarient,
+			Requester:    "Other Requester",
+			Project:      project,
+		}
+		assert.NoError(otherRequester.Insert())
+		task, err = ByBeforeMidwayTaskFromIds(tasks[0].Id, otherRequester.Id)
+		assert.Error(err)
+		assert.Nil(task)
 
-	otherProject := Task{
-		Id:           "otherTaskProject",
-		DisplayName:  displayName,
-		BuildVariant: buildVarient,
-		Requester:    requester,
-		Project:      "Other project",
-	}
-	assert.NoError(otherProject.Insert())
-	task, err = findMidwayTask(tasks[0], otherProject)
-	assert.Error(err)
-	assert.Nil(task)
+		otherProject := Task{
+			Id:           "otherTaskProject",
+			DisplayName:  displayName,
+			BuildVariant: buildVarient,
+			Requester:    requester,
+			Project:      "Other project",
+		}
+		assert.NoError(otherProject.Insert())
+		task, err = ByBeforeMidwayTaskFromIds(tasks[0].Id, otherProject.Id)
+		assert.Error(err)
+		assert.Nil(task)
+	})
+
+	// Usually, the midway task will be found- but if what would be the midway
+	// task is from a version (like periodic builds) that does not have the task
+	// we should get the task from earlier versions.
+	t.Run("MissingTasks", func(t *testing.T) {
+		assert.NoError(db.ClearCollections(Collection))
+		// tasks 7-13 are missing.
+		for i := 1; i <= 20; i++ {
+			if i > 6 && i < 14 {
+				continue
+			}
+			task := Task{
+				Id:                  "t" + fmt.Sprint(i),
+				DisplayName:         displayName,
+				BuildVariant:        buildVarient,
+				Requester:           requester,
+				Project:             project,
+				RevisionOrderNumber: i,
+			}
+			assert.NoError(task.Insert())
+		}
+
+		// The midway task would be t10, but since tasks 7-13 are missing
+		// it gets the next task earliest task that is not missing, which is t6.
+		t6, err := ByBeforeMidwayTaskFromIds("t1", "t20")
+		assert.NoError(err)
+		require.NotNil(t, t6)
+		assert.Equal(6, t6.RevisionOrderNumber)
+
+		t6, err = ByBeforeMidwayTaskFromIds("t5", "t20")
+		assert.NoError(err)
+		require.NotNil(t, t6)
+		assert.Equal(6, t6.RevisionOrderNumber)
+
+		t6, err = ByBeforeMidwayTaskFromIds("t5", "t16")
+		assert.NoError(err)
+		require.NotNil(t, t6)
+		assert.Equal(6, t6.RevisionOrderNumber)
+
+		t6, err = ByBeforeMidwayTaskFromIds("t6", "t14")
+		assert.NoError(err)
+		require.NotNil(t, t6)
+		assert.Equal(6, t6.RevisionOrderNumber)
+
+		// Using a task that doesn't exist should return an error.
+		_, err = ByBeforeMidwayTaskFromIds("t7", "t20")
+		assert.Error(err)
+	})
 }
 
 func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -609,9 +609,9 @@ func doBisectStepback(ctx context.Context, t *task.Task) error {
 	}
 
 	// The midway task is our next stepback target.
-	nextTask, err := task.FindMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
+	nextTask, err := task.ByBeforeMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	if err != nil {
-		return errors.Wrapf(err, "finding midway task between tasks '%s' and '%s'", s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
+		return errors.Wrap(err, "finding previous task")
 	}
 	if nextTask == nil {
 		return errors.Errorf("midway task could not be found for tasks '%s' '%s'", s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
@@ -709,7 +709,7 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 	}
 
 	// The midway task is our next stepback target.
-	nextTask, err := task.FindMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
+	nextTask, err := task.ByBeforeMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	if err != nil {
 		return errors.Wrapf(err, "finding midway task between tasks '%s' and '%s'", s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6303,13 +6303,13 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.UpdateOne(bson.M{"_id": "t1"},
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
+			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
 			require.NoError(err)
 			assert.False(midTask.Activated)
 		},
 		"FailedTaskInStepback": func(t *testing.T, t10 task.Task) {
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
+			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
 			prevTask := *midTask
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -6339,7 +6339,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
 			// Activate next stepback
 			require.NoError(evalStepback(ctx, &prevTask, evergreen.TaskFailed))
-			midTask, err = task.FindMidwayTaskFromIds("t1", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds(prevTask.Id, "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6363,7 +6363,7 @@ func TestEvalBisectStepback(t *testing.T) {
 		},
 		"PassedTaskInStepback": func(t *testing.T, t10 task.Task) {
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
+			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6393,7 +6393,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": evergreen.TaskSucceeded}}))
 			// Activate next stepback
 			require.NoError(evalStepback(ctx, midTask, evergreen.TaskSucceeded))
-			midTask, err = task.FindMidwayTaskFromIds("t10", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds("t10", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6475,7 +6475,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": generated2Tasks[9].Status}}))
 			require.NoError(evalStepback(ctx, &generated1Tasks[9], evergreen.TaskFailed))
 			require.NoError(evalStepback(ctx, &generated2Tasks[9], evergreen.TaskFailed))
-			midTask, err := task.FindMidwayTaskFromIds("t1", "t10")
+			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)
@@ -6544,7 +6544,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(evalStepback(ctx, midTaskG2, evergreen.TaskFailed))
 
 			// Check mid task stepback info relating to generated task 1.
-			midTask, err = task.FindMidwayTaskFromIds("t10", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds("t10", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)
@@ -6566,7 +6566,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.Nil(g2Info)
 
 			// Check mid task stepback info relating to generated task 2.
-			midTask, err = task.FindMidwayTaskFromIds("t1", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds(prevTask.Id, "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)


### PR DESCRIPTION
DEVPROD-6601

### Description
This switches the midway task function to get the midway task, and if it doesn't exist, the closest one (with a lower order revision number). 

It switches the function to us ByBeforeRevision instead of directly a find.

### Testing
Unit testing and staging (view comment left for screenshots/explanation)