### PR TITLE
DEVPROD-6951 update cocoa

### DIFF
--- a/cloud/pod_util_test.go
+++ b/cloud/pod_util_test.go
@@ -28,7 +28,6 @@ func TestMakeECSClient(t *testing.T) {
 		c, err := MakeECSClient(ctx, validPodClientSettings())
 		assert.NoError(t, err)
 		assert.NotZero(t, c)
-		assert.NoError(t, c.Close(ctx))
 	})
 }
 
@@ -40,7 +39,6 @@ func TestMakeSecretsManagerClient(t *testing.T) {
 		c, err := MakeSecretsManagerClient(ctx, validPodClientSettings())
 		assert.NoError(t, err)
 		assert.NotZero(t, c)
-		assert.NoError(t, c.Close(ctx))
 	})
 }
 
@@ -129,14 +127,8 @@ func TestExportECSPod(t *testing.T) {
 			}
 			ecsClient, err := MakeECSClient(ctx, validPodClientSettings())
 			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, ecsClient.Close(ctx))
-			}()
 			smClient, err := MakeSecretsManagerClient(ctx, validPodClientSettings())
 			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, smClient.Close(ctx))
-			}()
 			vault, err := MakeSecretsManagerVault(smClient)
 			require.NoError(t, err)
 
@@ -567,16 +559,10 @@ func TestGetFilteredResourceIDs(t *testing.T) {
 	defer cocoaMock.ResetGlobalSecretCache()
 
 	tagClient := &cocoaMock.TagClient{}
-	defer func() {
-		tagClient.Close(ctx)
-	}()
 
 	sc := &NoopSecretCache{Tag: "cache-tag"}
 
 	smClient := &cocoaMock.SecretsManagerClient{}
-	defer func() {
-		smClient.Close(ctx)
-	}()
 	v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().
 		SetClient(smClient).
 		SetCache(sc))

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20220408180137-e70afe67cc1b
-	github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0
+	github.com/evergreen-ci/cocoa v0.0.0-20240523192623-2e730fcd1784
 	github.com/evergreen-ci/gimlet v0.0.0-20240426164856-8c2db742f7b0
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
 	github.com/evergreen-ci/pail v0.0.0-20240503141904-b600c21b5f20

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/evergreen-ci/bond v0.0.0-20220411194221-3710ea2ac361 h1:ku4xLg9Sd1LVk
 github.com/evergreen-ci/bond v0.0.0-20220411194221-3710ea2ac361/go.mod h1:El8TbR7WK0E0Saj4qDx6leFK0IwW7tgMb6DnJ4WwSOI=
 github.com/evergreen-ci/certdepot v0.0.0-20220408180137-e70afe67cc1b h1:NlIvWEtubWsc/15rUdIvHagQWhwbpnX1m65luMJAB9I=
 github.com/evergreen-ci/certdepot v0.0.0-20220408180137-e70afe67cc1b/go.mod h1:Q8u+ffRb4TPqiRpizwdrq7+MKXdoXTvtbAx4++g7rnE=
-github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0 h1:q065j1sPZ2dwI+0jxcveTBHMh/xT6o/h3riJxjEN9Tc=
-github.com/evergreen-ci/cocoa v0.0.0-20230918160723-69a3ef4b69a0/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
+github.com/evergreen-ci/cocoa v0.0.0-20240523192623-2e730fcd1784 h1:kMBy+4X0yEPNG3/2fCo6PhvlqLP0K4UjFdRcxAwHOQ0=
+github.com/evergreen-ci/cocoa v0.0.0-20240523192623-2e730fcd1784/go.mod h1:FDr7ryMJV8Z7y0IdBQbJmGbzKa++WUGVDmgjlpm2L18=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57 h1:CIUR6i5YWJ/z5RbZ11UomO7aZxQjeHqAjOqGwPh7sCY=
 github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lbmNkNEkJEuhIdctIEbJhx4hMzjRvbUg172mQRvNnKo=
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=

--- a/rest/data/pod.go
+++ b/rest/data/pod.go
@@ -26,7 +26,6 @@ func CreatePod(apiPod model.APICreatePod) (*model.APICreatePodResponse, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "getting Secrets Manager client")
 		}
-		defer smClient.Close(ctx)
 
 		v, err := cloud.MakeSecretsManagerVault(smClient)
 		if err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -173,7 +173,6 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	if err != nil {
 		return errors.Wrap(err, "setting up Secrets Manager client to store newly-created project's container secrets")
 	}
