### PR TITLE
DEVPROD-6752: add route to fix building hosts that are running

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -205,6 +205,8 @@ func (a *Agent) Start(ctx context.Context) error {
 // populateEC2InstanceID sets the agent's instance ID based on the EC2 instance
 // metadata service if it's an EC2 instance. If it's not an EC2 instance or the
 // EC2 instance ID has already been populated, this is a no-op.
+// TODO (DEVPROD-6752): remove this logic once agents have rolled over to using
+// the new route.
 func (a *Agent) populateEC2InstanceID(ctx context.Context) {
 	if a.ec2InstanceID != "" || !utility.StringSliceContains(evergreen.ProviderEc2Type, a.opts.CloudProvider) {
 		return

--- a/config.go
+++ b/config.go
@@ -34,11 +34,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-04-19"
+	ClientVersion = "2024-04-23"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-22"
+	AgentVersion = "2024-04-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1406,12 +1406,12 @@ func UnsafeReplace(ctx context.Context, env evergreen.Environment, idToRemove st
 	}
 
 	grip.Info(message.Fields{
-		"message":              "successfully replaced host document",
-		"host_id":              toInsert.Id,
-		"host_tag":             toInsert.Tag,
-		"distro":               toInsert.Distro.Id,
-		"old_host_id":          idToRemove,
-		"transaction_duration": time.Since(txnStart),
+		"message":                   "successfully replaced host document",
+		"host_id":                   toInsert.Id,
+		"host_tag":                  toInsert.Tag,
+		"distro":                    toInsert.Distro.Id,
+		"old_host_id":               idToRemove,
+		"transaction_duration_secs": time.Since(txnStart).Seconds(),
 	})
 
 	return nil

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1236,6 +1236,11 @@ func (h *Host) GenerateFetchProvisioningScriptUserData(ctx context.Context, env 
 		fmt.Sprintf("--api_server=%s", env.Settings().ApiUrl),
 		fmt.Sprintf("--host_id=%s", h.Id),
 		fmt.Sprintf("--host_secret=%s", h.Secret),
+		// TODO (DEVPROD-6752): set this flag once all the
+		// currently-provisioning hosts from before the deploy have all
+		// finished. This is intentionally not yet set to maintain temporary
+		// backward compatibility.
+		// fmt.Sprintf("--provider=%s", h.Distro.Provider),
 		fmt.Sprintf("--working_dir=%s", h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperBinaryDir)),
 		fmt.Sprintf("--shell_path=%s", h.Distro.ShellBinary()),
 	}, " ")

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -124,6 +124,9 @@ type Communicator interface {
 	// Evergreen binary for a given distro.
 	GetClientURLs(ctx context.Context, distroID string) ([]string, error)
 
+	// PostHostIsUp indicates to the app server that the task host is up and
+	// running.
+	PostHostIsUp(ctx context.Context, hostID, hostSecret, instanceID string) (*restmodel.APIHost, error)
 	// GetHostProvisioningOptions gets the options to provision a host.
 	GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error)
 

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1516,11 +1516,11 @@ func (c *communicatorImpl) PostHostIsUp(ctx context.Context, hostID, hostSecret,
 		method: http.MethodPost,
 		path:   fmt.Sprintf("/hosts/%s/is_up", hostID),
 	}
-	params := restmodel.APIHostIsUpParams{
+	opts := restmodel.APIHostIsUpOptions{
 		HostID:        hostID,
 		EC2InstanceID: ec2InstanceID,
 	}
-	r, err := c.createRequest(info, params)
+	r, err := c.createRequest(info, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
 	}
@@ -1536,7 +1536,7 @@ func (c *communicatorImpl) PostHostIsUp(ctx context.Context, hostID, hostSecret,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, util.RespErrorf(resp, "posting that host is up")
+		return nil, util.RespErrorf(resp, "posting that host '%s' is up", hostID)
 	}
 	var h restmodel.APIHost
 	if err = utility.ReadJSON(resp.Body, &h); err != nil {

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -341,7 +341,13 @@ func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
 	return []string{"https://example.com"}, nil
 }
 
-func (c *Mock) GetHostProvisioningOptions(context.Context, string, string) (*restmodel.APIHostProvisioningOptions, error) {
+func (c *Mock) PostHostIsUp(ctx context.Context, hostID, hostSecret, instanceID string) (*restmodel.APIHost, error) {
+	return &restmodel.APIHost{
+		Id: utility.ToStringPtr("mock_host_id"),
+	}, nil
+}
+
+func (c *Mock) GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error) {
 	return &restmodel.APIHostProvisioningOptions{
 		Content: "echo hello world",
 	}, nil

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/rest/model"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
@@ -260,4 +262,122 @@ func makeSpawnOptions(options *restmodel.HostRequestOptions, user *user.DBUser) 
 		},
 	}
 	return &spawnOptions, nil
