### PR TITLE
DEVPROD-7946 Redact webhook secret and authorization from UI and API

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -377,6 +377,10 @@ const (
 	// HostServicePasswordExpansion is the expansion for the service password that is stored on the host,
 	// and is meant to be set as a private variable so that it will be redacted in all logs.
 	HostServicePasswordExpansion = "host_service_password"
+
+	// RedactedWebhookAuthorizationHeaderValue is the value that is shown in the REST API and UI for a redacted
+	// webhook header authorization value.
+	RedactedWebhookAuthorizationHeaderValue = "<REDACTED>"
 )
 
 var VersionSucceededStatuses = []string{

--- a/globals.go
+++ b/globals.go
@@ -378,9 +378,8 @@ const (
 	// and is meant to be set as a private variable so that it will be redacted in all logs.
 	HostServicePasswordExpansion = "host_service_password"
 
-	// RedactedWebhookSecretsValue is the value that is shown in the REST API and UI for a redacted
-	// webhook header authorization value.
-	RedactedWebhookSecretsValue = "<REDACTED>"
+	// RedactedValue is the value that is shown in the REST API and UI for redacted values.
+	RedactedValue = "<REDACTED>"
 )
 
 var VersionSucceededStatuses = []string{

--- a/globals.go
+++ b/globals.go
@@ -378,9 +378,9 @@ const (
 	// and is meant to be set as a private variable so that it will be redacted in all logs.
 	HostServicePasswordExpansion = "host_service_password"
 
-	// RedactedWebhookAuthorizationHeaderValue is the value that is shown in the REST API and UI for a redacted
+	// RedactedWebhookSecretsValue is the value that is shown in the REST API and UI for a redacted
 	// webhook header authorization value.
-	RedactedWebhookAuthorizationHeaderValue = "<REDACTED>"
+	RedactedWebhookSecretsValue = "<REDACTED>"
 )
 
 var VersionSucceededStatuses = []string{

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -144,7 +144,7 @@ type WebhookSubscriber struct {
 
 type WebhookHeader struct {
 	Key   string `bson:"key"`
-	Value string `bson:"value"`
+	Value string `bson:"value,omitempty"`
 }
 
 func (s *WebhookSubscriber) String() string {

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -176,6 +176,15 @@ func (s *WebhookSubscriber) validate() error {
 	return catcher.Resolve()
 }
 
+func (s *WebhookSubscriber) GetHeader(key string) string {
+	for _, h := range s.Headers {
+		if h.Key == key {
+			return h.Value
+		}
+	}
+	return ""
+}
+
 type JIRAIssueSubscriber struct {
 	Project   string `bson:"project"`
 	IssueType string `bson:"issue_type"`

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -144,7 +144,7 @@ type WebhookSubscriber struct {
 
 type WebhookHeader struct {
 	Key   string `bson:"key"`
-	Value string `bson:"value,omitempty"`
+	Value string `bson:"value"`
 }
 
 func (s *WebhookSubscriber) String() string {

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -176,6 +176,7 @@ func (s *WebhookSubscriber) validate() error {
 	return catcher.Resolve()
 }
 
+// GetHeader gets the value for the given key.
 func (s *WebhookSubscriber) GetHeader(key string) string {
 	for _, h := range s.Headers {
 		if h.Key == key {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -146,6 +146,16 @@ func (s *Subscription) SetBSON(raw mgobson.Raw) error {
 	return nil
 }
 
+// GetSubscriptionTarget asserts a type on the subscription's subscriber's target
+// and if it is not found, returns an error.
+func GetSubscriptionTarget[T any](s Subscription) (*T, error) {
+	found, ok := s.Subscriber.Target.(*T)
+	if !ok {
+		return found, errors.Errorf("programmatic error: subscription with ID '%s' was expected to be %T, but it was actually %T", s.ID, found, s.Subscriber.Target)
+	}
+	return found, nil
+}
+
 type Selector struct {
 	Type string `bson:"type"`
 	Data string `bson:"data"`

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -437,8 +437,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				continue
 			}
 			if utility.FromStringPtr(webhook.Secret) == evergreen.RedactedValue {
-				previousSecret := string(previousSubscription.Secret)
-				webhook.Secret = &previousSecret
+				webhook.Secret = utility.ToStringPtr(string(previousSubscription.Secret))
 			}
 			newHeaders := []restModel.APIWebhookHeader{}
 			for _, header := range webhook.Headers {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -416,6 +416,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		for _, subscription := range changes.Subscriptions {
 			webhook := subscription.Subscriber.WebhookSubscriber
 			if webhook == nil {
+				subscriptionChanges = append(subscriptionChanges, subscription)
 				continue
 			}
 			newHeaders := []restModel.APIWebhookHeader{}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -432,7 +432,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				}
 			}
 			if previousSubscription == nil {
-				return nil, errors.Errorf("could not find subscription with ID '%s'", utility.FromStringPtr(subscription.ID))
+				// If there are no previous subscriptions, we should just add the new subscription.
+				subscriptionChanges = append(subscriptionChanges, subscription)
+				continue
 			}
 			if webhook.Secret != nil && *webhook.Secret == evergreen.RedactedWebhookSecretsValue {
 				previousSecret := string(previousSubscription.Secret)

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -511,7 +511,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 }
 
 // getUnredactedSubscriptions parses the new subscriptions for any values that are redacted and if they are redacted,
-// it replaces the redacted value with the previous value for that subscription.
+// it replaces the placeholder string with the unredacted value.
 func getUnredactedSubscriptions(unredactedPreviousSubscriptions []event.Subscription, redactedNewSubscriptions []restModel.APISubscription) ([]restModel.APISubscription, error) {
 	unredactedNewSubscriptions := []restModel.APISubscription{}
 	for _, redactedSub := range redactedNewSubscriptions {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -436,13 +436,13 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				subscriptionChanges = append(subscriptionChanges, subscription)
 				continue
 			}
-			if webhook.Secret != nil && *webhook.Secret == evergreen.RedactedWebhookSecretsValue {
+			if webhook.Secret != nil && *webhook.Secret == evergreen.RedactedValue {
 				previousSecret := string(previousSubscription.Secret)
 				webhook.Secret = &previousSecret
 			}
 			newHeaders := []restModel.APIWebhookHeader{}
 			for _, header := range webhook.Headers {
-				if utility.FromStringPtr(header.Key) == "Authorization" && utility.FromStringPtr(header.Value) == evergreen.RedactedWebhookSecretsValue {
+				if utility.FromStringPtr(header.Key) == "Authorization" && utility.FromStringPtr(header.Value) == evergreen.RedactedValue {
 					// Do not update the value if redacted Authorization header in changes.
 					var previousHeaderValue string
 					for _, h := range previousSubscription.Headers {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -426,7 +426,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 					var ok bool
 					previousSubscription, ok = beforeSubscription.Subscriber.Target.(*event.WebhookSubscriber)
 					if !ok {
-						return nil, errors.Errorf("could not find subscription with ID '%s'", utility.FromStringPtr(subscription.ID))
+						return nil, errors.Errorf("programmatic error: subscription with ID '%s' was expected to be webhook subscription, but it was actually %T", utility.FromStringPtr(subscription.ID), previousSubscription)
 					}
 					break
 				}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -436,7 +436,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				subscriptionChanges = append(subscriptionChanges, subscription)
 				continue
 			}
-			if webhook.Secret != nil && *webhook.Secret == evergreen.RedactedValue {
+			if utility.FromStringPtr(webhook.Secret) == evergreen.RedactedValue {
 				previousSecret := string(previousSubscription.Secret)
 				webhook.Secret = &previousSecret
 			}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -518,7 +518,7 @@ func getUnredactedSubscriptions(unredactedPreviousSubscriptions []event.Subscrip
 		// Apply all subscription unredaction functions.
 		err := unredactWebhookSubscription(unredactedPreviousSubscriptions, &redactedSub)
 		if err != nil {
-			return nil, errors.Wrapf(err, "while unredacting webhook subscription")
+			return nil, errors.Wrapf(err, "unredacting webhook subscription")
 		}
 		// Add to final subscription slice.
 		unredactedNewSubscriptions = append(unredactedNewSubscriptions, redactedSub)

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -622,120 +622,130 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.True(t, varsFromDb.PrivateVars["change"])
 		},
 		model.ProjectPageNotificationsSection: func(t *testing.T, ref model.ProjectRef) {
-			newSubscription := event.Subscription{
-				ID:           "existingSub1",
-				Owner:        ref.Id,
-				OwnerType:    event.OwnerTypeProject,
-				ResourceType: event.ResourceTypeTask,
-				Trigger:      event.TriggerSuccess,
-				Selectors: []event.Selector{
-					{Type: "id", Data: "1234"},
-				},
-				Subscriber: event.Subscriber{
-					Type:   event.EmailSubscriberType,
-					Target: "a@gmail.com",
-				},
-			}
-			apiSub := restModel.APISubscription{}
-			assert.NoError(t, apiSub.BuildFromService(newSubscription))
+			// When saving a webhook that has redacted values, it should not update to the redacted
+			// values but stay as the existing values.
 
-			webhookSubscriber := restModel.APIWebhookSubscriber{
-				URL:    utility.ToStringPtr("http://example.com"),
-				Secret: utility.ToStringPtr("super_secret_2"),
-				Headers: []restModel.APIWebhookHeader{
-					{
-						Key:   utility.ToStringPtr("Key"),
-						Value: utility.ToStringPtr("A new value"),
+			// This subscription just makes sure we don't accidently affect other subscriptions
+			// when saving subscriptions.
+			t.Run("SaveRedactedWebhookSecretAndHeader", func(t *testing.T) {
+				noiseSubscription := event.Subscription{
+					ID:           "existingSub1",
+					Owner:        ref.Id,
+					OwnerType:    event.OwnerTypeProject,
+					ResourceType: event.ResourceTypeTask,
+					Trigger:      event.TriggerSuccess,
+					Selectors: []event.Selector{
+						{Type: "id", Data: "1234"},
 					},
-					{
-						Key:   utility.ToStringPtr("Authorization"),
-						Value: utility.ToStringPtr(evergreen.RedactedValue),
+					Subscriber: event.Subscriber{
+						Type:   event.EmailSubscriberType,
+						Target: "a@gmail.com",
 					},
-				},
-			}
-			apiSub2 := restModel.APISubscription{
-				ID:           utility.ToStringPtr("existingSub2"),
-				Owner:        utility.ToStringPtr(ref.Id),
-				OwnerType:    utility.ToStringPtr(string(event.OwnerTypeProject)),
-				ResourceType: utility.ToStringPtr(event.ResourceTypeTask),
-				Trigger:      utility.ToStringPtr(event.TriggerSuccess),
-				Selectors: []restModel.APISelector{
-					{
-						Type: utility.ToStringPtr("id"),
-						Data: utility.ToStringPtr("1234"),
-					},
-				},
-				Subscriber: restModel.APISubscriber{
-					Type:              utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
-					Target:            webhookSubscriber,
-					WebhookSubscriber: &webhookSubscriber,
-				},
-			}
-			apiChanges := &restModel.APIProjectSettings{
-				Subscriptions: []restModel.APISubscription{apiSub, apiSub2},
-			}
-			settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
-			assert.NoError(t, err)
-			assert.NotNil(t, settings)
-			subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
-			assert.NoError(t, err)
-			require.Len(t, subsFromDb, 2)
-			assert.Equal(t, subsFromDb[0].Trigger, event.TriggerSuccess)
-			// Check if webhooks Authorization header is kept as before.
-			webhookAPI, ok := subsFromDb[1].Subscriber.Target.(*event.WebhookSubscriber)
-			require.True(t, ok)
-			assert.Equal(t, "A new value", webhookAPI.Headers[0].Value, "webhook headers should persist after saving")
-			assert.Equal(t, "a_very_super_secret", webhookAPI.Headers[1].Value, "Authorization header should not be changed when saving as redacted value")
-			assert.Equal(t, "super_secret_2", string(webhookAPI.Secret), "webhook secret should be updated to the new value")
+				}
+				apiSub := restModel.APISubscription{}
+				assert.NoError(t, apiSub.BuildFromService(noiseSubscription))
 
-			// Update the Authorization header to a new value and delete the first subscription.
-			webhookSubscriber = restModel.APIWebhookSubscriber{
-				URL:    utility.ToStringPtr("http://example.com"),
-				Secret: utility.ToStringPtr(evergreen.RedactedValue),
-				Headers: []restModel.APIWebhookHeader{
-					{
-						Key:   utility.ToStringPtr("Key"),
-						Value: utility.ToStringPtr("A new value"),
+				webhookSubscriber := restModel.APIWebhookSubscriber{
+					URL:    utility.ToStringPtr("http://example.com"),
+					Secret: utility.ToStringPtr("super_secret_2"),
+					Headers: []restModel.APIWebhookHeader{
+						{
+							Key:   utility.ToStringPtr("Key"),
+							Value: utility.ToStringPtr("A new value"),
+						},
+						{
+							Key:   utility.ToStringPtr("Authorization"),
+							Value: utility.ToStringPtr(evergreen.RedactedValue), // This is testing that the webhook stays redacted.
+						},
 					},
-					{
-						Key:   utility.ToStringPtr("Authorization"),
-						Value: utility.ToStringPtr("a_different_secret"),
+				}
+				webhookSubscription := restModel.APISubscription{
+					ID:           utility.ToStringPtr("existingSub2"),
+					Owner:        utility.ToStringPtr(ref.Id),
+					OwnerType:    utility.ToStringPtr(string(event.OwnerTypeProject)),
+					ResourceType: utility.ToStringPtr(event.ResourceTypeTask),
+					Trigger:      utility.ToStringPtr(event.TriggerSuccess),
+					Selectors: []restModel.APISelector{
+						{
+							Type: utility.ToStringPtr("id"),
+							Data: utility.ToStringPtr("1234"),
+						},
 					},
-				},
-			}
-			apiSub2 = restModel.APISubscription{
-				ID:           utility.ToStringPtr("existingSub2"),
-				Owner:        utility.ToStringPtr(ref.Id),
-				OwnerType:    utility.ToStringPtr(string(event.OwnerTypeProject)),
-				ResourceType: utility.ToStringPtr(event.ResourceTypeTask),
-				Trigger:      utility.ToStringPtr(event.TriggerSuccess),
-				Selectors: []restModel.APISelector{
-					{
-						Type: utility.ToStringPtr("id"),
-						Data: utility.ToStringPtr("1234"),
+					Subscriber: restModel.APISubscriber{
+						Type:              utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
+						Target:            webhookSubscriber,
+						WebhookSubscriber: &webhookSubscriber,
 					},
-				},
-				Subscriber: restModel.APISubscriber{
-					Type:              utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
-					Target:            webhookSubscriber,
-					WebhookSubscriber: &webhookSubscriber,
-				},
-			}
-			apiChanges = &restModel.APIProjectSettings{
-				Subscriptions: []restModel.APISubscription{apiSub2},
-			}
-			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
-			assert.NoError(t, err)
-			assert.NotNil(t, settings)
-			subsFromDb, err = event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
-			assert.NoError(t, err)
-			require.Len(t, subsFromDb, 1)
-			// Check if webhooks Authorization header is the new value.
-			webhookAPI, ok = subsFromDb[0].Subscriber.Target.(*event.WebhookSubscriber)
-			require.True(t, ok)
-			assert.Equal(t, "A new value", webhookAPI.Headers[0].Value, "webhook headers should persist after saving")
-			assert.Equal(t, "a_different_secret", webhookAPI.Headers[1].Value, "Authorization header should be updated to the new value")
-			assert.Equal(t, "super_secret_2", string(webhookAPI.Secret), "webhook secret should not be changed when saving as redacted value")
+				}
+				apiChanges := &restModel.APIProjectSettings{
+					Subscriptions: []restModel.APISubscription{apiSub, webhookSubscription},
+				}
+				settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
+				require.NoError(t, err)
+				require.NotNil(t, settings)
+				subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
+				require.NoError(t, err)
+				require.Len(t, subsFromDb, 2)
+				assert.Equal(t, subsFromDb[0].Trigger, event.TriggerSuccess)
+				// Check if webhooks Authorization header is kept as before.
+				webhookAPI, ok := subsFromDb[1].Subscriber.Target.(*event.WebhookSubscriber)
+				require.True(t, ok)
+				assert.Equal(t, "A new value", webhookAPI.Headers[0].Value, "webhook headers should persist after saving")
+				assert.Equal(t, "a_very_super_secret", webhookAPI.Headers[1].Value, "Authorization header should not be changed when saving as redacted value")
+				assert.Equal(t, "super_secret_2", string(webhookAPI.Secret), "webhook secret should be updated to the new value")
+			})
+
+			// This should save these new values that are not redacted values.
+			// Also the noise subscription should be removed from the database.
+			t.Run("SaveNewWebhookSecretAndHeader", func(t *testing.T) {
+				webhookSubscriber := restModel.APIWebhookSubscriber{
+					URL:    utility.ToStringPtr("http://example.com"),
+					Secret: utility.ToStringPtr(evergreen.RedactedValue),
+					Headers: []restModel.APIWebhookHeader{
+						{
+							Key:   utility.ToStringPtr("Key"),
+							Value: utility.ToStringPtr("A new value"),
+						},
+						{
+							Key:   utility.ToStringPtr("Authorization"),
+							Value: utility.ToStringPtr("a_different_secret"),
+						},
+					},
+				}
+				webhookSubscription := restModel.APISubscription{
+					ID:           utility.ToStringPtr("existingSub2"),
+					Owner:        utility.ToStringPtr(ref.Id),
+					OwnerType:    utility.ToStringPtr(string(event.OwnerTypeProject)),
+					ResourceType: utility.ToStringPtr(event.ResourceTypeTask),
+					Trigger:      utility.ToStringPtr(event.TriggerSuccess),
+					Selectors: []restModel.APISelector{
+						{
+							Type: utility.ToStringPtr("id"),
+							Data: utility.ToStringPtr("1234"),
+						},
+					},
+					Subscriber: restModel.APISubscriber{
+						Type:              utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
+						Target:            webhookSubscriber,
+						WebhookSubscriber: &webhookSubscriber,
+					},
+				}
+				apiChanges := &restModel.APIProjectSettings{
+					Subscriptions: []restModel.APISubscription{webhookSubscription},
+				}
+				settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
+				assert.NoError(t, err)
+				assert.NotNil(t, settings)
+				subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
+				assert.NoError(t, err)
+				require.Len(t, subsFromDb, 1)
+				// Check if webhooks Authorization header is the new value.
+				webhookAPI, ok := subsFromDb[0].Subscriber.Target.(*event.WebhookSubscriber)
+				require.True(t, ok)
+				assert.Equal(t, "A new value", webhookAPI.Headers[0].Value, "webhook headers should persist after saving")
+				assert.Equal(t, "a_different_secret", webhookAPI.Headers[1].Value, "Authorization header should be updated to the new value")
+				assert.Equal(t, "super_secret_2", string(webhookAPI.Secret), "webhook secret should not be changed when saving as redacted value")
+			})
 		},
 		model.ProjectPageTriggersSection: func(t *testing.T, ref model.ProjectRef) {
 			upstreamProject := model.ProjectRef{

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -649,7 +649,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 					},
 					{
 						Key:   utility.ToStringPtr("Authorization"),
-						Value: utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue),
+						Value: utility.ToStringPtr(evergreen.RedactedValue),
 					},
 				},
 			}
@@ -691,7 +691,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			// Update the Authorization header to a new value and delete the first subscription.
 			webhookSubscriber = restModel.APIWebhookSubscriber{
 				URL:    utility.ToStringPtr("http://example.com"),
-				Secret: utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue),
+				Secret: utility.ToStringPtr(evergreen.RedactedValue),
 				Headers: []restModel.APIWebhookHeader{
 					{
 						Key:   utility.ToStringPtr("Key"),

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -700,7 +700,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			t.Run("SaveNewWebhookSecretAndHeader", func(t *testing.T) {
 				webhookSubscriber := restModel.APIWebhookSubscriber{
 					URL:    utility.ToStringPtr("http://example.com"),
-					Secret: utility.ToStringPtr(evergreen.RedactedValue),
+					Secret: utility.ToStringPtr("super_secret_3"),
 					Headers: []restModel.APIWebhookHeader{
 						{
 							Key:   utility.ToStringPtr("Key"),
@@ -734,17 +734,17 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 					Subscriptions: []restModel.APISubscription{webhookSubscription},
 				}
 				settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
-				assert.NoError(t, err)
-				assert.NotNil(t, settings)
+				require.NoError(t, err)
+				require.NotNil(t, settings)
 				subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.Len(t, subsFromDb, 1)
 				// Check if webhooks Authorization header is the new value.
 				webhookAPI, ok := subsFromDb[0].Subscriber.Target.(*event.WebhookSubscriber)
 				require.True(t, ok)
 				assert.Equal(t, "A new value", webhookAPI.Headers[0].Value, "webhook headers should persist after saving")
 				assert.Equal(t, "a_different_secret", webhookAPI.Headers[1].Value, "Authorization header should be updated to the new value")
-				assert.Equal(t, "super_secret_2", string(webhookAPI.Secret), "webhook secret should not be changed when saving as redacted value")
+				assert.Equal(t, "super_secret_3", string(webhookAPI.Secret), "webhook secret should be updated to the new value")
 			})
 		},
 		model.ProjectPageTriggersSection: func(t *testing.T, ref model.ProjectRef) {

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -625,7 +625,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			// When saving a webhook that has redacted values, it should not update to the redacted
 			// values but stay as the existing values.
 
-			// This subscription just makes sure we don't accidently affect other subscriptions
+			// This subscription just makes sure we don't accidentally affect other subscriptions
 			// when saving subscriptions.
 			t.Run("SaveRedactedWebhookSecretAndHeader", func(t *testing.T) {
 				noiseSubscription := event.Subscription{

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -97,6 +97,7 @@ func (s *APISubscriber) BuildFromService(in event.Subscriber) error {
 			return err
 		}
 		target = sub
+		s.WebhookSubscriber = &sub
 
 	case event.JIRAIssueSubscriberType:
 		sub := APIJIRAIssueSubscriber{}
@@ -105,6 +106,7 @@ func (s *APISubscriber) BuildFromService(in event.Subscriber) error {
 			return err
 		}
 		target = sub
+		s.JiraIssueSubscriber = &sub
 
 	case event.JIRACommentSubscriberType, event.EmailSubscriberType,
 		event.SlackSubscriberType, event.EnqueuePatchSubscriberType:

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -311,7 +311,7 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 	sub := event.WebhookSubscriber{
 		URL:        utility.FromStringPtr(s.URL),
-		Secret:     []byte(utility.FromStringPtr(s.Secret)),
+		Secret:     []byte(evergreen.RedactedWebhookSecretsValue),
 		Headers:    []event.WebhookHeader{},
 		Retries:    s.Retries,
 		MinDelayMS: s.MinDelayMS,
@@ -326,7 +326,7 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 	s.Key = &h.Key
 	if h.Key == "Authorization" {
-		s.Value = utility.ToStringPtr(evergreen.RedactedWebhookAuthorizationHeaderValue)
+		s.Value = utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue)
 	} else {
 		s.Value = &h.Value
 	}

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -290,7 +290,7 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case *event.WebhookSubscriber:
 		s.URL = utility.ToStringPtr(v.URL)
-		s.Secret = utility.ToStringPtr(string(v.Secret))
+		s.Secret = utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue)
 		s.Headers = []APIWebhookHeader{}
 		s.Retries = v.Retries
 		s.MinDelayMS = v.MinDelayMS
@@ -311,7 +311,7 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 	sub := event.WebhookSubscriber{
 		URL:        utility.FromStringPtr(s.URL),
-		Secret:     []byte(evergreen.RedactedWebhookSecretsValue),
+		Secret:     []byte(utility.FromStringPtr(s.Secret)),
 		Headers:    []event.WebhookHeader{},
 		Retries:    s.Retries,
 		MinDelayMS: s.MinDelayMS,

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -333,7 +333,7 @@ func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 func (s *APIWebhookHeader) ToService() event.WebhookHeader {
 	return event.WebhookHeader{
 		Key:   *s.Key,
-		Value: utility.FromStringPtr(s.Value),
+		Value: *s.Value,
 	}
 }
 

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
@@ -322,7 +323,11 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 
 func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 	s.Key = &h.Key
-	s.Value = &h.Value
+	if h.Key == "Authorization" {
+		s.Value = utility.ToStringPtr(evergreen.RedactedWebhookAuthorizationHeaderValue)
+	} else {
+		s.Value = &h.Value
+	}
 }
 
 func (s *APIWebhookHeader) ToService() event.WebhookHeader {

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -290,7 +290,7 @@ func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case *event.WebhookSubscriber:
 		s.URL = utility.ToStringPtr(v.URL)
-		s.Secret = utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue)
+		s.Secret = utility.ToStringPtr(evergreen.RedactedValue)
 		s.Headers = []APIWebhookHeader{}
 		s.Retries = v.Retries
 		s.MinDelayMS = v.MinDelayMS
@@ -326,7 +326,7 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 	s.Key = &h.Key
 	if h.Key == "Authorization" {
-		s.Value = utility.ToStringPtr(evergreen.RedactedWebhookSecretsValue)
+		s.Value = utility.ToStringPtr(evergreen.RedactedValue)
 	} else {
 		s.Value = &h.Value
 	}

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -333,7 +333,7 @@ func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 func (s *APIWebhookHeader) ToService() event.WebhookHeader {
 	return event.WebhookHeader{
 		Key:   *s.Key,
-		Value: *s.Value,
+		Value: utility.FromStringPtr(s.Value),
 	}
 }
 

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -69,6 +70,8 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 	origWebhookSubscriber, err := apiWebhookSubscriber.ToService()
 	assert.NoError(err)
 
+	target.Secret = []byte(evergreen.RedactedWebhookSecretsValue)
+
 	assert.EqualValues(webhookSubscriber.Type, origWebhookSubscriber.Type)
 	assert.EqualValues(target, origWebhookSubscriber.Target)
 
@@ -77,7 +80,7 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 		Type: utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
 		Target: map[string]interface{}{
 			"url":          "foo",
-			"secret":       "bar",
+			"secret":       evergreen.RedactedWebhookSecretsValue,
 			"retries":      3,
 			"min_delay_ms": 500,
 			"timeout_ms":   10000,

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -70,7 +70,7 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 	origWebhookSubscriber, err := apiWebhookSubscriber.ToService()
 	assert.NoError(err)
 
-	target.Secret = []byte(evergreen.RedactedWebhookSecretsValue)
+	target.Secret = []byte(evergreen.RedactedValue)
 
 	assert.EqualValues(webhookSubscriber.Type, origWebhookSubscriber.Type)
 	assert.EqualValues(target, origWebhookSubscriber.Target)
@@ -80,7 +80,7 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 		Type: utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
 		Target: map[string]interface{}{
 			"url":          "foo",
-			"secret":       evergreen.RedactedWebhookSecretsValue,
+			"secret":       evergreen.RedactedValue,
 			"retries":      3,
 			"min_delay_ms": 500,
 			"timeout_ms":   10000,


### PR DESCRIPTION
DEVPROD-7946

### Description
This adds redaction to the webhook secret and authorization in the ui and API.

### Testing
Unit and staging tests

For staging I just deployed, added a couple headers (one being Authorization), and changed the values and changed unrelated values and checked the db for the secret value, making sure it updates when appropriately and never updates to the `<REDACTED>` value.