### PR TITLE
DEVPROD-6682 Add test selection interface

### DIFF
--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -1,0 +1,72 @@
+package route
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+type selectTestsHandler struct {
+	selectTests SelectTestsRequest
+}
+
+func makeSelectTestsHandler() gimlet.RouteHandler {
+	return &selectTestsHandler{}
+}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Select tests
+//	@Description	Return a subset of tests to run for a given task. This endpoint is not yet ready. Please do not use it.
+//	@Tags			select
+//	@Router			/select/tests [post]
+//	@Param			{object}	body	SelectTestsRequest	true	"Select tests request"
+//	@Security		Api-User || Api-Key
+func (t *selectTestsHandler) Factory() gimlet.RouteHandler {
+	return &selectTestsHandler{}
+}
+
+func (t *selectTestsHandler) Parse(ctx context.Context, r *http.Request) error {
+	body := utility.NewRequestReader(r)
+	defer body.Close()
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return errors.Wrap(err, "reading request body")
+	}
+	if err = json.Unmarshal(b, &t.selectTests); err != nil {
+		return errors.Wrap(err, "parsing request body")
+	}
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(t.selectTests.Project == "", "project is required")
+	catcher.NewWhen(t.selectTests.Requester == "", "requester is required")
+	catcher.NewWhen(t.selectTests.BuildVariant == "", "build variant is required")
+	catcher.NewWhen(t.selectTests.TaskID == "", "task ID is required")
+	catcher.NewWhen(t.selectTests.TaskName == "", "task name is required")
+	catcher.NewWhen(len(t.selectTests.Tests) == 0, "tests array must not be empty")
+	return catcher.Resolve()
+}
+
+func (t *selectTestsHandler) Run(ctx context.Context) gimlet.Responder {
+	return gimlet.NewJSONResponse(t.selectTests)
+}
+
+type SelectTestsRequest struct {
+	// Project is the project identifier.
+	Project string `json:"project" bson:"project"`
+	// Requester is the Evergreen requester type.
+	Requester string `json:"requester" bson:"requester"`
+	// BuildVariant is the Evergreen build variant.
+	BuildVariant string `json:"build_variant" bson:"build_variant"`
+	// TaskID is the Evergreen task ID.
+	TaskID string `json:"task_id" bson:"task_id"`
+	// TaskName is the Evergreen task name.
+	TaskName string `json:"task_name" bson:"task_name"`
+	// Tests is a list of test names.
+	Tests []string `json:"tests" bson:"tests"`
+}

