### PR TITLE
DEVPROD-8038 get parameters from parameter store

### DIFF
--- a/config_splunk.go
+++ b/config_splunk.go
@@ -3,11 +3,10 @@ package evergreen
 import (
 	"context"
 
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type SplunkConfig struct {
@@ -17,32 +16,16 @@ type SplunkConfig struct {
 func (c *SplunkConfig) SectionId() string { return "splunk" }
 
 func (c *SplunkConfig) Get(ctx context.Context) error {
-	res := GetEnvironment().DB().Collection(ConfigCollection).FindOne(ctx, byId(c.SectionId()))
-	if err := res.Err(); err != nil {
-		if err != mongo.ErrNoDocuments {
-			return errors.Wrapf(err, "getting config section '%s'", c.SectionId())
-		}
-		*c = SplunkConfig{}
-		return nil
-	}
-
-	if err := res.Decode(&c); err != nil {
-		return errors.Wrapf(err, "decoding config section '%s'", c.SectionId())
-	}
-
-	return nil
+	// SSM parameters may not be available such as when running locally.
+	grip.Error(message.WrapError(decodeParameter(ctx, c), message.Fields{
+		"section_id": c.SectionId(),
+		"message":    "getting config section from SSM",
+	}))
+	return errors.Wrapf(decodeDBConfig(ctx, c), "getting config section '%s' from the database", c.SectionId())
 }
 
 func (c *SplunkConfig) Set(ctx context.Context) error {
-	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
-		"$set": bson.M{
-			"url":     c.SplunkConnectionInfo.ServerURL,
-			"token":   c.SplunkConnectionInfo.Token,
-			"channel": c.SplunkConnectionInfo.Channel,
-		},
-	}, options.Update().SetUpsert(true))
-
-	return errors.Wrapf(err, "updating config section '%s'", c.SectionId())
+	return errors.Wrapf(setParameter(ctx, c), "setting config section '%s'", c.SectionId())
 }
 
 func (c *SplunkConfig) ValidateAndDefault() error { return nil }

--- a/config_ssm.go
+++ b/config_ssm.go
@@ -1,0 +1,110 @@
+package evergreen
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/pkg/errors"
+)
+
+var (
+	awsConfig     *aws.Config
+	parameterPath = os.Getenv("SSM_PARAMETER_PATH")
+)
+
+func getClient(ctx context.Context) (*ssm.Client, error) {
+	if awsConfig == nil {
+		config, err := config.LoadDefaultConfig(ctx,
+			config.WithRegion(DefaultEC2Region),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "loading AWS config")
+		}
+
+		awsConfig = &config
+	}
+
+	return ssm.NewFromConfig(*awsConfig), nil
+}
+
+func getAllParameters(ctx context.Context) (map[string]string, error) {
+	if parameterPath == "" {
+		return nil, errors.New("parameter path is not set")
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting SSM client")
+	}
+
+	res, err := client.GetParametersByPath(ctx, &ssm.GetParametersByPathInput{
+		Path:           aws.String(parameterPath),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting parameters")
+	}
+
+	params := make(map[string]string)
+	for _, param := range res.Parameters {
+		if param.Name == nil && param.Value == nil {
+			continue
+		}
+		sectionID, _ := strings.CutPrefix(*param.Name, parameterPath)
+		params[sectionID] = *param.Value
+	}
+	return params, nil
+}
+
+func decodeParameter(ctx context.Context, target ConfigSection) error {
+	if parameterPath == "" {
+		return errors.New("parameter path is not set")
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting SSM client")
+	}
+
+	res, err := client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(fmt.Sprintf("%s%s", parameterPath, target.SectionId())),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "getting parameter '%s'", target.SectionId())
+	}
+	if res.Parameter.Value == nil {
+		return errors.Errorf("parameter value is nil for '%s'", target.SectionId())
+	}
+
+	return errors.Wrapf(json.Unmarshal([]byte(*res.Parameter.Value), target), "unmarshalling parameter '%s'", target.SectionId())
+}
+
+func setParameter(ctx context.Context, input ConfigSection) error {
+	if parameterPath == "" {
+		return errors.New("parameter path is not set")
+	}
+
+	client, err := getClient(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting config")
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		return errors.Wrap(err, "marshalling input as json")
+	}
+	_, err = client.PutParameter(ctx, &ssm.PutParameterInput{
+		Name:  aws.String(parameterPath + input.SectionId()),
+		Value: aws.String(string(data)),
+		Type:  types.ParameterTypeSecureString,
+	})
+	return errors.Wrapf(err, "setting parameter for '%s'", input.SectionId())
+}

--- a/go.mod
+++ b/go.mod
@@ -194,6 +194,7 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.42.1
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.52.1
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
 	github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/aws/aws-sdk-go-v2/service/ses v1.19.6 h1:2WWiQwUVU39kD8EGYw/sTGU+REd5
 github.com/aws/aws-sdk-go-v2/service/ses v1.19.6/go.mod h1:huHEdSNRqZOquzLTTjbBoEpoz7snBRwu2fe1dvvhZwE=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7 h1:tRNrFDGRm81e6nTX5Q4CFblea99eAfm0dxXazGpLceU=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.29.7/go.mod h1:8GWUDux5Z2h6z2efAtr54RdHXtLm8sq7Rg85ZNY/CZM=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.52.1 h1:zeWJA3f0Td70984ZoSocVAEwVtZBGQu+Q0p/pA7dNoE=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.52.1/go.mod h1:xvWzNAXicm5A+1iOiH4sqMLwYHEbiQqpRSe6hvHdQrE=
 github.com/aws/aws-sdk-go-v2/service/sso v1.22.1 h1:p1GahKIjyMDZtiKoIn0/jAj/TkMzfzndDv5+zi2Mhgc=
 github.com/aws/aws-sdk-go-v2/service/sso v1.22.1/go.mod h1:/vWdhoIoYA5hYoPZ6fm7Sv4d8701PiG5VKe8/pPJL60=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.2 h1:ORnrOK0C4WmYV/uYt3koHEWBLYsRDwk2Np+eEoyV4Z0=


### PR DESCRIPTION
[DEVPROD-8038](https://jira.mongodb.org/browse/DEVPROD-8038)

### Description
When we're all running staging environments it will be annoying to keep them all up-to-date with configuration changes. For example, if you add a field to the admin page that evergreen can't function without you'll have to get everyone to update their staging. Storing parameters in Parameter Store will allow the configuration to be shared. It's also probably more secure than storing our deepest darkest API keys in so many copies of the database. And storing encrypted parameters in Parameter Store is probably better than storing them in the db anyways.

Nonetheless, there are scenarios where you may want to make configuration changes to your staging that won't propagate to everyone's staging. For this case we leave the db configuration in place as an override. If you want to change something (e.g. toggle a service flag) that shouldn't happen for everyone else you can do so through a direct update to your db. It would be nice to have a way to do this through the UI, but there didn't seem to be an obvious way to implement it.

Follow on PRs will apply this strategy to the rest of the admin settings.

Before merging this I'll need to open a PR to add the SSM permissions to the Evergreen roles and another PR to set the `SSM_PARAMETER_PATH` environment variable.

### Testing
Works in staging™️. I removed the splunk document from the staging db and the configuration was loaded from Parameter Store.

### Documentation
Docs for using the shared staging will be forthcoming before we start handing them out.

