### PR TITLE
Revert "DEVPROD-6943 Unmatching tasks/tags in variants resulting in a validation warning rather than a translation error (#7821)

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -413,10 +413,9 @@ type BuildVariant struct {
 	Tasks        []BuildVariantTaskUnit `yaml:"tasks,omitempty" bson:"tasks"`
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 
-	// TranslationWarnings are validation warnings that are only detectable during project translation.
-	// e.g. task selectors that don't target any tasks in a build variant but the build
-	// variant still has tasks.
-	TranslationWarnings []string `yaml:"-" bson:"-"`
+	// EmptyTaskSelectors stores task selectors that don't target any tasks for this build variant.
+	// This is only for validation purposes.
+	EmptyTaskSelectors []string `yaml:"-" bson:"-"`
 }
 
 // CheckRun is used to provide information about a github check run.

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -690,21 +690,19 @@ func TestRulesEvaluation(t *testing.T) {
 		Convey("a 'remove' rule for an unknown task should fail", func() {
 			bvs := []parserBV{{
 				Name: "test",
-				Tasks: parserBVTaskUnits{ // This starts with blue, brown, black, and white.
+				Tasks: parserBVTaskUnits{
 					{Name: "blue"},
 					{Name: ".special"},
 					{Name: ".tertiary"},
 				},
 				MatrixRules: []ruleAction{
-					{RemoveTasks: []string{".amazing"}}, // Nothing is tagged with amazing, so this step should not remove any and should not fail.
-					{RemoveTasks: []string{"blue"}},     // This should remove blue.
+					{RemoveTasks: []string{".amazing"}}, //remove blue
+					{RemoveTasks: []string{"rainbow"}},
 				},
 			}}
-			evaluated, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
-			So(errs, ShouldBeNil)
-			v1 := evaluated[0]
-			So(v1.Name, ShouldEqual, "test")
-			So(len(v1.Tasks), ShouldEqual, 3) // Brown, black, and white left
+			_, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
+			So(errs, ShouldNotBeNil)
+			So(len(errs), ShouldEqual, 2)
 		})
 	})
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1138,12 +1138,9 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 		// expand, validate that tasks defined in a group are listed in the project tasks
 		var taskNames []string
 		for _, taskName := range ptg.Tasks {
-			names, unmatched, err := tse.evalSelector(ParseSelector(taskName))
+			names, err := tse.evalSelector(ParseSelector(taskName))
 			if err != nil {
 				evalErrs = append(evalErrs, err)
-			}
-			if len(unmatched) > 0 {
-				evalErrs = append(evalErrs, errors.Errorf("task group '%s' has unmatched selector: '%s'", ptg.Name, strings.Join(unmatched, "', '")))
 			}
 			taskNames = append(taskNames, names...)
 		}
