### PR TITLE
DEVPROD-8099: Fix nil dereference errors in AbortInfo resolver

### DIFF
--- a/graphql/host_resolver.go
+++ b/graphql/host_resolver.go
@@ -44,7 +44,7 @@ func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (
 		}
 		if volume == nil {
 			grip.Error(message.Fields{
-				"message":   "could not find the volume associated with this host",
+				"message":   "can't find the volume associated with this host",
 				"ticket":    "EVG-16149",
 				"host_id":   obj.Id,
 				"volume_id": volId,

--- a/graphql/host_resolver.go
+++ b/graphql/host_resolver.go
@@ -44,7 +44,7 @@ func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (
 		}
 		if volume == nil {
 			grip.Error(message.Fields{
-				"message":   "cannot find the volume associated with this host",
+				"message":   "could not find the volume associated with this host",
 				"ticket":    "EVG-16149",
 				"host_id":   obj.Id,
 				"volume_id": volId,

--- a/graphql/host_resolver.go
+++ b/graphql/host_resolver.go
@@ -44,7 +44,7 @@ func (r *hostResolver) HomeVolume(ctx context.Context, obj *restModel.APIHost) (
 		}
 		if volume == nil {
 			grip.Error(message.Fields{
-				"message":   "can't find the volume associated with this host",
+				"message":   "cannot find the volume associated with this host",
 				"ticket":    "EVG-16149",
 				"host_id":   obj.Id,
 				"volume_id": volId,

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -37,14 +37,14 @@ func (r *taskResolver) AbortInfo(ctx context.Context, obj *restModel.APITask) (*
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Problem getting aborted task %s: %s", *obj.Id, err.Error()))
 		}
 		if abortedTask == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find aborted task %s", obj.AbortInfo.TaskID))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find aborted task '%s'", obj.AbortInfo.TaskID))
 		}
 		abortedTaskBuild, err := build.FindOneId(abortedTask.BuildId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Problem getting build for aborted task %s: %s", abortedTask.BuildId, err.Error()))
 		}
 		if abortedTaskBuild == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find build %s for aborted task", abortedTask.BuildId))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find build '%s' for aborted task", abortedTask.BuildId))
 		}
 		info.TaskDisplayName = abortedTask.DisplayName
 		info.BuildVariantDisplayName = abortedTaskBuild.DisplayName

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -37,14 +37,14 @@ func (r *taskResolver) AbortInfo(ctx context.Context, obj *restModel.APITask) (*
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Problem getting aborted task %s: %s", *obj.Id, err.Error()))
 		}
 		if abortedTask == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find aborted task %s: %s", obj.AbortInfo.TaskID, err.Error()))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find aborted task %s", obj.AbortInfo.TaskID))
 		}
 		abortedTaskBuild, err := build.FindOneId(abortedTask.BuildId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("Problem getting build for aborted task %s: %s", abortedTask.BuildId, err.Error()))
 		}
 		if abortedTaskBuild == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find build %s for aborted task: %s", abortedTask.BuildId, err.Error()))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Unable to find build %s for aborted task", abortedTask.BuildId))
 		}
 		info.TaskDisplayName = abortedTask.DisplayName
 		info.BuildVariantDisplayName = abortedTaskBuild.DisplayName


### PR DESCRIPTION
DEVPROD-8099

### Description
Removed err.Error() messages when err is nil in AbortInfo resolver. 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
