### PR TITLE
Docs: update max patch size

### DIFF
--- a/docs/Reference/Limits.md
+++ b/docs/Reference/Limits.md
@@ -33,7 +33,7 @@ This cannot be lifted because Evergreen cannot safely handle larger file sizes f
 
 ## Patch size
 
-Evergreen has a 100MB system limit on patch size (the number of files changed or the diff size for the changes). In order to submit patches that are larger than 16MB from the CLI, the `--large` flag needs to be used. Large patches may hit the CLI’s one minute timeout. To work around that, users can open a PR and run the patch from there.
+Evergreen has a 100MB system limit on patch size (the diff size for the changes). In order to submit patches that are larger than 16MB from the CLI, the `--large` flag needs to be used. Large patches may hit the CLI’s one minute timeout. To work around that, users can open a PR and run the patch from there.
 
 ## What is the largest file size I can upload to Parsley?
 

--- a/docs/Reference/Limits.md
+++ b/docs/Reference/Limits.md
@@ -33,7 +33,7 @@ This cannot be lifted because Evergreen cannot safely handle larger file sizes f
 
 ## Patch size
 
-Evergreen has no limits on patch size (the number of files changed or the diff size for the changes). In order to submit patches that are larger than 16MB from the CLI, the `--large` flag needs to be used. While we don’t block large patches, they may hit the CLI’s one minute timeout. To work around that, users can open a PR and run the patch from there.
+Evergreen has a 100MB system limit on patch size (the number of files changed or the diff size for the changes). In order to submit patches that are larger than 16MB from the CLI, the `--large` flag needs to be used. Large patches may hit the CLI’s one minute timeout. To work around that, users can open a PR and run the patch from there.
 
 ## What is the largest file size I can upload to Parsley?
 


### PR DESCRIPTION
### Documentation
Our current docs say there is no patch limit size, but it is actually 100MB.