### PR TITLE
DEVPROD-1616 Remove confusing conflicting documentation on configure patch route

### DIFF
--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -549,13 +549,8 @@ type patchTasks struct {
 	// Optional, if sent will update the patch's description
 	Description string `json:"description"`
 	// Required, these are the variants and tasks that the patch should run.
-	// Each variant object is of the format { "variant": "\<variant name>",
-	// "tasks": ["task name"] }. This field is analogous in syntax and usage to
-	// the "buildvariants" field in the project's evergreen.yml file. Names of
-	// display tasks can be specified in the tasks array and will work as one
-	// would expect. For an already-scheduled patch, any new tasks in this array
-	// will be created, and any existing tasks not in this array will be
-	// unscheduled.
+	// For an already-scheduled patch, any new tasks in this array will be
+	// created and any existing tasks not in this array will be unscheduled.
 	Variants []variant `json:"variants"`
 }
 


### PR DESCRIPTION
DEVPROD-1616

### Description
This removes an excerpt from the `Variants` field documentation for the /patches/{patch_id}/configure route.

The exercpt doesn't give that much useful information, is wordy, and misleads users by giving an incorrect format. Since our docs moved to automagically generate based off of code, the `variant` struct details users in our pine documentation what the field names are and we shouldn't reiterate