### PR TITLE
DEVPROD-5122: show failing commands that don't fail the task in task end details

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1165,6 +1165,16 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 		detail.Description = description
 	}
 
+	var otherFailingCmds []apimodels.FailingCommand
+	for _, otherFailingCmd := range tc.getOtherFailingCommands() {
+		// kim: TODO: add agent suite test
+		otherFailingCmds = append(otherFailingCmds, apimodels.FailingCommand{
+			FullDisplayName:     otherFailingCmd.FullDisplayName(),
+			FailureMetadataTags: utility.UniqueStrings(append(otherFailingCmd.FailureMetadataTags(), failureMetadataTagsToAdd...)),
+		})
+	}
+	detail.OtherFailingCommands = otherFailingCmds
+
 	if !detail.TimedOut {
 		// Only set timeout details if a prior command in the task hasn't
 		// already recorded a timeout. For example, if a command times out in
@@ -1174,7 +1184,6 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 		detail.TimeoutType = string(tc.getTimeoutType())
 		detail.TimeoutDuration = tc.getTimeoutDuration()
 	}
-
 }
 
 func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupCheck bool, reason string) {

--- a/agent/command.go
+++ b/agent/command.go
@@ -306,6 +306,9 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 			if options.block == command.PostBlock {
 				tc.setPostErrored(true)
 			}
+			if !options.canFailTask {
+				tc.addOtherFailingCommand(cmd)
+			}
 			if options.canFailTask ||
 				(cmd.Name() == "git.get_project" && tc.taskConfig.Task.Requester == evergreen.MergeTestRequester) {
 				// any git.get_project in the commit queue should fail
@@ -321,6 +324,10 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		select {
 		case <-timer.C:
 		case <-cmdChan:
+		}
+
+		if !options.canFailTask {
+			tc.addOtherFailingCommand(cmd)
 		}
 
 		tc.logger.Task().Errorf("Command %s stopped early: %s.", cmd.FullDisplayName(), ctx.Err())

--- a/agent/command.go
+++ b/agent/command.go
@@ -303,11 +303,9 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 	case err := <-cmdChan:
 		if err != nil {
 			tc.logger.Task().Errorf("Command %s failed: %s.", cmd.FullDisplayName(), err)
+			tc.addFailingCommand(cmd)
 			if options.block == command.PostBlock {
 				tc.setPostErrored(true)
-			}
-			if !options.canFailTask {
-				tc.addOtherFailingCommand(cmd)
 			}
 			if options.canFailTask ||
 				(cmd.Name() == "git.get_project" && tc.taskConfig.Task.Requester == evergreen.MergeTestRequester) {
@@ -326,9 +324,7 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		case <-cmdChan:
 		}
 
-		if !options.canFailTask {
-			tc.addOtherFailingCommand(cmd)
-		}
+		tc.addFailingCommand(cmd)
 
 		tc.logger.Task().Errorf("Command %s stopped early: %s.", cmd.FullDisplayName(), ctx.Err())
 		return errors.Wrap(ctx.Err(), "command stopped early")

--- a/agent/command.go
+++ b/agent/command.go
@@ -325,6 +325,9 @@ func (a *Agent) runCommand(ctx context.Context, tc *taskContext, logger client.L
 		}
 
 		tc.addFailingCommand(cmd)
+		if options.block == command.PostBlock {
+			tc.setPostErrored(true)
+		}
 
 		tc.logger.Task().Errorf("Command %s stopped early: %s.", cmd.FullDisplayName(), ctx.Err())
 		return errors.Wrap(ctx.Err(), "command stopped early")

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -24,11 +24,13 @@ import (
 
 type taskContext struct {
 	currentCommand command.Command
-	// failingCommand keeps track of the command that caused the task to fail.
+	// failingCommand keeps track of the command that caused the task to fail,
+	// if any.
 	failingCommand command.Command
 	// otherFailingCommands keeps track of commands that have run and failed but
 	// have not caused the task to fail (e.g. a post command that fails without
-	// post_error_fails_task).
+	// post_error_fails_task). Does not include commands that suppress errors,
+	// such as s3.put with optional: true.
 	otherFailingCommands []command.Command
 	postErrored          bool
 	logger               client.LoggerProducer

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -64,14 +64,23 @@ type TaskEndDetail struct {
 	Description string `bson:"desc,omitempty" json:"desc,omitempty"`
 	// FailureMetadataTags are user metadata tags associated with the
 	// command that caused the task to fail.
-	FailureMetadataTags []string        `bson:"failure_metadata_tags,omitempty" json:"failure_metadata_tags,omitempty"`
-	TimedOut            bool            `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
-	TimeoutType         string          `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
-	TimeoutDuration     time.Duration   `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
-	OOMTracker          *OOMTrackerInfo `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
-	Modules             ModuleCloneInfo `bson:"modules,omitempty" json:"modules,omitempty"`
-	TraceID             string          `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
-	DiskDevices         []string        `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
+	FailureMetadataTags []string `bson:"failure_metadata_tags,omitempty" json:"failure_metadata_tags,omitempty"`
+	// OtherFailingCommands contains information about commands that failed
+	// while the task was running but did not cause the task to fail.
+	OtherFailingCommands []FailingCommand `bson:"other_failing_commands,omitempty" json:"other_failing_commands,omitempty"`
+	TimedOut             bool             `bson:"timed_out,omitempty" json:"timed_out,omitempty"`
+	TimeoutType          string           `bson:"timeout_type,omitempty" json:"timeout_type,omitempty"`
+	TimeoutDuration      time.Duration    `bson:"timeout_duration,omitempty" json:"timeout_duration,omitempty" swaggertype:"primitive,integer"`
+	OOMTracker           *OOMTrackerInfo  `bson:"oom_killer,omitempty" json:"oom_killer,omitempty"`
+	Modules              ModuleCloneInfo  `bson:"modules,omitempty" json:"modules,omitempty"`
+	TraceID              string           `bson:"trace_id,omitempty" json:"trace_id,omitempty"`
+	DiskDevices          []string         `bson:"disk_devices,omitempty" json:"disk_devices,omitempty"`
+}
+
+// FailingCommand represents a command that failed in a task.
+type FailingCommand struct {
+	Name                string   `bson:"name,omitempty" json:"name,omitempty"`
+	FailureMetadataTags []string `bson:"failure_metadata_tags,omitempty" json:"failure_metadata_tags,omitempty"`
 }
 
 type OOMTrackerInfo struct {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -79,7 +79,7 @@ type TaskEndDetail struct {
 
 // FailingCommand represents a command that failed in a task.
 type FailingCommand struct {
-	Name                string   `bson:"name,omitempty" json:"name,omitempty"`
+	FullDisplayName     string   `bson:"full_display_name,omitempty" json:"full_display_name,omitempty"`
 	FailureMetadataTags []string `bson:"failure_metadata_tags,omitempty" json:"failure_metadata_tags,omitempty"`
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-05-20"
+	AgentVersion = "2024-05-21"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -24,8 +24,8 @@ Explanation:
     seconds.
 -   `retry_on_failure`: an optional field. If set to true, it will automatically restart the task upon failure. The
      automatic restart will process after the command has failed and the task has completed its subsequent post task commands.
--   `failure_metadata_tags`: an optional set of tags to attribute to the command if it fails. if set, these tags will
-    appear in the task end data for failed tasks that are returned from the REST API.
+-   `failure_metadata_tags`: an optional set of tags to attribute to the command if it fails. If these are set and the
+    command fails, the tags will appear in the task details returned from the REST API.
 -   `params`: values for the pre defined set of parameters the command can take. Available parameters vary per command.
 
 

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -10,6 +10,7 @@ Project Commands are the fundamental units of functionality in an Evergreen task
   type: system ## optional
   timeout_secs: 10 ## optional
   retry_on_failure: true ## optional
+  failure_metadata_tags: ["tag0", "tag1"] ## optional
   params:
     script: echo "my script"
 ```
@@ -23,6 +24,8 @@ Explanation:
     seconds.
 -   `retry_on_failure`: an optional field. If set to true, it will automatically restart the task upon failure. The
      automatic restart will process after the command has failed and the task has completed its subsequent post task commands.
+-   `failure_metadata_tags`: an optional set of tags to attribute to the command if it fails. if set, these tags will
+    appear in the task end data for failed tasks that are returned from the REST API.
 -   `params`: values for the pre defined set of parameters the command can take. Available parameters vary per command.
 
 

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -227,18 +227,18 @@ func (ad *ApiTaskEndDetail) ToService() apimodels.TaskEndDetail {
 }
 
 type APIFailingCommand struct {
-	Name                *string  `json:"name"`
+	FullDisplayName     *string  `json:"name"`
 	FailureMetadataTags []string `json:"failure_metadata_tags"`
 }
 
 func (afc *APIFailingCommand) BuildFromService(fc apimodels.FailingCommand) {
-	afc.Name = utility.ToStringPtr(fc.Name)
+	afc.FullDisplayName = utility.ToStringPtr(fc.FullDisplayName)
 	afc.FailureMetadataTags = fc.FailureMetadataTags
 }
 
 func (afc *APIFailingCommand) ToService() apimodels.FailingCommand {
 	return apimodels.FailingCommand{
-		Name:                utility.FromStringPtr(afc.Name),
+		FullDisplayName:     utility.FromStringPtr(afc.FullDisplayName),
 		FailureMetadataTags: afc.FailureMetadataTags,
 	}
 }

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -172,9 +172,12 @@ type ApiTaskEndDetail struct {
 	// PostErrored is true when the post command errored.
 	PostErrored bool `json:"post_errored"`
 	// FailureMetadataTags contains the metadata tags associated with the
-	// failing command.
-	FailureMetadataTags  []string            `json:"failing_command_metadata_tags"`
-	OtherFailingCommands []APIFailingCommand `json:"other_failing_commands"`
+	// command that caused the task to fail. These are not set if the task
+	// succeeded.
+	FailureMetadataTags []string `json:"failure_metadata_tags"`
+	// OtherFailingCommands contain information about commands that failed but
+	// did not cause the task to fail.
+	OtherFailingCommands []APIFailingCommand `json:"other_failing_commands,omitempty"`
 	// Whether this task ended in a timeout.
 	TimedOut    bool              `json:"timed_out"`
 	TimeoutType *string           `json:"timeout_type"`
@@ -226,9 +229,13 @@ func (ad *ApiTaskEndDetail) ToService() apimodels.TaskEndDetail {
 	}
 }
 
+// APIFailingCommand represents information about a command that failed in a
+// task.
 type APIFailingCommand struct {
-	FullDisplayName     *string  `json:"name"`
-	FailureMetadataTags []string `json:"failure_metadata_tags"`
+	// FullDisplayName is the full display name of the failing command.
+	FullDisplayName *string `json:"full_display_name,omitempty"`
+	// FailureMetadataTags are tags associated with the failing command.
+	FailureMetadataTags []string `json:"failure_metadata_tags,omitempty"`
 }
 
 func (afc *APIFailingCommand) BuildFromService(fc apimodels.FailingCommand) {


### PR DESCRIPTION
DEVPROD-5122

### Description
Follow-up to #7880. That PR added support to show user-defined tags in the REST API for the command that causes the task to fail. This PR supports showing those user-defined tags for commands that fail but don't cause the task to fail. For example, a post command that fails with `post_error_fails_task: false` will appear in the list of other failed commands, along with its tags (if any). On top of just showing command tags, this feature could also be more generally used to more easily deduce out which commands in the task failed (rather than scroll through all the task logs for failed commands).

Note that the list of failed commands could be quite long depending on how much people are relying on pre/post to continue on error. I don't think it would be problematic though because there's only so many commands that can run in a task and REST API users can simply ignore them if they're not interested.

### Testing
* Added unit tests.
* Tested in staging with a patch to verify that the tags show up when a command fails (even though the task succeeds), and the tags don't appear if the command succeeds.

### Documentation
Updated docs and updated REST API documentation, which will appear in Pine.