### PR TITLE
DEVPROD-7768: idle terminate single host task group hosts less aggressively

### DIFF
--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -119,46 +119,19 @@ func (j *hostDrawdownJob) checkAndTerminateHost(ctx context.Context, h *host.Hos
 		return err
 	}
 
-	// don't drawdown hosts that are currently in the middle of tearing down a task group
-	// kim: TODO: file ticket for idle host termination while running teardown
-	// group.
+	// Don't drawdown hosts that are currently in the middle of tearing down a task group.
 	if h.IsTearingDown() && h.TeardownTimeExceededMax() {
 		return nil
 	}
 
-	// don't drawdown hosts that are running task groups
-	// kim: TODO: test that this is equ ivalent
-	isRunningSingleHostTaskGroup, err := hasSingleHostTaskGroupLock(h)
+	// Don't drawdown hosts that are running single host task groups.
+	isRunningSingleHostTaskGroup, err := isAssignedSingleHostTaskGroup(h)
 	if err != nil {
 		return errors.Wrap(err, "checking if host is running single host task group")
 	}
 	if isRunningSingleHostTaskGroup {
 		return nil
 	}
-	// kim: TODO: remove
-	// if h.RunningTaskGroup != "" {
-	//     t, err := task.FindOneIdAndExecution(h.RunningTask, h.RunningTaskExecution)
-	//     if err != nil {
-	//         return errors.Wrapf(err, "finding task '%s' execution '%d' running on host '%s'", h.RunningTask, h.RunningTaskExecution, h.Id)
-	//     }
-	//     if t == nil {
-	//         return errors.Errorf("task '%s' running on host '%s' execution '%d' not found", h.RunningTask, h.Id, h.RunningTaskExecution)
-	//     }
-	//     if t.IsPartOfSingleHostTaskGroup() {
-	//         return nil
-	//     }
-	// } else if h.LastGroup != "" && h.RunningTask == "" { // if we're currently running a task not in a group, then we already know the group is finished running.
-	//     t, err := task.FindOneId(h.LastTask)
-	//     if err != nil {
-	//         return errors.Wrapf(err, "finding last run task '%s' on host '%s'", h.LastTask, h.Id)
-	//     }
-	//     if t == nil {
-	//         return errors.Errorf("last run task '%s' on host '%s' not found", h.LastTask, h.Id)
-	//     }
-	//     if t.IsPartOfSingleHostTaskGroup() && t.Status == evergreen.TaskSucceeded {
-	//         return nil
-	//     }
-	// }
 
 	idleTime := h.IdleTime()
 

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -140,11 +140,11 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 
 	if idleTime > idleThreshold {
 		(*drawdownTarget)--
-		j.Decommissioned++
-		j.DecommissionedHosts = append(j.DecommissionedHosts, h.Id)
 		if err = h.SetDecommissioned(ctx, evergreen.User, false, "host decommissioned due to overallocation"); err != nil {
 			return errors.Wrapf(err, "decommissioning host '%s'", h.Id)
 		}
+		j.Decommissioned++
+		j.DecommissionedHosts = append(j.DecommissionedHosts, h.Id)
 		return nil
 	}
 	return nil

