### PR TITLE
DEVPROD-8514: reduce log level for invalid parser project

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1308,7 +1308,7 @@ func FindLatestVersionWithValidProject(projectId string, preGeneration bool) (*V
 		env := evergreen.GetEnvironment()
 		project, pp, err = FindAndTranslateProjectForVersion(ctx, env.Settings(), lastGoodVersion, preGeneration)
 		if err != nil {
-			grip.Critical(message.WrapError(err, message.Fields{
+			grip.Error(message.WrapError(err, message.Fields{
 				"message": "last known good version has malformed config",
 				"version": lastGoodVersion.Id,
 				"project": projectId,


### PR DESCRIPTION
DEVPROD-8514

### Description
If the most recent mainline commit has an invalid parser project, log an error so it's traceable but doesn't appear in our alerts.