### PR TITLE
DEVPROD-8408 Add no permission group group in GitHub permission groups

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -160,6 +160,12 @@ var defaultGitHubTokenPermissionGroup = GitHubDynamicTokenPermissionGroup{
 	AllPermissions: true,
 }
 
+// noPermissionsGitHubTokenPermissionGroup is an empty, no permissions, group.
+var noPermissionsGitHubTokenPermissionGroup = GitHubDynamicTokenPermissionGroup{
+	Name:           "No Permissions",
+	AllPermissions: false,
+}
+
 // GetGitHubPermissionGroup returns the GitHubDynamicTokenPermissionGroup for the given requester.
 // If the requester is not found, it returns the default.
 func (p *ProjectRef) GetGitHubPermissionGroup(requester string) GitHubDynamicTokenPermissionGroup {
@@ -167,6 +173,9 @@ func (p *ProjectRef) GetGitHubPermissionGroup(requester string) GitHubDynamicTok
 		return defaultGitHubTokenPermissionGroup
 	}
 	if groupName, ok := p.GitHubPermissionGroupByRequester[requester]; ok {
+		if groupName == noPermissionsGitHubTokenPermissionGroup.Name {
+			return noPermissionsGitHubTokenPermissionGroup
+		}
 		for _, group := range p.GitHubDynamicTokenPermissionGroups {
 			if group.Name == groupName {
 				return group
@@ -188,6 +197,9 @@ func (p *ProjectRef) ValidateGitHubPermissionGroups() error {
 	for requester, groupName := range p.GitHubPermissionGroupByRequester {
 		if !utility.StringSliceContains(evergreen.AllRequesterTypes, requester) {
 			catcher.Add(errors.Errorf("requester '%s' is not a valid requester", requester))
+		}
+		if groupName == noPermissionsGitHubTokenPermissionGroup.Name {
+			continue
 		}
 		foundGroup := false
 		for _, group := range p.GitHubDynamicTokenPermissionGroups {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1812,6 +1812,7 @@ func TestGithubPermissionGroups(t *testing.T) {
 	}
 	orgRequesters := map[string]string{
 		evergreen.PatchVersionRequester: "some-group",
+		evergreen.GithubPRRequester:     noPermissionsGitHubTokenPermissionGroup.Name,
 	}
 	p := &ProjectRef{
 		GitHubDynamicTokenPermissionGroups: orgGroup,


### PR DESCRIPTION
DEVPROD-8408

### Description
This adds a hard-coded "No Permissions" group to our github logic. It will be used as an option in the dropdown menu on the UI.

### Testing
Unit testing
