### PR TITLE
DEVPROD-6943 Unmatching tasks/tags in variants resulting in a validation warning rather than a translation error

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -414,7 +414,7 @@ type BuildVariant struct {
 	Tasks        []BuildVariantTaskUnit `yaml:"tasks,omitempty" bson:"tasks"`
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 
-	// TranslationWarnings are warnings that are only detectable during project translation.
+	// TranslationWarnings are validation warnings that are only detectable during project translation.
 	// e.g. task selectors that don't target any tasks in a build variant but the build
 	// variant still has tasks.
 	TranslationWarnings []string `yaml:"-" bson:"-"`

--- a/model/project.go
+++ b/model/project.go
@@ -414,10 +414,6 @@ type BuildVariant struct {
 	Tasks        []BuildVariantTaskUnit `yaml:"tasks,omitempty" bson:"tasks"`
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 
-	// EmptyTaskSelectors stores task selectors that don't target any tasks for this build variant.
-	// This is only for validation purposes.
-	EmptyTaskSelectors []string `yaml:"-" bson:"-"`
-
 	// TranslationWarnings are warnings that are only detectable during project translation.
 	// e.g. task selectors that don't target any tasks in a build variant but the build
 	// variant still has tasks.

--- a/model/project.go
+++ b/model/project.go
@@ -417,6 +417,11 @@ type BuildVariant struct {
 	// EmptyTaskSelectors stores task selectors that don't target any tasks for this build variant.
 	// This is only for validation purposes.
 	EmptyTaskSelectors []string `yaml:"-" bson:"-"`
+
+	// TranslationWarnings are warnings that are only detectable during project translation.
+	// e.g. task selectors that don't target any tasks in a build variant but the build
+	// variant still has tasks.
+	TranslationWarnings []string `yaml:"-" bson:"-"`
 }
 
 // CheckRun is used to provide information about a github check run.

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -690,14 +690,14 @@ func TestRulesEvaluation(t *testing.T) {
 		Convey("a 'remove' rule for an unknown task should fail", func() {
 			bvs := []parserBV{{
 				Name: "test",
-				Tasks: parserBVTaskUnits{
+				Tasks: parserBVTaskUnits{ // This starts with blue, brown, black, and white.
 					{Name: "blue"},
 					{Name: ".special"},
 					{Name: ".tertiary"},
 				},
 				MatrixRules: []ruleAction{
-					{RemoveTasks: []string{".amazing"}}, //remove blue
-					{RemoveTasks: []string{"blue"}},
+					{RemoveTasks: []string{".amazing"}}, // Nothing is tagged with amazing, so this step should not remove any and should not fail.
+					{RemoveTasks: []string{"blue"}},     // This should remove blue.
 				},
 			}}
 			evaluated, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -697,12 +697,14 @@ func TestRulesEvaluation(t *testing.T) {
 				},
 				MatrixRules: []ruleAction{
 					{RemoveTasks: []string{".amazing"}}, //remove blue
-					{RemoveTasks: []string{"rainbow"}},
+					{RemoveTasks: []string{"blue"}},
 				},
 			}}
-			_, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
-			So(errs, ShouldNotBeNil)
-			So(len(errs), ShouldEqual, 2)
+			evaluated, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
+			So(errs, ShouldBeNil)
+			v1 := evaluated[0]
+			So(v1.Name, ShouldEqual, "test")
+			So(len(v1.Tasks), ShouldEqual, 3) // Brown, black, and white left
 		})
 	})
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1183,7 +1183,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' has task names/tags that do not match any tasks: '%s'", pbv.Name, strings.Join(emptyTaskSelectors, "', '")))
 		}
 		if len(tse.tagEval.unmatchedTagNames) > 0 {
-			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' has tags that do not match any tasks: '%s'", pbv.Name, strings.Join(tse.tagEval.unmatchedTagNames, "', '")))
+			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' uses tags that do not match any tasks: '%s'", pbv.Name, strings.Join(tse.tagEval.unmatchedTagNames, "', '")))
 			tse.tagEval.unmatchedTagNames = []string{}
 		}
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1140,9 +1140,12 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 		// expand, validate that tasks defined in a group are listed in the project tasks
 		var taskNames []string
 		for _, taskName := range ptg.Tasks {
-			names, _, err := tse.evalSelector(ParseSelector(taskName))
+			names, unmatched, err := tse.evalSelector(ParseSelector(taskName))
 			if err != nil {
 				evalErrs = append(evalErrs, err)
+			}
+			if len(unmatched) > 0 {
+				evalErrs = append(evalErrs, errors.Errorf("task group '%s' has unmatched selector: '%s'", ptg.Name, strings.Join(unmatched, "', '")))
 			}
 			taskNames = append(taskNames, names...)
 		}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1140,7 +1140,7 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 		// expand, validate that tasks defined in a group are listed in the project tasks
 		var taskNames []string
 		for _, taskName := range ptg.Tasks {
-			names, _, err := tse.evalSelector(ParseSelector(taskName), false)
+			names, _, err := tse.evalSelector(ParseSelector(taskName))
 			if err != nil {
 				evalErrs = append(evalErrs, err)
 			}
@@ -1194,7 +1194,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				prunedTasks := []BuildVariantTaskUnit{}
 				toRemove := []string{}
 				for _, t := range r.RemoveTasks {
-					removed, _, err := tse.evalSelector(ParseSelector(t), false)
+					removed, _, err := tse.evalSelector(ParseSelector(t))
 					if err != nil {
 						evalErrs = append(evalErrs, errors.Wrap(err, "remove rule"))
 						continue
@@ -1334,7 +1334,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		} else {
 			var err1, err2 error
 			if tse != nil {
-				temp, unmatched, err1 = tse.evalSelector(ParseSelector(pbvt.Name), true)
+				temp, unmatched, err1 = tse.evalSelector(ParseSelector(pbvt.Name))
 				names = append(names, temp...)
 			}
 			if tgse != nil {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1271,7 +1271,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 					errs = append(errs, err)
 				}
 				if len(unmatched) > 0 {
-					errs = append(errs, errors.Errorf("display task '%s' contains unmatched selector: '%s'", dt.Name, strings.Join(unmatched, "', '")))
+					errs = append(errs, errors.Errorf("display task '%s' contains unmatched criteria: '%s'", dt.Name, strings.Join(unmatched, "', '")))
 				}
 				tasks = append(tasks, results...)
 			}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -757,6 +757,7 @@ func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEva
 			for _, t := range taskUnit {
 				if t.Name == e.Name && t.Priority == e.Priority && len(t.DependsOn) == len(e.DependsOn) {
 					exists = true
+					break
 				}
 				So(t.Variant, ShouldEqual, pbv.Name)
 			}
@@ -768,6 +769,7 @@ func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEva
 			for _, emptySelector := range emptySelectors {
 				if emptySelector == expectedEmptySelector {
 					exists = true
+					break
 				}
 			}
 			So(exists, ShouldBeTrue)
@@ -778,6 +780,7 @@ func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEva
 			for _, unmatchedTag := range unmatchedTags {
 				if unmatchedTag == expectedUnmatchedTag {
 					exists = true
+					break
 				}
 			}
 			So(exists, ShouldBeTrue)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1043,7 +1043,7 @@ tasks:
 	proj = &Project{}
 	_, err = LoadProjectInto(ctx, []byte(nonexistentTaskYml), nil, "id", proj)
 	assert.NotNil(proj)
-	assert.Contains(err.Error(), "notHere: nothing named 'notHere'")
+	assert.Contains(err.Error(), "contains unmatched criteria: 'notHere'")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecTasks, 2)
 	assert.Len(proj.BuildVariants[1].DisplayTasks, 0)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1463,7 +1463,7 @@ buildvariants:
 		_, err := LoadProjectInto(ctx, []byte(wrongTaskYml), nil, "id", proj)
 		assert.NotNil(t, proj)
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), `nothing named 'example_task_3'`)
+		assert.Contains(t, err.Error(), `'example_task_group' has unmatched selector: 'example_task_3'`)
 	})
 
 	t.Run("MaintainsTaskGroupTaskOrdering", func(t *testing.T) {

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -198,6 +198,8 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 				return nil, errors.Errorf("nothing named '%v'", sc.name)
 			}
 			tse.unmatchedTagNames = append(tse.unmatchedTagNames, sc.name)
+			// If the item is not found, we match no items and should return an empty slice.
+			return []string{}, nil
 		}
 		return []string{item.name()}, nil
 

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -152,12 +152,12 @@ func newTagSelectorEvaluator(selectees []tagged) *tagSelectorEvaluator {
 	}
 }
 