--- a/units/host_drawdown_test.go
+++ b/units/host_drawdown_test.go
@@ -6,125 +6,280 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/amboy"
-	"github.com/mongodb/amboy/queue"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func numHostsTerminated(ctx context.Context, env evergreen.Environment, drawdownInfo DrawdownInfo, t *testing.T) (int, []string) {
-	queue := queue.NewLocalLimitedSize(3, 1024)
-	require.NoError(t, queue.Start(ctx))
-	defer queue.Runner().Close(ctx)
+func numHostsDecommissionedForDrawdown(ctx context.Context, t *testing.T, env evergreen.Environment, drawdownInfo DrawdownInfo) (int, []string) {
+	j, ok := NewHostDrawdownJob(env, drawdownInfo, utility.RoundPartOfHour(1).Format(TSFormat)).(*hostDrawdownJob)
+	require.True(t, ok)
 
-	require.NoError(t, queue.Put(ctx, NewHostDrawdownJob(env, drawdownInfo, utility.RoundPartOfHour(1).Format(TSFormat))))
+	j.Run(ctx)
+	assert.NoError(t, j.Error())
 
-	assert.True(t, amboy.WaitInterval(ctx, queue, 50*time.Millisecond))
-	out := []string{}
-	num := 0
-	for j := range queue.Results(ctx) {
-		if ij, ok := j.(*hostDrawdownJob); ok {
-			num += ij.Terminated
-			out = append(out, ij.TerminatedHosts...)
-		}
-	}
+	assert.Equal(t, len(j.TerminatedHosts), j.Terminated)
 
-	assert.Equal(t, num, len(out))
-
-	return num, out
+	return j.Terminated, j.TerminatedHosts
 }
 
-////////////////////////////////////////////////////////////////////////
-// Testing with reference distro ids that are not present in the 'distro' collection in the database
-//
+func TestHostDrawdown(t *testing.T) {
 
-func TestTerminatingHosts(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = testutil.TestSpan(ctx, t)
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment){
+		"DecommissionsHostsDownToCap": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			distro1 := distro.Distro{
+				Id:       "distro1",
+				Provider: evergreen.ProviderNameMock,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MinimumHosts: 2,
+				},
+			}
+			require.NoError(t, distro1.Insert(ctx))
 
-	env := evergreen.GetEnvironment()
+			// insert a gaggle of hosts, some of which reference a host.Distro that doesn't exist in the distro collection
+			host1 := host.Host{
+				Id:           "h1",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-10 * time.Minute),
+				Status:       evergreen.HostRunning,
+				RunningTask:  "dummy_task_name1",
+				StartedBy:    evergreen.User,
+			}
+			host2 := host.Host{
+				Id:           "h2",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-20 * time.Minute),
+				Status:       evergreen.HostRunning,
+				RunningTask:  "dummy_task_name2",
+				StartedBy:    evergreen.User,
+			}
+			host3 := host.Host{
+				Id:           "h3",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-30 * time.Minute),
+				Status:       evergreen.HostRunning,
+				StartedBy:    evergreen.User,
+			}
+			host4 := host.Host{
+				Id:           "h4",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-30 * time.Minute),
+				Status:       evergreen.HostRunning,
+				StartedBy:    evergreen.User,
+			}
+			host5 := host.Host{
+				Id:           "h5",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-20 * time.Minute),
+				Status:       evergreen.HostRunning,
+				StartedBy:    evergreen.User,
+			}
+			require.NoError(t, host1.Insert(ctx))
+			require.NoError(t, host2.Insert(ctx))
+			require.NoError(t, host3.Insert(ctx))
+			require.NoError(t, host4.Insert(ctx))
+			require.NoError(t, host5.Insert(ctx))
+			tsk1 := task.Task{
+				Id: "dummy_task_name1",
+			}
+			tsk2 := task.Task{
+				Id: "dummy_task_name2",
+			}
+			require.NoError(t, tsk1.Insert())
+			require.NoError(t, tsk2.Insert())
 
