### PR TITLE
DEVPROD-2446, DEVPROD-5685 improve /rotate route

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -106,6 +106,7 @@ func FindMergedProjectVars(projectID string) (*ProjectVars, error) {
 // UpdateProjectVarsByValue searches all projects who have a variable set to the toReplace input parameter, and replaces all
 // matching project variables with the replacement input parameter. If dryRun is set to true, the update is not performed.
 // We return a list of keys that were replaced (or, the list of keys that would be replaced in the case that dryRun is true).
+// If enabledOnly is set to true, we update only projects that are enabled, and repos.
 func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun, enabledOnly bool) (map[string][]string, error) {
 	catcher := grip.NewBasicCatcher()
 	matchingProjectVars, err := getVarsByValue(toReplace)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -106,7 +106,7 @@ func FindMergedProjectVars(projectID string) (*ProjectVars, error) {
 // UpdateProjectVarsByValue searches all projects who have a variable set to the toReplace input parameter, and replaces all
 // matching project variables with the replacement input parameter. If dryRun is set to true, the update is not performed.
 // We return a list of keys that were replaced (or, the list of keys that would be replaced in the case that dryRun is true).
-func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun bool) (map[string][]string, error) {
+func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun, enabledOnly bool) (map[string][]string, error) {
 	catcher := grip.NewBasicCatcher()
 	matchingProjectVars, err := getVarsByValue(toReplace)
 	if err != nil {
@@ -119,6 +119,17 @@ func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun bo
 	for _, projectVars := range matchingProjectVars {
 		for key, val := range projectVars.Vars {
 			if val == toReplace {
+				identifier := projectVars.Id
+				// Don't error if this doesn't work, since we can just use the ID instead, and this may be a repo project.
+				pRef, _ := FindBranchProjectRef(projectVars.Id)
+				if pRef != nil {
+					if enabledOnly && !pRef.Enabled {
+						continue
+					}
+					if pRef.Identifier != "" {
+						identifier = pRef.Identifier
+					}
+				}
 				if !dryRun {
 					var beforeVars ProjectVars
 					err = util.DeepCopy(*projectVars, &beforeVars)
@@ -145,7 +156,7 @@ func UpdateProjectVarsByValue(toReplace, replacement, username string, dryRun bo
 						catcher.Wrapf(err, "logging project modification for project '%s'", projectVars.Id)
 					}
 				}
-				changes[projectVars.Id] = append(changes[projectVars.Id], key)
+				changes[identifier] = append(changes[identifier], key)
 			}
 		}
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1455,9 +1455,9 @@ func makeProjectVarsPut() gimlet.RouteHandler {
 //	@Security		Api-User || Api-Key
 //	@Param			to_replace		query		string				true	"Variable value to search and replace."
 //	@Param			replacement		query		string				true	"Value to replace the variables that match to_replace."
-//	@Param			dry_run			query		bool				false	"If set to true, we don't complete the update"
-//	@Param			enabled_only	query		bool				false	"If set to true, we only return enabled projects"
-//	@Success		200				{object}	map[string][]string	"If dry_run is set, a map of projectId to a list of keys that would be replaced. Otherwise, a map of projectId to a list of keys that were replaced."
+//	@Param			dry_run			query		bool				false	"If set to true, we don't complete the update, but we return the projects we would've updated"
+//	@Param			enabled_only	query		bool				false	"If set to true, we only update variables for enabled projects and repos."
+//	@Success		200				{object}	map[string][]string	"A map of project identifiers to a list of keys that are replaced (or would have been, in the case of dry_run).
 func (h *projectVarsPutHandler) Factory() gimlet.RouteHandler {
 	return &projectVarsPutHandler{}
 }


### PR DESCRIPTION
DEVPROD-2446 
DEVPROD-5685 

### Description
1) Printing IDs is super annoying; made a change to print identifiers.
2) Added an option to only look at enabled projects (this isn't fool proof but I think it's good enough; I think this is really only useful for debugging. We could enforce that also)
3) Drive-by removed artifact rotation (DEVPROD-5685) since it doesn't work, and infra has a workaround if this is ever needed.

### Testing
Added a unit test and confirmed existing unit tests still work.

### Documentation
updated swaggo
