### PR TITLE
DEVPROD-5189 Remove patch command validation for --repeat-failed and --repeat-patch being exclusive

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-06-30"
+	ClientVersion = "2024-07-16"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -53,9 +53,17 @@ To use the same tasks and variants defined for the previous patch created for th
 ```
 evergreen patch --reuse
 ```
-Similarly, to using the `--repeat-failed` flag will perform the same behavior as the `--reuse` flag, with the only difference being that it will repeat only the failed tasks and build variants from the most recent patch (if any failures exist).
+To repeat a specific patch id, you can use the '--repeat-patch' flag.
+```
+evergreen patch --repeat-patch <patch_id>
+```
+Similarly, using the `--repeat-failed` flag will perform the same behavior as the `--reuse` flag, with the only difference being that it will repeat only the failed tasks and build variants from the most recent patch (if any failures exist).
 ```
 evergreen patch --repeat-failed
+```
+To repeat the failed of a specific patch, the '--repeat-failed' flag can be used with the '--repeat-patch' flag to specify the patch id.
+```
+evergreen patch --repeat-failed --repeat-patch <patch_id>
 ```
 
 To skip all (y/n) prompts, the `-y` keyword can be given:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -57,7 +57,7 @@ To repeat a specific patch id, you can use the '--repeat-patch' flag.
 ```
 evergreen patch --repeat-patch <patch_id>
 ```
-Similarly, using the `--repeat-failed` flag will perform the same behavior as the `--reuse` flag, with the only difference being that it will repeat only the failed tasks and build variants from the most recent patch (if any failures exist).
+Similarly, using the `--repeat-failed` flag will perform the same behavior as the `--reuse` flag and by default use the last patch as a reference, with the only difference being that it will repeat only the failed tasks and build variants from the most recent patch (if any failures exist).
 ```
 evergreen patch --repeat-failed
 ```

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -274,18 +274,18 @@ func addUncommittedChangesFlag(flags ...cli.Flag) []cli.Flag {
 }
 
 func addReuseFlags(flags ...cli.Flag) []cli.Flag {
-	message := "repeat %s: use the %s tasks/variants defined for the %s patch"
+	message := "repeat %s: use the %s tasks/variants defined for the %s patch %s"
 	res := append(flags, cli.BoolFlag{
 		Name:  joinFlagNames(repeatDefinitionFlag, "reuse"),
-		Usage: fmt.Sprintf(message, "latest", "same", "latest"),
+		Usage: fmt.Sprintf(message, "latest", "same", "latest", ""),
 	})
 	res = append(res, cli.BoolFlag{
 		Name:  joinFlagNames(repeatFailedDefinitionFlag, "rf"),
-		Usage: fmt.Sprintf(message, "latest failed", "failed", "latest"),
+		Usage: fmt.Sprintf(message, "latest failed", "failed", "latest", "(can be overridden by the --reuse-patch flag)"),
 	})
 	res = append(res, cli.StringFlag{
 		Name:  joinFlagNames(repeatPatchIdFlag, "reuse-patch"),
-		Usage: fmt.Sprintf(message, "specific patch", "same", "given"),
+		Usage: fmt.Sprintf(message, "specific patch", "same", "given", ""),
 	})
 	return res
 }

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -97,7 +97,7 @@ func Patch() cli.Command {
 			setPlainLogger,
 			mutuallyExclusiveArgs(false, patchDescriptionFlagName, autoDescriptionFlag),
 			mutuallyExclusiveArgs(false, preserveCommitsFlag, uncommittedChangesFlag),
-			mutuallyExclusiveArgs(false, repeatDefinitionFlag, repeatPatchIdFlag, repeatFailedDefinitionFlag),
+			mutuallyExclusiveArgs(false, repeatDefinitionFlag, repeatPatchIdFlag),
 			func(c *cli.Context) error {
 				catcher := grip.NewBasicCatcher()
 				for _, status := range utility.SplitCommas(c.StringSlice(syncStatusesFlagName)) {


### PR DESCRIPTION
DEVPROD-5189

### Description
This removes the validation that prevents --repeat-failed and --repeat-patch <patch id> to be used together.

### Testing
After this change, I ran `evg patch --repeat-failed --repeat-patch 668ec6e08b58d60007bd1f55` (`evg` comamnd builds local evergreen) and it produced [this](https://spruce.mongodb.com/version/6696b5768e640b000735f4c6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) patch. The failing patch I used was [this](https://spruce.mongodb.com/version/668ec6e08b58d60007bd1f55/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) one.

For unit tests, we have some existing [here](https://github.com/ZackarySantana/evergreen/blob/b40a1d76eb1cc752da5536c2e8050207ffb03a1d/units/patch_intent_test.go#L440) (also below that one we have another one) that tests doing repeat patch and repeat failed options together. Our CLI doesn't need any unit tests for this since it's really just passing along the values to the API request that boils down to the patch intent job.

### Documentation
Added docs
