### PR TITLE
DEVPROD-6001 Use github.generate_token rather than global github_token expansion

### DIFF
--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -326,7 +326,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	conf.ProjectRef.Repo = "invalidRepo"
 	conf.Distro = nil
 	token := "abcdefghij"
-	s.comm.CreateInstallationTokenResult = "unauthed-token"
+	s.comm.CreateInstallationTokenResult = token
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -326,8 +326,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	conf.ProjectRef.Repo = "invalidRepo"
 	conf.Distro = nil
 	token := "abcdefghij"
-	conf.Expansions.Put(evergreen.GlobalGitHubTokenExpansion, token)
-	s.comm.CreateInstallationTokenResult = token
+	s.comm.CreateInstallationTokenResult = "unauthed-token"
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -369,7 +369,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
 	s.Require().NoError(err)
 	conf.ProjectRef.Repo = "invalidRepo"
-	s.comm.CreateInstallationTokenResult = conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion)
+	s.comm.CreateInstallationTokenResult = "unauthed-token"
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -325,9 +325,9 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 	s.Require().NoError(err)
 	conf.ProjectRef.Repo = "invalidRepo"
 	conf.Distro = nil
-	s.comm.CreateInstallationTokenFail = true
 	token := "abcdefghij"
 	conf.Expansions.Put(evergreen.GlobalGitHubTokenExpansion, token)
+	s.comm.CreateInstallationTokenResult = token
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -350,7 +350,7 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 		if strings.Contains(line.Data, "https://[redacted oauth token]:x-oauth-basic@github.com/evergreen-ci/invalidRepo.git") {
 			foundCloneCommand = true
 		}
