### PR TITLE
DEVPROD-6680 remove dist task

### DIFF
--- a/makefile
+++ b/makefile
@@ -94,8 +94,7 @@ clientBinaries := $(macOSBinaries) $(linuxBinaries) $(windowsBinaries)
 clientSource := cmd/evergreen/evergreen.go
 uiFiles := $(shell find public/static -not -path "./public/static/app" -name "*.js" -o -name "*.css" -o -name "*.html")
 
-distArtifacts :=  ./public ./service/templates
-distContents := $(clientBinaries) $(distArtifacts)
+staticArtifacts :=  ./public ./service/templates
 srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
 testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 currentHash := $(shell git rev-parse HEAD)
@@ -128,15 +127,15 @@ $(clientBuildDir)/%/$(unixBinaryBasename) $(clientBuildDir)/%/$(windowsBinaryBas
 
 build-linux_%: $(clientBuildDir)/linux_%/$(unixBinaryBasename);
 build-windows_%: $(clientBuildDir)/windows_%/$(windowsBinaryBasename);
-build-darwin_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename) $(if $(SIGN_MACOS),$(clientBuildDir)/darwin_%/.signed);
+build-darwin_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename) $(clientBuildDir)/darwin_%/.signed;
 
-sign-macos:$(foreach platform,$(macOSPlatforms),$(clientBuildDir)/$(platform)/.signed)
-# Targets to upload the CLI binaries to S3.
-$(buildDir)/upload-s3:cmd/upload-s3/upload-s3.go
-	@$(gobin) build -o $@ $<
-upload-clis:$(buildDir)/upload-s3 clis
-	$(buildDir)/upload-s3 -bucket="${BUCKET_NAME}" -local="${LOCAL_PATH}" -remote="${REMOTE_PATH}" -exclude="${EXCLUDE_PATTERN}"
-phony += cli clis upload-clis sign-macos
+build-linux-staging_%: $(clientBuildDir)/linux_%/$(unixBinaryBasename);
+build-windows-staging_%: $(clientBuildDir)/windows_%/$(windowsBinaryBasename);
+build-darwin-staging_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename) $(clientBuildDir)/darwin_%/.signed;
+
+build-darwin-unsigned_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename);
+
+phony += cli clis
 # end client build directives
 
 
@@ -180,13 +179,13 @@ local-evergreen:$(localClientBinary) load-local-data
 
 ######################################################################
 ##
-## Build, Test, and Dist targets and mechisms.
+## Build and Test targets and mechisms.
 ##
 ######################################################################
 
 # most of the targets and variables in this section are generic
 # instructions for go programs of all kinds, and are not particularly
-# specific to evergreen; though the dist targets are more specific than the rest.
+# specific to evergreen; though the build targets are more specific than the rest.
 
 # start output files
 testOutput := $(foreach target,$(packages) $(testOnlyPackages),$(buildDir)/output.$(target).test)
@@ -244,16 +243,8 @@ $(buildDir)/macnotary:$(buildDir)/sign-executable
 $(clientBuildDir)/%/.signed:$(buildDir)/sign-executable $(clientBuildDir)/%/$(unixBinaryBasename) $(buildDir)/macnotary
 	./$< sign --client $(buildDir)/macnotary --executable $(@D)/$(unixBinaryBasename) --server-url $(NOTARY_SERVER_URL) --bundle-id $(EVERGREEN_BUNDLE_ID)
 	touch $@
