### PR TITLE
DEVPROD-7003 Expose close function for github client's underlying http client usage

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -205,14 +205,14 @@ func getInstallationIDFromCache(ctx context.Context, app int64, owner, repo stri
 	return installation.InstallationID, nil
 }
 
-// WrappedGitHubClient adds a Close method to the GitHub client that
+// GitHubClient adds a Close method to the GitHub client that
 // puts the underlying HTTP client back into the pool.
-type WrappedGitHubClient struct {
+type GitHubClient struct {
 	*github.Client
 }
 
 // Close puts the underlying HTTP client back into the pool.
-func (g *WrappedGitHubClient) Close() {
+func (g *GitHubClient) Close() {
 	if g == nil {
 		return
 	}
@@ -224,7 +224,7 @@ func (g *WrappedGitHubClient) Close() {
 // getGitHubClientForAuth returns a GitHub client with the GitHub app's private key.
 // This function cannot be moved to thirdparty because it is needed to set up the environment.
 // Couple this with a defered call with Close() to clean up the client.
-func getGitHubClientForAuth(authFields *githubAppAuth) (*WrappedGitHubClient, error) {
+func getGitHubClientForAuth(authFields *githubAppAuth) (*GitHubClient, error) {
 	retryConf := utility.NewDefaultHTTPRetryConf()
 	retryConf.MaxDelay = GitHubRetryMaxDelay
 	retryConf.BaseDelay = GitHubRetryMinDelay
@@ -239,7 +239,7 @@ func getGitHubClientForAuth(authFields *githubAppAuth) (*WrappedGitHubClient, er
 	itr := ghinstallation.NewAppsTransportFromPrivateKey(httpClient.Transport, authFields.appId, key)
 	httpClient.Transport = itr
 	client := github.NewClient(httpClient)
-	wrappedClient := WrappedGitHubClient{Client: client}
+	wrappedClient := GitHubClient{Client: client}
 	return &wrappedClient, nil
 }
 

--- a/github_app.go
+++ b/github_app.go
@@ -205,11 +205,14 @@ func getInstallationIDFromCache(ctx context.Context, app int64, owner, repo stri
 	return installation.InstallationID, nil
 }
 
-type githubClient struct {
+// WrappedGitHubClient adds a Close method to the GitHub client that
+// puts the underlying HTTP client back into the pool.
+type WrappedGitHubClient struct {
 	*github.Client
 }
 
-func (g *githubClient) Close() {
+// Close puts the underlying HTTP client back into the pool.
+func (g *WrappedGitHubClient) Close() {
 	if g == nil {
 		return
 	}
@@ -221,7 +224,7 @@ func (g *githubClient) Close() {
 // getGitHubClientForAuth returns a GitHub client with the GitHub app's private key.
 // This function cannot be moved to thirdparty because it is needed to set up the environment.
 // Couple this with a defered call with Close() to clean up the client.
-func getGitHubClientForAuth(authFields *githubAppAuth) (*githubClient, error) {
+func getGitHubClientForAuth(authFields *githubAppAuth) (*WrappedGitHubClient, error) {
 	retryConf := utility.NewDefaultHTTPRetryConf()
 	retryConf.MaxDelay = GitHubRetryMaxDelay
 	retryConf.BaseDelay = GitHubRetryMinDelay
@@ -236,7 +239,7 @@ func getGitHubClientForAuth(authFields *githubAppAuth) (*githubClient, error) {
 	itr := ghinstallation.NewAppsTransportFromPrivateKey(httpClient.Transport, authFields.appId, key)
 	httpClient.Transport = itr
 	client := github.NewClient(httpClient)
-	wrappedClient := githubClient{Client: client}
+	wrappedClient := WrappedGitHubClient{Client: client}
 	return &wrappedClient, nil
 }
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -289,7 +289,8 @@ func githubShouldRetry(caller string, config retryConfig) utility.HTTPRetryFunct
 
 // getGithubClient returns a client that provides the given token, retries requests,
 // caches responses, and creates a span for each request.
-func getGithubClient(token, caller string, config retryConfig) *github.Client {
+// Couple this with a defered call with Close() to clean up the client.
+func getGithubClient(token, caller string, config retryConfig) *evergreen.WrappedGitHubClient {
 	grip.Info(message.Fields{
 		"ticket":  GithubInvestigation,
 		"message": "called getGithubClient",
@@ -305,6 +306,9 @@ func getGithubClient(token, caller string, config retryConfig) *github.Client {
 		cacheTransport.Cache = httpcache.NewMemoryCache()
 	}
 
+	httpClient := utility.GetHTTPClient()
+	httpClient.Transport = githubTransport
+
 	client := utility.SetupOauth2CustomHTTPRetryableClient(
 		token,
 		githubShouldRetry(caller, config),
@@ -312,10 +316,11 @@ func getGithubClient(token, caller string, config retryConfig) *github.Client {
 			MaxAttempts: evergreen.GitHubMaxRetries,
 			MinDelay:    evergreen.GitHubRetryMinDelay,
 		}),
-		utility.DefaultHttpClient(githubTransport),
+		httpClient,
 	)
 
-	return github.NewClient(client)
+	githubClient := evergreen.WrappedGitHubClient{Client: github.NewClient(client)}
+	return &githubClient
 }
 
 // getInstallationToken creates an installation token using Github app auth.
@@ -353,6 +358,7 @@ func RevokeInstallationToken(ctx context.Context, token string) error {
 	defer span.End()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 	resp, err := githubClient.Apps.RevokeInstallationToken(ctx)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -425,6 +431,7 @@ func getCommits(ctx context.Context, token, owner, repo, ref string, until time.
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	options := github.CommitsListOptions{
 		SHA: ref,
@@ -509,6 +516,7 @@ func getFile(ctx context.Context, token, owner, repo, path, ref string) (*github
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	var opt *github.RepositoryContentGetOptions
 	if len(ref) != 0 {
@@ -670,6 +678,7 @@ func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, 
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	compare, resp, err := githubClient.Repositories.CompareCommits(ctx,
 		owner, repo, baseRevision, currentCommitHash, nil)
@@ -733,6 +742,7 @@ func commitEvent(ctx context.Context, token, owner, repo, githash string) (*gith
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	grip.Info(message.Fields{
 		"message": "requesting commit from github",
@@ -814,6 +824,7 @@ func commitDiff(ctx context.Context, token, owner, repo, sha string) (string, er
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	commit, resp, err := githubClient.Repositories.GetCommitRaw(ctx, owner, repo, sha, github.RawOptions{Type: github.Diff})
 	if resp != nil {
@@ -874,6 +885,7 @@ func branchEvent(ctx context.Context, token, owner, repo, branch string) (*githu
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	grip.Debugf("requesting github commit for '%s/%s': branch: %s\n", owner, repo, branch)
 
@@ -1070,6 +1082,7 @@ func taggedCommit(ctx context.Context, token, owner, repo, tag string) (string, 
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 	ref, resp, err := githubClient.Git.GetRef(ctx, owner, repo, tag)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -1124,6 +1137,7 @@ func getObjectTag(ctx context.Context, token, owner, repo, sha string) (*github.
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	tag, resp, err := githubClient.Git.GetTag(ctx, owner, repo, sha)
 	if resp != nil {
@@ -1177,6 +1191,7 @@ func userInTeam(ctx context.Context, token string, teams []string, org, user, ow
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	grip.Info(message.Fields{
 		"ticket":  GithubInvestigation,
@@ -1214,6 +1229,7 @@ func GetGithubTokenUser(ctx context.Context, token string, requiredOrg string) (
 	defer span.End()
 
 	githubClient := getGithubClient(fmt.Sprintf("token %s", token), caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	user, resp, err := githubClient.Users.Get(ctx, "")
 	if resp != nil {
@@ -1286,6 +1302,7 @@ func apiLimit(ctx context.Context, token string) (int64, error) {
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	limits, resp, err := githubClient.RateLimits(ctx)
 	if resp != nil {
@@ -1340,6 +1357,7 @@ func getUser(ctx context.Context, token, loginName string) (*github.User, error)
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	user, resp, err := githubClient.Users.Get(ctx, loginName)
 	if resp != nil {
@@ -1393,6 +1411,7 @@ func userInOrganization(ctx context.Context, token, requiredOrganization, userna
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	isMember, resp, err := githubClient.Organizations.IsMember(context.Background(), requiredOrganization, username)
 	if resp != nil {
@@ -1438,6 +1457,7 @@ func authorizedForOrg(ctx context.Context, token, requiredOrganization, name str
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	// GitHub often appends [bot] to GitHub App usage, but this doesn't match the App slug, so we should check without this.
 	nameWithoutBotSuffix := strings.TrimSuffix(name, botSuffix)
@@ -1509,6 +1529,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
+	defer githubClient.Close()
 
 	permissionLevel, resp, err := githubClient.Repositories.GetPermissionLevel(ctx, owner, repo, username)
 	if resp != nil {
@@ -1564,6 +1585,7 @@ func getPRMergeBase(ctx context.Context, token string, data GithubPatch) (string
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
+	defer githubClient.Close()
 
 	commits, resp, err := githubClient.PullRequests.ListCommits(ctx, data.BaseOwner, data.BaseRepo, data.PRNumber, nil)
 	if resp != nil {
@@ -1614,6 +1636,7 @@ func getCommit(ctx context.Context, token, owner, repo, sha string) (*github.Rep
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
+	defer githubClient.Close()
 
 	commit, resp, err := githubClient.Repositories.GetCommit(ctx, owner, repo, sha, nil)
 	if resp != nil {
@@ -1667,6 +1690,7 @@ func getPullRequest(ctx context.Context, token, baseOwner, baseRepo string, prNu
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
+	defer githubClient.Close()
 
 	pr, resp, err := githubClient.PullRequests.Get(ctx, baseOwner, baseRepo, prNumber)
 	if resp != nil {
@@ -1717,6 +1741,7 @@ func pullRequestDiff(ctx context.Context, token string, gh GithubPatch) (string,
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
+	defer githubClient.Close()
 
 	diff, resp, err := githubClient.PullRequests.GetRaw(ctx, gh.BaseOwner, gh.BaseRepo, gh.PRNumber, github.RawOptions{Type: github.Diff})
 	if resp != nil {
@@ -1893,6 +1918,7 @@ func mergePR(ctx context.Context, token, owner, repo, commitMessage string, prNu
 	defer span.End()
 
 	githubClient := getGithubClient(token, caller, retryConfig{})
+	defer githubClient.Close()
 	res, resp, err := githubClient.PullRequests.Merge(ctx, owner, repo,
 		prNum, commitMessage, mergeOpts)
 	if resp != nil {
@@ -1945,6 +1971,7 @@ func postComment(ctx context.Context, token, owner, repo string, prNum int, comm
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
+	defer githubClient.Close()
 
 	githubComment := &github.IssueComment{
 		Body: &comment,
@@ -2002,6 +2029,7 @@ func GetBranchProtectionRules(ctx context.Context, token, owner, repo, branch st
 		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
+	defer githubClient.Close()
 
 	protection, resp, err := githubClient.Repositories.GetBranchProtection(ctx, owner, repo, branch)
 	if resp != nil {
@@ -2061,6 +2089,7 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 
 	opts := github.CreateCheckRunOptions{
 		Name:        makeCheckRunName(task),
@@ -2119,6 +2148,7 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 	checkRun, resp, err := githubClient.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, updateOpts)
 
 	if resp != nil {
@@ -2185,6 +2215,7 @@ func ListCheckRunCheckSuite(ctx context.Context, owner, repo string, checkSuiteI
 	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 	listCheckRunsResult, resp, err := githubClient.Checks.ListCheckRunsCheckSuite(ctx, owner, repo, checkSuiteID, nil)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -2217,6 +2248,7 @@ func GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*gi
 	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
+	defer githubClient.Close()
 	checkRun, resp, err := githubClient.Checks.GetCheckRun(ctx, owner, repo, checkRunID)
 	if resp != nil {
 		defer resp.Body.Close()

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -289,8 +289,8 @@ func githubShouldRetry(caller string, config retryConfig) utility.HTTPRetryFunct
 
 // getGithubClient returns a client that provides the given token, retries requests,
 // caches responses, and creates a span for each request.
-// Couple this with a defered call with Close() to clean up the client.
-func getGithubClient(token, caller string, config retryConfig) *evergreen.WrappedGitHubClient {
+// Couple this with a deferred call with Close() to clean up the client.
+func getGithubClient(token, caller string, config retryConfig) *evergreen.GitHubClient {
 	grip.Info(message.Fields{
 		"ticket":  GithubInvestigation,
 		"message": "called getGithubClient",
@@ -319,7 +319,7 @@ func getGithubClient(token, caller string, config retryConfig) *evergreen.Wrappe
 		httpClient,
 	)
 
-	githubClient := evergreen.WrappedGitHubClient{Client: github.NewClient(client)}
+	githubClient := evergreen.GitHubClient{Client: github.NewClient(client)}
 	return &githubClient
 }
 


### PR DESCRIPTION
DEVPROD-7003

### Description
This exposes the wrapped github client in the evergreen package which adds a Close function, and then consumes that struct in some internal github client code.
