### PR TITLE
DEVPROD-7041 Remove Honeycomb version trace from parent

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type StatusChanges struct {
@@ -1913,7 +1914,7 @@ func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error
 			if err != nil {
 				return errors.Wrap(err, "getting context for tracing")
 			}
-			_, span := tracer.Start(traceContext, "version-completion")
+			_, span := tracer.Start(traceContext, "version-completion", trace.WithNewRoot())
 			defer span.End()
 
 			return nil
@@ -1953,7 +1954,7 @@ func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error
 			if err != nil {
 				return errors.Wrap(err, "getting context for tracing")
 			}
-			_, span := tracer.Start(traceContext, "version-completion")
+			_, span := tracer.Start(traceContext, "version-completion", trace.WithNewRoot())
 			defer span.End()
 		}
 


### PR DESCRIPTION
DEVPROD-7041

### Description
We intentionally [only keep 1/30 calls ](https://github.com/10gen/devprod-refinery/blob/b947d585650d4f3d848925ea464bbac074b6fe23/rules.yaml#L49) for http call spans. Since this was part of a call to endtask, it didn't log every instance. This doesn't work well for a dashboard that keeps track of version duration because we ended up with some projects that had very little information logged. 

This removes it from the parent span so that it is not subject to the sample rate.  

