### PR TITLE
docs: improve docs around limiting when a task will run

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -582,7 +582,7 @@ tasks:
           sleep 1000
 ```
 
-### Limiting When a Task Will Run
+### Limiting When a Task/Variant Will Run
 
 To limit the conditions when a task will run, the following settings can be
 added to a task definition, to a build variant definition, or to a specific task

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -303,14 +303,14 @@ Fields:
     to project commit activity. To run something on a regular schedule
     regardless of commit activity, consider using [periodic builds](Project-and-Distro-Settings#periodic-builds)
     instead.
--   `task_group`: a [task
-    group](#task-groups)
+-   `task_group`: a [task group](#task-groups)
     may be defined directly inline or using YAML aliases on a build
     variant task. This is an alternative to referencing a task group
     defined in `task_groups` under the tasks of a given build variant.
 -   `tags`: optional list of tags to group the build variant for alias definitions (explained [here](#task-and-variant-tags))
--   Build variants support [all options that limit when a task will run](#limiting-when-a-task-will-run). If set for the
-    build variant, it will apply to all tasks under the build variant.
+-   Build variants support [all options that limit when a task will run](#limiting-when-a-task-will-run)
+    (`allowed_requesters`, `patch_only`, `patchable`, `disable`, etc.). If set for the
+    build variant, it will apply to all tasks under the build variant. 
 
 Additionally, an item in the `tasks` list can be of the form
 
@@ -626,6 +626,7 @@ tasks:
   allowed_requesters: ["patch", "github_tag"]
 ```
 
+
 The valid requester values are:
 - `patch`: manual patches.
 - `github_pr`: GitHub PR patches.
@@ -649,6 +650,21 @@ project settings configure a [GitHub PR patch
 definition](Project-and-Distro-Settings#github-pull-request-testing) to run
 tasks A and B but task A has `allowed_requesters: ["commit"]`, then GitHub PR
 patches will only run task B.
+
+This can also be set for build variants as a whole:
+```yaml
+buildvariants:
+- name: github_pr_only
+allowed_requesters: ["github_pr"]
+```
+or for particular tasks under a build variant:
+```yaml
+buildvariants:
+  - name: anything
+    tasks: 
+      - name: only_commit_queue
+        allowed_requesters: ["github_pr"]
+```
 
 ### Expansions
 


### PR DESCRIPTION

### Description
Allowed_requester is technically documented for variants but is hard to find since it can't be grepped for in the buildvariant section, and the section it links to doesn't confirm that it works for variants. 

### Documentation
<img width="875" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26798134/2301103d-7202-462c-bb64-2cc5f237650f">

<img width="611" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26798134/58d0c78a-61a3-49c0-9bda-560f0638ca33">