### PR TITLE
DEVPROD-8473: Add GetEvents function to thirdparty/runtime_environments to use GetHistory and GetImageDiffs

### DIFF
--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -329,14 +329,18 @@ type ImageEvent struct {
 	AMIAfter  string
 }
 
+// EventHistoryOptions represents the filtering arguments for getEvents. Distro is a required argument.
 type EventHistoryOptions struct {
 	Distro string
 	Page   int
 	Limit  int
 }
 
-// getEvents (TODO!)
+// getEvents returns information about the changes between AMIs that occurred on the image.
 func (c *RuntimeEnvironmentsClient) getEvents(ctx context.Context, opts EventHistoryOptions) ([]ImageEvent, error) {
+	if opts.Distro == "" {
+		return nil, errors.Errorf("no distro provided")
+	}
 	limit := 10
 	if opts.Limit != 0 {
 		limit = opts.Limit
@@ -344,7 +348,7 @@ func (c *RuntimeEnvironmentsClient) getEvents(ctx context.Context, opts EventHis
 	optsHistory := DistroHistoryFilterOptions{
 		Distro: opts.Distro,
 		Page:   opts.Page,
-		Limit:  limit,
+		Limit:  limit + 1,
 	}
 	imageHistory, err := c.getHistory(ctx, optsHistory)
 	if err != nil {

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -381,7 +381,7 @@ func (c *RuntimeEnvironmentsClient) getEvents(ctx context.Context, opts EventHis
 		return nil, errors.Wrap(err, "getting image history")
 	}
 	result := []ImageEvent{}
-	for i := 0; i <= len(imageHistory)-1; i++ {
+	for i := 0; i < len(imageHistory)-1; i++ {
 		amiBefore := imageHistory[i+1].AMI
 		optsImageDiffs := ImageDiffOptions{
 			BeforeAMI: amiBefore,

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -308,3 +308,59 @@ func (c *RuntimeEnvironmentsClient) getHistory(ctx context.Context, opts DistroH
 	}
 	return amiHistory, nil
 }
+
+// ImageEventEntry represents a change to the image.
+type ImageEventEntry struct {
+	Name   string
+	After  string
+	Before string
+	Type   string
+	Action string
+}
+
+// ImageEvent contains information about changes to an image when the ami changes.
+type ImageEvent struct {
+	Entries   []ImageEventEntry
+	Timestamp string
+	AMIBefore string
+	AMIAfter  string
+}
+
+type EventHistoryOptions struct {
+	Distro string
+	Page   int
+	Limit  int
+}
+
+// getEvents (TODO!)
+func (c *RuntimeEnvironmentsClient) getEvents(ctx context.Context, opts EventHistoryOptions) ([]ImageEvent, error) {
+	limit := 10
+	if opts.Limit != 0 {
+		limit = opts.Limit
+	}
+	optsHistory := DistroHistoryFilterOptions{
+		Distro: opts.Distro,
+		Page:   opts.Page,
+		Limit:  limit,
+	}
+	imageHistory, err := c.getHistory(ctx, optsHistory)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting image history")
+	}
+	result := []ImageEvent{}
+	for i, imageHistoryEntry := range imageHistory {
+		amiBefore := ""
+		if i < len(imageHistory) - 1 {
+			amiBefore = imageHistory[i + 1].AMI
+		}
+		imageEvent := ImageEvent {
+			Entries: ,
+			Timestamp: imageHistoryEntry.CreationDate, 
+			AMIBefore: amiBefore, 
+			AMIAfter: imageHistoryEntry.AMI, 
+		}
+		result = append(result, )
+	}
+
+	return result, nil
+}

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -223,18 +222,17 @@ func TestGetEvents(t *testing.T) {
 	assert.Error(err)
 
 	// Verify that getEvents provides the image events for a distribution.
-	result, err := c.getEvents(ctx, EventHistoryOptions{Distro: "ubuntu2204"})
+	result, err := c.getEvents(ctx, EventHistoryOptions{Image: "ubuntu2204"})
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 
 	// Verify that getEvents functions correctly with page and limit.
 	opts := EventHistoryOptions{
-		Distro: "ubuntu2204",
-		Page:   0,
-		Limit:  5,
+		Image: "ubuntu2204",
+		Page:  0,
+		Limit: 5,
 	}
 	result, err = c.getEvents(ctx, opts)
-	grip.Debug(result)
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 	assert.Len(result, 5)

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -221,18 +221,13 @@ func TestGetEvents(t *testing.T) {
 	_, err := c.getEvents(ctx, EventHistoryOptions{})
 	assert.Error(err)
 
-	// Verify that getEvents provides the image events for a distribution.
-	result, err := c.getEvents(ctx, EventHistoryOptions{Image: "ubuntu2204"})
-	require.NoError(t, err)
-	assert.NotEmpty(t, result)
-
 	// Verify that getEvents functions correctly with page and limit.
 	opts := EventHistoryOptions{
 		Image: "ubuntu2204",
 		Page:  0,
 		Limit: 5,
 	}
-	result, err = c.getEvents(ctx, opts)
+	result, err := c.getEvents(ctx, opts)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result)
 	assert.Len(result, 5)

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -224,7 +224,7 @@ func TestGetEvents(t *testing.T) {
 	// Verify that getEvents provides the image events for a distribution.
 	result, err := c.getEvents(ctx, EventHistoryOptions{Image: "ubuntu2204"})
 	require.NoError(t, err)
-	require.NotEmpty(t, result)
+	assert.NotEmpty(t, result)
 
 	// Verify that getEvents functions correctly with page and limit.
 	opts := EventHistoryOptions{
@@ -234,6 +234,6 @@ func TestGetEvents(t *testing.T) {
 	}
 	result, err = c.getEvents(ctx, opts)
 	require.NoError(t, err)
-	require.NotEmpty(t, result)
+	assert.NotEmpty(t, result)
 	assert.Len(result, 5)
 }

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -106,8 +106,8 @@ func TestGetImageDiff(t *testing.T) {
 
 	// Verify that getImageDiff correctly returns Toolchain/Package changes for a pair of sample AMIs.
 	opts := ImageDiffOptions{
-		BeforeAMI: "ami-029ab576546a58916",
-		AfterAMI:  "ami-02b25f680ad574d33",
+		AMIBefore: "ami-029ab576546a58916",
+		AMIAfter:  "ami-02b25f680ad574d33",
 	}
 	result, err := c.getImageDiff(ctx, opts)
 	require.NoError(t, err)
@@ -118,8 +118,8 @@ func TestGetImageDiff(t *testing.T) {
 
 	// Verify that getImageDiff finds no differences between the same AMI.
 	opts = ImageDiffOptions{
-		BeforeAMI: "ami-016662ab459a49e9d",
-		AfterAMI:  "ami-016662ab459a49e9d",
+		AMIBefore: "ami-016662ab459a49e9d",
+		AMIAfter:  "ami-016662ab459a49e9d",
 	}
 	result, err = c.getImageDiff(ctx, opts)
 	require.NoError(t, err)
@@ -221,7 +221,11 @@ func TestGetEvents(t *testing.T) {
 	_, err := c.getEvents(ctx, EventHistoryOptions{})
 	assert.Error(err)
 
-	// Verify that getEvents functions correctly with page and limit.
+	// Verify that getEvents errors with missing limit.
+	_, err = c.getEvents(ctx, EventHistoryOptions{Image: "ubuntu2204"})
+	assert.Error(err)
+
+	// Verify that getEvents functions correctly with page and limit and returns in chronological order.
 	opts := EventHistoryOptions{
 		Image: "ubuntu2204",
 		Page:  0,
@@ -231,4 +235,7 @@ func TestGetEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, result)
 	assert.Len(result, 5)
+	for i := 0; i < len(result)-1; i++ {
+		assert.Greater(result[i].Timestamp, result[i+1].Timestamp)
+	}
 }


### PR DESCRIPTION
DEVPROD-8473

### Description
Added GetEvents function to thirdparty/runtime_environments to use GetHistory and GetImageDiffs.

### Testing
Added testing function and used grip Debug statements to ensure proper output. 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
