### PR TITLE
DEVPROD-5486 remove system stats

### DIFF
--- a/units/stats_sysinfo.go
+++ b/units/stats_sysinfo.go
@@ -48,6 +48,5 @@ func makeSysInfoStatsCollector() *sysInfoStatsCollector {
 func (j *sysInfoStatsCollector) Run(_ context.Context) {
 	defer j.MarkComplete()
 
-	j.logger.Info(message.CollectSystemInfo())
 	j.logger.Info(message.CollectGoStatsRates())
 }

--- a/units/stats_test.go
+++ b/units/stats_test.go
@@ -153,15 +153,9 @@ func (s *StatUnitsSuite) TestSysInfoCollector() {
 	s.False(j.HasErrors())
 	s.True(s.sender.HasMessage())
 
-	m1, ok1 := s.sender.GetMessageSafe()
-	if s.True(ok1) {
-		s.True(m1.Logged)
-		s.True(strings.Contains(m1.Message.String(), "cpu"), m1.Message.String())
-	}
-
-	m2, ok2 := s.sender.GetMessageSafe()
-	if s.True(ok2) {
-		s.True(m2.Logged)
-		s.True(strings.Contains(m2.Message.String(), "cgo.calls"), m2.Message.String())
+	m, ok := s.sender.GetMessageSafe()
+	if s.True(ok) {
+		s.True(m.Logged)
+		s.True(strings.Contains(m.Message.String(), "cgo.calls"), m.Message.String())
 	}
 }


### PR DESCRIPTION
[DEVPROD-5486](https://jira.mongodb.org/browse/DEVPROD-5486)

### Description
The system info struct is not meaningful in the context of a container running on a machine with other stuff.
We have the stats we need in Prometheus (and possibly Honeycomb soon).
