### PR TITLE
DEVPROD-8436 Reduce size for GitHub checks text for invalid config/project validation

### DIFF
--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -46,9 +46,9 @@ const (
 	noChildPatchTasksOrVariants = "no tasks/variants were configured for child patch"
 	NoSyncTasksOrVariants       = "no tasks/variants were configured for sync"
 	GitHubInternalError         = "GitHub returned an error"
-	InvalidConfig               = "config file was invalid: please sync with base branch and run `evergreen validate -p <project>`"
+	InvalidConfig               = "config file was invalid: sync with base branch & run `evergreen validate -p <project>`"
 	EmptyConfig                 = "config file was empty"
-	ProjectFailsValidation      = "Project fails validation: please sync with base branch and run `evergreen validate -p <project>`"
+	ProjectFailsValidation      = "project fails validation: sync with base branch & run `evergreen validate -p <project>`"
 	OtherErrors                 = "Evergreen error"
 	MergeBaseTooOld             = "merge base is too old"
 )


### PR DESCRIPTION
DEVPROD-8436

### Description
This reduces the size so it's viewable on smaller screen sizes. This won't work for very small screens but there's not much we can do besides something extreme like [DEVPROD-8730](https://jira.mongodb.org/browse/DEVPROD-8730)


This was the before:
![image](https://github.com/user-attachments/assets/7e470b6d-bdef-4119-9e9e-3730bb052a44)

This would be with the change:
![image](https://github.com/user-attachments/assets/05fd091c-7e27-4f62-a58a-232307fde1d8)

This was an *alternative* design for comparison:
![image](https://github.com/user-attachments/assets/6518cc30-d600-47d5-a341-95ec8c1a55c5)
