### PR TITLE
DEVPROD-8537: Require imageId in GraphQL distro object

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -17336,11 +17336,14 @@ func (ec *executionContext) _Distro_imageId(ctx context.Context, field graphql.C
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_imageId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -69077,7 +69080,7 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj i
 			it.IcecreamSettings = data
 		case "imageId":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("imageId"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -74711,6 +74714,9 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 			}
 		case "imageId":
 			out.Values[i] = ec._Distro_imageId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "isCluster":
 			out.Values[i] = ec._Distro_isCluster(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -129,7 +129,7 @@ input DistroInput {
   homeVolumeSettings: HomeVolumeSettingsInput!
   hostAllocatorSettings: HostAllocatorSettingsInput!
   iceCreamSettings: IceCreamSettingsInput!
-  imageId: String
+  imageId: String!
   isCluster: Boolean!
   isVirtualWorkStation: Boolean!
   name: String! @requireDistroAccess(access: EDIT)
@@ -279,7 +279,7 @@ type Distro {
   homeVolumeSettings: HomeVolumeSettings!
   hostAllocatorSettings: HostAllocatorSettings!
   iceCreamSettings: IceCreamSettings!
-  imageId: String
+  imageId: String!
   isCluster: Boolean!
   isVirtualWorkStation: Boolean!
   name: String!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -3,6 +3,7 @@ mutation {
     opts: {
       distro: {
         name: "fake"
+        imageId: "rhel71-power8"
         adminOnly: false
         aliases: ["new-alias"]
         arch: LINUX_PPC_64_BIT

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -3,6 +3,7 @@ mutation {
     opts: {
       distro: {
         name: "rhel71-power8-large"
+        imageId: "rhel71-power8"
         adminOnly: false
         workDir: ""
         mountpoints: ["/"]


### PR DESCRIPTION
DEVPROD-8537

### Description
Require image ID in the GraphQL distro object. Have confirmed all staging / prod distros have this field.
