### PR TITLE
DEVPROD-5918 Add log when using local tasks for patch

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-05-17"
+	ClientVersion = "2024-05-22a"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-05-22a"
+	ClientVersion = "2024-05-23"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -201,9 +201,6 @@ func Patch() cli.Command {
 			if hasVariants && !hasTasks {
 				grip.Warningf("warning - you specified variants without specifying tasks")
 			}
-			if hasVariants && hasTasks {
-				grip.Infof("Submitting patch with locally defined tasks and variants")
-			}
 
 			isReusing := params.RepeatDefinition || params.RepeatFailed
 			hasTasksOrVariants := len(params.Tasks) > 0 || len(params.Variants) > 0

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -201,6 +201,9 @@ func Patch() cli.Command {
 			if hasVariants && !hasTasks {
 				grip.Warningf("warning - you specified variants without specifying tasks")
 			}
+			if hasVariants && hasTasks {
+				grip.Infof("Submitting patch with locally defined tasks and variants")
+			}
 
 			isReusing := params.RepeatDefinition || params.RepeatFailed
 			hasTasksOrVariants := len(params.Tasks) > 0 || len(params.Variants) > 0

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -454,8 +454,16 @@ func (p *patchParams) loadTasks(conf *ClientSettings) error {
 				return errors.Wrap(err, "setting default tasks")
 			}
 		}
+		if len(defaultTasks) > 0 {
+			grip.Info("Using default tasks set in local config")
+		}
 	} else if p.Alias == "" && !p.isUsingLocalAlias {
-		p.Tasks = conf.FindDefaultTasks(p.Project)
+		defaultTasks := conf.FindDefaultTasks(p.Project)
+		p.Tasks = defaultTasks
+		if len(defaultTasks) > 0 {
+			grip.Info("Using default tasks set in local config")
+		}
+
 	}
 
 	return nil

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -395,6 +395,7 @@ func (p *patchParams) loadAlias(conf *ClientSettings) error {
 	} else if len(p.Variants) == 0 || len(p.Tasks) == 0 {
 		// No --alias or variant/task pair was passed, use the default
 		p.Alias = conf.FindDefaultAlias(p.Project)
+		grip.InfoWhen(p.Alias != "", "Using default alias set in local config")
 	}
 
 	return nil
@@ -413,6 +414,7 @@ func (p *patchParams) loadVariants(conf *ClientSettings) error {
 		}
 	} else if p.Alias == "" && !p.isUsingLocalAlias {
 		p.Variants = conf.FindDefaultVariants(p.Project)
+		grip.InfoWhen(len(p.Variants) > 0, "Using default variants set in local config")
 	}
 
 	return nil
@@ -454,15 +456,9 @@ func (p *patchParams) loadTasks(conf *ClientSettings) error {
 				return errors.Wrap(err, "setting default tasks")
 			}
 		}
-		if len(defaultTasks) > 0 {
-			grip.Info("Using default tasks set in local config")
-		}
 	} else if p.Alias == "" && !p.isUsingLocalAlias {
-		defaultTasks := conf.FindDefaultTasks(p.Project)
-		p.Tasks = defaultTasks
-		if len(defaultTasks) > 0 {
-			grip.Info("Using default tasks set in local config")
-		}
+		p.Tasks = conf.FindDefaultTasks(p.Project)
+		grip.InfoWhen(len(p.Tasks) > 0, "Using default tasks set in local config")
 
 	}
 


### PR DESCRIPTION
DEVPROD-5918

### Description
user was receiving errors while trying to patch with default tasks and variants in local evergreen settings. 
this just logs that local tasks are being used 

### Testing
locally tested with user's case 

<img width="1221" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/a794a6db-39ae-446b-91dc-c21416181f17">
