### PR TITLE
DEVPROD-7552: validate sleep schedule before spawning host

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -787,6 +787,11 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, err
 	}
 
+	if spawnHostInput.SleepSchedule != nil {
+		if err := spawnHostInput.SleepSchedule.Validate(); err != nil {
+			return nil, InputValidationError.Send(ctx, fmt.Sprintf("Invalid sleep schedule: %s", err))
+		}
+	}
 	spawnHost, err := data.NewIntentHost(ctx, options, usr, evergreen.GetEnvironment())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error spawning host: %s", err))


### PR DESCRIPTION
DEVPROD-7552

### Description
If spawning an unexpirable host in the UI and setting a sleep schedule, do not start the host unless the sleep schedule is valid.

Setting a sleep schedule isn't required until the feature is fully rolled out, so it's still an optional parameter for now. Later on, it'll be a required field for creating unexpirable hosts.

### Testing
Tested in staging by trying to spawn a host with an invalid sleep schedule and checked that it errored + didn't make the host.

### Documentation
N/A