### PR TITLE
DEVPROD-4090 Error when receiving a server error when validating config

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-06-04"
+	ClientVersion = "2024-06-06"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -50,19 +50,11 @@ func Validate() cli.Command {
 			if err != nil {
 				return err
 			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-
-			client, err := conf.setupRestCommunicator(ctx, !quiet)
-			if err != nil {
-				return errors.Wrap(err, "setting up REST communicator")
-			}
-			defer client.Close()
 
 			ac, _, err := conf.getLegacyClients()
 			if err != nil {
@@ -147,7 +139,7 @@ func validateFile(path string, ac *legacyClient, quiet, includeLong, errorOnWarn
 	}
 	projErrors, err := ac.ValidateLocalConfig(projectYaml, quiet, includeLong, projectID)
 	if err != nil {
-		return nil
+		return errors.Wrapf(err, "validating project '%s'", projectID)
 	}
 
 	grip.Info(projErrors)


### PR DESCRIPTION
DEVPROD-4090

### Description
Before, during config validation we would just no-op when we get an error. This treats the error as an error and says it to the user.

### Testing
Built and ran locally. I didn't add unit testing since it's not that easy to add for this one, and pretty niche. We don't test that in our other commands from what I saw- since the crux of it is just API requests that error for this command return nil rather than the error (seems like a typo / mishap, git blame dates it back 6 years).