### PR TITLE
DEVPROD-6233: fix race when decommissioning host and assigning task

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1788,7 +1788,6 @@ func (h *Host) UpdateRunningTaskWithContext(ctx context.Context, env evergreen.E
 		},
 	}
 
-	// kim: TODO: add test
 	res, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update)
 	if err != nil {
 		grip.DebugWhen(db.IsDuplicateKey(err), message.WrapError(err, message.Fields{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1788,15 +1788,18 @@ func (h *Host) UpdateRunningTaskWithContext(ctx context.Context, env evergreen.E
 		},
 	}
 
-	// kim: TODO: check num matched in result to ensure it actually updates the
-	// host document.
-	if _, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update); err != nil {
+	// kim: TODO: add test
+	res, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update)
+	if err != nil {
 		grip.DebugWhen(db.IsDuplicateKey(err), message.WrapError(err, message.Fields{
 			"message": "found duplicate running task",
 			"task":    t.Id,
 			"host_id": h.Id,
 		}))
 		return err
+	}
+	if res.ModifiedCount != 1 {
+		return errors.Errorf("expected to update 1 host to set running task information, but actually updated %d", res.ModifiedCount)
 	}
 
 	h.RunningTask = t.Id

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1788,6 +1788,8 @@ func (h *Host) UpdateRunningTaskWithContext(ctx context.Context, env evergreen.E
 		},
 	}
 
+	// kim: TODO: check num matched in result to ensure it actually updates the
+	// host document.
 	if _, err := env.DB().Collection(Collection).UpdateOne(ctx, query, update); err != nil {
 		grip.DebugWhen(db.IsDuplicateKey(err), message.WrapError(err, message.Fields{
 			"message": "found duplicate running task",

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -925,8 +925,13 @@ func TestUpdateHostRunningTask(t *testing.T) {
 				},
 			},
 		}
+		h3 := Host{
+			Id:     "test3",
+			Status: evergreen.HostDecommissioned,
+		}
 		So(h.Insert(ctx), ShouldBeNil)
 		So(h2.Insert(ctx), ShouldBeNil)
+		So(h3.Insert(ctx), ShouldBeNil)
 		Convey("updating the running task id should set proper fields", func() {
 			So(h.UpdateRunningTaskWithContext(ctx, env, &task.Task{Id: newTaskId}), ShouldBeNil)
 			found, err := FindOne(ctx, ById(h.Id))
@@ -947,6 +952,9 @@ func TestUpdateHostRunningTask(t *testing.T) {
 			runningTaskHosts, err := Find(ctx, IsRunningTask)
 			So(err, ShouldBeNil)
 			So(len(runningTaskHosts), ShouldEqual, 1)
+		})
+		Convey("updating a running task on a decommissioned host should error", func() {
+			So(h3.UpdateRunningTaskWithContext(ctx, env, &task.Task{Id: newTaskId}), ShouldNotBeNil)
 		})
 	})
 }

--- a/units/crons.go
+++ b/units/crons.go
@@ -236,6 +236,9 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			continue
 		}
 		jobs = append(jobs, NewHostTerminationJob(env, &h, HostTerminationOptions{
+			// kim: NOTE: likely should not terminate if busy. It should
+			// gracefully refuse to terminate when the host is assigned a task
+			// to avoid interrupting it.
 			TerminateIfBusy:   true,
 			TerminationReason: "host is expired, decommissioned, or failed to provision",
 		}))

--- a/units/crons.go
+++ b/units/crons.go
@@ -239,7 +239,6 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			// kim: NOTE: likely should not terminate if busy. It should
 			// gracefully refuse to terminate when the host is assigned a task
 			// to avoid interrupting it.
-			TerminateIfBusy:   true,
 			TerminationReason: "host is expired, decommissioned, or failed to provision",
 		}))
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -236,9 +236,6 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			continue
 		}
 		jobs = append(jobs, NewHostTerminationJob(env, &h, HostTerminationOptions{
-			// kim: NOTE: likely should not terminate if busy. It should
-			// gracefully refuse to terminate when the host is assigned a task
-			// to avoid interrupting it.
 			TerminationReason: "host is expired, decommissioned, or failed to provision",
 		}))
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -236,6 +236,7 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			continue
 		}
 		jobs = append(jobs, NewHostTerminationJob(env, &h, HostTerminationOptions{
+			TerminateIfBusy:   true,
 			TerminationReason: "host is expired, decommissioned, or failed to provision",
 		}))
 	}


### PR DESCRIPTION
DEVPROD-6233

### Description
Fixes an issue with decommissioning a task just as it's about to be assigned to a host. The host can be assigned a task after it's been decommissioned because the query to assign the task to the host doesn't check that the update modified the host. This resulted in the task running on the host but not being assigned as the host's current task. Evergreen then terminated the host thinking that it's idle (because it's not assigned a task in the DB).

### Testing
Kind of hard to test a race but I added a unit test. I'm also going to monitor after the deploy to see if the issue goes away.

### Documentation
N/A