### PR TITLE
DEVPROD-7643: Add GetLatestTaskFromImage function to query database

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -894,7 +894,7 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 	return d, nil
 }
 
-// getDistrosForImage returns the distros for a given image
-func getDistrosForImage(ctx context.Context, imageID string) ([]Distro, error) {
+// GetDistrosForImage returns the distros for a given image
+func GetDistrosForImage(ctx context.Context, imageID string) ([]Distro, error) {
 	return Find(ctx, bson.M{ImageIDKey: imageID})
 }

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -894,7 +894,7 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 	return d, nil
 }
 
-// GetDistrosForImage returns the distros for a given image
+// GetDistrosForImage returns the distros for a given image.
 func GetDistrosForImage(ctx context.Context, imageID string) ([]Distro, error) {
 	return Find(ctx, bson.M{ImageIDKey: imageID})
 }

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -666,7 +666,7 @@ func TestGetDistrosForImage(t *testing.T) {
 	}
 	assert.Nil(t, d4.Insert(ctx))
 
-	found, err := getDistrosForImage(ctx, imageID)
+	found, err := GetDistrosForImage(ctx, imageID)
 	assert.NoError(t, err)
 	assert.Len(t, found, 3)
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2963,8 +2963,8 @@ func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, disp
 	return results, nil
 }
 
-// getLatestTask retrieves the latest task from all the distros corresponding to the imageID
-func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
+// GetLatestTask retrieves the latest task from all the distros corresponding to the imageID.
+func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) {
 	distros, err := distro.GetDistrosForImage(ctx, imageID)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving distros from imageID")
@@ -3003,5 +3003,5 @@ func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
 		}
 		return &task, nil
 	}
-	return nil, errors.New("found no latest task")
+	return nil, errors.New("Found no latest task.")
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2974,7 +2974,7 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		distroNames[i] = d.Id
 	}
 	if len(distroNames) == 0 {
-		return nil, errors.New("No distros found for image.")
+		return nil, errors.New("no distros found for image")
 	}
 	pipeline := []bson.M{
 		{
@@ -3003,5 +3003,5 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		}
 		return &task, nil
 	}
-	return nil, errors.New("Found no latest task.")
+	return nil, errors.New("no latest task found for image")
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2963,7 +2963,7 @@ func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, disp
 	return results, nil
 }
 
