### PR TITLE
DEVPROD-6000 Remove the github oauth token from tests 

### DIFF
--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -287,9 +287,6 @@ func (s *GitGetProjectSuite) TestGitPlugin() {
 	conf := s.taskConfig1
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
 	s.Require().NoError(err)
-	token, err := s.settings.GetGithubOauthToken()
-	s.Require().NoError(err)
-	conf.Expansions.Put("github", token)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -329,8 +326,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	conf.ProjectRef.Repo = "invalidRepo"
 	conf.Distro = nil
 	s.comm.CreateInstallationTokenFail = true
-	token, err := s.settings.GetGithubOauthToken()
-	s.Require().NoError(err)
+	token := "abcdefghij"
 	conf.Expansions.Put(evergreen.GlobalGitHubTokenExpansion, token)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -414,9 +410,7 @@ func (s *GitGetProjectSuite) TestValidateGitCommands() {
 	conf := s.taskConfig2
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
 	s.Require().NoError(err)
-	token, err := s.settings.GetGithubOauthToken()
-	s.Require().NoError(err)
-	conf.Expansions.Put(evergreen.GlobalGitHubTokenExpansion, token)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var pluginCmds []Command
@@ -787,9 +781,7 @@ func (s *GitGetProjectSuite) TestMultipleModules() {
 
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
 	s.Require().NoError(err)
-	token, err := s.settings.GetGithubOauthToken()
-	s.Require().NoError(err)
-	conf.Expansions.Put(evergreen.GlobalGitHubTokenExpansion, token)
+
 	var pluginCmds []Command
 
 	conf.Expansions.Put(moduleRevExpansionName("sample-1"), sample1Hash)

--- a/config_test.go
+++ b/config_test.go
@@ -70,25 +70,6 @@ func TestGetGithubSettings(t *testing.T) {
 	settings, err := NewSettings(filepath.Join(FindEvergreenHome(),
 		"testdata", "mci_settings.yml"))
 	assert.NoError(err)
-	assert.Empty(settings.Credentials["github"])
-
-	token, err := settings.GetGithubOauthToken()
-	assert.NoError(err)
-	assert.Empty(token)
-
-	settings, err = NewSettings(filepath.Join(FindEvergreenHome(),
-		"config_test", "evg_settings.yml"))
-	assert.NoError(err)
-	assert.NotNil(settings.Credentials["github"])
-
-	token, err = settings.GetGithubOauthString()
-	assert.NoError(err)
-	assert.Equal(settings.Credentials["github"], token)
-
-	settings.AuthConfig.Github = &GithubAuthConfig{
-		AppId: 0,
-	}
-	settings.Expansions[GithubAppPrivateKey] = ""
 
 	authFields := settings.CreateGitHubAppAuth()
 	assert.Nil(authFields)
@@ -105,15 +86,6 @@ func TestGetGithubSettings(t *testing.T) {
 	assert.NotNil(authFields)
 	assert.Equal(int64(1234), authFields.AppID)
 	assert.Equal([]byte("key"), authFields.PrivateKey)
-
-	assert.NotPanics(func() {
-		settings := &Settings{}
-		assert.Nil(settings.Credentials)
-
-		token, err = settings.GetGithubOauthToken()
-		assert.NoError(err)
-		assert.Empty(token)
-	})
 }
 
 type AdminSuite struct {

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -197,13 +197,11 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 	defer cancel()
 
 	testutil.ConfigureIntegrationTest(t, patchTestConfig, t.Name())
-	token, err := patchTestConfig.GetGithubOauthToken()
-	require.NoError(t, err)
 	Convey("With calling GetPatchedProject with a config and remote configuration path",
 		t, func() {
 			Convey("Calling GetPatchedProject returns a valid project given a patch and settings", func() {
 				configPatch := resetPatchSetup(ctx, t, remotePath)
-				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, token)
+				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, "")
 				So(err, ShouldBeNil)
 				So(project, ShouldNotBeNil)
 				So(patchConfig, ShouldNotBeNil)
@@ -211,7 +209,7 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 				So(patchConfig.PatchedParserProject, ShouldNotBeNil)
 
 				Convey("Calling GetPatchedProjectConfig should return the same project config as GetPatchedProject", func() {
-					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, token)
+					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, "")
 					So(err, ShouldBeNil)
 					So(projectConfig, ShouldEqual, patchConfig.PatchedProjectConfig)
 				})
@@ -235,7 +233,7 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 					So(patchConfigFromPatchAndDB.PatchedProjectConfig, ShouldEqual, patchConfig.PatchedProjectConfig)
 
 					Convey("Calling GetPatchedProjectConfig should return the same project config as GetPatchedProject", func() {
-						projectConfigFromPatch, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, token)
+						projectConfigFromPatch, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, "")
 						So(err, ShouldBeNil)
 						So(projectConfigFromPatch, ShouldEqual, patchConfig.PatchedProjectConfig)
 					})
@@ -244,13 +242,13 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 
 			Convey("Calling GetPatchedProject on a project-less version returns a valid project", func() {
 				configPatch := resetProjectlessPatchSetup(ctx, t)
-				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, token)
+				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, "")
 				So(err, ShouldBeNil)
 				So(patchConfig, ShouldNotBeEmpty)
 				So(project, ShouldNotBeNil)
 
 				Convey("Calling GetPatchedProjectConfig should return the same project config as GetPatchedProject", func() {
-					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, token)
+					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, "")
 					So(err, ShouldBeNil)
 					So(projectConfig, ShouldEqual, patchConfig.PatchedProjectConfig)
 				})
@@ -264,13 +262,13 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 				configPatch.Patches[0].PatchSet.Patch = ""
 				configPatch.Patches[0].PatchSet.PatchFileId = patchFileID.Hex()
 
-				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, token)
+				project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, configPatch, "")
 				So(err, ShouldBeNil)
 				So(patchConfig, ShouldNotBeEmpty)
 				So(project, ShouldNotBeNil)
 
 				Convey("Calling GetPatchedProjectConfig should return the same project config as GetPatchedProject", func() {
-					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, token)
+					projectConfig, err := GetPatchedProjectConfig(ctx, patchTestConfig, configPatch, "")
 					So(err, ShouldBeNil)
 					So(projectConfig, ShouldEqual, patchConfig.PatchedProjectConfig)
 				})
