### PR TITLE
DEVPROD-8517: include spawn host task ID in API host

### DIFF
--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -43,6 +43,18 @@ type APIHost struct {
 	CreationTime          *time.Time  `json:"creation_time"`
 	Expiration            *time.Time  `json:"expiration_time"`
 	AttachedVolumeIDs     []string    `json:"attached_volume_ids"`
+	// Contains options for spawn hosts.
+	ProvisionOptions APIProvisionOptions `json:"provision_options"`
+}
+
+// APIProvisionOptions contains options for spawn hosts.
+type APIProvisionOptions struct {
+	// ID of the task that the host was spawned from.
+	TaskID *string `json:"task_id"`
+}
+
+func (apiOpts *APIProvisionOptions) BuildFromService(opts host.ProvisionOptions) {
+	apiOpts.TaskID = utility.ToStringPtr(opts.TaskId)
 }
 
 // HostRequestOptions is a struct that holds the format of a POST request to
@@ -141,6 +153,9 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 		attachedVolumeIds = append(attachedVolumeIds, volAttachment.VolumeID)
 	}
 	apiHost.AttachedVolumeIDs = attachedVolumeIds
+	if h.ProvisionOptions != nil {
+		apiHost.ProvisionOptions.BuildFromService(*h.ProvisionOptions)
+	}
 	imageId, err := h.Distro.GetImageID()
 	if err != nil {
 		// report error but do not fail function because of a bad imageId

--- a/rest/model/host_test.go
+++ b/rest/model/host_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type hostCompare struct {
@@ -87,5 +89,19 @@ func TestHostBuildFromService(t *testing.T) {
 				So(utility.FromStringPtr(apiHost.Status), ShouldEqual, utility.FromStringPtr(hc.ah.Status))
 			}
 		})
+	})
+
+	t.Run("BuildFromServicePopulatesProvisionOptionsForHostSpawnedFromTask", func(t *testing.T) {
+		h := host.Host{
+			Id: "host_id",
+			ProvisionOptions: &host.ProvisionOptions{
+				TaskId: "task_id",
+			},
+		}
+		var apiHost APIHost
+		apiHost.BuildFromService(&h, nil)
+		assert.Equal(t, h.Id, utility.FromStringPtr(apiHost.Id))
+		require.NotZero(t, apiHost.ProvisionOptions)
+		assert.Equal(t, h.ProvisionOptions.TaskId, utility.FromStringPtr(apiHost.ProvisionOptions.TaskID))
 	})
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -114,7 +114,7 @@ type hostIDGetHandler struct {
 
 // Factory creates an instance of the handler.
 //
-//	@Summary		Fetch hosts by ID
+//	@Summary		Fetch host by ID
 //	@Description	Fetches a single host using its ID
 //	@Tags			hosts
 //	@Router			/hosts/{host_id} [get]


### PR DESCRIPTION
DEVPROD-8517

### Description
Expose the field containing the task ID when a spawn host is created from a task. Should be retrievable in the REST API now.

### Testing
* Added unit test.
* Spawned a host from a task in staging, and checked that the task ID was populated in a REST request for the host.

### Documentation
Updated the auto-generated swaggo docs.