### PR TITLE
DEVPROD-5993 Make github dynamic agent route use project's app 

### DIFF
--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -70,9 +70,8 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 	return err
 }
 
-// GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
-// for the given project.
-func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() *evergreen.GithubAppAuth {
+// CreateEvergreenGitHubAppAuth creates an evergreen.GithubAppAuth object from the current struct.
+func (githubAppAuth *GithubAppAuth) CreateEvergreenGitHubAppAuth() *evergreen.GithubAppAuth {
 	if githubAppAuth == nil {
 		return nil
 	}

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -67,6 +68,18 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 		},
 	)
 	return err
+}
+
+// GetGitHubAppAuth fulfills the GithubAppAuthProvider interface and returns the app auth
+// for the given project.
+func (githubAppAuth *GithubAppAuth) GetGitHubAppAuth() *evergreen.GithubAppAuth {
+	if githubAppAuth == nil {
+		return nil
+	}
+	return &evergreen.GithubAppAuth{
+		AppID:      githubAppAuth.AppId,
+		PrivateKey: githubAppAuth.PrivateKey,
+	}
 }
 
 // RemoveGithubAppAuth deletes the app auth for the given project id from the database

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1649,7 +1649,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 
 	// TODO DEVPROD-5991: Use the modified CreateInstallationToken/HasGitHubApp methods to create the token.
 	// Currently, it's going to use the global Evergreen GitHub app to create the token (from g.env.Settings()).
-	token, err := githubAppAuth.GetGitHubAppAuth().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
+	token, err := githubAppAuth.CreateEvergreenGitHubAppAuth().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1649,7 +1649,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 
 	// TODO DEVPROD-5991: Use the modified CreateInstallationToken/HasGitHubApp methods to create the token.
 	// Currently, it's going to use the global Evergreen GitHub app to create the token (from g.env.Settings()).
-	token, err := h.env.Settings().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
+	token, err := githubAppAuth.GetGitHubAppAuth().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {


### PR DESCRIPTION
DEVPROD-5993

### Description
This finishes connecting the agent route and project/user apps.

