### PR TITLE
DEVPROD-7531: set sleep schedule from REST/CLI

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-06-30"
+	ClientVersion = "2024-07-12"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -299,12 +299,10 @@ evergreen --delete-tag KEY
 Note these tags cannot overwrite Evergreen tags. 
 
 Hosts can be set to never expire using the `--no-expire` option. Keep in mind that if making a host unexpirable from the
-CLI, you should also set up a [sleep schedule](Hosts/Spawn-Hosts#unexpirable-host-sleep-schedules) from the command
-line as well; if you don't set one, your unexpirable host will be automatically assigned a default sleep schedule. The
-sleep schedule can be set in the CLI request. To set daily times when you'd like your host to be running/stopped, set
-`--daily-stop` and `--daily-start`. To set whole weekdays when you'd like your host to be stopped, set `--weekdays-off`.
-To set the time zone for your sleep schedule, set `--timezone`. For example, this command will make a host unexpirable
-and defines a sleep schedule so the host is on from 9 am to 5 pm between Monday and Friday in Eastern Time:
+CLI, you should also set up a [sleep schedule](Hosts/Spawn-Hosts#unexpirable-host-sleep-schedules) from the command line
+as well; if you don't set one, your unexpirable host will be automatically assigned a default sleep schedule. For
+example, this command will make a host unexpirable and defines a sleep schedule so the host is on from 9 am to 5 pm
+between Monday and Friday in Eastern Time:
 
 ```sh
 evergreen host modify --host "<HOST_ID>" --no-expire --daily-start '09:00' --daily-stop '17:00' --weekdays-off Saturday --weekdays-off Sunday --timezone "America/New_York"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -300,11 +300,11 @@ Note these tags cannot overwrite Evergreen tags.
 
 Hosts can be set to never expire using the `--no-expire` option. Keep in mind that if making a host unexpirable from the
 CLI, you should also set up a [sleep schedule](Hosts/Spawn-Hosts#unexpirable-host-sleep-schedules) from the command
-line as well; if you don't set one, your unexpirable host will be automatically assigned a default sleep schedule. To
-set daily times when you'd like your host to be running/stopped, set `--daily-stop` and `--daily-start`. To set whole
-days when you'd like your host to be stopped, set `--weekdays-off`. To set the time zone for your sleep schedule, set
-`--timezone`. For example, this command will make a host unexpirable and set it to be on from 9 am to 5 pm between
-Monday and Friday in Eastern Time:
+line as well; if you don't set one, your unexpirable host will be automatically assigned a default sleep schedule. The
+sleep schedule can be set in the CLI request. To set daily times when you'd like your host to be running/stopped, set
+`--daily-stop` and `--daily-start`. To set whole weekdays when you'd like your host to be stopped, set `--weekdays-off`.
+To set the time zone for your sleep schedule, set `--timezone`. For example, this command will make a host unexpirable
+and defines a sleep schedule so the host is on from 9 am to 5 pm between Monday and Friday in Eastern Time:
 
 ```sh
 evergreen host modify --host "<HOST_ID>" --no-expire --daily-start '09:00' --daily-stop '17:00' --weekdays-off Saturday --weekdays-off Sunday --timezone "America/New_York"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -298,7 +298,21 @@ evergreen --delete-tag KEY
 ```
 Note these tags cannot overwrite Evergreen tags. 
 
-Hosts can be set to never expire using the `--no-expire` tag (although each user has a limit for these kinds of hosts). Hosts can be set to expire again using the `--expire` tag, which will set the host to expire in 24 hours. This expiration can be extended using `--extend <hours>`, and you can extend its lifetime up to a max of 30 days past host creation.
+Hosts can be set to never expire using the `--no-expire` option. Keep in mind that if making a host unexpirable from the
+CLI, you should also set up a [sleep schedule](Hosts/Spawn-Hosts#unexpirable-host-sleep-schedules) from the command
+line as well; if you don't set one, your unexpirable host will be automatically assigned a default sleep schedule. To
+set daily times when you'd like your host to be running/stopped, set `--daily-stop` and `--daily-start`. To set whole
+days when you'd like your host to be stopped, set `--weekdays-off`. To set the time zone for your sleep schedule, set
+`--timezone`. For example, this command will make a host unexpirable and set it to be on from 9 am to 5 pm between
+Monday and Friday in Eastern Time:
+
+```sh
+evergreen host modify --host "<HOST_ID>" --no-expire --daily-start '09:00' --daily-stop '17:00' --weekdays-off Saturday --weekdays-off Sunday --timezone "America/New_York"
+```
+
+Hosts can be set to expire again using the `--expire` option, which will set the host to expire in 24 hours. This
+expiration can be extended using `--extend <hours>`, and you can extend its lifetime up to a max of 30 days past host
+creation. There are limits on the number of spawn hosts (expirable or unexpirable) that a user can have at once.
 
 
 ### Stop/Start Host to Change Instance Type

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -517,6 +517,18 @@ func (o *SleepScheduleOptions) HasSchedule() bool {
 	return len(o.WholeWeekdaysOff) > 0 || o.DailyStartTime != "" || o.DailyStopTime != ""
 }
 
+// SetDefaultSchedule sets a default sleep schedule if none is provided. This
+// does not specify a default time zone, which must be set using
+// SetDefaultTimeZone.
+func (o *SleepScheduleOptions) SetDefaultSchedule() {
+	if o.HasSchedule() {
+		return
+	}
+	o.WholeWeekdaysOff = []time.Weekday{time.Saturday, time.Sunday}
+	o.DailyStartTime = "08:00"
+	o.DailyStopTime = "20:00"
+}
+
 // SetDefaultTimeZone sets a default time zone if other sleep schedule options
 // are specified and the time zone is not explicitly set. If prefers the given
 // default timezone if it's not empty, but otherwise falls back to using a
@@ -606,18 +618,6 @@ func (o *SleepScheduleOptions) validateDailyTime(t string) error {
 	catcher.NewWhen(mins < 0 || mins >= 60, "minutes must be between 0 and 59 (inclusive)")
 
 	return catcher.Resolve()
-}
-
-// GetDefaultSleepSchedule returns the default sleep schedule in the user's time
-// zone.
-func GetDefaultSleepSchedule(timezone string) SleepScheduleOptions {
-	opts := SleepScheduleOptions{
-		WholeWeekdaysOff: []time.Weekday{time.Saturday, time.Sunday},
-		DailyStartTime:   "08:00",
-		DailyStopTime:    "20:00",
-	}
-	opts.SetDefaultTimeZone(timezone)
-	return opts
 }
 
 type SpawnHostUsage struct {

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -508,7 +508,13 @@ type SleepScheduleOptions struct {
 }
 
 func (o *SleepScheduleOptions) IsZero() bool {
-	return len(o.WholeWeekdaysOff) == 0 && o.DailyStartTime == "" && o.DailyStopTime == ""
+	return len(o.WholeWeekdaysOff) == 0 && o.DailyStartTime == "" && o.DailyStopTime == "" && o.TimeZone == ""
+}
+
+// HasSchedule returns whether a sleep schedule has been defined (with or
+// without an explicit time zone).
+func (o *SleepScheduleOptions) HasSchedule() bool {
+	return len(o.WholeWeekdaysOff) > 0 || o.DailyStartTime != "" || o.DailyStopTime != ""
 }
 
 // SetDefaultTimeZone sets a default time zone if other sleep schedule options

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -6169,14 +6169,15 @@ func TestNewSleepScheduleInfo(t *testing.T) {
 		assert.NotZero(t, info.NextStopTime)
 	})
 	t.Run("SucceedsWithDefaultOptions", func(t *testing.T) {
-		defaultOpts := GetDefaultSleepSchedule("America/New_York")
+		var defaultOpts SleepScheduleOptions
+		defaultOpts.SetDefaultSchedule()
+		defaultOpts.SetDefaultTimeZone("America/New_York")
 		info, err := NewSleepScheduleInfo(defaultOpts)
 		assert.NoError(t, err)
 		require.NotZero(t, info)
 		assert.ElementsMatch(t, defaultOpts.WholeWeekdaysOff, info.WholeWeekdaysOff)
 		assert.Equal(t, defaultOpts.DailyStartTime, info.DailyStartTime)
 		assert.Equal(t, defaultOpts.DailyStopTime, info.DailyStopTime)
-		assert.Equal(t, "America/New_York", info.TimeZone)
 		assert.Equal(t, defaultOpts.TimeZone, info.TimeZone)
 		assert.NotZero(t, info.NextStartTime)
 		assert.NotZero(t, info.NextStopTime)
@@ -6187,8 +6188,8 @@ func TestNewSleepScheduleInfo(t *testing.T) {
 		assert.Zero(t, info)
 	})
 	t.Run("FailsWithoutTimeZone", func(t *testing.T) {
-		defaultOpts := GetDefaultSleepSchedule("")
-		defaultOpts.TimeZone = ""
+		var defaultOpts SleepScheduleOptions
+		defaultOpts.SetDefaultSchedule()
 		info, err := NewSleepScheduleInfo(defaultOpts)
 		assert.Error(t, err)
 		assert.Zero(t, info)

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -82,7 +82,7 @@ func hostCreate() cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  wholeWeekdaysOffFlagName,
-				Usage: `for an unexpirable host, the days when the host should be turned off for its sleep schedule (allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)`,
+				Usage: "for an unexpirable host, the days when the host should be turned off for its sleep schedule (allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)",
 			},
 			cli.StringFlag{
 				Name:  dailyStartTimeFlagName,
@@ -279,7 +279,7 @@ func hostModify() cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  wholeWeekdaysOffFlagName,
-				Usage: `for an unexpirable host, the days when the host should be turned off for its sleep schedule (allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)`,
+				Usage: "for an unexpirable host, the days when the host should be turned off for its sleep schedule (allowed values: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)",
 			},
 			cli.StringFlag{
 				Name:  dailyStartTimeFlagName,

--- a/operations/host_spawn.go
+++ b/operations/host_spawn.go
@@ -86,15 +86,15 @@ func hostCreate() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  dailyStartTimeFlagName,
-				Usage: "for an unexpirable host, the time when the host should start each day for its sleep schedule",
+				Usage: "for an unexpirable host, the time when the host should start each day for its sleep schedule (format: HH:MM, e.g. 12:34)",
 			},
 			cli.StringFlag{
 				Name:  dailyStopTimeFlagName,
-				Usage: "for an unexpirable host, the time when the host should stop each day for its sleep schedule",
+				Usage: "for an unexpirable host, the time when the host should stop each day for its sleep schedule (format: HH:MM, e.g. 12:34)",
 			},
 			cli.StringFlag{
 				Name:  timeZoneFlagName,
-				Usage: "for an unexpirable host, the time zone of the sleep schedule",
+				Usage: "for an unexpirable host, the time zone of the sleep schedule (e.g. America/New_York)",
 			},
 			cli.StringFlag{
 				Name:  joinFlagNames(fileFlagName, "f"),
@@ -291,7 +291,7 @@ func hostModify() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  timeZoneFlagName,
-				Usage: "for an unexpirable host, the time zone of the sleep schedule",
+				Usage: "for an unexpirable host, the time zone of the sleep schedule (e.g. America/New_York)",
 			},
 			cli.StringFlag{
 				Name:  addSSHKeyFlag,

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -241,16 +241,8 @@ func makeSpawnOptions(options *restmodel.HostRequestOptions, user *user.DBUser) 
 	}
 
 	if options.NoExpiration {
-		var defaultTimeZone string
-		if options.TimeZone != "" {
-			defaultTimeZone = options.TimeZone
-		} else if user.Settings.Timezone != "" {
-			defaultTimeZone = user.Settings.Timezone
-		}
-		if !options.SleepScheduleOptions.HasSchedule() {
-			options.SleepScheduleOptions = host.GetDefaultSleepSchedule(defaultTimeZone)
-		}
-		options.SetDefaultTimeZone(defaultTimeZone)
+		options.SleepScheduleOptions.SetDefaultSchedule()
+		options.SetDefaultTimeZone(user.Settings.Timezone)
 	}
 
 	spawnOptions := cloud.SpawnOptions{

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -241,10 +241,16 @@ func makeSpawnOptions(options *restmodel.HostRequestOptions, user *user.DBUser) 
 	}
 
 	if options.NoExpiration {
-		if options.SleepScheduleOptions.IsZero() {
-			options.SleepScheduleOptions = host.GetDefaultSleepSchedule(user.Settings.Timezone)
+		var defaultTimeZone string
+		if options.TimeZone != "" {
+			defaultTimeZone = options.TimeZone
+		} else if user.Settings.Timezone != "" {
+			defaultTimeZone = user.Settings.Timezone
 		}
-		options.SleepScheduleOptions.SetDefaultTimeZone(user.Settings.Timezone)
+		if !options.SleepScheduleOptions.HasSchedule() {
+			options.SleepScheduleOptions = host.GetDefaultSleepSchedule(defaultTimeZone)
+		}
+		options.SetDefaultTimeZone(defaultTimeZone)
 	}
 
 	spawnOptions := cloud.SpawnOptions{

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -211,7 +211,9 @@ func (s *HostConnectorSuite) TestSpawnHost() {
 			s.NoError(err)
 			s.Require().NotZero(intentHost)
 			s.NotZero(intentHost.SleepSchedule)
-			defaultSchedule := host.GetDefaultSleepSchedule(testUser.Settings.Timezone)
+			var defaultSchedule host.SleepScheduleOptions
+			defaultSchedule.SetDefaultSchedule()
+			defaultSchedule.SetDefaultTimeZone(testUser.Settings.Timezone)
 			s.Equal(defaultSchedule.WholeWeekdaysOff, intentHost.SleepSchedule.WholeWeekdaysOff, "default weekdays off should be set for unexpirable host if no explicit sleep schedule")
 			s.Equal(defaultSchedule.DailyStartTime, intentHost.SleepSchedule.DailyStartTime, "default daily start time should be set for unexpirable host if no explicit sleep schedule")
 			s.Equal(defaultSchedule.DailyStopTime, intentHost.SleepSchedule.DailyStopTime, "default daily stop time should be set for unexpirable host if no explicit sleep schedule")

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -66,6 +66,19 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 		if err := CheckUnexpirableHostLimitExceeded(ctx, user.Id, hph.env.Settings().Spawnhost.UnexpirableHostsPerUser); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "checking expirable host limit"))
 		}
+
+		isSettingSleepSchedule := len(hph.options.WholeWeekdaysOff) != 0 || len(hph.options.DailyStartTime) != 0 || len(hph.options.DailyStopTime) != 0
+		defaultTimeZone := hph.options.TimeZone
+		if defaultTimeZone == "" {
+			defaultTimeZone = user.Settings.Timezone
+		}
+		if !isSettingSleepSchedule {
+			// If making an unexpirable host and the request did not specify a
+			// sleep schedule, set it to the default sleep schedule to ensure it
+			// sets some sleep schedule.
+			hph.options.SleepScheduleOptions = host.GetDefaultSleepSchedule(defaultTimeZone)
+		}
+		hph.options.SleepScheduleOptions.SetDefaultTimeZone(defaultTimeZone)
 	}
 
 	intentHost, err := data.NewIntentHost(ctx, hph.options, user, hph.env)
@@ -136,10 +149,21 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 		allowedTypes := h.env.Settings().Providers.AWS.AllowedInstanceTypes
 		catcher.Add(cloud.CheckInstanceTypeValid(ctx, foundHost.Distro, h.options.InstanceType, allowedTypes))
 	}
-	if h.options.NoExpiration != nil && *h.options.NoExpiration {
+	willBeUnexpirable := utility.FromBoolPtr(h.options.NoExpiration)
+	if willBeUnexpirable {
 		catcher.AddWhen(h.options.AddHours != 0, errors.New("can't specify no expiration and new expiration"))
 		catcher.Add(CheckUnexpirableHostLimitExceeded(ctx, user.Id, h.env.Settings().Spawnhost.UnexpirableHostsPerUser))
 	}
+
+	if !willBeUnexpirable && !foundHost.NoExpiration && !h.options.SleepScheduleOptions.IsZero() {
+		catcher.New("cannot set a sleep schedule on an expirable host")
+	}
+	if willBeUnexpirable || (foundHost.NoExpiration && !foundHost.SleepSchedule.PermanentlyExempt) {
+		// If the host is already or will become unexpirable, then it must have
+		// a sleep schedule set.
+		h.options.SleepScheduleOptions = h.getDefaultedSleepScheduleOpts(foundHost, user)
+	}
+
 	if catcher.HasErrors() {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(catcher.Resolve(), "invalid host modify request"))
 	}
@@ -159,6 +183,50 @@ func (h *hostModifyHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
+}
+
+// getDefaultedSleepScheduleOpts gets the sleep schedule options (if any) to
+// modify the host. If this is only partially modifying the sleep schedule (e.g.
+// just setting the time zone and nothing else), it'll attempt to retain the
+// rest of the host's existing sleep schedule settings.
+func (h *hostModifyHandler) getDefaultedSleepScheduleOpts(existingHost *host.Host, u *user.DBUser) host.SleepScheduleOptions {
+	if !existingHost.NoExpiration && !utility.FromBoolPtr(h.options.NoExpiration) {
+		return h.options.SleepScheduleOptions
+	}
+	if existingHost.SleepSchedule.PermanentlyExempt {
+		return h.options.SleepScheduleOptions
+	}
+
+	optsWithDefaults := h.options.SleepScheduleOptions
+
+	isOverwritingSleepSchedule := len(h.options.WholeWeekdaysOff) != 0 || h.options.DailyStartTime != "" || h.options.DailyStopTime != ""
+	var defaultTimeZone string
+	if h.options.TimeZone != "" {
+		defaultTimeZone = h.options.TimeZone
+	} else if existingHost.SleepSchedule.TimeZone != "" {
+		defaultTimeZone = existingHost.SleepSchedule.TimeZone
+	} else {
+		defaultTimeZone = u.Settings.Timezone
+	}
+
+	if !isOverwritingSleepSchedule && existingHost.SleepSchedule.IsZero() {
+		// The unexpirable host does not already have a sleep schedule set
+		// and the request did not specify a new sleep schedule. It needs to
+		// have some sleep schedule set, so just use the default.
+		optsWithDefaults = host.GetDefaultSleepSchedule(defaultTimeZone)
+	} else if isOverwritingSleepSchedule && len(h.options.TimeZone) == 0 {
+		// The host is setting a new sleep schedule. If the user didn't
+		// specify an explicit time zone, just set the default time zone.
+		optsWithDefaults.SetDefaultTimeZone(defaultTimeZone)
+	} else if !isOverwritingSleepSchedule && len(h.options.TimeZone) != 0 {
+		// The user is only overwriting the sleep schedule's time zone, so
+		// retain the rest of the host's existing sleep schedule.
+		optsWithDefaults.WholeWeekdaysOff = existingHost.SleepSchedule.WholeWeekdaysOff
+		optsWithDefaults.DailyStartTime = existingHost.SleepSchedule.DailyStartTime
+		optsWithDefaults.DailyStopTime = existingHost.SleepSchedule.DailyStopTime
+	}
+
+	return optsWithDefaults
 }
 
 // checkTemporaryExemption validates whether it's allowed to extend the


### PR DESCRIPTION
DEVPROD-7531

### Description
This is a follow-up to #8086 to let users set a sleep schedule from the REST API/CLI.

* Add CLI options to set a sleep schedule from the CLI.
* Add REST route handling for sleep schedule options (already added in #8086).

### Testing
* Added unit tests for host create/modify routes.
* Tested in staging that `evergreen host create` and `evergreen host modify` set sleep schedules as expected for unexpirable hosts.

### Documentation
Updated docs. I didn't mention it in the unexpirable host sleep schedule info just because I wanted to keep it brief, I don't think it's that common of a workflow to create/modify hosts using the CLI, and the UI is likely more user-friendly anyways.