### PR TITLE
DEVPROD-7586 avoid falsely marking decomissioned hosts as terminated

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -90,7 +89,7 @@ func ModifyHostsWithPermissions(hosts []host.Host, perm map[string]gimlet.Permis
 	return updated, httpStatus, catcher.Resolve()
 }
 
-func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue amboy.Queue, h *host.Host, newStatus string, notes string, u *user.DBUser) (string, int, error) {
+func ModifyHostStatus(ctx context.Context, env evergreen.Environment, h *host.Host, newStatus string, notes string, u *user.DBUser) (string, int, error) {
 	currentStatus := h.Status
 
 	if !utility.StringSliceContains(validUpdateToStatuses, newStatus) {
@@ -102,15 +101,11 @@ func ModifyHostStatus(ctx context.Context, env evergreen.Environment, queue ambo
 	}
 
 	if newStatus == evergreen.HostTerminated {
-		if !queue.Info().Started {
-			return "", http.StatusInternalServerError, errors.New(HostTerminationQueueingError)
-		}
-
 		reason := notes
 		if reason == "" {
 			reason = fmt.Sprintf("terminated by user '%s'", u.Username())
 		}
-		if err := amboy.EnqueueUniqueJob(ctx, queue, units.NewHostTerminationJob(env, h, units.HostTerminationOptions{
+		if err := units.EnqueueTerminateHostJob(ctx, env, units.NewHostTerminationJob(env, h, units.HostTerminationOptions{
 			TerminateIfBusy:   true,
 			TerminationReason: reason,
 		})); err != nil {
@@ -189,9 +184,10 @@ func GetReprovisionToNewCallback(ctx context.Context, env evergreen.Environment,
 	}
 }
 
-func GetUpdateHostStatusCallback(ctx context.Context, env evergreen.Environment, rq amboy.Queue, status string, notes string, user *user.DBUser) func(h *host.Host) (httpStatus int, err error) {
+func GetUpdateHostStatusCallback(ctx context.Context, env evergreen.Environment,
+	status string, notes string, user *user.DBUser) func(h *host.Host) (httpStatus int, err error) {
 	return func(h *host.Host) (httpStatus int, err error) {
-		_, httpStatus, modifyErr := ModifyHostStatus(ctx, env, rq, h, status, notes, user)
+		_, httpStatus, modifyErr := ModifyHostStatus(ctx, env, h, status, notes, user)
 		return httpStatus, modifyErr
 	}
 }

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -284,8 +284,7 @@ func (r *mutationResolver) UpdateHostStatus(ctx context.Context, hostIds []strin
 		return 0, mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}
 
-	rq := evergreen.GetEnvironment().RemoteQueue()
-	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(ctx, evergreen.GetEnvironment(), rq, status, *notes, user))
+	hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(ctx, evergreen.GetEnvironment(), status, *notes, user))
 	if err != nil {
 		return 0, mapHTTPStatusToGqlError(ctx, httpStatus, err)
 	}

--- a/service/host.go
+++ b/service/host.go
@@ -150,7 +150,6 @@ func (uis *UIServer) hostsPage(w http.ResponseWriter, r *http.Request) {
 
 func (uis *UIServer) modifyHost(w http.ResponseWriter, r *http.Request) {
 	env := uis.env
-	queue := env.RemoteQueue()
 	u := MustHaveUser(r)
 	id := gimlet.GetVars(r)["host_id"]
 
@@ -178,7 +177,7 @@ func (uis *UIServer) modifyHost(w http.ResponseWriter, r *http.Request) {
 			msg        string
 			statusCode int
 		)
-		msg, statusCode, err = api.ModifyHostStatus(r.Context(), env, queue, h, opts.Status, opts.Notes, u)
+		msg, statusCode, err = api.ModifyHostStatus(r.Context(), env, h, opts.Status, opts.Notes, u)
 		if err != nil {
 			gimlet.WriteResponse(w, gimlet.MakeTextErrorResponder(gimlet.ErrorResponse{
 				StatusCode: statusCode,
@@ -240,9 +239,7 @@ func (uis *UIServer) modifyHosts(w http.ResponseWriter, r *http.Request) {
 	// determine what action needs to be taken
 	switch opts.Action {
 	case "updateStatus":
-		rq := env.RemoteQueue()
-
-		hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(r.Context(), env, rq, opts.Status, opts.Notes, user))
+		hostsUpdated, httpStatus, err := api.ModifyHostsWithPermissions(hosts, permissions, api.GetUpdateHostStatusCallback(r.Context(), env, opts.Status, opts.Notes, user))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error updating status on selected hosts: %s", err.Error()), httpStatus)
 			return

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -37,7 +37,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		require.NoError(h.Insert(ctx))
 		opts := uiParams{Action: "updateStatus", Status: evergreen.HostQuarantined, Notes: "because I can"}
 
-		result, httpStatus, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		result, httpStatus, err := api.ModifyHostStatus(ctx, env, &h, opts.Status, opts.Notes, &user)
 		require.NoError(err)
 		assert.Equal(http.StatusOK, httpStatus)
 		assert.Equal(result, fmt.Sprintf(api.HostStatusUpdateSuccess, evergreen.HostRunning, evergreen.HostQuarantined))
@@ -64,7 +64,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		}
 		require.NoError(h.Insert(ctx))
 
-		_, httpStatus, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, evergreen.HostRunning, "", &user)
+		_, httpStatus, err := api.ModifyHostStatus(ctx, env, &h, evergreen.HostRunning, "", &user)
 		require.NoError(err)
 		assert.Equal(http.StatusOK, httpStatus)
 		assert.Equal(h.Status, evergreen.HostProvisioning)
@@ -80,7 +80,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		h := host.Host{Id: "h3", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
 		opts := uiParams{Action: "updateStatus", Status: evergreen.HostDecommissioned}
 
-		_, _, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		_, _, err := api.ModifyHostStatus(ctx, env, &h, opts.Status, opts.Notes, &user)
 		assert.Error(err)
 		assert.Contains(err.Error(), api.DecommissionStaticHostError)
 	})
@@ -89,7 +89,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		h := host.Host{Id: "h4", Status: evergreen.HostRunning, Provider: evergreen.ProviderNameStatic}
 		opts := uiParams{Action: "updateStatus", Status: "undefined"}
 
-		_, _, err := api.ModifyHostStatus(ctx, env, env.LocalQueue(), &h, opts.Status, opts.Notes, &user)
+		_, _, err := api.ModifyHostStatus(ctx, env, &h, opts.Status, opts.Notes, &user)
 		assert.Error(err)
 		assert.Contains(err.Error(), fmt.Sprintf(api.InvalidStatusError, "undefined"))
 	})

--- a/units/crons.go
+++ b/units/crons.go
@@ -256,11 +256,6 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			TerminationReason: "host spawned by task has gone out of scope",
 		}))
 	}
-	grip.Info(message.Fields{
-		"message": "unprocessed termination job count",
-		"pending": len(jobs),
-		"cron":    HostTerminationJobName,
-	})
 	return jobs, catcher.Resolve()
 }
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -250,14 +250,17 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 		"impact":    "hosts termination interrupted",
 	}))
 	catcher.Wrap(err, "finding hosts spawned by tasks to terminate")
