### PR TITLE
DEVPROD-7529 Allow patch trigger aliases to specify revision

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -778,6 +778,7 @@ type ComplexityRoot struct {
 		Alias                  func(childComplexity int) int
 		ChildProjectId         func(childComplexity int) int
 		ChildProjectIdentifier func(childComplexity int) int
+		DownstreamRevision     func(childComplexity int) int
 		ParentAsModule         func(childComplexity int) int
 		Status                 func(childComplexity int) int
 		TaskSpecifiers         func(childComplexity int) int
@@ -5346,6 +5347,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PatchTriggerAlias.ChildProjectIdentifier(childComplexity), true
+
+	case "PatchTriggerAlias.downstreamRevision":
+		if e.complexity.PatchTriggerAlias.DownstreamRevision == nil {
+			break
+		}
+
+		return e.complexity.PatchTriggerAlias.DownstreamRevision(childComplexity), true
 
 	case "PatchTriggerAlias.parentAsModule":
 		if e.complexity.PatchTriggerAlias.ParentAsModule == nil {
@@ -34787,6 +34795,8 @@ func (ec *executionContext) fieldContext_Patch_patchTriggerAliases(_ context.Con
 				return ec.fieldContext_PatchTriggerAlias_parentAsModule(ctx, field)
 			case "status":
 				return ec.fieldContext_PatchTriggerAlias_status(ctx, field)
+			case "downstreamRevision":
+				return ec.fieldContext_PatchTriggerAlias_downstreamRevision(ctx, field)
 			case "taskSpecifiers":
 				return ec.fieldContext_PatchTriggerAlias_taskSpecifiers(ctx, field)
 			case "variantsTasks":
@@ -36020,6 +36030,47 @@ func (ec *executionContext) _PatchTriggerAlias_status(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_PatchTriggerAlias_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PatchTriggerAlias",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PatchTriggerAlias_downstreamRevision(ctx context.Context, field graphql.CollectedField, obj *model.APIPatchTriggerDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PatchTriggerAlias_downstreamRevision(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DownstreamRevision, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PatchTriggerAlias_downstreamRevision(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "PatchTriggerAlias",
 		Field:      field,
@@ -40021,6 +40072,8 @@ func (ec *executionContext) fieldContext_Project_patchTriggerAliases(_ context.C
 				return ec.fieldContext_PatchTriggerAlias_parentAsModule(ctx, field)
 			case "status":
 				return ec.fieldContext_PatchTriggerAlias_status(ctx, field)
+			case "downstreamRevision":
+				return ec.fieldContext_PatchTriggerAlias_downstreamRevision(ctx, field)
 			case "taskSpecifiers":
 				return ec.fieldContext_PatchTriggerAlias_taskSpecifiers(ctx, field)
 			case "variantsTasks":
@@ -47442,6 +47495,8 @@ func (ec *executionContext) fieldContext_RepoRef_patchTriggerAliases(_ context.C
 				return ec.fieldContext_PatchTriggerAlias_parentAsModule(ctx, field)
 			case "status":
 				return ec.fieldContext_PatchTriggerAlias_status(ctx, field)
+			case "downstreamRevision":
+				return ec.fieldContext_PatchTriggerAlias_downstreamRevision(ctx, field)
 			case "taskSpecifiers":
 				return ec.fieldContext_PatchTriggerAlias_taskSpecifiers(ctx, field)
 			case "variantsTasks":
@@ -69840,7 +69895,7 @@ func (ec *executionContext) unmarshalInputPatchTriggerAliasInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"alias", "childProjectIdentifier", "parentAsModule", "status", "taskSpecifiers"}
+	fieldsInOrder := [...]string{"alias", "childProjectIdentifier", "parentAsModule", "status", "downstreamRevision", "taskSpecifiers"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69875,6 +69930,13 @@ func (ec *executionContext) unmarshalInputPatchTriggerAliasInput(ctx context.Con
 				return it, err
 			}
 			it.Status = data
+		case "downstreamRevision":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("downstreamRevision"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DownstreamRevision = data
 		case "taskSpecifiers":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskSpecifiers"))
 			data, err := ec.unmarshalNTaskSpecifierInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifierᚄ(ctx, v)
@@ -78682,6 +78744,8 @@ func (ec *executionContext) _PatchTriggerAlias(ctx context.Context, sel ast.Sele
 			out.Values[i] = ec._PatchTriggerAlias_parentAsModule(ctx, field, obj)
 		case "status":
 			out.Values[i] = ec._PatchTriggerAlias_status(ctx, field, obj)
+		case "downstreamRevision":
+			out.Values[i] = ec._PatchTriggerAlias_downstreamRevision(ctx, field, obj)
 		case "taskSpecifiers":
 			out.Values[i] = ec._PatchTriggerAlias_taskSpecifiers(ctx, field, obj)
 		case "variantsTasks":

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -100,6 +100,7 @@ type PatchTriggerAlias {
   childProjectIdentifier: String!
   parentAsModule: String
   status: String
+  downstreamRevision: String
   taskSpecifiers: [TaskSpecifier!]
   variantsTasks: [VariantTask!]!
 }

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -132,6 +132,7 @@ input PatchTriggerAliasInput {
   childProjectIdentifier: String!
   parentAsModule: String
   status: String
+  downstreamRevision: String
   taskSpecifiers: [TaskSpecifierInput!]!
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -208,6 +208,7 @@ type TriggerInfo struct {
 	Aliases              []string    `bson:"aliases,omitempty"`
 	ParentPatch          string      `bson:"parent_patch,omitempty"`
 	ParentProjectID      string      `bson:"parent_project_id,omitempty"`
+	DownstreamRevision   string      `bson:"downstream_revision,omitempty"`
 	SameBranchAsParent   bool        `bson:"same_branch_as_parent"`
 	ChildPatches         []string    `bson:"child_patches,omitempty"`
 	DownstreamParameters []Parameter `bson:"downstream_parameters,omitempty"`
@@ -218,8 +219,9 @@ type PatchTriggerDefinition struct {
 	ChildProject   string          `bson:"child_project" json:"child_project"`
 	TaskSpecifiers []TaskSpecifier `bson:"task_specifiers" json:"task_specifiers"`
 	// the parent status that the child patch should run on: failure, success, or *
-	Status         string `bson:"status,omitempty" json:"status,omitempty"`
-	ParentAsModule string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	Status             string `bson:"status,omitempty" json:"status,omitempty"`
+	ParentAsModule     string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	DownstreamRevision string `bson:"downstream_revision,omitempty" json:"downstream_revision,omitempty"`
 }
 
 type TaskSpecifier struct {

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -218,9 +218,10 @@ type PatchTriggerDefinition struct {
 	Alias          string          `bson:"alias" json:"alias"`
 	ChildProject   string          `bson:"child_project" json:"child_project"`
 	TaskSpecifiers []TaskSpecifier `bson:"task_specifiers" json:"task_specifiers"`
-	// the parent status that the child patch should run on: failure, success, or *
-	Status             string `bson:"status,omitempty" json:"status,omitempty"`
-	ParentAsModule     string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	// The parent status that the child patch should run on: failure, success, or *
+	Status         string `bson:"status,omitempty" json:"status,omitempty"`
+	ParentAsModule string `bson:"parent_as_module,omitempty" json:"parent_as_module,omitempty"`
+	// The revision to base the downstream patch off of
 	DownstreamRevision string `bson:"downstream_revision,omitempty" json:"downstream_revision,omitempty"`
 }
 

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -20,8 +20,9 @@ type TriggerIntent struct {
 	ParentProjectID string `bson:"parent_project"`
 	ParentAsModule  string `bson:"parent_as_module"`
 	// the parent status that the child patch should run on
-	ParentStatus string                   `bson:"parent_status"`
-	Definitions  []PatchTriggerDefinition `bson:"definitions"`
+	ParentStatus       string                   `bson:"parent_status"`
+	Definitions        []PatchTriggerDefinition `bson:"definitions"`
+	DownstreamRevision string                   `bson:"downstream_revision"`
 
 	Processed bool `bson:"processed"`
 }
@@ -60,11 +61,15 @@ func (t *TriggerIntent) GetType() string {
 
 func (t *TriggerIntent) NewPatch() *Patch {
 	return &Patch{
-		Id:       mgobson.ObjectIdHex(t.Id),
-		Author:   evergreen.ParentPatchUser,
-		Triggers: TriggerInfo{ParentPatch: t.ParentID, ParentProjectID: t.ParentProjectID},
-		Status:   evergreen.VersionCreated,
-		Project:  t.ProjectID,
+		Id:     mgobson.ObjectIdHex(t.Id),
+		Author: evergreen.ParentPatchUser,
+		Triggers: TriggerInfo{
+			ParentPatch:        t.ParentID,
+			ParentProjectID:    t.ParentProjectID,
+			DownstreamRevision: t.DownstreamRevision,
+		},
+		Status:  evergreen.VersionCreated,
+		Project: t.ProjectID,
 	}
 }
 
@@ -98,14 +103,15 @@ func (t *TriggerIntent) GetCalledBy() string {
 }
 
 type TriggerIntentOptions struct {
-	Requester       string
-	Author          string
-	ProjectID       string
-	ParentID        string
-	ParentProjectID string
-	ParentAsModule  string
-	ParentStatus    string
-	Definitions     []PatchTriggerDefinition
+	Requester          string
+	Author             string
+	ProjectID          string
+	ParentID           string
+	ParentProjectID    string
+	ParentAsModule     string
+	ParentStatus       string
+	DownstreamRevision string
+	Definitions        []PatchTriggerDefinition
 }
 
 func NewTriggerIntent(opts TriggerIntentOptions) Intent {

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -19,10 +19,11 @@ type TriggerIntent struct {
 	ParentID        string `bson:"parent_id"`
 	ParentProjectID string `bson:"parent_project"`
 	ParentAsModule  string `bson:"parent_as_module"`
-	// the parent status that the child patch should run on
-	ParentStatus       string                   `bson:"parent_status"`
-	Definitions        []PatchTriggerDefinition `bson:"definitions"`
-	DownstreamRevision string                   `bson:"downstream_revision"`
+	// The parent status that the child patch should run on
+	ParentStatus string                   `bson:"parent_status"`
+	Definitions  []PatchTriggerDefinition `bson:"definitions"`
+	// The revision to base the downstream patch off of
+	DownstreamRevision string `bson:"downstream_revision"`
 
 	Processed bool `bson:"processed"`
 }

--- a/model/patch/trigger_intent.go
+++ b/model/patch/trigger_intent.go
@@ -116,14 +116,15 @@ type TriggerIntentOptions struct {
 
 func NewTriggerIntent(opts TriggerIntentOptions) Intent {
 	return &TriggerIntent{
-		Id:              mgobson.NewObjectId().Hex(),
-		Requester:       opts.Requester,
-		Author:          opts.Author,
-		ProjectID:       opts.ProjectID,
-		ParentID:        opts.ParentID,
-		ParentProjectID: opts.ParentProjectID,
-		ParentAsModule:  opts.ParentAsModule,
-		ParentStatus:    opts.ParentStatus,
-		Definitions:     opts.Definitions,
+		Id:                 mgobson.NewObjectId().Hex(),
+		Requester:          opts.Requester,
+		Author:             opts.Author,
+		ProjectID:          opts.ProjectID,
+		ParentID:           opts.ParentID,
+		ParentProjectID:    opts.ParentProjectID,
+		ParentAsModule:     opts.ParentAsModule,
+		ParentStatus:       opts.ParentStatus,
+		Definitions:        opts.Definitions,
+		DownstreamRevision: opts.DownstreamRevision,
 	}
 }

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -106,6 +106,8 @@ type APIPatchTriggerDefinition struct {
 	// Name of the module corresponding to the upstream project in the
 	// downstream project's YAML.
 	ParentAsModule *string `json:"parent_as_module,omitempty"`
+	// The revision at which to create the downstream patch.
+	DownstreamRevision *string `json:"downstream_revision,omitempty"`
 	// The list of variants/tasks from the alias that will run in the downstream
 	// project.
 	VariantsTasks []VariantTask `json:"variants_tasks,omitempty"`
@@ -121,6 +123,7 @@ func (t *APIPatchTriggerDefinition) BuildFromService(def patch.PatchTriggerDefin
 	// not sure in which direction this should go
 	t.Alias = utility.ToStringPtr(def.Alias)
 	t.Status = utility.ToStringPtr(def.Status)
+	t.DownstreamRevision = utility.ToStringPtr(def.DownstreamRevision)
 	t.ParentAsModule = utility.ToStringPtr(def.ParentAsModule)
 	var specifiers []APITaskSpecifier
 	for _, ts := range def.TaskSpecifiers {
@@ -139,6 +142,7 @@ func (t *APIPatchTriggerDefinition) ToService() patch.PatchTriggerDefinition {
 	trigger.Status = utility.FromStringPtr(t.Status)
 	trigger.Alias = utility.FromStringPtr(t.Alias)
 	trigger.ParentAsModule = utility.FromStringPtr(t.ParentAsModule)
+	trigger.DownstreamRevision = utility.FromStringPtr(t.DownstreamRevision)
 	var specifiers []patch.TaskSpecifier
 	for _, ts := range t.TaskSpecifiers {
 		specifiers = append(specifiers, ts.ToService())

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -106,7 +106,9 @@ type APIPatchTriggerDefinition struct {
 	// Name of the module corresponding to the upstream project in the
 	// downstream project's YAML.
 	ParentAsModule *string `json:"parent_as_module,omitempty"`
-	// The revision at which to create the downstream patch.
+	// An optional field representing the revision at which to create the downstream patch.
+	// By default, this field is empty and the downstream patch will be based off of its
+	// most recent commit.
 	DownstreamRevision *string `json:"downstream_revision,omitempty"`
 	// The list of variants/tasks from the alias that will run in the downstream
 	// project.

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1186,9 +1186,9 @@ func fetchTriggerProjectInfo(ctx context.Context, patchDoc *patch.Patch) (*model
 		project, pp, err = model.FindAndTranslateProjectForVersion(ctx, evergreen.GetEnvironment().Settings(), v, true)
 	} else {
 		v, project, pp, err = model.FindLatestVersionWithValidProject(patchDoc.Project, true)
-		if err != nil {
-			return nil, nil, nil, errors.Wrapf(err, "getting latest version for project '%s'", patchDoc.Project)
-		}
+	}
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "getting downstream version to use for patch '%s'", patchDoc.Id.Hex())
 	}
 	return v, project, pp, nil
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1174,25 +1174,21 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 }
 
 func fetchTriggerVersionInfo(ctx context.Context, patchDoc *patch.Patch) (*model.Version, *model.Project, *model.ParserProject, error) {
-	var v *model.Version
-	var project *model.Project
-	var pp *model.ParserProject
-	var err error
 	if patchDoc.Triggers.DownstreamRevision != "" {
-		v, err = model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(patchDoc.Project, patchDoc.Triggers.DownstreamRevision))
+		v, err := model.VersionFindOne(model.BaseVersionByProjectIdAndRevision(patchDoc.Project, patchDoc.Triggers.DownstreamRevision))
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "getting version at revision '%s'", patchDoc.Triggers.DownstreamRevision)
 		}
 		if v == nil {
 			return nil, nil, nil, errors.Errorf("version at revision '%s' not found", patchDoc.Triggers.DownstreamRevision)
 		}
-		project, pp, err = model.FindAndTranslateProjectForVersion(ctx, evergreen.GetEnvironment().Settings(), v, true)
+		project, pp, err := model.FindAndTranslateProjectForVersion(ctx, evergreen.GetEnvironment().Settings(), v, true)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "getting downstream version at revision '%s' to use for patch '%s'", patchDoc.Triggers.DownstreamRevision, patchDoc.Id.Hex())
 		}
 		return v, project, pp, nil
 	}
-	v, project, pp, err = model.FindLatestVersionWithValidProject(patchDoc.Project, true)
+	v, project, pp, err := model.FindLatestVersionWithValidProject(patchDoc.Project, true)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "getting downstream version to use for patch '%s'", patchDoc.Id.Hex())
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1605,7 +1605,7 @@ tasks:
 	s.NoError(u.Insert())
 
 	projectRef, err := model.FindBranchProjectRef(s.project)
-	s.NotNil(projectRef)
+	s.Require().NotNil(projectRef)
 	s.NoError(err)
 
 	s.Len(p.Triggers.ChildPatches, 0)
@@ -1616,7 +1616,7 @@ tasks:
 	s.Require().NotZero(dbPatch)
 	s.Equal(p.Triggers.ChildPatches, dbPatch.Triggers.ChildPatches)
 
-	s.Require().NotEmpty(dbPatch.Triggers.ChildPatches)
+	s.Require().Len(dbPatch.Triggers.ChildPatches, 1)
 	dbChildPatch, err := patch.FindOneId(dbPatch.Triggers.ChildPatches[0])
 	s.NoError(err)
 	s.Require().NotZero(dbChildPatch)
@@ -1671,12 +1671,11 @@ tasks:
 	s.NoError(u.Insert())
 
 	projectRef, err := model.FindBranchProjectRef(s.project)
-	s.NotNil(projectRef)
+	s.Require().NotNil(projectRef)
 	s.NoError(err)
 	s.Require().Len(projectRef.PatchTriggerAliases, 1)
 	projectRef.PatchTriggerAliases[0].DownstreamRevision = "abc"
 
-	s.Len(p.Triggers.ChildPatches, 0)
 	s.NoError(ProcessTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
 
 	dbPatch, err := patch.FindOneId(p.Id.Hex())
@@ -1684,7 +1683,7 @@ tasks:
 	s.Require().NotZero(dbPatch)
 	s.Equal(p.Triggers.ChildPatches, dbPatch.Triggers.ChildPatches)
 
-	s.Require().NotEmpty(dbPatch.Triggers.ChildPatches)
+	s.Require().Len(dbPatch.Triggers.ChildPatches, 1)
 	dbChildPatch, err := patch.FindOneId(dbPatch.Triggers.ChildPatches[0])
 	s.NoError(err)
 	s.Require().NotZero(dbChildPatch)
@@ -1733,7 +1732,7 @@ tasks:
 	s.NoError(u.Insert())
 
 	projectRef, err := model.FindBranchProjectRef(s.project)
-	s.NotNil(projectRef)
+	s.Require().NotNil(projectRef)
 	s.NoError(err)
 
 	s.Len(p.Triggers.ChildPatches, 0)


### PR DESCRIPTION
DEVPROD-7529

### Description
This adds a new field on the patch trigger definition that specifies which revision to base the downstream patch off of, rather than having it always default to the latest revision for the downstream patch.

The team requesting / using this will only be setting this via API, should we keep this feature API-only?

### Testing
Confirmed expected behavior in staging + unit test
