### PR TITLE
DEVPROD-3876 Patch intent job should ignore duplicate key errors for GH merge queue

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -408,8 +408,9 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	patchDoc.ProjectStorageMethod = ppStorageMethod
 
 	if err = patchDoc.Insert(); err != nil {
-		// If this is GH merge queue, sometimes the patch gets sent again and because
-		// some processed failed (i.e. context cancelling early from deploy).
+		// If this is GH merge queue and the patch gets tried again
+		// the document may be already inserted in the DB but
+		// failed later (i.e. context cancelling early from deploy).
 		// And it's not easy to unstuck the merge queue, so we should continue on
 		// duplicate key errors, otherwise, return the error.
 		if !(mongo.IsDuplicateKeyError(err) && patchDoc.IsGithubMergePatch()) {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1019,6 +1019,12 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	for _, subscription := range out {
 		s.Equal("github_merge", subscription.Subscriber.Type)
 	}
+
+	// Attempting to finalize again should result in no errors
+	s.NoError(j.finishPatch(s.ctx, patchDoc))
+
+	s.NoError(j.Error())
+	s.False(j.HasErrors())
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -14,8 +14,10 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -1021,6 +1023,9 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	}
 
 	// Attempting to finalize again should result in no errors
+	// The below is to clear what is set in a transaction.
+	s.NoError(db.ClearCollections(model.VersionCollection, model.ProjectConfigCollection, manifest.Collection, build.Collection,
+		task.Collection))
 	patchDoc.Version = ""
 	s.NoError(j.finishPatch(s.ctx, patchDoc))
 

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1021,6 +1021,7 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	}
 
 	// Attempting to finalize again should result in no errors
+	patchDoc.Version = ""
 	s.NoError(j.finishPatch(s.ctx, patchDoc))
 
 	s.NoError(j.Error())


### PR DESCRIPTION
DEVPROD-3876

### Description
Makes our patch intent job ignore duplicate key errors when inserting patches. This can happen when the context suddenly is cancelled and the intent job attempts to take the job again.

### Testing
Add section in unit test