### PR TITLE
DEVPROD-6861: Gate permissions for Task.taskLogs in GraphQL

### DIFF
--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -548,6 +548,13 @@ func (r *taskResolver) Status(ctx context.Context, obj *restModel.APITask) (stri
 
 // TaskLogs is the resolver for the taskLogs field.
 func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*TaskLogs, error) {
+	canView, err := hasLogViewPermission(ctx, obj)
+	if err != nil {
+		return nil, err
+	}
+	if !canView {
+		return nil, Forbidden.Send(ctx, "insufficient permission for viewing task logs")
+	}
 	// Let the individual TaskLogs resolvers handle fetching logs for the task
 	// We can avoid the overhead of fetching task logs that we will not view
 	// and we can avoid handling errors that we will not see

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -548,10 +548,7 @@ func (r *taskResolver) Status(ctx context.Context, obj *restModel.APITask) (stri
 
 // TaskLogs is the resolver for the taskLogs field.
 func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*TaskLogs, error) {
-	canView, err := hasLogViewPermission(ctx, obj)
-	if err != nil {
-		return nil, err
-	}
+	canView := hasLogViewPermission(ctx, obj)
 	if !canView {
 		return nil, Forbidden.Send(ctx, "insufficient permission for viewing task logs")
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1301,7 +1301,7 @@ func isPatchAuthorForTask(ctx context.Context, obj *restModel.APITask) (bool, er
 	return false, nil
 }
 
-func hasLogViewPermission(ctx context.Context, obj *restModel.APITask) (bool, error) {
+func hasLogViewPermission(ctx context.Context, obj *restModel.APITask) bool {
 	authUser := gimlet.GetUser(ctx)
 	permissions := gimlet.PermissionOpts{
 		Resource:      *obj.ProjectId,
@@ -1309,10 +1309,7 @@ func hasLogViewPermission(ctx context.Context, obj *restModel.APITask) (bool, er
 		Permission:    evergreen.PermissionLogs,
 		RequiredLevel: evergreen.LogsView.Value,
 	}
-	if authUser.HasPermission(permissions) {
-		return true, nil
-	}
-	return isPatchAuthorForTask(ctx, obj)
+	return authUser.HasPermission(permissions)
 }
 
 func hasAnnotationPermission(ctx context.Context, obj *restModel.APITask, requiredLevel int) (bool, error) {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1284,17 +1284,8 @@ func getProjectPermissionLevel(projectPermission ProjectPermission, access Acces
 	return permission, level, nil
 }
 
-func hasAnnotationPermission(ctx context.Context, obj *restModel.APITask, requiredLevel int) (bool, error) {
+func isPatchAuthorForTask(ctx context.Context, obj *restModel.APITask) (bool, error) {
 	authUser := gimlet.GetUser(ctx)
-	permissions := gimlet.PermissionOpts{
-		Resource:      *obj.ProjectId,
-		ResourceType:  evergreen.ProjectResourceType,
-		Permission:    evergreen.PermissionAnnotations,
-		RequiredLevel: requiredLevel,
-	}
-	if authUser.HasPermission(permissions) {
-		return true, nil
-	}
 	if utility.StringSliceContains(evergreen.PatchRequesters, utility.FromStringPtr(obj.Requester)) {
 		p, err := patch.FindOneId(utility.FromStringPtr(obj.Version))
 		if err != nil {
@@ -1308,6 +1299,34 @@ func hasAnnotationPermission(ctx context.Context, obj *restModel.APITask, requir
 		}
 	}
 	return false, nil
+}
+
+func hasLogViewPermission(ctx context.Context, obj *restModel.APITask) (bool, error) {
+	authUser := gimlet.GetUser(ctx)
+	permissions := gimlet.PermissionOpts{
+		Resource:      *obj.ProjectId,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionLogs,
+		RequiredLevel: evergreen.LogsView.Value,
+	}
+	if authUser.HasPermission(permissions) {
+		return true, nil
+	}
+	return isPatchAuthorForTask(ctx, obj)
+}
+
+func hasAnnotationPermission(ctx context.Context, obj *restModel.APITask, requiredLevel int) (bool, error) {
+	authUser := gimlet.GetUser(ctx)
+	permissions := gimlet.PermissionOpts{
+		Resource:      *obj.ProjectId,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionAnnotations,
+		RequiredLevel: requiredLevel,
+	}
+	if authUser.HasPermission(permissions) {
+		return true, nil
+	}
+	return isPatchAuthorForTask(ctx, obj)
 }
 
 func annotationPermissionHelper(ctx context.Context, taskID string, execution *int) error {

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -406,32 +406,17 @@ func TestIsPatchAuthorForTask(t *testing.T) {
 
 func TestHasLogViewPermission(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User){
-		"TrueWhenUserHasRequiredLevelAndIsNotPatchOwner": func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User) {
+		"TrueWhenUserHasRequiredPermission": func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User) {
 			ctx = gimlet.AttachUser(ctx, userWithRole)
 			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
-			hasAccess, err := hasLogViewPermission(ctx, &task)
-			assert.NoError(t, err)
+			hasAccess := hasLogViewPermission(ctx, &task)
 			assert.True(t, hasAccess)
 		},
-		"FalseWhenUserDoesNotHaveRequiredLevelAndIsNotPatchOwner": func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User) {
+		"FalseWhenUserDoesNotHaveRequiredPermission": func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User) {
 			ctx = gimlet.AttachUser(ctx, userWithoutRole)
 			task := restModel.APITask{ProjectId: utility.ToStringPtr("project_id_belonging_to_user"), Version: utility.ToStringPtr("random_version_id")}
-			hasAccess, err := hasLogViewPermission(ctx, &task)
-			assert.NoError(t, err)
+			hasAccess := hasLogViewPermission(ctx, &task)
 			assert.False(t, hasAccess)
-		},
-		"TrueWhenUserIsPatchOwnerButDoesNotHaveViewRole": func(ctx context.Context, t *testing.T, userWithRole gimlet.User, userWithoutRole gimlet.User) {
-			ctx = gimlet.AttachUser(ctx, userWithoutRole)
-			versionAndPatchID := bson.NewObjectId()
-			patch := patch.Patch{
-				Id:     versionAndPatchID,
-				Author: "basic_user",
-			}
-			assert.NoError(t, patch.Insert())
-			task := restModel.APITask{ProjectId: utility.ToStringPtr("random_project_id"), Version: utility.ToStringPtr(versionAndPatchID.Hex()), Requester: utility.ToStringPtr(evergreen.PatchVersionRequester)}
-			hasAccess, err := hasLogViewPermission(ctx, &task)
-			assert.NoError(t, err)
-			assert.True(t, hasAccess)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-6861

### Description
These code changes allow the user to request `Task.taskLogs` if they have the LogsView role for the project.
