### PR TITLE
DEVPROD-7953 use git tag pusher as version author when able

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -265,6 +265,10 @@ authorized teams, no version will be created. **If git tag versions are not bein
 created as you expect them to**, please first check that the tag pusher is part of
 one of the above fields.
 
+If you'd like for Git Tag triggered versions to be associated with the pusher,
+ensure that they've set their GitHub username in 
+[their Evergreen preferences](https://spruce.mongodb.com/preferences/profile).
+
 2.  **Add aliases to determine what tasks will run.**
 
 There are two options for aliases:
@@ -298,9 +302,6 @@ Ambiguous behavior is outlined here:
     -   If all have variant/tasks configured, the union of these will
         determine what variants/tasks are created.
 
-
-3. **If you'd like for Git Tag triggered versions to be associated with the pusher,
-ensure that they've set their GitHub username in [their Evergreen preferences](https://spruce.mongodb.com/preferences/profile)**. 
 ### Project Triggers
 
 Users can specify that commits to another project (the "upstream"

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -298,6 +298,9 @@ Ambiguous behavior is outlined here:
     -   If all have variant/tasks configured, the union of these will
         determine what variants/tasks are created.
 
+
+3. **If you'd like for Git Tag triggered versions to be associated with the pusher,
+ensure that they've set their GitHub username in [their Evergreen preferences](https://spruce.mongodb.com/preferences/profile)**. 
 ### Project Triggers
 
 Users can specify that commits to another project (the "upstream"

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -686,13 +686,17 @@ func ShellVersionFromRevision(ref *model.ProjectRef, metadata model.VersionMetad
 	if metadata.GitTag.Pusher != "" {
 		usr, err = user.FindByGithubName(metadata.GitTag.Pusher)
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": fmt.Sprintf("failed to fetch Evergreen user with GitHub name %s", metadata.GitTag.Pusher),
+			"message":        "failed to fetch Evergreen user with GitHub info",
+			"method":         "git_tag",
+			"git_tag_pusher": metadata.GitTag.Pusher,
 		}))
 	}
 	if usr == nil && metadata.Revision.AuthorGithubUID != 0 {
 		usr, err = user.FindByGithubUID(metadata.Revision.AuthorGithubUID)
 		grip.Error(message.WrapError(err, message.Fields{
-			"message": fmt.Sprintf("failed to fetch Evergreen user with GitHub UID %d", metadata.Revision.AuthorGithubUID),
+			"message":             "failed to fetch Evergreen user with GitHub info",
+			"method":              "user_uid",
+			"revision_author_uid": metadata.Revision.AuthorGithubUID,
 		}))
 	}
 	if usr != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -680,14 +680,23 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 // ShellVersionFromRevision populates a new Version with metadata from a model.Revision.
 // Does not populate its config or store anything in the database.
 func ShellVersionFromRevision(ref *model.ProjectRef, metadata model.VersionMetadata) (*model.Version, error) {
-	if metadata.Revision.AuthorGithubUID != 0 {
-		u, err := user.FindByGithubUID(metadata.Revision.AuthorGithubUID)
+	var usr *user.DBUser
+	var err error
+	// Default to the pusher of the git tag, if relevant.
+	if metadata.GitTag.Pusher != "" {
+		usr, err = user.FindByGithubName(metadata.GitTag.Pusher)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message": fmt.Sprintf("failed to fetch Evergreen user with GitHub name %s", metadata.GitTag.Pusher),
+		}))
+	}
+	if usr == nil && metadata.Revision.AuthorGithubUID != 0 {
+		usr, err = user.FindByGithubUID(metadata.Revision.AuthorGithubUID)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": fmt.Sprintf("failed to fetch Evergreen user with GitHub UID %d", metadata.Revision.AuthorGithubUID),
 		}))
-		if err == nil {
-			metadata.User = u
-		}
+	}
+	if usr != nil {
+		metadata.User = usr
 	}
 
 	number, err := model.GetNewRevisionOrderNumber(ref.Id)


### PR DESCRIPTION
DEVPROD-7953
### Description
Use git tag pusher as git tag version author when able, otherwise default to what we do now (using the author of the commit that the tag was pushed to).

### Testing
Added to unit test.

### Documentation
Updated to make sure its clear this needs to be added to settings for it to work. 

<img width="491" alt="image" src="https://github.com/evergreen-ci/evergreen/assets/26798134/28de76d8-b27f-4b3b-9655-86907142041a">

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
