### PR TITLE
DEVPROD-6873 Disallow projects with GitHub merge queue to enqueue patches

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -329,6 +329,21 @@ func (r *mutationResolver) EnqueuePatch(ctx context.Context, patchID string, com
 		commitMessage = existingPatch.Description
 	}
 
+	if utility.FromStringPtr(existingPatch.Requester) == evergreen.GithubPRRequester {
+		info := commitqueue.EnqueuePRInfo{
+			PR:            existingPatch.GithubPatchData.PRNumber,
+			Repo:          utility.FromStringPtr(existingPatch.GithubPatchData.BaseRepo),
+			Owner:         utility.FromStringPtr(existingPatch.GithubPatchData.BaseOwner),
+			CommitMessage: utility.FromStringPtr(commitMessage),
+			Username:      utility.FromStringPtr(existingPatch.GithubPatchData.Author),
+		}
+		newPatch, err := data.EnqueuePRToCommitQueue(ctx, evergreen.GetEnvironment(), r.sc, info)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("enqueueing patch '%s': %s", patchID, err.Error()))
+		}
+		return newPatch, nil
+	}
+
 	newPatch, err := data.CreatePatchForMerge(ctx, evergreen.GetEnvironment().Settings(), patchID, utility.FromStringPtr(commitMessage))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error creating new patch: %s", err.Error()))

--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -42,12 +42,12 @@ func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProject
 	apiPatches := []*restModel.APIPatch{}
 	for _, p := range patches {
 		apiPatch := restModel.APIPatch{}
-		err = apiPatch.BuildFromService(p, nil) // Injecting DB info into APIPatch is handled by the resolvers.
+		err = apiPatch.BuildFromService(p, &restModel.APIPatchArgs{
+			UsesGitHubMergeQueue: obj.CommitQueue.MergeQueue == model.MergeQueueGitHub,
+		}) // Injecting DB info into APIPatch is handled by the resolvers.
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem building APIPatch from service for patch: %s : %s", p.Id.Hex(), err.Error()))
 		}
-		// Only show the enqueue button if the project uses the Evergreen commit queue.
-		apiPatch.CanEnqueueToCommitQueue = obj.CommitQueue.MergeQueue == model.MergeQueueEvergreen
 		apiPatches = append(apiPatches, &apiPatch)
 	}
 	return &Patches{Patches: apiPatches, FilteredPatchCount: count}, nil

--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -42,7 +42,7 @@ func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProject
 	apiPatches := []*restModel.APIPatch{}
 	for _, p := range patches {
 		apiPatch := restModel.APIPatch{}
-		err = apiPatch.BuildFromService(p, &restModel.APIPatchArgs{}) // Injecting DB info into APIPatch is handled by the resolvers.
+		err = apiPatch.BuildFromService(p, nil) // Injecting DB info into APIPatch is handled by the resolvers.
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem building APIPatch from service for patch: %s : %s", p.Id.Hex(), err.Error()))
 		}

--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -42,9 +42,7 @@ func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProject
 	apiPatches := []*restModel.APIPatch{}
 	for _, p := range patches {
 		apiPatch := restModel.APIPatch{}
-		err = apiPatch.BuildFromService(p, &restModel.APIPatchArgs{
-			UsesGitHubMergeQueue: obj.CommitQueue.MergeQueue == model.MergeQueueGitHub,
-		}) // Injecting DB info into APIPatch is handled by the resolvers.
+		err = apiPatch.BuildFromService(p, &restModel.APIPatchArgs{}) // Injecting DB info into APIPatch is handled by the resolvers.
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem building APIPatch from service for patch: %s : %s", p.Id.Hex(), err.Error()))
 		}

--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -46,6 +46,8 @@ func (r *projectResolver) Patches(ctx context.Context, obj *restModel.APIProject
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem building APIPatch from service for patch: %s : %s", p.Id.Hex(), err.Error()))
 		}
+		// Only show the enqueue button if the project uses the Evergreen commit queue.
+		apiPatch.CanEnqueueToCommitQueue = obj.CommitQueue.MergeQueue == model.MergeQueueEvergreen
 		apiPatches = append(apiPatches, &apiPatch)
 	}
 	return &Patches{Patches: apiPatches, FilteredPatchCount: count}, nil

--- a/graphql/tests/mutation/setPatchVisibility/data.json
+++ b/graphql/tests/mutation/setPatchVisibility/data.json
@@ -51,5 +51,15 @@
         }
       ]
     }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen",
+      "owner_name": "evergreen-ci",
+      "repo_name": "evergreen",
+      "enabled": true,
+      "repoRefId": "something"
+    }
   ]
 }

--- a/graphql/tests/query/commitQueue/data.json
+++ b/graphql/tests/query/commitQueue/data.json
@@ -207,6 +207,10 @@
       "commit_queue": {
         "enabled": false
       }
+    },
+        {
+      "_id": "mongodb-mongo-master",
+      "identifier": "mongodb-mongo-master"
     }
   ]
 }

--- a/graphql/tests/task/patch/data.json
+++ b/graphql/tests/task/patch/data.json
@@ -4,6 +4,7 @@
       "_id": {
         "$oid": "5e4ff3abe3c3317e352062e4"
       },
