### PR TITLE
docs: remove duplicate exec_timeout_secs example

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -582,10 +582,6 @@ tasks:
           sleep 1000
 ```
 
-```yaml
-exec_timeout_secs: 60
-```
-
 ### Limiting When a Task Will Run
 
 To limit the conditions when a task will run, the following settings can be


### PR DESCRIPTION
Noticed that there was an example in the project config that basically just duplicates a snippet of the example already above it. Seems like it can be deleted.