### PR TITLE
DEVPROD 8469: Create getDistrosForImage Method to Query Distros in Database

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -894,6 +894,7 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 	return d, nil
 }
 
+// getDistrosForImage returns the distros for a given image
 func getDistrosForImage(ctx context.Context, image_id string) ([]Distro, error) {
 	return Find(ctx, bson.M{"image_id": image_id})
 }

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -893,3 +893,7 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 	d.BootstrapSettings.Method = BootstrapMethodNone
 	return d, nil
 }
+
+func getDistrosForImage(ctx context.Context, image_id string) ([]Distro, error) {
+	return Find(ctx, bson.M{"image_id": image_id})
+}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -638,3 +638,36 @@ func TestGetAuthorizedKeysFile(t *testing.T) {
 		assert.Equal(t, expected, d.GetAuthorizedKeysFile())
 	})
 }
+
+func TestGetDistrosForImage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testConfig := testutil.TestConfig()
+	assert := assert.New(t)
+	session, _, err := db.GetGlobalSessionFactory().GetSession()
+	assert.NoError(err)
+	require.NotNil(t, session)
+	defer session.Close()
+	require.NoError(t, session.DB(testConfig.Database.DB).DropDatabase())
+
+	numCorrectDistros := 3
+	image_id := "distro"
+	other_image_id := "not_distro"
+	for i := 0; i < numCorrectDistros; i++ {
+		d := &Distro{
+			Id:      fmt.Sprintf("distro_%d", i),
+			ImageID: image_id,
+		}
+		assert.Nil(d.Insert(ctx))
+	}
+	d := &Distro{
+		Id:      fmt.Sprintf("distro_%d", rand.Int()),
+		ImageID: other_image_id,
+	}
+	assert.Nil(d.Insert(ctx))
+
+	found, err := getDistrosForImage(ctx, image_id)
+	assert.NoError(err)
+	assert.Len(found, numCorrectDistros)
+}


### PR DESCRIPTION
DEVPROD-8469

### Description
Added getDistrosForImage method which fetches the distros for a given image. 

### Testing
Added a function to test functionality with sample distros. 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
