### PR TITLE
DEVPROD-5122: allow commands to define failure metadata tags

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1110,9 +1110,9 @@ func (a *Agent) endTaskResponse(ctx context.Context, tc *taskContext, status str
 			tc.logger.Task().Errorf("'%s' is not a valid task status, defaulting to system failure.", userEndTaskResp.Status)
 			status = evergreen.TaskFailed
 			userDefinedFailureType = evergreen.CommandTypeSystem
-			userDefinedFailureMetadataTags = userEndTaskResp.AddFailureMetadataTags
 		} else {
 			status = userEndTaskResp.Status
+			userDefinedFailureMetadataTags = userEndTaskResp.AddFailureMetadataTags
 
 			if len(userEndTaskResp.Description) > globals.EndTaskMessageLimit {
 				tc.logger.Task().Warningf("Description from endpoint is too long to set (%d character limit), using default description.", globals.EndTaskMessageLimit)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -963,7 +963,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		tc.logger.Task().Info("Task completed - SUCCESS.")
 		if err := a.runPostOrTeardownTaskCommands(ctx, tc); err != nil {
 			tc.logger.Task().Info("Post task completed - FAILURE. Overall task status changed to FAILED.")
-			setEndTaskFailureDetails(tc, detail, evergreen.TaskFailed, "", "")
+			setEndTaskFailureDetails(tc, detail, evergreen.TaskFailed, "", "", nil)
 		}
 		detail.PostErrored = tc.getPostErrored()
 		a.runEndTaskSync(ctx, tc, detail)
@@ -1157,8 +1157,7 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 	if status != evergreen.TaskSucceeded {
 		detail.Type = failureType
 		detail.Description = description
-		// kim: TODO: add tests for failure in task and post.
-		detail.FailingCommandMetadataTags = utility.UniqueStrings(append(tc.getCurrentCommand().FailureMetadataTags(), failureMetadataTagsToAdd...))
+		detail.FailureMetadataTags = utility.UniqueStrings(append(tc.getCurrentCommand().FailureMetadataTags(), failureMetadataTagsToAdd...))
 	}
 	if !isDefaultDescription {
 		// If there's an explicit user-defined description, always set that

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1155,8 +1155,12 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 	if status != evergreen.TaskSucceeded {
 		detail.Type = failureType
 		detail.Description = description
+		// kim: TODO: add tests for failure in task and post.
+		detail.FailingCommandMetadataTags = tc.getCurrentCommand().FailureMetadataTags()
 	}
 	if !isDefaultDescription {
+		// If there's an explicit user-defined description, always set that
+		// description.
 		detail.Description = description
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -771,6 +771,7 @@ tasks:
   - name: this_is_a_task_name
     commands:
       - command: shell.exec
+        failure_metadata_tags: ["failure_tag0"]
         params:
           script: exit 0
 
@@ -778,6 +779,7 @@ post_error_fails_task: true
 post_timeout_secs: 1
 post:
   - command: shell.exec
+    failure_metadata_tags: ["failure_tag1"]
     params:
       script: sleep 5
 `
@@ -794,6 +796,7 @@ post:
 	s.True(s.mockCommunicator.EndTaskResult.Detail.TimedOut)
 	s.EqualValues(globals.PostTimeout, s.mockCommunicator.EndTaskResult.Detail.TimeoutType)
 	s.Equal(time.Second, s.mockCommunicator.EndTaskResult.Detail.TimeoutDuration)
+	s.ElementsMatch([]string{"failure_tag1"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "failure tags should be set for failing post command")
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -812,6 +815,243 @@ post:
 	}, []string{
 		panicLog,
 		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
+	})
+}
+
+func (s *AgentSuite) TestFailingPostDoesNotChangeEndTaskResults() {
+	projYml := `
+buildvariants:
+  - name: mock_build_variant
+
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 0
+
+post:
+  - command: shell.exec
+    params:
+      script: exit 1
+`
+	s.setupRunTask(projYml)
+
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+
+	s.NoError(err)
+	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description, "should not include command failure description for a successful task")
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type, "should not include command failure type for a successful task")
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "failure metadata tags should not be set for post command that fails but does not fail the task")
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+		"Finished running task commands",
+		"Running post-task commands",
+		"Setting heartbeat timeout to type 'post'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Resetting heartbeat timeout from type 'post' back to default",
+		"Finished running post-task commands",
+	}, []string{
+		panicLog,
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
+		"Running post-task commands failed",
+	})
+}
+
+func (s *AgentSuite) TestSucceedingPostShowsCorrectEndTaskResults() {
+	projYml := `
+buildvariants:
+  - name: mock_build_variant
+
+post_error_fails_task: true
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        failure_metadata_tags: ["failure_tag0"]
+        params:
+          script: exit 0
+
+post:
+  - command: shell.exec
+    failure_metadata_tags: ["failure_tag1"]
+    params:
+      script: exit 0
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+
+	s.NoError(err)
+	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description, "should not include command failure description for a successful task")
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type, "should not include command failure type for a successful task")
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "failure metadata tags should not be set for all successful commands")
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+		"Finished running task commands",
+		"Running post-task commands",
+		"Setting heartbeat timeout to type 'post'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Resetting heartbeat timeout from type 'post' back to default",
+		"Finished running post-task commands",
+	}, []string{
+		panicLog,
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
+		"Running post-task commands failed",
+	})
+}
+
+func (s *AgentSuite) TestTimedOutMainAndFailingPostShowsMainInEndTaskResults() {
+	projYml := `
+buildvariants:
+  - name: mock_build_variant
+
+post_error_fails_task: true
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        failure_metadata_tags: ["failure_tag0"]
+        timeout_secs: 1
+        params:
+          script: sleep 5
+
+post:
+  - command: shell.exec
+    failure_metadata_tags: ["failure_tag1"]
+    params:
+       script: exit 1
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+
+	s.NoError(err)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Equal("'shell.exec' (step 1 of 1)", s.mockCommunicator.EndTaskResult.Detail.Description, "should show main block command as the failing command if both main and post block commands fail")
+	s.True(s.mockCommunicator.EndTaskResult.Detail.TimedOut, "should show main block command hitting timeout")
+	s.ElementsMatch([]string{"failure_tag0"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "failure tags should be set for failing main task command")
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 1s.",
+		"Hit idle timeout",
+		"Running post-task commands",
+		"Setting heartbeat timeout to type 'post'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Resetting heartbeat timeout from type 'post' back to default",
+		"Running post-task commands failed",
+		"Finished running post-task commands",
+	}, []string{
+		panicLog,
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
+	})
+}
+
+func (s *AgentSuite) TestSucceedingPostAfterMainDoesNotChangeEndTaskResults() {
+	projYml := `
+buildvariants:
+  - name: mock_build_variant
+
+post_error_fails_task: true
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        failure_metadata_tags: ["failure_tag0"]
+        params:
+          script: exit 1
+
+post:
+  - command: shell.exec
+    failure_metadata_tags: ["failure_tag1"]
+    params:
+      script: exit 0
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+
+	s.NoError(err)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Equal("'shell.exec' (step 1 of 1)", s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.ElementsMatch([]string{"failure_tag0"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "failure tags should be set for failing main task command")
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+		"Finished running task commands",
+		"Running post-task commands",
+		"Setting heartbeat timeout to type 'post'",
+		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
+		"Resetting heartbeat timeout from type 'post' back to default",
+		"Finished running post-task commands",
+	}, []string{
+		panicLog,
+		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
+		"Running post-task commands failed",
+	})
+}
+
+func (s *AgentSuite) TestPostContinuesOnError() {
+	projYml := `
+post:
+  - command: shell.exec
+    params:
+      script: exit 1
+  - command: shell.exec
+    params:
+      script: exit 0
+`
+	s.setupRunTask(projYml)
+
+	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running post-task commands",
+		"Setting heartbeat timeout to type 'post'",
+		"Running command 'shell.exec' (step 1 of 2) in block 'post'",
+		"Finished command 'shell.exec' (step 1 of 2) in block 'post'",
+		"Running command 'shell.exec' (step 2 of 2) in block 'post'",
+		"Finished command 'shell.exec' (step 2 of 2) in block 'post'",
+		"Resetting heartbeat timeout from type 'post' back to default",
+		"Finished running post-task commands",
+	}, []string{
+		panicLog,
 	})
 }
 
