### PR TITLE
DEVPROD-6548 use authors for periodic builds

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -14,10 +14,11 @@ const (
 	// User is the generic user representing the Evergreen application as a
 	// whole entity. If there's a more specific user performing an operation,
 	// prefer to use that instead.
-	User            = "mci"
-	GithubPatchUser = "github_pull_request"
-	GithubMergeUser = "github_merge_queue"
-	ParentPatchUser = "parent_patch"
+	User              = "mci"
+	GithubPatchUser   = "github_pull_request"
+	GithubMergeUser   = "github_merge_queue"
+	PeriodicBuildUser = "periodic_build_user"
+	ParentPatchUser   = "parent_patch"
 
 	HostRunning       = "running"
 	HostTerminated    = "terminated"

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -282,6 +282,23 @@ func GetPatchUser(gitHubUID int) (*DBUser, error) {
 	return u, nil
 }
 
+// GetPeriodicBuild returns the matching user if applicable, and otherwise returns the default periodic build user.
+func GetPeriodicBuildUser(user string) (*DBUser, error) {
+	if user != "" {
+		usr, err := FindOneById(user)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding user '%s'", user)
+		}
+		return usr, nil
+	}
+
+	usr, err := FindOneById(evergreen.PeriodicBuildUser)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting periodic build user")
+	}
+	return usr, nil
+}
+
 // DeleteServiceUser deletes a service user by ID.
 func DeleteServiceUser(ctx context.Context, id string) error {
 	query := bson.M{

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -97,20 +97,20 @@ func byLatestProjectVersion(projectId string) bson.M {
 	}
 }
 
-// FindLatestRevisionForProject returns the latest revision for the project, and returns an error if it's not found.
-func FindLatestRevisionForProject(projectId string) (string, error) {
+// FindLatestRevisionAndAuthorForProject returns the latest revision and author ID for the project, and returns an error if it's not found.
+func FindLatestRevisionAndAuthorForProject(projectId string) (string, string, error) {
 	v, err := VersionFindOne(db.Query(byLatestProjectVersion(projectId)).
-		Sort([]string{"-" + VersionRevisionOrderNumberKey}).WithFields(VersionRevisionKey))
+		Sort([]string{"-" + VersionRevisionOrderNumberKey}).WithFields(VersionRevisionKey, VersionAuthorIDKey))
 	if err != nil {
-		return "", errors.Wrapf(err, "finding most recent version for project '%s'", projectId)
+		return "", "", errors.Wrapf(err, "finding most recent version for project '%s'", projectId)
 	}
 	if v == nil {
-		return "", errors.Errorf("no recent version found for project '%s'", projectId)
+		return "", "", errors.Errorf("no recent version found for project '%s'", projectId)
 	}
 	if v.Revision == "" {
-		return "", errors.Errorf("latest version '%s' has no revision", v.Id)
+		return "", "", errors.Errorf("latest version '%s' has no revision", v.Id)
 	}
-	return v.Revision, nil
+	return v.Revision, v.AuthorID, nil
 }
 
 // BaseVersionByProjectIdAndRevision finds a base version for the given project and revision.

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -259,7 +259,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 					Errors:   projErr.Errors,
 				}
 				if len(versionErrs.Errors) > 0 {
-					stubVersion, dbErr := ShellVersionFromRevision(ctx, ref, model.VersionMetadata{Revision: revisions[i]})
+					stubVersion, dbErr := ShellVersionFromRevision(ref, model.VersionMetadata{Revision: revisions[i]})
 					if dbErr != nil {
 						grip.Error(message.WrapError(dbErr, message.Fields{
 							"message":            "error creating shell version",
@@ -602,7 +602,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 
 	// create a version document
-	v, err := ShellVersionFromRevision(ctx, projectInfo.Ref, metadata)
+	v, err := ShellVersionFromRevision(projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
 	}
@@ -680,7 +680,7 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 
 // ShellVersionFromRevision populates a new Version with metadata from a model.Revision.
 // Does not populate its config or store anything in the database.
-func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metadata model.VersionMetadata) (*model.Version, error) {
+func ShellVersionFromRevision(ref *model.ProjectRef, metadata model.VersionMetadata) (*model.Version, error) {
 	var u *user.DBUser
 	var err error
 	if metadata.Revision.AuthorGithubUID != 0 {

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1297,7 +1297,7 @@ func TestShellVersionFromRevisionGitTags(t *testing.T) {
 		GitTagVersionsEnabled: utility.TruePtr(),
 	}
 	assert.NoError(t, evergreen.UpdateConfig(ctx, testutil.TestConfig()))
-	v, err := ShellVersionFromRevision(context.TODO(), pRef, metadata)
+	v, err := ShellVersionFromRevision(pRef, metadata)
 	assert.NoError(t, err)
 	require.NotNil(t, v)
 	assert.Equal(t, evergreen.GitTagRequester, v.Requester)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -1079,7 +1079,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 			Revision: revision,
 			GitTag:   tag,
 		}
-		stubVersion, dbErr := repotracker.ShellVersionFromRevision(ctx, &pRef, metadata)
+		stubVersion, dbErr := repotracker.ShellVersionFromRevision(&pRef, metadata)
 		if dbErr != nil {
 			grip.Error(message.WrapError(dbErr, message.Fields{
 				"message":            "error creating shell version",

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -106,6 +106,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 			"project": j.ProjectID,
 		}))
 	}
+
 	metadata := model.VersionMetadata{
 		IsAdHoc:         true,
 		Activate:        true,

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/evergreen-ci/evergreen/model/user"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -92,26 +94,36 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 		}))
 	}()
 
-	mostRecentRevision, err := model.FindLatestRevisionForProject(j.ProjectID)
+	mostRecentRevision, authorID, err := model.FindLatestRevisionAndAuthorForProject(j.ProjectID)
 	if err != nil {
 		j.AddError(err)
 		return
 	}
-	versionErr := j.addVersion(ctx, *definition, mostRecentRevision)
+	usr, err := user.GetPeriodicBuildUser(authorID)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": "problem getting periodic build user",
+			"project": j.ProjectID,
+		}))
+	}
+	metadata := model.VersionMetadata{
+		IsAdHoc:         true,
+		Activate:        true,
+		Message:         definition.Message,
+		PeriodicBuildID: definition.ID,
+		Alias:           definition.Alias,
+		Revision: model.Revision{
+			Revision: mostRecentRevision,
+		},
+		User: usr,
+	}
+	versionErr := j.addVersion(ctx, metadata, definition.ConfigFile)
 
 	if versionErr != nil {
 		// If the version fails to be added, create a stub version and
 		// log an event so users can get notified when notifications are configured
-		metadata := model.VersionMetadata{
-			IsAdHoc:         true,
-			Message:         definition.Message,
-			PeriodicBuildID: definition.ID,
-			Alias:           definition.Alias,
-			Revision: model.Revision{
-				Revision: mostRecentRevision,
-			},
-		}
-		stubVersion, dbErr := repotracker.ShellVersionFromRevision(ctx, j.project, metadata)
+		metadata.Activate = false
+		stubVersion, dbErr := repotracker.ShellVersionFromRevision(j.project, metadata)
 		if dbErr != nil {
 			grip.Error(message.WrapError(dbErr, message.Fields{
 				"message":            "error creating stub version for periodic build",
@@ -143,13 +155,13 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 	}
 }
 
-func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.PeriodicBuildDefinition, mostRecentRevision string) error {
+func (j *periodicBuildJob) addVersion(ctx context.Context, metadata model.VersionMetadata, configFilePath string) error {
 	token, err := j.env.Settings().GetGithubOauthToken()
 	if err != nil {
 		return errors.Wrap(err, "getting GitHub OAuth token")
 	}
 
-	configFile, err := thirdparty.GetGithubFile(ctx, token, j.project.Owner, j.project.Repo, definition.ConfigFile, mostRecentRevision)
+	configFile, err := thirdparty.GetGithubFile(ctx, token, j.project.Owner, j.project.Repo, configFilePath, metadata.Revision.Revision)
 	if err != nil {
 		return errors.Wrap(err, "getting config file from GitHub")
 	}
@@ -160,7 +172,7 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.Peri
 	proj := &model.Project{}
 	opts := &model.GetProjectOpts{
 		Ref:          j.project,
-		Revision:     mostRecentRevision,
+		Revision:     metadata.Revision.Revision,
 		Token:        token,
 		ReadFileFrom: model.ReadFromGithub,
 	}
@@ -174,16 +186,6 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, definition model.Peri
 		if err != nil {
 			return errors.Wrap(err, "parsing project config")
 		}
-	}
-	metadata := model.VersionMetadata{
-		IsAdHoc:         true,
-		Activate:        true,
-		Message:         definition.Message,
-		PeriodicBuildID: definition.ID,
-		Alias:           definition.Alias,
-		Revision: model.Revision{
-			Revision: mostRecentRevision,
-		},
 	}
 
 	projectInfo := &model.ProjectInfo{

--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPeriodicBuildsJob(t *testing.T) {
@@ -67,7 +66,6 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	assert.Equal(prevVersion.Revision, createdVersion.Revision)
 	tasks, err := task.Find(task.ByVersion(createdVersion.Id))
 	assert.NoError(err)
-	require.Len(t, tasks, 1)
 	assert.True(tasks[0].Activated)
 	dbProject, err := model.FindBranchProjectRef(sampleProject.Id)
 	assert.NoError(err)

--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/evergreen/model/user"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPeriodicBuildsJob(t *testing.T) {
@@ -67,6 +67,7 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	assert.Equal(prevVersion.Revision, createdVersion.Revision)
 	tasks, err := task.Find(task.ByVersion(createdVersion.Id))
 	assert.NoError(err)
+	require.Len(t, tasks, 1)
 	assert.True(tasks[0].Activated)
 	dbProject, err := model.FindBranchProjectRef(sampleProject.Id)
 	assert.NoError(err)


### PR DESCRIPTION
DEVPROD-6548

### Description
Use the previous version's author by default, otherwise use a new periodic build user for readability (i'll add this via rest API after approval).

Right now for periodic builds we just leave author blank; for papertrail.trace they expect tasks to have an author associated (which also just seems reasonable). 

### Testing
Augmented unit tests.
