### PR TITLE
DEVPROD-6991 Account for single host TG and display task limit upon SetResetWhenFinished

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -362,7 +362,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 			toArchive = append(toArchive, t)
 		}
 	}
-	if err := checkUsersPatchTaskLimit(allFinishedTasks[0].Requester, caller, true, toArchive...); err != nil {
+	if err := task.CheckUsersPatchTaskLimit(allFinishedTasks[0].Requester, caller, toArchive...); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err := task.ArchiveMany(ctx, toArchive); err != nil {
@@ -379,7 +379,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	restartIds := []string{}
 	for _, t := range allFinishedTasks {
 		if t.IsPartOfSingleHostTaskGroup() {
-			if err := t.SetResetWhenFinished(); err != nil {
+			if err := t.SetResetWhenFinished(caller); err != nil {
 				return errors.Wrapf(err, "marking '%s' for restart when finished", t.Id)
 			}
 			taskGroupsToCheck[taskGroupAndBuild{
@@ -873,35 +873,6 @@ func createTasksForBuild(creationInfo TaskCreationInfo) (task.Tasks, error) {
 
 	// return all of the tasks created
 	return tasks, nil
-}
-
-// checkUsersPatchTaskLimit takes in an input list of tasks that is set to get activated, and checks if they're
-// non commit-queue patch tasks, and that the request has been submitted by a user. If so, the maximum hourly patch tasks counter
-// will be incremented accordingly. The addExecutionTasks parameter indicates that execution tasks are included
-// as part of the input tasks param, otherwise we need to account for them.
-func checkUsersPatchTaskLimit(requester, username string, addExecutionTasks bool, tasks ...task.Task) error {
-	// we only care about patch tasks that are to be activated by an actual user
-	if !(requester == evergreen.PatchVersionRequester || requester == evergreen.GithubPRRequester) || evergreen.IsSystemActivator(username) {
-		return nil
-	}
-	s := evergreen.GetEnvironment().Settings()
-	if s.TaskLimits.MaxHourlyPatchTasks == 0 {
-		return nil
-	}
-	numTasksToActivate := 0
-	for _, t := range tasks {
-		if t.Activated {
-			if addExecutionTasks && t.DisplayOnly {
-				execTaskIdsToRestart, err := findExecTasksToReset(&t)
-				if err != nil {
-					return errors.Wrap(err, "finding execution tasks to restart")
-				}
-				numTasksToActivate += len(execTaskIdsToRestart)
-			}
-			numTasksToActivate++
-		}
-	}
-	return task.UpdateSchedulingLimit(username, requester, numTasksToActivate, true)
 }
 
 // addSingleHostTaskGroupDependencies adds dependencies to any tasks in a single-host task group
@@ -1762,7 +1733,7 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			buildIdsToActivate = append(buildIdsToActivate, b.Id)
 		}
 	}
-	if err = checkUsersPatchTaskLimit(creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(creationInfo.Version.Requester, creationInfo.Version.Author, activatedTasks...); err != nil {
 		return nil, errors.Wrap(err, "updating patch task limit for user")
 	}
 	if len(buildIdsToActivate) > 0 {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -362,7 +362,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 			toArchive = append(toArchive, t)
 		}
 	}
-	if err := task.CheckUsersPatchTaskLimit(allFinishedTasks[0].Requester, caller, toArchive...); err != nil {
+	if err := task.CheckUsersPatchTaskLimit(allFinishedTasks[0].Requester, caller, false, toArchive...); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err := task.ArchiveMany(ctx, toArchive); err != nil {
@@ -1733,7 +1733,7 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			buildIdsToActivate = append(buildIdsToActivate, b.Id)
 		}
 	}
-	if err = task.CheckUsersPatchTaskLimit(creationInfo.Version.Requester, creationInfo.Version.Author, activatedTasks...); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
 		return nil, errors.Wrap(err, "updating patch task limit for user")
 	}
 	if len(buildIdsToActivate) > 0 {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2252,7 +2252,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	assert.NoError(resetTaskData())
 	dt, err := task.FindOneId("displayTask")
 	assert.NoError(err)
-	assert.NoError(dt.SetResetFailedWhenFinished())
+	assert.NoError(dt.SetResetFailedWhenFinished("caller"))
 	assert.NoError(resetTask(ctx, dt.Id, "caller"))
 	tasks, err = task.FindAll(db.Query(task.ByIds(allTasks)))
 	assert.NoError(err)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3022,9 +3022,12 @@ func (t *Task) CreateTestResultsTaskOptions() ([]testresult.TaskOptions, error) 
 
 // SetResetWhenFinished requests that a display task or single-host task group
 // reset itself when finished. Will mark itself as system failed.
-func (t *Task) SetResetWhenFinished() error {
+func (t *Task) SetResetWhenFinished(caller string) error {
 	if t.ResetWhenFinished {
 		return nil
+	}
+	if err := updateSchedulingLimitForResetWhenFinished(t, caller); err != nil {
+		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
 	t.ResetWhenFinished = true
 	return UpdateOne(
@@ -3071,9 +3074,12 @@ func (t *Task) SetResetWhenFinishedWithInc() error {
 
 // SetResetFailedWhenFinished requests that a display task
 // only restarts failed tasks.
-func (t *Task) SetResetFailedWhenFinished() error {
+func (t *Task) SetResetFailedWhenFinished(caller string) error {
 	if t.ResetFailedWhenFinished {
 		return nil
+	}
+	if err := updateSchedulingLimitForResetWhenFinished(t, caller); err != nil {
+		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
 	t.ResetFailedWhenFinished = true
 	return UpdateOne(
@@ -3086,6 +3092,68 @@ func (t *Task) SetResetFailedWhenFinished() error {
 			},
 		},
 	)
+}
+
+func updateSchedulingLimitForResetWhenFinished(t *Task, caller string) error {
+	if !(t.Requester == evergreen.PatchVersionRequester || t.Requester == evergreen.GithubPRRequester) || evergreen.IsSystemActivator(caller) {
+		return nil
+	}
+	var tasks []Task
+	var err error
+	if t.DisplayOnly {
+		tasks, err = Find(ByIds(t.ExecutionTasks))
+		if err != nil {
+			return errors.Wrapf(err, "finding execution tasks for '%s'", t.Id)
+		}
+	} else if t.IsPartOfSingleHostTaskGroup() {
+		tasks, err = FindTaskGroupFromBuild(t.BuildId, t.TaskGroup)
+		if err != nil {
+			return errors.Wrapf(err, "finding task group '%s'", t.TaskGroup)
+		}
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+	return errors.Wrap(CheckUsersPatchTaskLimit(t.Requester, caller, tasks...), "updating patch task limit for user")
+}
+
+// CheckUsersPatchTaskLimit takes in an input list of tasks that is set to get activated, and checks if they're
+// non commit-queue patch tasks, and that the request has been submitted by a user. If so, the maximum hourly patch tasks counter
+// will be incremented accordingly.
+func CheckUsersPatchTaskLimit(requester, username string, tasks ...Task) error {
+	// we only care about patch tasks that are to be activated by an actual user
+	if !(requester == evergreen.PatchVersionRequester || requester == evergreen.GithubPRRequester) || evergreen.IsSystemActivator(username) {
+		return nil
+	}
+	s := evergreen.GetEnvironment().Settings()
+	if s.TaskLimits.MaxHourlyPatchTasks == 0 {
+		return nil
+	}
+	numTasksToActivate := 0
+	for _, t := range tasks {
+		if t.DisplayOnly || t.IsPartOfDisplay() || t.IsPartOfSingleHostTaskGroup() {
+			continue
+		}
+		if t.Activated {
+			numTasksToActivate++
+		}
+	}
+	return UpdateSchedulingLimit(username, requester, numTasksToActivate, true)
+}
+
+func FindExecTasksToReset(t *Task) ([]string, error) {
+	if !t.ResetFailedWhenFinished {
+		return t.ExecutionTasks, nil
+	}
+	failedExecTasks, err := FindWithFields(FailedTasksByIds(t.ExecutionTasks), IdKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving failed execution tasks")
+	}
+	failedExecTaskIds := []string{}
+	for _, et := range failedExecTasks {
+		failedExecTaskIds = append(failedExecTaskIds, et.Id)
+	}
+	return failedExecTaskIds, nil
 }
 
 // FindHostSchedulable finds all tasks that can be scheduled for a distro

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -388,7 +388,7 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 	if t.IsPartOfDisplay() {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
-	if err = task.CheckUsersPatchTaskLimit(t.Requester, caller, *t); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(t.Requester, caller, false, *t); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err = t.Archive(ctx); err != nil {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -369,7 +369,7 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 		caller = user
 	}
 	if t.IsPartOfSingleHostTaskGroup() {
-		if err = t.SetResetWhenFinished(); err != nil {
+		if err = t.SetResetWhenFinished(user); err != nil {
 			return errors.Wrap(err, "marking task group for reset")
 		}
 		return errors.Wrap(checkResetSingleHostTaskGroup(ctx, t, caller), "resetting single host task group")
@@ -388,7 +388,7 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 	if t.IsPartOfDisplay() {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
-	if err = checkUsersPatchTaskLimit(t.Requester, caller, true, *t); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(t.Requester, caller, *t); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err = t.Archive(ctx); err != nil {
@@ -2072,7 +2072,7 @@ func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
 
 func MarkOneTaskReset(ctx context.Context, t *task.Task, caller string) error {
 	if t.DisplayOnly {
-		execTaskIdsToRestart, err := findExecTasksToReset(t)
+		execTaskIdsToRestart, err := task.FindExecTasksToReset(t)
 		if err != nil {
 			return errors.Wrap(err, "finding execution tasks to restart")
 		}
@@ -2094,21 +2094,6 @@ func MarkOneTaskReset(ctx context.Context, t *task.Task, caller string) error {
 	}
 
 	return nil
-}
-
-func findExecTasksToReset(t *task.Task) ([]string, error) {
-	if !t.ResetFailedWhenFinished {
-		return t.ExecutionTasks, nil
-	}
-	failedExecTasks, err := task.FindWithFields(task.FailedTasksByIds(t.ExecutionTasks), task.IdKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "retrieving failed execution tasks")
-	}
-	failedExecTaskIds := []string{}
-	for _, et := range failedExecTasks {
-		failedExecTaskIds = append(failedExecTaskIds, et.Id)
-	}
-	return failedExecTaskIds, nil
 }
 
 // MarkTasksReset resets many tasks by their IDs. For execution tasks, this also
@@ -2199,7 +2184,7 @@ func RestartFailedTasks(ctx context.Context, opts RestartOptions) (RestartResult
 		if dt.IsFinished() {
 			idsToRestart = append(idsToRestart, id)
 		} else {
-			if err = dt.SetResetWhenFinished(); err != nil {
+			if err = dt.SetResetWhenFinished(opts.User); err != nil {
 				return results, errors.Wrapf(err, "marking display task '%s' for reset", id)
 			}
 		}
@@ -2442,11 +2427,11 @@ func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t
 	}
 	if taskToReset.DisplayOnly {
 		if failedOnly {
-			if err := taskToReset.SetResetFailedWhenFinished(); err != nil {
+			if err := taskToReset.SetResetFailedWhenFinished(user); err != nil {
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		} else {
-			if err := taskToReset.SetResetWhenFinished(); err != nil {
+			if err := taskToReset.SetResetWhenFinished(user); err != nil {
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2278,7 +2278,7 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 			assert.Equal(t, evergreen.TaskFailed, runningTaskDB.Status)
 		},
 		"ResetWhenFinished": func(t *testing.T) {
-			assert.NoError(t, runningTask.SetResetWhenFinished())
+			assert.NoError(t, runningTask.SetResetWhenFinished("test"))
 			assert.NoError(t, MarkEnd(ctx, settings, runningTask, "test", time.Now(), detail, false))
 
 			runningTaskDB, err := task.FindOneId(runningTask.Id)
@@ -5955,7 +5955,7 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 	settings := testutil.TestConfig()
 
 	// request that the task restarts when it's done
-	assert.NoError(dt.SetResetWhenFinished())
+	assert.NoError(dt.SetResetWhenFinished("caller"))
 	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.True(dbTask.ResetWhenFinished)


### PR DESCRIPTION
DEVPROD-6991

### Description
This removes display tasks and single host task group tasks from the `CheckUsersPatchTaskLimit`, in favor of immediately updating the user's patch task scheduling limit with the number of tasks in the group / display task when marking the task to reset upon completion. This can be safely done because a display task and a single host TG task will only ever reset if it has been previously marked as `ResetWhenFinished = true`.

For display tasks, since we cannot know in advance which tasks will fail when marking `ResetFailedWhenFinished`, we'll pessimistically assume all tasks will need to be reset. For the time being, the benefit of making this perfectly accurate is likely not worth the potential complexity.
### Testing
Existing tests and added more test cases confirming that display tasks update the scheduling limit when they get marked to reset when finished, but not when they actually get reset.