-	defer smClient.Close(ctx)
 
 	vault, err := cloud.MakeSecretsManagerVault(smClient)
 	if err != nil {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -1030,9 +1030,6 @@ func TestCopyProject(t *testing.T) {
 	defer cocoaMock.ResetGlobalSecretCache()
 
 	smClient := &cocoaMock.SecretsManagerClient{}
-	defer func() {
-		assert.NoError(t, smClient.Close(ctx))
-	}()
 
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		"SuccessfullyCopiesProject": func(t *testing.T, ref model.ProjectRef) {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -413,9 +413,6 @@ func TestCreateProject(t *testing.T) {
 	}()
 
 	smClient := &cocoaMock.SecretsManagerClient{}
-	defer func() {
-		assert.NoError(t, smClient.Close(ctx))
-	}()
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, pRef model.ProjectRef, u user.DBUser){
 		"Succeeds": func(ctx context.Context, t *testing.T, env *mock.Environment, pRef model.ProjectRef, u user.DBUser) {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -503,7 +503,6 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "initializing Secrets Manager client"))
 		}
-		defer smClient.Close(ctx)
 		v, err := cloud.MakeSecretsManagerVault(smClient)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "initializing Secrets Manager vault"))

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -442,9 +442,6 @@ func (s *ProjectPatchByIDSuite) TestRotateAndDeleteProjectPodSecret() {
 
 	smClient, err := cloud.MakeSecretsManagerClient(ctx, s.env.Settings())
 	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(smClient.Close(ctx))
-	}()
 	vault, err := cloud.MakeSecretsManagerVault(smClient)
 	s.Require().NoError(err)
 

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -572,7 +572,6 @@ func (sns *ecsSNS) cleanupUnrecognizedPod(ctx context.Context, detail ecsTaskEve
 	if err != nil {
 		return errors.Wrap(err, "getting ECS client")
 	}
-	defer c.Close(ctx)
 
 	resources := cocoa.NewECSPodResources().
 		SetCluster(detail.ClusterARN).
@@ -626,7 +625,6 @@ func (sns *ecsSNS) listECSTasks(ctx context.Context, details ecsContainerInstanc
 	if err != nil {
 		return nil, errors.Wrap(err, "getting ECS client")
 	}
-	defer c.Close(ctx)
 
 	var token *string
 	var taskARNs []string

--- a/units/container_secret_cleanup.go
+++ b/units/container_secret_cleanup.go
@@ -58,13 +58,6 @@ func NewContainerSecretCleanupJob(id string) amboy.Job {
 func (j *containerSecretCleanupJob) Run(ctx context.Context) {
 	defer func() {
 		j.MarkComplete()
-
-		if j.smClient != nil {
-			j.AddError(errors.Wrap(j.smClient.Close(ctx), "closing Secrets Manager client"))
-		}
-		if j.tagClient != nil {
-			j.AddError(errors.Wrap(j.tagClient.Close(ctx), "closing tag client"))
-		}
 	}()
 	if err := j.populate(ctx); err != nil {
 		j.AddError(err)

--- a/units/container_secret_cleanup_test.go
+++ b/units/container_secret_cleanup_test.go
@@ -111,13 +111,7 @@ func TestContainerSecretCleanupJob(t *testing.T) {
 			j, ok := NewContainerSecretCleanupJob(utility.RoundPartOfHour(0).Format(TSFormat)).(*containerSecretCleanupJob)
 			require.True(t, ok)
 			j.tagClient = &cocoaMock.TagClient{}
-			defer func() {
-				assert.NoError(t, j.tagClient.Close(tctx))
-			}()
 			j.smClient = &cocoaMock.SecretsManagerClient{}
-			defer func() {
-				assert.NoError(t, j.smClient.Close(tctx))
-			}()
 			v, err := secret.NewBasicSecretsManager(*secret.NewBasicSecretsManagerOptions().
 				SetClient(j.smClient).
 				SetCache(&cloud.NoopSecretCache{Tag: model.ContainerSecretTag}))

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -72,10 +72,6 @@ func NewPodAllocatorJob(taskID, ts string) amboy.Job {
 func (j *podAllocatorJob) Run(ctx context.Context) {
 	defer func() {
 		j.MarkComplete()
-
-		if j.smClient != nil {
-			j.AddError(errors.Wrap(j.smClient.Close(ctx), "closing Secrets Manager client"))
-		}
 	}()
 
 	canAllocate, err := j.systemCanAllocate(ctx)

--- a/units/pod_creation.go
+++ b/units/pod_creation.go
@@ -75,10 +75,6 @@ func (j *podCreationJob) Run(ctx context.Context) {
 	defer func() {
 		j.MarkComplete()
 
-		if j.ecsClient != nil {
-			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
-		}
-
 		if j.pod != nil && j.pod.Status == pod.StatusInitializing && (j.RetryInfo().GetRemainingAttempts() == 0 || !j.RetryInfo().ShouldRetry()) {
 			j.AddError(errors.Wrap(j.pod.UpdateStatus(pod.StatusDecommissioned, "pod failed to start and will not retry"), "updating pod status to decommissioned after pod failed to start"))
 

--- a/units/pod_creation_test.go
+++ b/units/pod_creation_test.go
@@ -189,9 +189,6 @@ func TestPodCreationJob(t *testing.T) {
 			j.env = env
 
 			j.ecsClient = &cocoaMock.ECSClient{}
-			defer func() {
-				assert.NoError(t, j.ecsClient.Close(tctx))
-			}()
 			pc, err := cloud.MakeECSPodCreator(j.ecsClient, nil)
 			require.NoError(t, err)
 			j.ecsPodCreator = cocoaMock.NewECSPodCreator(pc)

--- a/units/pod_definition_cleanup.go
+++ b/units/pod_definition_cleanup.go
@@ -61,10 +61,6 @@ func NewPodDefinitionCleanupJob(id string) amboy.Job {
 func (j *podDefinitionCleanupJob) Run(ctx context.Context) {
 	defer func() {
 		j.MarkComplete()
-
-		if j.ecsClient != nil {
-			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
-		}
 	}()
 	if err := j.populate(ctx); err != nil {
 		j.AddError(err)

--- a/units/pod_definition_cleanup_test.go
+++ b/units/pod_definition_cleanup_test.go
@@ -239,13 +239,7 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 			j.env = env
 
 			j.ecsClient = &cocoaMock.ECSClient{}
-			defer func() {
-				assert.NoError(t, j.ecsClient.Close(tctx))
-			}()
 			j.tagClient = &cocoaMock.TagClient{}
-			defer func() {
-				assert.NoError(t, j.tagClient.Close(tctx))
-			}()
 
 			pdm, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
 			require.NoError(t, err)

--- a/units/pod_definition_creation.go
+++ b/units/pod_definition_creation.go
@@ -75,20 +75,11 @@ func (j *podDefinitionCreationJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	defer func() {
-		if j.ecsClient != nil {
-			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
-		}
-
 		if j.HasErrors() && (!j.RetryInfo().ShouldRetry() || j.RetryInfo().GetRemainingAttempts() == 0) {
 			j.AddError(errors.Wrap(j.decommissionDependentIntentPods(), "decommissioning intent pods after pod definition creation failed"))
 		}
 	}()
 
-	defer func() {
-		if j.ecsClient != nil {
-			j.AddError(j.ecsClient.Close(ctx))
-		}
-	}()
 	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddRetryableError(err)
 		return

--- a/units/pod_definition_creation_test.go
+++ b/units/pod_definition_creation_test.go
@@ -216,9 +216,6 @@ func TestPodDefinitionCreationJob(t *testing.T) {
 			require.NoError(t, evergreen.UpdateConfig(ctx, env.Settings()))
 
 			j.ecsClient = &cocoaMock.ECSClient{}
-			defer func() {
-				assert.NoError(t, j.ecsClient.Close(tctx))
-			}()
 
 			pdm, err := cloud.MakeECSPodDefinitionManager(j.ecsClient, nil)
 			require.NoError(t, err)

--- a/units/pod_health_check.go
+++ b/units/pod_health_check.go
@@ -84,12 +84,6 @@ func (j *podHealthCheckJob) Run(ctx context.Context) {
 		return
 	}
 
-	defer func() {
-		if j.ecsClient != nil {
-			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
-		}
-	}()
-
 	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddError(err)
 		return

--- a/units/pod_health_check_test.go
+++ b/units/pod_health_check_test.go
@@ -105,9 +105,6 @@ func TestPodHealthCheckJob(t *testing.T) {
 			require.True(t, ok)
 			j.env = env
 			j.ecsClient = &cocoaMock.ECSClient{}
-			defer func() {
-				assert.NoError(t, j.ecsClient.Close(tctx))
-			}()
 			j.pod = &p
 
 			j.ecsPod = generateTestingECSPod(tctx, t, j.ecsClient, cluster, p.TaskContainerCreationOpts)

--- a/units/pod_termination.go
+++ b/units/pod_termination.go
@@ -73,12 +73,6 @@ func NewPodTerminationJob(podID, reason string, ts time.Time) amboy.Job {
 
 func (j *podTerminationJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
-
-	defer func() {
-		if j.ecsClient != nil {
-			j.AddError(errors.Wrap(j.ecsClient.Close(ctx), "closing ECS client"))
-		}
-	}()
 	if err := j.populateIfUnset(ctx); err != nil {
 		j.AddError(err)
 		return

--- a/units/pod_termination_test.go
+++ b/units/pod_termination_test.go
@@ -380,9 +380,6 @@ func TestPodTerminationJob(t *testing.T) {
 			require.NoError(t, env.Configure(tctx))
 			j.env = env
 			j.ecsClient = &cocoaMock.ECSClient{}
-			defer func() {
-				assert.NoError(t, j.ecsClient.Close(tctx))
-			}()
 			j.ecsPod = generateTestingECSPod(tctx, t, j.ecsClient, cluster, p.TaskContainerCreationOpts)
 			j.pod.Resources = cloud.ImportECSPodResources(j.ecsPod.Resources())
 


### PR DESCRIPTION
[DEVPROD-6951](https://jira.mongodb.org/browse/DEVPROD-6951)

### Description
Get [the changes to cache the config](https://github.com/evergreen-ci/cocoa/commit/2e730fcd1784daf69d07b1471ce05f95135f1d7d).
If the tests pass I will merge this PR without a review, unless someone would like to review it.

### Testing
Ran [a container task](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2004_container_test_auth_39d037e57cca47901275f980374d155d1f55db58_24_05_22_20_28_20/tests?execution=1&sortBy=STATUS&sortDir=ASC) on staging. It ran smoothly and I didn't see any errors in Splunk.
