### PR TITLE
DEVPROD-7904 use static credentials for presigning

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -93,11 +94,11 @@ func presignFile(file File) (string, error) {
 	}
 
 	// TODO (DEVPROD-6193): remove this special casing once artifacts from the old
-	// AWS key have expired (after 3/1/2025).
-	// Empty creds will use the SDK's default credentials chain.
+	// AWS key have expired (after 5/20/2025).
+	// EC2Keys[0] contains static credentials that only has permissions to access the mciuploads bucket.
 	if file.Bucket == "mciuploads" {
-		file.AwsKey = ""
-		file.AwsSecret = ""
+		file.AwsKey = evergreen.GetEnvironment().Settings().Providers.AWS.EC2Keys[0].Key
+		file.AwsSecret = evergreen.GetEnvironment().Settings().Providers.AWS.EC2Keys[0].Secret
 	}
 
 	requestParams := pail.PreSignRequestParams{


### PR DESCRIPTION
[DEVPROD-7904](https://jira.mongodb.org/browse/DEVPROD-7904)

### Description
https://github.com/evergreen-ci/evergreen/pull/7712 special cased the `mciuploads` bucket to allow us to rotate the key. The strategy there was to use the app's role to generate the presigned URL. The issue with this is that the presigned URL is only valid so long as the signing credentials are valid and the credentials we get for the app's role are temporary. So if you happen to get a presigned URL just before the app's credentials expire your link will expire soon thereafter.

From [the AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html#PresignedUrl-Expiration): (h/t @julianedwards)
> If you created a presigned URL using a temporary credential, the URL expires when the credential expires. This is true even if the URL was created with a later expiration time.

### Testing
In staging I was still able to download a signed artifact.
