### PR TITLE
DEVPROD-6651: limit how long spawn host setup script can run

### DIFF
--- a/units/host_setup_script.go
+++ b/units/host_setup_script.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -111,11 +112,16 @@ func (j *hostSetupScriptJob) Run(ctx context.Context) {
 	j.AddError(errors.Wrap(runSpawnHostSetupScript(ctx, j.env, j.host), "executing spawn host setup script"))
 }
 
+const maxSpawnHostSetupScriptDuration = 30 * time.Minute
+
 func runSpawnHostSetupScript(ctx context.Context, env evergreen.Environment, h *host.Host) error {
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, maxSpawnHostSetupScriptDuration)
+	defer timeoutCancel()
+
 	script := fmt.Sprintf("cd %s\n%s", h.Distro.HomeDir(), h.ProvisionOptions.SetupScript)
 	ts := utility.RoundPartOfMinute(0).Format(TSFormat)
 	j := NewHostExecuteJob(env, *h, script, false, "", ts)
-	j.Run(ctx)
+	j.Run(timeoutCtx)
 
 	return errors.Wrapf(j.Error(), "running setup script for spawn host")
 }


### PR DESCRIPTION
DEVPROD-6651

### Description
Only let the spawn host setup script run for 30 minutes at most. From looking at Splunk, the only ones that ran for more than this were clearly stalled and just running their script forever (until the app server restarted). In any case, I don't think it's reasonable to ask the app servers to do work for >30 minutes for a very long-running script, that seems like it would be better for the user to run something like that in their own SSH session.

### Testing
Didn't really seem worthwhile to add unit tests for a timeout.

### Documentation
N/A