-// evalSelector returns all names that fulfill a selector and all unmatched items.
+// evalSelector returns all names that fulfill a selector and all unmatched criterion.
 // This is done by evaluating each criterion individually and taking the intersection.
 func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
 	// keep a slice of results per criterion
 	results := []string{}
-	unmatchedItems := []string{}
+	unmatchedCriteria := []string{}
 	if len(s) == 0 {
 		return nil, nil, errors.New("cannot evaluate selector with no criteria")
 	}
@@ -167,7 +167,7 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, e
 			return nil, nil, errors.Wrapf(err, "%v", s)
 		}
 		if len(names) == 0 {
-			unmatchedItems = append(unmatchedItems, sc.String())
+			unmatchedCriteria = append(unmatchedCriteria, sc.String())
 			continue
 		}
 		if i == 0 {
@@ -177,7 +177,7 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, e
 			results = utility.StringSliceIntersection(results, names)
 		}
 	}
-	return results, unmatchedItems, nil
+	return results, unmatchedCriteria, nil
 }
 
 // evalCriterion returns all names that fulfill a single selection criterion.
@@ -394,10 +394,10 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 	}
 	results, unmatched, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
 	if err != nil {
-		return nil, errors.Wrap(err, "variant tag selector")
+		return nil, errors.Wrap(err, "variant selector")
 	}
 	if len(unmatched) > 0 {
-		return nil, errors.Errorf("variant tag selector contains unmatched criteria: %v", unmatched)
+		return nil, errors.Errorf("variant selector contains unmatched criteria: %v", unmatched)
 	}
 	return results, nil
 }

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -168,7 +168,10 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, e
 		}
 		if len(names) == 0 {
 			unmatchedCriteria = append(unmatchedCriteria, sc.String())
-			continue
+			// If this is a negated criteria, we do not want to intersect it with the rest
+			if sc.negated {
+				continue
+			}
 		}
 		if i == 0 {
 			results = names

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -130,9 +130,6 @@ type tagSelectorEvaluator struct {
 	items  []tagged
 	byName map[string]tagged
 	byTag  map[string][]tagged
-
-	ignoreUnmatchedTags bool
-	unmatchedTagNames   []string
 }
 
 // newTagSelectorEvaluator returns a new taskSelectorEvaluator.
@@ -270,7 +267,7 @@ func NewParserTaskSelectorEvaluator(tasks []parserTask) *taskSelectorEvaluator {
 }
 
 // evalSelector returns all tasks selected by a selector.
-func (t *taskSelectorEvaluator) evalSelector(s Selector, ignoreUnmatchedTags bool) ([]string, []string, error) {
+func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
 	results, unmatched, err := t.tagEval.evalSelector(s)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "evaluating task selector")

--- a/model/project_selector_test.go
+++ b/model/project_selector_test.go
@@ -84,17 +84,21 @@ func TestBasicSelector(t *testing.T) {
 	})
 }
 
