### PR TITLE
DEVPROD-7034 Fix mainline version-completion trace

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1909,18 +1909,19 @@ func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error
 		if err = checkUpdateBuildPRStatusPending(ctx, taskBuild); err != nil {
 			return errors.Wrapf(err, "updating build '%s' PR status", taskBuild.Id)
 		}
-		// only add tracing for versions, patches need to wait for child patches
-		if !evergreen.IsPatchRequester(taskVersion.Requester) {
-			traceContext, err := getVersionCtxForTracing(ctx, taskVersion, t.Project)
-			if err != nil {
-				return errors.Wrap(err, "getting context for tracing")
-			}
-			// use a new root span so that it logs it every time instead of only logging a small sample set as an http call span
-			_, span := tracer.Start(traceContext, "version-completion", trace.WithNewRoot())
-			defer span.End()
+	}
 
-			return nil
+	if evergreen.IsFinishedVersionStatus(newVersionStatus) && !evergreen.IsPatchRequester(taskVersion.Requester) {
+		// only add tracing for versions, patches need to wait for child patches
+		traceContext, err := getVersionCtxForTracing(ctx, taskVersion, t.Project)
+		if err != nil {
+			return errors.Wrap(err, "getting context for tracing")
 		}
+		// use a new root span so that it logs it every time instead of only logging a small sample set as an http call span
+		_, span := tracer.Start(traceContext, "version-completion", trace.WithNewRoot())
+		defer span.End()
+
+		return nil
 	}
 
 	if evergreen.IsPatchRequester(taskVersion.Requester) {


### PR DESCRIPTION
DEVPROD-7034

### Description
This fixes a bug that was preventing mainline commit versions from having a version-completion trace.
### Testing
Tested in [staging](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/BFbjssqGfiK?hideCompare) to confirm repotracker versions now have the version-completion trace
