### PR TITLE
Revert "DEVPROD-5857 use cached create time to improve cron activation time (#7888)"

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -840,7 +840,6 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasksWithBatchtime() {
 				BuildVariant: "a_variant",
 			},
 		},
-		CreateTime: time.Now(),
 	}
 	s.NoError(v.Insert())
 	pp := &ParserProject{}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -538,8 +538,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		if !bvtu.HasSpecificActivation() {
 			continue
 		}
-		// Use the version create time to ensure we're being consistent
-		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu, creationInfo.Version.CreateTime)
+		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu)
 		batchTimeCatcher.Wrapf(err, "getting activation time for task '%s'", t.DisplayName)
 		batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 			TaskName: t.DisplayName,
@@ -1605,13 +1604,12 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		var activateVariantAt time.Time
 		batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 		if !activateVariant {
-			activateVariantAt, err = creationInfo.ProjectRef.GetActivationTimeForVariant(
-				creationInfo.Project.FindBuildVariant(pair.Variant), creationInfo.Version.CreateTime)
+			activateVariantAt, err = creationInfo.ProjectRef.GetActivationTimeForVariant(creationInfo.Project.FindBuildVariant(pair.Variant))
 			batchTimeCatcher.Wrapf(err, "getting activation time for variant '%s'", pair.Variant)
 		}
 		for taskName, id := range batchTimeTasksToIds {
 			activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(
-				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant), creationInfo.Version.CreateTime)
+				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant))
 			batchTimeCatcher.Wrapf(err, "getting activation time for task '%s' in variant '%s'", taskName, pair.Variant)
 			batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 				TaskId:   id,

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -544,15 +544,13 @@ func TestGetActivationTimeForTask(t *testing.T) {
 	assert.NoError(t, versionWithoutTask.Insert())
 	assert.NoError(t, versionWithTask.Insert())
 
-	currentTime := time.Now()
-	activationTime, err := projectRef.GetActivationTimeForTask(bvt, currentTime)
+	activationTime, err := projectRef.GetActivationTimeForTask(bvt)
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(prevTime.Add(time.Hour)))
 
-	// Activation time should be the zero time, because this variant is disabled.
-	activationTime, err = projectRef.GetActivationTimeForTask(bvt2, currentTime)
+	activationTime, err = projectRef.GetActivationTimeForTask(bvt2)
 	assert.NoError(t, err)
-	assert.True(t, utility.IsZeroTime(activationTime))
+	assert.True(t, activationTime.Equal(utility.ZeroTime))
 }
 
 func TestGetActivationTimeWithCron(t *testing.T) {
@@ -3799,11 +3797,10 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	}
 	assert.Nil(projectRef.Insert())
 
-	// Set based on last activation time when no version is found
-	currentTime := time.Now().Add(-1 * time.Minute)
-	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
+	// set based on last activation time when no version is found
+	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
 	assert.NoError(err)
-	assert.Equal(activationTime, currentTime)
+	assert.NotZero(activationTime)
 
 	// set based on last activation time with a version
 	version := &Version{
@@ -3823,8 +3820,7 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	}
 	assert.Nil(version.Insert())
 
-	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
+	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
 	assert.NoError(err)
 	assert.NotZero(activationTime)
-	assert.Equal(activationTime, currentTime)
 }

