### PR TITLE
DEVPROD-760 Don't overwrite tasks when re-configuring a patch 

### DIFF
--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -900,6 +900,10 @@ buildvariants:
 	assert.True(t, foundCompile)
 	assert.True(t, foundPassing)
 
+	dbPatch, err := patch.FindOneId(unfinalized.Id.Hex())
+	assert.NoError(t, err)
+	assert.Equal(t, len(dbPatch.VariantsTasks[0].Tasks), len(tasks))
+
 	// valid request, reconfiguring a finalized patch
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
@@ -935,6 +939,11 @@ buildvariants:
 	assert.True(t, foundFailing)
 	assert.True(t, foundPassing)
 	assert.True(t, foundCompile)
+
+	// ensure that the patch contains all the tasks and didn't overwrite it with the new tasks
+	dbPatch, err = patch.FindOneId(unfinalized.Id.Hex())
+	assert.NoError(t, err)
+	assert.Equal(t, len(dbPatch.VariantsTasks[0].Tasks), len(tasks))
 
 	// * should select all tasks
 	patch2 := patch.Patch{


### PR DESCRIPTION
DEVPROD-760

### Description
When reconfiguring a patch, we had tests in place that made sure that we don't loose any tasks on the version. However, the same was not done for patches. That means that if a patch was reconfigured, if `evergreen patch --repeat-patch patch_id` is used for a patch that was reconfigured from 25 tasks to 2, the old version will run 27 tasks but the new patch will only have two. This fixes that. 

### Testing
Tested on staging and updated unit tests. 

### Documentation
remember to add or edit docs in the docs/ directory if relevant

