### PR TITLE
DEVPROD-7550: fix calculating next stop time when editing schedule

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -765,7 +765,7 @@ func (r *mutationResolver) EditSpawnHost(ctx context.Context, spawnHost *EditSpa
 
 	if spawnHost.SleepSchedule != nil {
 
-		if err = h.UpdateSleepSchedule(ctx, *spawnHost.SleepSchedule); err != nil {
+		if err = h.UpdateSleepSchedule(ctx, *spawnHost.SleepSchedule, time.Now()); err != nil {
 			gimletErr, ok := err.(gimlet.ErrorResponse)
 			if ok {
 				return nil, mapHTTPStatusToGqlError(ctx, gimletErr.StatusCode, err)
@@ -815,7 +815,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, InternalServerError.Send(ctx, "An error occurred Spawn host is nil")
 	}
 	if spawnHostInput.SleepSchedule != nil {
-		if err = spawnHost.UpdateSleepSchedule(ctx, *spawnHostInput.SleepSchedule); err != nil {
+		if err = spawnHost.UpdateSleepSchedule(ctx, *spawnHostInput.SleepSchedule, time.Now()); err != nil {
 			gimletErr, ok := err.(gimlet.ErrorResponse)
 			if ok {
 				return nil, mapHTTPStatusToGqlError(ctx, gimletErr.StatusCode, err)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3625,7 +3625,7 @@ func (h *Host) UnsetPersistentDNSInfo(ctx context.Context) error {
 // contain all the unmodified fields. For example, if this host is on a
 // temporary exemption when their daily schedule is updated, the new schedule
 // must still have the temporary exemption populated.
-func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleInfo) error {
+func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleInfo, now time.Time) error {
 	if err := schedule.Validate(); err != nil {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -3638,8 +3638,6 @@ func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleIn
 	schedule.NextStartTime = time.Time{}
 	schedule.NextStopTime = time.Time{}
 
-	now := time.Now()
-	var err error
 	nextStart, err := schedule.GetNextScheduledStartTime(now)
 	if err != nil {
 		return gimlet.ErrorResponse{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3657,8 +3657,6 @@ func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleIn
 	// calculating both the next start and next stop times. If the next start
 	// time is set first on the schedule, the next stop time can be pushed
 	// further into the future than necessary.
-	// kim: TODO: add test for next stop set based on now rather than next
-	// start.
 	schedule.NextStartTime = nextStart
 	schedule.NextStopTime = nextStop
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6298,7 +6298,7 @@ func TestUpdateSleepSchedule(t *testing.T) {
 				TimeZone:       userTZ.String(),
 			}
 
-			require.NoError(t, h.UpdateSleepSchedule(ctx, s))
+			require.NoError(t, h.UpdateSleepSchedule(ctx, s, now))
 
 			dbHost, err := FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -6333,7 +6333,7 @@ func TestUpdateSleepSchedule(t *testing.T) {
 				TimeZone:       userTZ.String(),
 			}
 
-			require.NoError(t, h.UpdateSleepSchedule(ctx, s))
+			require.NoError(t, h.UpdateSleepSchedule(ctx, s, now))
 
 			dbHost, err := FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -6372,7 +6372,7 @@ func TestUpdateSleepSchedule(t *testing.T) {
 				TemporarilyExemptUntil: temporarilyExemptUntil,
 			}
 
-			require.NoError(t, h.UpdateSleepSchedule(ctx, s))
+			require.NoError(t, h.UpdateSleepSchedule(ctx, s, now))
 
 			dbHost, err := FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -6386,15 +6386,49 @@ func TestUpdateSleepSchedule(t *testing.T) {
 			assert.True(t, temporarilyExemptUntil.Equal(dbHost.SleepSchedule.TemporarilyExemptUntil))
 			assert.False(t, dbHost.SleepSchedule.ShouldKeepOff)
 		},
+		"NextStartAndStopTimesIsBasedOnCurrentTime": func(ctx context.Context, t *testing.T, h *Host) {
+			require.NoError(t, h.Insert(ctx))
+
+			const easternTZ = "America/New_York"
+			easternTZLoc, err := time.LoadLocation(easternTZ)
+			require.NoError(t, err)
+
+			// Simulate the current time, which is:
+			// Wednesday February 21, 2024 at 15:00 EST
+			now, err := time.ParseInLocation(time.DateTime, "2024-02-21 15:00:00", easternTZLoc)
+			require.NoError(t, err)
+			now = utility.BSONTime(now.UTC())
+
+			s := SleepScheduleInfo{
+				DailyStartTime: "10:00",
+				DailyStopTime:  "18:00",
+				TimeZone:       userTZ.String(),
+			}
+
+			require.NoError(t, h.UpdateSleepSchedule(ctx, s, now))
+
+			dbHost, err := FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			checkRecurringSleepScheduleMatches(t, s, dbHost.SleepSchedule)
+
+			expectedNextStartTime, err := time.ParseInLocation(time.DateTime, "2024-02-22 10:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStartTime, dbHost.SleepSchedule.NextStartTime, 0, "next start time should be at 10:00 local time on the next day")
+
+			expectedNextStopTime, err := time.ParseInLocation(time.DateTime, "2024-02-21 18:00:00", easternTZLoc)
+			require.NoError(t, err)
+			assert.WithinDuration(t, expectedNextStopTime, dbHost.SleepSchedule.NextStopTime, 0, "next stop time should be at 18:00 local time on the same day")
+		},
 		"FailsWithZeroSleepSchedule": func(ctx context.Context, t *testing.T, h *Host) {
 			require.NoError(t, h.Insert(ctx))
-			assert.Error(t, h.UpdateSleepSchedule(ctx, SleepScheduleInfo{}))
+			assert.Error(t, h.UpdateSleepSchedule(ctx, SleepScheduleInfo{}, time.Now()))
 		},
 		"FailsWithInvalidSleepSchedule": func(ctx context.Context, t *testing.T, h *Host) {
 			require.NoError(t, h.Insert(ctx))
 			assert.Error(t, h.UpdateSleepSchedule(ctx, SleepScheduleInfo{
 				DailyStartTime: "10:00",
-			}))
+			}, time.Now()))
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-7550

### Description
Fix a bug where the sleep schedule's next stop time might be bumped too far in the future because the next start time is set on the schedule first. Both next start and next stop should be based on the current moment. For example, if it's 3pm right now and the user sets the host to a 9am - 5pm schedule, the next stop should logically be at 5pm today. However, the prior logic would set the next stop to 5pm tomorrow because it looked for a next stop time after the next start time (which is at 9am tomorrow).

### Testing
Added unit test.

### Documentation
N/A