### PR TITLE
DEVPROD-5373 Add a clause if no revisions are specified then git.get_project will clone all modules

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -513,7 +513,7 @@ by a patch submission.
 ```
 
 ``` yaml
-- modules: 
+modules: 
   - name: example
     owner: 10gen
     repo: mongo-example-modules

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -533,6 +533,7 @@ Parameters:
     means that for patch builds, editing the
     ["modules"](Project-Configuration-Files#modules)
     section of the project config will not change the checked out hash.
+    If you do not specify any revisions, all of them will be cloned.
 -   `token`: Use a token to clone instead of the ssh key on the host.
     Since this is a secret, it should be provided as a project
     expansion. For example, you could provide an expansion called


### PR DESCRIPTION
DEVPROD-5373

### Description
Add a clause in the docs that if no revisions are specified, it will clone all modules

### Testing
I made sure this behavior happens by running with config:
```
modules:
  - name: spruce
    owner: evergreen-ci
    repo: spruce
    branch: main
  - name: parsley
    owner: evergreen-ci
    repo: parsley
    branch: main

#######################################
#              Functions              #
#######################################
functions:
  get-project:
    - command: git.get_project
      type: setup
      params:
        directory: evergreen

#######################################
#                Tasks                #
#######################################

tasks:
  - name: my-task
    commands:
      - func: get-project
      - command: shell.exec
        params:
          script: |
            echo "I finished getting the project and modules"

#######################################
#            Buildvariants            #
#######################################
buildvariants:
  - name: ubuntu2204
    display_name: ubunutu2204
    run_on:
      - ubuntu2204-small
    tasks:
      - name: my-task
    modules:
      - spruce
      - parsley
```
Which made [this](https://spruce.mongodb.com/task/evergreen_ubuntu2204_my_task_patch_6918e0e5b1ba45f53140f62251a998f90718fc4a_6633b54675990800086eecf2_24_05_02_15_46_20/logs?execution=0&logtype=task) task which if you look at honeycomb, it cloned both modules.
