### PR TITLE
DEVPROD-5318: reduce updates per level of recursion

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1858,6 +1858,10 @@ func updateAllTasksForMatchingDependencies(ctx context.Context, taskIDs []string
 	return nil
 }
 
+// kim: NOTE: because taskIDs and dependencyIDs are very long, and each ID is
+// very long (one task had ID of length 250), this query could hit the 16 MB
+// limit. May have to update in batches if the list of both taskIDs and
+// dependencyIDs is unreasonably long.
 func updateAllTasksForAllMatchingDependencies(ctx context.Context, taskIDs []string, dependencyIDs []string, unattainable bool) error {
 	// Update the matching dependencies in the DependsOn array and the UnattainableDependency field that caches
 	// whether any of the dependencies are blocked. Combining both these updates in a single update operation makes it
@@ -1868,8 +1872,9 @@ func updateAllTasksForAllMatchingDependencies(ctx context.Context, taskIDs []str
 		},
 		[]bson.M{
 			{
-				// Iterate over the DependsOn array and set unattainable for dependencies that
-				// match the dependencyID. Leave other dependencies untouched.
+				// Iterate over the DependsOn array and set unattainable for
+				// dependencies matching by IDs. Leave other dependencies
+				// untouched.
 				"$set": bson.M{DependsOnKey: bson.M{
 					"$map": bson.M{
 						"input": "$" + DependsOnKey,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2662,19 +2662,6 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	return pipeline, nil
 }
 
-func (t *Task) FindAllUnmarkedBlockedDependencies() ([]Task, error) {
-	okStatusSet := []string{AllStatuses, t.Status}
-	query := db.Query(bson.M{
-		DependsOnKey: bson.M{"$elemMatch": bson.M{
-			DependencyTaskIdKey:       t.Id,
-			DependencyStatusKey:       bson.M{"$nin": okStatusSet},
-			DependencyUnattainableKey: false,
-		},
-		}},
-	)
-	return FindAll(query)
-}
-
 // FindAllUnmarkedDependenciesToBlock finds tasks that depend on one of the
 // given tasks. For each task dependency, it finds those that have not been
 // marked unattainable and currently have a status that would block the task

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1820,18 +1820,13 @@ func FindActivatedByVersionWithoutDisplay(versionId string) ([]Task, error) {
 // Secondly, for a given task, after updating individual dependency
 // attainability, it updates the cache of whether the task has all attainable
 // dependencies or not.
-// kim: NOTE: because taskIDs and dependencyIDs are very long, and each ID is
-// very long (one task had ID of length 250), this query could hit the 16 MB
-// limit. May have to update in batches if the list of both taskIDs and
-// dependencyIDs is unreasonably long. Could solve by having set of
-// dependencyIDs mapped to set of the taskIDs that need to be updated (or vice
-// versa).
 func updateAllTasksForAllMatchingDependencies(ctx context.Context, taskIDs []string, dependencyIDs []string, unattainable bool) error {
 	ctx, span := tracer.Start(ctx, "update-task-dependencies", trace.WithAttributes(
-		// Because some projects have huge dependency trees, this update has the
-		// potential to make an extremely large query that exceeds the 16 MB
-		// aggregation size limit. Track the number of tasks/dependencies that
-		// it's trying to update to diagnose such problems.
+		// Because some projects have huge dependency trees and task IDs are
+		// long strings, this update has the potential to make an extremely
+		// large query that exceeds the 16 MB aggregation size limit. Track the
+		// number of tasks/dependencies that it's trying to update to diagnose
+		// such problems.
 		attribute.Int("num_tasks", len(taskIDs)),
 		attribute.Int("num_dependencies", len(dependencyIDs)),
 		attribute.Bool("unattainable", unattainable),

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1793,7 +1793,7 @@ func TestHasMatchingTasks(t *testing.T) {
 	assert.False(t, hasMatchingTasks)
 }
 
-func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
+func TestFindAllUnmarkedDependenciesToBlock(t *testing.T) {
 	assert := assert.New(t)
 	require.NoError(t, db.ClearCollections(Collection))
 
@@ -1849,9 +1849,10 @@ func TestFindAllUnmarkedBlockedDependencies(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := t1.FindAllUnmarkedBlockedDependencies()
+	deps, err := FindAllUnmarkedDependenciesToBlock([]Task{*t1})
 	assert.NoError(err)
-	assert.Len(deps, 1)
+	require.Len(t, deps, 1)
+	assert.Equal("t2", deps[0].Id)
 }
 
 func TestFindAllMarkedUnattainableDependencies(t *testing.T) {

--- a/model/task/otel.go
+++ b/model/task/otel.go
@@ -1,0 +1,12 @@
+package task
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/model/task")
+
+var tracer = otel.GetTracerProvider().Tracer(packageName)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -700,8 +700,6 @@ func (t *Task) AddDependency(ctx context.Context, d Dependency) error {
 			if existingDependency.Unattainable == d.Unattainable {
 				return nil // nothing to be done
 			}
-			// kim: TODO: remove
-			// updatedTasks, err := MarkAllForUnattainableDependency(ctx, []Task{*t}, existingDependency.TaskId, d.Unattainable)
 			updatedTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{*t}, []string{existingDependency.TaskId}, d.Unattainable)
 			if err != nil {
 				return errors.Wrapf(err, "updating matching dependency '%s' for task '%s'", existingDependency.TaskId, t.Id)
@@ -2657,46 +2655,47 @@ func (t *Task) MarkUnscheduled() error {
 // the dependency (dependencyID) as attainable or not. If marking a dependency
 // unattainable, it creates an event log for each newly blocked task. This
 // returns all the tasks after the update.
-func MarkAllForUnattainableDependency(ctx context.Context, tasks []Task, dependencyID string, unattainable bool) ([]Task, error) {
-	if len(tasks) == 0 {
-		return tasks, nil
-	}
+// kim: TODO: remove
+// func MarkAllForUnattainableDependency(ctx context.Context, tasks []Task, dependencyID string, unattainable bool) ([]Task, error) {
+//     if len(tasks) == 0 {
+//         return tasks, nil
+//     }
+//
+//     taskIDs := make([]string, 0, len(tasks))
+//     newlyBlockedTaskData := make([]event.TaskBlockedData, 0, len(tasks))
+//     for _, t := range tasks {
+//         if !t.Blocked() && unattainable && !t.OverrideDependencies {
+//             data := event.TaskBlockedData{
+//                 ID:        t.Id,
+//                 Execution: t.Execution,
+//                 BlockedOn: dependencyID,
+//             }
+//             newlyBlockedTaskData = append(newlyBlockedTaskData, data)
+//         }
+//         taskIDs = append(taskIDs, t.Id)
+//     }
+//
+//     if err := updateAllTasksForMatchingDependencies(ctx, taskIDs, dependencyID, unattainable); err != nil {
+//         return nil, err
+//     }
+//
+//     event.LogManyTasksBlocked(newlyBlockedTaskData)
+//
+//     updatedTasks, err := FindAll(db.Query(ByIds(taskIDs)))
+//     if err != nil {
+//         return nil, errors.Wrap(err, "finding updated tasks")
+//     }
+//     if len(updatedTasks) != len(tasks) {
+//         return nil, errors.Errorf("updated dependencies for tasks but subsequent query for updated tasks returned a different number of tasks (%d) than expected (%d)", len(updatedTasks), len(tasks))
+//     }
+//
+//     return updatedTasks, nil
+// }
 
-	taskIDs := make([]string, 0, len(tasks))
-	newlyBlockedTaskData := make([]event.TaskBlockedData, 0, len(tasks))
-	for _, t := range tasks {
-		if !t.Blocked() && unattainable && !t.OverrideDependencies {
-			data := event.TaskBlockedData{
-				ID:        t.Id,
-				Execution: t.Execution,
-				BlockedOn: dependencyID,
-			}
-			newlyBlockedTaskData = append(newlyBlockedTaskData, data)
-		}
-		taskIDs = append(taskIDs, t.Id)
-	}
-
-	if err := updateAllTasksForMatchingDependencies(ctx, taskIDs, dependencyID, unattainable); err != nil {
-		return nil, err
-	}
-
-	event.LogManyTasksBlocked(newlyBlockedTaskData)
-
-	updatedTasks, err := FindAll(db.Query(ByIds(taskIDs)))
-	if err != nil {
-		return nil, errors.Wrap(err, "finding updated tasks")
-	}
-	if len(updatedTasks) != len(tasks) {
-		return nil, errors.Errorf("updated dependencies for tasks but subsequent query for updated tasks returned a different number of tasks (%d) than expected (%d)", len(updatedTasks), len(tasks))
-	}
-
-	return updatedTasks, nil
-}
-
-// MarkAllForUnattainableDependency updates many tasks (taskIDs) to mark many
-// dependencies (dependencies) as attainable or not. If marking a dependency
-// unattainable, it creates an event log for each newly blocked task. This
-// returns all the tasks after the update.
+// MarkAllForUnattainableDependency updates many tasks (taskIDs) to mark some of
+// their dependencies (dependencyIDs) as attainable or not. If marking the
+// dependencies unattainable, it creates an event log for each newly blocked
+// task. This returns all the tasks after the update.
 func MarkAllForUnattainableDependencies(ctx context.Context, tasks []Task, dependencyIDs []string, unattainable bool) ([]Task, error) {
 	if len(tasks) == 0 {
 		return tasks, nil
@@ -2713,23 +2712,23 @@ func MarkAllForUnattainableDependencies(ctx context.Context, tasks []Task, depen
 		taskIDs = append(taskIDs, t.Id)
 
 		if unattainable && !t.Blocked() && !t.OverrideDependencies { // kim: NOTE: it's being marked attainable OR it's already blocked (no need to log blocked again) OR it's overriding dependencies (logging blocked is pointless)
-			var taskDependsOnDependency string
+			var taskBlockedOn string
 			for _, dependsOn := range t.DependsOn {
 				if _, ok := dependencyIDSet[dependsOn.TaskId]; ok {
 					// At least one dependency has been found that will be
 					// blocked. Even if there are other dependencies that will
 					// also be blocked by this update, the task only needs to
 					// log that it's blocked on one of them.
-					taskDependsOnDependency = dependsOn.TaskId
+					taskBlockedOn = dependsOn.TaskId
 					break
 				}
 			}
 
-			if taskDependsOnDependency != "" {
+			if taskBlockedOn != "" {
 				data := event.TaskBlockedData{
 					ID:        t.Id,
 					Execution: t.Execution,
-					BlockedOn: taskDependsOnDependency,
+					BlockedOn: taskBlockedOn,
 				}
 				newlyBlockedTaskData = append(newlyBlockedTaskData, data)
 			}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -700,7 +700,9 @@ func (t *Task) AddDependency(ctx context.Context, d Dependency) error {
 			if existingDependency.Unattainable == d.Unattainable {
 				return nil // nothing to be done
 			}
-			updatedTasks, err := MarkAllForUnattainableDependency(ctx, []Task{*t}, existingDependency.TaskId, d.Unattainable)
+			// kim: TODO: remove
+			// updatedTasks, err := MarkAllForUnattainableDependency(ctx, []Task{*t}, existingDependency.TaskId, d.Unattainable)
+			updatedTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{*t}, []string{existingDependency.TaskId}, d.Unattainable)
 			if err != nil {
 				return errors.Wrapf(err, "updating matching dependency '%s' for task '%s'", existingDependency.TaskId, t.Id)
 			}
@@ -2675,6 +2677,66 @@ func MarkAllForUnattainableDependency(ctx context.Context, tasks []Task, depende
 	}
 
 	if err := updateAllTasksForMatchingDependencies(ctx, taskIDs, dependencyID, unattainable); err != nil {
+		return nil, err
+	}
+
+	event.LogManyTasksBlocked(newlyBlockedTaskData)
+
+	updatedTasks, err := FindAll(db.Query(ByIds(taskIDs)))
+	if err != nil {
+		return nil, errors.Wrap(err, "finding updated tasks")
+	}
+	if len(updatedTasks) != len(tasks) {
+		return nil, errors.Errorf("updated dependencies for tasks but subsequent query for updated tasks returned a different number of tasks (%d) than expected (%d)", len(updatedTasks), len(tasks))
+	}
+
+	return updatedTasks, nil
+}
+
+// MarkAllForUnattainableDependency updates many tasks (taskIDs) to mark many
+// dependencies (dependencies) as attainable or not. If marking a dependency
+// unattainable, it creates an event log for each newly blocked task. This
+// returns all the tasks after the update.
+func MarkAllForUnattainableDependencies(ctx context.Context, tasks []Task, dependencyIDs []string, unattainable bool) ([]Task, error) {
+	if len(tasks) == 0 {
+		return tasks, nil
+	}
+
+	dependencyIDSet := map[string]struct{}{}
+	for _, depID := range dependencyIDs {
+		dependencyIDSet[depID] = struct{}{}
+	}
+
+	taskIDs := make([]string, 0, len(tasks))
+	newlyBlockedTaskData := make([]event.TaskBlockedData, 0, len(tasks))
+	for _, t := range tasks {
+		taskIDs = append(taskIDs, t.Id)
+
+		if unattainable && !t.Blocked() && !t.OverrideDependencies { // kim: NOTE: it's being marked attainable OR it's already blocked (no need to log blocked again) OR it's overriding dependencies (logging blocked is pointless)
+			var taskDependsOnDependency string
+			for _, dependsOn := range t.DependsOn {
+				if _, ok := dependencyIDSet[dependsOn.TaskId]; ok {
+					// At least one dependency has been found that will be
+					// blocked. Even if there are other dependencies that will
+					// also be blocked by this update, the task only needs to
+					// log that it's blocked on one of them.
+					taskDependsOnDependency = dependsOn.TaskId
+					break
+				}
+			}
+
+			if taskDependsOnDependency != "" {
+				data := event.TaskBlockedData{
+					ID:        t.Id,
+					Execution: t.Execution,
+					BlockedOn: taskDependsOnDependency,
+				}
+				newlyBlockedTaskData = append(newlyBlockedTaskData, data)
+			}
+		}
+	}
+
+	if err := updateAllTasksForAllMatchingDependencies(ctx, taskIDs, dependencyIDs, unattainable); err != nil {
 		return nil, err
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2651,47 +2651,6 @@ func (t *Task) MarkUnscheduled() error {
 
 }
 
-// MarkAllForUnattainableDependency updates many tasks (taskIDs) to mark
-// the dependency (dependencyID) as attainable or not. If marking a dependency
-// unattainable, it creates an event log for each newly blocked task. This
-// returns all the tasks after the update.
-// kim: TODO: remove
-// func MarkAllForUnattainableDependency(ctx context.Context, tasks []Task, dependencyID string, unattainable bool) ([]Task, error) {
-//     if len(tasks) == 0 {
-//         return tasks, nil
-//     }
-//
-//     taskIDs := make([]string, 0, len(tasks))
-//     newlyBlockedTaskData := make([]event.TaskBlockedData, 0, len(tasks))
-//     for _, t := range tasks {
-//         if !t.Blocked() && unattainable && !t.OverrideDependencies {
-//             data := event.TaskBlockedData{
-//                 ID:        t.Id,
-//                 Execution: t.Execution,
-//                 BlockedOn: dependencyID,
-//             }
-//             newlyBlockedTaskData = append(newlyBlockedTaskData, data)
-//         }
-//         taskIDs = append(taskIDs, t.Id)
-//     }
-//
-//     if err := updateAllTasksForMatchingDependencies(ctx, taskIDs, dependencyID, unattainable); err != nil {
-//         return nil, err
-//     }
-//
-//     event.LogManyTasksBlocked(newlyBlockedTaskData)
-//
-//     updatedTasks, err := FindAll(db.Query(ByIds(taskIDs)))
-//     if err != nil {
-//         return nil, errors.Wrap(err, "finding updated tasks")
-//     }
-//     if len(updatedTasks) != len(tasks) {
-//         return nil, errors.Errorf("updated dependencies for tasks but subsequent query for updated tasks returned a different number of tasks (%d) than expected (%d)", len(updatedTasks), len(tasks))
-//     }
-//
-//     return updatedTasks, nil
-// }
-
 // MarkAllForUnattainableDependency updates many tasks (taskIDs) to mark some of
 // their dependencies (dependencyIDs) as attainable or not. If marking the
 // dependencies unattainable, it creates an event log for each newly blocked
@@ -2711,7 +2670,7 @@ func MarkAllForUnattainableDependencies(ctx context.Context, tasks []Task, depen
 	for _, t := range tasks {
 		taskIDs = append(taskIDs, t.Id)
 
-		if unattainable && !t.Blocked() && !t.OverrideDependencies { // kim: NOTE: it's being marked attainable OR it's already blocked (no need to log blocked again) OR it's overriding dependencies (logging blocked is pointless)
+		if unattainable && !t.Blocked() && !t.OverrideDependencies {
 			var taskBlockedOn string
 			for _, dependsOn := range t.DependsOn {
 				if _, ok := dependencyIDSet[dependsOn.TaskId]; ok {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3047,7 +3047,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", true)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", true)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, true)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]
@@ -3098,7 +3100,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				require.NoError(t, dependentTask.Insert())
 			}
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, dependentTasks, "t1", true)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, dependentTasks, "t1", true)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, dependentTasks, []string{"t1"}, true)
 			assert.NoError(t, err)
 			require.Len(t, updatedDependentTasks, len(dependentTasks))
 
@@ -3147,7 +3151,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t3", true)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t3", true)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t3"}, true)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]
@@ -3176,7 +3182,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]
@@ -3205,7 +3213,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]
@@ -3236,7 +3246,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 
 			dependentTask.DependsOn[1].Unattainable = true
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			// kim: TODO: remove
+			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
 			dependentTask = updatedDependentTasks[0]

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3047,8 +3047,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", true)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, true)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
@@ -3100,8 +3098,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				require.NoError(t, dependentTask.Insert())
 			}
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, dependentTasks, "t1", true)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, dependentTasks, []string{"t1"}, true)
 			assert.NoError(t, err)
 			require.Len(t, updatedDependentTasks, len(dependentTasks))
@@ -3135,6 +3131,9 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				}
 			}
 		},
+		// kim: TODO: add test for several tasks being blocked for several
+		// dependencies.
+		// "BlocksManyDependenciesForManyTasks": func(ctx context.Context, t *testing.T) {},
 		"NonexistentDependency": func(ctx context.Context, t *testing.T) {
 			dependentTask := Task{
 				Id: "t0",
@@ -3151,8 +3150,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t3", true)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t3"}, true)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
@@ -3182,8 +3179,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
@@ -3213,8 +3208,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 			}
 			require.NoError(t, dependentTask.Insert())
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)
@@ -3246,8 +3239,6 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 
 			dependentTask.DependsOn[1].Unattainable = true
 
-			// kim: TODO: remove
-			// updatedDependentTasks, err := MarkAllForUnattainableDependency(ctx, []Task{dependentTask}, "t1", false)
 			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, []Task{dependentTask}, []string{"t1"}, false)
 			require.NoError(t, err)
 			require.Len(t, updatedDependentTasks, 1)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3015,7 +3015,7 @@ func getTaskThatNeedsContainerAllocation() Task {
 	}
 }
 
-func TestMarkAllForUnattainableDependency(t *testing.T) {
+func TestMarkAllForUnattainableDependencies(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.Clear(Collection))
 	}()
@@ -3066,7 +3066,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 					Id: "t0",
 					DependsOn: []Dependency{
 						{
-							TaskId:       "t1",
+							TaskId:       "t4",
 							Unattainable: false,
 						},
 						{
@@ -3079,7 +3079,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 					Id: "t1",
 					DependsOn: []Dependency{
 						{
-							TaskId:       "t1",
+							TaskId:       "t4",
 							Unattainable: false,
 						},
 					},
@@ -3088,7 +3088,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 					Id: "t2",
 					DependsOn: []Dependency{
 						{
-							TaskId:       "t2",
+							TaskId:       "t5",
 							Unattainable: false,
 						},
 					},
@@ -3098,7 +3098,7 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				require.NoError(t, dependentTask.Insert())
 			}
 
-			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, dependentTasks, []string{"t1"}, true)
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, dependentTasks, []string{"t4"}, true)
 			assert.NoError(t, err)
 			require.Len(t, updatedDependentTasks, len(dependentTasks))
 
@@ -3131,9 +3131,82 @@ func TestMarkAllForUnattainableDependency(t *testing.T) {
 				}
 			}
 		},
-		// kim: TODO: add test for several tasks being blocked for several
-		// dependencies.
-		// "BlocksManyDependenciesForManyTasks": func(ctx context.Context, t *testing.T) {},
+		"BlocksManyDependenciesForManyTasks": func(ctx context.Context, t *testing.T) {
+			dependentTasks := []Task{
+				{
+					Id: "t0",
+					DependsOn: []Dependency{
+						{
+							TaskId:       "t2",
+							Unattainable: false,
+						},
+						{
+							TaskId:       "t4",
+							Unattainable: false,
+						},
+					},
+				},
+				{
+					Id: "t1",
+					DependsOn: []Dependency{
+						{
+							TaskId:       "t4",
+							Unattainable: false,
+						},
+						{
+							TaskId:       "t5",
+							Unattainable: false,
+						},
+					},
+				},
+				{
+					Id: "t2",
+					DependsOn: []Dependency{
+						{
+							TaskId:       "t6",
+							Unattainable: false,
+						},
+					},
+				},
+			}
+			for _, dependentTask := range dependentTasks {
+				require.NoError(t, dependentTask.Insert())
+			}
+
+			updatedDependentTasks, err := MarkAllForUnattainableDependencies(ctx, dependentTasks, []string{"t4", "t5"}, true)
+			assert.NoError(t, err)
+			require.Len(t, updatedDependentTasks, len(dependentTasks))
+
+			for _, updatedDependentTask := range updatedDependentTasks {
+				switch updatedDependentTask.Id {
+				case dependentTasks[0].Id:
+					checkTaskAndDB(t, updatedDependentTasks[0], func(t *testing.T, taskToCheck Task) {
+						assert.True(t, taskToCheck.Blocked())
+						assert.True(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 2)
+						assert.False(t, taskToCheck.DependsOn[0].Unattainable)
+						assert.True(t, taskToCheck.DependsOn[1].Unattainable)
+					})
+				case dependentTasks[1].Id:
+					checkTaskAndDB(t, updatedDependentTasks[1], func(t *testing.T, taskToCheck Task) {
+						assert.True(t, taskToCheck.Blocked())
+						assert.True(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 2)
+						assert.True(t, taskToCheck.DependsOn[0].Unattainable)
+						assert.True(t, taskToCheck.DependsOn[1].Unattainable)
+					})
+				case dependentTasks[2].Id:
+					checkTaskAndDB(t, updatedDependentTasks[2], func(t *testing.T, taskToCheck Task) {
+						assert.False(t, taskToCheck.Blocked())
+						assert.False(t, taskToCheck.UnattainableDependency)
+						require.Len(t, taskToCheck.DependsOn, 1)
+						assert.False(t, taskToCheck.DependsOn[0].Unattainable)
+					})
+				default:
+					assert.Fail(t, "unexpected task '%s' in updated tasks", updatedDependentTask.Id)
+				}
+			}
+		},
 		"NonexistentDependency": func(ctx context.Context, t *testing.T) {
 			dependentTask := Task{
 				Id: "t0",

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4554,7 +4554,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	require.NoError(v.Insert())
 
 	buildID := "buildtest"
-	// kim: NOTE: should end with failure
 	testTask := task.Task{
 		Id:          "testone",
 		DisplayName: "compile",
@@ -4572,7 +4571,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 		RunningTask: testTask.Id,
 	}
 	assert.NoError(taskHost.Insert(ctx))
-	// kim: NOTE: should be blocked and log blocked
 	anotherTask := task.Task{
 		Id:          "two",
 		Activated:   true,
@@ -4591,7 +4589,6 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	}
 	require.NoError(anotherTask.Insert())
 
-	// kim: NOTE: should log blocked
 	b := &build.Build{
 		Id:        buildID,
 		Status:    evergreen.BuildStarted,

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7284,7 +7284,6 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	events, err := event.Find(db.Q{})
 	assert.NoError(err)
 	assert.Len(events, 6)
-
 }
 
 func TestUpdateUnblockedDependencies(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4554,6 +4554,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	require.NoError(v.Insert())
 
 	buildID := "buildtest"
+	// kim: NOTE: should end with failure
 	testTask := task.Task{
 		Id:          "testone",
 		DisplayName: "compile",
@@ -4571,6 +4572,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 		RunningTask: testTask.Id,
 	}
 	assert.NoError(taskHost.Insert(ctx))
+	// kim: NOTE: should be blocked and log blocked
 	anotherTask := task.Task{
 		Id:          "two",
 		Activated:   true,
@@ -4589,6 +4591,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	}
 	require.NoError(anotherTask.Insert())
 
+	// kim: NOTE: should log blocked
 	b := &build.Build{
 		Id:        buildID,
 		Status:    evergreen.BuildStarted,
@@ -7234,7 +7237,7 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	}
 	assert.NoError(execTask.Insert())
 
-	assert.NoError(UpdateBlockedDependencies(ctx, &tasks[0]))
+	assert.NoError(UpdateBlockedDependencies(ctx, []task.Task{tasks[0]}))
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -145,7 +145,7 @@ func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCac
 	if err == nil {
 		for _, blockingTask := range finishedBlockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			err = model.UpdateBlockedDependencies(ctx, &blockingTask)
+			err = model.UpdateBlockedDependencies(ctx, []task.Task{blockingTask})
 			catcher.Wrapf(err, "updating blocked dependencies for '%s'", blockingTask.Id)
 			if err != nil {
 				err = t.MarkDependenciesFinished(ctx, false)


### PR DESCRIPTION
DEVPROD-5318

### Description
Follow-on to #8016 - it looks like end task is faster, but a few server tasks still struggle to finish blocking dependencies quickly enough during end task. The algorithm from #8016 handles a single task being depended on by many tasks, but doesn't handle many tasks having a couple of dependencies each. From [an example task trace](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/tsEFgBdJymG/trace/nyo7Zomh16V?fields[]=s_name&fields[]=s_serviceName&span=c5a2e94e67f290e7), it looks like compile fails and then initially blocks 19k tasks that immediately depend on it (this is fast thanks to #8016). Unfortunately, many of those 19k tasks also have one or two dependencies each, so it has to go through a ton of tiny updates for each of those tasks.

This improvement seeks to address that issue by making it so that, for a given recursion depth, instead of doing one update per parent dependency, it does one big find and one big update for _all_ tasks at that recursion depth. This means that overall, the number of finds/updates performed is dependent primarily on the _depth_ of the dependency tree, and less so on the _number_ of dependencies being blocked. Doing fewer large finds/updates is more efficient than many individual finds/updates because it reduces round-tripping to the DB.

The one tricky part of one big find/update is that if you make a query that's larger than 16 MB in total size, the DB will reject the query. Unfortunately, doing one big update can push that limit because it has to pass in a ton of IDs into the update, and each ID is hundreds of characters long (I estimated that a query like this on the 19k tasks above would likely exceed the 16 MB query limit). To mitigate problems around query size, I split the one huge update into a few updates of a few thousand IDs at a time.

* When blocking dependencies, reduce the number of find/update queries on each level of recursion.
* Run dependency updates in chunks to avoid 16 MB query limit.

### Testing
* Tweaked existing tests, which cover correctness for the most part. I did add one more to verify that updating many was the same as updating one at a time.
* Verified in staging that [blocking 6k tasks](https://spruce-staging.corp.mongodb.com/version/667d62ef1c9e3c0007ee4919/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&statuses=scheduled-umbrella,will-run,pending,unstarted&variant=%5Eubuntu2204%24) was fast and it correctly blocked the expected tasks.
* Will monitor after the deploy to see if it improves performance enough.

### Documentation
N/A