### PR TITLE
DEVPROD-4678 avoid creating commit queue jobs for merge queue

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -406,7 +406,7 @@ func (r *queryResolver) Patch(ctx context.Context, patchID string) (*restModel.A
 }
 
 // GithubProjectConflicts is the resolver for the githubProjectConflicts field.
-func (r *queryResolver) GithubProjectConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
+func (r *queryResolver) GithubConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
 	pRef, err := model.FindMergedProjectRef(projectID, "", false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting project: %v", err.Error()))

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -406,7 +406,7 @@ func (r *queryResolver) Patch(ctx context.Context, patchID string) (*restModel.A
 }
 
 // GithubProjectConflicts is the resolver for the githubProjectConflicts field.
-func (r *queryResolver) GithubConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
+func (r *queryResolver) GithubProjectConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
 	pRef, err := model.FindMergedProjectRef(projectID, "", false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error getting project: %v", err.Error()))

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3161,12 +3161,12 @@ func projectRefPipelineForCommitQueueEnabled() []bson.M {
 				{"$or": []bson.M{
 					{
 						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):    true,
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueMergeQueueKey): bson.M{"$ne": MergeQueueGitHub},
 					},
 					{
 						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):             nil,
 						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueEnabledKey):    true,
-						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
+						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueMergeQueueKey): bson.M{"$ne": MergeQueueGitHub},
 					},
 				}},
 			}},

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -164,7 +164,6 @@ type CommitQueueParams struct {
 	Enabled     *bool      `bson:"enabled" json:"enabled" yaml:"enabled"`
 	MergeMethod string     `bson:"merge_method" json:"merge_method" yaml:"merge_method"`
 	MergeQueue  MergeQueue `bson:"merge_queue" json:"merge_queue" yaml:"merge_queue"`
-	CLIOnly     bool       `bson:"cli_only" json:"cli_only" yaml:"cli_only"`
 	Message     string     `bson:"message,omitempty" json:"message,omitempty" yaml:"message"`
 }
 
@@ -352,6 +351,7 @@ var (
 	projectRefProjectHealthViewKey        = bsonutil.MustHaveTag(ProjectRef{}, "ProjectHealthView")
 
 	commitQueueEnabledKey          = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")
+	commitQueueMergeQueueKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "MergeQueue")
 	triggerDefinitionProjectKey    = bsonutil.MustHaveTag(TriggerDefinition{}, "Project")
 	containerSecretExternalNameKey = bsonutil.MustHaveTag(ContainerSecret{}, "ExternalName")
 	containerSecretExternalIDKey   = bsonutil.MustHaveTag(ContainerSecret{}, "ExternalID")
@@ -3160,11 +3160,13 @@ func projectRefPipelineForCommitQueueEnabled() []bson.M {
 				}},
 				{"$or": []bson.M{
 					{
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey): true,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):    true,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
 					},
 					{
-						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):          nil,
-						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueEnabledKey): true,
+						bsonutil.GetDottedKeyName(projectRefCommitQueueKey, commitQueueEnabledKey):             nil,
+						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueEnabledKey):    true,
+						bsonutil.GetDottedKeyName("repo_ref", RepoRefCommitQueueKey, commitQueueMergeQueueKey): MergeQueueEvergreen,
 					},
 				}},
 			}},

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1948,7 +1948,8 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	repoRef := RepoRef{ProjectRef{
 		Id: "my_repo",
 		CommitQueue: CommitQueueParams{
-			Enabled: utility.TruePtr(),
+			Enabled:    utility.TruePtr(),
+			MergeQueue: MergeQueueEvergreen,
 		},
 	}}
 	assert.NoError(repoRef.Upsert())
@@ -1961,7 +1962,8 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 		Id:         "mci1",
 		RepoRefId:  repoRef.Id,
 		CommitQueue: CommitQueueParams{
-			Enabled: utility.TruePtr(),
+			Enabled:    utility.TruePtr(),
+			MergeQueue: MergeQueueEvergreen,
 		},
 	}
 	require.NoError(doc.Insert())
@@ -1974,6 +1976,13 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	doc.Repo = "grip"
 	doc.Id = "mci3"
 	doc.CommitQueue.Enabled = utility.FalsePtr()
+	require.NoError(doc.Insert())
+
+	doc.Identifier = "merge"
+	doc.Repo = "merge"
+	doc.Id = "mci4"
+	doc.CommitQueue.Enabled = utility.TruePtr()
+	doc.CommitQueue.MergeQueue = MergeQueueGitHub
 	require.NoError(doc.Insert())
 
 	res, err = FindProjectRefIdsWithCommitQueueEnabled()

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1970,6 +1970,7 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 
 	doc.Branch = "fix"
 	doc.Id = "mci2"
+	doc.CommitQueue.MergeQueue = "" // legacy behavior is unpopulated
 	require.NoError(doc.Insert())
 
 	doc.Identifier = "grip"
@@ -1985,12 +1986,14 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	doc.CommitQueue.MergeQueue = MergeQueueGitHub
 	require.NoError(doc.Insert())
 
+	// Should find two projects, both enabled at the branch level.
 	res, err = FindProjectRefIdsWithCommitQueueEnabled()
 	assert.NoError(err)
 	require.Len(res, 2)
 	assert.Equal("mci1", res[0])
 	assert.Equal("mci2", res[1])
 
+	// Should find three projects, because this new project defaults to repo.
 	doc.Id = "commit_queue_setting_from_repo"
 	doc.CommitQueue.Enabled = nil
 	assert.NoError(doc.Insert())
@@ -1998,6 +2001,7 @@ func TestFindProjectRefIdsWithCommitQueueEnabled(t *testing.T) {
 	assert.NoError(err)
 	assert.Len(res, 3)
 
+	// Should find two projects again now that the repo isn't enabled.
 	repoRef.CommitQueue.Enabled = utility.FalsePtr()
 	assert.NoError(repoRef.Upsert())
 	res, err = FindProjectRefIdsWithCommitQueueEnabled()

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -337,9 +337,6 @@ func getAndEnqueueCommitQueueItemForPR(ctx context.Context, env evergreen.Enviro
 	if projectRef.CommitQueue.MergeQueue == model.MergeQueueGitHub {
 		return nil, pr, errors.Wrapf(errors.New("This project is using GitHub merge queue. Click the merge button instead."), "repo '%s:%s', branch '%s'", info.Owner, info.Repo, baseBranch)
 	}
-	if projectRef.CommitQueue.CLIOnly {
-		return nil, pr, errors.Errorf("This project can only use the CLI commit queue. Please use the command `evergreen commit-queue merge -p %s`", projectRef.Identifier)
-	}
 
 	authorized, err := sc.IsAuthorizedToPatchAndMerge(ctx, env.Settings(), NewUserRepoInfo(info))
 	if err != nil {

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -348,7 +348,8 @@ func (s *AdminRouteSuite) TestRestartVersionsRoute() {
 	projectRef := &model.ProjectRef{
 		Id: "my-project",
 		CommitQueue: model.CommitQueueParams{
-			Enabled: utility.TruePtr(),
+			Enabled:    utility.TruePtr(),
+			MergeQueue: model.MergeQueueEvergreen,
 		},
 		Enabled: true,
 		Owner:   "me",


### PR DESCRIPTION
[DEVPROD-4678](https://jira.mongodb.org/browse/DEVPROD-4678)

### Description
Flipped the logic of the original PR to just avoid projects that are explicitly set to github's queue.

### Testing
Unit tests
