### PR TITLE
DEVPROD-5996: Add GraphQL support for githubAppAuth field

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -296,3 +296,9 @@ func createInstallationTokenForID(ctx context.Context, authFields *GithubAppAuth
 	}
 	return token.GetToken(), nil
 }
+
+// RedactPrivateKey redacts the GitHub app's private key so that it's not exposed via the UI or GraphQL.
+func (g *GithubAppAuth) RedactPrivateKey() *GithubAppAuth {
+	g.PrivateKey = []byte("{REDACTED}")
+	return g
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -98,6 +98,10 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIFinderSettings
   GeneralSubscription:
     model: github.com/evergreen-ci/evergreen/rest/model.APISubscription
+  GithubAppAuth:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIGithubAppAuth
+  GithubAppAuthInput:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIGithubAppAuth
   GithubCheckSubscriber:
     model: github.com/evergreen-ci/evergreen/rest/model.APIGithubCheckSubscriber
   GitHubDynamicTokenPermissionGroupInput:
@@ -256,6 +260,8 @@ models:
       aliases:
         resolver: true
       subscriptions:
+        resolver: true
+      githubAppAuth:
         resolver: true
   ProjectSettingsInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIProjectSettings

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -382,6 +382,11 @@ type ComplexityRoot struct {
 		Tag    func(childComplexity int) int
 	}
 
+	GithubAppAuth struct {
+		AppID      func(childComplexity int) int
+		PrivateKey func(childComplexity int) int
+	}
+
 	GithubCheckSubscriber struct {
 		Owner func(childComplexity int) int
 		Ref   func(childComplexity int) int
@@ -971,6 +976,7 @@ type ComplexityRoot struct {
 
 	ProjectSettings struct {
 		Aliases               func(childComplexity int) int
+		GithubAppAuth         func(childComplexity int) int
 		GithubWebhooksEnabled func(childComplexity int) int
 		ProjectRef            func(childComplexity int) int
 		Subscriptions         func(childComplexity int) int
@@ -1775,6 +1781,7 @@ type ProjectResolver interface {
 }
 type ProjectSettingsResolver interface {
 	Aliases(ctx context.Context, obj *model.APIProjectSettings) ([]*model.APIProjectAlias, error)
+	GithubAppAuth(ctx context.Context, obj *model.APIProjectSettings) (*model.APIGithubAppAuth, error)
 	GithubWebhooksEnabled(ctx context.Context, obj *model.APIProjectSettings) (bool, error)
 
 	Subscriptions(ctx context.Context, obj *model.APIProjectSettings) ([]*model.APISubscription, error)
@@ -3183,6 +3190,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GitTag.Tag(childComplexity), true
+
+	case "GithubAppAuth.appId":
+		if e.complexity.GithubAppAuth.AppID == nil {
+			break
+		}
+
+		return e.complexity.GithubAppAuth.AppID(childComplexity), true
+
+	case "GithubAppAuth.privateKey":
+		if e.complexity.GithubAppAuth.PrivateKey == nil {
+			break
+		}
+
+		return e.complexity.GithubAppAuth.PrivateKey(childComplexity), true
 
 	case "GithubCheckSubscriber.owner":
 		if e.complexity.GithubCheckSubscriber.Owner == nil {
@@ -6328,6 +6349,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProjectSettings.Aliases(childComplexity), true
+
+	case "ProjectSettings.githubAppAuth":
+		if e.complexity.ProjectSettings.GithubAppAuth == nil {
+			break
+		}
+
+		return e.complexity.ProjectSettings.GithubAppAuth(childComplexity), true
 
 	case "ProjectSettings.githubWebhooksEnabled":
 		if e.complexity.ProjectSettings.GithubWebhooksEnabled == nil {
@@ -9716,6 +9744,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputExternalLinkInput,
 		ec.unmarshalInputFinderSettingsInput,
 		ec.unmarshalInputGitHubDynamicTokenPermissionGroupInput,
+		ec.unmarshalInputGithubAppAuthInput,
 		ec.unmarshalInputGithubUserInput,
 		ec.unmarshalInputHomeVolumeSettingsInput,
 		ec.unmarshalInputHostAllocatorSettingsInput,
@@ -20227,6 +20256,88 @@ func (ec *executionContext) fieldContext_GitTag_pusher(_ context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _GithubAppAuth_appId(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubAppAuth) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GithubAppAuth_appId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AppID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalOInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GithubAppAuth_appId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GithubAppAuth",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GithubAppAuth_privateKey(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubAppAuth) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GithubAppAuth_privateKey(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrivateKey, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GithubAppAuth_privateKey(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GithubAppAuth",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _GithubCheckSubscriber_owner(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubCheckSubscriber) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_GithubCheckSubscriber_owner(ctx, field)
 	if err != nil {
@@ -29663,6 +29774,8 @@ func (ec *executionContext) fieldContext_Mutation_saveProjectSettingsForSection(
 			switch field.Name {
 			case "aliases":
 				return ec.fieldContext_ProjectSettings_aliases(ctx, field)
+			case "githubAppAuth":
+				return ec.fieldContext_ProjectSettings_githubAppAuth(ctx, field)
 			case "githubWebhooksEnabled":
 				return ec.fieldContext_ProjectSettings_githubWebhooksEnabled(ctx, field)
 			case "projectRef":
@@ -42717,6 +42830,53 @@ func (ec *executionContext) fieldContext_ProjectSettings_aliases(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _ProjectSettings_githubAppAuth(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProjectSettings_githubAppAuth(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ProjectSettings().GithubAppAuth(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.APIGithubAppAuth)
+	fc.Result = res
+	return ec.marshalOGithubAppAuth2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProjectSettings_githubAppAuth(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectSettings",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "appId":
+				return ec.fieldContext_GithubAppAuth_appId(ctx, field)
+			case "privateKey":
+				return ec.fieldContext_GithubAppAuth_privateKey(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GithubAppAuth", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProjectSettings_githubWebhooksEnabled(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectSettings) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ProjectSettings_githubWebhooksEnabled(ctx, field)
 	if err != nil {
@@ -44841,6 +45001,8 @@ func (ec *executionContext) fieldContext_Query_projectSettings(ctx context.Conte
 			switch field.Name {
 			case "aliases":
 				return ec.fieldContext_ProjectSettings_aliases(ctx, field)
+			case "githubAppAuth":
+				return ec.fieldContext_ProjectSettings_githubAppAuth(ctx, field)
 			case "githubWebhooksEnabled":
 				return ec.fieldContext_ProjectSettings_githubWebhooksEnabled(ctx, field)
 			case "projectRef":
@@ -69558,6 +69720,40 @@ func (ec *executionContext) unmarshalInputGitHubDynamicTokenPermissionGroupInput
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputGithubAppAuthInput(ctx context.Context, obj interface{}) (model.APIGithubAppAuth, error) {
+	var it model.APIGithubAppAuth
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"appId", "privateKey"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "appId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("appId"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AppID = data
+		case "privateKey":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privateKey"))
+			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PrivateKey = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputGithubUserInput(ctx context.Context, obj interface{}) (model.APIGithubUser, error) {
 	var it model.APIGithubUser
 	asMap := map[string]interface{}{}
@@ -71097,7 +71293,7 @@ func (ec *executionContext) unmarshalInputProjectSettingsInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"projectId", "aliases", "githubWebhooksEnabled", "projectRef", "subscriptions", "vars"}
+	fieldsInOrder := [...]string{"projectId", "aliases", "githubAppAuth", "githubWebhooksEnabled", "projectRef", "subscriptions", "vars"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -71141,6 +71337,28 @@ func (ec *executionContext) unmarshalInputProjectSettingsInput(ctx context.Conte
 				return it, err
 			}
 			it.Aliases = data
+		case "githubAppAuth":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("githubAppAuth"))
+			directive0 := func(ctx context.Context) (interface{}, error) {
+				return ec.unmarshalOGithubAppAuthInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx, v)
+			}
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				if ec.directives.RedactSecrets == nil {
+					return nil, errors.New("directive redactSecrets is not implemented")
+				}
+				return ec.directives.RedactSecrets(ctx, obj, directive0)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(model.APIGithubAppAuth); ok {
+				it.GithubAppAuth = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be github.com/evergreen-ci/evergreen/rest/model.APIGithubAppAuth`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "githubWebhooksEnabled":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("githubWebhooksEnabled"))
 			data, err := ec.unmarshalOBoolean2bool(ctx, v)
@@ -75600,6 +75818,44 @@ func (ec *executionContext) _GitTag(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var githubAppAuthImplementors = []string{"GithubAppAuth"}
+
+func (ec *executionContext) _GithubAppAuth(ctx context.Context, sel ast.SelectionSet, obj *model.APIGithubAppAuth) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, githubAppAuthImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GithubAppAuth")
+		case "appId":
+			out.Values[i] = ec._GithubAppAuth_appId(ctx, field, obj)
+		case "privateKey":
+			out.Values[i] = ec._GithubAppAuth_privateKey(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -80687,6 +80943,39 @@ func (ec *executionContext) _ProjectSettings(ctx context.Context, sel ast.Select
 					}
 				}()
 				res = ec._ProjectSettings_aliases(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "githubAppAuth":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ProjectSettings_githubAppAuth(ctx, field, obj)
 				return res
 			}
 
@@ -93249,6 +93538,18 @@ func (ec *executionContext) marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋev
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOGithubAppAuth2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx context.Context, sel ast.SelectionSet, v *model.APIGithubAppAuth) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._GithubAppAuth(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOGithubAppAuthInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx context.Context, v interface{}) (model.APIGithubAppAuth, error) {
+	res, err := ec.unmarshalInputGithubAppAuthInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOGithubCheckSubscriber2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubCheckSubscriber(ctx context.Context, sel ast.SelectionSet, v *model.APIGithubCheckSubscriber) graphql.Marshaler {

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -2,8 +2,10 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
@@ -14,6 +16,22 @@ import (
 // Aliases is the resolver for the aliases field.
 func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIProjectSettings) ([]*restModel.APIProjectAlias, error) {
 	return getAPIAliasesForProject(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
+}
+
+// GithubAppAuth is the resolver for the githubAppAuth field.
+func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIGithubAppAuth, error) {
+	app, err := model.FindOneGithubAppAuth(utility.FromStringPtr(obj.ProjectRef.Id))
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
+	}
+	// It's valid for a project to not have a Github app defined.
+	if app == nil {
+		return nil, nil
+	}
+	res := &restModel.APIGithubAppAuth{}
+	app = app.RedactPrivateKey()
+	res.BuildFromService(*app)
+	return res, nil
 }
 
 // GithubWebhooksEnabled is the resolver for the githubWebhooksEnabled field.

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -28,10 +28,10 @@ func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restMo
 	if app == nil {
 		return nil, nil
 	}
-	res := &restModel.APIGithubAppAuth{}
-	app = app.RedactPrivateKey()
-	res.BuildFromService(*app)
-	return res, nil
+	return &restModel.APIGithubAppAuth{
+		AppID:      int(app.AppID),
+		PrivateKey: utility.ToStringPtr(""),
+	}, nil
 }
 
 // GithubWebhooksEnabled is the resolver for the githubWebhooksEnabled field.

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -24,7 +24,7 @@ func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restMo
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
 	}
-	// It's valid for a project to not have a Github app defined.
+	// It's valid for a project to not have a GitHub app defined.
 	if app == nil {
 		return nil, nil
 	}

--- a/graphql/redacted_fields_gen.go
+++ b/graphql/redacted_fields_gen.go
@@ -2,6 +2,7 @@
 package graphql
 
 var redactedFields = map[string]bool{
+	"githubAppAuth": true,
 	"publicKey": true,
 	"secret": true,
 	"servicePassword": true,

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -189,6 +189,11 @@ input PromoteVarsToRepoInput {
   varNames: [String!]!
 }
 
+input GithubAppAuthInput {
+  appId: Int!
+  privateKey: String!
+}
+
 ###### TYPES ######
 """
 GroupedProjects is the return value for the projects & viewableProjectRefs queries.
@@ -329,4 +334,9 @@ type ParsleyFilter {
   expression: String!
   caseSensitive: Boolean!
   exactMatch: Boolean!
+}
+
+type GithubAppAuth {
+  appId: Int
+  privateKey: String
 }

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -27,6 +27,7 @@ update the settings for a given project.
 input ProjectSettingsInput {
   projectId: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)
   aliases: [ProjectAliasInput!]
+  githubAppAuth: GithubAppAuthInput @redactSecrets
   githubWebhooksEnabled: Boolean
   projectRef: ProjectInput
   subscriptions: [SubscriptionInput!]
@@ -89,6 +90,7 @@ ProjectSettings models the settings for a given Project.
 """
 type ProjectSettings {
   aliases: [ProjectAlias!]
+  githubAppAuth: GithubAppAuth
   githubWebhooksEnabled: Boolean!
   projectRef: Project @requireProjectSettingsAccess
   subscriptions: [GeneralSubscription!]

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/github_app_settings.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/github_app_settings.graphql
@@ -2,6 +2,7 @@ mutation {
   saveProjectSettingsForSection(
     projectSettings: {
       projectId: "sandbox_project_id"
+      githubAppAuth: { appId: 12345, privateKey: "secret" }
       projectRef: {
         id: "sandbox_project_id"
         githubPermissionGroupByRequester: {
@@ -12,6 +13,10 @@ mutation {
     }
     section: GITHUB_APP_SETTINGS
   ) {
+    githubAppAuth {
+      appId
+      privateKey
+    }
     projectRef {
       id
       githubPermissionGroupByRequester

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -220,7 +220,7 @@
           "saveProjectSettingsForSection": {
             "githubAppAuth": {
               "appId": 12345,
-              "privateKey": "{REDACTED}"
+              "privateKey": ""
             },
             "projectRef": {
               "id": "sandbox_project_id",

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -218,6 +218,10 @@
       "result": {
         "data": {
           "saveProjectSettingsForSection": {
+            "githubAppAuth": {
+              "appId": 12345,
+              "privateKey": "{REDACTED}"
+            },
             "projectRef": {
               "id": "sandbox_project_id",
               "githubPermissionGroupByRequester": {

--- a/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
+++ b/graphql/tests/projectSettings/projectRef/queries/project_ref.graphql
@@ -1,5 +1,9 @@
 {
   projectSettings(projectIdentifier: "sandbox") {
+    githubAppAuth {
+      appId
+      privateKey
+    }
     githubWebhooksEnabled
     projectRef {
       id

--- a/graphql/tests/projectSettings/projectRef/results.json
+++ b/graphql/tests/projectSettings/projectRef/results.json
@@ -5,6 +5,7 @@
       "result": {
         "data": {
           "projectSettings": {
+            "githubAppAuth": null,
             "githubWebhooksEnabled": true,
             "projectRef": {
               "id": "sandbox_project_id",

--- a/graphql/tests/query/spruceConfig/results.json
+++ b/graphql/tests/query/spruceConfig/results.json
@@ -1,106 +1,107 @@
 {
-    "tests": [
-        {
-            "query_file": "default_project.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "ui": {
-                            "defaultProject": "evergreen"
-                        }
-                    }
-                }
+  "tests": [
+    {
+      "query_file": "default_project.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "ui": {
+              "defaultProject": "evergreen"
             }
-        },
-        {
-            "query_file": "user_voice.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "ui": {
-                            "userVoice": "https://uservoice.com"
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "banner.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "banner": "This is an important notification",
-                        "bannerTheme": "important"
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "jira.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "jira": {
-                            "email": "evg-user@jira.mongodb.org",
-                            "host": "jira.mongodb.org"
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "spawn_host.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "spawnHost": {
-                            "unexpirableHostsPerUser": 0,
-                            "unexpirableVolumesPerUser": 0,
-                            "spawnHostsPerUser": 0
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "container_pools.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "containerPools": {
-                            "pools": [
-                                {
-                                    "id": "test-pool",
-                                    "distro": "localhost",
-                                    "maxContainers": 5,
-                                    "port": 2525
-                                },
-                                {
-                                    "id": "ubuntu-test-pool",
-                                    "distro": "localhost",
-                                    "maxContainers": 10,
-                                    "port": 4649
-                                }
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        {
-            "query_file": "secretFields.graphql",
-            "result": {
-                "data": {
-                    "spruceConfig": {
-                        "secretFields": [
-                            "publicKey",
-                            "secret",
-                            "servicePassword",
-                            "vars"
-                        ]
-                    }
-                }
-            }
+          }
         }
-    ]
+      }
+    },
+    {
+      "query_file": "user_voice.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "ui": {
+              "userVoice": "https://uservoice.com"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "banner.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "banner": "This is an important notification",
+            "bannerTheme": "important"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "jira.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "jira": {
+              "email": "evg-user@jira.mongodb.org",
+              "host": "jira.mongodb.org"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "spawn_host.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "spawnHost": {
+              "unexpirableHostsPerUser": 0,
+              "unexpirableVolumesPerUser": 0,
+              "spawnHostsPerUser": 0
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "container_pools.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "containerPools": {
+              "pools": [
+                {
+                  "id": "test-pool",
+                  "distro": "localhost",
+                  "maxContainers": 5,
+                  "port": 2525
+                },
+                {
+                  "id": "ubuntu-test-pool",
+                  "distro": "localhost",
+                  "maxContainers": 10,
+                  "port": 4649
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "secretFields.graphql",
+      "result": {
+        "data": {
+          "spruceConfig": {
+            "secretFields": [
+              "githubAppAuth",
+              "publicKey",
+              "secret",
+              "servicePassword",
+              "vars"
+            ]
+          }
+        }
+      }
+    }
+  ]
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -15,12 +16,12 @@ import (
 )
 
 type ProjectSettings struct {
-	ProjectRef         ProjectRef           `bson:"proj_ref" json:"proj_ref"`
-	GithubHooksEnabled bool                 `bson:"github_hooks_enabled" json:"github_hooks_enabled"`
-	Vars               ProjectVars          `bson:"vars" json:"vars"`
-	Aliases            []ProjectAlias       `bson:"aliases" json:"aliases"`
-	Subscriptions      []event.Subscription `bson:"subscriptions" json:"subscriptions"`
-	GitHubAppID        int64                `bson:"github_app_id" json:"github_app_id"`
+	ProjectRef         ProjectRef              `bson:"proj_ref" json:"proj_ref"`
+	GitHubAppAuth      evergreen.GithubAppAuth `bson:"github_app_auth" json:"github_app_auth"`
+	GithubHooksEnabled bool                    `bson:"github_hooks_enabled" json:"github_hooks_enabled"`
+	Vars               ProjectVars             `bson:"vars" json:"vars"`
+	Aliases            []ProjectAlias          `bson:"aliases" json:"aliases"`
+	Subscriptions      []event.Subscription    `bson:"subscriptions" json:"subscriptions"`
 }
 
 type ProjectSettingsEvent struct {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1988,22 +1988,23 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 		return nil, errors.Wrapf(err, "finding subscription for project '%s'", p.Id)
 	}
 
+	githubApp, err := FindOneGithubAppAuth(p.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding GitHub app for project '%s'", p.Id)
+	}
+	if githubApp == nil {
+		githubApp = &evergreen.GithubAppAuth{}
+	}
+
 	projectSettingsEvent := ProjectSettings{
 		ProjectRef:         *p,
+		GitHubAppAuth:      *githubApp,
 		GithubHooksEnabled: hasEvergreenAppInstalled,
 		Vars:               *projectVars,
 		Aliases:            projectAliases,
 		Subscriptions:      subscriptions,
 	}
 
-	githubAppID, err := GetGitHubAppID(p.Id)
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding github app for project '%s'", p.Id)
-	}
-	if githubAppID != nil {
-		projectSettingsEvent.GitHubAppID = *githubAppID
-
-	}
 	return &projectSettingsEvent, nil
 }
 

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -473,7 +473,8 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 	// This section does not support repo-level at this time.
 	case model.ProjectPageGithubAppSettingsSection:
 		mergedSection.Id = mergedBeforeRef.Id
-		if changes.GithubAppAuth.AppID != int(before.GitHubAppAuth.AppID) {
+		if changes.GithubAppAuth.AppID != int(before.GitHubAppAuth.AppID) ||
+			utility.FromStringPtr(changes.GithubAppAuth.PrivateKey) != string(before.GitHubAppAuth.PrivateKey) {
 			if err = mergedSection.SetGithubAppCredentials(int64(changes.GithubAppAuth.AppID), []byte(utility.FromStringPtr(changes.GithubAppAuth.PrivateKey))); err != nil {
 				return nil, errors.Wrap(err, "updating GitHub app credentials")
 			}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -486,6 +486,23 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
 			assert.Equal(t, githubAppFromDB.PrivateKey, []byte("my_secret"))
 
+			// Should be able to update GitHub app credentials.
+			apiChanges = &restModel.APIProjectSettings{
+				GithubAppAuth: restModel.APIGithubAppAuth{
+					AppID:      12345,
+					PrivateKey: utility.ToStringPtr("my_new_secret"),
+				},
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGithubAppSettingsSection, false, "me")
+			assert.NoError(t, err)
+			assert.NotNil(t, settings)
+
+			githubAppFromDB, err = model.FindOneGithubAppAuth(ref.Id)
+			assert.NoError(t, err)
+			require.NotNil(t, githubAppFromDB)
+			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
+			assert.Equal(t, githubAppFromDB.PrivateKey, []byte("my_new_secret"))
+
 			// Should be able to clear GitHub app credentials.
 			apiChanges = &restModel.APIProjectSettings{
 				GithubAppAuth: restModel.APIGithubAppAuth{


### PR DESCRIPTION
DEVPROD-5996

### Description
Adds GraphQL support for `githubAppAuth` field in ProjectSettings.

Since this PR is already long, I will handle adding this field to the event logs (with redaction) in [DEVPROD-8877](https://jira.mongodb.org/browse/DEVPROD-8877).

### Testing
* Added unit tests & GraphQL tests
