### PR TITLE
DEVPROD-5318: update unattainable dependencies in bulk

### DIFF
--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -129,7 +129,7 @@ func LogManyHostsCreated(hostIDs []string) {
 	if err := LogManyEvents(events); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"resource_type": ResourceTypeHost,
-			"message":       "error logging event",
+			"message":       "error logging events",
 			"source":        "event-log-fail",
 		}))
 	}

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -96,7 +96,7 @@ func logManyTaskEvents(taskIds []string, eventType string, eventData TaskEventDa
 	if err := LogManyEvents(events); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"resource_type": ResourceTypeTask,
-			"message":       "error logging event",
+			"message":       "error logging events",
 			"source":        "event-log-fail",
 		}))
 	}
@@ -196,7 +196,7 @@ func LogManyTasksBlocked(data []TaskBlockedData) {
 		grip.Error(message.WrapError(err, message.Fields{
 			"resource_type": ResourceTypeTask,
 			"event_type":    TaskBlocked,
-			"message":       "error logging event",
+			"message":       "error logging events",
 			"source":        "event-log-fail",
 		}))
 	}

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -164,15 +164,19 @@ func LogTaskRestarted(taskId string, execution int, userId string) {
 	logTaskEvent(taskId, TaskRestarted, TaskEventData{Execution: execution, UserId: userId})
 }
 