+}
+
+// PostHostIsUp indicates to the app server that a host is up.
+func PostHostIsUp(ctx context.Context, params restmodel.APIHostIsUpParams) (*restmodel.APIHost, error) {
+	h, err := host.FindOneByIdOrTag(ctx, params.HostID)
+	if err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrapf(err, "finding host '%s'", params.HostID).Error(),
+		}
+	}
+	if h == nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host '%s' not found", params.HostID),
+		}
+	}
+
+	if err := fixProvisioningIntentHost(ctx, h, params.EC2InstanceID); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "fixing intent host").Error(),
+		}
+	}
+
+	var apiHost model.APIHost
+	apiHost.BuildFromService(h, nil)
+	return &apiHost, nil
+}
+
+func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID string) error {
+	if cloud.IsEC2InstanceID(h.Id) {
+		// If the host already has an instance ID, it's not an intent host.
+		return nil
+	}
+	if !evergreen.IsEc2Provider(h.Distro.Provider) {
+		// Intent host issues only affect ephemeral (i.e. EC2) hosts.
+		return nil
+	}
+	if instanceID == "" {
+		// If the host is an intent host but the agent does not send the EC2
+		// instance ID, there's nothing that can be done to fix it here.
+
+		// TODO (DEVPROD-6752): should log and return an error once all hosts
+		// roll over from the deploy. All intent hosts should be sending their
+		// EC2 instance ID. If they don't, it should fail provisioning and
+		// should not start the agent.
+		// msg := "intent host is running, but it did not provide an EC2 instance ID, which is required"
+		// grip.Warning(message.Fields{
+		//     "message":     msg,
+		//     "host_id":     h.Id,
+		//     "host_status": h.Status,
+		//     "provider":    h.Distro.Provider,
+		//     "distro":      h.Distro.Id,
+		// })
+		return nil
+	}
+
+	env := evergreen.GetEnvironment()
+	switch h.Status {
+	case evergreen.HostBuilding:
+		return errors.Wrap(transitionIntentHostToStarting(ctx, env, h, instanceID), "starting intent host that actually succeeded")
+	case evergreen.HostBuildingFailed, evergreen.HostTerminated:
+		return errors.Wrap(transitionIntentHostToDecommissioned(ctx, env, h, instanceID), "decommissioning intent host")
+	default:
+		return errors.Errorf("logical error: intent host is in state '%s', which should be impossible when the agent is running", h.Status)
+	}
+}
+
+func transitionIntentHostToStarting(ctx context.Context, env evergreen.Environment, hostToStart *host.Host, instanceID string) error {
+	grip.Notice(message.Fields{
+		"message":     "DB-EC2 state mismatch - EC2 instance started but Evergreen still has it stored as an intent host, fixing now",
+		"old_host_id": hostToStart.Id,
+		"new_host_id": instanceID,
+		"host_tag":    hostToStart.Tag,
+		"distro":      hostToStart.Distro.Id,
+		"host_status": hostToStart.Status,
+	})
+
+	intentHostID := hostToStart.Id
+	hostToStart.Id = instanceID
+	hostToStart.Status = evergreen.HostStarting
+	hostToStart.StartTime = time.Now()
+	if err := host.UnsafeReplace(ctx, env, intentHostID, hostToStart); err != nil {
+		return errors.Wrap(err, "replacing intent host with real host")
+	}
+
+	event.LogHostStartSucceeded(hostToStart.Id)
+
+	return nil
+}
+
+func transitionIntentHostToDecommissioned(ctx context.Context, env evergreen.Environment, hostToDecommission *host.Host, instanceID string) error {
+	grip.Notice(message.Fields{
+		"message":     "DB-EC2 state mismatch - EC2 instance started but Evergreen already gave up on this host, fixing now",
+		"host_id":     hostToDecommission.Id,
+		"instance_id": instanceID,
+		"host_status": hostToDecommission.Status,
+	})
+
+	intentHostID := hostToDecommission.Id
+	hostToDecommission.Id = instanceID
+	oldStatus := hostToDecommission.Status
+	hostToDecommission.Status = evergreen.HostDecommissioned
+	if err := host.UnsafeReplace(ctx, env, intentHostID, hostToDecommission); err != nil {
+		return errors.Wrap(err, "replacing intent host with real host")
+	}
+
+	event.LogHostStatusChanged(hostToDecommission.Id, oldStatus, hostToDecommission.Status, evergreen.User, "host started agent but intent host is already considered a failure")
+	grip.Info(message.Fields{
+		"message":    "intent host decommissioned",
+		"host_id":    hostToDecommission.Id,
+		"host_tag":   hostToDecommission.Tag,
+		"distro":     hostToDecommission.Distro.Id,
+		"old_status": oldStatus,
+	})
+
+	return nil
 }

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -265,7 +265,7 @@ func makeSpawnOptions(options *restmodel.HostRequestOptions, user *user.DBUser) 
 }
 
 // PostHostIsUp indicates to the app server that a host is up.
