### PR TITLE
DEVPROD-5636: Add B3 propagation to OTel configuration

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -974,10 +974,10 @@ func (e *envState) initTracer(ctx context.Context, useInternalDNS bool, tracer t
 	spanLimits.AttributeValueLengthLimit = OtelAttributeMaxLength
 
 	// Set up propagators. This allows traces from Spruce to connect to traces from Evergreen.
-	p := b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader | b3.B3SingleHeader))
+	propagatorB3 := b3.New(b3.WithInjectEncoding(b3.B3MultipleHeader | b3.B3SingleHeader))
 	otel.SetTextMapPropagator(
 		propagation.NewCompositeTextMapPropagator(
-			p,
+			propagatorB3,
 			propagation.TraceContext{},
 			propagation.Baggage{}),
 	)

--- a/go.mod
+++ b/go.mod
@@ -201,6 +201,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/mongodb/jasper v0.0.0-20240424195530-4a5968d6fc0f
 	github.com/shirou/gopsutil/v3 v3.24.3
+	go.opentelemetry.io/contrib/propagators/b3 v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,8 @@ go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.46
 go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.46.1/go.mod h1:YfFNem80G9UZ/mL5zd5GGXZSy95eXK+RhzIWBkLjLSc=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1/go.mod h1:sEGXWArGqc3tVa+ekntsN65DmVbVeW+7lTKTjZF3/Fo=
+go.opentelemetry.io/contrib/propagators/b3 v1.21.0 h1:uGdgDPNzwQWRwCXJgw/7h29JaRqcq9B87Iv4hJDKAZw=
+go.opentelemetry.io/contrib/propagators/b3 v1.21.0/go.mod h1:D9GQXvVGT2pzyTfp1QBOnD1rzKEWzKjjwu5q2mslCUI=
 go.opentelemetry.io/otel v1.21.0 h1:hzLeKBZEL7Okw2mGzZ0cc4k/A7Fta0uoPgaJCr8fsFc=
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 h1:jd0+5t/YynESZqsSyPz+7PAFdEop0dlN0+PkyHYo8oI=


### PR DESCRIPTION
DEVPROD-5636

### Description
Adds B3 propagation to OTel which allows frontend traces to connect with backend traces.

I installed a module into go for the first time so let me know if I did it wrong 😥

### Testing
- On staging. [Example of a connected trace](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/spruce/result/9LxMb1Ygzso/trace/hwbkmvaZPgK?fields[]=s_name&fields[]=s_serviceName&span=066125dfce5477d2)
