### PR TITLE
DEVPROD-5993 Use valid github auth to create installation token

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1649,7 +1649,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 
 	// TODO DEVPROD-5991: Use the modified CreateInstallationToken/HasGitHubApp methods to create the token.
 	// Currently, it's going to use the global Evergreen GitHub app to create the token (from g.env.Settings()).
-	token, err := h.env.Settings().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
+	token, err := h.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {


### PR DESCRIPTION
DEVPROD-5993

### Description
Uses the github auth to create installation token
