### PR TITLE
DEVPROD-6951 pail AWS SDK session caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
 	github.com/evergreen-ci/gimlet v0.0.0-20240426164856-8c2db742f7b0
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
-	github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30
+	github.com/evergreen-ci/pail v0.0.0-20240503141904-b600c21b5f20
 	github.com/evergreen-ci/poplar v0.0.0-20240129220701-28919e26f3a3
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20230905184025-88c53a14c47b
@@ -211,6 +211,7 @@ require (
 
 require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/go-test/deep v1.1.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/google/go-github/v29 v29.0.2 // indirect
 	github.com/moby/term v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/s
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
 github.com/evergreen-ci/pail v0.0.0-20211018155204-833e3187cfe7/go.mod h1:5gJ3srLW+mTEtewtmEs5qdnFiKFtwoggc/U3oFCVAdc=
 github.com/evergreen-ci/pail v0.0.0-20220405154537-920afff49d92/go.mod h1:Vne1WBTeJaI2zRTv3forHzliSSQmr1zCogZIcpjFsUo=
-github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30 h1:qhQjz4osMb5A34PPtvu+oOYshFnNAhJ0fRt05Q8Mgnk=
-github.com/evergreen-ci/pail v0.0.0-20240408143903-e5e256a7ef30/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
+github.com/evergreen-ci/pail v0.0.0-20240503141904-b600c21b5f20 h1:p76qYBvgaJP7m1oxqyEeR4NQDnyghjy321yZTMqQ6n4=
+github.com/evergreen-ci/pail v0.0.0-20240503141904-b600c21b5f20/go.mod h1:ddlI3t2hibi2yKaOuHT5YMFRS1MRMuoArI6lWU10a44=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20211028170046-0999224b53df/go.mod h1:xiggfkrlxlu2C2e58tvk0WAYFetgNC7U9ONqcP29xZs=
@@ -302,8 +302,9 @@ github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3yg
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
-github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
+github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -879,9 +879,8 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasksWithBatchtime() {
 	s.Require().Len(v.BuildVariants[1].BatchTimeTasks, 1)
 	s.InDelta(time.Now().Add(15*time.Minute).Unix(), v.BuildVariants[1].BatchTimeTasks[0].ActivateAt.Unix(), 1)
 
-	ppStorage, err := GetParserProjectStorage(s.ctx, s.env.Settings(), v.ProjectStorageMethod)
+	_, err = GetParserProjectStorage(s.ctx, s.env.Settings(), v.ProjectStorageMethod)
 	s.Require().NoError(err)
-	defer ppStorage.Close(s.ctx)
 	pp, err = ParserProjectFindOneByID(s.ctx, s.env.Settings(), v.ProjectStorageMethod, v.Id)
 	s.NoError(err)
 	s.Require().NotNil(pp)

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -106,8 +106,3 @@ func (s ParserProjectDBStorage) FindOneByIDWithFields(_ context.Context, id stri
 func (s ParserProjectDBStorage) UpsertOne(ctx context.Context, pp *ParserProject) error {
 	return parserProjectUpsertOne(bson.M{ParserProjectIdKey: pp.Id}, pp)
 }
-
-// Close is a no-op.
-func (s ParserProjectDBStorage) Close(ctx context.Context) error {
-	return nil
-}

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
-	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -18,39 +16,24 @@ import (
 // access parser projects stored in S3.
 type ParserProjectS3Storage struct {
 	bucket pail.Bucket
-	client *http.Client
-	closed bool
 }
 
 // NewParserProjectS3Storage sets up access to parser projects stored in S3.
-// If this returns a non-nil ParserProjectS3Storage, callers are expected to
-// call Close when they are finished with it.
 func NewParserProjectS3Storage(ppConf evergreen.ParserProjectS3Config) (*ParserProjectS3Storage, error) {
-	c := utility.GetHTTPClient()
-
-	b, err := pail.NewS3MultiPartBucketWithHTTPClient(c, pail.S3Options{
+	b, err := pail.NewS3MultiPartBucket(pail.S3Options{
 		Name:   ppConf.Bucket,
 		Prefix: ppConf.Prefix,
 		Region: endpoints.UsEast1RegionID,
 	})
 	if err != nil {
-		utility.PutHTTPClient(c)
 		return nil, errors.Wrap(err, "setting up S3 multipart bucket")
 	}
-	s := ParserProjectS3Storage{
-		bucket: b,
-		client: c,
-	}
-	return &s, nil
+	return &ParserProjectS3Storage{bucket: b}, nil
 }
 
 // FindOneByID finds a parser project in S3 using its ID. If the context errors,
 // it will return the context error.
 func (s *ParserProjectS3Storage) FindOneByID(ctx context.Context, id string) (*ParserProject, error) {
-	if s.closed {
-		return nil, errors.New("cannot access parser project S3 storage when it is closed")
-	}
-
 	r, err := s.bucket.Get(ctx, id)
 	if pail.IsKeyNotFoundError(err) {
 		return nil, nil
@@ -88,10 +71,6 @@ func (s *ParserProjectS3Storage) FindOneByIDWithFields(ctx context.Context, id s
 // UpsertOne replaces a parser project if the parser project in S3 with the same
 // ID already exists. If it does not exist yet, it inserts a new parser project.
 func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProject) error {
-	if s.closed {
-		return errors.New("cannot access parser project S3 storage when it is closed")
-	}
-
 	bsonPP, err := bson.Marshal(pp)
 	if err != nil {
 		return errors.Wrapf(err, "marshalling parser project '%s' to BSON", pp.Id)
@@ -103,26 +82,10 @@ func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProjec
 // UpsertOneBSON upserts a parser project by its ID when has already been
 // marshalled to BSON.
 func (s *ParserProjectS3Storage) UpsertOneBSON(ctx context.Context, id string, bsonPP []byte) error {
-	if s.closed {
-		return errors.New("cannot access parser project S3 storage when it is closed")
-	}
-
 	r := bytes.NewBuffer(bsonPP)
 	if err := s.bucket.Put(ctx, id, r); err != nil {
 		return errors.Wrapf(err, "upserting BSON parser project '%s'", id)
 	}
-
-	return nil
-}
-
-// Close returns the HTTP client that is being used back to the client pool.
-func (s *ParserProjectS3Storage) Close(ctx context.Context) error {
-	if s.closed {
-		return nil
-	}
-
-	utility.PutHTTPClient(s.client)
-	s.closed = true
 
 	return nil
 }

--- a/model/project_parser_storage.go
+++ b/model/project_parser_storage.go
@@ -28,15 +28,10 @@ type ParserProjectStorage interface {
 	// same ID already exists. If it does not exist yet, it inserts a new parser
 	// project.
 	UpsertOne(ctx context.Context, pp *ParserProject) error
-	// Close cleans up the accessor to the parser project storage. Users of
-	// ParserProjectStorage implementations must call Close once they are
-	// finished using it.
-	Close(ctx context.Context) error
 }
 
 // GetParserProjectStorage returns the parser project storage mechanism to
-// access the persistent copy of it. Users of the returned ParserProjectStorage
-// must call Close once they are finished using it.
+// access the persistent copy of it.
 func GetParserProjectStorage(ctx context.Context, settings *evergreen.Settings, method evergreen.ParserProjectStorageMethod) (ParserProjectStorage, error) {
 	switch method {
 	case "", evergreen.ProjectStorageMethodDB:
@@ -62,7 +57,6 @@ func ParserProjectFindOneByID(ctx context.Context, settings *evergreen.Settings,
 	if err != nil {
 		return nil, errors.Wrap(err, "getting parser project storage")
 	}
-	defer ppStorage.Close(ctx)
 	return ppStorage.FindOneByID(ctx, id)
 }
 
@@ -73,7 +67,6 @@ func ParserProjectUpsertOne(ctx context.Context, settings *evergreen.Settings, m
 	if err != nil {
 		return errors.Wrap(err, "getting parser project storage")
 	}
-	defer ppStorage.Close(ctx)
 	return ppStorage.UpsertOne(ctx, pp)
 }
 

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2020,7 +2020,6 @@ func TestParserProjectStorage(t *testing.T) {
 				"FindOneByIDReturnsNilErrorAndResultForNonexistentParserProject": func(ctx context.Context, t *testing.T, env *mock.Environment) {
 					ppStorage, err := GetParserProjectStorage(ctx, env.Settings(), ppStorageMethod)
 					require.NoError(t, err)
-					defer ppStorage.Close(ctx)
 
 					pp, err := ppStorage.FindOneByID(ctx, "nonexistent")
 					assert.NoError(t, err)
@@ -2029,7 +2028,6 @@ func TestParserProjectStorage(t *testing.T) {
 				"FindOneByIDWithFieldsReturnsNilErrorAndResultForNonexistentParserProject": func(ctx context.Context, t *testing.T, env *mock.Environment) {
 					ppStorage, err := GetParserProjectStorage(ctx, env.Settings(), ppStorageMethod)
 					require.NoError(t, err)
-					defer ppStorage.Close(ctx)
 
 					pp, err := ppStorage.FindOneByIDWithFields(ctx, "nonexistent", ParserProjectBuildVariantsKey)
 					assert.NoError(t, err)
@@ -2042,7 +2040,6 @@ func TestParserProjectStorage(t *testing.T) {
 					}
 					ppStorage, err := GetParserProjectStorage(ctx, env.Settings(), ppStorageMethod)
 					require.NoError(t, err)
-					defer ppStorage.Close(ctx)
 
 					assert.NoError(t, ppStorage.UpsertOne(ctx, pp))
 
@@ -2058,7 +2055,6 @@ func TestParserProjectStorage(t *testing.T) {
 					}
 					ppStorage, err := GetParserProjectStorage(ctx, env.Settings(), ppStorageMethod)
 					require.NoError(t, err)
-					defer ppStorage.Close(ctx)
 
 					assert.NoError(t, ppStorage.UpsertOne(ctx, pp))
 					pp.Owner = utility.ToStringPtr("you")
@@ -2144,7 +2140,6 @@ func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Envir
 
 	ppStorage, err := GetParserProjectStorage(ctx, env.Settings(), ppStorageMethod)
 	require.NoError(t, err)
-	defer ppStorage.Close(ctx)
 
 	yamlToCompare, err := yaml.Marshal(pp)
 	assert.NoError(t, err)

--- a/model/task/generated_json_db.go
+++ b/model/task/generated_json_db.go
@@ -20,8 +20,3 @@ func (s generatedJSONDBStorage) Find(_ context.Context, t *Task) (GeneratedJSONF
 func (s generatedJSONDBStorage) Insert(_ context.Context, t *Task, files GeneratedJSONFiles) error {
 	return t.SetGeneratedJSON(files)
 }
-
-// Close is a no-op.
-func (s generatedJSONDBStorage) Close(context.Context) error {
-	return nil
-}

--- a/model/task/generated_json_storage.go
+++ b/model/task/generated_json_storage.go
@@ -18,10 +18,6 @@ type GeneratedJSONFileStorage interface {
 	// Insert inserts all the generated JSON files for the given task. If any
 	// of the files already exist, they are replaced.
 	Insert(ctx context.Context, t *Task, files GeneratedJSONFiles) error
-	// Close cleans up the accessor to the generated JSON file storage. Users of
-	// GeneratedJSONFileStorage implementations must call Close once they are
-	// finished using it.
-	Close(ctx context.Context) error
 }
 
 // GetGeneratedJSONFileStorage returns the generated JSON file storage mechanism
@@ -45,7 +41,6 @@ func GeneratedJSONFind(ctx context.Context, settings *evergreen.Settings, t *Tas
 	if err != nil {
 		return nil, errors.Wrap(err, "getting generated JSON file storage")
 	}
-	defer fileStorage.Close(ctx)
 	return fileStorage.Find(ctx, t)
 }
 
@@ -56,7 +51,6 @@ func GeneratedJSONInsert(ctx context.Context, settings *evergreen.Settings, t *T
 	if err != nil {
 		return errors.Wrap(err, "getting generated JSON file storage")
 	}
-	defer fileStorage.Close(ctx)
 	return fileStorage.Insert(ctx, t, files)
 }
 

--- a/model/task/generated_json_storage_test.go
+++ b/model/task/generated_json_storage_test.go
@@ -52,7 +52,6 @@ func TestGeneratedJSONStorage(t *testing.T) {
 				"FindReturnsNilErrorAndResultForTaskWithNoGeneratedJSON": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
 					filesStorage, err := GetGeneratedJSONFileStorage(env.Settings(), storageMethod)
 					require.NoError(t, err)
-					defer filesStorage.Close(ctx)
 
 					files, err := filesStorage.Find(ctx, tsk)
 					assert.NoError(t, err)
@@ -61,7 +60,6 @@ func TestGeneratedJSONStorage(t *testing.T) {
 				"InsertStoresGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
 					fileStorage, err := GetGeneratedJSONFileStorage(env.Settings(), storageMethod)
 					require.NoError(t, err)
-					defer fileStorage.Close(ctx)
 
 					files := GeneratedJSONFiles{`{"key0": "value0"}`, `{"key1": "value1"}`}
 					assert.NoError(t, fileStorage.Insert(ctx, tsk, files))
@@ -74,7 +72,6 @@ func TestGeneratedJSONStorage(t *testing.T) {
 				"InsertNoopsForExistingGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
 					fileStorage, err := GetGeneratedJSONFileStorage(env.Settings(), storageMethod)
 					require.NoError(t, err)
-					defer fileStorage.Close(ctx)
 
 					files := GeneratedJSONFiles{`{"key": "value"}`}
 					assert.NoError(t, fileStorage.Insert(ctx, tsk, files))

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -323,7 +323,6 @@ func TestCreateVersionFromConfig(t *testing.T) {
 
 	ppStorage, err := model.GetParserProjectStorage(ctx, env.Settings(), newVersion.ProjectStorageMethod)
 	require.NoError(t, err)
-	defer ppStorage.Close(ctx)
 
 	pp, err = ppStorage.FindOneByID(ctx, newVersion.Id)
 	assert.NoError(err)


### PR DESCRIPTION
[DEVPROD-6951](https://jira.mongodb.org/browse/DEVPROD-6951)

### Description
https://github.com/evergreen-ci/pail/pull/111 made that pail caches the session so it won't need to make calls to STS for each time we create a bucket. This PR go gets the new pail.

### Testing
Can still load logs in staging, fwiw.