@@ -922,233 +1162,6 @@ tasks:
 	}, []string{
 		panicLog,
 		fmt.Sprintf("Command is set to automatically restart on completion, this can be done %d total times per task.", evergreen.MaxAutomaticRestarts),
-	})
-}
-
-func (s *AgentSuite) TestFailingPostDoesNotChangeEndTaskResults() {
-	projYml := `
-buildvariants:
-  - name: mock_build_variant
-
-tasks:
-  - name: this_is_a_task_name
-    commands:
-      - command: shell.exec
-        params:
-          script: exit 0
-
-post:
-  - command: shell.exec
-    params:
-      script: exit 1
-`
-	s.setupRunTask(projYml)
-
-	nextTask := &apimodels.NextTaskResponse{
-		TaskId:     s.tc.task.ID,
-		TaskSecret: s.tc.task.Secret,
-	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
-
-	s.NoError(err)
-	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
-	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description, "should not include command failure description for a successful task")
-	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type, "should not include command failure type for a successful task")
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running task commands",
-		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
-		"Finished running task commands",
-		"Running post-task commands",
-		"Setting heartbeat timeout to type 'post'",
-		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Resetting heartbeat timeout from type 'post' back to default",
-		"Finished running post-task commands",
-	}, []string{
-		panicLog,
-		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
-		"Running post-task commands failed",
-	})
-}
-
-func (s *AgentSuite) TestSucceedingPostShowsCorrectEndTaskResults() {
-	projYml := `
-buildvariants:
-  - name: mock_build_variant
-
-post_error_fails_task: true
-tasks:
-  - name: this_is_a_task_name
-    commands:
-      - command: shell.exec
-        params:
-          script: exit 0
-
-post:
-  - command: shell.exec
-    params:
-      script: exit 0
-`
-	s.setupRunTask(projYml)
-	nextTask := &apimodels.NextTaskResponse{
-		TaskId:     s.tc.task.ID,
-		TaskSecret: s.tc.task.Secret,
-	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
-
-	s.NoError(err)
-	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
-	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description, "should not include command failure description for a successful task")
-	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type, "should not include command failure type for a successful task")
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running task commands",
-		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
-		"Finished running task commands",
-		"Running post-task commands",
-		"Setting heartbeat timeout to type 'post'",
-		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Resetting heartbeat timeout from type 'post' back to default",
-		"Finished running post-task commands",
-	}, []string{
-		panicLog,
-		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
-		"Running post-task commands failed",
-	})
-}
-
-func (s *AgentSuite) TestTimedOutMainAndFailingPostShowsMainInEndTaskResults() {
-	projYml := `
-buildvariants:
-  - name: mock_build_variant
-
-post_error_fails_task: true
-tasks:
-  - name: this_is_a_task_name
-    commands:
-      - command: shell.exec
-        timeout_secs: 1
-        params:
-          script: sleep 5
-
-post:
-  - command: shell.exec
-    params:
-       script: exit 1
-`
-	s.setupRunTask(projYml)
-	nextTask := &apimodels.NextTaskResponse{
-		TaskId:     s.tc.task.ID,
-		TaskSecret: s.tc.task.Secret,
-	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
-
-	s.NoError(err)
-	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
-	s.Equal("'shell.exec' (step 1 of 1)", s.mockCommunicator.EndTaskResult.Detail.Description, "should show main block command as the failing command if both main and post block commands fail")
-	s.True(s.mockCommunicator.EndTaskResult.Detail.TimedOut, "should show main block command hitting timeout")
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 1s.",
-		"Hit idle timeout",
-		"Running post-task commands",
-		"Setting heartbeat timeout to type 'post'",
-		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Resetting heartbeat timeout from type 'post' back to default",
-		"Running post-task commands failed",
-		"Finished running post-task commands",
-	}, []string{
-		panicLog,
-		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
-	})
-}
-
-func (s *AgentSuite) TestSucceedingPostAfterMainDoesNotChangeEndTaskResults() {
-	projYml := `
-buildvariants:
-  - name: mock_build_variant
-
-post_error_fails_task: true
-tasks:
-  - name: this_is_a_task_name
-    commands:
-      - command: shell.exec
-        params:
-          script: exit 1
-
-post:
-  - command: shell.exec
-    params:
-      script: exit 0
-`
-	s.setupRunTask(projYml)
-	nextTask := &apimodels.NextTaskResponse{
-		TaskId:     s.tc.task.ID,
-		TaskSecret: s.tc.task.Secret,
-	}
-	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
-
-	s.NoError(err)
-	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
-	s.Equal("'shell.exec' (step 1 of 1)", s.mockCommunicator.EndTaskResult.Detail.Description)
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running task commands",
-		"Set idle timeout for 'shell.exec' (step 1 of 1) (test) to 2h0m0s.",
-		"Running command 'shell.exec' (step 1 of 1)",
-		"Finished command 'shell.exec' (step 1 of 1)",
-		"Finished running task commands",
-		"Running post-task commands",
-		"Setting heartbeat timeout to type 'post'",
-		"Running command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Finished command 'shell.exec' (step 1 of 1) in block 'post'",
-		"Resetting heartbeat timeout from type 'post' back to default",
-		"Finished running post-task commands",
-	}, []string{
-		panicLog,
-		"Set idle timeout for 'shell.exec' (step 1 of 1) in block 'post'",
-		"Running post-task commands failed",
-	})
-}
-
-func (s *AgentSuite) TestPostContinuesOnError() {
-	projYml := `
-post:
-  - command: shell.exec
-    params:
-      script: exit 1
-  - command: shell.exec
-    params:
-      script: exit 0
-`
-	s.setupRunTask(projYml)
-
-	s.NoError(s.a.runPostOrTeardownTaskCommands(s.ctx, s.tc))
-
-	s.NoError(s.tc.logger.Close())
-	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
-		"Running post-task commands",
-		"Setting heartbeat timeout to type 'post'",
-		"Running command 'shell.exec' (step 1 of 2) in block 'post'",
-		"Finished command 'shell.exec' (step 1 of 2) in block 'post'",
-		"Running command 'shell.exec' (step 2 of 2) in block 'post'",
-		"Finished command 'shell.exec' (step 2 of 2) in block 'post'",
-		"Resetting heartbeat timeout from type 'post' back to default",
-		"Finished running post-task commands",
-	}, []string{
-		panicLog,
 	})
 }
 

