### PR TITLE
DEVPROD-6625 Set amboy DB timeout

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -406,6 +406,7 @@ func (e *envState) createRemoteQueues(ctx context.Context, tracer trace.Tracer) 
 
 	opts := options.Client().
 		ApplyURI(url).
+		SetTimeout(10 * time.Second).
 		SetConnectTimeout(5 * time.Second).
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(e.settings.Database.ReadConcernSettings.Resolve()).

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -26,6 +26,7 @@ import (
 const (
 	hostAllocatorJobName         = "host-allocator"
 	hostAllocatorAttributePrefix = "evergreen.host_allocator"
+	maxHostAllocatorJobTime      = 10 * time.Minute
 )
 
 func init() {
@@ -60,6 +61,9 @@ func NewHostAllocatorJob(env evergreen.Environment, distroID string, timestamp t
 	j.SetID(fmt.Sprintf("%s.%s.%s", hostAllocatorJobName, distroID, timestamp.Format(TSFormat)))
 	j.SetScopes([]string{fmt.Sprintf("%s.%s", hostAllocatorJobName, distroID)})
 	j.SetEnqueueAllScopes(true)
+	j.UpdateTimeInfo(amboy.JobTimeInfo{
+		MaxTime: maxHostAllocatorJobTime,
+	})
 
 	return j
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	patchIntentJobName   = "patch-intent-processor"
-	githubDependabotUser = "dependabot[bot]"
+	patchIntentJobName    = "patch-intent-processor"
+	githubDependabotUser  = "dependabot[bot]"
+	maxPatchIntentJobTime = 10 * time.Minute
 )
 
 func init() {
@@ -65,6 +66,9 @@ func NewPatchIntentProcessor(env evergreen.Environment, patchID mgobson.ObjectId
 	j.env = env
 
 	j.SetID(fmt.Sprintf("%s-%s-%s", patchIntentJobName, j.IntentType, j.IntentID))
+	j.UpdateTimeInfo(amboy.JobTimeInfo{
+		MaxTime: maxPatchIntentJobTime,
+	})
 	return j
 }
 


### PR DESCRIPTION
DEVPROD-6625

### Description
This introduces a max time that the patch intent processor and host allocator job can run, in the hopes that it prevents these jobs from getting stuck in the future. Per this [suggestion](https://jira.mongodb.org/browse/DEVPROD-7230?focusedCommentId=6345805&focusedId=6345805&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-6345805), this change also introduces a timeout for all Amboy queries in the hopes that it mitigates stuck queries. Looking at the Amboy cluster profiler, it looks like 10 seconds is a fair turnaround time during normal operation.

### Testing
Existing tests