### PR TITLE
DEVPROD-8420 Rename Keys 

### DIFF
--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	GHAuthIdKey         = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
-	GHAuthAppIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
-	GHAuthPrivateKeyKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
+	ghAuthIdKey         = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
+	ghAuthAppIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
+	ghAuthPrivateKeyKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 // FindOneGithubAppAuth finds the github app auth for the given project id
 func FindOneGithubAppAuth(projectId string) (*evergreen.GithubAppAuth, error) {
 	githubAppAuth := &evergreen.GithubAppAuth{}
-	q := db.Query(bson.M{GHAuthIdKey: projectId})
+	q := db.Query(bson.M{ghAuthIdKey: projectId})
 	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
@@ -48,12 +48,12 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{
-			GHAuthIdKey: githubAppAuth.Id,
+			ghAuthIdKey: githubAppAuth.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				GHAuthAppIdKey:      githubAppAuth.AppID,
-				GHAuthPrivateKeyKey: githubAppAuth.PrivateKey,
+				ghAuthAppIdKey:      githubAppAuth.AppID,
+				ghAuthPrivateKeyKey: githubAppAuth.PrivateKey,
 			},
 		},
 	)
@@ -64,6 +64,6 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 func RemoveGithubAppAuth(id string) error {
 	return db.Remove(
 		GitHubAppAuthCollection,
-		bson.M{GHAuthIdKey: id},
+		bson.M{ghAuthIdKey: id},
 	)
 }

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	IdKey         = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
-	AppIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
-	PrivateKeyKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
+	GHAuthIdKey         = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
+	GHAuthAppIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
+	GHAuthPrivateKeyKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 // FindOneGithubAppAuth finds the github app auth for the given project id
 func FindOneGithubAppAuth(projectId string) (*evergreen.GithubAppAuth, error) {
 	githubAppAuth := &evergreen.GithubAppAuth{}
-	q := db.Query(bson.M{IdKey: projectId})
+	q := db.Query(bson.M{GHAuthIdKey: projectId})
 	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
@@ -48,12 +48,12 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{
-			IdKey: githubAppAuth.Id,
+			GHAuthIdKey: githubAppAuth.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				AppIdKey:      githubAppAuth.AppID,
-				PrivateKeyKey: githubAppAuth.PrivateKey,
+				GHAuthAppIdKey:      githubAppAuth.AppID,
+				GHAuthPrivateKeyKey: githubAppAuth.PrivateKey,
 			},
 		},
 	)
@@ -64,6 +64,6 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 func RemoveGithubAppAuth(id string) error {
 	return db.Remove(
 		GitHubAppAuthCollection,
-		bson.M{IdKey: id},
+		bson.M{GHAuthIdKey: id},
 	)
 }

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	githubAppAuthIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
-	githubAppAuthAppId      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
-	githubAppAuthPrivateKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
+	IdKey         = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "Id")
+	AppIdKey      = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "AppID")
+	PrivateKeyKey = bsonutil.MustHaveTag(evergreen.GithubAppAuth{}, "PrivateKey")
 )
 
 const (
@@ -21,7 +21,7 @@ const (
 // FindOneGithubAppAuth finds the github app auth for the given project id
 func FindOneGithubAppAuth(projectId string) (*evergreen.GithubAppAuth, error) {
 	githubAppAuth := &evergreen.GithubAppAuth{}
-	q := db.Query(bson.M{githubAppAuthIdKey: projectId})
+	q := db.Query(bson.M{IdKey: projectId})
 	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
@@ -48,12 +48,12 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 	_, err := db.Upsert(
 		GitHubAppAuthCollection,
 		bson.M{
-			githubAppAuthIdKey: githubAppAuth.Id,
+			IdKey: githubAppAuth.Id,
 		},
 		bson.M{
 			"$set": bson.M{
-				githubAppAuthAppId:      githubAppAuth.AppID,
-				githubAppAuthPrivateKey: githubAppAuth.PrivateKey,
+				AppIdKey:      githubAppAuth.AppID,
+				PrivateKeyKey: githubAppAuth.PrivateKey,
 			},
 		},
 	)
@@ -64,6 +64,6 @@ func UpsertGithubAppAuth(githubAppAuth *evergreen.GithubAppAuth) error {
 func RemoveGithubAppAuth(id string) error {
 	return db.Remove(
 		GitHubAppAuthCollection,
-		bson.M{githubAppAuthIdKey: id},
+		bson.M{IdKey: id},
 	)
 }


### PR DESCRIPTION
DEVPROD-8420 

### Description
I realized when working on https://github.com/evergreen-ci/evergreen/pull/8036 that it's very easy to accidentally mix up githubAppAuthAppId and githubAppAuthIdKey. I shortened the names to try to bring more clarity. We have some precedence of keys without the name of the struct as part of it. 


