### PR TITLE
DEVPROD-6266 Fix duplication for --repeat-patch 

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1578,12 +1578,21 @@ func (p *Project) GetModuleByName(name string) (*Module, error) {
 	return nil, errors.New("no such module on this project")
 }
 
+// FindTasksForVariant returns all tasks in a variant, including tasks in task groups.
 func (p *Project) FindTasksForVariant(build string) []string {
 	for _, b := range p.BuildVariants {
 		if b.Name == build {
-			tasks := make([]string, 0, len(b.Tasks))
+			tasks := []string{}
 			for _, task := range b.Tasks {
 				tasks = append(tasks, task.Name)
+				// add tasks in task groups
+				if task.IsGroup {
+					tg := p.FindTaskGroup(task.Name)
+					if tg != nil {
+						tasks = append(tasks, tg.Tasks...)
+					}
+				}
+
 			}
 			return tasks
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1805,6 +1805,21 @@ func FindProjectForTask(taskID string) (string, error) {
 	return t.Project, nil
 }
 
+func FindActivatedByVersionWithoutDisplay(versionId string) ([]Task, error) {
+	query := db.Query(bson.M{
+		VersionKey:     versionId,
+		ActivatedKey:   true,
+		DisplayOnlyKey: bson.M{"$ne": true},
+	})
+	activatedTasks, err := FindAll(query)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting previous patch tasks")
+	}
+
+	return activatedTasks, nil
+
+}
+
 func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, dependencyID string, unattainable bool) error {
 	// Update the matching dependencies in the DependsOn array and the UnattainableDependency field that caches
 	// whether any of the dependencies are blocked. Combining both these updates in a single update operation makes it

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2548,7 +2548,7 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 		return nil, nil
 	}
 
-	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey)
+	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey, DisplayNameKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dependencies")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -683,7 +683,7 @@ func setToFilteredTasks(patchDoc, reusePatch *patch.Patch, project *model.Projec
 		// We only need to add dependencies and task group tasks for failed tasks because otherwise
 		// we can rely on them being there from the previous patch.
 		if failedOnly {
-			failedPlusNeeded, err := addTasksNeededByFailedForReuse(failedTasks, failedTaskDisplayNames, project, vt)
+			failedPlusNeeded, err := addDependenciesAndTaskGroups(failedTasks, failedTaskDisplayNames, project, vt)
 			if err != nil {
 				return errors.Wrap(err, "getting dependencies and task groups for activated tasks")
 			}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -680,7 +680,7 @@ func setToFilteredTasks(patchDoc, reusePatch *patch.Patch, project *model.Projec
 	filteredVariantTasks := []patch.VariantTasks{}
 	for _, vt := range reusePatch.VariantsTasks {
 		// Limit it to tasks that are failed or who have failed tasks depending on them.
-		// we only need to add dependencies and task group tasks for failed tasks because otherwise
+		// We only need to add dependencies and task group tasks for failed tasks because otherwise
 		// we can rely on them being there from the previous patch.
 		if failedOnly {
 			failedPlusNeeded, err := addTasksNeededByFailedForReuse(failedTasks, failedTaskDisplayNames, project, vt)
@@ -722,7 +722,7 @@ func filterToActiveForReuse(reusePatch *patch.Patch) ([]task.Task, error) {
 
 }
 
-// addTasksNeededByFailedForReuse add tasks that failed tasks need to run including dependencies and tasks from single host task groups.
+// addTasksNeededByFailedForReuse adds tasks that failed tasks need to run including dependencies and tasks from single host task groups.
 func addTasksNeededByFailedForReuse(failedTasks []task.Task, failedTaskDisplayNames []string, project *model.Project, vt patch.VariantTasks) ([]string, error) {
 	// only add tasks if they are in the current project definition
 	tasksInProjectVariant := project.FindTasksForVariant(vt.Variant)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -685,7 +685,7 @@ func setToFilteredTasks(patchDoc, reusePatch *patch.Patch, project *model.Projec
 		if failedOnly {
 			failedPlusNeeded, err := addTasksNeededByFailedForReuse(failedTasks, failedTaskDisplayNames, project, vt)
 			if err != nil {
-				return errors.Wrap(err, "getting dependencies for activated tasks")
+				return errors.Wrap(err, "getting dependencies and task groups for activated tasks")
 			}
 			filteredTasks = append(filteredTasks, failedPlusNeeded...)
 		}


### PR DESCRIPTION
[DEVPROD-6266](https://jira.mongodb.org/browse/DEVPROD-6266)

Description
--repeat-patch was relying on BuildProjectTVPairs to create the variant tasks for patches. However, that resulted in a previous patch of: {bv1: t1, bv2: t2} ending up with {bv1: t1, bv1: t2, bv2: t1, bv2: t2}. This fixes that by reusing the variant tasks from the previous patch and applying the filtering on top of that instead of just on the tasks.

Testing
Existing unit tests and testing on staging.