--- a/agent/command/initial_setup.go
+++ b/agent/command/initial_setup.go
@@ -28,6 +28,8 @@ func (*initialSetup) JasperManager() jasper.Manager                   { return n
 func (*initialSetup) SetJasperManager(_ jasper.Manager)               {}
 func (*initialSetup) RetryOnFailure() bool                            { return false }
 func (*initialSetup) SetRetryOnFailure(bool)                          {}
+func (*initialSetup) FailureMetadataTags() []string                   { return nil }
+func (*initialSetup) SetFailureMetadataTags([]string)                 {}
 func (*initialSetup) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -55,17 +55,24 @@ type Command interface {
 	// RetryOnFailure indicates whether the entire task should be retried if this command fails.
 	RetryOnFailure() bool
 	SetRetryOnFailure(bool)
+
+	// FailureMetadataTags are user-defined tags which are not used directly by
+	// Evergreen but can be used to allow users to set additional metadata about
+	// the command/function if it fails.
+	FailureMetadataTags() []string
+	SetFailureMetadataTags([]string)
 }
 
 // base contains a basic implementation of functionality that is
 // common to all command implementations.
 type base struct {
-	idleTimeout     time.Duration
-	typeName        string
-	fullDisplayName string
-	retryOnFailure  bool
-	jasper          jasper.Manager
-	mu              sync.RWMutex
+	idleTimeout         time.Duration
+	typeName            string
+	fullDisplayName     string
+	retryOnFailure      bool
+	failureMetadataTags []string
+	jasper              jasper.Manager
+	mu                  sync.RWMutex
 }
 
 func (b *base) Type() string {
@@ -136,4 +143,18 @@ func (b *base) RetryOnFailure() bool {
 	defer b.mu.RUnlock()
 
 	return b.retryOnFailure
+}
+
+func (b *base) SetFailureMetadataTags(tags []string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.failureMetadataTags = tags
+}
+
+func (b *base) FailureMetadataTags() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	return b.failureMetadataTags
 }

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -166,8 +166,6 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 					TotalSubCmds: len(cmdsInFunc),
 				}
 				c.DisplayName = GetFullDisplayName(c.Command, c.DisplayName, blockInfo, funcInfo)
