### PR TITLE
DEVPROD-2269 Add more metrics to host-allocator span

### DIFF
--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -288,9 +288,15 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
 		attribute.String(evergreen.DistroIDOtelAttribute, distro.Id),
+		attribute.String(fmt.Sprintf("%s.distro_provider", hostAllocatorAttributePrefix), distro.Provider),
+		attribute.String(fmt.Sprintf("%s.total_runtime", hostAllocatorAttributePrefix), distroQueueInfo.ExpectedDuration.String()),
+		attribute.String(fmt.Sprintf("%s.time_to_empty", hostAllocatorAttributePrefix), timeToEmpty.String()),
+		attribute.String(fmt.Sprintf("%s.time_to_empty_no_spawns", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.String()),
+		attribute.Int(fmt.Sprintf("%s.distro_max_hosts", hostAllocatorAttributePrefix), distro.HostAllocatorSettings.MaximumHosts),
 		attribute.Int(fmt.Sprintf("%s.hosts_requested", hostAllocatorAttributePrefix), len(hostsSpawned)),
 		attribute.Int(fmt.Sprintf("%s.hosts_free", hostAllocatorAttributePrefix), nHostsFree),
 		attribute.Int(fmt.Sprintf("%s.hosts_running", hostAllocatorAttributePrefix), len(upHosts)),
+		attribute.Int(fmt.Sprintf("%s.hosts_total", hostAllocatorAttributePrefix), existingHosts.Stats().Total),
 		attribute.Int(fmt.Sprintf("%s.hosts_active", hostAllocatorAttributePrefix), existingHosts.Stats().Active),
 		attribute.Int(fmt.Sprintf("%s.hosts_idle", hostAllocatorAttributePrefix), existingHosts.Stats().Idle),
 		attribute.Int(fmt.Sprintf("%s.hosts_provisioning", hostAllocatorAttributePrefix), existingHosts.Stats().Provisioning),
@@ -298,8 +304,13 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		attribute.Int(fmt.Sprintf("%s.hosts_decommissioned", hostAllocatorAttributePrefix), existingHosts.Stats().Decommissioned),
 		attribute.Int(fmt.Sprintf("%s.task_queue_length", hostAllocatorAttributePrefix), distroQueueInfo.Length),
 		attribute.Int(fmt.Sprintf("%s.overdue_tasks", hostAllocatorAttributePrefix), distroQueueInfo.CountWaitOverThreshold),
+		attribute.Int(fmt.Sprintf("%s.overdue_tasks_in_groups", hostAllocatorAttributePrefix), totalOverdueInTaskGroups),
 		attribute.Float64(fmt.Sprintf("%s.seconds_to_empty", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Seconds()),
 		attribute.Float64(fmt.Sprintf("%s.queue_ratio", hostAllocatorAttributePrefix), float64(noSpawnsRatio)),
+		attribute.Float64(fmt.Sprintf("%s.host_queue_ratio", hostAllocatorAttributePrefix), float64(hostQueueRatio)),
+		attribute.Float64(fmt.Sprintf("%s.runtime_secs", hostAllocatorAttributePrefix), distroQueueInfo.ExpectedDuration.Seconds()),
+		attribute.Float64(fmt.Sprintf("%s.time_to_empty_mins", hostAllocatorAttributePrefix), timeToEmpty.Minutes()),
+		attribute.Float64(fmt.Sprintf("%s.time_to_empty_no_spawns_mins", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Minutes()),
 	)
 }
 

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -289,9 +289,6 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 	span.SetAttributes(
 		attribute.String(evergreen.DistroIDOtelAttribute, distro.Id),
 		attribute.String(fmt.Sprintf("%s.distro_provider", hostAllocatorAttributePrefix), distro.Provider),
-		attribute.String(fmt.Sprintf("%s.total_runtime", hostAllocatorAttributePrefix), distroQueueInfo.ExpectedDuration.String()),
-		attribute.String(fmt.Sprintf("%s.time_to_empty", hostAllocatorAttributePrefix), timeToEmpty.String()),
-		attribute.String(fmt.Sprintf("%s.time_to_empty_no_spawns", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.String()),
 		attribute.Int(fmt.Sprintf("%s.distro_max_hosts", hostAllocatorAttributePrefix), distro.HostAllocatorSettings.MaximumHosts),
 		attribute.Int(fmt.Sprintf("%s.hosts_requested", hostAllocatorAttributePrefix), len(hostsSpawned)),
 		attribute.Int(fmt.Sprintf("%s.hosts_free", hostAllocatorAttributePrefix), nHostsFree),
@@ -305,12 +302,11 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		attribute.Int(fmt.Sprintf("%s.task_queue_length", hostAllocatorAttributePrefix), distroQueueInfo.Length),
 		attribute.Int(fmt.Sprintf("%s.overdue_tasks", hostAllocatorAttributePrefix), distroQueueInfo.CountWaitOverThreshold),
 		attribute.Int(fmt.Sprintf("%s.overdue_tasks_in_groups", hostAllocatorAttributePrefix), totalOverdueInTaskGroups),
-		attribute.Float64(fmt.Sprintf("%s.seconds_to_empty", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Seconds()),
 		attribute.Float64(fmt.Sprintf("%s.queue_ratio", hostAllocatorAttributePrefix), float64(noSpawnsRatio)),
 		attribute.Float64(fmt.Sprintf("%s.host_queue_ratio", hostAllocatorAttributePrefix), float64(hostQueueRatio)),
 		attribute.Float64(fmt.Sprintf("%s.runtime_secs", hostAllocatorAttributePrefix), distroQueueInfo.ExpectedDuration.Seconds()),
-		attribute.Float64(fmt.Sprintf("%s.time_to_empty_mins", hostAllocatorAttributePrefix), timeToEmpty.Minutes()),
-		attribute.Float64(fmt.Sprintf("%s.time_to_empty_no_spawns_mins", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Minutes()),
+		attribute.Float64(fmt.Sprintf("%s.time_to_empty_secs", hostAllocatorAttributePrefix), timeToEmpty.Seconds()),
+		attribute.Float64(fmt.Sprintf("%s.time_to_empty_no_spawns_secs", hostAllocatorAttributePrefix), timeToEmptyNoSpawns.Seconds()),
 	)
 }
 


### PR DESCRIPTION
DEVPROD-2269

### Description
This adds all of the [metrics](https://github.com/evergreen-ci/evergreen/blob/d14e6b9b731ba240dd597c5e4f419c12ac35493a/units/host_allocator.go#L261-L283) we're currently sending to Splunk for the host allocator job to OTel.

### Testing
[staging example](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/eiaxJVEf4Bv/trace/tbcvWE3g1HM?fields[]=s_name&fields[]=s_serviceName&source=query&span=58610e4a07a30529)