### PR TITLE
DEVPROD-6943 Unmatching tasks/tags in variants resulting in a validation warning rather than a translation error

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -413,9 +413,10 @@ type BuildVariant struct {
 	Tasks        []BuildVariantTaskUnit `yaml:"tasks,omitempty" bson:"tasks"`
 	DisplayTasks []patch.DisplayTask    `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
 
-	// EmptyTaskSelectors stores task selectors that don't target any tasks for this build variant.
-	// This is only for validation purposes.
-	EmptyTaskSelectors []string `yaml:"-" bson:"-"`
+	// TranslationWarnings are validation warnings that are only detectable during project translation.
+	// e.g. task selectors that don't target any tasks in a build variant but the build
+	// variant still has tasks.
+	TranslationWarnings []string `yaml:"-" bson:"-"`
 }
 
 // CheckRun is used to provide information about a github check run.

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -690,19 +690,21 @@ func TestRulesEvaluation(t *testing.T) {
 		Convey("a 'remove' rule for an unknown task should fail", func() {
 			bvs := []parserBV{{
 				Name: "test",
-				Tasks: parserBVTaskUnits{
+				Tasks: parserBVTaskUnits{ // This starts with blue, brown, black, and white.
 					{Name: "blue"},
 					{Name: ".special"},
 					{Name: ".tertiary"},
 				},
 				MatrixRules: []ruleAction{
-					{RemoveTasks: []string{".amazing"}}, //remove blue
-					{RemoveTasks: []string{"rainbow"}},
+					{RemoveTasks: []string{".amazing"}}, // Nothing is tagged with amazing, so this step should not remove any and should not fail.
+					{RemoveTasks: []string{"blue"}},     // This should remove blue.
 				},
 			}}
-			_, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
-			So(errs, ShouldNotBeNil)
-			So(len(errs), ShouldEqual, 2)
+			evaluated, errs := evaluateBuildVariants(tse, nil, nil, bvs, taskDefs, nil)
+			So(errs, ShouldBeNil)
+			v1 := evaluated[0]
+			So(v1.Name, ShouldEqual, "test")
+			So(len(v1.Tasks), ShouldEqual, 3) // Brown, black, and white left
 		})
 	})
 }

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -647,49 +647,6 @@ func TestTranslateBuildVariants(t *testing.T) {
 	})
 }
 
-func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEvaluator, tasks parserBVTaskUnits, taskDefs []parserTask, expected []BuildVariantTaskUnit, expectedEmptySelectors []string) {
-	names := []string{}
-	exp := []string{}
-	for _, t := range tasks {
-		names = append(names, t.Name)
-	}
-	for _, e := range expected {
-		exp = append(exp, e.Name)
-	}
-	vse := NewVariantSelectorEvaluator([]parserBV{}, nil)
-	Convey(fmt.Sprintf("tasks [%v] should evaluate to [%v]",
-		strings.Join(names, ", "), strings.Join(exp, ", ")), func() {
-		pbv := parserBV{Name: "build-variant-wow", Tasks: tasks}
-		ts, es, errs := evaluateBVTasks(tse, tsge, vse, pbv, taskDefs)
-		if expected != nil {
-			So(errs, ShouldBeNil)
-		} else {
-			So(errs, ShouldNotBeNil)
-		}
-		So(len(ts), ShouldEqual, len(expected))
-		for _, e := range expected {
-			exists := false
-			for _, t := range ts {
-				if t.Name == e.Name && t.Priority == e.Priority && len(t.DependsOn) == len(e.DependsOn) {
-					exists = true
-				}
-				So(t.Variant, ShouldEqual, pbv.Name)
-			}
-			So(exists, ShouldBeTrue)
-		}
-		So(len(es), ShouldEqual, len(expectedEmptySelectors))
-		for _, expectedEmptySelector := range expectedEmptySelectors {
-			exists := false
-			for _, emptySelector := range es {
-				if emptySelector == expectedEmptySelector {
-					exists = true
-				}
-			}
-			So(exists, ShouldBeTrue)
-		}
-	})
-}
-
 func TestParserTaskSelectorEvaluation(t *testing.T) {
 	Convey("With a colorful set of ProjectTasks", t, func() {
 		taskDefs := []parserTask{
@@ -711,17 +668,17 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: "white"}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "white"}}, nil)
+					[]BuildVariantTaskUnit{{Name: "white"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: "red", Priority: 500}, {Name: ".secondary"}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "red", Priority: 500}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil)
+					[]BuildVariantTaskUnit{{Name: "red", Priority: 500}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
 						{Name: ".warm .secondary", Distros: []string{"d1"}}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "orange", RunOn: []string{"d1"}}}, nil)
+					[]BuildVariantTaskUnit{{Name: "orange", RunOn: []string{"d1"}}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
@@ -730,7 +687,7 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					[]BuildVariantTaskUnit{
 						{Name: "orange", RunOn: []string{"d1"}},
 						{Name: "purple", RunOn: []string{"d1"}},
-						{Name: "green", RunOn: []string{"d1"}}}, nil)
+						{Name: "green", RunOn: []string{"d1"}}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: "*"}},
 					taskDefs,
@@ -738,7 +695,7 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 						{Name: "red"}, {Name: "blue"}, {Name: "yellow"},
 						{Name: "orange"}, {Name: "purple"}, {Name: "green"},
 						{Name: "brown"}, {Name: "white"}, {Name: "black"},
-					}, nil)
+					}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
 						{Name: "red", Priority: 100},
@@ -747,25 +704,91 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					[]BuildVariantTaskUnit{
 						{Name: "red", Priority: 100},
 						{Name: "purple", Priority: 100},
-						{Name: "green", Priority: 100}}, nil)
+						{Name: "green", Priority: 100}}, nil, nil)
 			})
 			Convey("should ignore selectors that do not select any tasks if another does select a task", func() {
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: ".warm .cool"}, {Name: "white"}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "white"}}, []string{".warm .cool"})
+					[]BuildVariantTaskUnit{{Name: "white"}}, []string{".warm .cool"}, nil)
 			})
 			Convey("should error when all selectors combined do not select any tasks", func() {
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: ".warm .cool"}},
 					taskDefs,
-					nil, []string{".warm .cool"})
+					nil, []string{".warm .cool"}, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{{Name: ".warm .cool"}, {Name: ".secondary .primary"}},
 					taskDefs,
-					nil, []string{".warm .cool", ".secondary .primary"})
+					nil, []string{".warm .cool", ".secondary .primary"}, nil)
+			})
+			Convey("should warn when some selectors do not exist", func() {
+				parserTaskSelectorTaskEval(tse, tgse,
+					parserBVTaskUnits{{Name: ".warm .doesnt-exist"}, {Name: "white"}},
+					taskDefs,
+					[]BuildVariantTaskUnit{{Name: "white"}}, []string{".warm .doesnt-exist"}, []string{".doesnt-exist"})
+				parserTaskSelectorTaskEval(tse, tgse,
+					parserBVTaskUnits{{Name: ".warm !.doesnt-exist"}, {Name: "white"}},
+					taskDefs,
+					[]BuildVariantTaskUnit{{Name: "red"}, {Name: "orange"}, {Name: "yellow"}, {Name: "white"}}, nil, []string{"!.doesnt-exist"})
 			})
 		})
+	})
+}
+
+func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEvaluator, tasks parserBVTaskUnits, taskDefs []parserTask, expected []BuildVariantTaskUnit, expectedEmptySelectors, expectedUnmatchedCriteria []string) {
+	names := []string{}
+	exp := []string{}
+	for _, t := range tasks {
+		names = append(names, t.Name)
+	}
+	for _, e := range expected {
+		exp = append(exp, e.Name)
+	}
+	vse := NewVariantSelectorEvaluator([]parserBV{}, nil)
+	Convey(fmt.Sprintf("tasks [%v] should evaluate to [%v]",
+		strings.Join(names, ", "), strings.Join(exp, ", ")), func() {
+		pbv := parserBV{Name: "build-variant-wow", Tasks: tasks}
+		taskUnit, unmatchedSelectors, unmatchedCriteria, errs := evaluateBVTasks(tse, tsge, vse, pbv, taskDefs)
+		if expected != nil {
+			So(errs, ShouldBeNil)
+		} else {
+			So(errs, ShouldNotBeNil)
+		}
+		So(len(taskUnit), ShouldEqual, len(expected))
+		for _, e := range expected {
+			exists := false
+			for _, t := range taskUnit {
+				if t.Name == e.Name && t.Priority == e.Priority && len(t.DependsOn) == len(e.DependsOn) {
+					exists = true
+					break
+				}
+				So(t.Variant, ShouldEqual, pbv.Name)
+			}
+			So(exists, ShouldBeTrue)
+		}
+		So(len(unmatchedSelectors), ShouldEqual, len(expectedEmptySelectors))
+		for _, expectedEmptySelector := range expectedEmptySelectors {
+			exists := false
+			for _, emptySelector := range unmatchedSelectors {
+				if emptySelector == expectedEmptySelector {
+					exists = true
+					break
+				}
+			}
+			So(exists, ShouldBeTrue)
+		}
+		So(len(unmatchedCriteria), ShouldEqual, len(expectedUnmatchedCriteria))
+		for _, expectedUnmatchedTag := range expectedUnmatchedCriteria {
+			exists := false
+			for _, unmatchedTag := range unmatchedCriteria {
+				if unmatchedTag == expectedUnmatchedTag {
+					exists = true
+					break
+				}
+			}
+			So(exists, ShouldBeTrue)
+		}
 	})
 }
 
@@ -1020,7 +1043,7 @@ tasks:
 	proj = &Project{}
 	_, err = LoadProjectInto(ctx, []byte(nonexistentTaskYml), nil, "id", proj)
 	assert.NotNil(proj)
-	assert.Contains(err.Error(), "notHere: nothing named 'notHere'")
+	assert.Contains(err.Error(), "contains unmatched criteria: 'notHere'")
 	assert.Len(proj.BuildVariants[0].DisplayTasks, 1)
 	assert.Len(proj.BuildVariants[0].DisplayTasks[0].ExecTasks, 2)
 	assert.Len(proj.BuildVariants[1].DisplayTasks, 0)
@@ -1440,7 +1463,7 @@ buildvariants:
 		_, err := LoadProjectInto(ctx, []byte(wrongTaskYml), nil, "id", proj)
 		assert.NotNil(t, proj)
 		require.NotNil(t, err)
-		assert.Contains(t, err.Error(), `nothing named 'example_task_3'`)
+		assert.Contains(t, err.Error(), `'example_task_group' has unmatched selector: 'example_task_3'`)
 	})
 
 	t.Run("MaintainsTaskGroupTaskOrdering", func(t *testing.T) {

--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -152,18 +152,26 @@ func newTagSelectorEvaluator(selectees []tagged) *tagSelectorEvaluator {
 	}
 }
 
-// evalSelector returns all names that fulfill a selector. This is done
-// by evaluating each criterion individually and taking the intersection.
-func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
+// evalSelector returns all names that fulfill a selector and all unmatched criterion.
+// This is done by evaluating each criterion individually and taking the intersection.
+func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
 	// keep a slice of results per criterion
 	results := []string{}
+	unmatchedCriteria := []string{}
 	if len(s) == 0 {
-		return nil, errors.New("cannot evaluate selector with no criteria")
+		return nil, nil, errors.New("cannot evaluate selector with no criteria")
 	}
 	for i, sc := range s {
 		names, err := tse.evalCriterion(sc)
 		if err != nil {
-			return nil, errors.Wrapf(err, "%v", s)
+			return nil, nil, errors.Wrapf(err, "%v", s)
+		}
+		if len(names) == 0 {
+			unmatchedCriteria = append(unmatchedCriteria, sc.String())
+			// If this is a negated criteria, we do not want to intersect it with the rest
+			if sc.negated {
+				continue
+			}
 		}
 		if i == 0 {
 			results = names
@@ -172,7 +180,7 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
 			results = utility.StringSliceIntersection(results, names)
 		}
 	}
-	return results, nil
+	return results, unmatchedCriteria, nil
 }
 
 // evalCriterion returns all names that fulfill a single selection criterion.
@@ -191,14 +199,14 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 	case !sc.tagged && !sc.negated: // just a regular name
 		item := tse.byName[sc.name]
 		if item == nil {
-			return nil, errors.Errorf("nothing named '%v'", sc.name)
+			return nil, nil
 		}
 		return []string{item.name()}, nil
 
 	case sc.tagged && !sc.negated: // expand a tag
 		taggedItems := tse.byTag[sc.name]
 		if len(taggedItems) == 0 {
-			return nil, errors.Errorf("nothing has the tag '%v'", sc.name)
+			return nil, nil
 		}
 		names := make([]string, len(taggedItems))
 		for i, item := range taggedItems {
@@ -208,8 +216,7 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 
 	case !sc.tagged && sc.negated: // everything *but* a specific item
 		if tse.byName[sc.name] == nil {
-			// we want to treat this as an error for better usability
-			return nil, errors.Errorf("nothing named '%v'", sc.name)
+			return nil, nil
 		}
 		names := []string{}
 		for _, item := range tse.items {
@@ -222,8 +229,7 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 	case sc.tagged && sc.negated: // everything *but* a tag
 		items := tse.byTag[sc.name]
 		if len(items) == 0 {
-			// we want to treat this as an error for better usability
-			return nil, errors.Errorf("nothing has the tag '%v'", sc.name)
+			return nil, nil
 		}
 		illegalItems := map[string]bool{}
 		for _, item := range items {
@@ -264,12 +270,12 @@ func NewParserTaskSelectorEvaluator(tasks []parserTask) *taskSelectorEvaluator {
 }
 
 // evalSelector returns all tasks selected by a selector.
-func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, error) {
-	results, err := t.tagEval.evalSelector(s)
+func (t *taskSelectorEvaluator) evalSelector(s Selector) ([]string, []string, error) {
+	results, unmatched, err := t.tagEval.evalSelector(s)
 	if err != nil {
-		return nil, errors.Wrap(err, "evaluating task selector")
+		return nil, nil, errors.Wrap(err, "evaluating task selector")
 	}
-	return results, nil
+	return results, unmatched, nil
 }
 
 func newTaskGroupSelectorEvaluator(groups []parserTaskGroup) *tagSelectorEvaluator {
@@ -334,9 +340,12 @@ func (ase *axisSelectorEvaluator) evalSelector(axis string, s Selector) ([]strin
 	if !ok {
 		return nil, errors.Errorf("axis '%v' does not exist", axis)
 	}
-	results, err := tagEval.evalSelector(s)
+	results, unmatched, err := tagEval.evalSelector(s)
 	if err != nil {
 		return nil, errors.Wrapf(err, "evaluating axis '%v' selector", axis)
+	}
+	if len(unmatched) > 0 {
+		return nil, errors.Errorf("axis '%v' selector contains unmatched criteria: %v", axis, unmatched)
 	}
 	return results, nil
 }
@@ -386,9 +395,12 @@ func (v *variantSelectorEvaluator) evalSelector(vs *variantSelector) ([]string, 
 		}
 		return results, nil
 	}
-	results, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
+	results, unmatched, err := v.tagEval.evalSelector(ParseSelector(vs.StringSelector))
 	if err != nil {
-		return nil, errors.Wrap(err, "variant tag selector")
+		return nil, errors.Wrap(err, "variant selector")
+	}
+	if len(unmatched) > 0 {
+		return nil, errors.Errorf("variant selector contains unmatched criteria: %v", unmatched)
 	}
 	return results, nil
 }

--- a/model/project_selector_test.go
+++ b/model/project_selector_test.go
@@ -84,17 +84,21 @@ func TestBasicSelector(t *testing.T) {
 	})
 }
 
-func tagSelectorShouldEval(tse *tagSelectorEvaluator, s string, expected []string) {
-	Convey(fmt.Sprintf(`selector "%v" should evaluate to %v`, s, expected), func() {
-		names, err := tse.evalSelector(ParseSelector(s))
-		if expected != nil {
+func tagSelectorShouldEval(tse *tagSelectorEvaluator, s string, expectedNames, expectedUnmatched []string) {
+	Convey(fmt.Sprintf(`selector "%v" should evaluate to '%v' with unmatched '%v'`, s, expectedNames, expectedUnmatched), func() {
+		names, unmatched, err := tse.evalSelector(ParseSelector(s))
+		if expectedNames != nil || expectedUnmatched != nil {
 			So(err, ShouldBeNil)
 		} else {
 			So(err, ShouldNotBeNil)
 		}
-		So(len(names), ShouldEqual, len(expected))
-		for _, e := range expected {
+		So(len(names), ShouldEqual, len(expectedNames))
+		for _, e := range expectedNames {
 			So(names, ShouldContain, e)
+		}
+		So(len(unmatched), ShouldEqual, len(expectedUnmatched))
+		for _, e := range expectedUnmatched {
+			So(unmatched, ShouldContain, e)
 		}
 	})
 }
@@ -127,69 +131,64 @@ func TestTaskSelectorEvaluation(t *testing.T) {
 			tse = newTagSelectorEvaluator(defs)
 
 			Convey("should evaluate single name selectors properly", func() {
-				tagSelectorShouldEval(tse, "red", []string{"red"})
-				tagSelectorShouldEval(tse, "white", []string{"white"})
+				tagSelectorShouldEval(tse, "red", []string{"red"}, nil)
+				tagSelectorShouldEval(tse, "white", []string{"white"}, nil)
 			})
 
 			Convey("should evaluate single tag selectors properly", func() {
-				tagSelectorShouldEval(tse, ".warm", []string{"red", "orange", "yellow"})
-				tagSelectorShouldEval(tse, ".cool", []string{"blue", "green", "purple"})
-				tagSelectorShouldEval(tse, ".special", []string{"white", "black"})
-				tagSelectorShouldEval(tse, ".primary", []string{"red", "blue", "yellow"})
+				tagSelectorShouldEval(tse, ".warm", []string{"red", "orange", "yellow"}, nil)
+				tagSelectorShouldEval(tse, ".cool", []string{"blue", "green", "purple"}, nil)
+				tagSelectorShouldEval(tse, ".special", []string{"white", "black"}, nil)
+				tagSelectorShouldEval(tse, ".primary", []string{"red", "blue", "yellow"}, nil)
 			})
 
 			Convey("should evaluate multi-tag selectors properly", func() {
-				tagSelectorShouldEval(tse, ".warm .cool", []string{})
-				tagSelectorShouldEval(tse, ".cool .primary", []string{"blue"})
-				tagSelectorShouldEval(tse, ".warm .secondary", []string{"orange"})
+				tagSelectorShouldEval(tse, ".warm .cool", []string{}, nil)
+				tagSelectorShouldEval(tse, ".cool .primary", []string{"blue"}, nil)
+				tagSelectorShouldEval(tse, ".warm .secondary", []string{"orange"}, nil)
 			})
 
 			Convey("should evaluate selectors with negation properly", func() {
 				tagSelectorShouldEval(tse, "!.special",
-					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown"})
-				tagSelectorShouldEval(tse, ".warm !yellow", []string{"red", "orange"})
-				tagSelectorShouldEval(tse, "!.primary !.secondary", []string{"black", "white", "brown"})
+					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown"}, nil)
+				tagSelectorShouldEval(tse, ".warm !yellow", []string{"red", "orange"}, nil)
+				tagSelectorShouldEval(tse, "!.primary !.secondary", []string{"black", "white", "brown"}, nil)
 			})
 
 			Convey("should evaluate special selectors", func() {
 				tagSelectorShouldEval(tse, "*",
-					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown", "black", "white"})
+					[]string{"red", "orange", "yellow", "green", "blue", "purple", "brown", "black", "white"}, nil)
+			})
+
+			Convey("names that don't exist", func() {
+				tagSelectorShouldEval(tse, "salmon", nil, []string{"salmon"})
+			})
+
+			Convey("tags that don't exist", func() {
+				tagSelectorShouldEval(tse, ".fail", nil, []string{".fail"})
+				tagSelectorShouldEval(tse, "!.spring", nil, []string{"!.spring"})
 			})
 
 			Convey("should fail on bad selectors like", func() {
 
 				Convey("empty selectors", func() {
-					_, err := tse.evalSelector(Selector{})
-					So(err, ShouldNotBeNil)
-				})
-
-				Convey("names that don't exist", func() {
-					_, err := tse.evalSelector(ParseSelector("salmon"))
-					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!azure"))
-					So(err, ShouldNotBeNil)
-				})
-
-				Convey("tags that don't exist", func() {
-					_, err := tse.evalSelector(ParseSelector(".fall"))
-					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!.spring"))
+					_, _, err := tse.evalSelector(Selector{})
 					So(err, ShouldNotBeNil)
 				})
 
 				Convey("using . and ! with *", func() {
-					_, err := tse.evalSelector(ParseSelector(".*"))
+					_, _, err := tse.evalSelector(ParseSelector(".*"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("!*"))
+					_, _, err = tse.evalSelector(ParseSelector("!*"))
 					So(err, ShouldNotBeNil)
 				})
 
 				Convey("illegal names", func() {
-					_, err := tse.evalSelector(ParseSelector("!!purple"))
+					_, _, err := tse.evalSelector(ParseSelector("!!purple"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector(".!purple"))
+					_, _, err = tse.evalSelector(ParseSelector(".!purple"))
 					So(err, ShouldNotBeNil)
-					_, err = tse.evalSelector(ParseSelector("..purple"))
+					_, _, err = tse.evalSelector(ParseSelector("..purple"))
 					So(err, ShouldNotBeNil)
 				})
 			})

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2392,13 +2392,8 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 			)
 		}
 
-		if len(buildVariant.EmptyTaskSelectors) > 0 {
-			errs = append(errs,
-				ValidationError{
-					Message: fmt.Sprintf("buildvariant '%s' has task names/tags that do not match any tasks: '%s'", buildVariant.Name, strings.Join(buildVariant.EmptyTaskSelectors, "', '")),
-					Level:   Warning,
-				},
-			)
+		for _, warning := range buildVariant.TranslationWarnings {
+			errs = append(errs, ValidationError{Message: warning, Level: Warning})
 		}
 
 		errs = append(errs, checkBVNames(&buildVariant)...)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1767,15 +1767,15 @@ func TestValidateBVNames(t *testing.T) {
 			So(validationResults[0].Level, ShouldEqual, Error)
 		})
 
-		Convey("if any variant has task selectors that don't target anything, an warning should be returned", func() {
+		Convey("if any variant has warnings from translating, an warning should be returned", func() {
 			project := &model.Project{
 				BuildVariants: []model.BuildVariant{
-					{Name: "linux", EmptyTaskSelectors: []string{".task1"}},
+					{Name: "linux", TranslationWarnings: []string{"this is a warning"}},
 				},
 			}
 			validationResults := checkBuildVariants(project)
 
-			So(validationResults.String(), ShouldContainSubstring, "WARNING: buildvariant 'linux' has task names/tags that do not match any tasks: '.task1'")
+			So(validationResults.String(), ShouldContainSubstring, "WARNING: this is a warning")
 		})
 
 		Convey("if two variants have the same display name, a warning should be returned, but no errors", func() {


### PR DESCRIPTION
DEVPROD-6943

### Description
This reverts a revert we had done that was thought to block/error when it wasn't (more details in comments of jira ticket!)

Original PR: https://github.com/evergreen-ci/evergreen/pull/7821 