### PR TITLE
DEVPROD-6088 Include scheduling estimations for generator tasks in limit

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1528,6 +1528,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 	newBuildIds := make([]string, 0)
 	newActivatedTaskIds := make([]string, 0)
 	newBuildStatuses := make([]VersionBuildStatus, 0)
+	numEstimatedActivatedGeneratedTasks := 0
 
 	variantsProcessed := map[string]bool{}
 	for _, b := range existingBuilds {
@@ -1596,6 +1597,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		for _, t := range tasks {
 			if t.Activated {
 				newActivatedTaskIds = append(newActivatedTaskIds, t.Id)
+				numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 			}
 			if evergreen.ShouldConsiderBatchtime(t.Requester) && creationInfo.ActivationInfo.taskHasSpecificActivation(t.BuildVariant, t.DisplayName) {
 				batchTimeTasksToIds[t.DisplayName] = t.Id
@@ -1633,7 +1635,8 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			},
 		)
 	}
-	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, len(newActivatedTaskIds), true); err != nil {
+	numTasksModified := numEstimatedActivatedGeneratedTasks + len(newActivatedTaskIds)
+	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, numTasksModified, true); err != nil {
 		return nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
 	}
 	grip.Error(message.WrapError(batchTimeCatcher.Resolve(), message.Fields{

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -746,6 +746,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	for _, t := range tasksToInsert {
 		if t.Activated {
 			numActivatedTasks++
+			numActivatedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 		}
 	}
 	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, numActivatedTasks, true); err != nil {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1849,6 +1849,7 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 	}
 	tasksToActivate := make([]Task, 0, len(tasks))
 	taskIDs := make([]string, 0, len(tasks))
+	numEstimatedActivatedGeneratedTasks := 0
 	for _, t := range tasks {
 		// Activating an activated task is a noop.
 		if t.Activated {
@@ -1856,14 +1857,19 @@ func ActivateTasks(tasks []Task, activationTime time.Time, updateDependencies bo
 		}
 		tasksToActivate = append(tasksToActivate, t)
 		taskIDs = append(taskIDs, t.Id)
+		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 	}
 	depTasksToUpdate, depTaskIDsToUpdate, err := getDependencyTaskIdsToActivate(taskIDs, updateDependencies)
 	if err != nil {
 		return errors.Wrap(err, "getting dependency tasks to activate")
 	}
+	for _, depTask := range depTasksToUpdate {
+		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(depTask.EstimatedNumActivatedGeneratedTasks)
+	}
 	// Tasks passed into this function will all be from the same version or build, so we can assume
 	// all tasks also share the same requester field.
-	if err = UpdateSchedulingLimit(caller, tasks[0].Requester, len(taskIDs)+len(depTaskIDsToUpdate), true); err != nil {
+	numTasksModified := len(taskIDs) + len(depTaskIDsToUpdate) + numEstimatedActivatedGeneratedTasks
+	if err = UpdateSchedulingLimit(caller, tasks[0].Requester, numTasksModified, true); err != nil {
 		return err
 	}
 	err = activateTasks(taskIDs, caller, activationTime)
@@ -2107,6 +2113,7 @@ func DeactivateTasks(tasks []Task, updateDependencies bool, caller string) error
 		return nil
 	}
 	taskIDs := make([]string, 0, len(tasks))
+	numEstimatedActivatedGeneratedTasks := 0
 	for _, t := range tasks {
 		// Deactivating a deactivated task is a noop.
 		if !t.Activated {
@@ -2116,6 +2123,7 @@ func DeactivateTasks(tasks []Task, updateDependencies bool, caller string) error
 			taskIDs = append(taskIDs, t.ExecutionTasks...)
 		}
 		taskIDs = append(taskIDs, t.Id)
+		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 	}
 
 	depTasksToUpdate, depTaskIDsToUpdate, err := getDependencyTasksToUpdate(taskIDs, updateDependencies)
@@ -2123,9 +2131,13 @@ func DeactivateTasks(tasks []Task, updateDependencies bool, caller string) error
 		return errors.Wrap(err, "retrieving dependency tasks to deactivate")
 	}
 
+	for _, depTask := range depTasksToUpdate {
+		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(depTask.EstimatedNumActivatedGeneratedTasks)
+	}
 	// Tasks passed into this function will all be from the same version or build, so we can assume
 	// all tasks also share the same requester field.
-	if err = UpdateSchedulingLimit(caller, tasks[0].Requester, len(taskIDs)+len(depTaskIDsToUpdate), false); err != nil {
+	numTasksModified := len(taskIDs) + len(depTaskIDsToUpdate) + numEstimatedActivatedGeneratedTasks
+	if err = UpdateSchedulingLimit(caller, tasks[0].Requester, numTasksModified, false); err != nil {
 		return err
 	}
 
@@ -3172,6 +3184,7 @@ func CheckUsersPatchTaskLimit(requester, username string, includeDisplayAndTaskG
 		}
 		if t.Activated {
 			numTasksToActivate++
+			numTasksToActivate += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 		}
 	}
 	return UpdateSchedulingLimit(username, requester, numTasksToActivate, true)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2335,7 +2335,7 @@ func TestActivateTasks(t *testing.T) {
 		}
 
 		err = ActivateTasks([]Task{tasks[1]}, time.Time{}, true, u.Id)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("cannot schedule %d tasks, maximum hourly per-user limit is %d", 102, 100))
 	})
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/testresult"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/taskoutput"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"


### PR DESCRIPTION
DEVPROD-6088

### Description
This includes the `EstimatedNumActivatedGeneratedTasks` field for generator tasks when considering a user's patch task scheduling limit.
### Testing
Add a unit test
