### PR TITLE
DEVPROD-8924 git.get_project cloning assuming tokens are always oauth

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -71,7 +71,7 @@ type gitFetchProject struct {
 	Revisions map[string]string `plugin:"expand"`
 
 	Token   string `plugin:"expand" mapstructure:"token"`
-	isOauth bool   `mapstructure:"is_oauth"`
+	IsOauth bool   `mapstructure:"is_oauth"`
 
 	// ShallowClone sets CloneDepth to 100, and is kept for backwards compatibility.
 	ShallowClone bool `mapstructure:"shallow_clone"`
@@ -494,7 +494,7 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 
-	projectMethod, projectToken, err := getProjectMethodAndToken(ctx, comm, td, conf, c.Token, c.isOauth)
+	projectMethod, projectToken, err := getProjectMethodAndToken(ctx, comm, td, conf, c.Token, c.IsOauth)
 	if err != nil {
 		return errors.Wrap(err, "getting method of cloning and token")
 	}

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -25,7 +25,6 @@ type gitPush struct {
 	// Must be a valid non-blank directory name.
 	Directory string `yaml:"directory" plugin:"expand"`
 	DryRun    bool   `yaml:"dry_run" mapstructure:"dry_run"`
-	Token     string `yaml:"token" plugin:"expand" mapstructure:"token"`
 
 	base
 }
@@ -82,12 +81,11 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 
 	// get commit information
 	var projectToken string
-	_, projectToken, err = getProjectMethodAndToken(ctx, comm, td, conf, c.Token)
+	_, projectToken, err = getProjectMethodAndToken(ctx, comm, td, conf, "", false)
 	if err != nil {
 		return errors.Wrap(err, "getting token")
 	}
 	params := pushParams{token: projectToken}
-
 	// push module patches
 	for _, modulePatch := range p.Patches {
 		if modulePatch.ModuleName == "" {

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -30,6 +30,7 @@ func TestGitPush(t *testing.T) {
 		Directory: "src",
 	}
 	comm := client.NewMock("http://localhost.com")
+	comm.CreateInstallationTokenResult = "token"
 	conf := &internal.TaskConfig{
 		Task:       task.Task{},
 		ProjectRef: model.ProjectRef{Branch: "main"},

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -28,7 +28,6 @@ func TestGitPush(t *testing.T) {
 	token := "0123456789"
 	c := gitPush{
 		Directory: "src",
-		Token:     token,
 	}
 	comm := client.NewMock("http://localhost.com")
 	conf := &internal.TaskConfig{

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -414,6 +414,8 @@ func (s *GitGetProjectSuite) TestValidateGitCommands() {
 	defer cancel()
 	var pluginCmds []Command
 
+	s.comm.CreateGitHubDynamicAccessTokenResult = mockedGitHubAppToken
+
 	for _, task := range conf.Project.Tasks {
 		for _, command := range task.Commands {
 			pluginCmds, err = Render(command, &conf.Project, BlockInfo{})
@@ -786,6 +788,8 @@ func (s *GitGetProjectSuite) TestMultipleModules() {
 	conf.Expansions.Put(moduleRevExpansionName("sample-1"), sample1Hash)
 	conf.Expansions.Put(moduleRevExpansionName("sample-2"), sample2Hash)
 
+	s.comm.CreateInstallationTokenResult = mockedGitHubAppToken
+
 	for _, task := range conf.Project.Tasks {
 		s.NotEqual(len(task.Commands), 0)
 		for _, command := range task.Commands {
@@ -956,46 +960,46 @@ func (s *GitGetProjectSuite) TestGetProjectMethodAndToken() {
 		},
 	}
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken)
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken, true)
 	s.NoError(err)
 	s.Equal(projectGitHubToken, token)
 	s.Equal(cloneMethodOAuth, method)
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "")
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "", false)
 	s.NoError(err)
 	s.Equal(mockedGitHubAppToken, token)
 	s.Equal(cloneMethodAccessToken, method)
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "")
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "", false)
 	s.NoError(err)
 	s.Equal(mockedGitHubAppToken, token)
 	s.Equal(cloneMethodAccessToken, method)
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken)
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken, true)
 	s.NoError(err)
 	s.Equal(projectGitHubToken, token)
 	s.Equal(cloneMethodOAuth, method)
 
 	conf.Expansions[evergreen.GlobalGitHubTokenExpansion] = ""
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken)
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken, true)
 	s.NoError(err)
 	s.Equal(projectGitHubToken, token)
 	s.Equal(cloneMethodOAuth, method)
 
-	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken)
+	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken, true)
 	s.NoError(err)
 	s.Equal(projectGitHubToken, token)
 	s.Equal(cloneMethodOAuth, method)
 
 	s.comm.CreateInstallationTokenFail = true
 
