### PR TITLE
DEVPROD-5978 Add intersection function for GitHub dynamic access token permission groups

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -210,6 +210,14 @@ func (p *GitHubDynamicTokenPermissionGroup) Intersection(other GitHubDynamicToke
 		intersectionGroup.AllPermissions = true
 		return intersectionGroup, nil
 	}
+	if p.AllPermissions {
+		intersectionGroup.Permissions = other.Permissions
+		return intersectionGroup, nil
+	}
+	if other.AllPermissions {
+		intersectionGroup.Permissions = p.Permissions
+		return intersectionGroup, nil
+	}
 
 	// To keep up to date with GitHub's different permissions,
 	// we use reflection to iterate over the fields of the struct.
@@ -243,17 +251,6 @@ func (p *GitHubDynamicTokenPermissionGroup) Intersection(other GitHubDynamicToke
 		catcher.Add(thirdparty.ValidateGitHubPermission(perm2))
 		if catcher.HasErrors() {
 			return GitHubDynamicTokenPermissionGroup{}, catcher.Resolve()
-		}
-
-		// If the first group is all permissions, set it to the second group to
-		// ensure that the intersection is just the second group.
-		if p.AllPermissions {
-			perm1 = perm2
-		}
-
-		// Same as above
-		if other.AllPermissions {
-			perm2 = perm1
 		}
 
 		mostRestrictivePermission := thirdparty.MostRestrictiveGitHubPermission(perm1, perm2)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -245,7 +245,6 @@ func (p *GitHubDynamicTokenPermissionGroup) Intersection(other GitHubDynamicToke
 		// If either are nil, that counts as the most restrictive
 		// permission (no permission).
 		if perm1 == nil || perm2 == nil {
-			intersection.Field(i).Set(reflect.ValueOf((*string)(nil)))
 			continue
 		}
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -152,7 +152,7 @@ type GitHubDynamicTokenPermissionGroup struct {
 	// If this is set to true, the Permissions field is ignored.
 	// If this is set to false, the Permissions field is used (and may be
 	// nil, representing no permissions).
-	AllPermissions bool `bson:"no_permissions,omitempty" json:"no_permissions,omitempty" yaml:"no_permissions,omitempty"`
+	AllPermissions bool `bson:"all_permissions,omitempty" json:"all_permissions,omitempty" yaml:"all_permissions,omitempty"`
 }
 
 // defaultGitHubTokenPermissionGroup is an empty, all permissions, group.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -150,7 +150,7 @@ type GitHubDynamicTokenPermissionGroup struct {
 	Permissions github.InstallationPermissions `bson:"permissions,omitempty" json:"permissions,omitempty" yaml:"permissions,omitempty"`
 	// AllPermissions is a flag that indicates that the group has all permissions.
 	// If this is set to true, the Permissions field is ignored.
-	// If this is set to false, the Permissions field is used (and may be all
+	// If this is set to false, the Permissions field is used (and may be
 	// nil, representing no permissions).
 	AllPermissions bool `bson:"no_permissions,omitempty" json:"no_permissions,omitempty" yaml:"no_permissions,omitempty"`
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -254,6 +254,10 @@ func (p *GitHubDynamicTokenPermissionGroup) Intersection(other GitHubDynamicToke
 		}
 
 		mostRestrictivePermission := thirdparty.MostRestrictiveGitHubPermission(perm1, perm2)
+
+		if mostRestrictivePermission == "" {
+			continue
+		}
 		intersection.Field(i).Set(reflect.ValueOf(&mostRestrictivePermission))
 	}
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1858,6 +1858,8 @@ func TestGithubPermissionGroups(t *testing.T) {
 		assert.Nil(intersection.Permissions.Followers, "nope1 and nope2 should be ignored and restrict to nil")
 		assert.Equal("read", utility.FromStringPtr(intersection.Permissions.Checks), "write and read should restrict to read when reversed")
 		assert.Equal("write", utility.FromStringPtr(intersection.Permissions.Metadata), "both write should restrict to write")
+
+		assert.Nil(intersection.Permissions.Emails, "an unspecified field should restrict to nil")
 	})
 
 	t.Run("Intersection of permissions with no permissions should return no permissions", func(t *testing.T) {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -435,7 +435,12 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 						},
 						restModel.APIGitHubDynamicTokenPermissionGroup{
 							Name:        utility.ToStringPtr("other-group"),
-							Permissions: map[string]string{}, // Should have NoPermissions set on the translated struct
+							Permissions: map[string]string{}, // Should have no permissions.
+						},
+						restModel.APIGitHubDynamicTokenPermissionGroup{
+							Name:           utility.ToStringPtr("all-group"),
+							Permissions:    map[string]string{},
+							AllPermissions: utility.TruePtr(), // Should have all permissions.
 						},
 					},
 					PRTestingEnabled: utility.FalsePtr(),
