### PR TITLE
DEVPROD-8736 rename the redaction log for the token oauth --> github

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -237,7 +237,7 @@ func (opts cloneOpts) buildHTTPCloneCommand(forApp bool) ([]string, error) {
 		clone = fmt.Sprintf("%s --branch '%s'", clone, opts.branch)
 	}
 
-	redactedClone := strings.Replace(clone, opts.token, "[redacted oauth token]", -1)
+	redactedClone := strings.Replace(clone, opts.token, "[redacted github token]", -1)
 	return []string{
 		"set +o xtrace",
 		fmt.Sprintf(`echo %s`, strconv.Quote(redactedClone)),
@@ -546,7 +546,7 @@ func (c *gitFetchProject) fetchSource(ctx context.Context,
 		logger.Execution().Info("Fetching source from git...")
 		redactedCmds := fetchScript
 		if opts.token != "" {
-			redactedCmds = strings.Replace(redactedCmds, opts.token, "[redacted oauth token]", -1)
+			redactedCmds = strings.Replace(redactedCmds, opts.token, "[redacted github token]", -1)
 		}
 		logger.Execution().Debugf("Commands are: %s", redactedCmds)
 
@@ -563,7 +563,7 @@ func (c *gitFetchProject) fetchSource(ctx context.Context,
 		out := stdErr.String()
 		if out != "" {
 			if opts.token != "" {
-				out = strings.Replace(out, opts.token, "[redacted oauth token]", -1)
+				out = strings.Replace(out, opts.token, "[redacted github token]", -1)
 			}
 			logger.Execution().Error(out)
 		}
@@ -787,7 +787,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		errOutput := stdErr.String()
 		if errOutput != "" {
 			if opts.token != "" {
-				errOutput = strings.Replace(errOutput, opts.token, "[redacted oauth token]", -1)
+				errOutput = strings.Replace(errOutput, opts.token, "[redacted github token]", -1)
 			}
 			logger.Execution().Error(fmt.Sprintf("%s: %s", module.Name, errOutput))
 		}

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -167,7 +167,7 @@ func (c *gitPush) pushPatch(ctx context.Context, logger client.LoggerProducer, p
 	errorOutput := stdErr.String()
 	if errorOutput != "" {
 		if p.token != "" {
-			errorOutput = strings.Replace(errorOutput, p.token, "[redacted oauth token]", -1)
+			errorOutput = strings.Replace(errorOutput, p.token, "[redacted github token]", -1)
 		}
 		logger.Execution().Error(errorOutput)
 	}

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -161,7 +161,7 @@ func TestGitPush(t *testing.T) {
 
 			assert.NoError(t, logger.Close())
 			lines := comm.GetTaskLogs("")
-			assert.Equal(t, "The key: [redacted oauth token]", lines[len(lines)-1].Data)
+			assert.Equal(t, "The key: [redacted github token]", lines[len(lines)-1].Data)
 		},
 		"RevParse": func(*testing.T) {
 			manager := &mock.Manager{}

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -347,7 +347,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	foundCloneCommand := false
 	foundCloneErr := false
 	for _, line := range s.comm.GetTaskLogs(conf.Task.Id) {
-		if strings.Contains(line.Data, "https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/invalidRepo.git") {
+		if strings.Contains(line.Data, "https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/invalidRepo.git") {
 			foundCloneCommand = true
 		}
 		if strings.Contains(line.Data, "Repository not found.") {
@@ -458,7 +458,7 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 		"set -o xtrace",
 		"cd dir",
@@ -470,7 +470,7 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir'",
 		"set -o xtrace",
 		"cd dir",
@@ -484,7 +484,7 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 	}))
 
@@ -495,7 +495,7 @@ func (s *GitGetProjectSuite) TestBuildHTTPCloneCommand() {
 	s.NoError(err)
 	s.Require().Len(cmds, 5)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@someothergithost.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 	}))
 }
@@ -532,7 +532,7 @@ func (s *GitGetProjectSuite) TestBuildSourceCommand() {
 		"set -o errexit",
 		"rm -rf dir",
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'dir' --branch 'main'",
 		"set -o xtrace",
 		"cd dir",
@@ -652,7 +652,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 		"set -o xtrace",
 		"set -o errexit",
 		"set +o xtrace",
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'",
 		"set -o xtrace",
 		"cd module",
@@ -665,7 +665,7 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	s.NoError(err)
 	s.Require().Len(cmds, 8)
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
-		"echo \"git clone https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'\"",
+		"echo \"git clone https://[redacted github token]:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'\"",
 		"git clone https://PROJECTTOKEN:x-oauth-basic@github.com/evergreen-ci/sample.git 'module'",
 	}))
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-07-01"
+	AgentVersion = "2024-07-09"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-8736

### Description
After https://github.com/evergreen-ci/evergreen/pull/7146 the token we are redacting is an app token not an oauth token. I didn't capitalized github because it will show up as part of the url like so: 

 https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/evergreen.git 