-func PostHostIsUp(ctx context.Context, params restmodel.APIHostIsUpParams) (*restmodel.APIHost, error) {
+func PostHostIsUp(ctx context.Context, params restmodel.APIHostIsUpOptions) (*restmodel.APIHost, error) {
 	h, err := host.FindOneByIdOrTag(ctx, params.HostID)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -294,7 +294,7 @@ type APIOffboardUserResults struct {
 	TerminatedVolumes []string `json:"terminated_volumes"`
 }
 
-type APIHostIsUpParams struct {
+type APIHostIsUpOptions struct {
 	HostID        string `json:"host_id"`
 	EC2InstanceID string `json:"ec2_instance_id,omitempty"`
 }

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -294,6 +294,11 @@ type APIOffboardUserResults struct {
 	TerminatedVolumes []string `json:"terminated_volumes"`
 }
 
+type APIHostIsUpParams struct {
+	HostID        string `json:"host_id"`
+	EC2InstanceID string `json:"ec2_instance_id,omitempty"`
+}
+
 // APIHostProvisioningOptions represents the script to provision a host.
 type APIHostProvisioningOptions struct {
 	Content string `json:"content"`

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -408,6 +408,35 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 	return gimlet.NewJSONResponse(apiOpts)
 }
 
+// GET /hosts/{host_id}/is_up
+
+type hostIsUpPostHandler struct {
+	params model.APIHostIsUpParams
+}
+
+func makeHostIsUpPostHandler() gimlet.RouteHandler {
+	return &hostIsUpPostHandler{}
+}
+
+func (rh *hostIsUpPostHandler) Factory() gimlet.RouteHandler {
+	return &hostIsUpPostHandler{}
+}
+
+func (rh *hostIsUpPostHandler) Parse(ctx context.Context, r *http.Request) error {
+	if err := utility.ReadJSON(r.Body, &rh.params); err != nil {
+		return errors.Wrap(err, "reading host is up parameters from JSON request body")
+	}
+	return nil
+}
+
+func (rh *hostIsUpPostHandler) Run(ctx context.Context) gimlet.Responder {
+	apiHost, err := data.PostHostIsUp(ctx, rh.params)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(err)
+	}
+	return gimlet.NewJSONResponse(apiHost)
+}
+
 // //////////////////////////////////////////////////////////////////////
 //
 // POST /rest/v2/hosts/{host_id}/disable

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -411,7 +411,7 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 // GET /hosts/{host_id}/is_up
 
 type hostIsUpPostHandler struct {
-	params model.APIHostIsUpParams
+	params model.APIHostIsUpOptions
 }
 
 func makeHostIsUpPostHandler() gimlet.RouteHandler {

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -325,6 +325,8 @@ func (h *hostAgentNextTask) prepareHostForAgentExit(ctx context.Context, params 
 // fixIntentHostRunningAgent handles an exceptional case in which an ephemeral
 // host is still believed to be an intent host but somehow the agent is running
 // on an EC2 instance associated with that intent host.
+// TODO (DEVPROD-6752): remove this once hosts have all transitioned to using
+// new route.
 func (h *hostAgentNextTask) fixIntentHostRunningAgent(ctx context.Context, host *host.Host, instanceID string) error {
 	if !evergreen.IsEc2Provider(host.Provider) {
 		// Intent host issues only affect ephemeral (i.e. EC2) hosts.
@@ -360,6 +362,8 @@ func (h *hostAgentNextTask) fixIntentHostRunningAgent(ctx context.Context, host 
 // transitionIntentHostToStarting converts an intent host to a real host
 // because it's alive in the cloud. It is marked as starting to indicate that
 // the host has started and can run tasks.
+// TODO (DEVPROD-6752): remove this once hosts have transitioned to using new
+// route.
 func (h *hostAgentNextTask) transitionIntentHostToStarting(ctx context.Context, hostToStart *host.Host, instanceID string) error {
 	grip.Notice(message.Fields{
 		"message":     "DB-EC2 state mismatch - found EC2 instance running an agent, but Evergreen believes the host still an intent host",
@@ -385,6 +389,8 @@ func (h *hostAgentNextTask) transitionIntentHostToStarting(ctx context.Context, 
 // transitionIntentHostToDecommissioned converts an intent host to a real
 // host because it's alive in the cloud. It is marked as decommissioned to
 // indicate that the host is not valid and should be terminated.
+// TODO (DEVPROD-6752): remove this once hosts have transitioned to using new
+// route.
 func (h *hostAgentNextTask) transitionIntentHostToDecommissioned(ctx context.Context, hostToDecommission *host.Host, instanceID string) error {
 	grip.Notice(message.Fields{
 		"message":     "DB-EC2 state mismatch - found EC2 instance running an agent, but Evergreen believes the host is a stale building intent host",

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1023,7 +1023,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			instanceID := generateFakeEC2InstanceID()
 
-			rh.params = restmodel.APIHostIsUpParams{
+			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        h.Id,
 				EC2InstanceID: instanceID,
 			}
@@ -1051,7 +1051,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 
 			instanceID := generateFakeEC2InstanceID()
 
-			rh.params = restmodel.APIHostIsUpParams{
+			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        h.Id,
 				EC2InstanceID: instanceID,
 			}
@@ -1081,7 +1081,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 
 			instanceID := generateFakeEC2InstanceID()
-			rh.params = restmodel.APIHostIsUpParams{
+			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        h.Id,
 				EC2InstanceID: instanceID,
 			}
@@ -1112,7 +1112,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			h.Status = evergreen.HostStarting
 			require.NoError(t, h.Insert(ctx))
 
-			rh.params = restmodel.APIHostIsUpParams{
+			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        instanceID,
 				EC2InstanceID: instanceID,
 			}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -1006,6 +1007,155 @@ func TestDisableHostHandler(t *testing.T) {
 	foundHost, err := host.FindOneId(ctx, hostID)
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.HostDecommissioned, foundHost.Status)
+}
+
+func TestHostIsUpPostHandler(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(host.Collection))
+	}()
+
+	generateFakeEC2InstanceID := func() string {
+		return "i-" + utility.RandomString()
+	}
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host){
+		"ConvertsBuildingIntentHostToStartingRealHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
+			require.NoError(t, h.Insert(ctx))
+			instanceID := generateFakeEC2InstanceID()
+
+			rh.params = restmodel.APIHostIsUpParams{
+				HostID:        h.Id,
+				EC2InstanceID: instanceID,
+			}
+			resp := rh.Run(ctx)
+
+			require.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+			apiHost, ok := resp.Data().(*restmodel.APIHost)
+			require.True(t, ok, resp.Data())
+			require.NotZero(t, apiHost)
+			assert.Equal(t, instanceID, utility.FromStringPtr(apiHost.Id))
+
+			dbIntentHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			assert.Zero(t, dbIntentHost)
+
+			realHost, err := host.FindOneId(ctx, instanceID)
+			require.NoError(t, err)
+			require.NotZero(t, realHost)
+			assert.Equal(t, realHost.Status, evergreen.HostStarting, "intent host should be converted to real host when it's up")
+		},
+		"ConvertsFailedIntentHostToDecommissionedRealHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
+			h.Status = evergreen.HostBuildingFailed
+			require.NoError(t, h.Insert(ctx))
+
+			instanceID := generateFakeEC2InstanceID()
+
+			rh.params = restmodel.APIHostIsUpParams{
+				HostID:        h.Id,
+				EC2InstanceID: instanceID,
+			}
+
+			resp := rh.Run(ctx)
+
+			require.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+			apiHost, ok := resp.Data().(*restmodel.APIHost)
+			require.True(t, ok, resp.Data())
+			require.NotZero(t, apiHost)
+			assert.Equal(t, instanceID, utility.FromStringPtr(apiHost.Id))
+			assert.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			dbIntentHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			assert.Zero(t, dbIntentHost)
+
+			realHost, err := host.FindOneId(ctx, instanceID)
+			require.NoError(t, err)
+			require.NotZero(t, realHost)
+			assert.Equal(t, evergreen.HostDecommissioned, realHost.Status, "host that fails to build should be decommissioned when it comes up")
+		},
+		"ConvertsTerminatedHostIntoDecommissionedRealHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
+			h.Status = evergreen.HostTerminated
+			require.NoError(t, h.Insert(ctx))
+
+			instanceID := generateFakeEC2InstanceID()
+			rh.params = restmodel.APIHostIsUpParams{
+				HostID:        h.Id,
+				EC2InstanceID: instanceID,
+			}
+
+			resp := rh.Run(ctx)
+
+			require.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+			apiHost, ok := resp.Data().(*restmodel.APIHost)
+			require.True(t, ok, resp.Data())
+			require.NotZero(t, apiHost)
+			assert.Equal(t, instanceID, utility.FromStringPtr(apiHost.Id))
+			assert.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			dbIntentHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			assert.Zero(t, dbIntentHost)
+
+			realHost, err := host.FindOneId(ctx, instanceID)
+			require.NoError(t, err)
+			require.NotZero(t, realHost)
+			assert.Equal(t, realHost.Status, evergreen.HostDecommissioned, "already-terminated intent host should be decommissioned when it's up")
+		},
+		"NoopsForNonIntentHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
+			instanceID := generateFakeEC2InstanceID()
+			h.Id = instanceID
+			h.Status = evergreen.HostStarting
+			require.NoError(t, h.Insert(ctx))
+
+			rh.params = restmodel.APIHostIsUpParams{
+				HostID:        instanceID,
+				EC2InstanceID: instanceID,
+			}
+
+			resp := rh.Run(ctx)
+
+			require.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+			apiHost, ok := resp.Data().(*restmodel.APIHost)
+			require.True(t, ok, resp.Data())
+			require.NotZero(t, apiHost)
+			assert.Equal(t, instanceID, utility.FromStringPtr(apiHost.Id))
+			assert.NotZero(t, resp)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			dbHost, err := host.FindOneId(ctx, instanceID)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostStarting, dbHost.Status, "host should not be modified if it's not an intent host")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, db.ClearCollections(host.Collection))
+
+			rh, ok := makeHostIsUpPostHandler().(*hostIsUpPostHandler)
+			require.True(t, ok)
+
+			h := &host.Host{
+				Id:       "evg-12345",
+				Status:   evergreen.HostBuilding,
+				Provider: evergreen.ProviderNameEc2Fleet,
+				Distro: distro.Distro{
+					Id:       "distro_id",
+					Provider: evergreen.ProviderNameEc2Fleet,
+				},
+			}
+
+			tCase(ctx, t, rh, h)
+		})
+	}
 }
 
 func TestHostProvisioningOptionsGetHandler(t *testing.T) {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -167,6 +167,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{host_id}/terminate").Version(2).Post().Wrap(requireUser).RouteHandler(makeTerminateHostRoute())
 	app.AddRoute("/hosts/{host_id}/attach").Version(2).Post().Wrap(requireUser).RouteHandler(makeAttachVolume(env))
 	app.AddRoute("/hosts/{host_id}/detach").Version(2).Post().Wrap(requireUser).RouteHandler(makeDetachVolume(env))
+	app.AddRoute("/hosts/{host_id}/is_up").Version(2).Post().Wrap(requireHost).RouteHandler(makeHostIsUpPostHandler())
 	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostProvisioningOptionsGetHandler(env))
 	app.AddRoute("/hosts/ip_address/{ip_address}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetHostByIpAddress())
 	app.AddRoute("/volumes").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetVolumes())


### PR DESCRIPTION
DEVPROD-6752

## Description
Worth calling out that I thought this bug was fixed a long time ago, but apparently it's still an issue. So most of this change is actually a copy-paste to make it work better, not wholly new logic. There will be a follow-up PR to finalize the fix and remove the redundant fallback logic after this one is deployed.

### What is the bug
The app server starting hosts is a rather error-prone and race-heavy process because EC2 operates separately from the Evergreen apps, so EC2 hosts can end up doing things that aren't always in sync with what Evergreen thinks is the current state of affairs. Hosts are created in a two-step process:

1. [It requests the host from EC2](https://github.com/evergreen-ci/evergreen/blob/fe548c06abac8878db33b1fab2fa98c759685085/units/provisioning_create_host.go#L409)
2. [It actually stores the EC2 instance ID for the host it just made based on EC2's response](https://github.com/evergreen-ci/evergreen/blob/fe548c06abac8878db33b1fab2fa98c759685085/units/provisioning_create_host.go#L432).

After step 2, the EC2 instance ID is the unique `_id` for the host document and almost all other logic in Evergreen assumes that the `_id` is the EC2 instance ID. That's the easy, happy path where everything goes well.

Unfortunately, if Evergreen succeeds in step 1 but is interrupted (e.g. by a deploy) before step 2 happens, it may simply not realize that it already made the host because it's not in the DB. Later on, the host will come up on its own but Evergreen will have no idea what the host's EC2 instance ID is. That Evergreen doesn't know the EC2 instance ID is what causes issues with that host running tasks, because so much logic in the agent protocol and task lifecycle assumes that `_id` is the EC2 instance ID.

### How it's fixed
EC2 instances can ping [a local metadata endpoint to get their EC2 instance ID](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html), so they can retrieve their own EC2 instance ID even if Evergreen can't. Using their EC2 instance ID, they can come back to Evergreen and say "use this instance ID" if Evergreen doesn't know it, and then Evergreen can do step 2 above to set the EC2 instance ID in the DB. The effect of moving it is that the agent will always start up with the correct host ID (i.e. the EC2 instance ID), and thus the bug is fixed.

### What actually changed
* Add logic to the CLI send Evergreen the EC2 instance ID when the host is up and running.
* Copy-paste existing app server logic [from here](https://github.com/evergreen-ci/evergreen/blob/fc4540460683212584cecd7347fc6ff6d123b256/rest/route/host_agent.go#L325-L328) into the new route to fix building hosts that are running.
* Add TODOs for follow-up work to finish this change.

## Testing
* Tested in staging to verify that:
    * Existing hosts that started before the deployed changes could still provision.
    * New hosts used the new route and provisioned successfully by passing their own EC2 instance ID to Evergreen.
* Copy-pasted [unit tests from original tests](https://github.com/evergreen-ci/evergreen/blob/fc4540460683212584cecd7347fc6ff6d123b256/rest/route/host_agent_test.go#L234) to new route.
* Post-deploy, going to monitor for errors related to this.

## Documentation
N/A