-	_, _, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "")
+	_, _, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "", false)
 	s.Error(err)
 
 	conf.Expansions[evergreen.GlobalGitHubTokenExpansion] = globalGitHubToken
 
-	_, _, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "token this is not a real token")
+	_, _, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, "token this is not a real token", false)
 	s.Error(err)
 }
 

--- a/agent/command/testdata/git/multiple_modules.yml
+++ b/agent/command/testdata/git/multiple_modules.yml
@@ -7,6 +7,7 @@ tasks:
         params:
           directory: src
           token: ${github}
+          is_oauth: true
 
 modules:
   - name: sample-1

--- a/agent/command/testdata/git/plugin_clone.yml
+++ b/agent/command/testdata/git/plugin_clone.yml
@@ -1,26 +1,27 @@
 batch_time: 180
 
 tasks:
-    - name: testtask1
-      commands:
-        - command: git.get_project
-          params:
-            directory: src
-            token: ${github}
+  - name: testtask1
+    commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: ${github}
+          is_oauth: true
 
 modules:
-- name: enterprise
-  owner: 10gen
-  repo: mongo-enterprise-modules
-  prefix: src/mongo/db/modules
-  branch: v2.6
+  - name: enterprise
+    owner: 10gen
+    repo: mongo-enterprise-modules
+    prefix: src/mongo/db/modules
+    branch: v2.6
 
 buildvariants:
-- name: linux-64
-  display_name: Linux 64-bit
-  modules:
-    - enterprise
-  test_flags: --continue-on-failure
-  expansions:
-    blah: "blah"
-  push: true
+  - name: linux-64
+    display_name: Linux 64-bit
+    modules:
+      - enterprise
+    test_flags: --continue-on-failure
+    expansions:
+      blah: "blah"
+    push: true

--- a/agent/command/testdata/git/plugin_patch.yml
+++ b/agent/command/testdata/git/plugin_patch.yml
@@ -1,26 +1,27 @@
 batch_time: 180
 
 tasks:
-    - name: testtask1
-      commands:
-        - command: git.get_project
-          params:
-            directory: src
-            token: ${github}
+  - name: testtask1
+    commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: ${github}
+          is_oauth: true
 
 modules:
-- name: enterprise
-  owner: 10gen
-  repo: mongo-enterprise-modules
-  prefix: src/mongo/db/modules
-  branch: v2.6
+  - name: enterprise
+    owner: 10gen
+    repo: mongo-enterprise-modules
+    prefix: src/mongo/db/modules
+    branch: v2.6
 
 buildvariants:
-- name: linux-64
-  display_name: Linux 64-bit
-  modules:
-    - enterprise
-  test_flags: --continue-on-failure
-  expansions:
-    blah: "blah"
-  push: true
+  - name: linux-64
+    display_name: Linux 64-bit
+    modules:
+      - enterprise
+    test_flags: --continue-on-failure
+    expansions:
+      blah: "blah"
+    push: true

--- a/agent/command/testdata/git/test_config.yml
+++ b/agent/command/testdata/git/test_config.yml
@@ -7,6 +7,7 @@ tasks:
         params:
           directory: src
           token: ${github}
+          is_oauth: true
 
 modules:
   - name: sample

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-07-16"
+	AgentVersion = "2024-07-17"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -600,6 +600,8 @@ Parameters:
     "github_token" and then set this field to \${github_token}.
     Evergreen will populate the expansion when it parses the project
     yaml.
+-   `is_oauth`: If a project token is provided and that token is an OAuth token and not a
+    GitHub app token, `is_oauth` must be set to true so that the clone command is formatted properly.
 -   `clone_depth`: Clone with `git clone --depth <clone_depth>`. For
     patch builds, Evergreen will `git fetch --unshallow` if the base
     commit is older than `<clone_depth>` commits. `clone_depth` takes precedence over `shallow_clone`.


### PR DESCRIPTION
DEVPROD-8924

### Description
Only our project and two more (one of which is a test project with a public repo so it will continue to work) passes a token to git.get_project. Once the dynamic GitHub token project rolls out, those tokens will be either oauth or GitHub app tokens. Because the url needs to be formatted differently based on the token, we need to have a way to differentiate. Because GitHub app will soon be the default, it will be a smoother experience if the default is an app token and if someone wants to use oauth, they need to set oauth to true. I'll reach out to the two projects that currently use it and have them add it before merging this. 

### Testing
Tested on staging by adding a module to our self tests that already use an app token. 