@@ -294,12 +292,9 @@ func TestFinalizePatch(t *testing.T) {
 	// first before any documents can be inserted.
 	require.NoError(t, db.CreateCollections(manifest.Collection, VersionCollection, ParserProjectCollection, ProjectConfigCollection))
 
-	token, err := patchTestConfig.GetGithubOauthToken()
-	require.NoError(t, err)
-
 	for name, test := range map[string]func(t *testing.T, p *patch.Patch, patchConfig *PatchConfig){
 		"VersionCreationWithParserProjectInDB": func(t *testing.T, p *patch.Patch, patchConfig *PatchConfig) {
-			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, token)
+			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, "")
 			require.NoError(t, err)
 			assert.NotNil(t, project)
 
@@ -309,7 +304,7 @@ func TestFinalizePatch(t *testing.T) {
 			p.ProjectStorageMethod = ppStorageMethod
 			require.NoError(t, p.Insert())
 
-			version, err := FinalizePatch(ctx, p, evergreen.PatchVersionRequester, token)
+			version, err := FinalizePatch(ctx, p, evergreen.PatchVersionRequester, "")
 			require.NoError(t, err)
 			assert.NotNil(t, version)
 			assert.Len(t, version.Parameters, 1)
@@ -353,7 +348,7 @@ func TestFinalizePatch(t *testing.T) {
 			p.ProjectStorageMethod = evergreen.ProjectStorageMethodDB
 			require.NoError(t, p.Insert())
 
-			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, token)
+			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, "")
 			require.NoError(t, err)
 			assert.NotNil(t, project)
 
@@ -369,7 +364,7 @@ func TestFinalizePatch(t *testing.T) {
 			_, err = baseManifest.TryInsert()
 			require.NoError(t, err)
 
-			version, err := FinalizePatch(ctx, p, evergreen.PatchVersionRequester, token)
+			version, err := FinalizePatch(ctx, p, evergreen.PatchVersionRequester, "")
 			require.NoError(t, err)
 			assert.NotNil(t, version)
 			// Ensure that the manifest was created and that auto_update worked for
@@ -393,13 +388,13 @@ func TestFinalizePatch(t *testing.T) {
 			p.VariantsTasks = []patch.VariantTasks{}
 			require.NoError(t, p.Insert())
 
-			_, err := FinalizePatch(ctx, p, evergreen.MergeTestRequester, token)
+			_, err := FinalizePatch(ctx, p, evergreen.MergeTestRequester, "")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "cannot finalize patch with no tasks")
 
 			// commit queue patch should fail with different error
 			p.Alias = evergreen.CommitQueueAlias
-			_, err = FinalizePatch(ctx, p, evergreen.MergeTestRequester, token)
+			_, err = FinalizePatch(ctx, p, evergreen.MergeTestRequester, "")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "no builds or tasks for commit queue version")
 		},
