### PR TITLE
DEVPROD-3138: upload deploy artifacts to new bucket

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -145,6 +145,19 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "${task_name}" }
+      - command: s3.put
+        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_files_include_filter_prefix: evergreen/clients
+          local_files_include_filter: "*_*/evergreen*"
+          remote_file: evergreen/clients/${version_id}/
+          content_type: binary/octet-stream
+          bucket: mciuploads
+          permissions: public-read
+          preserve_path: true
       - func: assume-role
         vars:
           assume_role_arn: ${client_assume_role_arn}
@@ -158,19 +171,6 @@ variables:
           remote_file: evergreen/clients/${version_id}/
           content_type: binary/octet-stream
           bucket: evg-bucket-evergreen
-          permissions: public-read
-          preserve_path: true
-      - command: s3.put
-        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
-        params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
-          local_files_include_filter_prefix: evergreen/clients
-          local_files_include_filter: "*_*/evergreen*"
-          remote_file: evergreen/clients/${version_id}/
-          content_type: binary/octet-stream
-          bucket: mciuploads
           permissions: public-read
           preserve_path: true
 
@@ -179,6 +179,17 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "bin/static_assets.tgz" }
+      - command: s3.put
+        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_file: evergreen/bin/static_assets.tgz
+          remote_file: evergreen/clients/${version_id}/static_assets.tgz
+          content_type: application/gzip
+          bucket: mciuploads
+          permissions: public-read
       - func: assume-role
         vars:
           assume_role_arn: ${client_assume_role_arn}
@@ -191,17 +202,6 @@ variables:
           remote_file: evergreen/clients/${version_id}/static_assets.tgz
           content_type: application/gzip
           bucket: evg-bucket-evergreen
-          permissions: public-read
-      - command: s3.put
-        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
-        params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
-          local_file: evergreen/bin/static_assets.tgz
-          remote_file: evergreen/clients/${version_id}/static_assets.tgz
-          content_type: application/gzip
-          bucket: mciuploads
           permissions: public-read
 
 #######################################

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -145,6 +145,10 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "${task_name}" }
+        # kim: NOTE: this should overwrite the existing AWS vars from pre.
+      - func: assume-role
+        vars:
+          assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}
@@ -154,7 +158,7 @@ variables:
           local_files_include_filter: "*_*/evergreen*"
           remote_file: evergreen/clients/${version_id}/
           content_type: binary/octet-stream
-          bucket: mciuploads
+          bucket: evg-bucket-evergreen
           permissions: public-read
           preserve_path: true
 
@@ -163,6 +167,10 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "bin/static_assets.tgz" }
+        # kim: NOTE: this should overwrite the existing AWS vars from pre.
+      - func: assume-role
+        vars:
+          assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}
@@ -171,7 +179,7 @@ variables:
           local_file: evergreen/bin/static_assets.tgz
           remote_file: evergreen/clients/${version_id}/static_assets.tgz
           content_type: application/gzip
-          bucket: mciuploads
+          bucket: evg-bucket-evergreen
           permissions: public-read
 #######################################
 #              Functions              #
@@ -199,11 +207,11 @@ functions:
             [[ $? -eq 0 ]] && break;
           done
 
-  assume-role:
-    - command: ec2.assume_role
-      type: setup
-      params:
-        role_arn: ${assume_role_arn}
+  assume-role: &assume-role
+    command: ec2.assume_role
+    type: setup
+    params:
+      role_arn: ${assume_role_arn}
 
   run-make:
     command: subprocess.exec
@@ -256,10 +264,6 @@ functions:
         EVG_VERSION_ID: ${version_id}
 
   setup-credentials:
-    - command: ec2.assume_role
-      type: setup
-      params:
-        role_arn: ${assume_role_arn}
     - command: subprocess.exec
       type: setup
       params:
@@ -347,7 +351,7 @@ functions:
         args: ["scripts/verify-agent-version-update.sh"]
         env:
           BRANCH_NAME: ${branch_name}
-  
+
   verify-swaggo-fmt:
     - command: subprocess.exec
       params:
@@ -356,7 +360,7 @@ functions:
         args: ["scripts/verify-swaggo-fmt.sh"]
         env:
           GOPATH: ${workdir}/gopath
-  
+
   check-go-vulnerabilities:
     - command: subprocess.exec
       params:
@@ -647,7 +651,7 @@ tasks:
       - func: get-project-and-modules
       - func: verify-merge-function-update
   - name: generate-api-docs
-    commands: 
+    commands:
       - func: get-project-and-modules
       - command: subprocess.exec
         params:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -230,7 +230,7 @@ functions:
             [[ $? -eq 0 ]] && break;
           done
 
-  assume-role: &assume-role
+  assume-role:
     command: ec2.assume_role
     type: setup
     params:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -145,7 +145,6 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "${task_name}" }
-        # kim: NOTE: this should overwrite the existing AWS vars from pre.
       - func: assume-role
         vars:
           assume_role_arn: ${client_assume_role_arn}
@@ -161,13 +160,25 @@ variables:
           bucket: evg-bucket-evergreen
           permissions: public-read
           preserve_path: true
+      - command: s3.put
+        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_files_include_filter_prefix: evergreen/clients
+          local_files_include_filter: "*_*/evergreen*"
+          remote_file: evergreen/clients/${version_id}/
+          content_type: binary/octet-stream
+          bucket: mciuploads
+          permissions: public-read
+          preserve_path: true
 
   - &tar-and-push-static-assets
     commands:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "bin/static_assets.tgz" }
-        # kim: NOTE: this should overwrite the existing AWS vars from pre.
       - func: assume-role
         vars:
           assume_role_arn: ${client_assume_role_arn}
@@ -181,6 +192,18 @@ variables:
           content_type: application/gzip
           bucket: evg-bucket-evergreen
           permissions: public-read
+      - command: s3.put
+        # TODO (DEVPROD-3138): remove duplicate upload once app servers are switched to using new bucket.
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_file: evergreen/bin/static_assets.tgz
+          remote_file: evergreen/clients/${version_id}/static_assets.tgz
+          content_type: application/gzip
+          bucket: mciuploads
+          permissions: public-read
+
 #######################################
 #              Functions              #
 #######################################


### PR DESCRIPTION
DEVPROD-3138

### Description
Upload prod deploy artifacts to both new bucket and old bucket temporarily. This is so that we can smoothly transition from deploying from the old bucket to using the new one once Evergreen devs are informed of how to deploy to prod from the new bucket.

### Testing
Ran a patch in staging and manually verified that the artifacts were uploaded to the old and new buckets. Also, build-and-push in this PR patch should succeed.

### Documentation
Will update docs and send comms about how to use the new bucket once https://github.com/10gen/kernel-tools/pull/437 and https://github.com/evergreen-ci/evergreen-deploys/pull/28 are merged.