### PR TITLE
DEVPROD-7031: log host ID when agent is exiting with error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -81,10 +81,10 @@ type Options struct {
 	SendTaskLogsToGlobalSender bool
 }
 
-// SetLoggableInfo is a helper to add relevant information about the agent
+// AddLoggableInfo is a helper to add relevant information about the agent
 // runtime to the log message. This is typically to make high priority error
 // logs more informative.
-func (o *Options) SetLoggableInfo(msg message.Fields) message.Fields {
+func (o *Options) AddLoggableInfo(msg message.Fields) message.Fields {
 	if o.HostID != "" {
 		msg["host_id"] = o.HostID
 	}
@@ -1238,7 +1238,7 @@ func (a *Agent) logPanic(tc *taskContext, pErr, originalErr error, op string) er
 		"message":   "programmatic error: Evergreen agent hit panic",
 		"operation": op,
 	}
-	logMsg = a.opts.SetLoggableInfo(logMsg)
+	logMsg = a.opts.AddLoggableInfo(logMsg)
 	if tc.logger != nil && !tc.logger.Closed() {
 		tc.logger.Task().Error(logMsg)
 	}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-05-02-a"
+	AgentVersion = "2024-05-03"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -199,9 +199,10 @@ func Agent() cli.Command {
 				}
 				msg = opts.SetLoggableInfo(msg)
 				grip.Emergency(message.WrapError(err, msg))
+				return err
 			}
 
-			return err
+			return nil
 		},
 	}
 }

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -197,7 +197,7 @@ func Agent() cli.Command {
 				msg := message.Fields{
 					"message": "agent is exiting due to unrecoverable error",
 				}
-				msg = opts.SetLoggableInfo(msg)
+				msg = opts.AddLoggableInfo(msg)
 				grip.Emergency(message.WrapError(err, msg))
 				return err
 			}

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -193,7 +193,13 @@ func Agent() cli.Command {
 			agt.SetDefaultLogger(sender)
 
 			err = agt.Start(ctx)
-			grip.Emergency(err)
+			if err != nil {
+				msg := message.Fields{
+					"message": "agent is exiting due to unrecoverable error",
+				}
+				msg = opts.SetLoggableInfo(msg)
+				grip.Emergency(message.WrapError(err, msg))
+			}
 
 			return err
 		},


### PR DESCRIPTION
DEVPROD-7031

### Description
The perf team is working on migrating Cedar to Kanopy and they hit an error while the agent was trying to connect to Cedar. I included some more log info about which particular host hit the issue so it's more traceable in Splunk (and wrapped it in a helper).

### Testing
It's just a logging change, so it didn't seem that worthwhile to add tests.

### Documentation
N/A