@@ -449,7 +454,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, pRefFromDB)
 			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups)
-			require.Len(t, pRefFromDB.GitHubDynamicTokenPermissionGroups, 2)
+			require.Len(t, pRefFromDB.GitHubDynamicTokenPermissionGroups, 3)
 
 			assert.Equal(t, "some-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Name)
 			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[0].Permissions)
@@ -457,7 +462,11 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 
 			assert.Equal(t, "other-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[1].Name)
 			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[1].Permissions)
-			assert.Equal(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[1].NoPermissions, true)
+			assert.Equal(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[1].AllPermissions, false)
+
+			assert.Equal(t, "all-group", pRefFromDB.GitHubDynamicTokenPermissionGroups[2].Name)
+			require.NotNil(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[2].Permissions)
+			assert.Equal(t, pRefFromDB.GitHubDynamicTokenPermissionGroups[2].AllPermissions, true)
 		},
 		"a commit queue document exists after the feature is turned on": func(t *testing.T, ref model.ProjectRef) {
 			oldRef := model.ProjectRef{

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -552,7 +552,7 @@ type APIGitHubDynamicTokenPermissionGroup struct {
 	// Permissions for the GitHub permission group.
 	Permissions map[string]string `json:"permissions"`
 	// AllPermissions is true if the group has all permissions.
-	// This would appear as an empty 'Permissions' map.
+	// The 'Permissions' map must be empty if 'AllPermissions' is true.
 	AllPermissions *bool `json:"all_permissions"`
 }
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -551,8 +551,10 @@ type APIGitHubDynamicTokenPermissionGroup struct {
 	Name *string `json:"name"`
 	// Permissions for the GitHub permission group.
 	Permissions map[string]string `json:"permissions"`
-	// AllPermissions is true if the group has all permissions.
-	// The 'Permissions' map must be empty if 'AllPermissions' is true.
+	// AllPermissions is a flag that indicates that the group has all permissions.
+	// If this is set to true, the Permissions field is ignored.
+	// If this is set to false, the Permissions field is used (and may be
+	// nil, representing no permissions).
 	AllPermissions *bool `json:"all_permissions"`
 }
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -551,6 +551,9 @@ type APIGitHubDynamicTokenPermissionGroup struct {
 	Name *string `json:"name"`
 	// Permissions for the GitHub permission group.
 	Permissions map[string]string `json:"permissions"`
+	// AllPermissions is true if the group has all permissions.
+	// This would appear as an empty 'Permissions' map.
+	AllPermissions *bool `json:"all_permissions"`
 }
 
 type APIGitHubDynamicTokenPermissionGroups []APIGitHubDynamicTokenPermissionGroup
@@ -575,7 +578,12 @@ func (p *APIGitHubDynamicTokenPermissionGroup) ToService() (model.GitHubDynamicT
 	if err != nil {
 		return group, errors.Wrap(err, "decoding GitHub permissions")
 	}
-	group.NoPermissions = len(metadata.Keys) == 0
+	// If the 'Permissions' map is empty and 'AllPermissions' is true, the group
+	// has all permissions.
+	group.AllPermissions = utility.FromBoolPtr(p.AllPermissions)
+	if group.AllPermissions && len(metadata.Keys) > 0 {
+		return group, errors.New("a group will all permissions must have no permissions set")
+	}
 	return group, nil
 }
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1558,7 +1558,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 
 // ValidateGitHubPermission checks if the given permission is a valid GitHub permission.
 func ValidateGitHubPermission(permission string) error {
-	if !utility.StringSliceContains(allGitHubPermissions, permission) {
+	if !utility.StringSliceContains(allGitHubPermissions, permission) && permission != "" {
 		return errors.Errorf("invalid GitHub permission '%s'", permission)
 	}
 	return nil

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1556,6 +1556,27 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 	return utility.StringSliceContains(githubWritePermissions, permissionLevel.GetPermission()), nil
 }
 
+func ValidateGitHubPermission(permission string) error {
+	if !utility.StringSliceContains(AllGitHubPermissions, permission) {
+		return errors.Errorf("invalid GitHub permission '%s'", permission)
+	}
+	return nil
+}
+
+func MostRestrictiveGitHubPermission(perm1, perm2 string) string {
+	// Most restrictive permission is no permissions.
+	if perm1 == "" || perm2 == "" {
+		return ""
+	}
+	// AllGitHubPermissions is ordered from most to least restrictive.
+	for _, perm := range AllGitHubPermissions {
+		if perm1 == perm || perm2 == perm {
+			return perm
+		}
+	}
+	return ""
+}
+
 // GetPullRequestMergeBase returns the merge base hash for the given PR.
 // This function will retry up to 5 times, regardless of error response (unless
 // error is the result of hitting an api limit)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -66,6 +66,15 @@ var githubWritePermissions = []string{
 	"write",
 }
 
+// AllGithubPermissions is an ascending slice of GitHub
+// permissions where the first element is the lowest
+// permission and the last element is the highest.
+var AllGitHubPermissions = []string{
+	"read",
+	"write",
+	"admin",
+}
+
 const (
 	GithubPRBlocked = "blocked"
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1556,6 +1556,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 	return utility.StringSliceContains(githubWritePermissions, permissionLevel.GetPermission()), nil
 }
 
+// ValidateGitHubPermission checks if the given permission is a valid GitHub permission.
 func ValidateGitHubPermission(permission string) error {
 	if !utility.StringSliceContains(allGitHubPermissions, permission) {
 		return errors.Errorf("invalid GitHub permission '%s'", permission)
@@ -1563,6 +1564,9 @@ func ValidateGitHubPermission(permission string) error {
 	return nil
 }
 
+// MostRestrictiveGitHubPermission returns the permission from the two given permissions that is the most restrictive.
+// This function assumes that the given permissions are valid GitHub permissions or empty strings (which is no
+// permissions).
 func MostRestrictiveGitHubPermission(perm1, perm2 string) string {
 	// Most restrictive permission is no permissions.
 	if perm1 == "" || perm2 == "" {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -69,7 +69,7 @@ var githubWritePermissions = []string{
 // AllGithubPermissions is an ascending slice of GitHub
 // permissions where the first element is the lowest
 // permission and the last element is the highest.
-var AllGitHubPermissions = []string{
+var allGitHubPermissions = []string{
 	"read",
 	"write",
 	"admin",
@@ -1557,7 +1557,7 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 }
 
 func ValidateGitHubPermission(permission string) error {
-	if !utility.StringSliceContains(AllGitHubPermissions, permission) {
+	if !utility.StringSliceContains(allGitHubPermissions, permission) {
 		return errors.Errorf("invalid GitHub permission '%s'", permission)
 	}
 	return nil
@@ -1569,7 +1569,7 @@ func MostRestrictiveGitHubPermission(perm1, perm2 string) string {
 		return ""
 	}
 	// AllGitHubPermissions is ordered from most to least restrictive.
-	for _, perm := range AllGitHubPermissions {
+	for _, perm := range allGitHubPermissions {
 		if perm1 == perm || perm2 == perm {
 			return perm
 		}


### PR DESCRIPTION
DEVPROD-5978

### Description
This adds an intersection function for our GitHub dynamic access to get the most restrictive permissions between them. This will be needed when we add the agent route/code that should create a token with the most restrictive permissions.


We want to avoid hard coding as much as possible with GitHub's values so this uses reflection (see [Config](https://github.com/ZackarySantana/evergreen/blob/a2ea4040c4dfad5fe588235a56690c42142e8aea/config.go#L283) or [ProjectConfig](https://github.com/ZackarySantana/evergreen/blob/a2ea4040c4dfad5fe588235a56690c42142e8aea/model/project_config.go#L51) as existing examples). I wanted to avoid using reflection, but I think it's the cleanest way to avoid some heavy hard coding and it is still more efficient than an alternative like parsing it back to a map and using two maps. I added some heavy comments (please let me know if they're too much) so anyone that comes in to it, won't be (too) scared to edit it and can read the code as a cohesive though.

### Testing
Added a couple unit tests