### PR TITLE
DEVPROD-7639: Create getOSInfo method to query Runtime Environments API

### DIFF
--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -16,6 +16,18 @@ type RuntimeEnvironmentsClient struct {
 	APIKey  string
 }
 
+type ImageInfo struct {
+}
+type OSInfo struct {
+	Id      string
+	AMIId   string
+	Distro  string
+	Version string
+	Type    string
+	Manager string
+	Name    string
+}
+
 func NewRuntimeEnvironmentsClient(baseURL string, apiKey string) *RuntimeEnvironmentsClient {
 	c := RuntimeEnvironmentsClient{
 		Client:  &http.Client{},
@@ -57,4 +69,23 @@ func (c *RuntimeEnvironmentsClient) getImageNames(ctx context.Context) ([]string
 		}
 	}
 	return filteredImages, nil
+}
+
+func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiId string, page int, limit int) ([]ImageInfo, error) {
+	apiURL := fmt.Sprintf("%s/rest/api/v1/image", c.BaseURL)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Add("Content-Type", "application/json")
+	request.Header.Add("Api-Key", c.APIKey)
+	resp, err := c.Client.Do(request)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return nil, errors.Errorf("HTTP request returned unexpected status '%s': %s", resp.Status, string(msg))
+	}
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -68,7 +68,7 @@ func (c *RuntimeEnvironmentsClient) getImageNames(ctx context.Context) ([]string
 }
 
 // getOSInfo returns a list of operating system information for an AMI.
-func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page int, limit int) ([]OSInfo, error) {
+func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page, limit int) ([]OSInfo, error) {
 	params := url.Values{}
 	params.Set("ami", amiID)
 	params.Set("page", strconv.Itoa(page))

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
@@ -17,6 +18,7 @@ type RuntimeEnvironmentsClient struct {
 	APIKey  string
 }
 
+// OSInfo stores operating system information.
 type OSInfo struct {
 	Version string
 	Name    string
@@ -66,11 +68,11 @@ func (c *RuntimeEnvironmentsClient) getImageNames(ctx context.Context) ([]string
 }
 
 // getOSInfo returns a list of operating system information for an AMI.
-func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page string, limit string) ([]OSInfo, error) {
+func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page int, limit int) ([]OSInfo, error) {
 	params := url.Values{}
 	params.Set("ami", amiID)
-	params.Set("page", page)
-	params.Set("limit", limit)
+	params.Set("page", strconv.Itoa(page))
+	params.Set("limit", strconv.Itoa(limit))
 	params.Set("type", "OS")
 	apiURL := fmt.Sprintf("%s/rest/api/v1/image?%s", c.BaseURL, params.Encode())
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -65,7 +65,7 @@ func (c *RuntimeEnvironmentsClient) getImageNames(ctx context.Context) ([]string
 	return filteredImages, nil
 }
 
-// getOSInfo returns a list of operating system changes (name and version) from the corresponding AMI id.
+// getOSInfo returns a list of operating system information for an AMI.
 func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page string, limit string) ([]OSInfo, error) {
 	params := url.Values{}
 	params.Set("ami", amiID)

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -66,19 +66,14 @@ func (c *RuntimeEnvironmentsClient) getImageNames(ctx context.Context) ([]string
 }
 
 // getOSInfo returns a list of operating system changes (name and version) from the corresponding AMI id.
-func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiId string, page string, limit string) ([]OSInfo, error) {
-	apiURL := fmt.Sprintf("%s/rest/api/v1/image", c.BaseURL)
+func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiID string, page string, limit string) ([]OSInfo, error) {
 	params := url.Values{}
-	params.Set("ami", amiId)
+	params.Set("ami", amiID)
 	params.Set("page", page)
 	params.Set("limit", limit)
 	params.Set("type", "OS")
-	reqURL, err := url.Parse(apiURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing API url")
-	}
-	reqURL.RawQuery = params.Encode()
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	apiURL := fmt.Sprintf("%s/rest/api/v1/image?%s", c.BaseURL, params.Encode())
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -93,9 +88,9 @@ func (c *RuntimeEnvironmentsClient) getOSInfo(ctx context.Context, amiId string,
 		msg, _ := io.ReadAll(resp.Body)
 		return nil, errors.Errorf("HTTP request returned unexpected status '%s': %s", resp.Status, string(msg))
 	}
-	var decodedOSInfo []OSInfo
-	if err := gimlet.GetJSON(resp.Body, &decodedOSInfo); err != nil {
+	var osInfo []OSInfo
+	if err := gimlet.GetJSON(resp.Body, &osInfo); err != nil {
 		return nil, errors.Wrap(err, "decoding http body")
 	}
-	return decodedOSInfo, nil
+	return osInfo, nil
 }

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -34,5 +34,5 @@ func TestGetOSInfo(t *testing.T) {
 	result, err := c.getOSInfo(ctx, "ami-0e12ef25a5f7712a4", "0", "10")
 	require.NoError(t, err)
 	assert.NotEmpty(result)
-	assert.Equal(len(result), 10)
+	assert.Len(result, 10)
 }

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -31,7 +31,7 @@ func TestGetOSInfo(t *testing.T) {
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config, "TestGetOSInfo")
 	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
-	result, err := c.getOSInfo(ctx, "ami-0e12ef25a5f7712a4", "0", "10")
+	result, err := c.getOSInfo(ctx, "ami-0e12ef25a5f7712a4", 0, 10)
 	require.NoError(t, err)
 	assert.NotEmpty(result)
 	assert.Len(result, 10)

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetImageNames(t *testing.T) {
@@ -20,4 +21,18 @@ func TestGetImageNames(t *testing.T) {
 	assert.NoError(err)
 	assert.NotEmpty(result)
 	assert.NotContains(result, "")
+}
+
+func TestGetOSInfo(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert := assert.New(t)
+	config := testutil.TestConfig()
+	testutil.ConfigureIntegrationTest(t, config, "TestGetOSInfo")
+	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
+	result, err := c.getOSInfo(ctx, "ami-0e12ef25a5f7712a4", "0", "10")
+	require.NoError(t, err)
+	assert.NotEmpty(result)
+	assert.Equal(len(result), 10)
 }

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -33,6 +33,5 @@ func TestGetOSInfo(t *testing.T) {
 	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	result, err := c.getOSInfo(ctx, "ami-0e12ef25a5f7712a4", 0, 10)
 	require.NoError(t, err)
-	assert.NotEmpty(result)
 	assert.Len(result, 10)
 }


### PR DESCRIPTION
DEVPROD-7639

### Description
Added getOSInfo method to query runtime environments API given an AMI. 

### Testing
Wrote TestGetOSInfo and validated correct results with independent testing using grip debug statements. 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
