### PR TITLE
DEVPROD-5483 add automaxprocs

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"
 	"github.com/urfave/cli"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -201,6 +201,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/mongodb/jasper v0.0.0-20240424195530-4a5968d6fc0f
 	github.com/shirou/gopsutil/v3 v3.24.5
+	go.uber.org/automaxprocs v1.5.3
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3gMACTjAbMZBjXAqTOzOwFaj2Ld6cjeQ7Rig=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/ravilushqa/otelgqlgen v0.15.0 h1:U85nrlweMXTGaMChUViYM39/MXBZVeVVlpuHq+6eECQ=
 github.com/ravilushqa/otelgqlgen v0.15.0/go.mod h1:o+1Eju0VySmgq2BP8Vupz2YrN21Bj7D7imBqu3m2uB8=
@@ -754,6 +755,8 @@ go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v1.2.0 h1:pVeZGk7nXDC9O2hncA6nHldxEjm6LByfA2aN8IOkz94=
 go.opentelemetry.io/proto/otlp v1.2.0/go.mod h1:gGpR8txAl5M03pDhMC79G6SdqNV26naRm/KDsgaHD8A=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
[DEVPROD-5483](https://jira.mongodb.org/browse/DEVPROD-5483)

### Description
By default go doesn't see its number of CPUs is limited by a cgroup. Including this library will set GOMAXPROCS to the appropriate number of CPUs. noops if running outside a container.

### Testing
In staging [it limited to 1 CPU](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Ddevprod-evergreen-staging%20%22maxprocs%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1717710628.406&latest=1717710638.407&sid=1717711403.25667179), which is consistent with [the CPU limit](https://github.com/evergreen-ci/evergreen-deploys/blob/4fc29d8d298d8465958e24dc8c1a9d51aaa04cb8/charts/staging.yml#L12). Interestingly, the [CPU time we used actually went down](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/JFLdEtVc2Ex?hideCompare&omitMissingValues) 🤔 .

On my laptop and on a Linux spawn host it logged:
```
2024/06/06 21:44:37 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
```
meaning it left the value unchanged because there was no limit set.