### PR TITLE
DEVPROD-8738: log when host creation fails

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -217,6 +217,12 @@ func (j *createHostJob) Run(ctx context.Context) {
 
 	defer func() {
 		if j.IsLastAttempt() && j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
+			grip.Error(message.WrapError(j.Error(), message.Fields{
+				"message": "no attempts remaining to create host",
+				"outcome": "giving up on creating this host",
+				"host_id": j.HostID,
+				"distro":  j.host.Distro.Id,
+			}))
 			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.host.SpawnOptions.TaskExecutionNumber, j.Error()); err != nil {
 				j.AddError(errors.Wrapf(err, "adding host create error details"))
 			}


### PR DESCRIPTION
DEVPROD-8738

### Description
We've been relying on Amboy's retry mechanism producing errors in the error rate when the job has no more attempts to get alerts about persistent issues creating hosts. Instead of relying on that log (which we're reducing to a warning here: https://github.com/mongodb/amboy/pull/345), add a replacement log that we can use to alert on host creation problems.

Once this is merged, I'll adjust the error rate in production alert so that it doesn't filter out this log (it currently filters host creation job errors).

### Testing
N/A

### Documentation
N/A