### PR TITLE
DEVPROD-2647: fix file deduplication in evergreen fetch

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-04-30"
+	ClientVersion = "2024-05-02"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -468,8 +468,9 @@ func fileNameWithIndex(filename string, index int) string {
 	if len(parts) == 1 {
 		return fmt.Sprintf("%s_(%d)", filename, index-1)
 	}
+
 	// If the file has an extension, add _N (index) just before the extension.
-	return fmt.Sprintf("%s_(%d).%s", parts[0], index-1, strings.Join(parts[1:], "."))
+	return fmt.Sprintf("%s_(%d).%s", strings.Join(parts[:len(parts)-1], "."), index-1, parts[len(parts)-1])
 }
 
 // truncateFilename truncates the filename (minus any extensions) so the entire filename length is less than the max
@@ -551,6 +552,7 @@ func downloadUrls(root string, urls chan artifactDownload, workers int) error {
 						}
 						// something else went wrong.
 						errs <- errors.Wrapf(err, "checking if file '%s' exists", testFileName)
+						fileNamesUsed.Unlock()
 						return
 					}
 				}
@@ -578,7 +580,6 @@ func downloadUrls(root string, urls chan artifactDownload, workers int) error {
 
 				// If we can get the info, determine the file size so that the human can get an
 				// idea of how long the file might take to download.
-				// TODO: progress bars.
 				length, _ := strconv.Atoi(resp.Header.Get(evergreen.ContentLengthHeader))
 				sizeLog := ""
 				if length > 0 {

--- a/operations/fetch_test.go
+++ b/operations/fetch_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -96,4 +97,25 @@ func TestTruncateName(t *testing.T) {
 	newName = truncateFilename(fileName)
 	assert.Len(t, newName, 250)
 	assert.Equal(t, strings.Repeat("a", 250), newName)
+}
+
+func TestFileNameWithIndex(t *testing.T) {
+	t.Run("JustFilename", func(t *testing.T) {
+		assert.Equal(t, "file_(4).txt", fileNameWithIndex("file.txt", 5))
+	})
+	t.Run("DirectoryAndFilename", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("path", "to", "file_(4).txt"), fileNameWithIndex(filepath.Join("path", "to", "file.txt"), 5))
+	})
+	t.Run("FilenameWithoutExtensions", func(t *testing.T) {
+		assert.Equal(t, "file_(4)", fileNameWithIndex("file", 5))
+	})
+	t.Run("DirectoryAndFilenameWithoutExtensions", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("path", "to", "file_(4)"), fileNameWithIndex(filepath.Join("path", "to", "file"), 5))
+	})
+	t.Run("DirectoryAndFilenameWithMultipleExtensions", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("path", "to", "file_(4).tar.gz"), fileNameWithIndex(filepath.Join("path", "to", "file.tar.gz"), 5))
+	})
+	t.Run("DirectoryWithPeriodsAndFilenameWithExtension", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("path.with.dots", "to", "file_(4).tar.gz"), fileNameWithIndex(filepath.Join("path.with.dots", "to", "file.tar.gz"), 5))
+	})
 }


### PR DESCRIPTION
DEVPROD-2647

### Description
This helper function is supposed to deduplicate files downloaded by `evergreen fetch` by adding indexes to the file name (e.g. `my_file_(1).txt`, `my_file_(2).txt`). The issue was that the file name being passed in was actually the full file path including the directory, and sometimes the directory would also have periods in it, so the helper would add the index to the directory instead of the file name (e.g. `/home/hello.world/file.txt` became `/home/hello_(1).world/file.txt` instead of `/home/hello.world/file_(1).txt`). To work around this, I kept the directory as-is, and then used the file name alone to splice in the index.

Also fixed a spot that had a potential deadlock in the error case. It's not that big of a deal, but it seemed easy enough to not deadlock the goroutines.

### Testing
Added unit tests.

### Documentation
N/A