### PR TITLE
DEVPROD-7418 Ensure index is used for fetching task queue distros

### DIFF
--- a/cmd/load-smoke-data/load-smoke-data.go
+++ b/cmd/load-smoke-data/load-smoke-data.go
@@ -73,6 +73,7 @@ func insertFileDocsToDB(ctx context.Context, fn string, db *mongo.Database) erro
 		if _, err = collection.Indexes().CreateMany(ctx, []mongo.IndexModel{
 			{Keys: host.StatusIndex},
 			{Keys: host.StartedByStatusIndex},
+			{Keys: host.DistroIdStatusIndex},
 		}); err != nil {
 			return errors.Wrap(err, "creating host index")
 		}

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -189,7 +189,7 @@ func setup(ctx context.Context, t *testing.T, state *AtomicGraphQLState) {
 
 	require.NoError(t, usr.UpdateAPIKey(apiKey))
 
-	require.NoError(t, setupDBIndexes(ctx, env))
+	require.NoError(t, setupDBIndexes())
 	require.NoError(t, setupDBData(ctx, env, state.DBData, *state))
 	require.NoError(t, setupTaskOutputData(ctx, env, state))
 	roleManager := env.RoleManager()

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type AtomicGraphQLState struct {
@@ -188,6 +189,7 @@ func setup(ctx context.Context, t *testing.T, state *AtomicGraphQLState) {
 
 	require.NoError(t, usr.UpdateAPIKey(apiKey))
 
+	require.NoError(t, setupDBIndexes(ctx, env))
 	require.NoError(t, setupDBData(ctx, env, state.DBData, *state))
 	require.NoError(t, setupTaskOutputData(ctx, env, state))
 	roleManager := env.RoleManager()
@@ -383,6 +385,13 @@ type test struct {
 // escapeGQLQuery replaces literal newlines with '\n' and literal double quotes with '\"'
 func escapeGQLQuery(in string) string {
 	return strings.Replace(strings.Replace(in, "\n", "\\n", -1), "\"", "\\\"", -1)
+}
+
+// setupDBIndexes ensures that the indexes required for the tests are created.
+func setupDBIndexes() error {
+	return db.EnsureIndex(host.Collection, mongo.IndexModel{
+		Keys: host.DistroIdStatusIndex,
+	})
 }
 
 func setupDBData(ctx context.Context, env evergreen.Environment, data map[string]json.RawMessage, state AtomicGraphQLState) error {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -281,7 +281,7 @@ func idleHostsQuery(distroID string) bson.M {
 }
 
 func CountRunningHosts(ctx context.Context, distroID string) (int, error) {
-	num, err := Count(ctx, runningHostsQuery(distroID), nil)
+	num, err := Count(ctx, runningHostsQuery(distroID))
 	return num, errors.Wrap(err, "counting running hosts")
 }
 
@@ -299,14 +299,14 @@ func CountHostsCanRunTasks(ctx context.Context, distroID string) (int, error) {
 func CountAllRunningDynamicHosts(ctx context.Context) (int, error) {
 	query := IsLive()
 	query[ProviderKey] = bson.M{"$in": evergreen.ProviderSpawnable}
-	num, err := Count(ctx, query, nil)
+	num, err := Count(ctx, query)
 	return num, errors.Wrap(err, "counting running dynamic hosts")
 }
 
 // CountIdleStartedTaskHosts returns the count of task hosts that are starting
 // and not currently running a task.
 func CountIdleStartedTaskHosts(ctx context.Context) (int, error) {
-	num, err := Count(ctx, idleStartedTaskHostsQuery(""), nil)
+	num, err := Count(ctx, idleStartedTaskHostsQuery(""))
 	return num, errors.Wrap(err, "counting starting hosts")
 }
 
@@ -465,7 +465,7 @@ func NumHostsByTaskSpec(ctx context.Context, group, buildVariant, project, versi
 			"project is '%s' and version is '%s')", group, buildVariant, project, version)
 	}
 
-	numHosts, err := Count(ctx, ByTaskSpec(group, buildVariant, project, version), nil)
+	numHosts, err := Count(ctx, ByTaskSpec(group, buildVariant, project, version))
 	if err != nil {
 		return 0, errors.Wrap(err, "counting hosts by task spec")
 	}
@@ -916,8 +916,8 @@ func Aggregate(ctx context.Context, pipeline []bson.M, options ...*options.Aggre
 }
 
 // Count returns the number of hosts that satisfy the given query.
-func Count(ctx context.Context, query bson.M, opts *options.CountOptions) (int, error) {
-	res, err := evergreen.GetEnvironment().DB().Collection(Collection).CountDocuments(ctx, query, opts)
+func Count(ctx context.Context, query bson.M, opts ...*options.CountOptions) (int, error) {
+	res, err := evergreen.GetEnvironment().DB().Collection(Collection).CountDocuments(ctx, query, opts...)
 	return int(res), errors.Wrap(err, "getting host count")
 }
 

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func TestConsolidateHostsForUser(t *testing.T) {
@@ -800,8 +801,14 @@ func TestFindHostsScheduledToStart(t *testing.T) {
 	}
 }
 
+func setupDistroIdStatusIndex(t *testing.T) {
+	assert.NoError(t, db.EnsureIndex(Collection, mongo.IndexModel{
+		Keys: DistroIdStatusIndex,
+	}))
+}
 func TestCountHostsCanRunTasks(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
+	setupDistroIdStatusIndex(t)
 	d1 := distro.Distro{
 		Id: "d1",
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2268,6 +2268,18 @@ var StartedByStatusIndex = bson.D{
 	},
 }
 
+// DistroIdStatusIndex is the distro_id_1_status_1 index.
+var DistroIdStatusIndex = bson.D{
+	{
+		Key:   bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
+		Value: 1,
+	},
+	{
+		Key:   StatusKey,
+		Value: 1,
+	},
+}
+
 func CountInactiveHostsByProvider(ctx context.Context) ([]InactiveHostCounts, error) {
 	cur, err := evergreen.GetEnvironment().DB().Collection(Collection).Aggregate(ctx, inactiveHostCountPipeline())
 	if err != nil {
@@ -2407,7 +2419,7 @@ func (h *Host) IsIdleParent(ctx context.Context) (bool, error) {
 		ParentIDKey: h.Id,
 		StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
 	}
-	num, err := Count(ctx, query)
+	num, err := Count(ctx, query, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "counting non-terminated containers")
 	}
@@ -2564,7 +2576,7 @@ func (hosts HostGroup) CountContainersOnParents(ctx context.Context) (int, error
 		StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
 		ParentIDKey: bson.M{"$in": ids},
 	}
-	return Count(ctx, query)
+	return Count(ctx, query, nil)
 }
 
 // FindUphostContainersOnParents returns the containers that are children of the given hosts
@@ -2790,7 +2802,7 @@ func (h *Host) CountContainersRunningAtTime(ctx context.Context, timestamp time.
 			{TerminationTimeKey: time.Time{}},
 		},
 	}
-	return Count(ctx, query)
+	return Count(ctx, query, nil)
 }
 
 func (h *Host) addTag(new Tag, hasPermissions bool) {
@@ -3020,7 +3032,7 @@ func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (in
 		NoExpirationKey: true,
 		StatusKey:       bson.M{"$in": evergreen.UpHostStatus},
 	}
-	return Count(ctx, query)
+	return Count(ctx, query, nil)
 }
 
 // FindSpawnhostsWithNoExpirationToExtend returns all hosts that are set to never

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2419,7 +2419,7 @@ func (h *Host) IsIdleParent(ctx context.Context) (bool, error) {
 		ParentIDKey: h.Id,
 		StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
 	}
-	num, err := Count(ctx, query, nil)
+	num, err := Count(ctx, query)
 	if err != nil {
 		return false, errors.Wrap(err, "counting non-terminated containers")
 	}
@@ -2576,7 +2576,7 @@ func (hosts HostGroup) CountContainersOnParents(ctx context.Context) (int, error
 		StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
 		ParentIDKey: bson.M{"$in": ids},
 	}
-	return Count(ctx, query, nil)
+	return Count(ctx, query)
 }
 
 // FindUphostContainersOnParents returns the containers that are children of the given hosts
@@ -2802,7 +2802,7 @@ func (h *Host) CountContainersRunningAtTime(ctx context.Context, timestamp time.
 			{TerminationTimeKey: time.Time{}},
 		},
 	}
-	return Count(ctx, query, nil)
+	return Count(ctx, query)
 }
 
 func (h *Host) addTag(new Tag, hasPermissions bool) {
@@ -3032,7 +3032,7 @@ func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (in
 		NoExpirationKey: true,
 		StatusKey:       bson.M{"$in": evergreen.UpHostStatus},
 	}
-	return Count(ctx, query, nil)
+	return Count(ctx, query)
 }
 
 // FindSpawnhostsWithNoExpirationToExtend returns all hosts that are set to never

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -865,10 +865,10 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 
 		Convey("host statistics should properly count this host as active"+
 			" but not idle", func() {
-			count, err = Count(ctx, IsActive)
+			count, err = Count(ctx, IsActive, nil)
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
-			count, err = Count(ctx, IsIdle)
+			count, err = Count(ctx, IsIdle, nil)
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 0)
 		})
@@ -888,12 +888,12 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 			So(host.LastTask, ShouldEqual, "prevTask")
 
 			Convey("the count of idle hosts should go up", func() {
-				count, err := Count(ctx, IsIdle)
+				count, err := Count(ctx, IsIdle, nil)
 				So(err, ShouldBeNil)
 				So(count, ShouldEqual, 1)
 
 				Convey("but the active host count should remain the same", func() {
-					count, err = Count(ctx, IsActive)
+					count, err = Count(ctx, IsActive, nil)
 					So(err, ShouldBeNil)
 					So(count, ShouldEqual, 1)
 				})
@@ -3837,7 +3837,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 	assert.Contains(ids, "host7")
 	assert.Contains(ids, "host8")
 
-	totalHosts, err := Count(ctx, All)
+	totalHosts, err := Count(ctx, All, nil)
 	require.NoError(err)
 	assert.Equal(totalHosts, len(distro1Hosts)+len(distro2Hosts))
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -865,10 +865,10 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 
 		Convey("host statistics should properly count this host as active"+
 			" but not idle", func() {
-			count, err = Count(ctx, IsActive, nil)
+			count, err = Count(ctx, IsActive)
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
-			count, err = Count(ctx, IsIdle, nil)
+			count, err = Count(ctx, IsIdle)
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 0)
 		})
@@ -888,12 +888,12 @@ func TestHostClearRunningAndSetLastTask(t *testing.T) {
 			So(host.LastTask, ShouldEqual, "prevTask")
 
 			Convey("the count of idle hosts should go up", func() {
-				count, err := Count(ctx, IsIdle, nil)
+				count, err := Count(ctx, IsIdle)
 				So(err, ShouldBeNil)
 				So(count, ShouldEqual, 1)
 
 				Convey("but the active host count should remain the same", func() {
-					count, err = Count(ctx, IsActive, nil)
+					count, err = Count(ctx, IsActive)
 					So(err, ShouldBeNil)
 					So(count, ShouldEqual, 1)
 				})
@@ -3837,7 +3837,7 @@ func TestRemoveStaleInitializing(t *testing.T) {
 	assert.Contains(ids, "host7")
 	assert.Contains(ids, "host8")
 
-	totalHosts, err := Count(ctx, All, nil)
+	totalHosts, err := Count(ctx, All)
 	require.NoError(err)
 	assert.Equal(totalHosts, len(distro1Hosts)+len(distro2Hosts))
 }


### PR DESCRIPTION
DEVPROD-7418

### Description
The task queue page would occasionally perform an extremely slow query due to possibly using the wrong index this pr adds a hint to the query.

### Testing
Test in production! Since the query planner only sometimes uses the wrong index its difficult to test this locally. The hope is that the hint will force it to consistently use a known fast index.

![image](https://github.com/evergreen-ci/evergreen/assets/4605522/f31c5192-5120-437e-bfad-78dab606eab4)

