### PR TITLE
DEVPROD-5993 Combine GithubAppAuth structs and use the user's app for agent route

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -46,9 +46,16 @@ type GitHubAppInstallation struct {
 	AppID int64 `bson:"app_id"`
 }
 
+// GithubAppAuth hold the appId and privateKey for the github app associated with the project.
+// It will not be stored along with the project settings, instead it is fetched only when needed
+// Sometimes this struct is used as a way to pass around AppId and PrivateKey for Evergreen's
+// github app, in which the Id is set to empty.
 type GithubAppAuth struct {
-	AppID      int64
-	PrivateKey []byte
+	// Should match the identifier of the project it refers to
+	Id string `bson:"_id" json:"_id"`
+
+	AppID      int64  `bson:"app_id" json:"app_id"`
+	PrivateKey []byte `bson:"private_key" json:"private_key"`
 }
 
 // CreateGitHubAppAuth returns the app id and app private key if they exist.

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
@@ -8,28 +9,18 @@ import (
 )
 
 var (
-	githubAppAuthIdKey      = bsonutil.MustHaveTag(GithubAppAuth{}, "Id")
-	githubAppAuthAppId      = bsonutil.MustHaveTag(GithubAppAuth{}, "AppId")
-	githubAppAuthPrivateKey = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKey")
+	githubAppAuthIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
+	githubAppAuthAppId      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppId")
+	githubAppAuthPrivateKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
 )
 
 const (
 	GitHubAppAuthCollection = "github_app_auth"
 )
 
-// GithubAppAuth hold the appId and privateKey for the github app associated with the project.
-// It will not be stored along with the project settings, instead it is fetched only when needed
-type GithubAppAuth struct {
-	// Should match the identifier of the project it refers to
-	Id string `bson:"_id" json:"_id"`
-
-	AppId      int64  `bson:"app_id" json:"app_id"`
-	PrivateKey []byte `bson:"private_key" json:"private_key"`
-}
-
 // FindOneGithubAppAuth finds the github app auth for the given project id
-func FindOneGithubAppAuth(projectId string) (*GithubAppAuth, error) {
-	githubAppAuth := &GithubAppAuth{}
+func FindOneGithubAppAuth(projectId string) (*evergreen.GithubAppAuth, error) {
+	githubAppAuth := &evergreen.GithubAppAuth{}
 	q := db.Query(bson.M{githubAppAuthIdKey: projectId})
 	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
 	if adb.ResultsNotFound(err) {
@@ -43,7 +34,7 @@ func FindOneGithubAppAuth(projectId string) (*GithubAppAuth, error) {
 
 // HasGithubAppAuth checks if the github app auth for the given project id exists
 func HasGithubAppAuth(projectId string) (bool, error) {
-	var app *GithubAppAuth
+	var app *evergreen.GithubAppAuth
 	var err error
 	if app, err = FindOneGithubAppAuth(projectId); err != nil {
 		return false, err
@@ -52,8 +43,8 @@ func HasGithubAppAuth(projectId string) (bool, error) {
 	return app != nil, nil
 }
 
-// Upsert inserts or updates the app auth for the given project id in the database
-func (githubAppAuth *GithubAppAuth) Upsert() error {
+// UpsertGithubAppAuth inserts or updates the app auth for the given project id in the database
+func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{
@@ -61,7 +52,7 @@ func (githubAppAuth *GithubAppAuth) Upsert() error {
 		},
 		bson.M{
 			"$set": bson.M{
-				githubAppAuthAppId:      githubAppAuth.AppId,
+				githubAppAuthAppId:      githubAppAuth.AppID,
 				githubAppAuthPrivateKey: githubAppAuth.PrivateKey,
 			},
 		},

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	githubAppAuthIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
-	githubAppAuthAppId      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppId")
+	githubAppAuthAppId      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
 	githubAppAuthPrivateKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
 )
 

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,19 +16,19 @@ func TestFindOneGithubAppAuth(t *testing.T) {
 		"Error clearing collection")
 
 	key := []byte("I'm private!")
-	githubAppAuth := GithubAppAuth{
+	githubAppAuth := evergreen.GithubAppAuth{
 		Id:         "mongodb",
-		AppId:      1234,
+		AppID:      1234,
 		PrivateKey: key,
 	}
-	err := githubAppAuth.Upsert()
-
+	err := UpsertGithubAppAuth(&githubAppAuth)
 	require.NoError(t, err)
+
 	githubAppAuthFromDB, err := FindOneGithubAppAuth("mongodb")
 	require.NoError(t, err)
 
 	assert.Equal("mongodb", githubAppAuthFromDB.Id)
-	assert.Equal(int64(1234), githubAppAuthFromDB.AppId)
+	assert.Equal(int64(1234), githubAppAuthFromDB.AppID)
 	assert.Equal(key, githubAppAuthFromDB.PrivateKey)
 }
 
@@ -37,12 +38,12 @@ func TestRemoveGithubAppAuth(t *testing.T) {
 		"Error clearing collection")
 
 	key := []byte("I'm private")
-	githubAppAuth := GithubAppAuth{
+	githubAppAuth := evergreen.GithubAppAuth{
 		Id:         "mongodb",
-		AppId:      1234,
+		AppID:      1234,
 		PrivateKey: key,
 	}
-	err := githubAppAuth.Upsert()
+	err := UpsertGithubAppAuth(&githubAppAuth)
 	require.NoError(t, err)
 
 	hasGithubAppAuth, err := HasGithubAppAuth("mongodb")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -732,12 +732,12 @@ func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) err
 	if appID == 0 || len(privateKey) == 0 {
 		return errors.New("both app ID and private key must be provided")
 	}
-	auth := GithubAppAuth{
+	auth := evergreen.GithubAppAuth{
 		Id:         p.Id,
-		AppId:      appID,
+		AppID:      appID,
 		PrivateKey: privateKey,
 	}
-	return auth.Upsert()
+	return UpsertGithubAppAuth(&auth)
 }
 
 // AddToRepoScope validates that the branch can be attached to the matching repo,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1649,7 +1649,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 
 	// TODO DEVPROD-5991: Use the modified CreateInstallationToken/HasGitHubApp methods to create the token.
 	// Currently, it's going to use the global Evergreen GitHub app to create the token (from g.env.Settings()).
-	token, err := h.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
+	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {


### PR DESCRIPTION
DEVPROD-5993

### Description
This combines the struct and uses the new user app for the agent route

### Testing
Existing testing
