### PR TITLE
DEVPROD-8338: switch default commit queue type to GitHub merge queue

### DIFF
--- a/graphql/tests/projectSettings/projectRef/results.json
+++ b/graphql/tests/projectSettings/projectRef/results.json
@@ -13,7 +13,7 @@
               "commitQueue": {
                 "enabled": true,
                 "mergeMethod": "squash",
-                "mergeQueue": "EVERGREEN"
+                "mergeQueue": "GITHUB"
               },
               "periodicBuilds": null,
               "githubChecksEnabled": false,

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -269,7 +269,7 @@ func (cqParams *APICommitQueueParams) BuildFromService(params model.CommitQueueP
 	cqParams.Message = utility.ToStringPtr(params.Message)
 
 	if params.MergeQueue == "" {
-		params.MergeQueue = model.MergeQueueEvergreen
+		params.MergeQueue = model.MergeQueueGitHub
 	}
 	cqParams.MergeQueue = params.MergeQueue
 }
@@ -281,7 +281,7 @@ func (cqParams *APICommitQueueParams) ToService() model.CommitQueueParams {
 	serviceParams.Message = utility.FromStringPtr(cqParams.Message)
 
 	if cqParams.MergeQueue == "" {
-		cqParams.MergeQueue = model.MergeQueueEvergreen
+		cqParams.MergeQueue = model.MergeQueueGitHub
 	}
 	serviceParams.MergeQueue = cqParams.MergeQueue
 


### PR DESCRIPTION
DEVPROD-8338

### Description
I don't think the UI propagates the merge queue type, so when the GH/commit queue project settings are saved, the field is always empty, which then reverts the project back to the legacy commit queue. All projects should be using the GH merge queue so it this seems like it's fine to auto-set it.

There's gonna be a follow-up DB update to re-switch projects back over to the GH merge queue if they were accidentally reverted to the legacy commit queue.

### Testing
1. I reproduced the issue in staging with the sandbox. I manually switched the project to the GH merge queue, edited the commit queue alias, saved, and then checked the DB and the commit queue was invisibly reverted from the GH merge queue back to the legacy commit queue.
2. Did the same thing as 1 after applying my fix, and it preserved/set the GH merge queue setting.

### Documentation
N/A