@@ -1158,8 +1155,6 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
 	pbvs []parserBV, tasks []parserTask, tgs []TaskGroup) ([]BuildVariant, []error) {
 	bvs := []BuildVariant{}
-	var unmatchedSelectors []string
-	var unmatchedCriteria []string
 	var evalErrs, errs []error
 	for _, pbv := range pbvs {
 		bv := BuildVariant{
@@ -1180,13 +1175,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			Tags:           pbv.Tags,
 		}
 		bv.AllowedRequesters = pbv.AllowedRequesters
-		bv.Tasks, unmatchedSelectors, unmatchedCriteria, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
-		if len(unmatchedSelectors) > 0 {
-			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' has unmatched selector: '%s'", pbv.Name, strings.Join(unmatchedSelectors, "', '")))
-		}
-		if len(unmatchedCriteria) > 0 {
-			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' has unmatched criteria: '%s'", pbv.Name, strings.Join(unmatchedCriteria, "', '")))
-		}
+		bv.Tasks, bv.EmptyTaskSelectors, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 
 		// evaluate any rules passed in during matrix construction
 		for _, r := range pbv.MatrixRules {
@@ -1195,7 +1184,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 				prunedTasks := []BuildVariantTaskUnit{}
 				toRemove := []string{}
 				for _, t := range r.RemoveTasks {
-					removed, _, err := tse.evalSelector(ParseSelector(t))
+					removed, err := tse.evalSelector(ParseSelector(t))
 					if err != nil {
 						evalErrs = append(evalErrs, errors.Wrap(err, "remove rule"))
 						continue
@@ -1220,7 +1209,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 
 				var added []BuildVariantTaskUnit
 				pbv.Tasks = r.AddTasks
-				added, _, _, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
+				added, _, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
 				evalErrs = append(evalErrs, errs...)
 				// check for conflicting duplicates
 				for _, t := range added {
@@ -1267,12 +1256,9 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			//resolve tags for display tasks
 			tasks := []string{}
 			for _, et := range dt.ExecutionTasks {
-				results, unmatched, err := dtse.evalSelector(ParseSelector(et))
+				results, err := dtse.evalSelector(ParseSelector(et))
 				if err != nil {
 					errs = append(errs, err)
-				}
-				if len(unmatched) > 0 {
-					errs = append(errs, errors.Errorf("display task '%s' contains unmatched criteria: '%s'", dt.Name, strings.Join(unmatched, "', '")))
 				}
 				tasks = append(tasks, results...)
 			}
@@ -1308,15 +1294,11 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 // tasks.
 // For task units that represent task groups, the resulting BuildVariantTaskUnit
 // represents the task group itself, not the individual tasks in the task group.
-// Returns the list of BuildVariantTaskUnits, the list of selectors that did not
-// match anything, the list of criteria that did not match any tasks, and
-// any errors encountered during evaluation.
 func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
-	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []string, []string, []error) {
+	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []string, []error) {
 	var evalErrs, errs []error
 	ts := []BuildVariantTaskUnit{}
-	unmatchedSelectors := []string{}
-	unmatchedCriteria := []string{}
+	emptySelectors := []string{}
 	taskUnitsByName := map[string]BuildVariantTaskUnit{}
 	tasksByName := map[string]parserTask{}
 	for _, t := range tasks {
@@ -1327,43 +1309,32 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		// only error if both selectors error because each task should only be found
 		// in one or the other.  Skip selector checking if task group is defined
 		// directly on the build variant task.
-		var names, unmatchedCriteriaFromTasks, unmatchedCriteriaFromTaskGroups, temp []string
+		var names, temp []string
 		isGroup := false
 		if pbvt.TaskGroup != nil {
 			names = append(names, pbvt.Name)
 			isGroup = true
 		} else {
-			var taskSelectorErr, taskGroupSelectorErr error
+			var err1, err2 error
 			if tse != nil {
-				temp, unmatchedCriteriaFromTasks, taskSelectorErr = tse.evalSelector(ParseSelector(pbvt.Name))
+				temp, err1 = tse.evalSelector(ParseSelector(pbvt.Name))
 				names = append(names, temp...)
 			}
 			if tgse != nil {
-				temp, unmatchedCriteriaFromTaskGroups, taskGroupSelectorErr = tgse.evalSelector(ParseSelector(pbvt.Name))
+				temp, err2 = tgse.evalSelector(ParseSelector(pbvt.Name))
 				if len(temp) > 0 {
 					names = append(names, temp...)
 					isGroup = true
 				}
 			}
-			if taskSelectorErr != nil && taskGroupSelectorErr != nil {
-				evalErrs = append(evalErrs, taskSelectorErr, taskGroupSelectorErr)
-				unmatchedSelectors = append(unmatchedSelectors, pbvt.Name)
+			if err1 != nil && err2 != nil {
+				evalErrs = append(evalErrs, err1, err2)
+				emptySelectors = append(emptySelectors, pbvt.Name)
 				continue
 			}
 		}
-		initialUnmatchedCriteriaLen := len(unmatchedCriteriaFromTasks)
-		for _, unmatchedTask := range unmatchedCriteriaFromTasks {
-			if utility.StringSliceContains(unmatchedCriteriaFromTaskGroups, unmatchedTask) {
-				unmatchedCriteria = append(unmatchedCriteria, unmatchedTask)
-			}
-		}
 		if len(names) == 0 {
-			unmatchedSelectors = append(unmatchedSelectors, pbvt.Name)
-			continue
-		}
-		// If any were unmatched, do not add any matched tasks to the list.
-		if len(unmatchedCriteriaFromTasks) > initialUnmatchedCriteriaLen {
-			continue
+			emptySelectors = append(emptySelectors, pbvt.Name)
 		}
 		// create new task definitions--duplicates must have the same status requirements
 		for _, name := range names {
@@ -1407,7 +1378,7 @@ func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse
 		evalErrs = append(evalErrs, errors.Errorf("task selectors for build variant '%s' did not match any tasks", pbv.Name))
 
 	}
-	return ts, unmatchedSelectors, unmatchedCriteria, evalErrs
+	return ts, emptySelectors, evalErrs
 }
 
 // getParserBuildVariantTaskUnit combines the parser project's build variant
@@ -1528,7 +1499,7 @@ func evaluateDependsOn(tse *tagSelectorEvaluator, tgse *tagSelectorEvaluator, vs
 	newDeps := []TaskUnitDependency{}
 	newDepsByNameAndVariant := map[TVPair]TaskUnitDependency{}
 	for _, d := range deps {
-		var names, unmatched []string
+		var names []string
 
 		if d.TaskSelector.Name == AllDependencies {
 			// * is a special case for dependencies, so don't eval it
@@ -1537,18 +1508,12 @@ func evaluateDependsOn(tse *tagSelectorEvaluator, tgse *tagSelectorEvaluator, vs
 			var temp []string
 			var err1, err2 error
 			if tse != nil {
-				temp, unmatched, err1 = tse.evalSelector(ParseSelector(d.TaskSelector.Name))
+				temp, err1 = tse.evalSelector(ParseSelector(d.TaskSelector.Name))
 				names = append(names, temp...)
-				if err1 == nil && len(unmatched) > 0 {
-					err1 = errors.Errorf("unmatched criteria: '%s' from selector '%s'", strings.Join(unmatched, ", "), d.TaskSelector.Name)
-				}
 			}
 			if tgse != nil {
-				temp, unmatched, err2 = tgse.evalSelector(ParseSelector(d.TaskSelector.Name))
+				temp, err2 = tgse.evalSelector(ParseSelector(d.TaskSelector.Name))
 				names = append(names, temp...)
-				if err2 == nil && len(unmatched) > 0 {
-					err2 = errors.Errorf("unmatched criteria: '%s' from selector '%s'", strings.Join(unmatched, ", "), d.TaskSelector.Name)
-				}
 			}
 			if err1 != nil && err2 != nil {
 				evalErrs = append(evalErrs, err1, err2)

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -152,26 +152,18 @@ func newTagSelectorEvaluator(selectees []tagged) *tagSelectorEvaluator {
 	}
 }
 
-// evalSelector returns all names that fulfill a selector and all unmatched criterion.
-// This is done by evaluating each criterion individually and taking the intersection.
-func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
+// evalSelector returns all names that fulfill a selector. This is done
+// by evaluating each criterion individually and taking the intersection.
+func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
 	// keep a slice of results per criterion
 	results := []string{}
-	unmatchedCriteria := []string{}
 	if len(s) == 0 {
-		return nil, nil, errors.New("cannot evaluate selector with no criteria")
+		return nil, errors.New("cannot evaluate selector with no criteria")
 	}
 	for i, sc := range s {
 		names, err := tse.evalCriterion(sc)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "%v", s)
-		}
-		if len(names) == 0 {
-			unmatchedCriteria = append(unmatchedCriteria, sc.String())
-			// If this is a negated criteria, we do not want to intersect it with the rest
-			if sc.negated {
-				continue
-			}
+			return nil, errors.Wrapf(err, "%v", s)
 		}
 		if i == 0 {
 			results = names
@@ -180,7 +172,7 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, e
 			results = utility.StringSliceIntersection(results, names)
 		}
 	}
-	return results, unmatchedCriteria, nil
+	return results, nil
 }
 
 // evalCriterion returns all names that fulfill a single selection criterion.
@@ -199,14 +191,14 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 	case !sc.tagged && !sc.negated: // just a regular name
 		item := tse.byName[sc.name]
 		if item == nil {
-			return nil, nil
+			return nil, errors.Errorf("nothing named '%v'", sc.name)
 		}
 		return []string{item.name()}, nil
 
 	case sc.tagged && !sc.negated: // expand a tag
 		taggedItems := tse.byTag[sc.name]
 		if len(taggedItems) == 0 {
-			return nil, nil
+			return nil, errors.Errorf("nothing has the tag '%v'", sc.name)
 		}
 		names := make([]string, len(taggedItems))
 		for i, item := range taggedItems {
@@ -216,7 +208,8 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 
 	case !sc.tagged && sc.negated: // everything *but* a specific item
 		if tse.byName[sc.name] == nil {
-			return nil, nil
+			// we want to treat this as an error for better usability
+			return nil, errors.Errorf("nothing named '%v'", sc.name)
 		}
 		names := []string{}
 		for _, item := range tse.items {
@@ -229,7 +222,8 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 	case sc.tagged && sc.negated: // everything *but* a tag
 		items := tse.byTag[sc.name]
 		if len(items) == 0 {
-			return nil, nil
+			// we want to treat this as an error for better usability
+			return nil, errors.Errorf("nothing has the tag '%v'", sc.name)
 		}
 		illegalItems := map[string]bool{}
 		for _, item := range items {
@@ -270,12 +264,12 @@ func NewParserTaskSelectorEvaluator(tasks []parserTask) *taskSelectorEvaluator {
 }
 
 // evalSelector returns all tasks selected by a selector.
-func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
-	results, unmatched, err := t.tagEval.evalSelector(s)
+func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
+	results, err := t.tagEval.evalSelector(s)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "evaluating task selector")
+		return nil, errors.Wrap(err, "evaluating task selector")
 	}
-	return results, unmatched, nil
+	return results, nil
 }
 
 func newTaskGroupSelectorEvaluator(groups []parserTaskGroup) *tagSelectorEvaluator {
@@ -340,12 +334,9 @@ func (ase *axisSelectorEvaluator) evalSelector(axis string, s Selector) ([]strin
 	if !ok {
 		return nil, errors.Errorf("axis '%v' does not exist", axis)
 	}
-	results, unmatched, err := tagEval.evalSelector(s)
+	results, err := tagEval.evalSelector(s)
 	if err != nil {
 		return nil, errors.Wrapf(err, "evaluating axis '%v' selector", axis)
-	}
-	if len(unmatched) > 0 {
-		return nil, errors.Errorf("axis '%v' selector contains unmatched criteria: %v", axis, unmatched)
 	}
 	return results, nil
 }
@@ -395,12 +386,9 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 		}
 		return results, nil
 	}
-	results, unmatched, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
+	results, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
 	if err != nil {
-		return nil, errors.Wrap(err, "variant selector")
-	}
-	if len(unmatched) > 0 {
-		return nil, errors.Errorf("variant selector contains unmatched criteria: %v", unmatched)
+		return nil, errors.Wrap(err, "variant tag selector")
 	}
 	return results, nil
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2392,8 +2392,13 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 			)
 		}
 
-		for _, warning := range buildVariant.TranslationWarnings {
-			errs = append(errs, ValidationError{Message: warning, Level: Warning})
+		if len(buildVariant.EmptyTaskSelectors) > 0 {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("buildvariant '%s' has task names/tags that do not match any tasks: '%s'", buildVariant.Name, strings.Join(buildVariant.EmptyTaskSelectors, "', '")),
+					Level:   Warning,
+				},
+			)
 		}
 
 		errs = append(errs, checkBVNames(&buildVariant)...)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1767,15 +1767,15 @@ func TestValidateBVNames(t *testing.T) {
 			So(validationResults[0].Level, ShouldEqual, Error)
 		})
 
-		Convey("if any variant has warnings from translating, an warning should be returned", func() {
+		Convey("if any variant has task selectors that don't target anything, an warning should be returned", func() {
 			project := &model.Project{
 				BuildVariants: []model.BuildVariant{
-					{Name: "linux", TranslationWarnings: []string{"this is a warning"}},
+					{Name: "linux", EmptyTaskSelectors: []string{".task1"}},
 				},
 			}
 			validationResults := checkBuildVariants(project)
 
-			So(validationResults.String(), ShouldContainSubstring, "WARNING: this is a warning")
+			So(validationResults.String(), ShouldContainSubstring, "WARNING: buildvariant 'linux' has task names/tags that do not match any tasks: '.task1'")
 		})
 
 		Convey("if two variants have the same display name, a warning should be returned, but no errors", func() {


### PR DESCRIPTION
This reverts commit b7a571dc55cf0c52e87deef41d391f02424d54bd.

Reverting due to [user-reported issue](https://mongodb.slack.com/archives/C0V896UV8/p1719349145144089) that seems related.