-
 	for _, h := range hosts {
 		jobs = append(jobs, NewHostTerminationJob(env, &h, HostTerminationOptions{
 			TerminateIfBusy:   true,
 			TerminationReason: "host spawned by task has gone out of scope",
 		}))
 	}
-
+	grip.Info(message.Fields{
+		"message": "unprocessed termination job count",
+		"pending": len(jobs),
+		"cron":    HostTerminationJobName,
+	})
 	return jobs, catcher.Resolve()
 }
 

--- a/units/crons.go
+++ b/units/crons.go
@@ -30,7 +30,7 @@ const (
 
 	// createHostQueueGroup is the queue group for the provisioning-create-host job.
 	createHostQueueGroup = "service.host.create"
-	// terminateHostQueueGroup is the queue group for host-termination-jobs created by cron jobs.
+	// terminateHostQueueGroup is the queue group for host-termination-jobs.
 	terminateHostQueueGroup         = "service.host.termination"
 	commitQueueQueueGroup           = "service.commitqueue"
 	eventNotifierQueueGroup         = "service.event.notifier"

--- a/units/crons.go
+++ b/units/crons.go
@@ -29,7 +29,9 @@ const (
 	TSFormat = "2006-01-02.15-04-05"
 
 	// createHostQueueGroup is the queue group for the provisioning-create-host job.
-	createHostQueueGroup            = "service.host.create"
+	createHostQueueGroup = "service.host.create"
+	// terminateHostQueueGroup is the queue group for host-termination-jobs created by cron jobs.
+	terminateHostQueueGroup         = "service.host.termination"
 	commitQueueQueueGroup           = "service.commitqueue"
 	eventNotifierQueueGroup         = "service.event.notifier"
 	podAllocationQueueGroup         = "service.pod.allocate"

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -51,7 +51,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 		"container state":            containerStateJobs,
 		"event send":                 sendNotificationJobs,
 		"host monitoring":            hostMonitoringJobs,
-		"host termination":           hostTerminationJobs,
 		"last container finish time": lastContainerFinishTimeJobs,
 		"oldest image removal":       oldestImageRemovalJobs,
 		"parent decommission":        parentDecommissionJobs,
@@ -78,11 +77,12 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
 	catcher.Add(enqueueHostSetupJobs(ctx, j.env, j.env.RemoteQueue(), ts))
 
-	// Create dedicated queues for host creation, event notifier, and commit queue jobs.
+	// Create dedicated queues for host creation, host termination, event notifier, and commit queue jobs.
 	catcher.Add(populateQueueGroup(ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, spawnHostModificationQueueGroup, sleepSchedulerJobs, ts))
+	catcher.Add(populateQueueGroup(ctx, j.env, terminateHostQueueGroup, hostTerminationJobs, ts))
 
 	// Add generate tasks fallbacks to their versions' queues.
 	catcher.Add(enqueueFallbackGenerateTasksJobs(ctx, j.env, ts))

--- a/units/crons_remote_minute.go
+++ b/units/crons_remote_minute.go
@@ -77,7 +77,6 @@ func (j *cronsRemoteMinuteJob) Run(ctx context.Context) {
 	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
 	catcher.Add(enqueueHostSetupJobs(ctx, j.env, j.env.RemoteQueue(), ts))
 
-	// Create dedicated queues for host creation, host termination, event notifier, and commit queue jobs.
 	catcher.Add(populateQueueGroup(ctx, j.env, createHostQueueGroup, hostCreationJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, commitQueueQueueGroup, commitQueueJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, eventNotifierQueueGroup, eventNotifierJobs, ts))

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -101,6 +101,10 @@ func (j *hostMonitorExternalStateCheckJob) Run(ctx context.Context) {
 // so, clean up the host. Returns true if the host has been externally terminated
 // or stopped.
 func handleExternallyTerminatedHost(ctx context.Context, id string, env evergreen.Environment, h *host.Host) (bool, error) {
+	queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+	if err != nil {
+		return false, errors.Wrap(err, "getting host termination queue")
+	}
 	if h.Provider == evergreen.ProviderNameStatic {
 		return false, nil
 	}
@@ -162,7 +166,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 			"cloud_status": cloudStatus.String(),
 		})
 
-		err = amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewHostTerminationJob(env, h, HostTerminationOptions{
+		err = amboy.EnqueueUniqueJob(ctx, queue, NewHostTerminationJob(env, h, HostTerminationOptions{
 			TerminateIfBusy:          true,
 			TerminationReason:        fmt.Sprintf("host was found in state '%s'", cloudStatus.String()),
 			SkipCloudHostTermination: isTerminated,

--- a/units/host_monitoring_external_termination.go
+++ b/units/host_monitoring_external_termination.go
@@ -162,7 +162,7 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 			"cloud_status": cloudStatus.String(),
 		})
 
-		err = enqueueTerminateHostJob(ctx, env, NewHostTerminationJob(env, h, HostTerminationOptions{
+		err = EnqueueTerminateHostJob(ctx, env, NewHostTerminationJob(env, h, HostTerminationOptions{
 			TerminateIfBusy:          true,
 			TerminationReason:        fmt.Sprintf("host was found in state '%s'", cloudStatus.String()),
 			SkipCloudHostTermination: isTerminated,

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -60,7 +60,9 @@ func TestHostMonitoringCheckJob(t *testing.T) {
 	assert.NoError(j.Error())
 	assert.True(j.Status().Completed)
 
-	require.True(amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+	queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+	assert.NoError(err)
+	require.True(amboy.WaitInterval(ctx, queue, 100*time.Millisecond))
 
 	dbHost, err := host.FindOneId(ctx, h.Id)
 	require.NoError(err)
@@ -124,7 +126,10 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 				require.NoError(t, err)
 				assert.True(t, terminated)
 
-				require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond), "failed while waiting for host termination job to complete")
+				queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+				assert.NoError(t, err)
+				require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+					"failed while waiting for host termination job to complete")
 
 				dbHost, err := host.FindOneId(ctx, h.Id)
 				require.NoError(t, err)
@@ -154,7 +159,10 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, terminated)
 
-		require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond), "failed while waiting for host termination job to complete")
+		queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+		assert.NoError(t, err)
+		require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+			"failed while waiting for host termination job to complete")
 
 		dbHost, err := host.FindOneId(ctx, h.Id)
 		require.NoError(t, err)
@@ -182,7 +190,10 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, terminated)
 
-			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond), "failed while waiting for host termination job to complete")
+			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			assert.NoError(t, err)
+			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+				"failed while waiting for host termination job to complete")
 
 			dbHost, err := host.FindOneId(ctx, h.Id)
 			require.NoError(t, err)

--- a/units/host_monitoring_external_termination_test.go
+++ b/units/host_monitoring_external_termination_test.go
@@ -61,7 +61,7 @@ func TestHostMonitoringCheckJob(t *testing.T) {
 	assert.True(j.Status().Completed)
 
 	queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-	assert.NoError(err)
+	require.NoError(err)
 	require.True(amboy.WaitInterval(ctx, queue, 100*time.Millisecond))
 
 	dbHost, err := host.FindOneId(ctx, h.Id)
@@ -127,7 +127,7 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 				assert.True(t, terminated)
 
 				queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 					"failed while waiting for host termination job to complete")
 
@@ -160,7 +160,7 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 		assert.True(t, terminated)
 
 		queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 			"failed while waiting for host termination job to complete")
 
@@ -191,7 +191,7 @@ func TestHandleExternallyTerminatedHost(t *testing.T) {
 			assert.True(t, terminated)
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 				"failed while waiting for host termination job to complete")
 

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -185,7 +185,7 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig
 		j.Terminated++
 		j.TerminatedHosts = append(j.TerminatedHosts, h.Id)
 		terminationJob := NewHostTerminationJob(j.env, h, HostTerminationOptions{TerminationReason: terminateReason})
-		return enqueueTerminateHostJob(ctx, j.env, terminationJob)
+		return EnqueueTerminateHostJob(ctx, j.env, terminationJob)
 	}
 
 	return nil

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -155,6 +155,10 @@ func getMinNumHostsToEvaluate(info host.IdleHostsByDistroID, minimumHosts int) i
 }
 
 func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig evergreen.SchedulerConfig, h *host.Host, d distro.Distro) error {
+	queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+	if err != nil {
+		return errors.Wrap(err, "getting host termination queue")
+	}
 	exitEarly, err := checkTerminationExemptions(ctx, h, j.env, j.Type().Name, j.ID())
 	if exitEarly {
 		return err
@@ -185,7 +189,7 @@ func (j *idleHostJob) checkAndTerminateHost(ctx context.Context, schedulerConfig
 		j.Terminated++
 		j.TerminatedHosts = append(j.TerminatedHosts, h.Id)
 		terminationJob := NewHostTerminationJob(j.env, h, HostTerminationOptions{TerminationReason: terminateReason})
-		return amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminationJob)
+		return amboy.EnqueueUniqueJob(ctx, queue, terminationJob)
 	}
 
 	return nil

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -306,10 +306,6 @@ func (j *cloudHostReadyJob) logHostStatusMessage(h *host.Host, cloudStatus cloud
 // marking it for termination and handling any other cleanup necessary for a
 // host that fails to start up.
 func (j *cloudHostReadyJob) prepareToTerminateHost(ctx context.Context, h *host.Host, terminationReason string, skipCloudHostTermination bool) error {
-	queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-	if err != nil {
-		return errors.Wrap(err, "getting host termination queue")
-	}
 	event.LogHostTerminatedExternally(h.Id, h.Status)
 
 	catcher := grip.NewBasicCatcher()
@@ -321,7 +317,7 @@ func (j *cloudHostReadyJob) prepareToTerminateHost(ctx context.Context, h *host.
 		SkipCloudHostTermination: skipCloudHostTermination,
 	})
 
-	catcher.Wrap(amboy.EnqueueUniqueJob(ctx, queue, terminationJob), "enqueueing job to terminate host")
+	catcher.Wrap(enqueueTerminateHostJob(ctx, j.env, terminationJob), "enqueueing job to terminate host")
 
 	return catcher.Resolve()
 }

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -317,7 +317,7 @@ func (j *cloudHostReadyJob) prepareToTerminateHost(ctx context.Context, h *host.
 		SkipCloudHostTermination: skipCloudHostTermination,
 	})
 
