### PR TITLE
DEVPROD-3955: reformat sleep schedule stats to be more queryable

### DIFF
--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -102,11 +102,13 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 		event.LogHostStartSucceeded(h.Id)
 		grip.Info(message.Fields{
-			"message":  "started spawn host",
-			"host_id":  h.Id,
-			"host_tag": h.Tag,
-			"distro":   h.Distro.Id,
-			"job":      j.ID(),
+			"message":    "started spawn host",
+			"host_id":    h.Id,
+			"started_by": h.StartedBy,
+			"host_tag":   h.Tag,
+			"distro":     h.Distro.Id,
+			"source":     j.Source,
+			"job":        j.ID(),
 		})
 
 		if j.Source == evergreen.ModifySpawnHostSleepSchedule {

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -124,6 +124,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 			"started_by": h.StartedBy,
 			"host_tag":   h.Tag,
 			"distro":     h.Distro.Id,
+			"source":     j.Source,
 			"job":        j.ID(),
 		})
 

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -69,12 +69,27 @@ func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 	stats := j.getStats(hosts)
 
 	grip.Info(message.Fields{
-		"message":                      "unexpirable spawn host stats",
-		"job_id":                       j.ID(),
-		"total_uptime_secs":            stats.totalUptime.Seconds(),
-		"uptime_secs_by_distro":        stats.uptimeSecsByDistro,
-		"uptime_secs_by_instance_type": stats.uptimeSecsByInstanceType,
+		"message":           "unexpirable spawn host stats",
+		"job_id":            j.ID(),
+		"total_uptime_secs": stats.totalUptime.Seconds(),
 	})
+
+	for distroID, uptimeSecs := range stats.uptimeSecsByDistro {
+		grip.Info(message.Fields{
+			"message":     "unexpirable spawn host stats by distro",
+			"job_id":      j.ID(),
+			"distro":      distroID,
+			"uptime_secs": uptimeSecs,
+		})
+	}
+	for instanceType, uptimeSecs := range stats.uptimeSecsByInstanceType {
+		grip.Info(message.Fields{
+			"message":       "unexpirable spawn host stats by instance type",
+			"job_id":        j.ID(),
+			"instance_type": instanceType,
+			"uptime_secs":   uptimeSecs,
+		})
+	}
 }
 
 type unexpirableSpawnHostStats struct {


### PR DESCRIPTION
DEVPROD-3955

### Description
The stats for host uptime are already logged but they're not that easy to query in Splunk because it's a map. I modified it a little bit to make it easier to query/make dashboards.

### Testing
Tested in staging to verify the log format.

### Documentation
N/A