### PR TITLE
DEVPROD-5991 Make CreateInstallationToken and HasGitHubApp work for user apps

### DIFF
--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -19,7 +19,7 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
+	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -19,7 +19,7 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 
-	appToken, err := settings.CreateInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, settings, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -19,7 +19,7 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, settings, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -91,14 +91,14 @@ func TestGetGithubSettings(t *testing.T) {
 	settings.Expansions[GithubAppPrivateKey] = ""
 
 	authFields, err := settings.GetGitHubAppAuth()
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "github app id")
 	assert.Nil(authFields)
 
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 1234,
 	}
 	authFields, err = settings.GetGitHubAppAuth()
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "github app private key")
 	assert.Nil(authFields)
 
 	settings.Expansions[GithubAppPrivateKey] = "key"

--- a/config_test.go
+++ b/config_test.go
@@ -90,20 +90,23 @@ func TestGetGithubSettings(t *testing.T) {
 	}
 	settings.Expansions[GithubAppPrivateKey] = ""
 
-	authFields := getGithubAppAuth(settings)
+	authFields, err := settings.GetGitHubAppAuth()
+	require.NoError(t, err)
 	assert.Nil(authFields)
 
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 1234,
 	}
-	authFields = getGithubAppAuth(settings)
+	authFields, err = settings.GetGitHubAppAuth()
+	require.NoError(t, err)
 	assert.Nil(authFields)
 
 	settings.Expansions[GithubAppPrivateKey] = "key"
-	authFields = getGithubAppAuth(settings)
+	authFields, err = settings.GetGitHubAppAuth()
+	require.NoError(t, err)
 	assert.NotNil(authFields)
