### PR TITLE
DEVPROD-5977 Add GitHub dynamic access token permission groups to project ref

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -156,10 +156,6 @@ type GitHubDynamicTokenPermission struct {
 }
 
 func (p *GitHubDynamicTokenPermissions) Add(permission GitHubDynamicTokenPermission) error {
-	if p == nil {
-		fmt.Println("Testing")
-		p = &GitHubDynamicTokenPermissions{}
-	}
 	for _, r := range permission.Requesters {
 		if !utility.StringSliceContains(evergreen.AllRequesterTypes, r) {
 			return errors.Errorf("requester '%s' is not a valid requester", r)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -137,8 +137,8 @@ type ProjectRef struct {
 	ParsleyFilters    []parsley.Filter  `bson:"parsley_filters,omitempty" json:"parsley_filters,omitempty"`
 
 	// GitHubTokenPermissionByRequester contains what permissions each requester has for each token.
-	// By default, requesters have inherit all of the GitHub app permissions. Once a single permission
-	// is specified for a requester, it will only have those permissions.
+	// By default, requesters inherit all of the GitHub app permissions. Once a permissions
+	// are specified for a requester, it will only have those permissions.
 	GitHubTokenPermissionByRequester GitHubDynamicTokenPermissions `bson:"github_token_permission_by_requester,omitempty" json:"github_token_permission_by_requester,omitempty" yaml:"github_token_permission_by_requester,omitempty"`
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -179,7 +179,7 @@ func (p *ProjectRef) ValidateGitHubPermissionGroups() error {
 	// Group validation
 	for _, group := range p.GitHubDynamicTokenPermissionGroups {
 		if group.Name == "" {
-			catcher.Add(errors.New("group name is unset"))
+			catcher.Add(errors.New("group name cannot be empty"))
 		}
 	}
 	// Requester validation
@@ -400,7 +400,7 @@ var (
 	projectRefParsleyFiltersKey                  = bsonutil.MustHaveTag(ProjectRef{}, "ParsleyFilters")
 	projectRefProjectHealthViewKey               = bsonutil.MustHaveTag(ProjectRef{}, "ProjectHealthView")
 	projectRefGitHubDynamicTokenPermissionGroups = bsonutil.MustHaveTag(ProjectRef{}, "GitHubDynamicTokenPermissionGroups")
-	projectRefGitHubTokenPermissionByRequester   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubTokenPermissionByRequester")
+	projectRefGithubPermissionGroupByRequester   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubPermissionGroupByRequester")
 
 	commitQueueEnabledKey          = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")
 	commitQueueMergeQueueKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "MergeQueue")
@@ -2145,7 +2145,7 @@ func SaveProjectPageForSection(projectId string, p *ProjectRef, section ProjectP
 					projectRefCommitQueueKey:                     p.CommitQueue,
 					projectRefOldestAllowedMergeBaseKey:          p.OldestAllowedMergeBase,
 					projectRefGitHubDynamicTokenPermissionGroups: p.GitHubDynamicTokenPermissionGroups,
-					projectRefGitHubTokenPermissionByRequester:   p.GitHubPermissionGroupByRequester,
+					projectRefGithubPermissionGroupByRequester:   p.GitHubPermissionGroupByRequester,
 				},
 			})
 	case ProjectPageNotificationsSection:

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -156,14 +156,14 @@ type GitHubDynamicTokenPermission struct {
 }
 
 // Get returns the GitHubDynamicTokenPermission for the given requester.
-func (g *GitHubDynamicTokenPermissions) Get(requester string) *GitHubDynamicTokenPermission {
-	if g == nil {
+func (p *GitHubDynamicTokenPermissions) Get(requester string) *GitHubDynamicTokenPermission {
+	if p == nil {
 		return nil
 	}
-	for _, p := range *g {
-		for _, r := range p.Requesters {
+	for _, permission := range *p {
+		for _, r := range permission.Requesters {
 			if r == requester {
-				return &p
+				return &permission
 			}
 		}
 	}
@@ -172,7 +172,7 @@ func (g *GitHubDynamicTokenPermissions) Get(requester string) *GitHubDynamicToke
 
 // AsGitHubPermissions returns the github.InstallationPermissions for the GitHubDynamicTokenPermission.
 // These are used in the requests to GitHub for what permissions to use.
-func (g *GitHubDynamicTokenPermission) AsGitHubInstallationPermissions() (github.InstallationPermissions, error) {
+func (g *GitHubDynamicTokenPermission) ToGitHubInstallationPermissions() (github.InstallationPermissions, error) {
 	perms := github.InstallationPermissions{}
 	if g == nil || g.Permissions == nil {
 		return perms, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,9 +148,8 @@ type GitHubDynamicTokenPermissionGroup struct {
 	Name string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
 	// Permissions are a key-value pair of GitHub token permissions to their permission level
 	Permissions github.InstallationPermissions `bson:"permissions,omitempty" json:"permissions,omitempty" yaml:"permissions,omitempty"`
-	// NoPermissions is a boolean that indiciates if the group has no permissions. If true, we
-	// should not even send a request to GitHub as an empty permissions object would result in
-	// all permissions.
+	// NoPermissions is a boolean indicating that tokens should be fully restricted with no permissions at all. 
+	// An empty permissions object is not enough to indicate that as it would result in all permissions.
 	NoPermissions bool `bson:"no_permissions,omitempty" json:"no_permissions,omitempty" yaml:"no_permissions,omitempty"`
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,7 +148,7 @@ type GitHubDynamicTokenPermissionGroup struct {
 	Name string `bson:"name,omitempty" json:"name,omitempty" yaml:"name,omitempty"`
 	// Permissions are a key-value pair of GitHub token permissions to their permission level
 	Permissions github.InstallationPermissions `bson:"permissions,omitempty" json:"permissions,omitempty" yaml:"permissions,omitempty"`
-	// NoPermissions is a boolean indicating that tokens should be fully restricted with no permissions at all. 
+	// NoPermissions is a boolean indicating that tokens should be fully restricted with no permissions at all.
 	// An empty permissions object is not enough to indicate that as it would result in all permissions.
 	NoPermissions bool `bson:"no_permissions,omitempty" json:"no_permissions,omitempty" yaml:"no_permissions,omitempty"`
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -149,7 +149,7 @@ type GitHubDynamicTokenPermissions []GitHubDynamicTokenPermission
 // GitHubDynamicTokenPermission is used to specify an individiual group of permissions and requesters
 // for GitHub dynamic access tokens.
 type GitHubDynamicTokenPermission struct {
-	// Requesters is a list of the Evergreen requester from globals.go.
+	// Requesters is a list of the Evergreen requester that these permissions apply to (corresponds to requesters in  globals.go.)
 	Requesters []string `bson:"requesters,omitempty" json:"requesters,omitempty" yaml:"requesters,omitempty"`
 	// Permissions are a key-value pair of GitHub token permissions to their permission level
 	Permissions map[string]string `bson:"permissions,omitempty" json:"permissions,omitempty" yaml:"permissions,omitempty"`

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -180,7 +180,7 @@ func (g *GitHubDynamicTokenPermission) ToGitHubInstallationPermissions() (github
 
 	// The github.InstallationPermissions struct has json struct tags that we can
 	// latch on to for decoding the permissions.
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &perms})
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &perms, ErrorUnused: true})
 	if err != nil {
 		return perms, errors.Wrap(err, "creating decoder for GitHub permissions")
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1708,10 +1708,8 @@ func TestGitHubDynamicTokenPermission(t *testing.T) {
 			},
 		}
 
-		githubPerms, err := perm.ToGitHubInstallationPermissions()
-		require.NoError(t, err)
-		require.NotNil(t, githubPerms.Contents)
-		assert.Equal(t, "read", *githubPerms.Contents)
+		_, err := perm.ToGitHubInstallationPermissions()
+		require.Error(t, err, "Decoding GitHub permissions")
 	})
 }
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/google/go-github/v52/github"
 	adb "github.com/mongodb/anser/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1641,11 +1642,72 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.NotContains(t, scope.Resources, doc1.Id)
 }
 
-// TODO: HERE
+func TestGithubPermissionGroups(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
+	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
+
+	orgGroup := GitHubDynamicTokenPermissionGroups{
+		GitHubDynamicTokenPermissionGroup{
+			Name: "some-group",
+			Permissions: github.InstallationPermissions{
+				Actions: utility.ToStringPtr("read"),
+			},
+		},
+	}
+	orgRequesters := map[string]string{
+		evergreen.PatchVersionRequester: "some-group",
+	}
+	p := &ProjectRef{
+		GitHubDynamicTokenPermissionGroups: orgGroup,
+		GitHubPermissionGroupByRequester:   orgRequesters,
+	}
+	require.NoError(p.Insert())
+
+	t.Run("Not found requester should return default permissions", func(t *testing.T) {
+		group := p.GetGitHubPermissionGroup("requester")
+		assert.Equal(defaultGitHubTokenPermissionGroup, group)
+	})
+
+	t.Run("Found requester should return correct group", func(t *testing.T) {
+		group := p.GetGitHubPermissionGroup(evergreen.PatchVersionRequester)
+		assert.Equal("some-group", group.Name)
+		assert.Equal("read", utility.FromStringPtr(group.Permissions.Actions))
+	})
+
+	t.Run("Valid group passes validation", func(t *testing.T) {
+		assert.NoError(p.ValidateGitHubPermissionGroups())
+	})
+
+	t.Run("Invalid name in group fails validation", func(t *testing.T) {
+		p.GitHubDynamicTokenPermissionGroups = append(orgGroup,
+			GitHubDynamicTokenPermissionGroup{
+				Name: "",
+			},
+		)
+		assert.ErrorContains(p.ValidateGitHubPermissionGroups(), "group name cannot be empty")
+	})
+
+	t.Run("Invalid requester in group fails validation", func(t *testing.T) {
+		p.GitHubPermissionGroupByRequester = map[string]string{
+			"second-requester": "some-group",
+		}
+		assert.ErrorContains(p.ValidateGitHubPermissionGroups(), "requester 'second-requester' is not a valid requester")
+	})
+
+	t.Run("Valid requester pointing to not found group fails validation", func(t *testing.T) {
+		p.GitHubPermissionGroupByRequester = map[string]string{
+			evergreen.GithubPRRequester: "second-group",
+		}
+		assert.ErrorContains(p.ValidateGitHubPermissionGroups(), fmt.Sprintf("group 'second-group' for requester '%s' not found", evergreen.GithubPRRequester))
+	})
+}
 
 func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
-	assert := assert.New(t)   //nolint
-	require := require.New(t) //nolint
+	assert := assert.New(t)
+	require := require.New(t)
 
 	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	require.NoError(db.CreateCollections(evergreen.ScopeCollection))

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1649,8 +1649,8 @@ func TestGithubPermissionGroups(t *testing.T) {
 	require.NoError(db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	require.NoError(db.CreateCollections(evergreen.ScopeCollection))
 
-	orgGroup := GitHubDynamicTokenPermissionGroups{
-		GitHubDynamicTokenPermissionGroup{
+	orgGroup := []GitHubDynamicTokenPermissionGroup{
+		{
 			Name: "some-group",
 			Permissions: github.InstallationPermissions{
 				Actions: utility.ToStringPtr("read"),
@@ -3344,8 +3344,8 @@ func TestSaveProjectPageForSection(t *testing.T) {
 
 	// Test GitHub dynamic token permission groups
 	update = &ProjectRef{
-		GitHubDynamicTokenPermissionGroups: GitHubDynamicTokenPermissionGroups{
-			GitHubDynamicTokenPermissionGroup{
+		GitHubDynamicTokenPermissionGroups: []GitHubDynamicTokenPermissionGroup{
+			{
 				Name: "some-group",
 				Permissions: github.InstallationPermissions{
 					Actions: utility.ToStringPtr("read"),

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1689,6 +1689,10 @@ func TestGitHubDynamicTokenPermissions(t *testing.T) {
 			},
 		}
 		require.NoError(t, perms.Add(perm))
+
+		permission := perms.Get(evergreen.GithubPRRequester)
+		require.NotNil(t, permission)
+		assert.Equal(t, "read", permission.Permissions["checks"])
 	})
 
 	t.Run("Fails at adding permissions for an existing requester", func(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1659,7 +1659,7 @@ func TestGitHubDynamicTokenPermissions(t *testing.T) {
 		},
 	}
 
-	t.Run("Invalid requester specified", func(t *testing.T) {
+	t.Run("Nonexistent requester specified", func(t *testing.T) {
 		assert.Nil(t, perms.Get("requester0"))
 	})
 
@@ -1691,7 +1691,7 @@ func TestGitHubDynamicTokenPermission(t *testing.T) {
 			},
 		}
 
-		githubPerms, err := perm.AsGitHubInstallationPermissions()
+		githubPerms, err := perm.ToGitHubInstallationPermissions()
 		require.NoError(t, err)
 		require.NotNil(t, githubPerms.Checks)
 		assert.Equal(t, "write", *githubPerms.Checks)
@@ -1708,7 +1708,7 @@ func TestGitHubDynamicTokenPermission(t *testing.T) {
 			},
 		}
 
-		githubPerms, err := perm.AsGitHubInstallationPermissions()
+		githubPerms, err := perm.ToGitHubInstallationPermissions()
 		require.NoError(t, err)
 		require.NotNil(t, githubPerms.Contents)
 		assert.Equal(t, "read", *githubPerms.Contents)
@@ -3370,7 +3370,7 @@ func TestSaveProjectPageForSection(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, projectRef)
 	assert.Len(projectRef.GitHubTokenPermissionByRequester, 1)
-	perms, err := projectRef.GitHubTokenPermissionByRequester.Get(evergreen.PatchVersionRequester).AsGitHubInstallationPermissions()
+	perms, err := projectRef.GitHubTokenPermissionByRequester.Get(evergreen.PatchVersionRequester).ToGitHubInstallationPermissions()
 	require.NoError(t, err)
 	require.NotNil(t, perms.Contents)
 	assert.Equal("read", *perms.Contents)

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -394,6 +394,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		if err = validateFeaturesHaveAliases(mergedBeforeRef, mergedSection, changes.Aliases); err != nil {
 			return nil, err
 		}
+		if err = mergedSection.ValidateGitHubPermissionGroups(); err != nil {
+			return nil, err
+		}
 		modified, err = updateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPagePatchAliasSection:

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -433,6 +433,10 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 								"actions": "read",
 							},
 						},
+						restModel.APIGitHubDynamicTokenPermissionGroup{
+							Name:        utility.ToStringPtr("other-group"),
+							Permissions: map[string]string{}, // Should have NoPermissions set on the translated struct
+						},
 					},
 					PRTestingEnabled: utility.FalsePtr(),
 				},
@@ -445,11 +449,15 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, pRefFromDB)
 			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups)
-			require.Len(t, pRefFromDB.GitHubDynamicTokenPermissionGroups, 1)
+			require.Len(t, pRefFromDB.GitHubDynamicTokenPermissionGroups, 2)
 
 			assert.Equal(t, "some-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Name)
 			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Permissions)
 			assert.Equal(t, "read", utility.FromStringPtr(pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Permissions.Actions))
+
+			assert.Equal(t, "other-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[1].Name)
+			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[1].Permissions)
+			assert.Equal(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[1].NoPermissions, true)
 		},
 		"a commit queue document exists after the feature is turned on": func(t *testing.T, ref model.ProjectRef) {
 			oldRef := model.ProjectRef{

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -423,6 +423,34 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NotContains(t, err.Error(), "the commit queue")
 			assert.NotContains(t, err.Error(), "commit checks")
 		},
+		model.ProjectPageGithubAndCQSection: func(t *testing.T, ref model.ProjectRef) {
+			apiChanges := &restModel.APIProjectSettings{
+				ProjectRef: restModel.APIProjectRef{
+					GitHubDynamicTokenPermissionGroups: restModel.APIGitHubDynamicTokenPermissionGroups{
+						restModel.APIGitHubDynamicTokenPermissionGroup{
+							Name: utility.ToStringPtr("some-group"),
+							Permissions: map[string]string{
+								"actions": "read",
+							},
+						},
+					},
+					PRTestingEnabled: utility.FalsePtr(),
+				},
+			}
+			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGithubAndCQSection, false, "me")
+			require.NoError(t, err)
+			require.NotNil(t, settings)
+
+			pRefFromDB, err := model.FindBranchProjectRef(ref.Id)
+			require.NoError(t, err)
+			require.NotNil(t, pRefFromDB)
+			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups)
+			require.Len(t, pRefFromDB.GitHubDynamicTokenPermissionGroups, 1)
+
+			assert.Equal(t, "some-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Name)
+			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Permissions)
+			assert.Equal(t, "read", utility.FromStringPtr(pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Permissions.Actions))
+		},
 		"a commit queue document exists after the feature is turned on": func(t *testing.T, ref model.ProjectRef) {
 			oldRef := model.ProjectRef{
 				Owner:   ref.Owner,

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
+	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
@@ -566,6 +567,40 @@ func (t *APIRepositoryErrorDetails) BuildFromService(h model.RepositoryErrorDeta
 	t.MergeBaseRevision = utility.ToStringPtr(h.MergeBaseRevision)
 }
 
+type APIGitHubDynamicTokenPermissionGroup struct {
+	// Name of the GitHub permission group.
+	Name *string `json:"name"`
+	// Permissions for the GitHub permission group.
+	Permissions map[string]string `json:"permissions"`
+}
+
+type APIGitHubDynamicTokenPermissionGroups []APIGitHubDynamicTokenPermissionGroup
+
+func (p *APIGitHubDynamicTokenPermissionGroup) ToService() (model.GitHubDynamicTokenPermissionGroup, error) {
+	group := model.GitHubDynamicTokenPermissionGroup{
+		Name: utility.FromStringPtr(p.Name),
+	}
+	// The github.InstallationPermissions struct has json struct tags that we can
+	// latch on to for decoding the permissions.
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{TagName: "json", Result: &group.Permissions, ErrorUnused: true})
+	if err != nil {
+		return group, errors.Wrap(err, "creating decoder for GitHub permissions")
+	}
+	return group, errors.Wrap(decoder.Decode(p.Permissions), "decoding GitHub permissions")
+}
+
+func (p *APIGitHubDynamicTokenPermissionGroups) ToService() (model.GitHubDynamicTokenPermissionGroups, error) {
+	groups := model.GitHubDynamicTokenPermissionGroups{}
+	for _, group := range *p {
+		serviceGroup, err := group.ToService()
+		if err != nil {
+			return groups, errors.Wrapf(err, "converting GitHub permission group '%s'", utility.FromStringPtr(group.Name))
+		}
+		groups = append(groups, serviceGroup)
+	}
+	return groups, nil
+}
+
 type APIProjectRef struct {
 	Id *string `json:"id"`
 	// Owner of project repository.
@@ -687,6 +722,10 @@ type APIProjectRef struct {
 	ParsleyFilters []APIParsleyFilter `json:"parsley_filters"`
 	// Default project health view.
 	ProjectHealthView model.ProjectHealthView `json:"project_health_view"`
+	// List of GitHub permission groups.
+	GitHubDynamicTokenPermissionGroups APIGitHubDynamicTokenPermissionGroups `json:"github_dynamic_token_permission_groups,omitempty"`
+	// GitHub permission group by requester.
+	GitHubPermissionGroupByRequester map[string]string `json:"github_permission_group_by_requester,omitempty"`
 }
 
 // ToService returns a service layer ProjectRef using the data from APIProjectRef
@@ -781,6 +820,14 @@ func (p *APIProjectRef) ToService() (*model.ProjectRef, error) {
 			patchTriggers = append(patchTriggers, a.ToService())
 		}
 		projectRef.PatchTriggerAliases = patchTriggers
+	}
+
+	if p.GitHubDynamicTokenPermissionGroups != nil {
+		groups, err := p.GitHubDynamicTokenPermissionGroups.ToService()
+		if err != nil {
+			return nil, errors.Wrap(err, "converting GitHub permission groups")
+		}
+		projectRef.GitHubDynamicTokenPermissionGroups = groups
 	}
 
 	for _, size := range p.ContainerSizeDefinitions {


### PR DESCRIPTION
DEVPROD-5977

### Description
This adds a new field to the project ref, `GitHubTokenPermissionByRequester` which is a list of `GitHubDynamicTokenPermission`. These store what requesters have access to what permission levels.

### Testing
Unit testing