### PR TITLE
DEVPROD-3996 Add test for project validations to only return respective levels

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -122,6 +122,9 @@ type ValidationInput struct {
 }
 
 // Functions used to validate the syntax of a project configuration file.
+// These are expected to only return ValidationError's with
+// a level of Error ValidationLevel. They must also explicitly return
+// Error as opposed to leaving the field blank.
 var projectErrorValidators = []projectValidator{
 	validateBVFields,
 	validateDependencyGraph,
@@ -151,6 +154,8 @@ var projectConfigErrorValidators = []projectConfigValidator{
 }
 
 // Functions used to validate the semantics of a project configuration file.
+// These are expected to only return ValidationError's with
+// a level of Warning ValidationLevel or Notice ValidationLevel.
 var projectWarningValidators = []projectValidator{
 	checkTaskGroups,
 	checkProjectFields,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -130,7 +130,7 @@ var projectErrorValidators = []projectValidator{
 	validateDependencyGraph,
 	validatePluginCommands,
 	validateProjectFields,
-	validateTaskDependencies,
+	validateStatusesForTaskDependencies,
 	validateTaskNames,
 	validateBVNames,
 	validateBVBatchTimes,
@@ -162,7 +162,7 @@ var projectWarningValidators = []projectValidator{
 	checkTaskRuns,
 	checkModules,
 	checkTasks,
-	checkTaskDependencies,
+	checkReferencesForTaskDependencies,
 	checkRequestersForTaskDependencies,
 	checkBuildVariants,
 	checkTaskUsage,
@@ -1585,9 +1585,9 @@ func checkTaskRuns(project *model.Project) ValidationErrors {
 	return errs
 }
 
-// validateTaskDependencies checks that, for all tasks that have
+// validateStatusesForTaskDependencies checks that, for all tasks that have
 // the status field is a valid status.
-func validateTaskDependencies(project *model.Project) ValidationErrors {
+func validateStatusesForTaskDependencies(project *model.Project) ValidationErrors {
 	var errs ValidationErrors
 	for _, bvtu := range project.FindAllBuildVariantTasks() {
 		for _, d := range bvtu.DependsOn {
@@ -1605,11 +1605,11 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 	return errs
 }
 
-// checkTaskDependencies checks that, for all tasks that have
+// checkReferencesForTaskDependencies checks that, for all tasks that have
 // dependencies, those dependencies set the expected fields and all dependencies
 // reference tasks that will actually run. For example, if task t1 in build
 // variant bv1 depends on task t2, t2 should also be listed under bv1.
-func checkTaskDependencies(project *model.Project) ValidationErrors {
+func checkReferencesForTaskDependencies(project *model.Project) ValidationErrors {
 	bvtus := map[model.TVPair]model.BuildVariantTaskUnit{}
 	bvs := map[string]struct{}{}
 	tasks := map[string]struct{}{}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1581,9 +1581,7 @@ func checkTaskRuns(project *model.Project) ValidationErrors {
 }
 
 // validateTaskDependencies checks that, for all tasks that have
-// dependencies, those dependencies set the expected fields and all dependencies
-// reference tasks that will actually run. For example, if task t1 in build
-// variant bv1 depends on task t2, t2 should also be listed under bv1.
+// the status field is a valid status.
 func validateTaskDependencies(project *model.Project) ValidationErrors {
 	var errs ValidationErrors
 	for _, bvtu := range project.FindAllBuildVariantTasks() {
@@ -1602,7 +1600,7 @@ func validateTaskDependencies(project *model.Project) ValidationErrors {
 	return errs
 }
 
-// validateTaskDependencies checks that, for all tasks that have
+// checkTaskDependencies checks that, for all tasks that have
 // dependencies, those dependencies set the expected fields and all dependencies
 // reference tasks that will actually run. For example, if task t1 in build
 // variant bv1 depends on task t2, t2 should also be listed under bv1.

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -115,31 +115,6 @@ buildvariants:
 
 		assert.Empty(t, errs)
 	})
-	t.Run("WarnsWithTaskDependingOnNonexistentTaskInSpecificBuildVariant", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-  depends_on:
-  - name: t2
-    variant: bv2
-- name: t2
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: t1
-  - name: t2
-- name: bv2
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv2', but it was not found")
-	})
 	t.Run("IgnoresDuplicateDependencies", func(t *testing.T) {
 		// Duplicate dependencies are allowed because when the project is
 		// translated, it consolidates all the duplicates.
@@ -238,29 +213,6 @@ buildvariants:
 
 		assert.Empty(t, errs)
 	})
-	t.Run("WarnsWithTaskImplicitlyDependingOnNonexistentTaskInSameBuildVariant", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-  depends_on:
-  - name: t2
-- name: t2
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: t1
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
-	})
 	t.Run("SucceedsWithTaskImplicitlyDependingOnTaskGroupTaskInSameBuildVariant", func(t *testing.T) {
 		projYAML := `
 tasks:
@@ -286,33 +238,6 @@ buildvariants:
 		errs := validateTaskDependencies(&p)
 
 		assert.Empty(t, errs)
-	})
-	t.Run("WarnsWithTaskImplicitlyDependingOnNonexistentTaskGroupTaskInSameBuildVariant", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-  depends_on:
-  - name: t2
-- name: t2
-
-task_groups:
-- name: tg1
-  tasks:
-  - t2
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: t1
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
 	})
 	t.Run("SucceedsWithTaskGroupTaskImplicitlyDependingOnTask", func(t *testing.T) {
 		projYAML := `
@@ -340,33 +265,6 @@ buildvariants:
 
 		assert.Empty(t, errs)
 	})
-	t.Run("WarnsWithTaskGroupTaskImplicitlyDependingOnNonexistentTask", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-  depends_on:
-  - name: t2
-- name: t2
-
-task_groups:
-- name: tg1
-  tasks:
-  - t1
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: tg1
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
-	})
 	t.Run("SucceedsWithBuildVariantTaskDependingOnTask", func(t *testing.T) {
 		projYAML := `
 tasks:
@@ -387,29 +285,6 @@ buildvariants:
 		errs := validateTaskDependencies(&p)
 
 		assert.Empty(t, errs)
-	})
-	t.Run("WarnsWithBuildVariantTaskDependingOnNonexistentTask", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-- name: t2
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: t1
-    depends_on:
-    - name: t2
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
 	})
 	t.Run("SucceedsWithBuildVariantTaskDependingOnTaskAndOverridingTaskDependencyDefinition", func(t *testing.T) {
 		projYAML := `
@@ -435,33 +310,6 @@ buildvariants:
 
 		assert.Empty(t, errs)
 	})
-	t.Run("WarnsWithBuildVariantTaskDependingOnNonexistentTaskAndOverridingTaskDependencyDefinition", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-  depends_on:
-  - name: t2
-- name: t2
-- name: t3
-
-buildvariants:
-- name: bv1
-  tasks:
-  - name: t1
-    depends_on:
-    - name: t3
-  - name: t2
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't3' in build variant 'bv1', but it was not found")
-	})
 	t.Run("SucceedsWithBuildVariantDependingOnTask", func(t *testing.T) {
 		projYAML := `
 tasks:
@@ -485,30 +333,6 @@ buildvariants:
 		errs := validateTaskDependencies(&p)
 
 		assert.Empty(t, errs)
-	})
-	t.Run("WarnsWithBuildVariantDependingOnNonexistentTask", func(t *testing.T) {
-		projYAML := `
-tasks:
-- name: t1
-- name: t2
-
-buildvariants:
-- name: bv1
-  depends_on:
-  - name: t2
-    variant: bv2
-  tasks:
-  - name: t1
-- name: bv2
-`
-		var p model.Project
-		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
-		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
-
-		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv2', but it was not found")
 	})
 	t.Run("SucceedsWithTaskDependingOnAllTasksAndAllVariants", func(t *testing.T) {
 		projYAML := `
@@ -554,6 +378,449 @@ buildvariants:
 
 		assert.Empty(t, errs)
 	})
+	t.Run("SucceedsWithTaskDependingOnSpecificTaskInAllBuildVariants", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+    variant: "*"
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+- name: bv2
+  tasks:
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := validateTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+}
+
+func TestCheckTaskDependencies(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("WarnsWithTaskDependingOnNonexistentTaskInSpecificBuildVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+    variant: bv2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+  - name: t2
+- name: bv2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv2', but it was not found")
+	})
+	t.Run("IgnoresDuplicateDependencies", func(t *testing.T) {
+		// Duplicate dependencies are allowed because when the project is
+		// translated, it consolidates all the duplicates.
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+  - name: t2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("AllowsDependenciesOnSameTaskInDifferentBuildVariants", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+    variant: bv1
+  - name: t2
+    variant: bv2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+  - name: t2
+- name: bv2
+  tasks:
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("SucceedsWithTaskImplicitlyDependingOnTaskInSameBuildVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithTaskImplicitlyDependingOnNonexistentTaskInSameBuildVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
+	})
+	t.Run("SucceedsWithTaskImplicitlyDependingOnTaskGroupTaskInSameBuildVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+task_groups:
+- name: tg1
+  tasks:
+  - t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+  - name: tg1
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithTaskImplicitlyDependingOnNonexistentTaskGroupTaskInSameBuildVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+task_groups:
+- name: tg1
+  tasks:
+  - t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
+	})
+	t.Run("SucceedsWithTaskGroupTaskImplicitlyDependingOnTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+task_groups:
+- name: tg1
+  tasks:
+  - t1
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: tg1
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithTaskGroupTaskImplicitlyDependingOnNonexistentTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+
+task_groups:
+- name: tg1
+  tasks:
+  - t1
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: tg1
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
+	})
+	t.Run("SucceedsWithBuildVariantTaskDependingOnTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+    depends_on:
+    - name: t2
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithBuildVariantTaskDependingOnNonexistentTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+    depends_on:
+    - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv1', but it was not found")
+	})
+	t.Run("SucceedsWithBuildVariantTaskDependingOnTaskAndOverridingTaskDependencyDefinition", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t3
+- name: t2
+- name: t3
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+    depends_on:
+    - name: t2
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithBuildVariantTaskDependingOnNonexistentTaskAndOverridingTaskDependencyDefinition", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: t2
+- name: t2
+- name: t3
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+    depends_on:
+    - name: t3
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't3' in build variant 'bv1', but it was not found")
+	})
+	t.Run("SucceedsWithBuildVariantDependingOnTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+- name: t2
+
+buildvariants:
+- name: bv1
+  depends_on:
+  - name: t2
+    variant: bv2
+  tasks:
+  - name: t1
+- name: bv2
+  tasks:
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("WarnsWithBuildVariantDependingOnNonexistentTask", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+- name: t2
+
+buildvariants:
+- name: bv1
+  depends_on:
+  - name: t2
+    variant: bv2
+  tasks:
+  - name: t1
+- name: bv2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		require.Len(t, errs, 1)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, errs[0].Message, "task 't1' in build variant 'bv1' depends on task 't2' in build variant 'bv2', but it was not found")
+	})
+	t.Run("SucceedsWithTaskDependingOnAllTasksAndAllVariants", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: "*"
+    variant: "*"
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
+	t.Run("SucceedsWithTaskDependingOnAllTasksInSpecificVariant", func(t *testing.T) {
+		projYAML := `
+tasks:
+- name: t1
+  depends_on:
+  - name: "*"
+    variant: bv2
+- name: t2
+
+buildvariants:
+- name: bv1
+  tasks:
+  - name: t1
+- name: bv2
+  tasks:
+  - name: t2
+`
+		var p model.Project
+		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
+		require.NoError(t, err)
+		errs := checkTaskDependencies(&p)
+
+		assert.Empty(t, errs)
+	})
 	t.Run("WarnsWithTaskDependingOnAllTasksInSpecificNonexistentVariant", func(t *testing.T) {
 		p := model.Project{
 			Tasks: []model.ProjectTask{
@@ -586,7 +853,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := validateTaskDependencies(&p)
+		errs := checkTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -612,7 +879,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := checkTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -633,7 +900,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := checkTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -669,7 +936,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := validateTaskDependencies(&p)
+		errs := checkTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -706,7 +973,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := validateTaskDependencies(&p)
+		errs := checkTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -45,6 +45,7 @@ func TestProjectWarningValidators(t *testing.T) {
 	})
 }
 
+// testProjectValidatorsFunctions parses through all the given project validators and runs the given test function on each one.
 func testProjectValidatorsFunctions(t *testing.T, projectValidators []projectValidator, test func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string)) {
 	node, err := parser.ParseFile(token.NewFileSet(), "project_validator.go", nil, parser.AllErrors)
 	require.NoError(t, err)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -63,9 +63,7 @@ func TestProjectWarningValidators(t *testing.T) {
 		return true
 	})
 
-	// projectErrorValidators have some restrictions and conventions that they must follow:
-	// 1. They must return an error explicitly.
-	// 2. They must not return any other type of ValidationError level.
+	// projectWarningValidators must only return Warning or Notice.
 	for _, validator := range projectWarningValidators {
 		funcPtr := runtime.FuncForPC(reflect.ValueOf(validator).Pointer())
 		funcName := funcPtr.Name()[strings.LastIndex(funcPtr.Name(), ".")+1:]

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -31,7 +31,7 @@ func TestProjectErrorValidators(t *testing.T) {
 	// projectErrorValidators have some restrictions and conventions that they must follow:
 	// 1. They must return an error explicitly.
 	// 2. They must not return any other type of ValidationError level.
-	testProjectValidators(t, projectErrorValidators, func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string) {
+	testProjectValidatorsFunctions(t, projectErrorValidators, func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string) {
 		assert.True(t, variablesInFunction(funcBodies, funcName, []string{"Error"}, map[string]bool{}), "ProjectErrorValidators should return at least one Error")
 		assert.False(t, variablesInFunction(funcBodies, funcName, []string{"Warning", "Notice"}, map[string]bool{}), "ProjectErrorValidators should never use Warnings or Notices")
 	})
@@ -39,13 +39,13 @@ func TestProjectErrorValidators(t *testing.T) {
 
 func TestProjectWarningValidators(t *testing.T) {
 	// projectWarningValidators must only return Warning or Notice.
-	testProjectValidators(t, projectWarningValidators, func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string) {
+	testProjectValidatorsFunctions(t, projectWarningValidators, func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string) {
 		assert.False(t, variablesInFunction(funcBodies, funcName, []string{"Error"}, map[string]bool{}), "ProjectWarningValidators should never use Error")
 		assert.True(t, variablesInFunction(funcBodies, funcName, []string{"Warning", "Notice"}, map[string]bool{}), "ProjectWarningValidators return at least one Warning or Notice")
 	})
 }
 
-func testProjectValidators(t *testing.T, projectValidators []projectValidator, test func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string)) {
+func testProjectValidatorsFunctions(t *testing.T, projectValidators []projectValidator, test func(t *testing.T, funcBodies map[string]*ast.BlockStmt, funcName string)) {
 	node, err := parser.ParseFile(token.NewFileSet(), "project_validator.go", nil, parser.AllErrors)
 	require.NoError(t, err)
 	funcBodies := make(map[string]*ast.BlockStmt)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -139,7 +139,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -163,7 +163,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -187,7 +187,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Error, errs[0].Level)
@@ -216,7 +216,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -237,7 +237,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -263,7 +263,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -289,7 +289,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -310,7 +310,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -334,7 +334,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -358,7 +358,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -378,7 +378,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -402,7 +402,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -426,7 +426,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := validateTaskDependencies(&p)
+		errs := validateStatusesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -455,7 +455,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -481,7 +481,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -508,7 +508,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -529,7 +529,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -550,7 +550,7 @@ buildvariants:
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -578,7 +578,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -603,7 +603,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -631,7 +631,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -656,7 +656,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -679,7 +679,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -700,7 +700,7 @@ buildvariants:
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -726,7 +726,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -751,7 +751,7 @@ buildvariants:
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -777,7 +777,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -799,7 +799,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -821,7 +821,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -845,7 +845,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -881,7 +881,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -907,7 +907,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		assert.Empty(t, errs)
 	})
@@ -928,7 +928,7 @@ buildvariants:
 		var p model.Project
 		_, err := model.LoadProjectInto(ctx, []byte(projYAML), nil, "", &p)
 		require.NoError(t, err)
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -964,7 +964,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
@@ -1001,7 +1001,7 @@ buildvariants:
 				},
 			},
 		}
-		errs := checkTaskDependencies(&p)
+		errs := checkReferencesForTaskDependencies(&p)
 
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)


### PR DESCRIPTION
DEVPROD-3996

### Description
We've been manually making sure functions added to the `projectErrorValidators` only returns errors. This has gone well but sometimes needed a follow up PR months later. This adds some checks to make sure we only use Error. 

I added a restriction in this PR, that the `Level` field must be populated to `Error` rather than blank (which would default to `Error`) since it helps the test's correctness and it might be (it was to me for a second) why some ValidationError{} declarations didn't include a `Level` field.

I've done the same thing for the `projectWarningValidators` only returning `Warning` and `Notice`.

### Testing
Unit testing. I added warning / error and then the tests would fail. The tests also work locally (if that was a concern)