-	catcher.Wrap(enqueueTerminateHostJob(ctx, j.env, terminationJob), "enqueueing job to terminate host")
+	catcher.Wrap(EnqueueTerminateHostJob(ctx, j.env, terminationJob), "enqueueing job to terminate host")
 
 	return catcher.Resolve()
 }

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -190,7 +190,10 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusNonExistent))
 
-			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			assert.NoError(t, err)
+			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+				"failed while waiting for host termination job to complete")
 
 			dbHost, err := host.FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -201,7 +204,10 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusFailed))
 
-			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			assert.NoError(t, err)
+			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+				"failed while waiting for host termination job to complete")
 
 			assert.Equal(t, cloud.StatusTerminated, cloud.GetMockProvider().Get(h.Id).Status)
 
@@ -219,7 +225,10 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusStopped))
 
-			require.True(t, amboy.WaitInterval(ctx, env.RemoteQueue(), 100*time.Millisecond))
+			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			assert.NoError(t, err)
+			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+				"failed while waiting for host termination job to complete")
 
 			assert.Equal(t, cloud.StatusTerminated, cloud.GetMockProvider().Get(h.Id).Status)
 

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -191,7 +191,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusNonExistent))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 				"failed while waiting for host termination job to complete")
 
@@ -205,7 +205,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusFailed))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 				"failed while waiting for host termination job to complete")
 
