### PR TITLE
 DEVPROD-6951 cache the AWS sdk configuration

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -435,7 +435,6 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	ec2Settings := &EC2ProviderSettings{}
 	err := ec2Settings.FromDistroSettings(h.Distro, m.region)
@@ -559,7 +558,6 @@ func (m *ec2Manager) CheckInstanceType(ctx context.Context, instanceType string)
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 	output, err := m.client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{})
 	if err != nil {
 		return errors.Wrapf(err, "describing instance types offered for region '%s'", m.region)
@@ -634,7 +632,6 @@ func (m *ec2Manager) ModifyHost(ctx context.Context, h *host.Host, opts host.Hos
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	// Validate modify options for user errors that should prevent all modifications
 	if err := validateEC2HostModifyOptions(h, opts); err != nil {
@@ -703,7 +700,6 @@ func (m *ec2Manager) GetInstanceStatuses(ctx context.Context, hosts []host.Host)
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	instanceIdToHostMap := map[string]*host.Host{}
 	hostsToCheck := []string{}
@@ -770,7 +766,6 @@ func (m *ec2Manager) GetInstanceStatus(ctx context.Context, h *host.Host) (Cloud
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return status, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
@@ -817,7 +812,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	if !IsEC2InstanceID(h.Id) {
 		return errors.Wrap(h.Terminate(ctx, user, fmt.Sprintf("detected invalid instance ID '%s'", h.Id)), "terminating instance in DB")
@@ -902,7 +896,6 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, shouldKeepO
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	out, err := m.client.StopInstances(ctx, &ec2.StopInstancesInput{
 		InstanceIds: []string{h.Id},
@@ -986,7 +979,6 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	_, err := m.client.StartInstances(ctx, &ec2.StartInstancesInput{
 		InstanceIds: []string{h.Id},
@@ -1033,7 +1025,6 @@ func (m *ec2Manager) AttachVolume(ctx context.Context, h *host.Host, attachment 
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	opts := generateDeviceNameOptions{
 		isWindows:           h.Distro.IsWindows(),
@@ -1074,7 +1065,6 @@ func (m *ec2Manager) DetachVolume(ctx context.Context, h *host.Host, volumeID st
 	if err = m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	_, err = m.client.DetachVolume(ctx, &ec2.DetachVolumeInput{
 		InstanceId: aws.String(h.Id),
@@ -1097,7 +1087,6 @@ func (m *ec2Manager) CreateVolume(ctx context.Context, volume *host.Volume) (*ho
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	volume.Expiration = time.Now().Add(evergreen.DefaultSpawnHostExpiration)
 	volumeTags := []types.Tag{
@@ -1144,7 +1133,6 @@ func (m *ec2Manager) DeleteVolume(ctx context.Context, volume *host.Volume) erro
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	_, err := m.client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
 		VolumeId: aws.String(volume.ID),
@@ -1160,7 +1148,6 @@ func (m *ec2Manager) GetVolumeAttachment(ctx context.Context, volumeID string) (
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	volumeInfo, err := m.client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
 		VolumeIds: []string{volumeID},
@@ -1216,7 +1203,6 @@ func (m *ec2Manager) ModifyVolume(ctx context.Context, volume *host.Volume, opts
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	if !utility.IsZeroTime(opts.Expiration) {
 		if err := m.modifyVolumeExpiration(ctx, volume, opts.Expiration); err != nil {
@@ -1272,7 +1258,6 @@ func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, erro
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return "", errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	return m.client.GetPublicDNSName(ctx, h)
 }
@@ -1291,7 +1276,6 @@ func (m *ec2Manager) AddSSHKey(ctx context.Context, pair evergreen.SSHKeyPair) e
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	return errors.Wrap(addSSHKey(ctx, m.client, pair), "adding public SSH key")
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -108,7 +108,6 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	ec2Settings := &EC2ProviderSettings{}
 	if err := ec2Settings.FromDistroSettings(h.Distro, ""); err != nil {
@@ -162,7 +161,6 @@ func (m *ec2FleetManager) GetInstanceStatuses(ctx context.Context, hosts []host.
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return nil, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	describeInstancesOutput, err := m.client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		InstanceIds: instanceIDs,
@@ -217,7 +215,6 @@ func (m *ec2FleetManager) GetInstanceStatus(ctx context.Context, h *host.Host) (
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return status, errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	instance, err := m.client.GetInstanceInfo(ctx, h.Id)
 	if err != nil {
@@ -260,7 +257,6 @@ func (m *ec2FleetManager) CheckInstanceType(ctx context.Context, instanceType st
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 	output, err := m.client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{})
 	if err != nil {
 		return errors.Wrapf(err, "describing instance types offered for region '%s", m.region)
@@ -282,7 +278,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
@@ -336,7 +331,6 @@ func (m *ec2FleetManager) Cleanup(ctx context.Context) error {
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	launchTemplates, err := m.client.GetLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
 		Filters: []types.Filter{
@@ -397,7 +391,6 @@ func (m *ec2FleetManager) GetDNSName(ctx context.Context, h *host.Host) (string,
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return "", errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	return m.client.GetPublicDNSName(ctx, h)
 }
@@ -571,7 +564,6 @@ func (m *ec2FleetManager) AddSSHKey(ctx context.Context, pair evergreen.SSHKeyPa
 	if err := m.client.Create(ctx, m.region); err != nil {
 		return errors.Wrap(err, "creating client")
 	}
-	defer m.client.Close()
 
 	return errors.Wrap(addSSHKey(ctx, m.client, pair), "adding public SSH key")
 }


### PR DESCRIPTION
[DEVPROD-6951](https://jira.mongodb.org/browse/DEVPROD-6951)

### Description
Each API call calls Create on its client. Now that we're using IRSA to auth this means that each API call is preceded by [a call to STS to get creds](https://github.com/aws/aws-sdk-go-v2/blob/b0a3c24ad3d64508103806eec1bd2db566bf6a88/credentials/stscreds/web_identity_provider.go#L131-L133). This is likely why we're seeing STS throttling.

This PR caches the AWS client config in memory. This way, we only call STS once per region per session duration (one hour by default). Now that we're going to be holding onto the HTTP client over the entire lifetime of the application it doesn't make sense anymore to deal with the HTTP client pool, so Close() is no longer needed.

### Testing
I was able to start a host in staging.
It's kind of hard to tell if it's making fewer calls to STS because of all the noise from prod. We'll definitely be able to tell if it's made a difference once we deploy to prod, though.