-// TaskBlockedEventData is event data for logging a single task blocked event.
-type TaskBlockedEventData struct {
+// TaskBlockedData is event data for logging a single task blocked event.
+type TaskBlockedData struct {
 	ID        string `bson:"-" json:"-"`
 	Execution int    `bson:"-" json:"-"`
 	BlockedOn string `bson:"-" json:"-"`
 }
 
 // LogManyTasksBlocked logs many task blocked events.
-func LogManyTasksBlocked(data []TaskBlockedEventData) {
+func LogManyTasksBlocked(data []TaskBlockedData) {
+	if len(data) == 0 {
+		return
+	}
+
 	events := make([]EventLogEntry, 0, len(data))
 	now := time.Now()
 	for _, d := range data {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1870,7 +1870,7 @@ func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, depende
 		// expected. The two fields that are set
 		// (DependsOn.UnattainableDependency and Task.UnattainableDependency)
 		// are not used in the rest of the UpdateUnblockedDependencies logic.
-		// However, it may be relevant to the event log.
+		// However, it may or may not be relevant to the event log.
 		options.FindOneAndUpdate().SetReturnDocument(options.After),
 	)
 	if res.Err() != nil {
@@ -1878,6 +1878,63 @@ func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, depende
 	}
 
 	return res.Decode(&t)
+}
+
+func updateAllTasksForMatchingDependencies(ctx context.Context, taskIDs []string, dependencyID string, unattainable bool) error {
+	// Update the matching dependencies in the DependsOn array and the UnattainableDependency field that caches
+	// whether any of the dependencies are blocked. Combining both these updates in a single update operation makes it
+	// impervious to races because updates to single documents are atomic.
+	if _, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateMany(ctx,
+		bson.M{
+			// kim: NOTE: this is the task ID of the dependent (i.e. child)
+			// task.
+			IdKey: bson.M{"$in": taskIDs},
+		},
+		[]bson.M{
+			{
+				// kim: NOTE: this sets individual dependency's
+				// UnattainableDependency.
+				// Iterate over the DependsOn array and set unattainable for dependencies that
+				// match the dependencyID. Leave other dependencies untouched.
+				"$set": bson.M{DependsOnKey: bson.M{
+					"$map": bson.M{
+						// kim: NOTE: for each of the child's dependencies.
+						"input": "$" + DependsOnKey,
+						"as":    "dependency",
+						"in": bson.M{
+							"$cond": bson.M{
+								// kim: NOTE: if dependency ID matches the
+								// parent task.
+								"if": bson.M{"$eq": []string{bsonutil.GetDottedKeyName("$$dependency", DependencyTaskIdKey), dependencyID}},
+								// kim: NOTE: then set unattainable.
+								"then": bson.M{"$mergeObjects": bson.A{"$$dependency", bson.M{DependencyUnattainableKey: unattainable}}},
+								// kim: NOTE: otherwise keep the dependency as-is.
+								"else": "$$dependency",
+							},
+						},
+					}},
+				},
+			},
+			{
+				// kim: NOTE: sets overall task's UnattainableDependency
+				// Cache whether any dependencies are unattainable.
+				"$set": bson.M{UnattainableDependencyKey: bson.M{"$cond": bson.M{
+					"if": bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					// kim: NOTE: if any of the individual dependencies for the
+					// child are unattainable, set the child
+					// UnattainableDependency to true.
+					"then": bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					// kim: NOTE: otherwise, no dependency has been marked
+					// unattainable, so set it to false.
+					"else": false,
+				}}},
+			},
+		},
+	); err != nil {
+		return errors.Wrap(err, "updating matching dependencies")
+	}
+
+	return nil
 }
 
 // HasUnfinishedTaskForVersions returns true if there are any scheduled but

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1814,26 +1814,36 @@ func FindActivatedByVersionWithoutDisplay(versionId string) ([]Task, error) {
 
 }
 
+// kim: NOTE: dependencyID is the task ID of the depended-on (i.e. parent) task.
 func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, dependencyID string, unattainable bool) error {
 	// Update the matching dependencies in the DependsOn array and the UnattainableDependency field that caches
 	// whether any of the dependencies are blocked. Combining both these updates in a single update operation makes it
 	// impervious to races because updates to single documents are atomic.
 	res := evergreen.GetEnvironment().DB().Collection(Collection).FindOneAndUpdate(ctx,
 		bson.M{
+			// kim: NOTE: this is the task ID of the dependent (i.e. child)
+			// task.
 			IdKey: t.Id,
 		},
 		[]bson.M{
 			{
+				// kim: NOTE: this sets individual dependency's
+				// UnattainableDependency.
 				// Iterate over the DependsOn array and set unattainable for dependencies that
 				// match the dependencyID. Leave other dependencies untouched.
 				"$set": bson.M{DependsOnKey: bson.M{
 					"$map": bson.M{
+						// kim: NOTE: for each of the child's dependencies.
 						"input": "$" + DependsOnKey,
 						"as":    "dependency",
 						"in": bson.M{
 							"$cond": bson.M{
-								"if":   bson.M{"$eq": []string{bsonutil.GetDottedKeyName("$$dependency", DependencyTaskIdKey), dependencyID}},
+								// kim: NOTE: if dependency ID matches the
+								// parent task.
+								"if": bson.M{"$eq": []string{bsonutil.GetDottedKeyName("$$dependency", DependencyTaskIdKey), dependencyID}},
+								// kim: NOTE: then set unattainable.
 								"then": bson.M{"$mergeObjects": bson.A{"$$dependency", bson.M{DependencyUnattainableKey: unattainable}}},
+								// kim: NOTE: otherwise keep the dependency as-is.
 								"else": "$$dependency",
 							},
 						},
@@ -1841,14 +1851,26 @@ func (t *Task) updateAllMatchingDependenciesForTask(ctx context.Context, depende
 				},
 			},
 			{
+				// kim: NOTE: sets overall task's UnattainableDependency
 				// Cache whether any dependencies are unattainable.
 				"$set": bson.M{UnattainableDependencyKey: bson.M{"$cond": bson.M{
-					"if":   bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					"if": bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					// kim: NOTE: if any of the individual dependencies for the
+					// child are unattainable, set the child
+					// UnattainableDependency to true.
 					"then": bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
+					// kim: NOTE: otherwise, no dependency has been marked
+					// unattainable, so set it to false.
 					"else": false,
 				}}},
 			},
 		},
+		// kim: NOTE: I believe returning the updated document isn't critical
+		// to ensure that the recursive UpdateBlockedDependencies call works as
+		// expected. The two fields that are set
+		// (DependsOn.UnattainableDependency and Task.UnattainableDependency)
+		// are not used in the rest of the UpdateUnblockedDependencies logic.
+		// However, it may be relevant to the event log.
 		options.FindOneAndUpdate().SetReturnDocument(options.After),
 	)
 	if res.Err() != nil {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1841,6 +1841,7 @@ func updateAllTasksForMatchingDependencies(ctx context.Context, taskIDs []string
 				},
 			},
 			{
+				// Cache whether any dependencies are unattainable.
 				"$set": bson.M{UnattainableDependencyKey: bson.M{"$cond": bson.M{
 					"if":   bson.M{"$isArray": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},
 					"then": bson.M{"$anyElementTrue": "$" + bsonutil.GetDottedKeyName(DependsOnKey, DependencyUnattainableKey)},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -124,7 +124,7 @@ type Task struct {
 	DependsOn               []Dependency     `bson:"depends_on" json:"depends_on"`
 	// UnattainableDependency caches the contents of DependsOn for more
 	// efficient querying. It is true if any of its dependencies is unattainable
-	// and is false if all dependencies are attainable.
+	// and is false if all of its dependencies are attainable.
 	UnattainableDependency bool `bson:"unattainable_dependency" json:"unattainable_dependency"`
 	NumDependents          int  `bson:"num_dependents,omitempty" json:"num_dependents,omitempty"`
 	// OverrideDependencies indicates whether a task should override its dependencies. If set, it will not

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2654,6 +2654,13 @@ func (t *Task) MarkUnattainableDependency(ctx context.Context, dependencyId stri
 	}
 
 	// Only want to log the task as blocked if it wasn't already blocked, and if we're not overriding dependencies.
+	// kim: NOTE: while this seemingly does require t.Blocked() to be up-to-date
+	// in the later recursive calls, I believe we can work around this by making
+	// it a BFS with one bulk update of all dependent children at this depth.
+	// That way, we can still record t.Blocked() initially before the update,
+	// but later iterations on later tasks at the same depth won't happen since
+	// it's now one big update.
+	// kim: NOTE: should add a test for only one task blocked log.
 	if !wasBlocked && unattainable && !t.OverrideDependencies {
 		event.LogTaskBlocked(t.Id, t.Execution, dependencyId)
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2656,6 +2656,10 @@ func (t *Task) MarkUnscheduled() error {
 // unattainable, it creates an event log for each newly blocked task. This
 // returns all the tasks after the update.
 func MarkAllForUnattainableDependency(ctx context.Context, tasks []Task, dependencyID string, unattainable bool) ([]Task, error) {
+	if len(tasks) == 0 {
+		return tasks, nil
+	}
+
 	taskIDs := make([]string, 0, len(tasks))
 	newlyBlockedTaskData := make([]event.TaskBlockedData, 0, len(tasks))
 	for _, t := range tasks {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3102,27 +3102,34 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			assert.NoError(t, err)
 			require.Len(t, updatedDependentTasks, len(dependentTasks))
 
-			checkTaskAndDB(t, updatedDependentTasks[0], func(t *testing.T, taskToCheck Task) {
-				assert.True(t, taskToCheck.Blocked())
-				assert.True(t, taskToCheck.UnattainableDependency)
-				require.Len(t, taskToCheck.DependsOn, 2)
-				assert.True(t, taskToCheck.DependsOn[0].Unattainable)
-				assert.False(t, taskToCheck.DependsOn[1].Unattainable)
-			})
-
-			checkTaskAndDB(t, updatedDependentTasks[1], func(t *testing.T, taskToCheck Task) {
-				assert.True(t, taskToCheck.Blocked())
-				assert.True(t, taskToCheck.UnattainableDependency)
-				require.Len(t, taskToCheck.DependsOn, 1)
-				assert.True(t, taskToCheck.DependsOn[0].Unattainable)
-			})
-
-			checkTaskAndDB(t, updatedDependentTasks[2], func(t *testing.T, taskToCheck Task) {
-				assert.False(t, taskToCheck.Blocked())
-				assert.False(t, taskToCheck.UnattainableDependency)
-				require.Len(t, taskToCheck.DependsOn, 1)
-				assert.False(t, taskToCheck.DependsOn[0].Unattainable)
-			})
+			for _, updatedDependentTask := range updatedDependentTasks {
+				switch updatedDependentTask.Id {
+				case dependentTasks[0].Id:
+					checkTaskAndDB(t, updatedDependentTasks[0], func(t *testing.T, taskToCheck Task) {
+						assert.True(t, taskToCheck.Blocked())
+						assert.True(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 2)
+						assert.True(t, taskToCheck.DependsOn[0].Unattainable)
+						assert.False(t, taskToCheck.DependsOn[1].Unattainable)
+					})
+				case dependentTasks[1].Id:
+					checkTaskAndDB(t, updatedDependentTasks[1], func(t *testing.T, taskToCheck Task) {
+						assert.True(t, taskToCheck.Blocked())
+						assert.True(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 1)
+						assert.True(t, taskToCheck.DependsOn[0].Unattainable)
+					})
+				case dependentTasks[2].Id:
+					checkTaskAndDB(t, updatedDependentTasks[2], func(t *testing.T, taskToCheck Task) {
+						assert.False(t, taskToCheck.Blocked())
+						assert.False(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 1)
+						assert.False(t, taskToCheck.DependsOn[0].Unattainable)
+					})
+				default:
+					assert.Fail(t, "unexpected task '%s' in updated tasks", updatedDependentTask.Id)
+				}
+			}
 		},
 		"NonexistentDependency": func(ctx context.Context, t *testing.T) {
 			dependentTask := Task{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3169,7 +3169,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", true)
+			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]
@@ -3178,7 +3178,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				assert.True(t, taskToCheck.Blocked())
 				assert.True(t, taskToCheck.UnattainableDependency)
 				require.Len(t, taskToCheck.DependsOn, 2)
-				assert.True(t, taskToCheck.DependsOn[0].Unattainable)
+				assert.False(t, taskToCheck.DependsOn[0].Unattainable)
 				assert.True(t, taskToCheck.DependsOn[1].Unattainable)
 			})
 		},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3015,6 +3015,7 @@ func getTaskThatNeedsContainerAllocation() Task {
 	}
 }
 
+// kim: TODO: test MarkAllWithUnattainableDependency
 func TestMarkUnattainableDependency(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1051,7 +1051,7 @@ func UpdateBlockedDependencies(ctx context.Context, t *task.Task) error {
 		return errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
 	}
 
-	dependentTasks, err = task.MarkAllWithUnattainableDependency(ctx, dependentTasks, t.Id, true)
+	dependentTasks, err = task.MarkAllForUnattainableDependency(ctx, dependentTasks, t.Id, true)
 	if err != nil {
 		return errors.Wrap(err, "marking unattainable dependency for tasks")
 	}
@@ -1100,7 +1100,7 @@ func UpdateUnblockedDependencies(ctx context.Context, t *task.Task) error {
 		return errors.Wrap(err, "getting dependencies marked unattainable")
 	}
 
-	blockedTasks, err = task.MarkAllWithUnattainableDependency(ctx, blockedTasks, t.Id, false)
+	blockedTasks, err = task.MarkAllForUnattainableDependency(ctx, blockedTasks, t.Id, false)
 	if err != nil {
 		return errors.Wrap(err, "marking attainable dependency for tasks")
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1034,18 +1034,37 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string) (c
 // UpdateBlockedDependencies traverses the dependency graph and recursively sets
 // each parent dependency as unattainable in depending tasks. It updates the
 // status of builds as well, in case they change due to blocking dependencies.
+// kim: NOTE: since the problem is with updating 4k+ blocked tasks, it could be
+// that just reducing the number of round trips to the DB is not enough, and
+// it's simply updating too many docs to fit within the 60s limit. If so, will
+// need either more creativity (e.g. somehow reducing number of docs to update)
+// or will need to move to a job (similar to generate.tasks but for end task).
 func UpdateBlockedDependencies(ctx context.Context, t *task.Task) error {
 	ctx, span := tracer.Start(ctx, "update-blocked-dependencies")
 	defer span.End()
 
+	// kim: NOTE: find all tasks that depend on this task and their dependency
+	// status filter doesn't match the task's status (e.g. the dependency needs
+	// success but the task failed).
 	dependentTasks, err := t.FindAllUnmarkedBlockedDependencies()
 	if err != nil {
 		return errors.Wrapf(err, "getting tasks depending on task '%s'", t.Id)
 	}
 
+	// kim: NOTE: bulk write may or may not help this loop depending on how much
+	// this loop relies on the prior UpdateOnes taking effect.
+	// kim: NOTE: doing bulk update of all child tasks will reduce number of
+	// updates so it's 1 update per parent dependency vertex, rather than 1
+	// update per child-parent dependency edge.
 	// Using a set then converting to a slice to avoid duplicate build IDs.
 	buildIDsSet := make(map[string]struct{})
 	for _, dependentTask := range dependentTasks {
+		// kim; NOTE: this loop of marking unattainable and then recursively
+		// going to the next dependency is the long loop that takes forever.
+		// kim: TODO: figure out how MarkUnattainableDependency works. It seems
+		// quite complicated.
+		// kim; NOTE: this passes unattainable=true because it only finds those
+		// tasks whose status filter won't match the task's status.
 		if err = dependentTask.MarkUnattainableDependency(ctx, t.Id, true); err != nil {
 			return errors.Wrap(err, "marking dependency unattainable")
 		}


### PR DESCRIPTION
DEVPROD-5318

### Description
[An example HC trace](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/cT2VBKpd4CE/trace/aKkt735hVpG?fields[]=s_name&fields[]=s_serviceName&span=7a2f6ea93711e813) (and other examples I looked through) suggest that the slowest part of end task is marking dependencies unattainable after a task fails that has lots of dependencies. For example, if one of the compile tasks in a server patch fails, it spends all of end task blocking thousands of tasks that depend on compile before the request eventually times out.

This attempts to optimize it by reducing the number of round-trips to the DB. It's the same update, but instead of doing thousands of single updates, it'll instead do one big bulk update. I'm not that confident that this will improve the performance enough, so I'll be monitoring the impact after this is deployed.

* Block/unblock tasks with unattainable dependencies in bulk.
* Log task blocked events in bulk.
* Refactor tests a little bit.

### Testing
* Existing tests cover that functionality works like before.
* Added a unit test for updating many tasks at once.
* Ran patches in staging to verify that it blocked dependencies like it did before.

### Documentation
N/A