### PR TITLE
DEVPROD-1617 Add task information to projects version route

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -654,6 +654,7 @@ func GetVersionsWithOptions(projectName string, opts GetVersionsOptions) ([]Vers
 				"as":   "tasks",
 				"pipeline": []bson.M{
 					{"$match": bson.M{"$expr": bson.M{"$and": taskMatch}}},
+					{"$project": bson.M{"id": "$_id"}},
 				},
 			}
 			innerPipeline = append(innerPipeline, bson.M{"$lookup": taskLookup})

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -236,7 +236,7 @@ func TestGetVersionsWithTaskOptions(t *testing.T) {
 
 	// test with tasks
 	opts := GetVersionsOptions{Requester: evergreen.RepotrackerVersionRequester, IncludeBuilds: true, IncludeTasks: true,
-		ByBuildVariant: "my_bv", ByTask: "my_task", Limit: 2}
+		Limit: 2}
 
 	versions, err := GetVersionsWithOptions("my_ident", opts)
 	assert.NoError(t, err)
@@ -245,10 +245,30 @@ func TestGetVersionsWithTaskOptions(t *testing.T) {
 	assert.Equal(t, 20, versions[0].RevisionOrderNumber)
 	require.Len(t, versions[0].Builds, 1)
 	require.Len(t, versions[0].Builds[0].Tasks, 1)
+	assert.Equal(t, "t20", versions[0].Builds[0].Tasks[0].Id)
 	assert.Equal(t, "v1", versions[1].Id)
 	assert.Equal(t, 1, versions[1].RevisionOrderNumber)
 	require.Len(t, versions[1].Builds, 1)
 	require.Len(t, versions[1].Builds[0].Tasks, 1)
+	assert.Equal(t, "t1", versions[1].Builds[0].Tasks[0].Id)
+
+	// test with tasks and ByBuildVariant and ByTask
+	opts = GetVersionsOptions{Requester: evergreen.RepotrackerVersionRequester, IncludeBuilds: true, IncludeTasks: true,
+		ByBuildVariant: "my_bv", ByTask: "my_task", Limit: 2}
+
+	versions, err = GetVersionsWithOptions("my_ident", opts)
+	assert.NoError(t, err)
+	require.Len(t, versions, 2)
+	assert.Equal(t, "v20", versions[0].Id)
+	assert.Equal(t, 20, versions[0].RevisionOrderNumber)
+	require.Len(t, versions[0].Builds, 1)
+	require.Len(t, versions[0].Builds[0].Tasks, 1)
+	assert.Equal(t, "t20", versions[0].Builds[0].Tasks[0].Id)
+	assert.Equal(t, "v1", versions[1].Id)
+	assert.Equal(t, 1, versions[1].RevisionOrderNumber)
+	require.Len(t, versions[1].Builds, 1)
+	require.Len(t, versions[1].Builds[0].Tasks, 1)
+	assert.Equal(t, "t1", versions[1].Builds[0].Tasks[0].Id)
 }
 
 func TestGetVersionsWithOptions(t *testing.T) {


### PR DESCRIPTION
DEVPROD-1617

### Description
When pinging /projects/{project_id}/versions (e.g. https://evergreen-staging.corp.mongodb.com/rest/v2/projects/zackary-bisect/versions) with a body that has `{ "include_builds": true, "include_tasks": true }` it should return the builds and the tasks. It does return the builds, but the tasks are just empty strings. This makes it also return the tasks.

### Testing
Added some unit testing and did staging test.

```
        "tasks": [
          "zackary_bisect_generated_ubuntu_generated_task_1_c92ca45d46807777699d8dace4032c5b2a70e396_24_06_05_15_46_36",
          "zackary_bisect_generated_ubuntu_generated_task_2_c92ca45d46807777699d8dace4032c5b2a70e396_24_06_05_15_46_36",
          "zackary_bisect_generated_ubuntu_generated_task_3_c92ca45d46807777699d8dace4032c5b2a70e396_24_06_05_15_46_36",
          "zackary_bisect_generated_ubuntu_generated_task_4_c92ca45d46807777699d8dace4032c5b2a70e396_24_06_05_15_46_36"
        ],
```
        
This is the example response, before it was just empty strings.

Should this be the task id (which is what it is now) or should this be the display name? I'm honestly not sure...