--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -19,7 +19,7 @@ type selectTestsHandler struct {
 // SelectTestsRequest represents a request to return a filtered set of tests to
 // run. It deliberately includes information that could be looked up in the
 // database in order to bypass database lookups. This allows Evergreen to pass
-// this information directly to the test selector without a database lookup.
+// this information directly to the test selector.
 type SelectTestsRequest struct {
 	// Project is the project identifier.
 	Project string `json:"project" bson:"project"`

--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -16,6 +16,25 @@ type selectTestsHandler struct {
 	selectTests SelectTestsRequest
 }
 
+// SelectTestsRequest represents a request to return a filtered set of tests to
+// run. It deliberately includes information that could be looked up in the
+// database in order to bypass database lookups. This allows Evergreen to pass
+// this information directly to the test selector without a database lookup.
+type SelectTestsRequest struct {
+	// Project is the project identifier.
+	Project string `json:"project" bson:"project"`
+	// Requester is the Evergreen requester type.
+	Requester string `json:"requester" bson:"requester"`
+	// BuildVariant is the Evergreen build variant.
+	BuildVariant string `json:"build_variant" bson:"build_variant"`
+	// TaskID is the Evergreen task ID.
+	TaskID string `json:"task_id" bson:"task_id"`
+	// TaskName is the Evergreen task name.
+	TaskName string `json:"task_name" bson:"task_name"`
+	// Tests is a list of test names.
+	Tests []string `json:"tests" bson:"tests"`
+}
+
 func makeSelectTestsHandler() gimlet.RouteHandler {
 	return &selectTestsHandler{}
 }
@@ -54,19 +73,4 @@ func (t *selectTestsHandler) Parse(ctx context.Context, r *http.Request) error {
 
 func (t *selectTestsHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(t.selectTests)
-}
-
-type SelectTestsRequest struct {
-	// Project is the project identifier.
-	Project string `json:"project" bson:"project"`
-	// Requester is the Evergreen requester type.
-	Requester string `json:"requester" bson:"requester"`
-	// BuildVariant is the Evergreen build variant.
-	BuildVariant string `json:"build_variant" bson:"build_variant"`
-	// TaskID is the Evergreen task ID.
-	TaskID string `json:"task_id" bson:"task_id"`
-	// TaskName is the Evergreen task name.
-	TaskName string `json:"task_name" bson:"task_name"`
-	// Tests is a list of test names.
-	Tests []string `json:"tests" bson:"tests"`
 }

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -1,0 +1,107 @@
+package route
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectTestsHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	j := []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ := http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth := makeSelectTestsHandler()
+	assert.NoError(t, sth.Parse(ctx, req))
+
+	result := sth.Run(ctx)
+	selectRequest := result.Data().(SelectTestsRequest)
+	assert.Equal(t, "my-project", selectRequest.Project)
+	assert.Equal(t, "patch", selectRequest.Requester)
+	assert.Equal(t, "variant", selectRequest.BuildVariant)
+	assert.Equal(t, "my-task-1234", selectRequest.TaskID)
+	assert.Equal(t, "my-task", selectRequest.TaskName)
+	assert.Equal(t, []string{"test1", "test2", "test3"}, selectRequest.Tests)
+
+	j = []byte(`{
+		"project": "",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+
+	j = []byte(`{
+		"project": "my-project",
+		"requester": "",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+
+	j = []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+
+	j = []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "",
+		"task_name": "my-task",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+
+	j = []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "",
+		"tests": ["test1", "test2", "test3"]
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+
+	j = []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "",
+		"tests": []
+	}`)
+	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth = makeSelectTestsHandler()
+	assert.Error(t, sth.Parse(ctx, req))
+}

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectTestsHandler(t *testing.T) {
@@ -22,16 +22,16 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ := http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth := makeSelectTestsHandler()
-	assert.NoError(t, sth.Parse(ctx, req))
+	require.NoError(t, sth.Parse(ctx, req), "request should parse successfully")
 
 	result := sth.Run(ctx)
 	selectRequest := result.Data().(SelectTestsRequest)
-	assert.Equal(t, "my-project", selectRequest.Project)
-	assert.Equal(t, "patch", selectRequest.Requester)
-	assert.Equal(t, "variant", selectRequest.BuildVariant)
-	assert.Equal(t, "my-task-1234", selectRequest.TaskID)
-	assert.Equal(t, "my-task", selectRequest.TaskName)
-	assert.Equal(t, []string{"test1", "test2", "test3"}, selectRequest.Tests)
+	require.Equal(t, "my-project", selectRequest.Project)
+	require.Equal(t, "patch", selectRequest.Requester)
+	require.Equal(t, "variant", selectRequest.BuildVariant)
+	require.Equal(t, "my-task-1234", selectRequest.TaskID)
+	require.Equal(t, "my-task", selectRequest.TaskName)
+	require.Equal(t, []string{"test1", "test2", "test3"}, selectRequest.Tests)
 
 	j = []byte(`{
 		"project": "",
@@ -43,7 +43,7 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when project is missing")
 
 	j = []byte(`{
 		"project": "my-project",
@@ -55,7 +55,7 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when requester is missing")
 
 	j = []byte(`{
 		"project": "my-project",
@@ -67,7 +67,7 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req))
 
 	j = []byte(`{
 		"project": "my-project",
@@ -79,7 +79,7 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when task ID is missing")
 
 	j = []byte(`{
 		"project": "my-project",
@@ -91,7 +91,7 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when task name is missing")
 
 	j = []byte(`{
 		"project": "my-project",
@@ -103,5 +103,5 @@ func TestSelectTestsHandler(t *testing.T) {
 	}`)
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler()
-	assert.Error(t, sth.Parse(ctx, req))
+	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when tests are empty")
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -221,6 +221,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/roles").Version(2).Post().Wrap(requireUser).RouteHandler(acl.NewUpdateRoleHandler(env.RoleManager()))
 	app.AddRoute("/roles/{role_id}/users").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetUsersWithRole())
 	app.AddRoute("/scheduler/compare_tasks").Version(2).Post().Wrap(requireUser).RouteHandler(makeCompareTasksRoute())
+	app.AddRoute("/select/tests").Version(2).Post().Wrap(requireUser).RouteHandler(makeSelectTestsHandler())
 	app.AddRoute("/status/cli_version").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchCLIVersionRoute(env))
 	app.AddRoute("/status/hosts/distros").Version(2).Get().Wrap(requireUser).RouteHandler(makeHostStatusByDistroRoute())
 	app.AddRoute("/status/notifications").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchNotifcationStatusRoute())


### PR DESCRIPTION
DEVPROD-6682

### Description

This adds an interface for [Evergreen Interfaces/APIs for Test Selection](https://docs.google.com/document/d/1UcK211V7_wLYTdE31OGsj9QZufJ-MQmIUBJgxUkYemw/edit#heading=h.1jak40y4seja). It takes a list of tests and then returns that list unchanged. This is intended for developers working on the integration before the test selector is ready.

### Testing

This is unit tested.

### Documentation

This will auto-generate API v2 docs.