-	t.Run("SimpleTerminationTest", func(t *testing.T) {
-		tctx := testutil.TestSpan(ctx, t)
-		// clear the distro and hosts collections; add an index on the host collection
-		testFlaggingIdleHostsSetupTest(t)
-		// insert two reference distro.Distro
+			// If we encounter missing distros, we decommission hosts from those
+			// distros.
 
-		distro1 := distro.Distro{
-			Id:       "distro1",
-			Provider: evergreen.ProviderNameMock,
-			HostAllocatorSettings: distro.HostAllocatorSettings{
-				MinimumHosts: 2,
-			},
-		}
-		require.NoError(t, distro1.Insert(tctx))
+			drawdownInfo := DrawdownInfo{
+				DistroID:     distro1.Id,
+				NewCapTarget: 3,
+			}
+			// 3 idle hosts, 2 need to be terminated to reach NewCapTarget
+			num, hosts := numHostsDecommissionedForDrawdown(ctx, t, env, drawdownInfo)
+			assert.Equal(t, 2, num)
 
-		// insert a gaggle of hosts, some of which reference a host.Distro that doesn't exist in the distro collection
-		host1 := host.Host{
-			Id:           "h1",
-			Distro:       distro1,
-			Provider:     evergreen.ProviderNameMock,
-			CreationTime: time.Now().Add(-10 * time.Minute),
-			Status:       evergreen.HostRunning,
-			RunningTask:  "dummy_task_name",
-			StartedBy:    evergreen.User,
-		}
-		host2 := host.Host{
-			Id:           "h2",
-			Distro:       distro1,
-			Provider:     evergreen.ProviderNameMock,
-			CreationTime: time.Now().Add(-20 * time.Minute),
-			Status:       evergreen.HostRunning,
-			RunningTask:  "dummy_task_name2",
-			StartedBy:    evergreen.User,
-		}
-		host3 := host.Host{
-			Id:           "h3",
-			Distro:       distro1,
-			Provider:     evergreen.ProviderNameMock,
-			CreationTime: time.Now().Add(-30 * time.Minute),
-			Status:       evergreen.HostRunning,
-			StartedBy:    evergreen.User,
-		}
-		host4 := host.Host{
-			Id:           "h4",
-			Distro:       distro1,
-			Provider:     evergreen.ProviderNameMock,
-			CreationTime: time.Now().Add(-30 * time.Minute),
-			Status:       evergreen.HostRunning,
-			StartedBy:    evergreen.User,
-		}
-		host5 := host.Host{
-			Id:           "h5",
-			Distro:       distro1,
-			Provider:     evergreen.ProviderNameMock,
-			CreationTime: time.Now().Add(-20 * time.Minute),
-			Status:       evergreen.HostRunning,
-			StartedBy:    evergreen.User,
-		}
-		require.NoError(t, host1.Insert(tctx))
-		require.NoError(t, host2.Insert(tctx))
-		require.NoError(t, host3.Insert(tctx))
-		require.NoError(t, host4.Insert(tctx))
-		require.NoError(t, host5.Insert(tctx))
+			assert.Contains(t, hosts, host3.Id)
+			assert.Contains(t, hosts, host4.Id)
+		},
+		"IgnoresSingleHostTaskGroupHosts": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			distro1 := distro.Distro{
+				Id:       "distro1",
+				Provider: evergreen.ProviderNameMock,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MinimumHosts: 0,
+				},
+			}
+			require.NoError(t, distro1.Insert(ctx))
 
-		// If we encounter missing distros, we decommission hosts from those
-		// distros.
+			host1 := host.Host{
+				Id:               "h1",
+				Distro:           distro1,
+				Provider:         evergreen.ProviderNameMock,
+				CreationTime:     time.Now().Add(-30 * time.Minute),
+				Status:           evergreen.HostRunning,
+				StartedBy:        evergreen.User,
+				RunningTaskGroup: "dummy_task_group1",
+				RunningTask:      "dummy_task_name1",
+			}
+			host2 := host.Host{
+				Id:           "h2",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-30 * time.Minute),
+				Status:       evergreen.HostRunning,
+				StartedBy:    evergreen.User,
+				LastGroup:    "dummy_task_group2",
+				LastTask:     "dummy_task_name2",
+			}
+			require.NoError(t, host1.Insert(ctx))
+			require.NoError(t, host2.Insert(ctx))
+			tsk1 := task.Task{
+				Id:                "dummy_task_name1",
+				TaskGroup:         "dummy_task_group1",
+				TaskGroupMaxHosts: 1,
+			}
+			tsk2 := task.Task{
+				Id:                "dummy_task_name2",
+				Status:            evergreen.TaskSucceeded,
+				TaskGroup:         "dummy_task_group2",
+				TaskGroupMaxHosts: 1,
+			}
+			require.NoError(t, tsk1.Insert())
+			require.NoError(t, tsk2.Insert())
 
-		drawdownInfo := DrawdownInfo{
-			DistroID:     "distro1",
-			NewCapTarget: 3,
-		}
-		// 3 idle hosts, 2 need to be terminated to reach NewCapTarget
-		num, hosts := numHostsTerminated(tctx, env, drawdownInfo, t)
-		assert.Equal(t, 2, num)
+			drawdownInfo := DrawdownInfo{
+				DistroID:     distro1.Id,
+				NewCapTarget: 0,
+			}
+			num, _ := numHostsDecommissionedForDrawdown(ctx, t, env, drawdownInfo)
+			assert.Zero(t, num, "should not draw down any hosts running single host task groups")
+		},
+		"IgnoresHostRunningTask": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			distro1 := distro.Distro{
+				Id:       "distro1",
+				Provider: evergreen.ProviderNameMock,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MinimumHosts: 0,
+				},
+			}
+			require.NoError(t, distro1.Insert(ctx))
 