+      "branch": "spruce",
       "patch_number": 1234,
       "author": "arjun",
       "githash": "ca82a6dff817ec66f44342007202690a93763949"

--- a/rest/data/commit_queue.go
+++ b/rest/data/commit_queue.go
@@ -479,6 +479,17 @@ func CreatePatchForMerge(ctx context.Context, settings *evergreen.Settings, exis
 		return nil, errors.Errorf("patch '%s' not found", existingPatchID)
 	}
 
+	proj, err := FindProjectById(existingPatch.Project, false, false)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting project '%s'", existingPatch.Project)
+	}
+	if proj == nil {
+		return nil, errors.Errorf("project '%s' not found", existingPatch.Project)
+	}
+	if proj.CommitQueue.MergeQueue == model.MergeQueueGitHub {
+		return nil, errors.New("Can't enqueue patches for projects with GitHub merge queue. Click the merge button on the PR instead.")
+	}
+
 	newPatch, err := model.MakeMergePatchFromExisting(ctx, settings, existingPatch, commitMessage)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating new patch from existing patch '%s'", existingPatchID)

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -159,7 +159,7 @@ func (apiPatch *APIPatch) BuildFromService(p patch.Patch, args *APIPatchArgs) er
 	if err != nil {
 		return errors.Wrapf(err, "finding project ref '%s'", projectIdentifier)
 	}
-	if proj != nil {
+	if proj == nil {
 		return errors.Errorf("project ref '%s' not found", projectIdentifier)
 	}
 	// Projects that use the GitHub merge queue cannot enqueue to the commit queue.

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -147,7 +147,6 @@ type APIPatchArgs struct {
 	IncludeProjectIdentifier   bool
 	IncludeCommitQueuePosition bool
 	IncludeChildPatches        bool
-	UsesGitHubMergeQueue       bool
 }
 
 // BuildFromService converts from service level structs to an APIPatch.
@@ -156,10 +155,17 @@ func (apiPatch *APIPatch) BuildFromService(p patch.Patch, args *APIPatchArgs) er
 	apiPatch.buildBasePatch(p)
 
 	projectIdentifier := p.Project
-	if args != nil {
-		// Projects that use the GitHub merge queue cannot enqueue to the commit queue.
-		apiPatch.CanEnqueueToCommitQueue = (p.HasValidGitInfo() || p.IsGithubPRPatch()) && !args.UsesGitHubMergeQueue
+	proj, err := model.FindMergedProjectRef(projectIdentifier, p.Version, false)
+	if err != nil {
+		return errors.Wrapf(err, "finding project ref '%s'", projectIdentifier)
+	}
+	if proj != nil {
+		return errors.Errorf("project ref '%s' not found", projectIdentifier)
+	}
+	// Projects that use the GitHub merge queue cannot enqueue to the commit queue.
+	apiPatch.CanEnqueueToCommitQueue = (p.HasValidGitInfo() || p.IsGithubPRPatch()) && proj.CommitQueue.MergeQueue != model.MergeQueueGitHub
 
+	if args != nil {
 		if args.IncludeProjectIdentifier && p.Project != "" {
 			apiPatch.GetIdentifier()
 			if apiPatch.ProjectIdentifier != nil {

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -421,7 +421,13 @@ func TestPatchRestartSuite(t *testing.T) {
 }
 
 func (s *PatchRestartSuite) SetupSuite() {
-	s.NoError(db.ClearCollections(patch.Collection, serviceModel.VersionCollection, task.Collection))
+	s.NoError(db.ClearCollections(patch.Collection, serviceModel.VersionCollection, task.Collection, serviceModel.ProjectRefCollection))
+	projectRef := serviceModel.ProjectRef{
+		Id:         "project_id",
+		Identifier: "project_identifier",
+	}
+	s.NoError(projectRef.Insert())
+
 	s.objIds = []string{"aabbccddeeff001122334455", "aabbccddeeff001122334456"}
 	version1 := "version1"
 
@@ -440,8 +446,8 @@ func (s *PatchRestartSuite) SetupSuite() {
 		},
 	}
 	patches := []patch.Patch{
-		{Id: patch.NewId(s.objIds[0]), Version: version1},
-		{Id: patch.NewId(s.objIds[1])},
+		{Id: patch.NewId(s.objIds[0]), Version: version1, Project: projectRef.Id},
+		{Id: patch.NewId(s.objIds[1]), Project: projectRef.Id},
 	}
 	for _, p := range patches {
 		s.NoError(p.Insert())


### PR DESCRIPTION
DEVPROD-6873

### Description
projects with GitHub merge queue enabled cannot have their patches enqueued to to the commit queue

### Testing
cannot enqueue patches anymore with routes or calling graphql queries manually (tested by not disabling button and clicking it)
<img width="420" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/68fd6f0e-4abd-466a-bcf0-9ed0c9a456f8">

button disabled on version page 
<img width="955" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/3586dc24-de5a-4f67-be9f-5af3dc62a080">

disabled on project patches page 
<img width="953" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/7ff84268-e6d2-4e61-9cc4-f96560c7dd1a">

disabled on user patches page
<img width="964" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/c1ade47c-8c01-4588-bb00-5eec249d1476">