### PR TITLE
DEVPROD-4264: add monitoring for temporary exemptions

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3728,13 +3728,20 @@ func (h *Host) SetTemporaryExemption(ctx context.Context, exemptUntil time.Time)
 		return err
 	}
 
+	var extendedBy time.Duration
+	now := time.Now()
+	if h.SleepSchedule.TemporarilyExemptUntil.After(now) {
+		extendedBy = exemptUntil.Sub(h.SleepSchedule.TemporarilyExemptUntil)
+	} else {
+		extendedBy = exemptUntil.Sub(now)
+	}
 	grip.Info(message.Fields{
-		"message":       "creating/extending temporary exemption from the sleep schedule",
-		"host_id":       h.Id,
-		"distro_id":     h.Distro.Id,
-		"exempt_until":  exemptUntil.Format(time.RFC3339),
-		"exemption_hrs": exemptUntil.Sub(time.Now()).Hours(),
-		"dashboard":     "evergreen sleep schedule health",
+		"message":                  "creating/extending temporary exemption from the sleep schedule",
+		"host_id":                  h.Id,
+		"distro_id":                h.Distro.Id,
+		"exempt_until":             exemptUntil.Format(time.RFC3339),
+		"additional_exemption_hrs": extendedBy.Hours(),
+		"dashboard":                "evergreen sleep schedule health",
 	})
 
 	temporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -72,6 +72,7 @@ func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 		"message":           "unexpirable spawn host stats",
 		"job_id":            j.ID(),
 		"total_uptime_secs": stats.totalUptime.Seconds(),
+		"dashboard":         "evergreen sleep schedule health",
 	})
 
 	for distroID, uptimeSecs := range stats.uptimeSecsByDistro {
@@ -80,6 +81,7 @@ func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 			"job_id":      j.ID(),
 			"distro":      distroID,
 			"uptime_secs": uptimeSecs,
+			"dashboard":   "evergreen sleep schedule health",
 		})
 	}
 	for instanceType, uptimeSecs := range stats.uptimeSecsByInstanceType {
@@ -88,6 +90,7 @@ func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 			"job_id":        j.ID(),
 			"instance_type": instanceType,
 			"uptime_secs":   uptimeSecs,
+			"dashboard":     "evergreen sleep schedule health",
 		})
 	}
 }


### PR DESCRIPTION
DEVPROD-4264

### Description
Add tracking for how often people request temporary exemptions and how long. Since there's no limit on how many times a user can request an exemption (only that it cannot be longer than a month), this is useful to better monitor how people use this feature.

### Testing
Tested in staging to verify the log appeared.

### Documentation
N/A