### PR TITLE
DEVPROD-5578 Clear distro task queue when disabling it

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -33,6 +33,16 @@ func UpdateDistro(ctx context.Context, old, new *distro.Distro) error {
 			}
 		}
 	}
+
+	if !old.Disabled && new.Disabled {
+		if err := model.ClearTaskQueue(new.Id); err != nil {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    errors.Wrapf(err, "clearing task queues for distro '%s'", new.Id).Error(),
+			}
+		}
+	}
+
 	if err := new.ReplaceOne(ctx); err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,


### PR DESCRIPTION
DEVPROD-5578

### Description
Clear the distro's task queue when disabling it (as is already advertised in Spruce UI).

### Testing
Added a unit test.
