### PR TITLE
DEVPROD-3663 support repeat flags for patch-file command

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-05-13"
+	ClientVersion = "2024-05-17"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -332,18 +332,21 @@ func PatchFile() cli.Command {
 			}
 			confPath := c.Parent().String(confFlagName)
 			params := &patchParams{
-				Project:         c.String(projectFlagName),
-				Variants:        utility.SplitCommas(c.StringSlice(variantsFlagName)),
-				Tasks:           utility.SplitCommas(c.StringSlice(tasksFlagName)),
-				Alias:           c.String(patchAliasFlagName),
-				SkipConfirm:     c.Bool(skipConfirmFlagName),
-				Description:     c.String(patchDescriptionFlagName),
-				AutoDescription: c.Bool(autoDescriptionFlag),
-				Finalize:        c.Bool(patchFinalizeFlagName),
-				ShowSummary:     c.Bool(patchVerboseFlagName),
-				Large:           c.Bool(largeFlagName),
-				SyncTasks:       utility.SplitCommas(c.StringSlice(syncTasksFlagName)),
-				PatchAuthor:     c.String(patchAuthorFlag),
+				Project:          c.String(projectFlagName),
+				Variants:         utility.SplitCommas(c.StringSlice(variantsFlagName)),
+				Tasks:            utility.SplitCommas(c.StringSlice(tasksFlagName)),
+				Alias:            c.String(patchAliasFlagName),
+				SkipConfirm:      c.Bool(skipConfirmFlagName),
+				Description:      c.String(patchDescriptionFlagName),
+				AutoDescription:  c.Bool(autoDescriptionFlag),
+				Finalize:         c.Bool(patchFinalizeFlagName),
+				ShowSummary:      c.Bool(patchVerboseFlagName),
+				Large:            c.Bool(largeFlagName),
+				SyncTasks:        utility.SplitCommas(c.StringSlice(syncTasksFlagName)),
+				PatchAuthor:      c.String(patchAuthorFlag),
+				RepeatPatchId:    c.String(repeatPatchIdFlag),
+				RepeatDefinition: c.Bool(repeatDefinitionFlag) || c.String(repeatPatchIdFlag) != "",
+				RepeatFailed:     c.Bool(repeatFailedDefinitionFlag),
 			}
 			var err error
 			diffPath := c.String(diffPathFlagName)


### PR DESCRIPTION
DEVPROD-3663
### Description
Pass through the repeat flags.

### Testing
Tested using https://spruce.mongodb.com/patch/6647a107bad5d90007db19cb/configure/tasks. 

