### PR TITLE
DEVPROD-7342: use non-namespaced dns for papertrail

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-05-09"
+	AgentVersion = "2024-05-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/thirdparty/papertrail.go
+++ b/thirdparty/papertrail.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	productionPapertrailAddress = "https://papertrail.devprod-infra.prod.corp.mongodb.com"
+	productionPapertrailAddress = "https://papertrail.prod.corp.mongodb.com"
 )
 
 // PapertrailSpan represents a span in json form from Papertrail.


### PR DESCRIPTION
DEVPROD-7342

### Description
This commit changes papertrail.trace to default to https://papertrail.prod.corp.mongodb.com instead of the namespaced value, https://papertrail.devprod-infra.prod.corp.mongodb.com. With recent changes to the network topology, this allows for AWS and allowed non-AWS hosts to talk to Papertrail.

### Testing
The existing tests should be sufficient!

### Documentation
No user-facing changes that are necessary to document.
