### PR TITLE
DEVPROD-7058: upgrade Amboy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/mongodb/amboy v0.0.0-20240529201533-be3ebe634749
+	github.com/mongodb/amboy v0.0.0-20240603145730-d49e4aef9c74
 	github.com/mongodb/anser v0.0.0-20231019191251-2a589a5299e6
 	github.com/mongodb/grip v0.0.0-20240213223901-f906268d82b9
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mongodb/amboy v0.0.0-20220408143015-94858bb64f00/go.mod h1:pyAwlkip3M7Hw91UqQpTo9Oo7clNgGFdOqa9EvgvhbM=
 github.com/mongodb/amboy v0.0.0-20220408184825-b2a14e2c511d/go.mod h1:pyAwlkip3M7Hw91UqQpTo9Oo7clNgGFdOqa9EvgvhbM=
-github.com/mongodb/amboy v0.0.0-20240529201533-be3ebe634749 h1:bGLmZBI4+pxvtlHywPN9BLtjz/ygD8dEV2GW59EXxBQ=
-github.com/mongodb/amboy v0.0.0-20240529201533-be3ebe634749/go.mod h1:XtYIRjheNi0/pf4NOV1qnyjdDncEpmUqAv4lRMIfBxo=
+github.com/mongodb/amboy v0.0.0-20240603145730-d49e4aef9c74 h1:Kbur7brFjafZ7hbqPk0a5CHJD5yRZPWUgeQws82iikg=
+github.com/mongodb/amboy v0.0.0-20240603145730-d49e4aef9c74/go.mod h1:XtYIRjheNi0/pf4NOV1qnyjdDncEpmUqAv4lRMIfBxo=
 github.com/mongodb/anser v0.0.0-20220408164649-99dd61768f4a/go.mod h1:iiM0FTD1XWGSxZPdM3NkCQeZEqatn9lGqwIZy3RwtgE=
 github.com/mongodb/anser v0.0.0-20231019191251-2a589a5299e6 h1:P0VNeg/cwHMRg/5K44kTxvBSXKMuxWEZpgXC3seWYEs=
 github.com/mongodb/anser v0.0.0-20231019191251-2a589a5299e6/go.mod h1:S55HFuPbd6Fq0e6c/cRbZZlbpvaiIQ7KiS/yZFT/p1c=


### PR DESCRIPTION
DEVPROD-7058

### Description
Upgrade Amboy for https://github.com/mongodb/amboy/pull/343. If the generate.tasks job has this same issue again, it'll handle it gracefully and the issue will show up in the Splunk logs.

### Testing
Existing tests compile.

### Documentation
N/A