### PR TITLE
DEVPROD-4511 Remove db logging from honeycomb

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -368,6 +368,7 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings, tracer trace
 	opts := options.Client().ApplyURI(settings.Url).SetWriteConcern(settings.WriteConcernSettings.Resolve()).
 		SetReadConcern(settings.ReadConcernSettings.Resolve()).
 		SetConnectTimeout(5 * time.Second).
+		// Removing WithCommandAttributeDisabled(false) to disable db command monitoring.
 		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeTransformer(redactSensitiveCollections)))
 
 	if settings.AWSAuthEnabled {
@@ -402,6 +403,7 @@ func (e *envState) createRemoteQueues(ctx context.Context, tracer trace.Tracer) 
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(e.settings.Database.ReadConcernSettings.Resolve()).
 		SetWriteConcern(e.settings.Database.WriteConcernSettings.Resolve()).
+		// Removing WithCommandAttributeDisabled(false) to disable db command monitoring.
 		SetMonitor(apm.NewMonitor())
 
 	if e.settings.Database.AWSAuthEnabled {

--- a/environment.go
+++ b/environment.go
@@ -368,7 +368,7 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings, tracer trace
 	opts := options.Client().ApplyURI(settings.Url).SetWriteConcern(settings.WriteConcernSettings.Resolve()).
 		SetReadConcern(settings.ReadConcernSettings.Resolve()).
 		SetConnectTimeout(5 * time.Second).
-		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeDisabled(false), apm.WithCommandAttributeTransformer(redactSensitiveCollections)))
+		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeTransformer(redactSensitiveCollections)))
 
 	if settings.AWSAuthEnabled {
 		opts.SetAuth(options.Credential{
@@ -402,7 +402,7 @@ func (e *envState) createRemoteQueues(ctx context.Context, tracer trace.Tracer) 
 		SetReadPreference(readpref.Primary()).
 		SetReadConcern(e.settings.Database.ReadConcernSettings.Resolve()).
 		SetWriteConcern(e.settings.Database.WriteConcernSettings.Resolve()).
-		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeDisabled(false)))
+		SetMonitor(apm.NewMonitor())
 
 	if e.settings.Database.AWSAuthEnabled {
 		opts.SetAuth(options.Credential{

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -92,7 +92,8 @@ func (e *Environment) Configure(ctx context.Context) error {
 		ApplyURI(e.EvergreenSettings.Database.Url).
 		SetWriteConcern(e.EvergreenSettings.Database.WriteConcernSettings.Resolve()).
 		SetReadConcern(e.EvergreenSettings.Database.ReadConcernSettings.Resolve()).
-		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeDisabled(false))))
+		// Removing WithCommandAttributeDisabled(false) to disable db command monitoring.
+		SetMonitor(apm.NewMonitor()))
 
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
DEVPROD-4511

### Description
don't log db statements in honeycomb because it could leak secrets

What removing [WithCommandAttributeDisabled()](https://github.com/mongodb/anser/blob/c62f11870fd43cfbdcc66dfc9db68fcdce047d4c/apm/otel_monitor.go#L86-L93) does is set our monitor to the default behavior of no longer adding MongoDB commands as attributes

According to @ybrill , that was the only reason we use a copy of the open telemetry library in anser and we could go back to using the [original](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo) if we don't plan on using this feature again. I don't believe that is necessary at the moment so no follow up tickets have been made. Similarly, no ticket has been created to re-enable this span after sanitizing our commands because it may not be necessary.

### Testing
no longer logs db.statement in staging 
<img width="959" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26491602/0ca004b0-0f21-49c7-8aae-d75aa3b44223">