@@ -226,7 +226,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusStopped))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 				"failed while waiting for host termination job to complete")
 

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -383,12 +383,7 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context, old
 			return errors.Wrap(err, "checking cloud host status")
 		}
 
-		catcher := grip.NewBasicCatcher()
-		catcher.Add(errors.Wrap(err, "getting cloud host instance status"))
-		if !utility.StringSliceContains(evergreen.UpHostStatus, oldStatus) {
-			catcher.Wrap(j.host.Terminate(ctx, evergreen.User, j.TerminationReason), "marking host as terminated")
-		}
-		return catcher.Resolve()
+		return errors.Wrap(err, "getting cloud host instance status")
 	}
 	if cloudStatus == cloud.StatusNonExistent {
 		return errors.Wrap(j.host.Terminate(ctx, evergreen.User, j.TerminationReason), "marking nonexistent host as terminated")

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -134,7 +134,7 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 				TerminationReason: "failed to mount volume",
 			})
 
-			j.AddError(enqueueTerminateHostJob(ctx, j.env, terminateJob))
+			j.AddError(EnqueueTerminateHostJob(ctx, j.env, terminateJob))
 
 			return
 		}

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -133,7 +133,12 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 				TerminateIfBusy:   true,
 				TerminationReason: "failed to mount volume",
 			})
