### PR TITLE
DEVPROD-5989 Add Honeycomb traces to the github.generate_token command

### DIFF
--- a/agent/command/github_generate_token.go
+++ b/agent/command/github_generate_token.go
@@ -114,7 +114,7 @@ func (r *githubGenerateToken) Execute(ctx context.Context, comm client.Communica
 	// We write or overwrite the expansion with the new token.
 	conf.NewExpansions.PutAndRedact(r.ExpansionName, token)
 
-	conf.AddCommandCleanup(r.FullDisplayName(), func(ctx context.Context) error {
+	conf.AddCommandCleanup(r.Name(), func(ctx context.Context) error {
 		// We remove the expansion and revoke the token. We do not restore
 		// the expansion to any previous value as overwriting the token
 		// reduces the scope of the token.

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -62,6 +62,7 @@ type TaskConfig struct {
 // block is executed, the cleanup function(s) are added to the TaskConfig. When
 // the command block is finished, the cleanup function(s) are collected by the
 // TaskContext and executed depending on what command block was executed.
+// For every command cleanup, a span is created with the Command as the name.
 type CommandCleanup struct {
 	// Command is the name of the command from (base).FullDisplayName().
 	Command string

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-07-11"
+	AgentVersion = "2024-07-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5989

### Description
This adds Honeycomb traces to the command, using these we can find out what owner+repo are using the token, if they are specifying permissions, and how many successful revocations happened.

To support the traces for revoking, I added a new span for the task command cleanups and setup group command cleanups and subspans for each one they run. The rest of this PR really is just adding the attributes to the existing span and the new cleanup spans

### Testing
Deployed to staging. Link to existing task's honeycomb trace [here](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/trace/aw9cNHyU6u1?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=dfeae8971e71a609), link to new task's honeycomb trace [here](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/trace/2WNzHuAc5BW?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=65f6239f4aa548c4).