### PR TITLE
BF-32559  Fix bug in generated task dependency check 

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -434,9 +434,9 @@ func addTasksToGraph(tasks TVPairSet, graph task.DependencyGraph, p *Project, ta
 		})
 	}
 
-	allNodes := graph.Nodes()
-	bvts := make([]BuildVariantTaskUnit, 0, len(allNodes))
-	for _, node := range graph.Nodes() {
+	nodes := graph.Nodes()
+	bvts := make([]BuildVariantTaskUnit, 0, len(nodes))
+	for _, node := range nodes {
 		bvt := p.FindTaskForVariant(node.Name, node.Variant)
 		if bvt != nil {
 			bvts = append(bvts, *bvt)
@@ -460,12 +460,13 @@ func (g *GeneratedProject) addDependencyEdgesToGraph(ctx context.Context, newTas
 	}
 
 	for _, newTask := range activatedNewTasks {
-		for _, edge := range graph.EdgesIntoTask(g.Task.ToTaskNode()) {
-			graph.AddEdge(edge.From, task.TaskNode{
-				ID:      taskIDs.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName),
-				Name:    newTask.TaskName,
-				Variant: newTask.Variant,
-			}, edge.Status)
+		node := task.TaskNode{
+			ID:      taskIDs.ExecutionTasks.GetId(newTask.Variant, newTask.TaskName),
+			Name:    newTask.TaskName,
+			Variant: newTask.Variant,
+		}
+		for _, edge := range graph.EdgesIntoTask(node) {
+			graph.AddEdge(edge.From, node, edge.Status)
 		}
 	}
 

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1664,17 +1664,30 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 	require.NoError(t, generatorTask.Insert())
 
 	t.Run("CreatesCycle", func(t *testing.T) {
+		// Generator generates: [ A (depends on B) , B (depends on) C), C (depends on A) ]
+		// the graph:
+		//   +-----+            +-----+
+		//   |  A  |            |  C  |
+		//   +-----+ <--------- +-----+
+		//            \         ^
+		//             v       /
+		//              +-----+
+		//              |  B  |
+		//              +-----+
+
 		project := &Project{
 			BuildVariants: []BuildVariant{
 				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
-					{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "dependedOn", Variant: "bv0"}}},
-					{Name: "dependedOn", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "A", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "B", Variant: "bv0"}}},
+					{Name: "B", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "C", Variant: "bv0"}}},
+					{Name: "C", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "A", Variant: "bv0"}}},
 					{Name: "generator", Variant: "bv0"},
 				}},
 			},
 			Tasks: []ProjectTask{
-				{Name: "generated"},
-				{Name: "dependedOn"},
+				{Name: "A"},
+				{Name: "B"},
+				{Name: "C"},
 				{Name: "generator"},
 			},
 		}
@@ -1685,7 +1698,9 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				{
 					Name: "bv0",
 					Tasks: []parserBVTaskUnit{
-						{Name: "generated"},
+						{Name: "A"},
+						{Name: "B"},
+						{Name: "C"},
 					},
 				},
 			},
@@ -1694,15 +1709,112 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 	})
 
 	t.Run("CreatesLoop", func(t *testing.T) {
+		// Generator generates: [ A (depends on B), B (depends on A) ]
+		// the graph:
+		//   +-----+ ---------> +-----+
+		//   |  A  |            |  B  |
+		//   +-----+ <--------- +-----+
+
 		project := &Project{
 			BuildVariants: []BuildVariant{
 				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
-					{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "A", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "B", Variant: "bv0"}}},
+					{Name: "B", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "A", Variant: "bv0"}}},
 					{Name: "generator", Variant: "bv0"},
 				}},
 			},
 			Tasks: []ProjectTask{
-				{Name: "generated"},
+				{Name: "A"},
+				{Name: "B"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "A"},
+						{Name: "B"},
+					},
+				},
+			},
+		}
+
+		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
+	})
+	t.Run("Dependent on Generator", func(t *testing.T) {
+		// Generator generates: [ A (depends on generator) ]
+		//   +-----+            +-------------+
+		//   |  A  | ---------> |  generator  |
+		//   +-----+            +-------------+
+		// This should not error. Because A will only be able to run after the generator, it is okay for it to be dependent on it.
+
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
+					{Name: "A", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generator", Variant: "bv0"},
+				}},
+			},
+			Tasks: []ProjectTask{
+				{Name: "A"},
+				{Name: "generator"},
+			},
+		}
+
+		g := GeneratedProject{
+			Task: &generatorTask,
+			BuildVariants: []parserBV{
+				{
+					Name: "bv0",
+					Tasks: []parserBVTaskUnit{
+						{Name: "A"},
+					},
+				},
+			},
+		}
+		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
+	})
+
+	t.Run("Loop with generator", func(t *testing.T) {
+		// Generator generates: [ generated (depends on) --> A (which depends on the generator) ]
+		//   +-----------+            +-----+
+		//   | generator |            |  A  |
+		//   +-----------+ <--------- +-----+
+		//                 \         ^
+		//                  v       /
+		//                +-----------+
+		//                | generated |
+		//                +-----------+
+
+		// This should not error because the arrow from generator to generated is not a dependency. As a dependency
+		// graph it would look like this, because generated can't run before the generator (and is therefore
+		// inherently "dependent" on the generator). It will execute in the following order with no problem:
+		// generator ->  A -> generated.
+		//   +-----------+            +-----+
+		//   | generator |            |  A  |
+		//   +-----------+ <--------- +-----+
+		//                  ^        ^
+		//                   \      /
+		//                 +-----------+
+		//                 | generated |
+		//                 +-----------+
+
+		project := &Project{
+			BuildVariants: []BuildVariant{
+				{Name: "bv0", Tasks: []BuildVariantTaskUnit{
+					{Name: "A", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "generator", Variant: "bv0"}}},
+					{Name: "generated", Variant: "bv0", DependsOn: []TaskUnitDependency{{Name: "A", Variant: "bv0"}}},
+					{Name: "generator", Variant: "bv0"},
+				}},
+			},
+			Tasks: []ProjectTask{
+				{Name: "A"},
+				{Name: "B"},
+				{Name: "C"},
 				{Name: "generator"},
 			},
 		}
@@ -1718,8 +1830,7 @@ func TestSimulateNewDependencyGraph(t *testing.T) {
 				},
 			},
 		}
-
-		assert.Error(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
+		assert.NoError(t, g.CheckForCycles(context.Background(), v, project, &ProjectRef{Identifier: "mci"}))
 	})
 
 	t.Run("NoCycles", func(t *testing.T) {


### PR DESCRIPTION
BF-32559

### Description
When adding dependency edges to the graph, we were passing in g.Task which is the generator task instead of passing in newTask which is the current task in the list of tasks being generated. This caused a bug where for each new task it was adding the edges going into the GENERATOR instead of the edges going into that new task. 

### Testing
Fixed and expanded the unit testing.