-			j.AddError(amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), terminateJob))
+			queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			if err != nil {
+				j.AddError(errors.Wrap(err, "getting host termination queue"))
+				return
+			}
+			j.AddError(amboy.EnqueueUniqueJob(ctx, queue, terminateJob))
 
 			return
 		}

--- a/units/provisioning_user_data_done.go
+++ b/units/provisioning_user_data_done.go
@@ -133,12 +133,8 @@ func (j *userDataDoneJob) Run(ctx context.Context) {
 				TerminateIfBusy:   true,
 				TerminationReason: "failed to mount volume",
 			})
-			queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			if err != nil {
-				j.AddError(errors.Wrap(err, "getting host termination queue"))
-				return
-			}
-			j.AddError(amboy.EnqueueUniqueJob(ctx, queue, terminateJob))
+
+			j.AddError(enqueueTerminateHostJob(ctx, j.env, terminateJob))
 
 			return
 		}

--- a/units/stats_amboy.go
+++ b/units/stats_amboy.go
@@ -92,15 +92,11 @@ func (j *amboyStatsCollector) Run(ctx context.Context) {
 			})
 		}
 
-		for _, queueGroupName := range j.env.RemoteQueueGroup().Queues(ctx) {
-			queueStatsByQueue := map[string]amboy.QueueStats{}
-			queueGroup, _ := j.env.RemoteQueueGroup().Get(ctx, queueGroupName)
-			if queueGroup != nil && queueGroup.Info().Started {
-				queueStatsByQueue[queueGroupName] = queueGroup.Stats(ctx)
-			}
-			j.logger.InfoWhen(len(queueStatsByQueue) > 0, message.Fields{
-				"message":        "pending amboy queue group stats",
-				"stats_by_queue": queueStatsByQueue,
+		queueGroup, _ := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+		if queueGroup != nil && queueGroup.Info().Started {
+			j.logger.Info(message.Fields{
+				"message": fmt.Sprintf("amboy '%s' group stats", terminateHostQueueGroup),
+				"stats":   queueGroup.Stats(ctx),
 			})
 		}
 	}

--- a/units/stats_amboy.go
+++ b/units/stats_amboy.go
@@ -83,11 +83,25 @@ func (j *amboyStatsCollector) Run(ctx context.Context) {
 		})
 	}
 
