### PR TITLE
DEVPROD-6266 Fix duplication for --repeat-patch

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1578,12 +1578,21 @@ func (p *Project) GetModuleByName(name string) (*Module, error) {
 	return nil, errors.New("no such module on this project")
 }
 
+// FindTasksForVariant returns all tasks in a variant, including tasks in task groups.
 func (p *Project) FindTasksForVariant(build string) []string {
 	for _, b := range p.BuildVariants {
 		if b.Name == build {
-			tasks := make([]string, 0, len(b.Tasks))
+			tasks := []string{}
 			for _, task := range b.Tasks {
 				tasks = append(tasks, task.Name)
+				// add tasks in task groups
+				if task.IsGroup {
+					tg := p.FindTaskGroup(task.Name)
+					if tg != nil {
+						tasks = append(tasks, tg.Tasks...)
+					}
+				}
+
 			}
 			return tasks
 		}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2548,7 +2548,7 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 		return nil, nil
 	}
 
-	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey)
+	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey, DisplayNameKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dependencies")
 	}


### PR DESCRIPTION
DEVPROD-6266

### Description
--repeat-patch was relying on BuildProjectTVPairs to create the variant tasks for patches. However, that resulted in a previous patch of: {bv1: t1, bv2: t2} ending up with  {bv1: t1, bv1: t2, bv2: t1, bv2: t2}. This fixes that by reusing the variant tasks from the previous patch and applying the filtering on top of that instead of just on the tasks.

### Testing
Existing unit tests and testing on staging. 