-				// kim: TODO: test that this merges unique strings from func
-				// level and cmd level.
 				c.FailureMetadataTags = utility.UniqueStrings(append(c.FailureMetadataTags, commandInfo.FailureMetadataTags...))
 
 				parsed = append(parsed, c)

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
@@ -165,6 +166,11 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 					TotalSubCmds: len(cmdsInFunc),
 				}
 				c.DisplayName = GetFullDisplayName(c.Command, c.DisplayName, blockInfo, funcInfo)
+				// kim: TODO: test that this merges unique strings from func
+				// level and cmd level.
+				// kim: TODO: manually test how this is stored in the parser
+				// project, either as combined or separate.
+				c.FailureMetadataTags = utility.UniqueStrings(append(c.FailureMetadataTags, commandInfo.FailureMetadataTags...))
 
 				parsed = append(parsed, c)
 			}
@@ -193,6 +199,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmd.SetFullDisplayName(c.DisplayName)
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
 		cmd.SetRetryOnFailure(c.RetryOnFailure)
+		cmd.SetFailureMetadataTags(c.FailureMetadataTags)
 
 		out = append(out, cmd)
 	}

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -168,8 +168,6 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 				c.DisplayName = GetFullDisplayName(c.Command, c.DisplayName, blockInfo, funcInfo)
 				// kim: TODO: test that this merges unique strings from func
 				// level and cmd level.
