### PR TITLE
DEVPROD-4597 Remove unused build / task Tags field

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -51,9 +51,6 @@ type Build struct {
 	ActualMakespan      time.Duration `bson:"actual_makespan" json:"actual_makespan,omitempty"`
 	Aborted             bool          `bson:"aborted" json:"aborted,omitempty"`
 
-	// Tags that describe the variant
-	Tags []string `bson:"tags,omitempty" json:"tags,omitempty"`
-
 	// The status of the subset of the build that's used for github checks
 	GithubCheckStatus string `bson:"github_check_status,omitempty" json:"github_check_status,omitempty"`
 	// does the build contain tasks considered for mainline github checks

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -624,7 +624,6 @@ func CreateBuildFromVersionNoInsert(creationInfo TaskCreationInfo) (*build.Build
 		TriggerID:           creationInfo.Version.TriggerID,
 		TriggerType:         creationInfo.Version.TriggerType,
 		TriggerEvent:        creationInfo.Version.TriggerEvent,
-		Tags:                buildVariant.Tags,
 	}
 
 	// create all the necessary tasks for the build
@@ -755,10 +754,6 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 			return nil, errors.Wrapf(err, "creating task '%s'", id)
 		}
 
-		projectTask := creationInfo.Project.FindProjectTask(t.Name)
-		if projectTask != nil {
-			newTask.Tags = projectTask.Tags
-		}
 		newTask.DependsOn = makeDeps(t.DependsOn, newTask, execTable)
 		newTask.GeneratedBy = creationInfo.GeneratedBy
 		if generatorIsGithubCheck {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1073,7 +1073,6 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			So(build, ShouldNotBeNil)
 			So(build.Id, ShouldNotEqual, "")
 			So(len(tasks), ShouldEqual, 4)
-			So(len(tasks[0].Tags), ShouldEqual, 2)
 		})
 
 		Convey("if a non-empty list of task names is passed in, only the"+

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -132,14 +132,10 @@ type Task struct {
 	// associated with a task. This is used for running tasks in case there are
 	// idle hosts in a distro with an empty primary queue. This is a distinct concept
 	// from distro aliases (i.e. alternative distro names).
-	// Tags refer to outdated naming; maintained for compatibility.
 	SecondaryDistros []string `bson:"distro_aliases,omitempty" json:"distro_aliases,omitempty"`
 
 	// Human-readable name
 	DisplayName string `bson:"display_name" json:"display_name"`
-
-	// Tags that describe the task
-	Tags []string `bson:"tags,omitempty" json:"tags,omitempty"`
 
 	// The host the task was run on. This value is only set for host tasks.
 	HostId string `bson:"host_id,omitempty" json:"host_id"`

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -125,7 +125,6 @@ func (apiBuild *APIBuild) BuildFromService(v build.Build, pp *model.ParserProjec
 	apiBuild.DisplayName = utility.ToStringPtr(v.DisplayName)
 	apiBuild.PredictedMakespan = NewAPIDuration(v.PredictedMakespan)
 	apiBuild.ActualMakespan = NewAPIDuration(v.ActualMakespan)
-	apiBuild.Tags = utility.ToStringPtrSlice(v.Tags)
 	var origin string
 	switch v.Requester {
 	case evergreen.RepotrackerVersionRequester:

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -286,7 +286,6 @@ func (at *APITask) buildTask(t *task.Task) error {
 		DisplayName:                 utility.ToStringPtr(t.DisplayName),
 		HostId:                      utility.ToStringPtr(t.HostId),
 		PodID:                       utility.ToStringPtr(t.PodID),
-		Tags:                        utility.ToStringPtrSlice(t.Tags),
 		Execution:                   t.Execution,
 		Order:                       t.RevisionOrderNumber,
 		Status:                      utility.ToStringPtr(t.Status),

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -294,7 +294,6 @@ func (s *TaskFinderComparisonSuite) SetupTest() {
 	s.NotEmpty(s.tasks)
 	for _, task := range s.tasks {
 		task.BuildVariant = "aBuildVariant"
-		task.Tags = []string{"tag1", "tag2"}
 		s.NoError(task.Insert())
 	}
 
@@ -350,19 +349,15 @@ func (s *TaskFinderComparisonSuite) TestFindRunnableHostsIsIdentical() {
 func (s *TaskFinderComparisonSuite) TestCheckThatTaskIsPopulated() {
 	for _, task := range s.oldRunnableTasks {
 		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
 	for _, task := range s.newRunnableTasks {
 		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
 	for _, task := range s.altRunnableTasks {
 		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
 	for _, task := range s.pllRunnableTasks {
 		s.Equal(task.BuildVariant, "aBuildVariant")
-		s.Equal(task.Tags, []string{"tag1", "tag2"})
 	}
 }
 


### PR DESCRIPTION
DEVPROD-4597

### Description
This removes unused `Tags` fields on both the build and the task struct.
### Testing
Existing tests
