### PR TITLE
DEVPROD-6752: return error if intent host does not provide instance ID

### DIFF
--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -301,7 +301,8 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 		return nil
 	}
 	if cloud.IsEC2InstanceID(h.Id) {
-		// If the host already has an instance ID, it's not an intent host.
+		// If the host already has an instance ID, it's not an intent host, so
+		// the host does not need to be fixed.
 		return nil
 	}
 	if instanceID == "" {
@@ -321,7 +322,7 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 		// route. All intent hosts should be sending their EC2 instance ID. If
 		// they don't, it should fail provisioning and should not start the
 		// agent.
-		return nil
+		return errors.New(msg)
 	}
 
 	env := evergreen.GetEnvironment()


### PR DESCRIPTION
DEVPROD-6752

### Description
After #7796 is deployed, all intent hosts should send their EC2 instance ID to this route. In the unlikely case that it doesn't, we should not let it continue provisioning because it doesn't have a proper host ID and without that ID, the host document will remain in a bad state. Just letting them error, stop provisioning, and eventually get reaped is good enough, as I suspect this case will rarely get hit.

### Testing
Already tested this change in staging as part of #7787.

### Documentation
N/A