### PR TITLE
DEVPROD-8301 Resolve catcher at the end of MarkEnd

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -882,7 +882,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		return TryResetTask(ctx, settings, t.Id, caller, "", detail)
 	}
 
-	return nil
+	return catcher.Resolve()
 }
 
 func markEndDisplayTask(ctx context.Context, settings *evergreen.Settings, t *task.Task, caller, origin string) error {


### PR DESCRIPTION
DEVPROD-8301

### Description
This resolves the catcher at the end of MarkEnd. Not resolving it was a programmatic error.