### PR TITLE
DEVPROD-4693: add helper to set temporary exemption

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3643,6 +3643,36 @@ func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleIn
 	return nil
 }
 
+const maxTemporaryExemptionDuration = 32 * utility.Day
+
+// SetTemporaryExemption sets a temporary exemption from the host's sleep
+// schedule.
+func (h *Host) SetTemporaryExemption(ctx context.Context, exemptUntil time.Time) error {
+	if h.SleepSchedule.TemporarilyExemptUntil.Equal(exemptUntil) {
+		return nil
+	}
+
+	if time.Now().Add(maxTemporaryExemptionDuration).Before(exemptUntil) {
+		return errors.Errorf("temporary exemption until '%s' is longer than max temporary exemption duration of '%s'", exemptUntil, maxTemporaryExemptionDuration.String())
+	}
+
+	temporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
+	update := bson.M{}
+	if utility.IsZeroTime(exemptUntil) {
+		update["$unset"] = bson.M{temporarilyExemptUntilKey: 1}
+	} else {
+		update["$set"] = bson.M{temporarilyExemptUntilKey: exemptUntil}
+	}
+
+	if err := UpdateOne(ctx, bson.M{IdKey: h.Id}, update); err != nil {
+		return err
+	}
+
+	h.SleepSchedule.TemporarilyExemptUntil = exemptUntil
+
+	return nil
+}
+
 // IsSleepScheduleEnabled returns whether or not a sleep schedule is enabled
 // for the host.
 func (h *Host) IsSleepScheduleEnabled() bool {


### PR DESCRIPTION
DEVPROD-4693

### Description
Temporary exemptions as a feature already work, but there's not a way to set a temporary exemption in the UI right now. This adds a DB helper so that Spruce can add options for users to set a temporary exemption in DEVPROD-4200.

Per the design, a temporary exemption can be extended to at most a month from today.

### Testing
Added unit tests.

### Documentation
N/A