-				// kim: TODO: manually test how this is stored in the parser
-				// project, either as combined or separate.
 				c.FailureMetadataTags = utility.UniqueStrings(append(c.FailureMetadataTags, commandInfo.FailureMetadataTags...))
 
 				parsed = append(parsed, c)

--- a/agent/status.go
+++ b/agent/status.go
@@ -107,10 +107,14 @@ func (a *Agent) statusHandler() http.HandlerFunc {
 }
 
 type triggerEndTaskResp struct {
-	Description    string `json:"desc,omitempty"`
-	Status         string `json:"status,omitempty"`
-	Type           string `json:"type,omitempty"`
-	ShouldContinue bool   `json:"should_continue"`
+	Description string `json:"desc,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Type        string `json:"type,omitempty"`
+	// kim: TODO: add documentation
+	// kim: TODO: add test for user-defined metadata set via task status
+	// endpoint
+	AddFailureMetadataTags []string `json:"add_failure_metadata_tags,omitempty"`
+	ShouldContinue         bool     `json:"should_continue"`
 }
 
 func (a *Agent) endTaskHandler(w http.ResponseWriter, r *http.Request) {

--- a/agent/status.go
+++ b/agent/status.go
@@ -110,9 +110,8 @@ type triggerEndTaskResp struct {
 	Description string `json:"desc,omitempty"`
 	Status      string `json:"status,omitempty"`
 	Type        string `json:"type,omitempty"`
-	// kim: TODO: add documentation
-	// kim: TODO: add test for user-defined metadata set via task status
-	// endpoint
+	// TODO (DEVPROD-5122): add documentation once the additional features for
+	// failing commands (which don't fail the task) are complete.
 	AddFailureMetadataTags []string `json:"add_failure_metadata_tags,omitempty"`
 	ShouldContinue         bool     `json:"should_continue"`
 }

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -58,17 +58,20 @@ type TaskTestResultsInfo struct {
 // TaskEndDetail contains data sent from the agent to the API server after each task run.
 // This should be used to store data relating to what happened when the task ran
 type TaskEndDetail struct {
-	Status          string          `bson:"status,omitempty" json:"status,omitempty"`
-	Type            string          `bson:"type,omitempty" json:"type,omitempty"`
-	PostErrored     bool            `bson:"post_errored,omitempty" json:"post_errored,omitempty"`
-	Description     string          `bson:"desc,omitempty" json:"desc,omitempty"`
-	TimedOut        bool            `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
-	TimeoutType     string          `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
-	TimeoutDuration time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
-	OOMTracker      *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
-	Modules         ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
-	TraceID         string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
-	DiskDevices     []string        `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
+	Status      string `bson:"status,omitempty" json:"status,omitempty"`
+	Type        string `bson:"type,omitempty" json:"type,omitempty"`
+	PostErrored bool   `bson:"post_errored,omitempty" json:"post_errored,omitempty"`
+	Description string `bson:"desc,omitempty" json:"desc,omitempty"`
+	// FailingCommandMetadataTags are metadata tags for the command that caused
+	// a task to fail.
+	FailingCommandMetadataTags []string        `bson:"failing_command_metadata_tags,omitempty" json:"failing_command_metadata_tags,omitempty"`
+	TimedOut                   bool            `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
+	TimeoutType                string          `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
+	TimeoutDuration            time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
+	OOMTracker                 *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
+	Modules                    ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
+	TraceID                    string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
+	DiskDevices                []string        `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
 }
 
 type OOMTrackerInfo struct {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -62,16 +62,16 @@ type TaskEndDetail struct {
 	Type        string `bson:"type,omitempty" json:"type,omitempty"`
 	PostErrored bool   `bson:"post_errored,omitempty" json:"post_errored,omitempty"`
 	Description string `bson:"desc,omitempty" json:"desc,omitempty"`
-	// FailingCommandMetadataTags are metadata tags for the command that caused
-	// a task to fail.
-	FailingCommandMetadataTags []string        `bson:"failing_command_metadata_tags,omitempty" json:"failing_command_metadata_tags,omitempty"`
-	TimedOut                   bool            `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
-	TimeoutType                string          `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
-	TimeoutDuration            time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
-	OOMTracker                 *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
-	Modules                    ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
-	TraceID                    string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
-	DiskDevices                []string        `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
+	// FailureMetadataTags are user metadata tags associated with the
+	// command that caused the task to fail.
+	FailureMetadataTags []string        `bson:"failure_metadata_tags,omitempty" json:"failure_metadata_tags,omitempty"`
+	TimedOut            bool            `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
+	TimeoutType         string          `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
+	TimeoutDuration     time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
+	OOMTracker          *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
+	Modules             ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
+	TraceID             string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
+	DiskDevices         []string        `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
 }
 
 type OOMTrackerInfo struct {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-05-09"
+	AgentVersion = "2024-05-09a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/model/project.go
+++ b/model/project.go
@@ -550,6 +550,14 @@ type PluginCommandConf struct {
 	// RetryOnFailure indicates whether the task should be retried if this command fails.
 	RetryOnFailure bool `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
 
+	// FailureMetadataTags are user-defined tags which are not used directly by
+	// Evergreen but can be used to allow users to set additional metadata about
+	// the command/function if it fails.
+	// kim: TODO: add docs
+	// kim: NOTE: If set for a function, all commands in that function inherit
+	// the tags.
+	FailureMetadataTags []string `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
+
 	Loggers *LoggerConfig `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 }
 
