### PR TITLE
DEVPROD-5993 add agent route to create github dynamic access tokens

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -102,6 +102,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/task/{task_id}/update_push_status").Version(2).Post().Wrap(requireTask).RouteHandler(makeUpdatePushStatus())
 	app.AddRoute("/task/{task_id}/restart").Version(2).Post().Wrap(requireTask).RouteHandler(makeMarkTaskForRestart())
 	app.AddRoute("/task/{task_id}/check_run").Version(2).Post().Wrap(requireTask).RouteHandler(makeCheckRun(settings))
+	app.AddRoute("/task/{task_id}/github_dynamic_access_token/{owner}/{repo}").Version(2).Post().Wrap(requireTask).RouteHandler(makeCreateGitHubDynamicAccessToken(env))
 
 	// REST v2 API Routes
 	app.AddRoute("/").Version(2).Get().Wrap(requireUser).RouteHandler(makePlaceHolder())


### PR DESCRIPTION
DEVPROD-5993

### Description
This creates an agent route `GET /rest/v2/task/{task_id}/github_dynamic_access_token/{owner}/{repo}` that takes in a user, owner, and repo, and returns an installation token with the permissions specified.

### Testing
TBA

### Documentation
TBA