@@ -409,7 +404,7 @@ func TestFinalizePatch(t *testing.T) {
 			p.ProjectStorageMethod = evergreen.ProjectStorageMethodDB
 			require.NoError(t, p.Insert())
 
-			version, err := FinalizePatch(ctx, p, evergreen.GithubPRRequester, token)
+			version, err := FinalizePatch(ctx, p, evergreen.GithubPRRequester, "")
 			require.NoError(t, err)
 			assert.NotNil(t, version)
 			assert.Len(t, version.Parameters, 1)
@@ -436,7 +431,7 @@ func TestFinalizePatch(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := resetPatchSetup(ctx, t, remotePath)
 
-			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, token)
+			project, patchConfig, err := GetPatchedProject(ctx, patchTestConfig, p, "")
 			require.NoError(t, err)
 			assert.NotNil(t, project)
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -346,11 +346,7 @@ func TestPopulateExpansions(t *testing.T) {
 		Project:      "mci",
 	}
 
-	settings := &evergreen.Settings{
-		Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
-	}
-	oauthToken, err := settings.GetGithubOauthToken()
-	assert.NoError(err)
+	oauthToken := "globalGitHubOauthToken"
 	expansions, err := PopulateExpansions(taskDoc, &h, oauthToken, "appToken", "")
 	assert.NoError(err)
 	assert.Len(map[string]string(expansions), 25)

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -193,9 +193,7 @@ func TestCLIFetchSource(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(testTask, ShouldNotBeNil)
 
-		token, err := testConfig.GetGithubOauthToken()
-		So(err, ShouldBeNil)
-		err = fetchSource(ctx, ac, rc, comm, "", testTask.Id, token, false)
+		err = fetchSource(ctx, ac, rc, comm, "", testTask.Id, "", false)
 		So(err, ShouldBeNil)
 
 		fileStat, err := os.Stat("./source-patch-1_sample/README.md")

--- a/operations/fetch_test.go
+++ b/operations/fetch_test.go
@@ -12,8 +12,6 @@ import (
 func TestClone(t *testing.T) {
 	settings := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, settings, "TestClone")
-	token, err := settings.GetGithubOauthToken()
-	assert.NoError(t, err)
 
 	type testCase struct {
 		opts      cloneOptions
@@ -26,21 +24,18 @@ func TestClone(t *testing.T) {
 			repository: "sample",
 			revision:   "cf46076567e4949f9fc68e0634139d4ac495c89b",
 			branch:     "main",
-			token:      token,
 		}},
 		"InvalidRepo": {isPassing: false, opts: cloneOptions{
 			owner:      "evergreen-ci",
 			repository: "foo",
 			revision:   "cf46076567e4949f9fc68e0634139d4ac495c89b",
 			branch:     "main",
-			token:      token,
 		}},
 		"InvalidRevision": {isPassing: false, opts: cloneOptions{
 			owner:      "evergreen-ci",
 			repository: "sample",
 			revision:   "9999999999999999999999999999999999999999",
 			branch:     "main",
-			token:      token,
 		}},
 		"InvalidToken": {isPassing: false, opts: cloneOptions{
 			owner:      "10gen",

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -296,9 +296,6 @@ func TestGetChangedFiles(t *testing.T) {
 
 	Convey("When fetching changed files from evergreen-ci/evergreen ", t, func() {
 		grp.ProjectRef = evgProjectRef
-		token, err := testConfig.GetGithubOauthToken()
-		So(err, ShouldBeNil)
-		grp.OauthToken = token
 
 		r1 := "b11fcb25624c6a0649dd35b895f5b550d649a128"
 		Convey("the revision "+r1+" should have 8 files", func() {

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -31,16 +31,13 @@ func TestFetchRevisions(t *testing.T) {
 	dropTestDB(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 	defer cancel()
-	Convey("With a GithubRepositoryPoller with a valid OAuth token...", t, func() {
+	Convey("With a GithubRepositoryPoller", t, func() {
 		err := modelutil.CreateTestLocalConfig(testConfig, "mci-test", "")
-		So(err, ShouldBeNil)
-		token, err := testConfig.GetGithubOauthToken()
 		So(err, ShouldBeNil)
 
 		resetProjectRefs()
-
+		token := ""
 		repoTracker := RepoTracker{
 			testConfig,
 			evgProjectRef,
@@ -63,6 +60,7 @@ func TestFetchRevisions(t *testing.T) {
 
 		Convey("Only get 2 revisions from the given repository if given a "+
 			"limit of 2 commits where 3 exist", func() {
+			testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 			testConfig.RepoTracker.NumNewRepoRevisionsToFetch = 2
 			require.NoError(t, repoTracker.FetchRevisions(ctx),
 				"Error running repository process %s", repoTracker.Settings.Id)
@@ -97,6 +95,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 		Convey("On storing a single repo revision, we expect a version to be created"+
 			" in the database for this project, which should be retrieved when we search"+
 			" for this project's most recent version", func() {
+			testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 			createTime := time.Now()
 			revisionOne := *createTestRevision("1d97b5e8127a684f341d9fea5b3a2848f075c3b0", createTime)
 			revisions := []model.Revision{revisionOne}
@@ -112,6 +111,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 
 		Convey("On storing several repo revisions, we expect a version to be created "+
 			"for each revision", func() {
+			testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 			createTime := time.Now()
 			laterCreateTime := createTime.Add(4 * time.Hour)
 
@@ -134,6 +134,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 			So(versionTwo.AuthorID, ShouldEqual, "")
 		})
 		Convey("if an evergreen user can be associated with the commit, record it", func() {
+			testutil.ConfigureIntegrationTest(t, testConfig, t.Name())
 			revisionOne := *createTestRevision("1d97b5e8127a684f341d9fea5b3a2848f075c3b0", time.Now())
 			revisions := []model.Revision{revisionOne}
 			revisions[0].AuthorGithubUID = 1234

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -95,11 +95,11 @@ func TestMetadataFromArgsWithoutVersion(t *testing.T) {
 func TestMakeDownstreamConfigFromFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
 	assert := assert.New(t)
+	assert.NoError(db.ClearCollections(evergreen.ConfigCollection))
+
 	testConfig := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestMakeDownstreamConfigFromFile")
-	assert.NoError(db.ClearCollections(evergreen.ConfigCollection))
 	assert.NoError(testConfig.Set(ctx))
 
 	ref := model.ProjectRef{

--- a/units/commit_queue_test.go
+++ b/units/commit_queue_test.go
@@ -360,9 +360,6 @@ func (s *commitQueueSuite) TestSetDefaultNotification() {
 }
 
 func (s *commitQueueSuite) TestUpdatePatch() {
-	githubToken, err := s.settings.GetGithubOauthToken()
-	s.NoError(err)
-
 	projectRef := &model.ProjectRef{
 		Id:         "evergreen",
 		Owner:      "evergreen-ci",
@@ -383,8 +380,8 @@ func (s *commitQueueSuite) TestUpdatePatch() {
 			{Variant: "my-variant", Tasks: []string{"my-task"}},
 		},
 	}
-
-	projectConfig, pp, err := updatePatch(s.ctx, s.settings, githubToken, projectRef, patchDoc)
+	testutil.ConfigureIntegrationTest(s.T(), s.settings, s.T().Name())
+	projectConfig, pp, err := updatePatch(s.ctx, s.settings, "", projectRef, patchDoc)
 	s.NoError(err)
 	s.NotEqual("abcdef", patchDoc.Patches[0].Githash)
 	s.NotEqual(model.Project{}, projectConfig)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -261,6 +261,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithNoTasksAndVariants() {
 	s.Require().NotNil(intent)
 	s.NoError(intent.Insert())
 
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	j := NewPatchIntentProcessor(s.env, mgobson.NewObjectId(), intent).(*patchIntentProcessor)
 	j.env = s.env
 
@@ -290,6 +291,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithBadAlias() {
 	s.Require().NotNil(intent)
 	s.NoError(intent.Insert())
 
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	j := NewPatchIntentProcessor(s.env, mgobson.NewObjectId(), intent).(*patchIntentProcessor)
 	j.env = s.env
 
@@ -324,7 +326,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVari
 	s.NoError(err)
 	s.Require().NotNil(intent)
 	s.NoError(intent.Insert())
-
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	j := NewPatchIntentProcessor(s.env, mgobson.NewObjectId(), intent).(*patchIntentProcessor)
 	j.env = s.env
 
@@ -1055,6 +1057,7 @@ func (s *PatchIntentUnitsSuite) TestBuildTasksAndVariantsWithReusePatchId() {
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	headRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
 	orgName := "evergreen-ci"
 	repoName := "commit-queue-sandbox"
@@ -1147,6 +1150,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 		Number:         github.Int(1),
 		MergeCommitSHA: github.String("abcdef"),
 	}
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	// SHA ed42b5e51e81724c5258686a0b9d515a99696eac is newer than the oldest allowed merge base and should be accepted
 	intent, err := patch.NewGithubIntent("id", "auto", "", "", "ed42b5e51e81724c5258686a0b9d515a99696eac", pr)
 
@@ -1172,15 +1176,13 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
-	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
-	s.Require().NoError(err)
-
 	flags := evergreen.ServiceFlags{
 		GithubPRTestingDisabled: true,
 	}
 	s.NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, githubOauthToken, s.githubPatchData)
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, "", s.githubPatchData)
 	s.Require().NoError(err)
 	s.Require().Len(summaries, 2)
 	s.NotEmpty(patchContent)
@@ -1240,15 +1242,14 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntentWithoutFinalizing() {
-	githubOauthToken, err := s.env.Settings().GetGithubOauthToken()
-	s.Require().NoError(err)
-
 	flags := evergreen.ServiceFlags{
 		GithubPRTestingDisabled: true,
 	}
 	s.NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, githubOauthToken, s.githubPatchData)
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
+
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, "", s.githubPatchData)
 	s.Require().NoError(err)
 	s.Require().Len(summaries, 2)
 	s.NotEmpty(patchContent)
@@ -1457,6 +1458,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	}
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	intent, err := patch.NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
@@ -1542,6 +1544,7 @@ func (s *PatchIntentUnitsSuite) TestCliBackport() {
 	s.NotNil(intent)
 	s.NoError(intent.Insert())
 
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
 	id := mgobson.NewObjectId()
 	j, ok := NewPatchIntentProcessor(s.env, id, intent).(*patchIntentProcessor)
 	j.env = s.env


### PR DESCRIPTION
DEVPROD-6000

### Description
This removes the reliance on the github oauth token in tests. The smoke test will be done separately in [DEVPROD-5999](https://jira.mongodb.org/browse/DEVPROD-5999) and agent-command will be done separately in [DEVPROD-8701](https://jira.mongodb.org/browse/DEVPROD-8701). 

### Testing
yes 
