### PR TITLE
Revert "DEVPROD-4678 create commit queue jobs only for legacy queue"

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -164,6 +164,7 @@ type CommitQueueParams struct {
 	Enabled     *bool      `bson:"enabled" json:"enabled" yaml:"enabled"`
 	MergeMethod string     `bson:"merge_method" json:"merge_method" yaml:"merge_method"`
 	MergeQueue  MergeQueue `bson:"merge_queue" json:"merge_queue" yaml:"merge_queue"`
+	CLIOnly     bool       `bson:"cli_only" json:"cli_only" yaml:"cli_only"`
 	Message     string     `bson:"message,omitempty" json:"message,omitempty" yaml:"message"`
 }
 
@@ -351,7 +352,6 @@ var (
 	projectRefProjectHealthViewKey        = bsonutil.MustHaveTag(ProjectRef{}, "ProjectHealthView")
 
 	commitQueueEnabledKey          = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")
-	commitQueueMergeQueueKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "MergeQueue")
 	triggerDefinitionProjectKey    = bsonutil.MustHaveTag(TriggerDefinition{}, "Project")
 	containerSecretExternalNameKey = bsonutil.MustHaveTag(ContainerSecret{}, "ExternalName")
 	containerSecretExternalIDKey   = bsonutil.MustHaveTag(ContainerSecret{}, "ExternalID")
@@ -3160,13 +3160,11 @@ func projectRefPipelineForCommitQueueEnabled() []bson.M {
 				}},
 				{"$or": []bson.M{
 					{
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):    true,
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey): true,
 					},
 					{
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):             nil,
-						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueEnabledKey):    true,
-						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):          nil,
+						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueEnabledKey): true,
 					},
 				}},
 			}},

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1948,8 +1948,7 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	repoRef := RepoRef{ProjectRef{
 		Id: "my_repo",
 		CommitQueue: CommitQueueParams{
-			Enabled:    utility.TruePtr(),
-			MergeQueue: MergeQueueEvergreen,
+			Enabled: utility.TruePtr(),
 		},
 	}}
 	assert.NoError(repoRef.Upsert())
@@ -1962,8 +1961,7 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 		Id:         "mci1",
 		RepoRefId:  repoRef.Id,
 		CommitQueue: CommitQueueParams{
-			Enabled:    utility.TruePtr(),
-			MergeQueue: MergeQueueEvergreen,
+			Enabled: utility.TruePtr(),
 		},
 	}
 	require.NoError(doc.Insert())
@@ -1976,13 +1974,6 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	doc.Repo = "grip"
 	doc.Id = "mci3"
 	doc.CommitQueue.Enabled = utility.FalsePtr()
-	require.NoError(doc.Insert())
-
-	doc.Identifier = "merge"
-	doc.Repo = "merge"
-	doc.Id = "mci4"
-	doc.CommitQueue.Enabled = utility.TruePtr()
-	doc.CommitQueue.MergeQueue = MergeQueueGitHub
 	require.NoError(doc.Insert())
 
 	res, err = FindProjectRefIdsWithCommitQueueEnabled()

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -337,6 +337,9 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 	if projectRef.CommitQueue.MergeQueue == model.MergeQueueGitHub {
 		return nil, pr, errors.Wrapf(errors.New("This project is using GitHub merge queue. Click the merge button instead."), "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
 	}
+	if projectRef.CommitQueue.CLIOnly {
+		return nil, pr, errors.Errorf("This project can only use the CLI commit queue. Please use the command `evergreen commit-queue merge -p %s`", projectRef.Identifier)
+	}
 
 	authorized, err := sc.IsAuthorizedToPatchAndMerge(ctx, env.Settings(), NewUserRepoInfo(info))
 	if err != nil {

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -348,8 +348,7 @@ func (s *AdminRouteSuite) TestRestartVersionsRoute() {
 	projectRef := &model.ProjectRef{
 		Id: "my-project",
 		CommitQueue: model.CommitQueueParams{
-			Enabled:    utility.TruePtr(),
-			MergeQueue: model.MergeQueueEvergreen,
+			Enabled: utility.TruePtr(),
 		},
 		Enabled: true,
 		Owner:   "me",


### PR DESCRIPTION
Reverts evergreen-ci/evergreen#7776

Re some conversation in [`#evergreen-ops`](https://mongodb.slack.com/archives/G979SL0HM/p1714502763037629), some projects are missing a merge queue field, so the legacy commit queue is silently not picking up new commits.