-	remoteQueue := j.env.RemoteQueue()
-	if !j.ExcludeRemote && (remoteQueue != nil && remoteQueue.Info().Started) {
-		j.logger.Info(message.Fields{
-			"message": "amboy remote queue stats",
-			"stats":   remoteQueue.Stats(ctx),
-		})
+	if !j.ExcludeRemote {
+		remoteQueue := j.env.RemoteQueue()
+		if remoteQueue != nil && remoteQueue.Info().Started {
+			j.logger.Info(message.Fields{
+				"message": "amboy remote queue stats",
+				"stats":   remoteQueue.Stats(ctx),
+			})
+		}
+
+		for _, queueGroupName := range j.env.RemoteQueueGroup().Queues(ctx) {
+			queueGroup, _ := j.env.RemoteQueueGroup().Get(ctx, queueGroupName)
+			if queueGroup != nil && queueGroup.Info().Started {
+				j.logger.Info(message.Fields{
+					"message":     "amboy queue group stats",
+					"queue_group": queueGroupName,
+					"stats":       queueGroup.Stats(ctx),
+				})
+			}
+		}
 	}
+
 }

--- a/units/stats_amboy.go
+++ b/units/stats_amboy.go
@@ -93,14 +93,15 @@ func (j *amboyStatsCollector) Run(ctx context.Context) {
 		}
 
 		for _, queueGroupName := range j.env.RemoteQueueGroup().Queues(ctx) {
+			queueStatsByQueue := map[string]amboy.QueueStats{}
 			queueGroup, _ := j.env.RemoteQueueGroup().Get(ctx, queueGroupName)
 			if queueGroup != nil && queueGroup.Info().Started {
-				j.logger.Info(message.Fields{
-					"message":     "amboy queue group stats",
-					"queue_group": queueGroupName,
-					"stats":       queueGroup.Stats(ctx),
-				})
+				queueStatsByQueue[queueGroupName] = queueGroup.Stats(ctx)
 			}
+			j.logger.InfoWhen(len(queueStatsByQueue) > 0, message.Fields{
+				"message":        "pending amboy queue group stats",
+				"stats_by_queue": queueStatsByQueue,
+			})
 		}
 	}
 

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -246,7 +246,7 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 			require.NoError(t, j.Error())
 
 			queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
 				"failed while waiting for host termination job to complete")
 

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -245,7 +245,10 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 			j.Run(ctx)
 			require.NoError(t, j.Error())
 
