### PR TITLE
DEVPROD-6607 unset annotations cache when restarting task

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2365,6 +2365,7 @@ func resetTaskUpdate(t *Task, caller string) []bson.M {
 		t.NumNextTaskDispatches = 0
 		t.CanReset = false
 		t.IsAutomaticRestart = false
+		t.HasAnnotations = false
 	}
 	update := []bson.M{
 		{
@@ -2407,6 +2408,7 @@ func resetTaskUpdate(t *Task, caller string) []bson.M {
 				HostCreateDetailsKey,
 				OverrideDependenciesKey,
 				CanResetKey,
+				HasAnnotationsKey,
 			},
 		},
 	}

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4879,6 +4879,7 @@ func TestReset(t *testing.T) {
 			ResetFailedWhenFinished: true,
 			OverrideDependencies:    true,
 			CanReset:                true,
+			HasAnnotations:          true,
 			AgentVersion:            "a1",
 			HostId:                  "h",
 			PodID:                   "p",
@@ -4896,6 +4897,7 @@ func TestReset(t *testing.T) {
 		assert.False(t, dbTask.IsAutomaticRestart)
 		assert.False(t, dbTask.ResetFailedWhenFinished)
 		assert.False(t, dbTask.OverrideDependencies)
+		assert.False(t, dbTask.HasAnnotations)
 		assert.False(t, dbTask.CanReset)
 		assert.Equal(t, "", dbTask.AgentVersion)
 		assert.Equal(t, "", dbTask.HostId)


### PR DESCRIPTION
DEVPROD-6607

### Description
unset annotations cache when restarting task (or else everything is a known issue!) 

### Testing
added to unit test