### PR TITLE
DEVPROD-6651: time out connections to check task data

### DIFF
--- a/units/host_setup_script.go
+++ b/units/host_setup_script.go
@@ -20,6 +20,9 @@ import (
 const (
 	hostSetupScriptJobName = "host-setup-script"
 	setupScriptRetryLimit  = 5
+
+	maxSpawnHostSetupScriptCheckDuration = 10 * time.Minute
+	maxSpawnHostSetupScriptDuration      = 30 * time.Minute
 )
 
 func init() {
@@ -58,6 +61,9 @@ func NewHostSetupScriptJob(env evergreen.Environment, h *host.Host) amboy.Job {
 	j.UpdateRetryInfo(amboy.JobRetryOptions{
 		Retryable:   utility.TruePtr(),
 		MaxAttempts: utility.ToIntPtr(setupScriptRetryLimit),
+	})
+	j.SetTimeInfo(amboy.JobTimeInfo{
+		MaxTime: maxSpawnHostSetupScriptCheckDuration + maxSpawnHostSetupScriptDuration,
 	})
 	j.SetID(fmt.Sprintf("%s.%s", hostSetupScriptJobName, j.HostID))
 	return j
@@ -100,7 +106,9 @@ func (j *hostSetupScriptJob) Run(ctx context.Context) {
 	}
 
 	if j.host.ProvisionOptions.TaskId != "" {
-		if err := j.host.CheckTaskDataFetched(ctx, j.env); err != nil {
+		checkCtx, checkCancel := context.WithTimeout(ctx, maxSpawnHostSetupScriptCheckDuration)
+		defer checkCancel()
+		if err := j.host.CheckTaskDataFetched(checkCtx, j.env); err != nil {
 			j.AddRetryableError(errors.Wrap(err, "checking if task data is fetched yet"))
 			return
 		}
@@ -110,8 +118,6 @@ func (j *hostSetupScriptJob) Run(ctx context.Context) {
 	// guarantee that the script is idempotent.
 	j.AddError(errors.Wrap(runSpawnHostSetupScript(ctx, j.env, j.host), "executing spawn host setup script"))
 }
-
-const maxSpawnHostSetupScriptDuration = 30 * time.Minute
 
 func runSpawnHostSetupScript(ctx context.Context, env evergreen.Environment, h *host.Host) error {
 	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, maxSpawnHostSetupScriptDuration)

--- a/units/host_setup_script.go
+++ b/units/host_setup_script.go
@@ -21,8 +21,12 @@ const (
 	hostSetupScriptJobName = "host-setup-script"
 	setupScriptRetryLimit  = 5
 
+	// maxSpawnHostSetupScriptCheckDuration is the total amount of time that the
+	// spawn host setup script job can poll to see if the task data is loaded.
 	maxSpawnHostSetupScriptCheckDuration = 10 * time.Minute
-	maxSpawnHostSetupScriptDuration      = 30 * time.Minute
+	// maxSpawnHostSetupScriptDuration is the total amount of time that the
+	// spawn host setup script can run after task data is loaded.
+	maxSpawnHostSetupScriptDuration = 30 * time.Minute
 )
 
 func init() {


### PR DESCRIPTION
DEVPROD-6651

### Description
The spawn host setup script job has to long poll the host to wait until the task data (from `evergreen fetch`) has been loaded on the spawn host (this is because the script was originally designed to run only once all the task data is loaded on the host). Since these requests can get stuck indefinitely waiting to connect (e.g. due to the host being terminated), polling for task data needs a timeout as well.

### Testing
Didn't seem worth testing since it's a timeout change.

### Documentation
N/A