### PR TITLE
DEVPROD-7549: error if creating sleep schedule that is always off

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -396,6 +396,7 @@ func (i *SleepScheduleInfo) Validate() error {
 
 	catcher := grip.NewBasicCatcher()
 
+	catcher.NewWhen(len(i.WholeWeekdaysOff) == 7, "cannot create a sleep schedule where the host is off 24/7 since the host could never turn on")
 	catcher.NewWhen(len(i.WholeWeekdaysOff) == 0 && i.DailyStartTime == "" && i.DailyStopTime == "", "cannot specify an empty sleep schedule that's missing both daily stop/start time and whole days off")
 	catcher.NewWhen(i.TimeZone == "", "sleep schedule time zone must be set")
 	catcher.ErrorfWhen(i.DailyStopTime != "" && i.DailyStartTime == "", "cannot specify a daily stop time without a daily start time")

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6272,6 +6272,12 @@ func TestSleepScheduleInfoValidate(t *testing.T) {
 			TimeZone:         "America/New_York",
 		}).Validate())
 	})
+	t.Run("FailsWithAllWeekdaysOff", func(t *testing.T) {
+		assert.Error(t, (&SleepScheduleInfo{
+			WholeWeekdaysOff: []time.Weekday{time.Sunday, time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday, time.Saturday},
+			TimeZone:         "America/New_York",
+		}).Validate())
+	})
 }
 
 func TestUpdateSleepSchedule(t *testing.T) {


### PR DESCRIPTION
DEVPROD-7549

### Description
Explicitly prevent users from selecting a sleep schedule where the host is off 24/7. While this kind of schedule sounds kind of similar to the option to keep a host off indefinitely when stopping it, it's not really the same because the option to keep a host indefinitely off just means it'll stay off (and ignore the sleep schedule waking hours) until the user chooses to turn it back on. In contrast, a schedule that keeps a host off 24/7 means it should never be awake, and would logically prevent the user from ever turning on their host.

### Testing
* Tested in staging that trying to set this schedule from the UI produced a validation error.
* Added unit test.

### Documentation
N/A