### PR TITLE
DEVPROD-7418 optimize hostsCanRunTasksQuery for task queue page

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -242,15 +242,8 @@ func hostsCanRunTasksQuery(distroID string) bson.M {
 	return bson.M{
 		distroIDKey:  distroID,
 		StartedByKey: evergreen.User,
-		"$or": []bson.M{
-			{
-				StatusKey: evergreen.HostRunning,
-			},
-			{
-				StatusKey:    evergreen.HostStarting,
-				bootstrapKey: distro.BootstrapMethodUserData,
-			},
-		},
+		StatusKey:    bson.M{"$in": []string{evergreen.HostRunning, evergreen.HostStarting}},
+		bootstrapKey: distro.BootstrapMethodUserData,
 	}
 }
 


### PR DESCRIPTION
DEVPROD-7418

### Description
The task queue page performs a query to fetch the number of hosts in the task queue for every distro. Sometimes this query becomes extremely poorly performing and can take > 100s to complete. My initial hypothesis was that this was due to the shape of the query causing it to sometimes use an incorrect index. In a previous [pr](https://github.com/evergreen-ci/evergreen/pull/7890) I introduced a hint to guide the database to using the correct index. 
It quickly became apparent that this didn't work. Even though the query always used the same index it exhibited dramatically different performance. In this [example](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/t8Xj4nXw5GC/trace/BTVktyjsjpW?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=50564a792f3775bf) out of 770 aggregations 10 of them took between 60-200s to execute. 
After consulting with TSE's it turns out the issue wasn't the index but was instead the query planner. In some cases (<1% of the time) the query planner would choose the wrong plan to execute the query and choose an extremely inefficient plan that would not actually use the status portion of the index causing the db to perform a fetch on millions of documents. 
The _good_ plan and _bad_ plan were both assigned the same score by the query planner and sometimes the query planner would choose the slow _bad_ plan instead of the correct one.
Updating the query shape helps improve the query planner's ability to choose the correct plan.  

This is a known performance issue in MongoDB 7.0 and should be [improved](https://jira.mongodb.org/browse/SPM-3316) in newer versions of the DB. 

While the new query is not the same as the previous query and may return slightly different results I think the tradeoff is acceptable since the performance of the page atm makes it unusable. 

### Testing
Tested this locally and generated 2 explain plans before and after showing a difference 

[explain before](https://github.com/user-attachments/files/15892254/output.1.json)
[explain after](https://github.com/user-attachments/files/15892229/output.json)
