### PR TITLE
docs: mention time zone from Spruce preferences for sleep schedule

### DIFF
--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -189,6 +189,13 @@ Host <your_persistent_dns_name>
     Hostname <your_persistent_dns_name>
 ```
 
+**Q: How do I choose the time zone when setting a sleep schedule?**
+
+A: The time zone is automatically inherited from the time zone in your [Spruce user preferences](https://spruce.mongodb.com/preferences/profile).
+If you'd like to change your sleep schedule's time zone, update your time zone under your Spruce preferences, then edit
+the host to set a sleep schedule. Note that updating just the Spruce preference will _not_ automatically update your
+sleep schedule's time zone until [DEVPROD-8685](https://jira.mongodb.org/browse/DEVPROD-8685) is complete.
+
 ---
 
 ### Option 2: Host Auto-Sleep Script {#host-auto-sleep-script}


### PR DESCRIPTION
Came up in a [Slack question](https://mongodb.slack.com/archives/C0V896UV8/p1720447304187349).