### PR TITLE
DEVPROD-6860: Gate permissions for Task.Annotation in GraphQL

### DIFF
--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1276,13 +1276,13 @@ func getProjectPermissionLevel(projectPermission ProjectPermission, access Acces
 	return permission, level, nil
 }
 
-func canModifyAnnotation(ctx context.Context, obj *restModel.APITask) (bool, error) {
+func hasAnnotationPermission(ctx context.Context, obj *restModel.APITask, requiredLevel int) (bool, error) {
 	authUser := gimlet.GetUser(ctx)
 	permissions := gimlet.PermissionOpts{
 		Resource:      *obj.ProjectId,
 		ResourceType:  evergreen.ProjectResourceType,
 		Permission:    evergreen.PermissionAnnotations,
-		RequiredLevel: evergreen.AnnotationsModify.Value,
+		RequiredLevel: requiredLevel,
 	}
 	if authUser.HasPermission(permissions) {
 		return true, nil
@@ -1307,7 +1307,7 @@ func annotationPermissionHelper(ctx context.Context, taskID string, execution *i
 	if err != nil {
 		return err
 	}
-	canModify, err := canModifyAnnotation(ctx, t)
+	canModify, err := hasAnnotationPermission(ctx, t, evergreen.AnnotationsModify.Value)
 	if err != nil {
 		return err
 	}

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -356,19 +356,19 @@ func TestConcurrentlyBuildVersionsMatchingTasksMap(t *testing.T) {
 
 func TestHasAnnotationPermission(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
-		"HasAnnotationPermission": func(ctx context.Context, t *testing.T) {
+		"TrueWhenUserHasRequiredLevelAndIsNotPatchOwner": func(ctx context.Context, t *testing.T) {
 			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
 			hasAccess, err := hasAnnotationPermission(ctx, &task, evergreen.AnnotationsView.Value)
 			assert.NoError(t, err)
 			assert.True(t, hasAccess)
 		},
-		"DoesNotOwnPatchAndDoesNotHaveAnnotationPermission": func(ctx context.Context, t *testing.T) {
+		"FalseWhenUserDoesNotHaveRequiredLevelAndIsNotPatchOwner": func(ctx context.Context, t *testing.T) {
 			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
 			hasAccess, err := hasAnnotationPermission(ctx, &task, evergreen.AnnotationsModify.Value)
 			assert.NoError(t, err)
 			assert.False(t, hasAccess)
 		},
-		"OwnsPatchButDoesNotHaveAnnotationPermission": func(ctx context.Context, t *testing.T) {
+		"TrueWhenUserIsPatchOwnerButDoesNotHaveRequiredLevel": func(ctx context.Context, t *testing.T) {
 			versionAndPatchID := bson.NewObjectId()
 			patch := patch.Patch{
 				Id:     versionAndPatchID,

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/annotations"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -350,4 +352,64 @@ func TestConcurrentlyBuildVersionsMatchingTasksMap(t *testing.T) {
 	assert.Equal(t, versionsMatchingTasksMap["v2"], false)
 	assert.Equal(t, versionsMatchingTasksMap["v3"], true)
 
+}
+
+func TestHasAnnotationPermission(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
+		"HasAnnotationPermission": func(ctx context.Context, t *testing.T) {
+			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
+			hasAccess, err := hasAnnotationPermission(ctx, &task, evergreen.AnnotationsView.Value)
+			assert.NoError(t, err)
+			assert.True(t, hasAccess)
+		},
+		"DoesNotOwnPatchAndDoesNotHaveAnnotationPermission": func(ctx context.Context, t *testing.T) {
+			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
+			hasAccess, err := hasAnnotationPermission(ctx, &task, evergreen.AnnotationsModify.Value)
+			assert.NoError(t, err)
+			assert.False(t, hasAccess)
+		},
+		"OwnsPatchButDoesNotHaveAnnotationPermission": func(ctx context.Context, t *testing.T) {
+			versionAndPatchID := bson.NewObjectId()
+			patch := patch.Patch{
+				Id:     versionAndPatchID,
+				Author: "basic_user",
+			}
+			assert.NoError(t, patch.Insert())
+			task := restModel.APITask{ProjectId: utility.ToStringPtr("random_project_id"), Version: utility.ToStringPtr(versionAndPatchID.Hex()), Requester: utility.ToStringPtr(evergreen.PatchVersionRequester)}
+			hasAccess, err := hasAnnotationPermission(ctx, &task, evergreen.AnnotationsView.Value)
+			assert.NoError(t, err)
+			assert.True(t, hasAccess)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			assert.NoError(t, db.ClearCollections(user.Collection, evergreen.RoleCollection, evergreen.ScopeCollection, annotations.Collection, task.Collection, patch.Collection))
+			usr := user.DBUser{
+				Id: "basic_user",
+			}
+			assert.NoError(t, usr.Insert())
+			ctx := gimlet.AttachUser(context.Background(), &usr)
+
+			env := evergreen.GetEnvironment()
+			roleManager := env.RoleManager()
+			projectScope := gimlet.Scope{
+				ID:        "projectScopeID",
+				Name:      "project scope",
+				Type:      evergreen.ProjectResourceType,
+				Resources: []string{"project_id_belonging_to_user"},
+			}
+			err := roleManager.AddScope(projectScope)
+
+			annotationViewRole := gimlet.Role{
+				ID:          "view_annotation",
+				Scope:       projectScope.ID,
+				Permissions: map[string]int{evergreen.PermissionAnnotations: evergreen.AnnotationsView.Value},
+			}
+			require.NoError(t, roleManager.UpdateRole(annotationViewRole))
+
+			require.NoError(t, usr.AddRole("view_annotation"))
+			require.NoError(t, err)
+
+			tCase(ctx, t)
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-6860

### Description
These code changes allow users to query `task.Annotation` if they are the patch author or have a valid annotation view permission. 
UI pages where `task.Annotation` is displayed alongside non-gated information are affected and I adjusted those pages to allow rendering in the corresponding [UI PR](https://github.com/evergreen-ci/ui/pull/208)