### PR TITLE
DEVPROD-7335: set scope for sleep scheduler job

### DIFF
--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -34,7 +34,8 @@ type sleepSchedulerJob struct {
 func NewSleepSchedulerJob(env evergreen.Environment, ts string) amboy.Job {
 	j := makeSleepSchedulerJob()
 	j.SetID(fmt.Sprintf("%s.%s", sleepSchedulerJobName, ts))
-	j.SetEnqueueScopes(sleepSchedulerJobName)
+	j.SetScopes([]string{sleepSchedulerJobName})
+	j.SetEnqueueAllScopes(true)
 	j.env = env
 	return j
 }


### PR DESCRIPTION
DEVPROD-7335

### Description
Set the scopes on the sleep scheduler to ensure that only one such job can run or be in the Amboy queue at a time. Prevents potential races that could happen if two sleep schedulers ran concurrently to manage sleep schedules.

### Testing
Didn't seem worth testing since this is an Amboy feature.

### Documentation
N/A