-// GetLatestTask retrieves the latest task from all the distros corresponding to the imageID.
+// GetLatestTaskFromImage retrieves the latest task from all the distros corresponding to the imageID.
 func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) {
 	distros, err := distro.GetDistrosForImage(ctx, imageID)
 	if err != nil {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -13,8 +13,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -2967,9 +2965,6 @@ func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, disp
 
 // getLatestTask retrieves the latest task from all the distros corresponding to the imageID
 func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
-	grip.Debug(message.Fields{
-		"imageID": imageID,
-	})
 	distros, err := distro.GetDistrosForImage(ctx, imageID)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving distros from imageID")
@@ -2978,9 +2973,6 @@ func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
 	for i, d := range distros {
 		distroNames[i] = d.Id
 	}
-	grip.Debug(message.Fields{
-		"distrosNames": distroNames,
-	})
 	if len(distroNames) == 0 {
 		return nil, errors.New("No distros found for image.")
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2965,6 +2965,7 @@ func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, disp
 
 // getLatestTask retrieves the latest task from all the distros corresponding to the imageID
 func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
+	// find all distros corresponding to imageID
 	tasks, err := FindAll(db.Query(bson.M{
 		DistroIdKey: bson.M{
 			"$in": []string{},

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2962,3 +2962,15 @@ func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, disp
 
 	return results, nil
 }
+
+// getLatestTask retrieves the latest task from all the distros corresponding to the imageID
+func getLatestTask(ctx context.Context, imageID string) (*Task, error) {
+	tasks, err := FindAll(db.Query(bson.M{
+		DistroIdKey: bson.M{
+			"$in": []string{},
+		},
+	}))
+	if err != nil {
+		return nil, err
+	}
+}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2974,7 +2974,7 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		distroNames[i] = d.Id
 	}
 	if len(distroNames) == 0 {
-		return nil, errors.New("no distros found for image")
+		return nil, errors.Errorf("no distros found for image: %s", imageID)
 	}
 	pipeline := []bson.M{
 		{
@@ -2997,11 +2997,11 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		return nil, errors.Wrap(err, "finding latest task")
 	}
 	if cursor.Next(ctx) {
-		var task Task
+		task := Task{}
 		if err := cursor.Decode(&task); err != nil {
 			return nil, errors.Wrap(err, "decoding task")
 		}
 		return &task, nil
 	}
-	return nil, errors.New("no latest task found for image")
+	return nil, errors.Errorf("no latest task found for image: %s", imageID)
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2974,7 +2974,7 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		distroNames[i] = d.Id
 	}
 	if len(distroNames) == 0 {
-		return nil, errors.Errorf("no distros found for image: %s", imageID)
+		return nil, errors.Errorf("no distros found for image '%s'", imageID)
 	}
 	pipeline := []bson.M{
 		{
@@ -3003,5 +3003,5 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		}
 		return &task, nil
 	}
-	return nil, errors.Errorf("no latest task found for image: %s", imageID)
+	return nil, errors.Errorf("no latest task found for image '%s'", imageID)
 }

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2227,40 +2227,36 @@ func TestFindGeneratedTasksFromID(t *testing.T) {
 	}
 }
 
-func TestGetLatestTask(t *testing.T) {
+func TestGetLatestTaskFromImage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	require.NoError(t, db.ClearCollections(Collection, OldCollection))
-	require.NoError(t, db.ClearCollections(distro.Collection))
-	DistroIdOne := "distro-1"
-	DistroIdTwo := "distro-2"
-	DistroIdThree := "distro-3"
+	require.NoError(t, db.ClearCollections(Collection, distro.Collection))
+	imageID := "distro"
+	d1 := &distro.Distro{
+		Id:      "distro-1",
+		ImageID: imageID,
+	}
+	require.NoError(t, d1.Insert(ctx))
+	d2 := &distro.Distro{
+		Id:      "distro-2",
+		ImageID: imageID,
+	}
+	require.NoError(t, d2.Insert(ctx))
+	d3 := &distro.Distro{
+		Id:      "distro-3",
+		ImageID: imageID,
+	}
+	require.NoError(t, d3.Insert(ctx))
 	tasks := []Task{
-		{Id: "t0", FinishTime: time.Date(2023, time.February, 1, 10, 30, 15, 0, time.UTC), DistroId: DistroIdOne},
-		{Id: "t1", FinishTime: time.Date(2023, time.January, 1, 10, 30, 15, 0, time.UTC), DistroId: DistroIdTwo},
-		{Id: "t2", FinishTime: time.Date(2023, time.March, 1, 10, 30, 15, 0, time.UTC), DistroId: DistroIdThree},
+		{Id: "t0", FinishTime: time.Date(2023, time.February, 1, 10, 30, 15, 0, time.UTC), DistroId: d1.Id},
+		{Id: "t1", FinishTime: time.Date(2023, time.January, 1, 10, 30, 15, 0, time.UTC), DistroId: d2.Id},
+		{Id: "t2", FinishTime: time.Date(2023, time.March, 1, 10, 30, 15, 0, time.UTC), DistroId: d3.Id},
 		{Id: "t3", FinishTime: time.Date(2024, time.January, 1, 10, 30, 15, 0, time.UTC), DistroId: "rando"},
 	}
 	for _, task := range tasks {
 		require.NoError(t, task.Insert())
 	}
-	imageID := "distro"
-	d1 := &distro.Distro{
-		Id:      DistroIdOne,
-		ImageID: imageID,
-	}
-	require.NoError(t, d1.Insert(ctx))
-	d2 := &distro.Distro{
-		Id:      DistroIdTwo,
-		ImageID: imageID,
-	}
-	require.NoError(t, d2.Insert(ctx))
-	d3 := &distro.Distro{
-		Id:      DistroIdThree,
-		ImageID: imageID,
-	}
-	require.NoError(t, d3.Insert(ctx))
-	latestTask, err := getLatestTask(ctx, imageID)
+	latestTask, err := GetLatestTaskFromImage(ctx, imageID)
 	assert.NoError(t, err)
 	require.NotNil(t, latestTask)
 	assert.Equal(t, latestTask.Id, "t2")

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2257,7 +2257,7 @@ func TestGetLatestTaskFromImage(t *testing.T) {
 		require.NoError(t, task.Insert())
 	}
 	latestTask, err := GetLatestTaskFromImage(ctx, imageID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, latestTask)
 	assert.Equal(t, latestTask.Id, "t2")
 }


### PR DESCRIPTION
DEVPROD-7643

### Description
Added GetLatestTaskFromImage function to query database and retrieve the latest task from all the distros corresponding to the imageID. 

### Testing
Added TestGetLatestTaskFromImage function to ensure function works correctly. Also ran bson queries that mimic function and it took ~200 milliseconds per query. 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
