### PR TITLE
DEVPROD-5867: use signed URLs for smoke test logs

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -22,7 +22,8 @@ post:
       remote_file: evergreen/${task_id}/app_server.log
       bucket: mciuploads
       content_type: text/plain
-      permissions: signed
+      permissions: private
+      visibility: private
       display_name: Evergreen smoke test application server logs
   - command: s3.put
     display_name: Upload smoke test agent logs to S3
@@ -35,7 +36,8 @@ post:
       remote_file: evergreen/${task_id}/
       bucket: mciuploads
       content_type: text/plain
-      permissions: signed
+      permissions: private
+      visibility: private
       display_name: (Evergreen smoke test agent logs)
 
 #######################################

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -22,7 +22,7 @@ post:
       remote_file: evergreen/${task_id}/app_server.log
       bucket: mciuploads
       content_type: text/plain
-      permissions: private
+      permissions: signed
       display_name: Evergreen smoke test application server logs
   - command: s3.put
     display_name: Upload smoke test agent logs to S3
@@ -35,7 +35,7 @@ post:
       remote_file: evergreen/${task_id}/
       bucket: mciuploads
       content_type: text/plain
-      permissions: private
+      permissions: signed
       display_name: (Evergreen smoke test agent logs)
 
 #######################################


### PR DESCRIPTION
DEVPROD-5867

### Description
This fixes a regression introduced by #7584, which removed the AWS static creds and replaced them  with temporary creds from `ec2.assume_role`. Temporary creds can't be used with `visibility: signed` (because the credentials would expire, thus making you unable to make signed URLs).

### Testing
PR patch runs the smoke test and URLs have signed permissions.

### Documentation
N/A