@@ -569,17 +577,18 @@ func (c *PluginCommandConf) resolveParams() error {
 
 func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	temp := struct {
-		Function       string                 `yaml:"func,omitempty" bson:"func,omitempty"`
-		Type           string                 `yaml:"type,omitempty" bson:"type,omitempty"`
-		DisplayName    string                 `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
-		Command        string                 `yaml:"command,omitempty" bson:"command,omitempty"`
-		Variants       []string               `yaml:"variants,omitempty" bson:"variants,omitempty"`
-		TimeoutSecs    int                    `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
-		Params         map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
-		ParamsYAML     string                 `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
-		Vars           map[string]string      `yaml:"vars,omitempty" bson:"vars,omitempty"`
-		RetryOnFailure bool                   `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
-		Loggers        *LoggerConfig          `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
+		Function            string                 `yaml:"func,omitempty" bson:"func,omitempty"`
+		Type                string                 `yaml:"type,omitempty" bson:"type,omitempty"`
+		DisplayName         string                 `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+		Command             string                 `yaml:"command,omitempty" bson:"command,omitempty"`
+		Variants            []string               `yaml:"variants,omitempty" bson:"variants,omitempty"`
+		TimeoutSecs         int                    `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
+		Params              map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
+		ParamsYAML          string                 `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
+		Vars                map[string]string      `yaml:"vars,omitempty" bson:"vars,omitempty"`
+		RetryOnFailure      bool                   `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
+		FailureMetadataTags []string               `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
+		Loggers             *LoggerConfig          `yaml:"loggers,omitempty" bson:"loggers,omitempty"`
 	}{}
 
 	if err := unmarshal(&temp); err != nil {
@@ -596,6 +605,7 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) err
 	c.ParamsYAML = temp.ParamsYAML
 	c.Params = temp.Params
 	c.RetryOnFailure = temp.RetryOnFailure
+	c.FailureMetadataTags = temp.FailureMetadataTags
 	return c.unmarshalParams()
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -553,9 +553,8 @@ type PluginCommandConf struct {
 	// FailureMetadataTags are user-defined tags which are not used directly by
 	// Evergreen but can be used to allow users to set additional metadata about
 	// the command/function if it fails.
-	// kim: TODO: add docs
-	// kim: NOTE: If set for a function, all commands in that function inherit
-	// the tags.
+	// TODO (DEVPROD-5122): add documentation once the additional features for
+	// failing commands (which don't fail the task) are complete.
 	FailureMetadataTags []string `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
 
 	Loggers *LoggerConfig `yaml:"loggers,omitempty" bson:"loggers,omitempty"`

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -171,6 +171,9 @@ type ApiTaskEndDetail struct {
 	Description *string `json:"desc"`
 	// PostErrored is true when the post command errored.
 	PostErrored bool `json:"post_errored"`
+	// FailingCommandMetadataTags contains the metadata tags of the failing
+	// command.
+	FailingCommandMetadataTags []string `json:"failure_metadata_tags"`
 	// Whether this task ended in a timeout.
 	TimedOut    bool              `json:"timed_out"`
 	TimeoutType *string           `json:"timeout_type"`
@@ -186,6 +189,7 @@ func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
 	at.PostErrored = t.PostErrored
 	at.TimedOut = t.TimedOut
 	at.TimeoutType = utility.ToStringPtr(t.TimeoutType)
+	at.FailingCommandMetadataTags = t.FailingCommandMetadataTags
 
 	apiOomTracker := APIOomTrackerInfo{}
 	apiOomTracker.BuildFromService(t.OOMTracker)
@@ -198,15 +202,16 @@ func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
 
 func (ad *ApiTaskEndDetail) ToService() apimodels.TaskEndDetail {
 	return apimodels.TaskEndDetail{
-		Status:      utility.FromStringPtr(ad.Status),
-		Type:        utility.FromStringPtr(ad.Type),
-		Description: utility.FromStringPtr(ad.Description),
-		PostErrored: ad.PostErrored,
-		TimedOut:    ad.TimedOut,
-		TimeoutType: utility.FromStringPtr(ad.TimeoutType),
-		OOMTracker:  ad.OOMTracker.ToService(),
-		TraceID:     utility.FromStringPtr(ad.TraceID),
-		DiskDevices: ad.DiskDevices,
+		Status:                     utility.FromStringPtr(ad.Status),
+		Type:                       utility.FromStringPtr(ad.Type),
+		Description:                utility.FromStringPtr(ad.Description),
+		PostErrored:                ad.PostErrored,
+		FailingCommandMetadataTags: ad.FailingCommandMetadataTags,
+		TimedOut:                   ad.TimedOut,
+		TimeoutType:                utility.FromStringPtr(ad.TimeoutType),
+		OOMTracker:                 ad.OOMTracker.ToService(),
+		TraceID:                    utility.FromStringPtr(ad.TraceID),
+		DiskDevices:                ad.DiskDevices,
 	}
 }
 

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -171,9 +171,9 @@ type ApiTaskEndDetail struct {
 	Description *string `json:"desc"`
 	// PostErrored is true when the post command errored.
 	PostErrored bool `json:"post_errored"`
-	// FailingCommandMetadataTags contains the metadata tags of the failing
-	// command.
-	FailingCommandMetadataTags []string `json:"failure_metadata_tags"`
+	// FailureMetadataTags contains the metadata tags associated with the
+	// failing command.
+	FailureMetadataTags []string `json:"failing_command_metadata_tags"`
 	// Whether this task ended in a timeout.
 	TimedOut    bool              `json:"timed_out"`
 	TimeoutType *string           `json:"timeout_type"`
@@ -189,7 +189,7 @@ func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
 	at.PostErrored = t.PostErrored
 	at.TimedOut = t.TimedOut
 	at.TimeoutType = utility.ToStringPtr(t.TimeoutType)
-	at.FailingCommandMetadataTags = t.FailingCommandMetadataTags
+	at.FailureMetadataTags = t.FailureMetadataTags
 
 	apiOomTracker := APIOomTrackerInfo{}
 	apiOomTracker.BuildFromService(t.OOMTracker)
@@ -202,16 +202,16 @@ func (at *ApiTaskEndDetail) BuildFromService(t apimodels.TaskEndDetail) error {
 
 func (ad *ApiTaskEndDetail) ToService() apimodels.TaskEndDetail {
 	return apimodels.TaskEndDetail{
-		Status:                     utility.FromStringPtr(ad.Status),
-		Type:                       utility.FromStringPtr(ad.Type),
-		Description:                utility.FromStringPtr(ad.Description),
-		PostErrored:                ad.PostErrored,
-		FailingCommandMetadataTags: ad.FailingCommandMetadataTags,
-		TimedOut:                   ad.TimedOut,
-		TimeoutType:                utility.FromStringPtr(ad.TimeoutType),
-		OOMTracker:                 ad.OOMTracker.ToService(),
-		TraceID:                    utility.FromStringPtr(ad.TraceID),
-		DiskDevices:                ad.DiskDevices,
+		Status:              utility.FromStringPtr(ad.Status),
+		Type:                utility.FromStringPtr(ad.Type),
+		Description:         utility.FromStringPtr(ad.Description),
+		PostErrored:         ad.PostErrored,
+		FailureMetadataTags: ad.FailureMetadataTags,
+		TimedOut:            ad.TimedOut,
+		TimeoutType:         utility.FromStringPtr(ad.TimeoutType),
+		OOMTracker:          ad.OOMTracker.ToService(),
+		TraceID:             utility.FromStringPtr(ad.TraceID),
+		DiskDevices:         ad.DiskDevices,
 	}
 }
 


### PR DESCRIPTION
DEVPROD-5122

### Description
This adds support for users to tag a failing command. When that command fails *and* that command failure causes the task to fail, Evergreen will set those tags in the task end details. These tags have no impact on Evergreen behavior other than the fact that they will appear in the task end details when the command fails (which users can view in the REST API for tasks).

These tags can be defined in two ways:
1. Statically in the YAML like this:
```yaml
- command: shell.exec
  failure_metadata_tags: ["tag_that_appears_if_the_task_fails"]
  params:
    script: |
      echo this command will fail
      exit 1
```
2. Added via the task status endpoint - this lets users dynamically set failure metadata tags when setting the task status manually. For now, the endpoint can only add to the existing tag set (and not replace/remove) because it would be preferable to not override static YAML configuration. We can always revisit/modify the append-only behavior if the need arises.

From the REST API, the result will look like this (example snippet) for the failing command:
```json
{
  "task_id": "some-task-id",
  "status_details": {
    "status": "...",
    "type": "...",
    "desc": "...",
    "failure_metadata_tags": [
      "tag_that_appears_if_the_task_fails"
    ],
  }
}
```

**This feature is not complete yet!** There was an additional request to show the metadata tags for commands that failed but didn't directly cause the task to fail (e.g. an `s3.put` fails in post, resulting in a dependent task not having that required file). Since this is somewhat complicated, I'm going to post a follow-up PR to reduce the complexity of this PR.

### Testing
* Added unit tests.
* Tested in staging with patches to verify that failure metadata tags appeared in failing tasks from the REST API.

### Documentation
Since the feature is not complete yet, I'm going to delay documenting until the follow-up PR.