### PR TITLE
DEVPROD-7063: check host status when clearing temporary exemption

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1669,6 +1669,7 @@ func ClearExpiredTemporaryExemptions(ctx context.Context) error {
 	sleepScheduleTemporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
 
 	res, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateMany(ctx, isSleepScheduleApplicable(bson.M{
+		StatusKey:                              bson.M{"$in": evergreen.SleepScheduleStatuses},
 		sleepScheduleTemporarilyExemptUntilKey: bson.M{"$lte": time.Now()},
 	}), bson.M{
 		"$unset": bson.M{


### PR DESCRIPTION
DEVPROD-7063

### Description
The original query in #7872 is a correct query, but is slightly more optimized if it filters the host status. That allows the query to use the collection's indexes more efficiently.

### Testing
Existing tests pass.

### Documentation
N/A