-		if strings.Contains(line.Data, "Repository not found.") {
+		if strings.Contains(line.Data, "Authentication failed for") {
 			foundCloneErr = true
 		}
 		if strings.Contains(line.Data, token) {
@@ -369,7 +369,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
 	s.Require().NoError(err)
 	conf.ProjectRef.Repo = "invalidRepo"
-	s.comm.CreateInstallationTokenFail = true
+	s.comm.CreateInstallationTokenResult = conf.Expansions.Get(evergreen.GlobalGitHubTokenExpansion)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -396,7 +396,7 @@ func (s *GitGetProjectSuite) TestStdErrLogged() {
 		if strings.Contains(line.Data, "/invalidRepo.git/' not found") {
 			foundCloneErr = true
 		}
-		if strings.Contains(line.Data, "Permission denied (publickey)") || strings.Contains(line.Data, "Host key verification failed.") {
+		if strings.Contains(line.Data, "Authentication failed for") && strings.Contains(line.Data, "/evergreen-ci/invalidRepo.git") {
 			foundSSHErr = true
 		}
 	}

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -343,6 +343,9 @@ func (c *Mock) GetLoggerProducer(ctx context.Context, tsk *task.Task, _ *LoggerC
 	// in tests, otherwise the append line function will try to access the
 	// task ID in the task pointer every time `sendTaskLogLine` is called.
 	taskID := tsk.Id
+
+	// Every time we make a new producer, we should flush it between tests.
+	c.flushTaskLog(taskID)
 	appendLine := func(line log.LogLine) error {
 		return c.sendTaskLogLine(taskID, line)
 	}
@@ -362,6 +365,14 @@ func (c *Mock) sendTaskLogLine(taskID string, line log.LogLine) error {
 	c.taskLogs[taskID] = append(c.taskLogs[taskID], line)
 
 	return nil
+}
+
+// flushTaskLog clears the log cache for a given task.
+func (c *Mock) flushTaskLog(taskID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.taskLogs[taskID] = []log.LogLine{}
 }
 
 func (c *Mock) GetTaskLogs(taskID string) []log.LogLine {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-07-01"
+	AgentVersion = "2024-07-10"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -18,7 +18,7 @@ domain_name: "evergreen.local"
 
 configdir: "config_test"
 credentials: {
-  github: "$GITHUB_TOKEN",
+  github: "token $GITHUB_TOKEN",
 }
 
 api_url: http://localhost:9090

--- a/scripts/setup-smoke-config.sh
+++ b/scripts/setup-smoke-config.sh
@@ -6,7 +6,7 @@ set -o errexit
 mkdir -p clients
 cat >> smoke/internal/testdata/admin_settings.yml <<EOF
 credentials:
-  github: "$GITHUB_TOKEN"
+  github: "token $GITHUB_TOKEN"
 
 auth:
   naive:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -98,6 +98,9 @@ variables:
       - func: setup-credentials
       - func: run-make
         vars: { target: "load-smoke-data" }
+      - command: github.generate_token
+        params:
+          expansion_name: github_token_new
       - command: subprocess.exec
         params:
           silent: true
@@ -105,7 +108,7 @@ variables:
           env:
             GITHUB_APP_ID: ${staging_github_app_id}
             GITHUB_APP_KEY: ${staging_github_app_key}
-            GITHUB_TOKEN: ${github_token}
+            GITHUB_TOKEN: ${github_token_new}
           command: bash scripts/setup-smoke-config.sh
       - func: run-make
         vars: { target: "set-smoke-vars" }
@@ -185,11 +188,14 @@ variables:
 #######################################
 functions:
   get-project-and-modules:
+    - command: github.generate_token
+      params:
+        expansion_name: github_token_new
     - command: git.get_project
       type: setup
       params:
         directory: evergreen
-        token: ${github_token}
+        token: ${github_token_new}
         shallow_clone: true
     - command: shell.exec
       type: setup
@@ -270,7 +276,6 @@ functions:
         silent: true
         working_dir: evergreen
         env:
-          GITHUB_TOKEN: ${github_token}
           GITHUB_APP_ID: ${staging_github_app_id}
           GITHUB_APP_KEY: ${staging_github_app_key}
           JIRA_SERVER: ${jiraserver}
@@ -594,11 +599,14 @@ tasks:
   - name: test-repotracker
     tags: ["db", "test"]
     commands:
+      - command: github.generate_token
+        params:
+          expansion_name: github_token_new
       - command: git.get_project
         type: setup
         params:
           directory: evergreen
-          token: ${github_token}
+          token: ${github_token_new}
           shallow_clone: false
       - func: setup-credentials
       - func: setup-mongodb
@@ -648,11 +656,14 @@ tasks:
   - name: verify-mod-tidy
     tags: ["linter"]
     commands:
+      - command: github.generate_token
+        params:
+          expansion_name: github_token_new
       - command: git.get_project
         type: setup
         params:
           directory: evergreen
-          token: ${github_token}
+          token: ${github_token_new}
       - func: run-make
         vars: { target: "${task_name}" }
   - name: verify-merge-function-update

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -270,12 +270,16 @@ functions:
         EVG_CLIENT_S3_BUCKET: evg-bucket-evergreen
 
   setup-credentials:
+    - command: github.generate_token
+      params:
+        expansion_name: github_token_new
     - command: subprocess.exec
       type: setup
       params:
         silent: true
         working_dir: evergreen
         env:
+          GITHUB_TOKEN: ${github_token_new}
           GITHUB_APP_ID: ${staging_github_app_id}
           GITHUB_APP_KEY: ${staging_github_app_key}
           JIRA_SERVER: ${jiraserver}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -100,7 +100,7 @@ variables:
         vars: { target: "load-smoke-data" }
       - command: github.generate_token
         params:
-          expansion_name: github_token_new
+          expansion_name: github_token
       - command: subprocess.exec
         params:
           silent: true
@@ -108,7 +108,7 @@ variables:
           env:
             GITHUB_APP_ID: ${staging_github_app_id}
             GITHUB_APP_KEY: ${staging_github_app_key}
-            GITHUB_TOKEN: ${github_token_new}
+            GITHUB_TOKEN: ${github_token}
           command: bash scripts/setup-smoke-config.sh
       - func: run-make
         vars: { target: "set-smoke-vars" }
@@ -190,12 +190,12 @@ functions:
   get-project-and-modules:
     - command: github.generate_token
       params:
-        expansion_name: github_token_new
+        expansion_name: github_token
     - command: git.get_project
       type: setup
       params:
         directory: evergreen
-        token: ${github_token_new}
+        token: ${github_token}
         shallow_clone: true
     - command: shell.exec
       type: setup
@@ -272,14 +272,14 @@ functions:
   setup-credentials:
     - command: github.generate_token
       params:
-        expansion_name: github_token_new
+        expansion_name: github_token
     - command: subprocess.exec
       type: setup
       params:
         silent: true
         working_dir: evergreen
         env:
-          GITHUB_TOKEN: ${github_token_new}
+          GITHUB_TOKEN: ${github_token}
           GITHUB_APP_ID: ${staging_github_app_id}
           GITHUB_APP_KEY: ${staging_github_app_key}
           JIRA_SERVER: ${jiraserver}
@@ -605,12 +605,12 @@ tasks:
     commands:
       - command: github.generate_token
         params:
-          expansion_name: github_token_new
+          expansion_name: github_token
       - command: git.get_project
         type: setup
         params:
           directory: evergreen
-          token: ${github_token_new}
+          token: ${github_token}
           shallow_clone: false
       - func: setup-credentials
       - func: setup-mongodb
@@ -662,12 +662,12 @@ tasks:
     commands:
       - command: github.generate_token
         params:
-          expansion_name: github_token_new
+          expansion_name: github_token
       - command: git.get_project
         type: setup
         params:
           directory: evergreen
-          token: ${github_token_new}
+          token: ${github_token}
       - func: run-make
         vars: { target: "${task_name}" }
   - name: verify-merge-function-update


### PR DESCRIPTION
DEVPROD-6001

### Description
This converts all tests (include smoke tests)

### Testing
[This commit](https://spruce.mongodb.com/version/668eadc8dff1e40007f45b06/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) was ran with all the changes (except the config.go agent version update) with a different named token to make sure it is using the new token and not the existing one.