### PR TITLE
DEVPROD-4474: suppress sleep schedule notifications

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -502,7 +502,7 @@ const (
 	ModifySpawnHostSleepSchedule ModifySpawnHostSource = "sleep_schedule"
 	// ModifySpawnHostManual means the spawn host is being modified by a
 	// user-owned sleep script.
-	ModifySpawnHostScript ModifySpawnHostSource = "script"
+	ModifySpawnHostSleepScript ModifySpawnHostSource = "script"
 )
 
 // Common OTEL constants and attribute keys

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -78,6 +78,10 @@ type HostEventData struct {
 	User               string        `bson:"usr" json:"user,omitempty"`
 	Successful         bool          `bson:"successful,omitempty" json:"successful"`
 	Duration           time.Duration `bson:"duration,omitempty" json:"duration"`
+	// Source is the source of a host modification. Only set in specific
+	// conditions where a notification may need to know the cause of a host
+	// being modified.
+	Source string `bson:"source,omitempty" json:"source,omitempty"`
 }
 
 var (
@@ -137,37 +141,37 @@ func LogHostCreatedError(hostID, logs string) {
 
 // LogHostStartSucceeded logs an event indicating that the host was successfully
 // started.
-func LogHostStartSucceeded(hostID string) {
-	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: true})
+func LogHostStartSucceeded(hostID string, source string) {
+	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: true, Source: source})
 }
 
 // LogHostStartError logs an event indicating that the host errored while
 // starting.
-func LogHostStartError(hostID, logs string) {
-	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: false, Logs: logs})
+func LogHostStartError(hostID, source, logs string) {
+	LogHostEvent(hostID, EventHostStarted, HostEventData{Successful: false, Source: source, Logs: logs})
 }
 
 // LogHostStopSucceeded logs an event indicating that the host was successfully
 // stopped.
-func LogHostStopSucceeded(hostID string) {
-	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: true})
+func LogHostStopSucceeded(hostID, source string) {
+	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: true, Source: source})
 }
 
 // LogHostStopError logs an event indicating that the host errored while
 // stopping.
-func LogHostStopError(hostID, logs string) {
-	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: false, Logs: logs})
+func LogHostStopError(hostID, source, logs string) {
+	LogHostEvent(hostID, EventHostStopped, HostEventData{Successful: false, Source: source, Logs: logs})
 }
 
 // LogHostModifySucceeded logs an event indicating that the host was
 // successfully modified.
-func LogHostModifySucceeded(hostID string) {
-	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: true})
+func LogHostModifySucceeded(hostID, source string) {
+	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: true, Source: source})
 }
 
 // LogHostModifyError logs an event indicating that the host errored while being
 // modified.
-func LogHostModifyError(hostID, logs string) {
+func LogHostModifyError(hostID, source, logs string) {
 	LogHostEvent(hostID, EventHostModified, HostEventData{Successful: false, Logs: logs})
 }
 

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -356,7 +356,7 @@ func transitionIntentHostToStarting(ctx context.Context, env evergreen.Environme
 		return errors.Wrap(err, "replacing intent host with real host")
 	}
 
-	event.LogHostStartSucceeded(hostToStart.Id)
+	event.LogHostStartSucceeded(hostToStart.Id, evergreen.User)
 
 	return nil
 }

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -185,6 +185,12 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 		//   running.
 		return nil, nil
 	}
+	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) {
+		// Skip notifying for host modifications due to the sleep schedule since
+		// they can be noisy if users regularly receive them.
+		return nil, nil
+	}
+
 	payload, err := t.makePayload(sub)
 	if err != nil {
 		return nil, errors.Wrap(err, "making payload")

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -185,9 +185,9 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 		//   running.
 		return nil, nil
 	}