-		assert.Contains(t, hosts, "h3")
-		assert.Contains(t, hosts, "h4")
-	})
+			host1 := host.Host{
+				Id:           "h1",
+				Distro:       distro1,
+				Provider:     evergreen.ProviderNameMock,
+				CreationTime: time.Now().Add(-30 * time.Minute),
+				Status:       evergreen.HostRunning,
+				StartedBy:    evergreen.User,
+				RunningTask:  "dummy_task_name1",
+			}
+			require.NoError(t, host1.Insert(ctx))
+			tsk1 := task.Task{
+				Id: "dummy_task_name1",
+			}
+			require.NoError(t, tsk1.Insert())
+
+			drawdownInfo := DrawdownInfo{
+				DistroID:     distro1.Id,
+				NewCapTarget: 0,
+			}
+			num, hosts := numHostsDecommissionedForDrawdown(ctx, t, env, drawdownInfo)
+			assert.Zero(t, num, "should not draw down host running task")
+			assert.Empty(t, hosts)
+		},
+		"IgnoresHostThatRecentlyRanTaskGroup": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			distro1 := distro.Distro{
+				Id:       "distro1",
+				Provider: evergreen.ProviderNameMock,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MinimumHosts: 0,
+				},
+			}
+			require.NoError(t, distro1.Insert(ctx))
+
+			host1 := host.Host{
+				Id:                    "h1",
+				Distro:                distro1,
+				Provider:              evergreen.ProviderNameMock,
+				CreationTime:          time.Now().Add(-30 * time.Minute),
+				Status:                evergreen.HostRunning,
+				StartedBy:             evergreen.User,
+				LastTask:              "dummy_task_group1",
+				LastGroup:             "dummy_task_group1",
+				LastTaskCompletedTime: time.Now().Add(-time.Minute),
+			}
+			require.NoError(t, host1.Insert(ctx))
+			tsk1 := task.Task{
+				Id:                "dummy_task_name1",
+				TaskGroup:         "dummy_task_group1",
+				TaskGroupMaxHosts: 5,
+			}
+			require.NoError(t, tsk1.Insert())
+
+			drawdownInfo := DrawdownInfo{
+				DistroID:     distro1.Id,
+				NewCapTarget: 0,
+			}
+			num, hosts := numHostsDecommissionedForDrawdown(ctx, t, env, drawdownInfo)
+			assert.Zero(t, 0, num, "should not draw down host that was recently running task group")
+			assert.Empty(t, hosts)
+		},
+		"DecommissionsIdleMultiHostTaskGroupHost": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+			distro1 := distro.Distro{
+				Id:       "distro1",
+				Provider: evergreen.ProviderNameMock,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MinimumHosts: 0,
+				},
+			}
+			require.NoError(t, distro1.Insert(ctx))
+
+			host1 := host.Host{
+				Id:                    "h1",
+				Distro:                distro1,
+				Provider:              evergreen.ProviderNameMock,
+				CreationTime:          time.Now().Add(-30 * time.Minute),
+				Status:                evergreen.HostRunning,
+				StartedBy:             evergreen.User,
+				LastTask:              "dummy_task_name1",
+				LastTaskCompletedTime: time.Now().Add(-20 * time.Minute),
+			}
+			require.NoError(t, host1.Insert(ctx))
+			tsk1 := task.Task{
+				Id: "dummy_task_name1",
+			}
+			require.NoError(t, tsk1.Insert())
+
+			drawdownInfo := DrawdownInfo{
+				DistroID:     distro1.Id,
+				NewCapTarget: 0,
+			}
+			num, hosts := numHostsDecommissionedForDrawdown(ctx, t, env, drawdownInfo)
+			assert.Equal(t, 1, num, "should draw down long idle hosts")
+			assert.Contains(t, hosts, host1.Id)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = testutil.TestSpan(ctx, t)
+			testFlaggingIdleHostsSetupTest(t)
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+
+			tCase(ctx, t, env)
+		})
+	}
 }

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -235,7 +235,8 @@ func isAssignedSingleHostTaskGroup(h *host.Host) (bool, error) {
 	if h.LastGroup != "" && h.RunningTask == "" {
 		// Check if the host just finished a successful single host task group
 		// task but hasn't gotten to the next one yet (if any). Assume that it
-		// will continue onto the next task group task ASAP.
+		// will continue onto the next task group task ASAP, so it's still
+		// assigned the task group.
 		prevTask, err := task.FindOneId(h.LastTask)
 		if err != nil {
 			return false, errors.Wrapf(err, "finding host's last task group task '%s'", h.LastTask)
@@ -264,8 +265,6 @@ func (j *idleHostJob) getTerminationReason(idleInfo hostIdleInfo) string {
 		return "host has an outdated AMI"
 	}
 	if idleInfo.timeSinceLastCommunication >= idleInfo.idleThreshold {
-		// kim: TODO: add test for idle for a few minutes and running single host
-		// task group
 		return fmt.Sprintf("host is idle or unreachable, communication time %s is over threshold time %s", idleInfo.timeSinceLastCommunication, idleInfo.idleThreshold)
 	}
 	if idleInfo.idleTime >= idleInfo.idleThreshold {

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -267,7 +267,7 @@ func (i hostIdleInfo) getTerminationReason() string {
 		return fmt.Sprintf("host is idle or unreachable, communication time %s is over threshold time %s", i.timeSinceLastCommunication, i.idleThreshold)
 	}
 	if i.idleTime >= i.idleThreshold {
-		return fmt.Sprintf("host is idle or unreachable, idle time %s is over threshold time %s", i.timeSinceLastCommunication, i.idleThreshold)
+		return fmt.Sprintf("host is idle or unreachable, idle time %s is over threshold time %s", i.idleTime, i.idleThreshold)
 	}
 
 	return ""

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -195,7 +195,7 @@ func (j *idleHostJob) getIdleInfo(h *host.Host, d *distro.Distro, schedulerConfi
 
 	// Allow additional idle time for single host task groups in case it is
 	// slightly slow getting to the next task in the task group. Disrupting a
-	// single host task group breaks continuity and the requires restarting the
+	// single host task group breaks continuity and requires restarting the
 	// entire task group from the start, which is undesirable.
 	const singleHostTaskGroupIdleCutoff = 5 * time.Minute
 	isRunningSingleHostTaskGroup, err := isAssignedSingleHostTaskGroup(h)

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -201,8 +201,8 @@ func (j *idleHostJob) getIdleInfo(h *host.Host, d *distro.Distro, schedulerConfi
 	// single host task group breaks continuity and the requires restarting the
 	// entire task group from the start.
 	var isRunningSingleHostTaskGroup bool
-	if h.RunningTask == "" {
-		runningTask, err := task.FindByIdExecution(h.RunningTask, &h.RunningTaskExecution)
+	if h.RunningTask != "" {
+		runningTask, err := task.FindOneIdAndExecution(h.RunningTask, h.RunningTaskExecution)
 		if err != nil {
 			return hostIdleInfo{}, errors.Wrapf(err, "finding host's running task '%s'", h.RunningTask)
 		}

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -249,7 +249,7 @@ func TestFlaggingIdleHosts(t *testing.T) {
 		}
 		require.NoError(t, distro1.Insert(tctx))
 
-		// Insert a host is running a task but has an outdated AMI.
+		// Insert a host that is running a task but has an outdated AMI.
 		host1 := host.Host{
 			Id:                    "h1",
 			Distro:                distro1,


### PR DESCRIPTION
DEVPROD-7768
BF-31821

### Description
The code change isn't actually that large, just lots of lines/tests got moved around to refactor.

This fixes 2 issues where the idle termination job would terminate hosts running single host task groups too eagerly:

1. Give single host task groups more grace period to be idle. If the host/task lifecycle finished one task and was a little slow to get to the next task in the single host task group, it would get idle terminated after 1 minute. This is undesirable because the only options once a single host task group is terminated is to start over all the way from the beginning (or in the case of BF-31821, create more BFGs).
    * I could be convinced to turn this into an admin setting rather than a constant if we really want it to be configurable.
3. Don't terminate hosts with outdated AMIs if they're in the middle of running a single host task group (either actively running a task or in between task group tasks). For similar reasons to 1, it would be expensive to start a single host task group all over from scratch.

I also refactored some of the logic because it was getting quite messy:
* Refactor idle termination logic to share single host task group logic with host drawdown.
* Refactor idle termination logic to be a little more organized.
* Refactor host drawdown tests to be less messy + provide more test coverage.
* Rename terminated -> decommissioned in the host drawdown job (it doesn't directly terminate hosts).

### Testing
Added lots of unit tests, including for existing functionality that wasn't tested.

### Documentation
N/A