### PR TITLE
DEVPROD-8230: add CLI option to keep unexpirable host off indefinitely

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-06-17"
+	ClientVersion = "2024-06-18"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -494,9 +494,9 @@ func hostStop() cli.Command {
 				Name:  joinFlagNames(waitFlagName, "w"),
 				Usage: "command will block until host stopped",
 			},
-			cli.BoolFlag{
+			cli.BoolTFlag{
 				Name:  joinFlagNames(shouldKeepOffFlagName, "k"),
-				Usage: "if stopping an unexpirable host with a sleep schedule, keep the host off indefinitely (and ignore its sleep schedule) until the host is manually started again",
+				Usage: "if stopping an unexpirable host with a sleep schedule, keep the host off indefinitely (and ignore its sleep schedule) until the host is manually started again (default: true)",
 			},
 		)),
 		Before: mergeBeforeFuncs(setPlainLogger, requireHostFlag),

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -51,7 +51,7 @@ type Communicator interface {
 	CreateSpawnHost(context.Context, *restmodel.HostRequestOptions) (*restmodel.APIHost, error)
 	GetSpawnHost(context.Context, string) (*restmodel.APIHost, error)
 	ModifySpawnHost(context.Context, string, host.HostModifyOptions) error
-	StopSpawnHost(context.Context, string, string, bool) error
+	StopSpawnHost(context.Context, string, string, bool, bool) error
 	StartSpawnHost(context.Context, string, string, bool) error
 	TerminateSpawnHost(context.Context, string) error
 	ChangeSpawnHostPassword(context.Context, string, string) error

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -108,7 +108,10 @@ func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, sub
 	options := struct {
 		SubscriptionType string `json:"subscription_type"`
 		ShouldKeepOff    bool   `json:"should_keep_off"`
-	}{SubscriptionType: subscriptionType}
+	}{
+		SubscriptionType: subscriptionType,
+		ShouldKeepOff:    shouldKeepOff,
+	}
 
 	resp, err := c.request(ctx, info, options)
 	if err != nil {

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -99,7 +99,7 @@ func (c *communicatorImpl) ModifySpawnHost(ctx context.Context, hostID string, c
 	return nil
 }
 
-func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, subscriptionType string, wait bool) error {
+func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, subscriptionType string, shouldKeepOff, wait bool) error {
 	info := requestInfo{
 		method: http.MethodPost,
 		path:   fmt.Sprintf("hosts/%s/stop", hostID),
@@ -107,6 +107,7 @@ func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, sub
 
 	options := struct {
 		SubscriptionType string `json:"subscription_type"`
+		ShouldKeepOff    bool   `json:"should_keep_off"`
 	}{SubscriptionType: subscriptionType}
 
 	resp, err := c.request(ctx, info, options)


### PR DESCRIPTION
DEVPROD-8230

### Description
Add CLI option to keep host off. The logic for the route to use this flag was already implemented, so the CLI just needs to pass the option along in the request body.

### Testing
Tested in staging that `evergreen host stop --keep-off` stopped the host and kept it off.

### Documentation
Docs will be bulk updated as part of DEVPROD-4055 so that it coincides with sleep schedule comms.