### PR TITLE
DEVPROD-7496: add more logging for next task teardown

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -228,10 +228,14 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	if nextTask == nil {
 		// we found a task, but it's not part of the task group so we didn't assign it
 		if shouldRunTeardown {
+			// kim: NOTE: this logged after the 4th task in the TG
+			// (integration_tests_replset), so assignNextAvailableTask thought
+			// it was the end of the task group and that teardown should run.
 			grip.Info(message.Fields{
-				"op":      "next_task",
-				"message": "host task group finished, not assigning task",
-				"host_id": h.host.Id,
+				"op":         "next_task",
+				"message":    "host task group finished, not assigning task and instead requesting host to run teardown group",
+				"host_id":    h.host.Id,
+				"task_group": h.details.TaskGroup,
 			})
 			err = h.host.SetTaskGroupTeardownStartTime(ctx)
 			if err != nil {
@@ -350,6 +354,8 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 	var amiUpdatedTime time.Time
 	if d.GetDefaultAMI() != currentHost.GetAMI() {
+		// kim: NOTE: AMI did not change during this time, so this is
+		// irrelevant to the bug.
 		amiEvent, err := event.FindLatestAMIModifiedDistroEvent(d.Id)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "problem getting AMI event log",
@@ -445,6 +451,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 			"message":            "could not find project ref for next task, skipping",
 			"project":            nextTask.Project,
 			"host_id":            currentHost.Id,
+			"distro_id":          d.Id,
 			"task_group":         nextTask.TaskGroup,
 			"task_build_variant": nextTask.BuildVariant,
 			"task_version":       nextTask.Version,
@@ -503,16 +510,22 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// If the current task group is finished we leave the task on the queue, and indicate the current group needs to be torn down.
 		if details.TaskGroup != "" && details.TaskGroup != nextTask.TaskGroup {
-			grip.DebugWhen(nextTask.TaskGroup != "", message.Fields{
-				"message":              "not updating running task group task, because current group needs to be torn down",
+			// kim: NOTE: this debug did not log, which suggests that this did
+			// not run. If it did, the 5th TG task would have triggered this
+			// debug log because the task doc has a task group.
+			grip.Debug(message.Fields{
+				"message":              "next task is a standalone task or part of a different task group; not updating running task group task, because current task group needs to be torn down",
+				"current_task_group":   details.TaskGroup,
 				"task_distro_id":       nextTask.DistroId,
 				"task_id":              nextTask.Id,
-				"task_group":           nextTask.TaskGroup,
+				"next_task_group":      nextTask.TaskGroup,
 				"task_build_variant":   nextTask.BuildVariant,
 				"task_version":         nextTask.Version,
 				"task_project":         nextTask.Project,
 				"task_group_max_hosts": nextTask.TaskGroupMaxHosts,
 			})
+			// kim: NOTE: this is a case that returns nil, true to indicate that
+			// there's no next task and it should start teardown group.
 			return nil, true, nil
 		}
 
@@ -579,16 +592,26 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 			"task_id":        nextTask.Id,
 			"task_execution": nextTask.Execution,
 			"host_id":        currentHost.Id,
+			"distro_id":      d.Id,
 		}))
 
 		return nextTask, false, nil
 	}
 
 	if taskQueue.Length() == 0 && details.TaskGroup != "" {
-		// if we have reached the end of the queue and the previous task was part of a task group,
+		grip.Debug(message.Fields{
+			"message":           "task queue is empty while task group is running, meaning there are no task group tasks remaining and the host should run teardown group",
+			"task_group":        details.TaskGroup,
+			"host_id":           currentHost.Id,
+			"distro_id":         d.Id,
+			"task_queue_is_nil": taskQueue == nil,
+			"task_queue":        fmt.Sprintf("%#v", taskQueue),
+		})
+		// If we have reached the end of the queue and the previous task was part of a task group,
 		// the current task group is finished and needs to be torn down.
+		// kim: NOTE: this is a case that returns nil, true to indicate that
+		// there's no next task and it should start teardown group.
 		return nil, true, nil
-
 	}
 
 	return nil, false, nil

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -228,9 +228,6 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	if nextTask == nil {
 		// we found a task, but it's not part of the task group so we didn't assign it
 		if shouldRunTeardown {
-			// kim: NOTE: this logged after the 4th task in the TG
-			// (integration_tests_replset), so assignNextAvailableTask thought
-			// it was the end of the task group and that teardown should run.
 			grip.Info(message.Fields{
 				"op":         "next_task",
 				"message":    "host task group finished, not assigning task and instead requesting host to run teardown group",
@@ -354,8 +351,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 	var amiUpdatedTime time.Time
 	if d.GetDefaultAMI() != currentHost.GetAMI() {
-		// kim: NOTE: AMI did not change during this time, so this is
-		// irrelevant to the bug.
 		amiEvent, err := event.FindLatestAMIModifiedDistroEvent(d.Id)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "problem getting AMI event log",
@@ -510,9 +505,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// If the current task group is finished we leave the task on the queue, and indicate the current group needs to be torn down.
 		if details.TaskGroup != "" && details.TaskGroup != nextTask.TaskGroup {
-			// kim: NOTE: this debug did not log, which suggests that this did
-			// not run. If it did, the 5th TG task would have triggered this
-			// debug log because the task doc has a task group.
 			grip.Debug(message.Fields{
 				"message":              "next task is a standalone task or part of a different task group; not updating running task group task, because current task group needs to be torn down",
 				"current_task_group":   details.TaskGroup,
@@ -524,8 +516,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 				"task_project":         nextTask.Project,
 				"task_group_max_hosts": nextTask.TaskGroupMaxHosts,
 			})
-			// kim: NOTE: this is a case that returns nil, true to indicate that
-			// there's no next task and it should start teardown group.
 			return nil, true, nil
 		}
 
@@ -609,8 +599,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		})
 		// If we have reached the end of the queue and the previous task was part of a task group,
 		// the current task group is finished and needs to be torn down.
-		// kim: NOTE: this is a case that returns nil, true to indicate that
-		// there's no next task and it should start teardown group.
 		return nil, true, nil
 	}
 


### PR DESCRIPTION
DEVPROD-7496
[BF-31821](https://jira.mongodb.org/browse/BF-31821)

### Description
Despite the comments in the BF, the reoccurence of this BF is due to a bug that's not related to the original host decommissioning bug. This time, the host ran 4 tasks in the task group. When it requested the next task, it should have received the 5th task in the task group, but [according to Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1714837320&latest=1714837380&q=search%20index%3Devergreen%20i-0dc02d730e25c0db6&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&sid=1716324343.22093443), it actually got an indication that there were no more task group tasks to run. Because of this, it ran teardown group and moved onto a new standalone task (the later task group tasks ran a few hours afterwards on a different host and failed).

Unfortunately, I don't have enough info to continue investigating and I can't reproduce it in staging. The task doc for the 4th and 5th tasks appear to be normal and both are part of the same task group. All I did was add logging so if this BF recurs, we can re-investigate then.

### Testing
Tested in staging to verify that the logging looks reasonable if this recurs.

### Documentation
N/A