### PR TITLE
DEVPROD-7734 Specifically propagate warning and errors, not a loose else

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -627,10 +627,10 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 		// Format them, as we need to store + display them to the user
 		var projectErrors, projectWarnings []string
 		for _, e := range verrs {
-			if e.Level == validator.Warning {
-				projectWarnings = append(projectWarnings, e.Error())
-			} else {
+			if e.Level == validator.Error {
 				projectErrors = append(projectErrors, e.Error())
+			} else if e.Level == validator.Warning {
+				projectWarnings = append(projectWarnings, e.Error())
 			}
 		}
 		v.Warnings = projectWarnings


### PR DESCRIPTION
DEVPROD-7734

### Description
There was a loose check that assumed if an validation error was not a warning, it was an error. This isn't true with the notice level! Fixed it.