### PR TITLE
DEVPROD-4788 move s3.get errors from agent to task logs

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -245,7 +245,7 @@ func (c *s3get) getWithRetry(ctx context.Context, logger client.LoggerProducer) 
 				return nil
 			}
 
-			logger.Execution().Errorf("Problem getting remote file '%s' from S3 bucket, retrying: %s",
+			logger.Task().Errorf("Problem getting remote file '%s' from S3 bucket, retrying: %s",
 				c.RemoteFile, err)
 			timer.Reset(backoffCounter.Duration())
 		}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-04-26"
+	AgentVersion = "2024-05-02"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-4788 
### Description
These errors are hard to find in the agent logs, and make sense to be in task logs 