--- a/model/version.go
+++ b/model/version.go
@@ -332,6 +332,8 @@ type VersionMetadata struct {
 var (
 	VersionBuildStatusVariantKey        = bsonutil.MustHaveTag(VersionBuildStatus{}, "BuildVariant")
 	VersionBuildStatusActivatedKey      = bsonutil.MustHaveTag(VersionBuildStatus{}, "Activated")
+	VersionBuildStatusActivateAtKey     = bsonutil.MustHaveTag(VersionBuildStatus{}, "ActivateAt")
+	VersionBuildStatusBuildIdKey        = bsonutil.MustHaveTag(VersionBuildStatus{}, "BuildId")
 	VersionBuildStatusBatchTimeTasksKey = bsonutil.MustHaveTag(VersionBuildStatus{}, "BatchTimeTasks")
 
 	BatchTimeTaskStatusTaskNameKey  = bsonutil.MustHaveTag(BatchTimeTaskStatus{}, "TaskName")

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -929,8 +929,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if evergreen.ShouldConsiderBatchtime(v.Requester) {
-			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime)
+		if v.Requester == evergreen.RepotrackerVersionRequester && evergreen.ShouldConsiderBatchtime(v.Requester) {
+			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant)
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
@@ -938,7 +938,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, v.CreateTime)
+				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt)
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 
 				taskStatuses = append(taskStatuses,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1084,7 +1084,7 @@ tasks:
 			s.InDelta(bv.ActivateAt.Unix(), now.Unix(), 1)
 			s.Require().Len(bv.BatchTimeTasks, 2)
 			for _, t := range bv.BatchTimeTasks {
-				if t.TaskName == "task1" { // activate time is now because there isn't a previous task
+				if t.TaskName == "task1" { // activate time is now because their isn't a previous task
 					s.InDelta(t.ActivateAt.Unix(), now.Unix(), 1)
 				} else {
 					// ensure that "daily" cron is set for the next day
@@ -1094,84 +1094,6 @@ tasks:
 					s.Equal(d, td)
 				}
 
-			}
-		}
-		if bv.BuildVariant == "bv2" {
-			s.False(bv.Activated)
-			s.Len(bv.BatchTimeTasks, 0)
-		}
-	}
-}
-
-func (s *CreateVersionFromConfigSuite) TestCreateVersionItemsBatchtime() {
-	// Test that we correctly use the version create time to determine task batchtimes, rather than the task create time.
-	configYml := `
-buildvariants:
-- name: bv
-  display_name: "bv_display"
-  run_on: d
-  tasks:
-  - name: task1
-    batchtime: 30
-  - name: task2
-    cron: "@daily"
-  - name: task3
-- name: bv2
-  batchtime: 15
-  display_name: bv2_display
-  run_on: d
-  tasks:
-  - name: task1
-tasks:
-- name: task1
-- name: task2
-- name: task3
-`
-	p := &model.Project{}
-	pp, err := model.LoadProjectInto(s.ctx, []byte(configYml), nil, s.ref.Id, p)
-	s.NoError(err)
-	projectInfo := &model.ProjectInfo{
-		Ref:                 s.ref,
-		IntermediateProject: pp,
-		Project:             p,
-	}
-	metadata := model.VersionMetadata{Revision: *s.rev}
-	versionCreateTime := time.Now().Add(time.Minute * -10)
-
-	v := &model.Version{
-		Id:                  "_abc",
-		CreateTime:          versionCreateTime,
-		Revision:            "abc",
-		Author:              "me",
-		RevisionOrderNumber: 12,
-		Owner:               "evergreen-ci",
-		Repo:                "evergreen",
-		Branch:              "main",
-		Requester:           evergreen.RepotrackerVersionRequester,
-	}
-
-	s.NoError(createVersionItems(s.ctx, v, metadata, projectInfo, nil))
-	tasks, err := task.FindAllTaskIDsFromVersion(v.Id)
-	s.NoError(err)
-	s.Len(tasks, 4)
-	tomorrow := versionCreateTime.Add(time.Hour * 24) // next day
-	y, m, d := tomorrow.Date()
-
-	s.Len(v.BuildVariants, 2)
-	for _, bv := range v.BuildVariants {
-		if bv.BuildVariant == "bv" {
-			s.Equal(versionCreateTime, bv.ActivateAt) // Build variant activate time should use the version create time
-			s.Require().Len(bv.BatchTimeTasks, 2)
-			for _, t := range bv.BatchTimeTasks {
-				if t.TaskName == "task1" { // activate time is the version create time because there isn't a previous task
-					s.Equal(versionCreateTime, t.ActivateAt)
-				} else {
-					// ensure that "daily" cron is set for the next day
-					ty, tm, td := t.ActivateAt.Date()
-					s.Equal(y, ty)
-					s.Equal(m, tm)
-					s.Equal(d, td)
-				}
 			}
 		}
 		if bv.BuildVariant == "bv2" {


### PR DESCRIPTION
This reverts commit 47ed875edb4b27a101ed2f25dc64b67f7f841c1f.

DEVPROD-5857 (being reverted)
DEVPROD-7894 (fixed by reverting)

### Description
The gist is that when GitHub has an outage, it'll potentially be delayed giving us webhooks for new commits and their API won't tell us about new commits at all. That means that commits might not appear on the waterfall until well after they're committed. Before DEVPROD-5857, if it was late in picking up a commit, it would just schedule the next cron in the future. DEVPROD-5857 changed the cron behavior 

For example, let's say we have a cron that runs every 4 hours (12pm, 4pm, 8pm, etc.).
* Commit 1 is made at 10am and the repotracker picks it up at 10am. The cron run is scheduled for 12pm.
* Commit 2 is made at 11:30pm but GitHub fails to report it in the API initially (because it's having an outage).
* At 12 pm, the cron runs for commit 1. The next earliest time the same cron could run is 4pm.
* At 12:30 pm, the GitHub outage ends and the repotracker runs at 12:30pm and sees the missed commit 2.

So now the repotracker has two choices - it either can skip commit 2's cron entirely (something already ran at the 12pm time that it would have run), or schedule commit 2's cron for 4 pm. Before DEVPROD-5857, it would schedule commit 2's cron to run at 4pm. After that, it now schedules the cron to run at 12pm, which effectively means run it immediately at 12:30pm when it was picked up. It seems preferable to stick to the cron and run it at the next available time rather than run it immediately and break the cron schedule.

### Testing
Existing tests should pass.

### Documentation
N/A