### PR TITLE
DEVPROD-7058: truncate long generate.tasks errors

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -462,6 +462,8 @@ Notes:
     it may appear that your generate.tasks is hanging until timeout.
     There may be details of this in the task logs; please ask
     if you aren't sure what to do with a hanging generate.tasks.
+-   If generate.tasks produces many errors, you may not be able to see the full
+    error output.
 
 ``` yaml
 - command: generate.tasks

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -229,9 +229,8 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 	shouldNoop := adb.ResultsNotFound(err) || db.IsDuplicateKey(err)
 	if err != nil && len(err.Error()) > maxGenerateTasksErrMsgLength {
 		// If the error is excessively long (e.g. due to lots of validation
-		// errors), truncate it to avoid hitting the 16 MB limit when setting the
-		// error message.
-		// kim: TODO: manually test truncation.
+		// errors), truncate it to avoid hitting the 16 MB limit when saving
+		// the generate.tasks error message back to the DB.
 		err = errors.New(err.Error()[:maxGenerateTasksErrMsgLength] + "(truncated due to excessively long errors)")
 	}
 
@@ -265,9 +264,6 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 	if err != nil && !shouldNoop {
 		j.AddError(err)
-		errMsg := err.Error()
-		if len(errMsg) > maxGenerateTasksErrMsgLength {
-		}
 		j.AddError(task.MarkGeneratedTasksErr(j.TaskID, err))
 		return
 	}

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -204,6 +204,8 @@ func (j *generateTasksJob) handleError(handledError error) error {
 	return handledError
 }
 
+const maxGenerateTasksErrMsgLength = 1024 * 250 // 250k chars * 4 bytes/char = 1 MB
+
 func (j *generateTasksJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 	start := time.Now()
@@ -225,6 +227,13 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 	err = j.generate(ctx, t)
 	shouldNoop := adb.ResultsNotFound(err) || db.IsDuplicateKey(err)
+	if err != nil && len(err.Error()) > maxGenerateTasksErrMsgLength {
+		// If the error is excessively long (e.g. due to lots of validation
+		// errors), truncate it to avoid hitting the 16 MB limit when setting the
+		// error message.
+		// kim: TODO: manually test truncation.
+		err = errors.New(err.Error()[:maxGenerateTasksErrMsgLength] + "(truncated due to excessively long errors)")
+	}
 
 	grip.InfoWhen(err == nil, message.Fields{
 		"message":       "generate.tasks finished",
@@ -256,6 +265,9 @@ func (j *generateTasksJob) Run(ctx context.Context) {
 
 	if err != nil && !shouldNoop {
 		j.AddError(err)
+		errMsg := err.Error()
+		if len(errMsg) > maxGenerateTasksErrMsgLength {
+		}
 		j.AddError(task.MarkGeneratedTasksErr(j.TaskID, err))
 		return
 	}


### PR DESCRIPTION
DEVPROD-7058

### Description
Follow-up to https://github.com/mongodb/amboy/pull/343 - When saving generate.tasks errors back to the task document, if the error string is really long, the job could hit the 16 MB size limit and prevent the error from saving to the task. Unfortunately, the task document is already tight on space because it saves the entire generate.tasks JSON file in it, which could be up to 16 MB large, so the max error message length is set pretty conservatively.

Note that the problem could still happen in an edge case, I just made it much less likely. For example, if the task doc is filled to almost 16 MB by generated JSON input, and then it can't accommodate even the shortened 1 MB error message. I believe this means we'll eventually have to re-apply #7303 or otherwise store multi-MB generated JSON files in some place other than the task document. However, it's unlikely enough that I don't think we need to do it as part of this work.

### Testing
I tried reproducing a long error message in staging but I think staging doesn't have enough memory to generate a huge error message (I tried and staging just froze and reported that it was unhealthy/down). I'm going to ask the user to resubmit the patch once this has been deployed to see if it works.

### Documentation
Updated docs to mention that extremely long errors might get cut off.