### PR TITLE
DEVPROD-4183: send notification if temporary exemption is expiring

### DIFF
--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -184,9 +184,9 @@ func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord,
 	return FindOne(db.Query(q).Limit(1))
 }
 
-// FindByTemporaryExemptionExpirationWithHours finds the most recent alert
-// record for a spawn host's temporary exemption that is about to expire.
-func FindMostRecentByTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
+// FindByMostRecentTemporaryExemptionExpirationWithHours finds the most recent
+// alert record for a spawn host's temporary exemption that is about to expire.
+func FindByMostRecentTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
 	alertType := fmt.Sprintf(hostTemporaryExemptionWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)
 	q[TypeKey] = alertType

--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -28,9 +28,9 @@ const (
 
 // Host triggers
 const (
-	spawnHostWarningTemplate          = "spawn_%dhour"
-	temporaryExemptionWarningTemplate = "temporary_exemption_%dhour"
-	volumeWarningTemplate             = "volume_%dhour"
+	spawnHostWarningTemplate              = "spawn_%dhour"
+	hostTemporaryExemptionWarningTemplate = "temporary_exemption_%dhour"
+	volumeWarningTemplate                 = "volume_%dhour"
 )
 
 const legacyAlertsSubscription = "legacy-alerts"
@@ -187,7 +187,7 @@ func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord,
 // FindByTemporaryExemptionExpirationWithHours finds the most recent alert
 // record for a spawn host's temporary exemption that is about to expire.
 func FindMostRecentByTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
-	alertType := fmt.Sprintf(temporaryExemptionWarningTemplate, hours)
+	alertType := fmt.Sprintf(hostTemporaryExemptionWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)
 	q[TypeKey] = alertType
 	q[HostIdKey] = hostID

--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -235,7 +235,7 @@ func InsertNewSpawnHostExpirationRecord(hostID string, hours int) error {
 // InsertNewTemporaryExemptionExpirationRecord inserts a new alert record for a
 // temporary exemption that is about to exipre.
 func InsertNewHostTemporaryExemptionExpirationRecord(hostID string, hours int) error {
-	alertType := fmt.Sprintf(temporaryExemptionWarningTemplate, hours)
+	alertType := fmt.Sprintf(hostTemporaryExemptionWarningTemplate, hours)
 	record := AlertRecord{
 		Id:             mgobson.NewObjectId(),
 		SubscriptionID: legacyAlertsSubscription,

--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -184,15 +184,14 @@ func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord,
 	return FindOne(db.Query(q).Limit(1))
 }
 
-// FindByTemporaryExemptionExpirationWithHours finds a matching alert record for
-// a spawn host's temporary exemption that is about to expire.
-// kim: TODO: test
-func FindByTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
+// FindByTemporaryExemptionExpirationWithHours finds the most recent alert
+// record for a spawn host's temporary exemption that is about to expire.
+func FindMostRecentByTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
 	alertType := fmt.Sprintf(temporaryExemptionWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)
 	q[TypeKey] = alertType
 	q[HostIdKey] = hostID
-	return FindOne(db.Query(q).Limit(1))
+	return FindOne(db.Query(q).Sort([]string{"-" + AlertTimeKey}).Limit(1))
 }
 
 func FindByVolumeExpirationWithHours(volumeID string, hours int) (*AlertRecord, error) {

--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -28,8 +28,9 @@ const (
 
 // Host triggers
 const (
-	spawnHostWarningTemplate = "spawn_%dhour"
-	volumeWarningTemplate    = "volume_%dhour"
+	spawnHostWarningTemplate          = "spawn_%dhour"
+	temporaryExemptionWarningTemplate = "temporary_exemption_%dhour"
+	volumeWarningTemplate             = "volume_%dhour"
 )
 
 const legacyAlertsSubscription = "legacy-alerts"
@@ -183,6 +184,17 @@ func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord,
 	return FindOne(db.Query(q).Limit(1))
 }
 
+// FindByTemporaryExemptionExpirationWithHours finds a matching alert record for
+// a spawn host's temporary exemption that is about to expire.
+// kim: TODO: test
+func FindByTemporaryExemptionExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
+	alertType := fmt.Sprintf(temporaryExemptionWarningTemplate, hours)
+	q := subscriptionIDQuery(legacyAlertsSubscription)
+	q[TypeKey] = alertType
+	q[HostIdKey] = hostID
+	return FindOne(db.Query(q).Limit(1))
+}
+
 func FindByVolumeExpirationWithHours(volumeID string, hours int) (*AlertRecord, error) {
 	alertType := fmt.Sprintf(volumeWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)
@@ -210,6 +222,21 @@ func InsertNewTaskRegressionByTestRecord(subscriptionID, taskID, testName, taskD
 
 func InsertNewSpawnHostExpirationRecord(hostID string, hours int) error {
 	alertType := fmt.Sprintf(spawnHostWarningTemplate, hours)
+	record := AlertRecord{
+		Id:             mgobson.NewObjectId(),
+		SubscriptionID: legacyAlertsSubscription,
+		Type:           alertType,
+		HostId:         hostID,
+		AlertTime:      time.Now(),
+	}
+
+	return errors.Wrapf(record.Insert(), "inserting alert record '%s'", alertType)
+}
+
+// InsertNewTemporaryExemptionExpirationRecord inserts a new alert record for a
+// temporary exemption that is about to exipre.
+func InsertNewHostTemporaryExemptionExpirationRecord(hostID string, hours int) error {
+	alertType := fmt.Sprintf(temporaryExemptionWarningTemplate, hours)
 	record := AlertRecord{
 		Id:             mgobson.NewObjectId(),
 		SubscriptionID: legacyAlertsSubscription,

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -13,6 +13,7 @@ import (
 func init() {
 	registry.AddType(ResourceTypeHost, func() interface{} { return &HostEventData{} })
 	registry.AllowSubscription(ResourceTypeHost, EventHostExpirationWarningSent)
+	registry.AllowSubscription(ResourceTypeHost, EventHostTemporaryExemptionExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventVolumeExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventSpawnHostIdleNotification)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisioned)
@@ -28,37 +29,37 @@ const (
 	ResourceTypeHost = "HOST"
 
 	// event types
-	EventHostCreated                       = "HOST_CREATED"
-	EventHostCreatedError                  = "HOST_CREATED_ERROR"
-	EventHostStarted                       = "HOST_STARTED"
-	EventHostStopped                       = "HOST_STOPPED"
-	EventHostModified                      = "HOST_MODIFIED"
-	EventHostAgentDeployed                 = "HOST_AGENT_DEPLOYED"
-	EventHostAgentDeployFailed             = "HOST_AGENT_DEPLOY_FAILED"
-	EventHostAgentMonitorDeployed          = "HOST_AGENT_MONITOR_DEPLOYED"
-	EventHostAgentMonitorDeployFailed      = "HOST_AGENT_MONITOR_DEPLOY_FAILED"
-	EventHostJasperRestarting              = "HOST_JASPER_RESTARTING"
-	EventHostJasperRestarted               = "HOST_JASPER_RESTARTED"
-	EventHostJasperRestartError            = "HOST_JASPER_RESTART_ERROR"
-	EventHostConvertingProvisioning        = "HOST_CONVERTING_PROVISIONING"
-	EventHostConvertedProvisioning         = "HOST_CONVERTED_PROVISIONING"
-	EventHostConvertingProvisioningError   = "HOST_CONVERTING_PROVISIONING_ERROR"
-	EventHostStatusChanged                 = "HOST_STATUS_CHANGED"
-	EventHostDNSNameSet                    = "HOST_DNS_NAME_SET"
-	EventHostProvisionError                = "HOST_PROVISION_ERROR"
-	EventHostProvisionFailed               = "HOST_PROVISION_FAILED"
-	EventHostProvisioned                   = "HOST_PROVISIONED"
-	EventHostRunningTaskSet                = "HOST_RUNNING_TASK_SET"
-	EventHostRunningTaskCleared            = "HOST_RUNNING_TASK_CLEARED"
-	EventHostTaskFinished                  = "HOST_TASK_FINISHED"
-	EventHostTerminatedExternally          = "HOST_TERMINATED_EXTERNALLY"
-	EventHostExpirationWarningSent         = "HOST_EXPIRATION_WARNING_SENT"
-	EventHostTemporaryExemptionWarningSent = "HOST_TEMPORARY_EXEMPTION_WARNING_SENT"
-	EventSpawnHostIdleNotification         = "HOST_IDLE_NOTIFICATION"
-	EventHostScriptExecuted                = "HOST_SCRIPT_EXECUTED"
-	EventHostScriptExecuteFailed           = "HOST_SCRIPT_EXECUTE_FAILED"
-	EventVolumeExpirationWarningSent       = "VOLUME_EXPIRATION_WARNING_SENT"
-	EventVolumeMigrationFailed             = "VOLUME_MIGRATION_FAILED"
+	EventHostCreated                                 = "HOST_CREATED"
+	EventHostCreatedError                            = "HOST_CREATED_ERROR"
+	EventHostStarted                                 = "HOST_STARTED"
+	EventHostStopped                                 = "HOST_STOPPED"
+	EventHostModified                                = "HOST_MODIFIED"
+	EventHostAgentDeployed                           = "HOST_AGENT_DEPLOYED"
+	EventHostAgentDeployFailed                       = "HOST_AGENT_DEPLOY_FAILED"
+	EventHostAgentMonitorDeployed                    = "HOST_AGENT_MONITOR_DEPLOYED"
+	EventHostAgentMonitorDeployFailed                = "HOST_AGENT_MONITOR_DEPLOY_FAILED"
+	EventHostJasperRestarting                        = "HOST_JASPER_RESTARTING"
+	EventHostJasperRestarted                         = "HOST_JASPER_RESTARTED"
+	EventHostJasperRestartError                      = "HOST_JASPER_RESTART_ERROR"
+	EventHostConvertingProvisioning                  = "HOST_CONVERTING_PROVISIONING"
+	EventHostConvertedProvisioning                   = "HOST_CONVERTED_PROVISIONING"
+	EventHostConvertingProvisioningError             = "HOST_CONVERTING_PROVISIONING_ERROR"
+	EventHostStatusChanged                           = "HOST_STATUS_CHANGED"
+	EventHostDNSNameSet                              = "HOST_DNS_NAME_SET"
+	EventHostProvisionError                          = "HOST_PROVISION_ERROR"
+	EventHostProvisionFailed                         = "HOST_PROVISION_FAILED"
+	EventHostProvisioned                             = "HOST_PROVISIONED"
+	EventHostRunningTaskSet                          = "HOST_RUNNING_TASK_SET"
+	EventHostRunningTaskCleared                      = "HOST_RUNNING_TASK_CLEARED"
+	EventHostTaskFinished                            = "HOST_TASK_FINISHED"
+	EventHostTerminatedExternally                    = "HOST_TERMINATED_EXTERNALLY"
+	EventHostExpirationWarningSent                   = "HOST_EXPIRATION_WARNING_SENT"
+	EventHostTemporaryExemptionExpirationWarningSent = "HOST_TEMPORARY_EXEMPTION_EXPIRATION_WARNING_SENT"
+	EventSpawnHostIdleNotification                   = "HOST_IDLE_NOTIFICATION"
+	EventHostScriptExecuted                          = "HOST_SCRIPT_EXECUTED"
+	EventHostScriptExecuteFailed                     = "HOST_SCRIPT_EXECUTE_FAILED"
+	EventVolumeExpirationWarningSent                 = "VOLUME_EXPIRATION_WARNING_SENT"
+	EventVolumeMigrationFailed                       = "VOLUME_MIGRATION_FAILED"
 )
 
 // implements EventData
@@ -281,7 +282,7 @@ func LogSpawnhostExpirationWarningSent(hostID string) {
 // LogHostTemporaryExemptionExpirationWarningSent logs an event warning about
 // the host's temporary exemption, which is about to expire.
 func LogHostTemporaryExemptionExpirationWarningSent(hostID string) {
-	LogHostEvent(hostID, EventHostTemporaryExemptionWarningSent, HostEventData{})
+	LogHostEvent(hostID, EventHostTemporaryExemptionExpirationWarningSent, HostEventData{})
 }
 
 func LogVolumeExpirationWarningSent(volumeID string) {

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -28,36 +28,37 @@ const (
 	ResourceTypeHost = "HOST"
 
 	// event types
-	EventHostCreated                     = "HOST_CREATED"
-	EventHostCreatedError                = "HOST_CREATED_ERROR"
-	EventHostStarted                     = "HOST_STARTED"
-	EventHostStopped                     = "HOST_STOPPED"
-	EventHostModified                    = "HOST_MODIFIED"
-	EventHostAgentDeployed               = "HOST_AGENT_DEPLOYED"
-	EventHostAgentDeployFailed           = "HOST_AGENT_DEPLOY_FAILED"
-	EventHostAgentMonitorDeployed        = "HOST_AGENT_MONITOR_DEPLOYED"
-	EventHostAgentMonitorDeployFailed    = "HOST_AGENT_MONITOR_DEPLOY_FAILED"
-	EventHostJasperRestarting            = "HOST_JASPER_RESTARTING"
-	EventHostJasperRestarted             = "HOST_JASPER_RESTARTED"
-	EventHostJasperRestartError          = "HOST_JASPER_RESTART_ERROR"
-	EventHostConvertingProvisioning      = "HOST_CONVERTING_PROVISIONING"
-	EventHostConvertedProvisioning       = "HOST_CONVERTED_PROVISIONING"
-	EventHostConvertingProvisioningError = "HOST_CONVERTING_PROVISIONING_ERROR"
-	EventHostStatusChanged               = "HOST_STATUS_CHANGED"
-	EventHostDNSNameSet                  = "HOST_DNS_NAME_SET"
-	EventHostProvisionError              = "HOST_PROVISION_ERROR"
-	EventHostProvisionFailed             = "HOST_PROVISION_FAILED"
-	EventHostProvisioned                 = "HOST_PROVISIONED"
-	EventHostRunningTaskSet              = "HOST_RUNNING_TASK_SET"
-	EventHostRunningTaskCleared          = "HOST_RUNNING_TASK_CLEARED"
-	EventHostTaskFinished                = "HOST_TASK_FINISHED"
-	EventHostTerminatedExternally        = "HOST_TERMINATED_EXTERNALLY"
-	EventHostExpirationWarningSent       = "HOST_EXPIRATION_WARNING_SENT"
-	EventSpawnHostIdleNotification       = "HOST_IDLE_NOTIFICATION"
-	EventHostScriptExecuted              = "HOST_SCRIPT_EXECUTED"
-	EventHostScriptExecuteFailed         = "HOST_SCRIPT_EXECUTE_FAILED"
-	EventVolumeExpirationWarningSent     = "VOLUME_EXPIRATION_WARNING_SENT"
-	EventVolumeMigrationFailed           = "VOLUME_MIGRATION_FAILED"
+	EventHostCreated                       = "HOST_CREATED"
+	EventHostCreatedError                  = "HOST_CREATED_ERROR"
+	EventHostStarted                       = "HOST_STARTED"
+	EventHostStopped                       = "HOST_STOPPED"
+	EventHostModified                      = "HOST_MODIFIED"
+	EventHostAgentDeployed                 = "HOST_AGENT_DEPLOYED"
+	EventHostAgentDeployFailed             = "HOST_AGENT_DEPLOY_FAILED"
+	EventHostAgentMonitorDeployed          = "HOST_AGENT_MONITOR_DEPLOYED"
+	EventHostAgentMonitorDeployFailed      = "HOST_AGENT_MONITOR_DEPLOY_FAILED"
+	EventHostJasperRestarting              = "HOST_JASPER_RESTARTING"
+	EventHostJasperRestarted               = "HOST_JASPER_RESTARTED"
+	EventHostJasperRestartError            = "HOST_JASPER_RESTART_ERROR"
+	EventHostConvertingProvisioning        = "HOST_CONVERTING_PROVISIONING"
+	EventHostConvertedProvisioning         = "HOST_CONVERTED_PROVISIONING"
+	EventHostConvertingProvisioningError   = "HOST_CONVERTING_PROVISIONING_ERROR"
+	EventHostStatusChanged                 = "HOST_STATUS_CHANGED"
+	EventHostDNSNameSet                    = "HOST_DNS_NAME_SET"
+	EventHostProvisionError                = "HOST_PROVISION_ERROR"
+	EventHostProvisionFailed               = "HOST_PROVISION_FAILED"
+	EventHostProvisioned                   = "HOST_PROVISIONED"
+	EventHostRunningTaskSet                = "HOST_RUNNING_TASK_SET"
+	EventHostRunningTaskCleared            = "HOST_RUNNING_TASK_CLEARED"
+	EventHostTaskFinished                  = "HOST_TASK_FINISHED"
+	EventHostTerminatedExternally          = "HOST_TERMINATED_EXTERNALLY"
+	EventHostExpirationWarningSent         = "HOST_EXPIRATION_WARNING_SENT"
+	EventHostTemporaryExemptionWarningSent = "HOST_TEMPORARY_EXEMPTION_WARNING_SENT"
+	EventSpawnHostIdleNotification         = "HOST_IDLE_NOTIFICATION"
+	EventHostScriptExecuted                = "HOST_SCRIPT_EXECUTED"
+	EventHostScriptExecuteFailed           = "HOST_SCRIPT_EXECUTE_FAILED"
+	EventVolumeExpirationWarningSent       = "VOLUME_EXPIRATION_WARNING_SENT"
+	EventVolumeMigrationFailed             = "VOLUME_MIGRATION_FAILED"
 )
 
 // implements EventData
@@ -277,11 +278,17 @@ func LogSpawnhostExpirationWarningSent(hostID string) {
 	LogHostEvent(hostID, EventHostExpirationWarningSent, HostEventData{})
 }
 
+// LogHostTemporaryExemptionExpirationWarningSent logs an event warning about
+// the host's temporary exemption, which is about to expire.
+func LogHostTemporaryExemptionExpirationWarningSent(hostID string) {
+	LogHostEvent(hostID, EventHostTemporaryExemptionWarningSent, HostEventData{})
+}
+
 func LogVolumeExpirationWarningSent(volumeID string) {
 	LogHostEvent(volumeID, EventVolumeExpirationWarningSent, HostEventData{})
 }
 
-// LogSpawnHostIdleNotification logs a notification for the spawn host being idle.
+// LogSpawnHostIdleNotification logs an event for the spawn host being idle.
 func LogSpawnHostIdleNotification(hostID string) {
 	LogHostEvent(hostID, EventSpawnHostIdleNotification, HostEventData{})
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -664,10 +664,10 @@ func ByExpiringBetween(lowerBound time.Time, upperBound time.Time) bson.M {
 // specified times.
 // kim: TODO: test
 func FindByTemporaryExemptionsExpiringBetween(ctx context.Context, lowerBound time.Time, upperBound time.Time) ([]Host, error) {
-	temporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
+	sleepScheduleTemporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
 	return Find(ctx, isSleepScheduleApplicable(bson.M{
-		StatusKey:                 evergreen.SleepScheduleStatuses,
-		temporarilyExemptUntilKey: bson.M{"$gte": lowerBound, "$lte": upperBound},
+		StatusKey:                              bson.M{"$in": evergreen.SleepScheduleStatuses},
+		sleepScheduleTemporarilyExemptUntilKey: bson.M{"$gte": lowerBound, "$lte": upperBound},
 	}))
 }
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -662,7 +662,6 @@ func ByExpiringBetween(lowerBound time.Time, upperBound time.Time) bson.M {
 // FindByTemporaryExemptionsExpiringBetween finds all spawn hosts with a
 // temporary exemption from the sleep schedule that will expire between the
 // specified times.
-// kim: TODO: test
 func FindByTemporaryExemptionsExpiringBetween(ctx context.Context, lowerBound time.Time, upperBound time.Time) ([]Host, error) {
 	sleepScheduleTemporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
 	return Find(ctx, isSleepScheduleApplicable(bson.M{

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -659,6 +659,18 @@ func ByExpiringBetween(lowerBound time.Time, upperBound time.Time) bson.M {
 	}
 }
 
+// FindByTemporaryExemptionsExpiringBetween finds all spawn hosts with a
+// temporary exemption from the sleep schedule that will expire between the
+// specified times.
+// kim: TODO: test
+func FindByTemporaryExemptionsExpiringBetween(ctx context.Context, lowerBound time.Time, upperBound time.Time) ([]Host, error) {
+	temporarilyExemptUntilKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
+	return Find(ctx, isSleepScheduleApplicable(bson.M{
+		StatusKey:                 evergreen.SleepScheduleStatuses,
+		temporarilyExemptUntilKey: bson.M{"$gte": lowerBound, "$lte": upperBound},
+	}))
+}
+
 // NeedsAgentDeploy finds hosts which need the agent to be deployed because
 // either they do not have an agent yet or their agents have not communicated
 // recently.

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -220,8 +220,6 @@ func (t *hostTemplateData) hostSlackPayload(messageString string, linkTitle stri
 func (t *hostTriggers) hostExpiration(sub *event.Subscription) (*notification.Notification, error) {
 	switch t.event.EventType {
 	case event.EventHostExpirationWarningSent:
-		// kim: TODO: manually test that this still works for spawn host
-		// expiration warning.
 		if t.host.NoExpiration {
 			return nil, nil
 		}
@@ -243,8 +241,6 @@ func (t *hostTriggers) hostExpiration(sub *event.Subscription) (*notification.No
 		t.templateData.ExpirationTime = t.host.ExpirationTime.In(timeZone).Format(time.RFC1123)
 		return t.generateExpiration(sub)
 	case event.EventHostTemporaryExemptionExpirationWarningSent:
-		// kim: TODO: add test
-		// kim: TODO: manually test
 		timeZone := time.Local
 		if sub.OwnerType == event.OwnerTypePerson {
 			userTimeZone, err := getUserTimeZone(sub.Owner)

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -18,6 +18,7 @@ import (
 
 func init() {
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostExpirationWarningSent, makeHostTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostTemporaryExemptionExpirationWarningSent, makeHostTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventSpawnHostIdleNotification, makeHostTriggers)
 
 }
@@ -28,6 +29,11 @@ const (
 	expiringHostEmailBody            = `Your {{.Distro}} host '{{.Name}}' will be terminated at {{.ExpirationTime}}. Visit the <a href={{.URL}}>spawnhost page</a> to extend its lifetime.`
 	expiringHostSlackBody            = `Your {{.Distro}} host '{{.Name}}' will be terminated at {{.ExpirationTime}}. Visit the <{{.URL}}|spawnhost page> to extend its lifetime.`
 	expiringHostSlackAttachmentTitle = "Spawn Host Page"
+
+	expiringHostTemporaryExemptionEmailSubject         = `{{.Distro}} host temporary exemption reminder`
+	expiringHostTemporaryExemptionEmailBody            = `Your {{.Distro}} host '{{.Name}}' has a temporary exemption that will end at {{.ExpirationTime}}. Visit the <a href={{.URL}}>spawnhost page</a> to extend its temporary exemption if needed.`
+	expiringHostTemporaryExemptionSlackAttachmentTitle = "Spawn Host Page"
+	expiringHostTemporaryExemptionSlackBody            = `Your {{.Distro}} host '{{.Name}}' has a temporary exemption that will end at {{.ExpirationTime}}. Visit the <{{.URL}}|spawnhost page> to extend its temporary exemption if needed.`
 
 	idleHostEmailSubject     = `{{.Distro}} idle stopped host notice`
 	idleStoppedHostEmailBody = `Your stopped {{.Distro}} host '{{.Name}}' has been idle for at least three months.
@@ -137,6 +143,24 @@ func (t *hostTriggers) generateExpiration(sub *event.Subscription) (*notificatio
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
 
+func (t *hostTriggers) generateTemporaryExemptionExpiration(sub *event.Subscription) (*notification.Notification, error) {
+	var payload interface{}
+	var err error
+	switch sub.Subscriber.Type {
+	case event.EmailSubscriberType:
+		payload, err = t.templateData.hostEmailPayload(expiringHostTemporaryExemptionEmailSubject, expiringHostEmailBody, t.Attributes())
+	case event.SlackSubscriberType:
+		payload, err = t.templateData.hostSlackPayload(expiringHostTemporaryExemptionSlackBody, expiringHostTemporaryExemptionSlackAttachmentTitle)
+	default:
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating template for event type '%s'", sub.Subscriber.Type)
+	}
+
+	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
+}
+
 func (t *hostTriggers) generateIdleSpawnHost(sub *event.Subscription, body string) (*notification.Notification, error) {
 	payload, err := t.templateData.hostEmailPayload(idleHostEmailSubject, body, t.Attributes())
 	if err != nil {
@@ -194,24 +218,52 @@ func (t *hostTemplateData) hostSlackPayload(messageString string, linkTitle stri
 }
 
 func (t *hostTriggers) hostExpiration(sub *event.Subscription) (*notification.Notification, error) {
-	if t.host.NoExpiration {
+	switch t.event.EventType {
+	case event.EventHostExpirationWarningSent:
+		// kim: TODO: manually test that this still works for spawn host
+		// expiration warning.
+		if t.host.NoExpiration {
+			return nil, nil
+		}
+
+		timeZone := time.Local
+		if sub.OwnerType == event.OwnerTypePerson {
+			userTimeZone, err := getUserTimeZone(sub.Owner)
+			if err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":    "problem getting time zone",
+					"user":       sub.Owner,
+					"event_type": t.event.EventType,
+					"trigger":    "hostExpiration",
+				}))
+			} else {
+				timeZone = userTimeZone
+			}
+		}
+		t.templateData.ExpirationTime = t.host.ExpirationTime.In(timeZone).Format(time.RFC1123)
+		return t.generateExpiration(sub)
+	case event.EventHostTemporaryExemptionExpirationWarningSent:
+		// kim: TODO: add test
+		// kim: TODO: manually test
+		timeZone := time.Local
+		if sub.OwnerType == event.OwnerTypePerson {
+			userTimeZone, err := getUserTimeZone(sub.Owner)
+			if err != nil {
+				grip.Error(message.WrapError(err, message.Fields{
+					"message":    "problem getting time zone",
+					"user":       sub.Owner,
+					"event_type": t.event.EventType,
+					"trigger":    "hostExpiration",
+				}))
+			} else {
+				timeZone = userTimeZone
+			}
+		}
+		t.templateData.ExpirationTime = t.host.SleepSchedule.TemporarilyExemptUntil.In(timeZone).Format(time.RFC1123)
+		return t.generateTemporaryExemptionExpiration(sub)
+	default:
 		return nil, nil
 	}
-	timeZone := time.Local
-	if sub.OwnerType == event.OwnerTypePerson {
-		userTimeZone, err := getUserTimeZone(sub.Owner)
-		if err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "problem getting time zone",
-				"user":    sub.Owner,
-				"trigger": "hostExpiration",
-			}))
-		} else {
-			timeZone = userTimeZone
-		}
-	}
-	t.templateData.ExpirationTime = t.host.ExpirationTime.In(timeZone).Format(time.RFC1123)
-	return t.generateExpiration(sub)
 }
 
 func (t *hostTriggers) spawnHostIdle(sub *event.Subscription) (*notification.Notification, error) {

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -227,35 +227,35 @@ func (t *hostTriggers) hostExpiration(sub *event.Subscription) (*notification.No
 		timeZone := time.Local
 		if sub.OwnerType == event.OwnerTypePerson {
 			userTimeZone, err := getUserTimeZone(sub.Owner)
-			if err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message":    "problem getting time zone",
-					"user":       sub.Owner,
-					"event_type": t.event.EventType,
-					"trigger":    "hostExpiration",
-				}))
-			} else {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":    "problem getting user's time zone",
+				"user":       sub.Owner,
+				"event_type": t.event.EventType,
+				"trigger":    "host temporary exemption expiration",
+			}))
+			if userTimeZone != nil {
 				timeZone = userTimeZone
 			}
 		}
 		t.templateData.ExpirationTime = t.host.ExpirationTime.In(timeZone).Format(time.RFC1123)
+
 		return t.generateExpiration(sub)
 	case event.EventHostTemporaryExemptionExpirationWarningSent:
 		timeZone := time.Local
 		if sub.OwnerType == event.OwnerTypePerson {
 			userTimeZone, err := getUserTimeZone(sub.Owner)
-			if err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message":    "problem getting time zone",
-					"user":       sub.Owner,
-					"event_type": t.event.EventType,
-					"trigger":    "hostExpiration",
-				}))
-			} else {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":    "problem getting user time zone",
+				"user":       sub.Owner,
+				"event_type": t.event.EventType,
+				"trigger":    " host expiration",
+			}))
+			if userTimeZone != nil {
 				timeZone = userTimeZone
 			}
 		}
 		t.templateData.ExpirationTime = t.host.SleepSchedule.TemporarilyExemptUntil.In(timeZone).Format(time.RFC1123)
+
 		return t.generateTemporaryExemptionExpiration(sub)
 	default:
 		return nil, nil

--- a/trigger/host_test.go
+++ b/trigger/host_test.go
@@ -203,7 +203,22 @@ func (s *hostSuite) TestAllTriggers() {
 }
 
 func (s *hostSuite) TestHostExpiration() {
-	s.t.host.NoExpiration = false
+	n, err := s.t.hostExpiration(&s.subs[0])
+	s.NoError(err)
+	s.NotNil(n)
+}
+
+func (s *hostSuite) TestHostTemporaryExemptionExpiration() {
+	s.t.event = &event.EventLogEntry{
+		ResourceType: event.ResourceTypeHost,
+		EventType:    event.EventHostTemporaryExemptionExpirationWarningSent,
+		ResourceId:   s.t.host.Id,
+		Data:         &event.HostEventData{},
+	}
+	s.t.host.NoExpiration = true
+	s.t.host.ExpirationTime = time.Now().Add(evergreen.SpawnHostExpireDays * evergreen.SpawnHostNoExpirationDuration)
+	s.t.host.SleepSchedule.TemporarilyExemptUntil = time.Now().Add(time.Hour)
+
 	n, err := s.t.hostExpiration(&s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -96,7 +96,7 @@ func (j *spawnhostExpirationWarningsJob) Run(ctx context.Context) {
 		}
 	}
 
-	// Notify for spawn host temporary exemptions expiring in the next 12 hours.
+	// Notify for spawn host temporary exemptions expiring soon.
 	temporaryExemptionExpiringSoonHosts, err := host.FindByTemporaryExemptionsExpiringBetween(ctx, now, thresholdTime)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "finding hosts with temporary exemptions expiring soon"))

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -133,8 +133,6 @@ func shouldNotifyForHostTemporaryExemptionExpiration(h *host.Host, numHours int)
 	if utility.IsZeroTime(h.SleepSchedule.TemporarilyExemptUntil) || h.SleepSchedule.TemporarilyExemptUntil.Sub(time.Now()) > time.Duration(numHours)*time.Hour {
 		return false, nil
 	}
-	// kim: TODO: need to build index in staging and prod for this to be
-	// efficient.
 	rec, err := alertrecord.FindMostRecentByTemporaryExemptionExpirationWithHours(h.Id, numHours)
 	if err != nil {
 		return false, err

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -133,7 +133,7 @@ func shouldNotifyForHostTemporaryExemptionExpiration(h *host.Host, numHours int)
 	if utility.IsZeroTime(h.SleepSchedule.TemporarilyExemptUntil) || time.Until(h.SleepSchedule.TemporarilyExemptUntil) > time.Duration(numHours)*time.Hour {
 		return false, nil
 	}
-	rec, err := alertrecord.FindMostRecentByTemporaryExemptionExpirationWithHours(h.Id, numHours)
+	rec, err := alertrecord.FindByMostRecentTemporaryExemptionExpirationWithHours(h.Id, numHours)
 	if err != nil {
 		return false, err
 	}

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -114,7 +114,7 @@ func (j *spawnhostExpirationWarningsJob) Run(ctx context.Context) {
 }
 
 func shouldNotifyForSpawnhostExpiration(h *host.Host, numHours int) (bool, error) {
-	if h == nil || h.ExpirationTime.IsZero() || h.ExpirationTime.Sub(time.Now()) > (time.Duration(numHours)*time.Hour) { //nolint:all
+	if h == nil || h.ExpirationTime.IsZero() || time.Until(h.ExpirationTime) > (time.Duration(numHours)*time.Hour) {
 		return false, nil
 	}
 	rec, err := alertrecord.FindBySpawnHostExpirationWithHours(h.Id, numHours)
@@ -130,7 +130,7 @@ func shouldNotifyForSpawnhostExpiration(h *host.Host, numHours int) (bool, error
 const temporaryExemptionRenotificationInterval = utility.Day
 
 func shouldNotifyForHostTemporaryExemptionExpiration(h *host.Host, numHours int) (bool, error) {
-	if utility.IsZeroTime(h.SleepSchedule.TemporarilyExemptUntil) || h.SleepSchedule.TemporarilyExemptUntil.Sub(time.Now()) > time.Duration(numHours)*time.Hour {
+	if utility.IsZeroTime(h.SleepSchedule.TemporarilyExemptUntil) || time.Until(h.SleepSchedule.TemporarilyExemptUntil) > time.Duration(numHours)*time.Hour {
 		return false, nil
 	}
 	rec, err := alertrecord.FindMostRecentByTemporaryExemptionExpirationWithHours(h.Id, numHours)

--- a/units/spawnhost_expiration_warning_test.go
+++ b/units/spawnhost_expiration_warning_test.go
@@ -152,8 +152,9 @@ func (s *spawnHostExpirationSuite) TestDuplicateEventsAreLoggedAfterRenotificati
 	s.NoError(err)
 	s.Len(events, 6, "should log expected events on first run")
 
-	// Update the alert records so that the temporary exemption events were
-	// logged a long time ago, meaning they're eligible to log again.
+	// Update the alert records to simulate a condition where the temporary
+	// exemption events were logged a long time ago, meaning they're eligible to
+	// log again.
 	var temporaryExemptionExpirationEventIDs []string
 	for _, e := range events {
 		if e.EventType == event.EventHostTemporaryExemptionExpirationWarningSent {


### PR DESCRIPTION
DEVPROD-4183

### Description
Add logic to notify the user when the temporary exemption is 2 hours and 12 hours away from expiring, which are the same as the current spawn host expiration warning thresholds. This reuses the same "spawn host expiration" subscription that users can already subscribe to in their notification preferences, so we don't need to add a new subscription option just for this.

Before this is deployed, I'm going to build an index for the alert record query so that it can find the most recent alert record efficiently.

### Testing
* Tested in staging that temporary exemption notifications were sent to Slack/email as expected when it was close to expiring.
* Tested in staging that regular spawn host expiration warnings still work like before.
* Added unit tests.

### Documentation
N/A