-	assert.Equal(int64(1234), authFields.appId)
-	assert.Equal([]byte("key"), authFields.privateKey)
+	assert.Equal(int64(1234), authFields.AppID)
+	assert.Equal([]byte("key"), authFields.PrivateKey)
 
 	assert.NotPanics(func() {
 		settings := &Settings{}

--- a/config_test.go
+++ b/config_test.go
@@ -90,19 +90,17 @@ func TestGetGithubSettings(t *testing.T) {
 	}
 	settings.Expansions[GithubAppPrivateKey] = ""
 
-	authFields, err := settings.GetGitHubAppAuth()
-	require.ErrorContains(t, err, "github app id")
+	authFields := settings.CreateGitHubAppAuth()
 	assert.Nil(authFields)
 
 	settings.AuthConfig.Github = &GithubAuthConfig{
 		AppId: 1234,
 	}
-	authFields, err = settings.GetGitHubAppAuth()
-	require.ErrorContains(t, err, "github app private key")
+	authFields = settings.CreateGitHubAppAuth()
 	assert.Nil(authFields)
 
 	settings.Expansions[GithubAppPrivateKey] = "key"
-	authFields, err = settings.GetGitHubAppAuth()
+	authFields = settings.CreateGitHubAppAuth()
 	require.NoError(t, err)
 	assert.NotNil(authFields)
 	assert.Equal(int64(1234), authFields.AppID)

--- a/environment.go
+++ b/environment.go
@@ -1121,7 +1121,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := e.settings.CreateInstallationToken(e.ctx, owner, repo, nil)
+	token, err := CreateInstallationToken(e.ctx, e.settings, owner, repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/environment.go
+++ b/environment.go
@@ -1121,7 +1121,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := CreateInstallationToken(e.ctx, e.settings, owner, repo, nil)
+	token, err := CreateInstallationToken(e.ctx, e.settings.CreateGitHubAppAuth(), owner, repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/environment.go
+++ b/environment.go
@@ -1121,7 +1121,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := CreateInstallationToken(e.ctx, e.settings.CreateGitHubAppAuth(), owner, repo, nil)
+	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/github_app.go
+++ b/github_app.go
@@ -58,12 +58,12 @@ type GithubAppAuthProvider interface {
 // GetGitHubAppAuth returns the app id and app private key if they exist.
 func (s *Settings) GetGitHubAppAuth() (*GithubAppAuth, error) {
 	if s.AuthConfig.Github == nil || s.AuthConfig.Github.AppId == 0 {
-		return nil, errors.New("GitHub app is not configured in admin settings")
+		return nil, errors.New("github app id is not configured in admin settings")
 	}
 
 	key := s.Expansions[GithubAppPrivateKey]
 	if key == "" {
-		return nil, errors.New("GitHub app private key is not configured in admin settings")
+		return nil, errors.New("github app private key is not configured in admin settings")
 	}
 
 	return &GithubAppAuth{

--- a/github_app.go
+++ b/github_app.go
@@ -51,7 +51,7 @@ type GithubAppAuth struct {
 	PrivateKey []byte
 }
 
-// GetGitHubAppAuth returns the app id and app private key if they exist.
+// CreateGitHubAppAuth returns the app id and app private key if they exist.
 // If the either are not set, it will return nil.
 func (s *Settings) CreateGitHubAppAuth() *GithubAppAuth {
 	if s.AuthConfig.Github == nil || s.AuthConfig.Github.AppId == 0 {

--- a/github_app.go
+++ b/github_app.go
@@ -51,10 +51,6 @@ type GithubAppAuth struct {
 	PrivateKey []byte
 }
 
-type GithubAppAuthProvider interface {
-	GetGitHubAppAuth() (*GithubAppAuth, error)
-}
-
 // GetGitHubAppAuth returns the app id and app private key if they exist.
 // If the either are not set, it will return nil.
 func (s *Settings) CreateGitHubAppAuth() *GithubAppAuth {

--- a/github_app_test.go
+++ b/github_app_test.go
@@ -68,8 +68,8 @@ func (s *installationSuite) TestGetInstallationID() {
 
 	s.NoError(installation.Upsert(s.ctx))
 
-	authFields := &githubAppAuth{
-		appId: 1234,
+	authFields := &GithubAppAuth{
+		AppID: 1234,
 	}
 
 	id, err := getInstallationID(s.ctx, authFields, "evergreen-ci", "evergreen")

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.AP
 func (r *projectSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.AP
 func (r *projectSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.GetEnvironment().Settings().HasGitHubApp(ctx, owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.AP
 func (r *projectSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), owner, repo)
+	hasApp, err := evergreen.GetEnvironment().Settings().CreateGitHubAppAuth().IsGithubAppInstalledOnRepo(ctx, owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/graphql/repo_settings_resolver.go
+++ b/graphql/repo_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIPr
 func (r *repoSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/graphql/repo_settings_resolver.go
+++ b/graphql/repo_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIPr
 func (r *repoSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), owner, repo)
+	hasApp, err := evergreen.GetEnvironment().Settings().CreateGitHubAppAuth().IsGithubAppInstalledOnRepo(ctx, owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/graphql/repo_settings_resolver.go
+++ b/graphql/repo_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIPr
 func (r *repoSettingsResolver) GithubWebhooksEnabled(ctx context.Context, obj *restModel.APIProjectSettings) (bool, error) {
 	owner := utility.FromStringPtr(obj.ProjectRef.Owner)
 	repo := utility.FromStringPtr(obj.ProjectRef.Repo)
-	hasApp, err := evergreen.GetEnvironment().Settings().HasGitHubApp(ctx, owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), owner, repo)
 	grip.Error(message.WrapError(err, message.Fields{
 		"message": "Error verifying GitHub app installation",
 		"project": utility.FromStringPtr(obj.ProjectRef.Id),

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -67,6 +68,15 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 		},
 	)
 	return err
+}
+
+// GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
+// for the given project.
+func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() (evergreen.GithubAppAuth, error) {
+	return evergreen.GithubAppAuth{
+		AppID:      githubAppAuth.AppId,
+		PrivateKey: githubAppAuth.PrivateKey,
+	}, nil
 }
 
 // RemoveGithubAppAuth deletes the app auth for the given project id from the database

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -68,18 +67,6 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 		},
 	)
 	return err
-}
-
-// GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
-// for the given project.
-func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() *evergreen.GithubAppAuth {
-	if githubAppAuth == nil {
-		return nil
-	}
-	return &evergreen.GithubAppAuth{
-		AppID:      githubAppAuth.AppId,
-		PrivateKey: githubAppAuth.PrivateKey,
-	}
 }
 
 // RemoveGithubAppAuth deletes the app auth for the given project id from the database

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"errors"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
@@ -74,14 +72,14 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 
 // GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
 // for the given project.
-func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() (evergreen.GithubAppAuth, error) {
+func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() *evergreen.GithubAppAuth {
 	if githubAppAuth == nil {
-		return evergreen.GithubAppAuth{}, errors.New("github app authentication not found")
+		return nil
 	}
-	return evergreen.GithubAppAuth{
+	return &evergreen.GithubAppAuth{
 		AppID:      githubAppAuth.AppId,
 		PrivateKey: githubAppAuth.PrivateKey,
-	}, nil
+	}
 }
 
 // RemoveGithubAppAuth deletes the app auth for the given project id from the database

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"errors"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
@@ -73,6 +75,9 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 // GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
 // for the given project.
 func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() (evergreen.GithubAppAuth, error) {
+	if githubAppAuth == nil {
+		return evergreen.GithubAppAuth{}, errors.New("github app authentication not found")
+	}
 	return evergreen.GithubAppAuth{
 		AppID:      githubAppAuth.AppId,
 		PrivateKey: githubAppAuth.PrivateKey,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1822,7 +1822,7 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 // SetTracksPushEvents returns true if the GitHub app is installed on the owner/repo for the given project.
 func SetTracksPushEvents(ctx context.Context, projectRef *ProjectRef) (bool, error) {
 	// Don't return errors because it could cause the project page to break if GitHub is down.
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), projectRef.Owner, projectRef.Repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), projectRef.Owner, projectRef.Repo)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "Error verifying GitHub app installation",
@@ -1963,7 +1963,7 @@ func GetProjectSettingsById(projectId string, isRepo bool) (*ProjectSettings, er
 func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 	// Don't error even if there is problem with verifying the GitHub app installation
 	// because a GitHub outage could cause project settings page to not load.
-	hasEvergreenAppInstalled, _ := evergreen.HasGitHubApp(context.Background(), evergreen.GetEnvironment().Settings(), p.Owner, p.Repo)
+	hasEvergreenAppInstalled, _ := evergreen.HasGitHubApp(context.Background(), evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), p.Owner, p.Repo)
 
 	projectVars, err := FindOneProjectVars(p.Id)
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1822,7 +1822,7 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 // SetTracksPushEvents returns true if the GitHub app is installed on the owner/repo for the given project.
 func SetTracksPushEvents(ctx context.Context, projectRef *ProjectRef) (bool, error) {
 	// Don't return errors because it could cause the project page to break if GitHub is down.
-	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), projectRef.Owner, projectRef.Repo)
+	hasApp, err := evergreen.GetEnvironment().Settings().CreateGitHubAppAuth().IsGithubAppInstalledOnRepo(ctx, projectRef.Owner, projectRef.Repo)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "Error verifying GitHub app installation",
@@ -1963,7 +1963,7 @@ func GetProjectSettingsById(projectId string, isRepo bool) (*ProjectSettings, er
 func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 	// Don't error even if there is problem with verifying the GitHub app installation
 	// because a GitHub outage could cause project settings page to not load.
-	hasEvergreenAppInstalled, _ := evergreen.HasGitHubApp(context.Background(), evergreen.GetEnvironment().Settings().CreateGitHubAppAuth(), p.Owner, p.Repo)
+	hasEvergreenAppInstalled, _ := evergreen.GetEnvironment().Settings().CreateGitHubAppAuth().IsGithubAppInstalledOnRepo(context.Background(), p.Owner, p.Repo)
 
 	projectVars, err := FindOneProjectVars(p.Id)
 	if err != nil {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1822,7 +1822,7 @@ func FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(owner, repo, branch st
 // SetTracksPushEvents returns true if the GitHub app is installed on the owner/repo for the given project.
 func SetTracksPushEvents(ctx context.Context, projectRef *ProjectRef) (bool, error) {
 	// Don't return errors because it could cause the project page to break if GitHub is down.
-	hasApp, err := evergreen.GetEnvironment().Settings().HasGitHubApp(ctx, projectRef.Owner, projectRef.Repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, evergreen.GetEnvironment().Settings(), projectRef.Owner, projectRef.Repo)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "Error verifying GitHub app installation",
@@ -1963,7 +1963,7 @@ func GetProjectSettingsById(projectId string, isRepo bool) (*ProjectSettings, er
 func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 	// Don't error even if there is problem with verifying the GitHub app installation
 	// because a GitHub outage could cause project settings page to not load.
-	hasEvergreenAppInstalled, _ := evergreen.GetEnvironment().Settings().HasGitHubApp(context.Background(), p.Owner, p.Repo)
+	hasEvergreenAppInstalled, _ := evergreen.HasGitHubApp(context.Background(), evergreen.GetEnvironment().Settings(), p.Owner, p.Repo)
 
 	projectVars, err := FindOneProjectVars(p.Id)
 	if err != nil {

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,7 +191,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
-	appToken, err := settings.CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, settings, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,7 +191,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), pRef.Owner, pRef.Repo, nil)
+	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,7 +191,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, settings, pRef.Owner, pRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -421,7 +421,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		})
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, h.settings, pRef.Owner, pRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, h.settings.CreateGitHubAppAuth(), pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
 	}
@@ -1401,7 +1401,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
-	token, err := evergreen.CreateInstallationToken(ctx, g.env.Settings(), g.owner, g.repo, nil)
+	token, err := evergreen.CreateInstallationToken(ctx, g.env.Settings().CreateGitHubAppAuth(), g.owner, g.repo, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -421,7 +421,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		})
 	}
 
-	appToken, err := evergreen.CreateInstallationToken(ctx, h.settings.CreateGitHubAppAuth(), pRef.Owner, pRef.Repo, nil)
+	appToken, err := h.settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
 	}
@@ -1401,7 +1401,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
-	token, err := evergreen.CreateInstallationToken(ctx, g.env.Settings().CreateGitHubAppAuth(), g.owner, g.repo, nil)
+	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -421,7 +421,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		})
 	}
 
-	appToken, err := h.settings.CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
+	appToken, err := evergreen.CreateInstallationToken(ctx, h.settings, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
 	}
@@ -1401,7 +1401,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
-	token, err := g.env.Settings().CreateInstallationToken(ctx, g.owner, g.repo, nil)
+	token, err := evergreen.CreateInstallationToken(ctx, g.env.Settings(), g.owner, g.repo, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -122,7 +122,7 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 // shouldSkipWebhook returns true if the event is from a GitHub app and the app is available for the owner/repo or,
 // the event is from webhooks and the app is not available for the owner/repo.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
-	hasApp, err := evergreen.HasGitHubApp(ctx, gh.settings.CreateGitHubAppAuth(), owner, repo)
+	hasApp, err := gh.settings.CreateGitHubAppAuth().IsGithubAppInstalledOnRepo(ctx, owner, repo)
 	if err != nil {
 		hasApp = false
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -122,7 +122,7 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 // shouldSkipWebhook returns true if the event is from a GitHub app and the app is available for the owner/repo or,
 // the event is from webhooks and the app is not available for the owner/repo.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
-	hasApp, err := evergreen.HasGitHubApp(ctx, gh.settings, owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, gh.settings.CreateGitHubAppAuth(), owner, repo)
 	if err != nil {
 		hasApp = false
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -122,7 +122,7 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 // shouldSkipWebhook returns true if the event is from a GitHub app and the app is available for the owner/repo or,
 // the event is from webhooks and the app is not available for the owner/repo.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
-	hasApp, err := gh.settings.HasGitHubApp(ctx, owner, repo)
+	hasApp, err := evergreen.HasGitHubApp(ctx, gh.settings, owner, repo)
 	if err != nil {
 		hasApp = false
 	}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -340,7 +340,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	token, err := evergreen.CreateInstallationToken(ctx, settings, owner, repo, opts)
+	token, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), owner, repo, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "error creating token",

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -340,7 +340,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	token, err := settings.CreateInstallationToken(ctx, owner, repo, opts)
+	token, err := evergreen.CreateInstallationToken(ctx, settings, owner, repo, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "error creating token",

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -340,7 +340,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	token, err := evergreen.CreateInstallationToken(ctx, settings.CreateGitHubAppAuth(), owner, repo, opts)
+	token, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, owner, repo, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "error creating token",


### PR DESCRIPTION
DEVPROD-5991

### Description
These two functions both were attached to the evergreen.Settings struct despite not using much from settings. I reversed it to take in a provider and then made our GithubAppAuth struct implement the interface as well.

I debated about making it just depend on the struct, but that would make everywhere that uses this to create the struct (essentially calling the interface's function) and then having their own error checks. With the interface, it reduces some code duplication and makes it a little more hidden.

EDIT: I removed the interface

### Testing
Existing unit tests