### PR TITLE
DEVPROD-6072 Add new degraded mode associated limits

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -38,6 +38,9 @@ type TaskLimitsConfig struct {
 
 	// MaxDegradedModeParserProjectSize is the maximum parser project size during CPU degraded mode.
 	MaxDegradedModeParserProjectSize int `bson:"max_degraded_mode_parser_project_size" json:"max_degraded_mode_parser_project_size" yaml:"max_degraded_mode_parser_project_size"`
+
+	// MaxParserProjectSize is the maximum allowed parser project size.
+	MaxParserProjectSize int `bson:"max_parser_project_size" json:"max_parser_project_size" yaml:"max_parser_project_size"`
 }
 
 var (
@@ -48,6 +51,7 @@ var (
 	maxGenerateTaskJSONSize              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
 	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
 	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
+	maxParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -79,6 +83,7 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			maxGenerateTaskJSONSize:              c.MaxGenerateTaskJSONSize,
 			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
 			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
+			maxParserProjectSize:                 c.MaxParserProjectSize,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -32,14 +32,22 @@ type TaskLimitsConfig struct {
 
 	// MaxGenerateTaskJSONSize is the maximum size of a JSON file in MB that can be specified in the GenerateTasks command.
 	MaxGenerateTaskJSONSize int `bson:"max_generate_task_json_size" json:"max_generate_task_json_size" yaml:"max_generate_task_json_size"`
+
+	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once.
+	MaxConcurrentLargeParserProjectTasks int `bson:"max_concurrent_large_parser_project_tasks" json:"max_concurrent_large_parser_project_tasks" yaml:"max_concurrent_large_parser_project_tasks"`
+
+	// MaxDegradedModeParserProjectSize is the maximum parser project size during CPU degraded mode.
+	MaxDegradedModeParserProjectSize int `bson:"max_degraded_mode_parser_project_size" json:"max_degraded_mode_parser_project_size" yaml:"max_degraded_mode_parser_project_size"`
 }
 
 var (
-	maxTasksPerVersionKey    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
-	maxIncludesPerVersionKey = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
-	maxHourlyPatchTasksKey   = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
-	maxPendingGeneratedTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
-	maxGenerateTaskJSONSize  = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
+	maxTasksPerVersionKey                = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxIncludesPerVersionKey             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
+	maxHourlyPatchTasksKey               = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
+	maxPendingGeneratedTasks             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
+	maxGenerateTaskJSONSize              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
+	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
+	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -64,11 +72,13 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey:    c.MaxTasksPerVersion,
-			maxIncludesPerVersionKey: c.MaxIncludesPerVersion,
-			maxPendingGeneratedTasks: c.MaxPendingGeneratedTasks,
-			maxHourlyPatchTasksKey:   c.MaxHourlyPatchTasks,
-			maxGenerateTaskJSONSize:  c.MaxGenerateTaskJSONSize,
+			maxTasksPerVersionKey:                c.MaxTasksPerVersion,
+			maxIncludesPerVersionKey:             c.MaxIncludesPerVersion,
+			maxPendingGeneratedTasks:             c.MaxPendingGeneratedTasks,
+			maxHourlyPatchTasksKey:               c.MaxHourlyPatchTasks,
+			maxGenerateTaskJSONSize:              c.MaxGenerateTaskJSONSize,
+			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
+			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -12,6 +12,9 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+// sizeLimit is a hard limit on parser project size.
+const sizeLimit = 1024 * 1024 * 50
+
 // ParserProjectS3Storage implements the ParserProjectStorage interface to
 // access parser projects stored in S3.
 type ParserProjectS3Storage struct {
@@ -75,7 +78,10 @@ func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProjec
 	if err != nil {
 		return errors.Wrapf(err, "marshalling parser project '%s' to BSON", pp.Id)
 	}
-
+	parserProjectLen := len(bsonPP)
+	if parserProjectLen > sizeLimit {
+		return errors.Errorf("parser project exceeds the system limit (%v > %v bytes).", parserProjectLen, sizeLimit)
+	}
 	return s.UpsertOneBSON(ctx, pp.Id, bsonPP)
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2693,11 +2693,13 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion       *int `json:"max_tasks_per_version"`
-	MaxIncludesPerVersion    *int `json:"max_includes_per_version"`
-	MaxHourlyPatchTasks      *int `json:"max_hourly_patch_tasks"`
-	MaxPendingGeneratedTasks *int `json:"max_pending_generated_tasks"`
-	MaxGenerateTaskJSONSize  *int `json:"max_generate_task_json_size"`
+	MaxTasksPerVersion                   *int `json:"max_tasks_per_version"`
+	MaxIncludesPerVersion                *int `json:"max_includes_per_version"`
+	MaxHourlyPatchTasks                  *int `json:"max_hourly_patch_tasks"`
+	MaxPendingGeneratedTasks             *int `json:"max_pending_generated_tasks"`
+	MaxGenerateTaskJSONSize              *int `json:"max_generate_task_json_size"`
+	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
+	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2708,6 +2710,8 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxPendingGeneratedTasks = utility.ToIntPtr(v.MaxPendingGeneratedTasks)
 		c.MaxHourlyPatchTasks = utility.ToIntPtr(v.MaxHourlyPatchTasks)
 		c.MaxGenerateTaskJSONSize = utility.ToIntPtr(v.MaxGenerateTaskJSONSize)
+		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
+		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2716,11 +2720,13 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion:       utility.FromIntPtr(c.MaxTasksPerVersion),
-		MaxIncludesPerVersion:    utility.FromIntPtr(c.MaxIncludesPerVersion),
-		MaxHourlyPatchTasks:      utility.FromIntPtr(c.MaxHourlyPatchTasks),
-		MaxPendingGeneratedTasks: utility.FromIntPtr(c.MaxPendingGeneratedTasks),
-		MaxGenerateTaskJSONSize:  utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
+		MaxTasksPerVersion:                   utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxIncludesPerVersion:                utility.FromIntPtr(c.MaxIncludesPerVersion),
+		MaxHourlyPatchTasks:                  utility.FromIntPtr(c.MaxHourlyPatchTasks),
+		MaxPendingGeneratedTasks:             utility.FromIntPtr(c.MaxPendingGeneratedTasks),
+		MaxGenerateTaskJSONSize:              utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
+		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
+		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
 	}, nil
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2700,6 +2700,7 @@ type APITaskLimitsConfig struct {
 	MaxGenerateTaskJSONSize              *int `json:"max_generate_task_json_size"`
 	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
 	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
+	MaxParserProjectSize                 *int `json:"max_parser_project_size"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2712,6 +2713,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxGenerateTaskJSONSize = utility.ToIntPtr(v.MaxGenerateTaskJSONSize)
 		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
 		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
+		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2727,6 +2729,7 @@ func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 		MaxGenerateTaskJSONSize:              utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
 		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
 		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
+		MaxParserProjectSize:                 utility.FromIntPtr(c.MaxParserProjectSize),
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -630,6 +630,14 @@ Admin Settings
 										<label>Generate Task JSON Limit (MB)</label>
 										<input type="number" ng-model="Settings.task_limits.max_generate_task_json_size">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>CPU Degraded Mode Parser Project Limit (MB)</label>
+										<input type="number" ng-model="Settings.task_limits.max_degraded_mode_parser_project_size">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Concurrent Large Parser Project Tasks</label>
+										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -639,7 +639,7 @@ Admin Settings
 										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Max Parser Project Size</label>
+										<label>Max Parser Project Size (MB)</label>
 										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
 									</md-input-container>
 								</md-card-content>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -638,6 +638,10 @@ Admin Settings
 										<label>Max Concurrent Large Parser Project Tasks</label>
 										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Parser Project Size</label>
+										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>


### PR DESCRIPTION
DEVPROD-6072

### Description

- Add two new task limits, one for the maximum number of large parser project tasks that can be concurrently running, and one for the maximum parser project size when degraded mode is enabled, per the two action items of the recent [engineering proposal](https://docs.google.com/document/d/1tC7rTIPb_VXld_iGn8jWgrWjJnrHNrka0rmevAgnlO0/edit#heading=h.gkhozkfcr28v).
- Introduce a parser project size hard cap for when large parser projects do get enabled.

There will be a followup PR that makes use of these two new limits.

### Testing
Existing
