### PR TITLE
DEVPROD-5986 Add expansion redaction for github.generate_token

### DIFF
--- a/agent/command/github_generate_token.go
+++ b/agent/command/github_generate_token.go
@@ -94,7 +94,7 @@ func (r *githubGenerateToken) Execute(ctx context.Context, comm client.Communica
 	// TODO DEVPROD-5986: Tokens should be redacted at the end, expanisions (or some other mechanism) should
 	// keep track of that and redact the token from GitHub.
 	// They also need to be redacted from logs.
-	conf.NewExpansions.Put(r.ExpansionName, token)
+	conf.NewExpansions.PutAndRedact(r.ExpansionName, token)
 
 	return nil
 }

--- a/agent/command/github_generate_token.go
+++ b/agent/command/github_generate_token.go
@@ -91,9 +91,6 @@ func (r *githubGenerateToken) Execute(ctx context.Context, comm client.Communica
 		return errors.Wrap(err, "creating github dynamic access token")
 	}
 
-	// TODO DEVPROD-5986: Tokens should be redacted at the end, expanisions (or some other mechanism) should
-	// keep track of that and redact the token from GitHub.
-	// They also need to be redacted from logs.
 	conf.NewExpansions.PutAndRedact(r.ExpansionName, token)
 
 	return nil

--- a/agent/command/github_generate_token_test.go
+++ b/agent/command/github_generate_token_test.go
@@ -104,6 +104,7 @@ func TestGitHubGenerateTokenExecute(t *testing.T) {
 			cmd.Repo = "new_repo"
 			require.NoError(t, cmd.Execute(ctx, client, logger, conf))
 			assert.Equal(t, "token!", conf.NewExpansions.Get(cmd.ExpansionName))
+			assert.Contains(t, conf.NewExpansions.GetRedacted(), agentutil.RedactInfo{Key: cmd.ExpansionName, Value: "token!"})
 			assert.Equal(t, "new_owner", cmd.Owner)
 			assert.Equal(t, "new_repo", cmd.Repo)
 		},

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-06-20"
+	AgentVersion = "2024-06-25-a"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5986

### Description
Redacts the token generated from `github.generate_token` calls.

### Testing
Unit testing