-	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) || t.data.Source == string(evergreen.ModifySpawnHostSleepScript) {
-		// Skip notifying for host modifications due to the sleep schedule or
-		// sleep script since they can be noisy if users regularly receive them.
+	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) {
+		// Skip notifying for host modifications due to the sleep schedule they
+		// can be noisy if users regularly receive them.
 		return nil, nil
 	}
 

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -185,9 +185,9 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Su
 		//   running.
 		return nil, nil
 	}
-	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) {
-		// Skip notifying for host modifications due to the sleep schedule since
-		// they can be noisy if users regularly receive them.
+	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) || t.data.Source == string(evergreen.ModifySpawnHostSleepScript) {
+		// Skip notifying for host modifications due to the sleep schedule or
+		// sleep script since they can be noisy if users regularly receive them.
 		return nil, nil
 	}
 

--- a/trigger/host_spawn_test.go
+++ b/trigger/host_spawn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -20,11 +21,14 @@ type spawnHostTriggersSuite struct {
 	h             host.Host
 	tProvisioning *spawnHostProvisioningTriggers
 	tStateChange  *spawnHostStateChangeTriggers
+	ctx           context.Context
+	cancel        context.CancelFunc
 
 	suite.Suite
 }
 
 func (s *spawnHostTriggersSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
 	s.Require().NoError(db.ClearCollections(host.Collection))
 	s.h = host.Host{
 		Id:          "t0",
@@ -49,13 +53,14 @@ func (s *spawnHostTriggersSuite) SetupTest() {
 	})
 }
 
-func (s *spawnHostTriggersSuite) TestSuccessfulSpawn() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func (s *spawnHostTriggersSuite) TearDownTest() {
+	s.cancel()
+}
 
