### PR TITLE
DEVPROD-2281: support add_to_path in shell.exec

### DIFF
--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -25,11 +25,11 @@ import (
 )
 
 type subprocessExec struct {
-	Binary  string            `mapstructure:"binary"`
-	Args    []string          `mapstructure:"args"`
-	Env     map[string]string `mapstructure:"env"`
-	Command string            `mapstructure:"command"`
-	Path    []string          `mapstructure:"add_to_path"`
+	Binary    string            `mapstructure:"binary"`
+	Args      []string          `mapstructure:"args"`
+	Env       map[string]string `mapstructure:"env"`
+	Command   string            `mapstructure:"command"`
+	AddToPath []string          `mapstructure:"add_to_path"`
 
 	// Add defined expansions to the environment of the process
 	// that's launched.
@@ -144,8 +144,8 @@ func (c *subprocessExec) doExpansions(exp *util.Expansions) error {
 		catcher.Wrap(err, "expanding environment variables")
 	}
 
-	for idx := range c.Path {
-		c.Path[idx], err = exp.ExpandString(c.Path[idx])
+	for idx := range c.AddToPath {
+		c.AddToPath[idx], err = exp.ExpandString(c.AddToPath[idx])
 		catcher.Wrap(err, "expanding path to add")
 	}
 
@@ -357,7 +357,7 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 		expansions:             conf.Expansions,
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
-		addToPath:              c.Path,
+		addToPath:              c.AddToPath,
 	})
 
 	if !c.KeepEmptyArgs {

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -42,6 +42,9 @@ type shellExec struct {
 	// included in the environment, if they are defined. It is not an error to
 	// specify expansions that are not defined in include_expansions_in_env.
 	IncludeExpansionsInEnv []string `mapstructure:"include_expansions_in_env"`
+	// AddToPath allows additional paths to be prepended to the PATH environment
+	// variable.
+	AddToPath []string `mapstructure:"add_to_path"`
 
 	// Background, if set to true, prevents shell code/output from
 	// waiting for the script to complete and immediately returns
@@ -152,6 +155,7 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		expansions:             conf.Expansions,
 		includeExpansionsInEnv: c.IncludeExpansionsInEnv,
 		addExpansionsToEnv:     c.AddExpansionsToEnv,
+		addToPath:              c.AddToPath,
 	})
 
 	logger.Execution().Debug(message.Fields{
@@ -260,6 +264,11 @@ func (c *shellExec) doExpansions(exp *util.Expansions) error {
 	for k, v := range c.Env {
 		c.Env[k], err = exp.ExpandString(v)
 		catcher.Wrapf(err, "expanding environment variable '%s'", k)
+	}
+
+	for idx := range c.AddToPath {
+		c.AddToPath[idx], err = exp.ExpandString(c.AddToPath[idx])
+		catcher.Wrapf(err, "expanding element %d to add to path", idx)
 	}
 
 	return catcher.Resolve()

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -183,6 +183,17 @@ func (s *shellExecuteCommandSuite) TestCancellingContextShouldCancelCommand() {
 	s.True(utility.IsContextError(errors.Cause(err)))
 }
 
+func (s *shellExecuteCommandSuite) TestExpansionsForAddToPath() {
+	cmd := &shellExec{
+		AddToPath:  []string{"${my_path}", "another_path"},
+		WorkingDir: testutil.GetDirectoryOfFile(),
+	}
+
+	s.NoError(cmd.doExpansions(util.NewExpansions(map[string]string{"my_path": "/my/expanded/path"})))
+	s.Require().Len(cmd.AddToPath, 2)
+	s.Equal([]string{"/my/expanded/path", "another_path"}, cmd.AddToPath)
+}
+
 func (s *shellExecuteCommandSuite) TestEnvIsSetAndDefaulted() {
 	cmd := &shellExec{
 		Script:     "echo hello world",

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-05-03"
+	AgentVersion = "2024-05-03-a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1436,6 +1436,12 @@ Parameters:
     not exist, it is ignored. In case of conflicting environment
     variables defined by `env` or `add_expansions_to_env`, this has
     highest priority.
+-   `add_to_path`: specify one or more paths to prepend to the command `PATH`,
+    which has the following effects:
+    - If `PATH` is explicitly set in `env`, that `PATH` is ignored.
+    - The command automatically inherits the runtime environment's `PATH`
+      environment variable. Then, any paths specified in `add_to_path` are
+      prepended in the given order.
 -   `background`: if set to true, the script runs in the background
     instead of the foreground. `shell.exec` starts the script but
     does not wait for the script to exit before running the next command. 


### PR DESCRIPTION
DEVPROD-2281

### Description
Add option to prepend paths to the `PATH` env var for shell.exec. subprocess.exec already supports this option, so most of the logic is being reused.

After this is merged, I'll also merge https://github.com/evergreen-ci/shrub/pull/51.

### Testing
* Updated unit tests for shell.exec.
* Tested manually in staging to verify that setting `add_to_path` prepended more paths to `PATH`.

### Documentation
Updated docs for shell.exec.