-			require.True(t, amboy.WaitInterval(ctx, j.env.RemoteQueue(), 100*time.Millisecond))
+			queue, err := j.env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
+			assert.NoError(t, err)
+			require.True(t, amboy.WaitInterval(ctx, queue, 100*time.Millisecond),
+				"failed while waiting for host termination job to complete")
 
 			dbHost, err := host.FindOneId(ctx, hostID)
 			require.NoError(t, err)

--- a/units/util.go
+++ b/units/util.go
@@ -93,3 +93,13 @@ func EnqueueSpawnHostModificationJob(ctx context.Context, env evergreen.Environm
 	}
 	return amboy.EnqueueUniqueJob(ctx, q, j)
 }
+
+// enqueueTerminateHostJob enqueues a job to terminate a host.
+func enqueueTerminateHostJob(ctx context.Context, env evergreen.Environment, j amboy.Job) error {
+	queueCtx, _ := env.Context()
+	q, err := env.RemoteQueueGroup().Get(queueCtx, terminateHostQueueGroup)
+	if err != nil {
+		return errors.Wrap(err, "getting host termination queue")
+	}
+	return amboy.EnqueueUniqueJob(ctx, q, j)
+}

--- a/units/util.go
+++ b/units/util.go
@@ -94,8 +94,8 @@ func EnqueueSpawnHostModificationJob(ctx context.Context, env evergreen.Environm
 	return amboy.EnqueueUniqueJob(ctx, q, j)
 }
 
-// enqueueTerminateHostJob enqueues a job to terminate a host.
-func enqueueTerminateHostJob(ctx context.Context, env evergreen.Environment, j amboy.Job) error {
+// EnqueueTerminateHostJob enqueues a job to terminate a host.
+func EnqueueTerminateHostJob(ctx context.Context, env evergreen.Environment, j amboy.Job) error {
 	queueCtx, _ := env.Context()
 	q, err := env.RemoteQueueGroup().Get(queueCtx, terminateHostQueueGroup)
 	if err != nil {


### PR DESCRIPTION
DEVPROD-7586

### Description
Previously we would falsely mark hosts as terminated if they were decomissioned and we couldn't verify their status -- this wasn't too problematic since they'd likely get cleaned up by spot, and reaper worst case, but now that we don't use spot, we often rely on the reaper timeout, which is pretty long. We should instead leave these hosts decommissioned so we'll try terminating again.

Moved termination to a queue group to avoid termination jobs gumming up the regular queue, in the worst case.

### Testing
Tweaked existing unit tests. 