-
-dist-staging:
-	STAGING_ONLY=1 DEBUG_ENABLED=1 SIGN_MACOS= $(MAKE) dist
-dist-unsigned:
-	SIGN_MACOS= $(MAKE) dist
-dist:$(buildDir)/dist.tar.gz
-$(buildDir)/dist.tar.gz:$(buildDir)/make-tarball $(clientBinaries) $(uiFiles) $(if $(SIGN_MACOS),sign-macos)
-	./$< --name $@ --prefix $(name) $(foreach item,$(distContents),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
 $(buildDir)/static_assets.tgz:$(buildDir)/make-tarball $(uiFiles)
-	./$< --name $@ --prefix static_assets $(foreach item,$(distArtifacts),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
+	./$< --name $@ --prefix static_assets $(foreach item,$(staticArtifacts),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
 local: $(buildDir)/static_assets.tgz $(clientBinaries)
 # end main build
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -712,6 +712,9 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin_arm64
     tags: ["build"]
+  - <<: *tar-and-push-static-assets
+    name: tar-and-push-static-assets
+    tags: ["build"]
 
   - <<: *build-and-push-client
     name: build-linux-staging_amd64
@@ -725,6 +728,10 @@ tasks:
     name: build-darwin-staging_amd64
     tags: ["build-staging"]
     activate: false
+  - <<: *tar-and-push-static-assets
+    name: tar-and-push-static-assets-staging
+    tags: ["build-staging"]
+    activate: false
 
   - <<: *build-and-push-client
     name: build-darwin-unsigned_amd64
@@ -734,14 +741,6 @@ tasks:
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
     activate: false
-
-  - <<: *tar-and-push-static-assets
-    name: tar-and-push-static-assets
-    tags: ["build"]
-
-  - <<: *tar-and-push-static-assets
-    name: tar-and-push-static-assets-staging
-    tags: ["build-staging"]
 
 #######################################
 #            Buildvariants            #

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -42,27 +42,6 @@ post:
 #         YAML Templates              #
 #######################################
 variables:
-  - &run-build
-    # runs a build operations. The task name in evergreen should
-    # correspond to a make target for the build operation.
-    name: test
-    commands:
-      - func: get-project-and-modules
-      - func: run-make
-        vars: { target: "${task_name}" }
-      - command: s3.put
-        type: system
-        params:
-          optional: true
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
-          local_file: evergreen/bin/dist.tar.gz
-          remote_file: evergreen/${build_id}-${build_variant}/evergreen-${task_name}-${revision}.tar.gz
-          bucket: mciuploads
-          content_type: application/x-gzip
-          permissions: public-read
-          display_name: dist.tar.gz
   - &run-go-test-suite
     # runs a make target and then uploads gotest output to
     # evergreen. The test name should correspond to a make target for
@@ -179,6 +158,21 @@ variables:
           permissions: public-read
           preserve_path: true
 
+  - &tar-and-push-static-assets
+    commands:
+      - func: get-project-and-modules
+      - func: run-make
+        vars: { target: "bin/static_assets.tgz" }
+      - command: s3.put
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_file: evergreen/bin/static_assets.tgz
+          remote_file: evergreen/clients/${version_id}/static_assets.tgz
+          content_type: application/gzip
+          bucket: mciuploads
+          permissions: public-read
 #######################################
 #              Functions              #
 #######################################
@@ -256,7 +250,6 @@ functions:
         MACOS_NOTARY_KEY: ${notary_server_id}
         MACOS_NOTARY_SECRET: ${notary_server_secret}
         EVERGREEN_BUNDLE_ID: ${evergreen_bundle_id}
-        SIGN_MACOS: ${sign_macos}
         OTEL_COLLECTOR_ENDPOINT: ${otel_collector_endpoint}
         OTEL_TRACE_ID: ${otel_trace_id}
         OTEL_PARENT_ID: ${otel_parent_id}
@@ -418,13 +411,6 @@ functions:
 #######################################
 
 tasks:
-  - <<: *run-build
-    name: dist-staging
-    patch_only: true
-  - <<: *run-build
-    name: dist
-  - <<: *run-build
-    name: dist-unsigned
   - <<: *run-smoke-test
     name: test-smoke-internal-host
     tags: ["smoke"]
@@ -603,27 +589,6 @@ tasks:
       - func: setup-mongodb
       - func: run-make
         vars: { target: "test-repotracker" }
-  - name: upload-clis
-    patchable: false
-    depends_on:
-      - name: dist
-        status: success
-    commands:
-      - command: subprocess.exec
-        params:
-          binary: make
-          args: ["upload-clis"]
-          working_dir: evergreen
-          include_expansions_in_env:
-            - GOROOT
-            - AWS_ACCESS_KEY_ID
-            - AWS_SECRET_ACCESS_KEY
-            - AWS_SESSION_TOKEN
-          env:
-            BUCKET_NAME: mciuploads
-            LOCAL_PATH: clients
-            EXCLUDE_PATTERN: .cache
-            REMOTE_PATH: evergreen/clients/${project}/${revision}
   - name: verify-swaggo-fmt
     tags: ["linter"]
     commands:
@@ -728,7 +693,7 @@ tasks:
           patchable: false
   - <<: *build-and-push-client
     name: build-linux_amd64
-    tags: ["build", "build-staging"]
+    tags: ["build"]
   - <<: *build-and-push-client
     name: build-linux_s390x
     tags: ["build"]
@@ -740,39 +705,43 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-windows_amd64
-    tags: ["build", "build-staging"]
+    tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_amd64
-    tags: ["build", "build-staging"]
+    tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_arm64
     tags: ["build"]
-  - name: tar-and-push-static-assets
-    tags: ["build", "build-staging"]
-    commands:
-      - func: get-project-and-modules
-      - func: run-make
-        vars: { target: "bin/static_assets.tgz" }
-      - command: s3.put
-        params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
-          local_file: evergreen/bin/static_assets.tgz
-          remote_file: evergreen/clients/${version_id}/static_assets.tgz
-          content_type: application/gzip
-          bucket: mciuploads
-          permissions: public-read
 
-task_groups:
-  - name: dist-and-upload-clis
-    max_hosts: 1
-    setup_task_can_fail_task: true
-    setup_task:
-      - func: assume-role
-    tasks:
-      - dist
-      - upload-clis
+  - <<: *build-and-push-client
+    name: build-linux-staging_amd64
+    tags: ["build-staging"]
+    activate: false
+  - <<: *build-and-push-client
+    name: build-windows-staging_amd64
+    tags: ["build-staging"]
+    activate: false
+  - <<: *build-and-push-client
+    name: build-darwin-staging_amd64
+    tags: ["build-staging"]
+    activate: false
+
+  - <<: *build-and-push-client
+    name: build-darwin-unsigned_amd64
+    tags: ["build-unsigned"]
+    activate: false
+  - <<: *build-and-push-client
+    name: build-darwin-unsigned_arm64
+    tags: ["build-unsigned"]
+    activate: false
+
+  - <<: *tar-and-push-static-assets
+    name: tar-and-push-static-assets
+    tags: ["build"]
+
+  - <<: *tar-and-push-static-assets
+    name: tar-and-push-static-assets-staging
+    tags: ["build-staging"]
 
 #######################################
 #            Buildvariants            #
@@ -792,12 +761,7 @@ buildvariants:
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-7.0.2.tgz
       mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
-      sign_macos: true
     tasks:
-      - name: "dist-and-upload-clis"
-      - name: "dist-staging"
-      - name: "dist-unsigned"
-        activate: false
       - name: ".smoke"
       - name: ".test"
       - name: ".linter"
@@ -833,13 +797,10 @@ buildvariants:
       mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       decompress: tar zxvf
     tasks:
-      - name: "dist-unsigned"
-        activate: false
       - name: ".smoke"
       - name: ".test"
       - name: "js-test"
       - name: ".linter !.skip-container"
-      - name: "dist-staging"
 
   - name: lint
     display_name: Lint
@@ -903,43 +864,21 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: ".build"
+      - name: ".build-staging"
+      - name: ".build-unsigned"
     expansions:
       GOROOT: /opt/golang/go1.20
-      sign_macos: true
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
     display_tasks:
       - name: build-and-push
         execution_tasks:
         - ".build"
-
-  - name: build-and-push-staging
-    display_name: Build and Push - Staging
-    run_on:
-      - ubuntu2204-small
-    activate: false
-    tasks:
-      - name: ".build-staging"
-        priority: 100
-    expansions:
-      GOROOT: /opt/golang/go1.20
-    display_tasks:
-      - name: build-and-push
+      - name: build-and-push-staging
         execution_tasks:
         - ".build-staging"
-
-  - name: build-and-push-unsigned
-    run_on:
-      - ubuntu2204-small
-    display_name: Build and Push - Unsigned
-    activate: false
-    tasks:
-      - name: ".build"
-    expansions:
-      GOROOT: /opt/golang/go1.20
-    display_tasks:
-      - name: build-and-push
+      - name: build-and-push-darwin-unsigned
         execution_tasks:
-        - ".build"
+        - ".build-unsigned"
 
 
 containers:


### PR DESCRIPTION
[DEVPROD-6680](https://jira.mongodb.org/browse/DEVPROD-6680)

### Description
We aren't using dists anymore so we can safely remove the make target and tasks that use it.

Thought more about Annie's questions from https://github.com/evergreen-ci/evergreen/pull/7352 about consolidating the build-and-push tasks into a single variant. `self-tests.yml` is a little more verbose now, but it is really nice to have it all in the same variant. Still seems nice to have it in a variant separate from testing.

A subsequent PR will remove [the logic to handle serving dist CLIs](https://github.com/evergreen-ci/evergreen/blob/80f2f43e406e38fd316bfae3716a6c50788dd83a/environment.go#L1279-L1329).

### Testing
Created patches to test [the main build-and-push](https://spruce.mongodb.com/version/664bc666a622d000082fe8de/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), [build-and-push-staging](https://spruce.mongodb.com/version/664bc6771d3feb00073dc9ef/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), and [build-and-push-unsigned](https://spruce.mongodb.com/version/664bc68355f7b70007b03a82/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