-func tagSelectorShouldEval(tse *tagSelectorEvaluator, s string, expected []string) {
-	Convey(fmt.Sprintf(`selector "%v" should evaluate to %v`, s, expected), func() {
-		names, err := tse.evalSelector(ParseSelector(s))
-		if expected != nil {
+func tagSelectorShouldEval(tse *tagSelectorEvaluator, s string, expectedNames, expectedUnmatched []string) {
+	Convey(fmt.Sprintf(`selector "%v" should evaluate to '%v' with unmatched '%v'`, s, expectedNames, expectedUnmatched), func() {
+		names, unmatched, err := tse.evalSelector(ParseSelector(s))
+		if expectedNames != nil || expectedUnmatched != nil {
 			So(err, ShouldBeNil)
 		} else {
 			So(err, ShouldNotBeNil)
 		}
-		So(len(names), ShouldEqual, len(expected))
-		for _, e := range expected {
+		So(len(names), ShouldEqual, len(expectedNames))
+		for _, e := range expectedNames {
 			So(names, ShouldContain, e)
+		}
+		So(len(unmatched), ShouldEqual, len(expectedUnmatched))
+		for _, e := range expectedUnmatched {
+			So(unmatched, ShouldContain, e)
 		}
 	})
 }
@@ -127,69 +131,64 @@ func TestTaskSelectorEvaluation(t *testing.T) {
 			tse = newTagSelectorEvaluator(defs)
 
 			Convey("should evaluate single name selectors properly", func() {
-				tagSelectorShouldEval(tse, "red", []string{"red"})
-				tagSelectorShouldEval(tse, "white", []string{"white"})
+				tagSelectorShouldEval(tse, "red", []string{"red"}, nil)
+				tagSelectorShouldEval(tse, "white", []string{"white"}, nil)
 			})
 
 			Convey("should evaluate single tag selectors properly", func() {
-				tagSelectorShouldEval(tse, ".warm", []string{"red", "orange", "yellow"})
-				tagSelectorShouldEval(tse, ".cool", []string{"blue", "green", "purple"})
-				tagSelectorShouldEval(tse, ".special", []string{"white", "black"})
-				tagSelectorShouldEval(tse, ".primary", []string{"red", "blue", "yellow"})
+				tagSelectorShouldEval(tse, ".warm", []string{"red", "orange", "yellow"}, nil)
+				tagSelectorShouldEval(tse, ".cool", []string{"blue", "green", "purple"}, nil)
+				tagSelectorShouldEval(tse, ".special", []string{"white", "black"}, nil)
+				tagSelectorShouldEval(tse, ".primary", []string{"red", "blue", "yellow"}, nil)
 			})
 
 			Convey("should evaluate multi-tag selectors properly", func() {
-				tagSelectorShouldEval(tse, ".warm .cool", []string{})
-				tagSelectorShouldEval(tse, ".cool .primary", []string{"blue"})
-				tagSelectorShouldEval(tse, ".warm .secondary", []string{"orange"})
+				tagSelectorShouldEval(tse, ".warm .cool", []string{}, nil)
+				tagSelectorShouldEval(tse, ".cool .primary", []string{"blue"}, nil)
+				tagSelectorShouldEval(tse, ".warm .secondary", []string{"orange"}, nil)
 			})
 
 			Convey("should evaluate selectors with negation properly", func() {
 				tagSelectorShouldEval(tse, "!.special",
-					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown"})
-				tagSelectorShouldEval(tse, ".warm !yellow", []string{"red", "orange"})
-				tagSelectorShouldEval(tse, "!.primary !.secondary", []string{"black", "white", "brown"})
+					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown"}, nil)
+				tagSelectorShouldEval(tse, ".warm !yellow", []string{"red", "orange"}, nil)
+				tagSelectorShouldEval(tse, "!.primary !.secondary", []string{"black", "white", "brown"}, nil)
 			})
 
 			Convey("should evaluate special selectors", func() {
 				tagSelectorShouldEval(tse, "*",
-					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown", "black", "white"})
+					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown", "black", "white"}, nil)
+			})
+
+			Convey("names that don't exist", func() {
+				tagSelectorShouldEval(tse, "salmon", nil, []string{"salmon"})
+			})
+
+			Convey("tags that don't exist", func() {
+				tagSelectorShouldEval(tse, ".fail", nil, []string{".fail"})
+				tagSelectorShouldEval(tse, "!.spring", nil, []string{"!.spring"})
 			})
 
 			Convey("should fail on bad selectors like", func() {
 
 				Convey("empty selectors", func() {
-					_, err := tse.evalSelector(Selector{})
-					So(err, ShouldNotBeNil)
-				})
-
-				Convey("names that don't exist", func() {
-					_, err := tse.evalSelector(ParseSelector("salmon"))
-					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!azure"))
-					So(err, ShouldNotBeNil)
-				})
-
-				Convey("tags that don't exist", func() {
-					_, err := tse.evalSelector(ParseSelector(".fall"))
-					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!.spring"))
+					_, _, err := tse.evalSelector(Selector{})
 					So(err, ShouldNotBeNil)
 				})
 
 				Convey("using . and ! with *", func() {
-					_, err := tse.evalSelector(ParseSelector(".*"))
+					_, _, err := tse.evalSelector(ParseSelector(".*"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!*"))
+					_, _, err = tse.evalSelector(ParseSelector("!*"))
 					So(err, ShouldNotBeNil)
 				})
 
 				Convey("illegal names", func() {
-					_, err := tse.evalSelector(ParseSelector("!!purple"))
+					_, _, err := tse.evalSelector(ParseSelector("!!purple"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector(".!purple"))
+					_, _, err = tse.evalSelector(ParseSelector(".!purple"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("..purple"))
+					_, _, err = tse.evalSelector(ParseSelector("..purple"))
 					So(err, ShouldNotBeNil)
 				})
 			})

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2361,13 +2361,8 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 			)
 		}
 
-		if len(buildVariant.EmptyTaskSelectors) > 0 {
-			errs = append(errs,
-				ValidationError{
-					Message: fmt.Sprintf("buildvariant '%s' has task names/tags that do not match any tasks: '%s'", buildVariant.Name, strings.Join(buildVariant.EmptyTaskSelectors, "', '")),
-					Level:   Warning,
-				},
-			)
+		for _, warning := range buildVariant.TranslationWarnings {
+			errs = append(errs, ValidationError{Message: warning, Level: Warning})
 		}
 
 		errs = append(errs, checkBVNames(&buildVariant)...)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1627,15 +1627,15 @@ func TestValidateBVNames(t *testing.T) {
 			So(validationResults[0].Level, ShouldEqual, Error)
 		})
 
-		Convey("if any variant has task selectors that don't target anything, an warning should be returned", func() {
+		Convey("if any variant has warnings from translating, an warning should be returned", func() {
 			project := &model.Project{
 				BuildVariants: []model.BuildVariant{
-					{Name: "linux", EmptyTaskSelectors: []string{".task1"}},
+					{Name: "linux", TranslationWarnings: []string{"this is a warning"}},
 				},
 			}
 			validationResults := checkBuildVariants(project)
 
-			So(validationResults.String(), ShouldContainSubstring, "WARNING: buildvariant 'linux' has task names/tags that do not match any tasks: '.task1'")
+			So(validationResults.String(), ShouldContainSubstring, "WARNING: this is a warning")
 		})
 
 		Convey("if two variants have the same display name, a warning should be returned, but no errors", func() {


### PR DESCRIPTION
DEVPROD-6943

### Description
This changes variant's erroring on unmatched tasks/tags to be a validation warning rather than translation error. Variants will still warn if they match _no_ tasks. 

I'm not sure how to differentiate the warnings without using too much domain specific logic, please critic as such!

### Testing
Unit testing and I ran tests locally with the config showed in the ticket