+func (s *spawnHostTriggersSuite) TestSuccessfulSpawn() {
 	s.e.EventType = event.EventHostProvisioned
-	s.NoError(s.h.Insert(ctx))
-	s.NoError(s.tProvisioning.Fetch(ctx, &s.e))
+	s.NoError(s.h.Insert(s.ctx))
+	s.NoError(s.tProvisioning.Fetch(s.ctx, &s.e))
 
 	sub := event.Subscription{
 		Trigger:    event.TriggerOutcome,
@@ -97,13 +102,10 @@ func (s *spawnHostTriggersSuite) TestSuccessfulSpawn() {
 }
 
 func (s *spawnHostTriggersSuite) TestFailedSpawn() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	s.e.EventType = event.EventHostProvisioned
-	s.NoError(s.h.Insert(ctx))
+	s.NoError(s.h.Insert(s.ctx))
 	s.e.EventType = event.EventHostProvisionError
-	s.NoError(s.tProvisioning.Fetch(ctx, &s.e))
+	s.NoError(s.tProvisioning.Fetch(s.ctx, &s.e))
 
 	sub := event.Subscription{
 		Trigger:    event.TriggerOutcome,
@@ -145,12 +147,9 @@ func (s *spawnHostTriggersSuite) TestFailedSpawn() {
 }
 
 func (s *spawnHostTriggersSuite) TestSpawnHostStateChange() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	s.e.EventType = event.EventHostStarted
-	s.NoError(s.h.Insert(ctx))
-	s.NoError(s.tStateChange.Fetch(ctx, &s.e))
+	s.NoError(s.h.Insert(s.ctx))
+	s.NoError(s.tStateChange.Fetch(s.ctx, &s.e))
 
 	sub := event.Subscription{
 		Trigger:    event.TriggerOutcome,
@@ -187,10 +186,50 @@ func (s *spawnHostTriggersSuite) TestSpawnHostStateChange() {
 	s.Error(err)
 }
 
-func (s *spawnHostTriggersSuite) TestSpawnHostSuccessfulStopForSleepSchedule() {
-	// kim: TODO: fill in test
+func (s *spawnHostTriggersSuite) TestSpawnHostSuccessfulStopForSleepScheduleDoesNotCreateNotification() {
+	s.e.EventType = event.EventHostStarted
+	data, ok := s.e.Data.(*event.HostEventData)
+	s.Require().True(ok)
+	data.Successful = true
+	data.Source = string(evergreen.ModifySpawnHostSleepSchedule)
+	s.NoError(s.h.Insert(s.ctx))
+	s.NoError(s.tStateChange.Fetch(s.ctx, &s.e))
+
+	sub := event.Subscription{
+		Trigger:    event.TriggerOutcome,
+		Subscriber: event.NewSlackSubscriber("@test.user"),
+	}
+
+	n, err := s.tStateChange.Process(&sub)
+	s.Nil(n)
+	s.NoError(err, "should suppress notification for successfully stopping spawn host")
+
+	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
+	n, err = s.tStateChange.Process(&sub)
+	s.Nil(n, "should suppress notification for successfully stopping spawn host")
+	s.NoError(err)
 }
 
-func (s *spawnHostTriggersSuite) TestSpawnHostUnsuccessfulStopForSleepSchedule() {
-	// kim: TODO: fill in test
+func (s *spawnHostTriggersSuite) TestSpawnHostUnsuccessfulStopForSleepScheduleCreatesNotification() {
+	s.e.EventType = event.EventHostStopped
+	data, ok := s.e.Data.(*event.HostEventData)
+	s.Require().True(ok)
+	data.Successful = false
+	data.Source = string(evergreen.ModifySpawnHostSleepSchedule)
+	s.NoError(s.h.Insert(s.ctx))
+	s.NoError(s.tStateChange.Fetch(s.ctx, &s.e))
+
+	sub := event.Subscription{
+		Trigger:    event.TriggerOutcome,
+		Subscriber: event.NewSlackSubscriber("@test.user"),
+	}
+
+	n, err := s.tStateChange.Process(&sub)
+	s.NotNil(n, "should create notification for error trying to stop spawn host")
+	s.NoError(err)
+
+	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
+	n, err = s.tStateChange.Process(&sub)
+	s.NotNil(n, "should create notification for error trying to stop spawn host")
+	s.NoError(err)
 }

--- a/trigger/host_spawn_test.go
+++ b/trigger/host_spawn_test.go
@@ -186,3 +186,11 @@ func (s *spawnHostTriggersSuite) TestSpawnHostStateChange() {
 	s.Nil(n)
 	s.Error(err)
 }
+
+func (s *spawnHostTriggersSuite) TestSpawnHostSuccessfulStopForSleepSchedule() {
+	// kim: TODO: fill in test
+}
+
+func (s *spawnHostTriggersSuite) TestSpawnHostUnsuccessfulStopForSleepSchedule() {
+	// kim: TODO: fill in test
+}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -339,7 +339,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	}
 
 	if hostReplaced {
-		event.LogHostStartSucceeded(j.host.Id)
+		event.LogHostStartSucceeded(j.host.Id, evergreen.User)
 	}
 
 	grip.Info(message.Fields{

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -119,7 +119,7 @@ func (j *spawnhostModifyJob) Run(ctx context.Context) {
 
 	modifyCloudHost := func(ctx context.Context, mgr cloud.Manager, h *host.Host, user string) error {
 		if err := mgr.ModifyHost(ctx, h, j.ModifyOptions); err != nil {
-			event.LogHostModifyError(h.Id, err.Error())
+			event.LogHostModifyError(h.Id, string(j.Source), err.Error())
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error modifying spawn host",
 				"host_id":  h.Id,
@@ -130,7 +130,7 @@ func (j *spawnhostModifyJob) Run(ctx context.Context) {
 			return errors.Wrap(err, "modifying spawn host")
 		}
 
-		event.LogHostModifySucceeded(h.Id)
+		event.LogHostModifySucceeded(h.Id, string(j.Source))
 		grip.Info(message.Fields{
 			"message":  "modified spawn host",
 			"host_id":  h.Id,

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -68,9 +68,8 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 
 	defer func() {
 		if j.HasErrors() && (!j.RetryInfo().ShouldRetry() || j.RetryInfo().GetRemainingAttempts() == 0) {
-			// Only log an error if the job is ending in failure and is not
-			// going to attempt to start the host again. Otherwise, it may retry
-			// and succeed on the next attempt.
+			// Only log an error if the final job attempt errors. Otherwise, it
+			// may retry and succeed on the next attempt.
 			event.LogHostStartError(j.HostID, string(j.Source), j.Error().Error())
 		}
 	}()

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -89,7 +89,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 		}
 
 		if err := mgr.StartInstance(ctx, h, user); err != nil {
-			event.LogHostStartError(h.Id, err.Error())
+			event.LogHostStartError(h.Id, string(j.Source), err.Error())
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error starting spawn host",
 				"host_id":  h.Id,
@@ -100,7 +100,7 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 			return errors.Wrap(err, "starting spawn host")
 		}
 
-		event.LogHostStartSucceeded(h.Id)
+		event.LogHostStartSucceeded(h.Id, string(j.Source))
 		grip.Info(message.Fields{
 			"message":  "started spawn host",
 			"host_id":  h.Id,

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -137,6 +138,9 @@ func TestSpawnhostStartJob(t *testing.T) {
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
 			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			// Simulate the job running out of retry attempts, which should
+			// cause an event to be logged.
+			j.UpdateRetryInfo(amboy.JobRetryOptions{CurrentAttempt: utility.ToIntPtr(j.RetryInfo().GetMaxAttempts())})
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -70,9 +70,8 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 
 	defer func() {
 		if j.HasErrors() && (!j.RetryInfo().ShouldRetry() || j.RetryInfo().GetRemainingAttempts() == 0) {
-			// Only log an error if the job is ending in failure and is not
-			// giong to attempt to stop the host again. Otherwise, it may retry
-			// and succeed on the next attempt.
+			// Only log an error if the final job attempt errors. Otherwise, it
+			// may retry and succeed on the next attempt.
 			event.LogHostStopError(j.HostID, string(j.Source), j.Error().Error())
 		}
 	}()

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -106,7 +106,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 		}
 
 		if err := mgr.StopInstance(ctx, h, j.ShouldKeepOff, user); err != nil {
-			event.LogHostStopError(h.Id, err.Error())
+			event.LogHostStopError(h.Id, string(j.Source), err.Error())
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":  "error stopping spawn host",
 				"host_id":  h.Id,
@@ -117,7 +117,7 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 			return errors.Wrap(err, "stopping spawn host")
 		}
 
-		event.LogHostStopSucceeded(h.Id)
+		event.LogHostStopSucceeded(h.Id, string(j.Source))
 		grip.Info(message.Fields{
 			"message":    "stopped spawn host",
 			"host_id":    h.Id,

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +137,9 @@ func TestSpawnhostStopJob(t *testing.T) {
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
 			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			// Simulate the job running out of retry attempts, which should
+			// cause an event to be logged.
+			j.UpdateRetryInfo(amboy.JobRetryOptions{CurrentAttempt: utility.ToIntPtr(j.RetryInfo().GetMaxAttempts())})
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())


### PR DESCRIPTION
DEVPROD-4474

### Description
The sleep schedule will stop/start hosts frequently, so users who are subscribed to spawn host change notifications probably don't want to see this. I filtered it so that the recurring notifications don't get sent. Users can still see all the stop/start events in the host event log if they wish.

* Check and filter spawn host notification if the sleep schedule stops/starts the host successfully.
* Only log a spawn host stop/start error if the job runs out of attempts and ends in error (i.e. failed to stop/start the host after retries). This reduces some noise in case there are transient errors stopping/starting the host.

### Testing
* Added unit tests.
* Tested in staging that notifications were suppressed when the sleep schedule successfully stopped/started the host. Persistent errors still sent notifications, and manually stopping/starting the host still sent notifications.

### Documentation
N/A