### PR TITLE
DEVPROD-7773: increase timeout and add more logging for webhook notification errors

### DIFF
--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -177,7 +177,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 				"message":       "error sending webhook notification",
 				"webhook_url":   req.URL.String(),
 				"status_code":   resp.StatusCode,
-				"response_body": body,
+				"response_body": string(body),
 				"ctx_err":       utility.IsContextError(ctx.Err()),
 			})
 		}
@@ -187,7 +187,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 			"notification_id": raw.NotificationID,
 			"url":             raw.URL,
 			"response_code":   resp.StatusCode,
-			"response_body":   body,
+			"response_body":   string(body),
 		})
 
 		return false, nil

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -160,35 +160,32 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 		}
 
 		resp, err := client.Do(req)
-		if resp != nil {
-			defer resp.Body.Close()
+		msgFields := message.Fields{
+			"message":         "error sending webhook notification",
+			"notification_id": raw.NotificationID,
+			"webhook_url":     raw.URL,
+			"is_ctx_err":      utility.IsContextError(ctx.Err()),
 		}
 		if err != nil {
-			return true, errors.Wrap(err, "sending webhook data")
+			return true, message.WrapError(errors.Wrap(err, "sending webhook data"), msgFields)
 		}
+
+		defer resp.Body.Close()
+
+		msgFields["status_code"] = resp.StatusCode
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return true, errors.Wrap(err, "reading webhook response")
+			return true, message.WrapError(errors.Wrap(err, "reading webhook response"), msgFields)
 		}
+		msgFields["response_body"] = string(body)
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return true, message.WrapError(errors.Errorf("webhook response was %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode)), message.Fields{
-				"message":       "error sending webhook notification",
-				"webhook_url":   req.URL.String(),
-				"status_code":   resp.StatusCode,
-				"response_body": string(body),
-				"ctx_err":       utility.IsContextError(ctx.Err()),
-			})
+			return true, message.WrapError(errors.Errorf("webhook response was %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode)), msgFields)
 		}
 
-		grip.Info(message.Fields{
-			"message":         "send webhook notification",
-			"notification_id": raw.NotificationID,
-			"url":             raw.URL,
-			"response_code":   resp.StatusCode,
-			"response_body":   string(body),
-		})
+		msgFields["message"] = "successfully sent webhook notification"
+		grip.Info(msgFields)
 
 		return false, nil
 	}, utility.RetryOptions{

--- a/util/webhook_grip_test.go
+++ b/util/webhook_grip_test.go
@@ -131,7 +131,7 @@ func TestEvergreenWebhookSender(t *testing.T) {
 			assert.Equal(t, "https://example.com", transport.lastUrl)
 			assert.Equal(t, retryCount+1, transport.attemptCount)
 			require.Error(t, capturedErr)
-			assert.EqualError(t, capturedErr, "after 4 attempts, operation failed: response was 400 (Bad Request)")
+			assert.ErrorContains(t, capturedErr, "response was 400 (Bad Request)")
 		},
 		"SucceedsAfterRetry": func(t *testing.T) {
 			attempts := 2
@@ -201,7 +201,7 @@ func TestEvergreenWebhookSenderWithBadSecret(t *testing.T) {
 	}))
 	s.Send(m)
 
-	assert.EqualError(<-channel, "after 1 attempts, operation failed: response was 400 (Bad Request)")
+	assert.ErrorContains(<-channel, "response was 400 (Bad Request)")
 	assert.Equal("https://example.com", transport.lastUrl)
 }
 


### PR DESCRIPTION
DEVPROD-7773

### Description
I can see that Evergreen is sending webhook notifications, but they're oftentimes receiving errors back from the webhook URL. Unfortunately, there's not enough info in the error message to easily figure out which of the many webhooks it's sending to, so this PR adds more info.

* Add extra logging information when receiving non-200s from the webhook server.
* Increase timeout for webhook notification. I noticed a couple of the webhook notifications just errored due to request timeout, so giving them a little more time may let the webhook server process them.

### Testing
* Existing tests pass.
* Checked the logging looked sufficient in staging.

### Documentation
N/A