### PR TITLE
DEVPROD-5857: allow delayed cron activation

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -924,6 +924,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasksWithBatchtime() {
 				BuildVariant: "a_variant",
 			},
 		},
+		CreateTime: time.Now(),
 	}
 	s.NoError(v.Insert())
 	pp := &ParserProject{}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -538,7 +538,8 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		if !bvtu.HasSpecificActivation() {
 			continue
 		}
-		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu)
+		// Use the version create time to ensure we're being consistent
+		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu, creationInfo.Version.CreateTime)
 		batchTimeCatcher.Wrapf(err, "getting activation time for task '%s'", t.DisplayName)
 		batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 			TaskName: t.DisplayName,
@@ -1609,12 +1610,13 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		var activateVariantAt time.Time
 		batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 		if !activateVariant {
-			activateVariantAt, err = creationInfo.ProjectRef.GetActivationTimeForVariant(creationInfo.Project.FindBuildVariant(pair.Variant))
+			activateVariantAt, err = creationInfo.ProjectRef.GetActivationTimeForVariant(
+				creationInfo.Project.FindBuildVariant(pair.Variant), creationInfo.Version.CreateTime)
 			batchTimeCatcher.Wrapf(err, "getting activation time for variant '%s'", pair.Variant)
 		}
 		for taskName, id := range batchTimeTasksToIds {
 			activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(
-				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant))
+				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant), creationInfo.Version.CreateTime)
 			batchTimeCatcher.Wrapf(err, "getting activation time for task '%s' in variant '%s'", taskName, pair.Variant)
 			batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 				TaskId:   id,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -538,7 +538,6 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		if !bvtu.HasSpecificActivation() {
 			continue
 		}
-		// Use the version create time to ensure we're being consistent
 		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu, creationInfo.Version.CreateTime, time.Now())
 		batchTimeCatcher.Wrapf(err, "getting activation time for task '%s'", t.DisplayName)
 		batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -539,7 +539,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 			continue
 		}
 		// Use the version create time to ensure we're being consistent
-		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu, creationInfo.Version.CreateTime)
+		activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(bvtu, creationInfo.Version.CreateTime, time.Now())
 		batchTimeCatcher.Wrapf(err, "getting activation time for task '%s'", t.DisplayName)
 		batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 			TaskName: t.DisplayName,
@@ -1611,12 +1611,12 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		batchTimeTaskStatuses := []BatchTimeTaskStatus{}
 		if !activateVariant {
 			activateVariantAt, err = creationInfo.ProjectRef.GetActivationTimeForVariant(
-				creationInfo.Project.FindBuildVariant(pair.Variant), creationInfo.Version.CreateTime)
+				creationInfo.Project.FindBuildVariant(pair.Variant), creationInfo.Version.CreateTime, time.Now())
 			batchTimeCatcher.Wrapf(err, "getting activation time for variant '%s'", pair.Variant)
 		}
 		for taskName, id := range batchTimeTasksToIds {
 			activateTaskAt, err := creationInfo.ProjectRef.GetActivationTimeForTask(
-				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant), creationInfo.Version.CreateTime)
+				creationInfo.Project.FindTaskForVariant(taskName, pair.Variant), creationInfo.Version.CreateTime, time.Now())
 			batchTimeCatcher.Wrapf(err, "getting activation time for task '%s' in variant '%s'", taskName, pair.Variant)
 			batchTimeTaskStatuses = append(batchTimeTaskStatuses, BatchTimeTaskStatus{
 				TaskId:   id,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2466,11 +2466,6 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant, versionC
 		return now, nil
 	}
 
-	// kim: NOTE: logic below is kind of similar to what we want to check if
-	// there's another version that might be activated, but we can't assume that
-	// the most recent variant is the one that contains the most recent cron
-	// run (because it could include irrelevant version types like periodic
-	// builds).
 	lastActivated, err := VersionFindOne(VersionByLastVariantActivation(p.Id, variant.Name).WithFields(VersionBuildVariantsKey))
 	if err != nil {
 		return time.Time{}, errors.Wrap(err, "finding version")

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2414,12 +2414,12 @@ func handleBatchTimeOverflow(in int) int {
 }
 
 // GetNextCronTime returns the next valid batch time
-func GetNextCronTime(curTime time.Time, cronBatchTime string) (time.Time, error) {
+func GetNextCronTime(baseTime time.Time, cronBatchTime string) (time.Time, error) {
 	sched, err := getCronParserSchedule(cronBatchTime)
 	if err != nil {
 		return time.Time{}, err
 	}
-	return sched.Next(curTime), nil
+	return sched.Next(baseTime), nil
 }
 
 func getCronParserSchedule(cronStr string) (cron.Schedule, error) {
@@ -2442,6 +2442,9 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant, versionC
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {
+		// kim: TODO: handle if versionCreateTime is too far in the past or
+		// another version is already scheduled to run at that time. If so, use
+		// the original logic to schedule the cron based on current ts.
 		return GetNextCronTime(versionCreateTime, variant.CronBatchTime)
 	}
 	// if activated explicitly set to true and we don't have batchtime, then we want to just activate now
@@ -2479,6 +2482,9 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, versionCr
 		return utility.ZeroTime, nil
 	}
 	if t.CronBatchTime != "" {
+		// kim: TODO: handle if versionCreateTime is too far in the past or
+		// another version is already scheduled to run at that time. If so, use
+		// the original logic to schedule the cron based on current ts.
 		return GetNextCronTime(versionCreateTime, t.CronBatchTime)
 	}
 	// If activated explicitly set to true and we don't have batchtime, then we want to just activate now

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2494,20 +2494,10 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant, versionC
 // scheduled late. This is used to check if the cron should have run recently.
 const allowedCronDelay = 5 * time.Minute
 
+// isCronTimeRangeValid checks that the proposed cron is not too far in the
+// past.
 func (p *ProjectRef) isCronTimeRangeValid(proposedCron time.Time, now time.Time) bool {
-	if proposedCron.After(now) {
-		// Cron is scheduled for the future, which is valid.
-		return true
-	}
-	const allowedCronDelay = 5 * time.Minute
-	if proposedCron.Before(now.Add(-allowedCronDelay)) {
-		// Cron is scheduled in the past, but it's been more than a few minutes
-		// since the time it should have activated, so it has missed its chance
-		// and is too late. Activating it past the allowed cron delay would be
-		// risky since activating may cause a conflict with future cron runs.
-		return false
-	}
-	return true
+	return !proposedCron.Before(now.Add(-allowedCronDelay))
 }
 
 // isValidBVCron checks if a proposed time to activate a cron for a build

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2434,14 +2434,15 @@ func getCronParserSchedule(cronStr string) (cron.Schedule, error) {
 	return sched, nil
 }
 
-func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Time, error) {
-	defaultRes := time.Now()
+// GetActivationTimeForVariant returns the time at which this variant should next be activated.
+// To ensure consistency across variants, the version create time is used to determine the next time.
+func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant, versionCreateTime time.Time) (time.Time, error) {
 	// if we don't want to activate the build, set batchtime to the zero time
 	if !utility.FromBoolTPtr(variant.Activate) {
 		return utility.ZeroTime, nil
 	}
 	if variant.CronBatchTime != "" {
-		return GetNextCronTime(time.Now(), variant.CronBatchTime)
+		return GetNextCronTime(versionCreateTime, variant.CronBatchTime)
 	}
 	// if activated explicitly set to true and we don't have batchtime, then we want to just activate now
 	if utility.FromBoolPtr(variant.Activate) && variant.BatchTime == nil {
@@ -2454,7 +2455,7 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 	}
 
 	if lastActivated == nil {
-		return defaultRes, nil
+		return versionCreateTime, nil
 	}
 
 	// find matching activated build variant
@@ -2467,19 +2468,18 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant) (time.Ti
 		}
 	}
 
-	return defaultRes, nil
+	return versionCreateTime, nil
 }
 
 // GetActivationTimeForTask returns the time at which this task should next be activated.
-// Temporarily takes in the task ID that prompted this query, for logging.
-func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Time, error) {
-	defaultRes := time.Now()
+// To ensure consistency across tasks, the version create time is used to determine the next time.
+func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit, versionCreateTime time.Time) (time.Time, error) {
 	// if we don't want to activate the task, set batchtime to the zero time
 	if !utility.FromBoolTPtr(t.Activate) || t.IsDisabled() {
 		return utility.ZeroTime, nil
 	}
 	if t.CronBatchTime != "" {
-		return GetNextCronTime(time.Now(), t.CronBatchTime)
+		return GetNextCronTime(versionCreateTime, t.CronBatchTime)
 	}
 	// If activated explicitly set to true and we don't have batchtime, then we want to just activate now
 	if utility.FromBoolPtr(t.Activate) && t.BatchTime == nil {
@@ -2488,10 +2488,10 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 
 	lastActivated, err := VersionFindOne(VersionByLastTaskActivation(p.Id, t.Variant, t.Name).WithFields(VersionBuildVariantsKey))
 	if err != nil {
-		return defaultRes, errors.Wrap(err, "finding version")
+		return versionCreateTime, errors.Wrap(err, "finding version")
 	}
 	if lastActivated == nil {
-		return defaultRes, nil
+		return versionCreateTime, nil
 	}
 
 	for _, buildStatus := range lastActivated.BuildVariants {
@@ -2506,7 +2506,7 @@ func (p *ProjectRef) GetActivationTimeForTask(t *BuildVariantTaskUnit) (time.Tim
 			return taskStatus.ActivateAt.Add(time.Minute * time.Duration(p.getBatchTimeForTask(t))), nil
 		}
 	}
-	return defaultRes, nil
+	return versionCreateTime, nil
 }
 
 // GetGithubProjectConflicts returns any potential conflicts; i.e. regardless of whether or not

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -545,12 +545,12 @@ func TestGetActivationTimeForTask(t *testing.T) {
 	assert.NoError(t, versionWithTask.Insert())
 
 	currentTime := time.Now()
-	activationTime, err := projectRef.GetActivationTimeForTask(bvt, currentTime)
+	activationTime, err := projectRef.GetActivationTimeForTask(bvt, currentTime, time.Now())
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(prevTime.Add(time.Hour)))
 
 	// Activation time should be the zero time, because this variant is disabled.
-	activationTime, err = projectRef.GetActivationTimeForTask(bvt2, currentTime)
+	activationTime, err = projectRef.GetActivationTimeForTask(bvt2, currentTime, time.Now())
 	assert.NoError(t, err)
 	assert.True(t, utility.IsZeroTime(activationTime))
 }
@@ -602,6 +602,157 @@ func TestGetActivationTimeWithCron(t *testing.T) {
 		},
 	} {
 		t.Run(name, test)
+	}
+
+	pRef := ProjectRef{
+		Id:         "project",
+		Identifier: "project",
+	}
+	versionCreatedAt, err := time.Parse(time.RFC3339, "2024-07-15T23:59:00Z")
+	require.NoError(t, err)
+	v := Version{
+		Id:         "version",
+		CreateTime: versionCreatedAt,
+	}
+	const cronExpr = "0 */4 * * *" // Every 4 hours
+	bvtu := BuildVariantTaskUnit{
+		Name:          "task_name",
+		Variant:       "bv_name",
+		CronBatchTime: cronExpr,
+	}
+	bv := BuildVariant{
+		Name:          "bv_name",
+		CronBatchTime: cronExpr,
+	}
+
+	for activationType, getActivationTime := range map[string]func(versionCreatedAt time.Time, now time.Time) (time.Time, error){
+		"Task": func(versionCreatedAt time.Time, now time.Time) (time.Time, error) {
+			return pRef.GetActivationTimeForTask(&bvtu, versionCreatedAt, now)
+		},
+		"Variant": func(versionCreatedAt time.Time, now time.Time) (time.Time, error) {
+			return pRef.GetActivationTimeForVariant(&bv, versionCreatedAt, now)
+		},
+	} {
+		t.Run(activationType, func(t *testing.T) {
+			for tName, tCase := range map[string]func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit){
+				"SchedulesPastCronWithRecentlyElapsedCron": func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit) {
+					now := v.CreateTime.Add(2 * time.Minute)
+
+					activateAt, err := getActivationTime(v.CreateTime, now)
+					require.NoError(t, err)
+
+					assert.True(t, activateAt.Before(now), "cron should be scheduled in the past")
+				},
+				"SchedulesFutureCronWithRecentlyElapsedCronButConflictingRecentCommitVersion": func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit) {
+					now := v.CreateTime.Add(2 * time.Minute)
+					conflictingVersionWithCron := Version{
+						Id:         "conflicting_version_with_cron",
+						Identifier: pRef.Id,
+						CreateTime: v.CreateTime.Add(-time.Hour),
+						Requester:  evergreen.RepotrackerVersionRequester,
+						BuildVariants: []VersionBuildStatus{
+							{
+								BuildVariant: "bv_name",
+								ActivationStatus: ActivationStatus{
+									ActivateAt: now,
+								},
+								BatchTimeTasks: []BatchTimeTaskStatus{
+									{
+										TaskName: "task_name",
+										ActivationStatus: ActivationStatus{
+											ActivateAt: now,
+										},
+									},
+								},
+							},
+						},
+					}
+					require.NoError(t, conflictingVersionWithCron.Insert())
+
+					activateAt, err := getActivationTime(v.CreateTime, now)
+					require.NoError(t, err)
+					assert.True(t, activateAt.After(now), "cron should be scheduled in the future due to conflicting recent commit version with cron task")
+				},
+				"SchedulesPastCronWithNonconflictingRecentCommitVersion": func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit) {
+					now := v.CreateTime.Add(2 * time.Minute)
+
+					recentVersionCreatedAt := v.CreateTime.Add(-6 * time.Hour)
+					recentVersionWithCron := Version{
+						Id:         "conflicting_version_with_cron",
+						Identifier: pRef.Id,
+						CreateTime: recentVersionCreatedAt,
+						Requester:  evergreen.AdHocRequester,
+						BuildVariants: []VersionBuildStatus{
+							{
+								BuildVariant: "bv_name",
+								ActivationStatus: ActivationStatus{
+									ActivateAt: recentVersionCreatedAt,
+								},
+								BatchTimeTasks: []BatchTimeTaskStatus{
+									{
+										TaskName: "task_name",
+										ActivationStatus: ActivationStatus{
+											ActivateAt: recentVersionCreatedAt,
+										},
+									},
+								},
+							},
+						},
+					}
+					require.NoError(t, recentVersionWithCron.Insert())
+
+					activateAt, err := getActivationTime(v.CreateTime, now)
+					require.NoError(t, err)
+
+					assert.True(t, activateAt.Before(now), "cron should be scheduled in the past because the most recent commit version's cron does not conflict")
+				},
+				"SchedulesPastCronWithNonconflictingPeriodicBuild": func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit) {
+					now := v.CreateTime.Add(2 * time.Minute)
+					conflictingVersionWithCron := Version{
+						Id:         "conflicting_version_with_cron",
+						Identifier: pRef.Id,
+						CreateTime: v.CreateTime.Add(-time.Hour),
+						Requester:  evergreen.AdHocRequester,
+						BuildVariants: []VersionBuildStatus{
+							{
+								BuildVariant: "bv_name",
+								ActivationStatus: ActivationStatus{
+									ActivateAt: now,
+								},
+								BatchTimeTasks: []BatchTimeTaskStatus{
+									{
+										TaskName: "task_name",
+										ActivationStatus: ActivationStatus{
+											ActivateAt: now,
+										},
+									},
+								},
+							},
+						},
+					}
+					require.NoError(t, conflictingVersionWithCron.Insert())
+
+					activateAt, err := getActivationTime(v.CreateTime, now)
+					require.NoError(t, err)
+
+					assert.True(t, activateAt.Before(now), "cron should be scheduled in the past since the most recent version is a periodic build")
+				},
+				"SchedulesFutureCronForLongElapsedCron": func(t *testing.T, pRef *ProjectRef, v *Version, bvtu *BuildVariantTaskUnit) {
+					now := v.CreateTime.Add(time.Hour)
+
+					activateAt, err := getActivationTime(v.CreateTime, now)
+					require.NoError(t, err)
+
+					assert.True(t, activateAt.After(now), "cron should be scheduled in the future because it has been a long time since the version was created")
+				},
+			} {
+				t.Run(tName, func(t *testing.T) {
+					require.NoError(t, db.ClearCollections(VersionCollection))
+
+					tCase(t, &pRef, &v, &bvtu)
+				})
+			}
+		})
 	}
 }
 
@@ -3820,10 +3971,10 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	assert.Nil(projectRef.Insert())
 
 	// Set based on last activation time when no version is found
-	currentTime := time.Now().Add(-1 * time.Minute)
-	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
+	versionCreatedAt := time.Now().Add(-1 * time.Minute)
+	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, versionCreatedAt, time.Now())
 	assert.NoError(err)
-	assert.Equal(activationTime, currentTime)
+	assert.Equal(activationTime, versionCreatedAt)
 
 	// set based on last activation time with a version
 	version := &Version{
@@ -3843,8 +3994,8 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	}
 	assert.Nil(version.Insert())
 
-	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
+	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, versionCreatedAt, time.Now())
 	assert.NoError(err)
 	assert.NotZero(activationTime)
-	assert.Equal(activationTime, currentTime)
+	assert.Equal(activationTime, versionCreatedAt)
 }

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -544,13 +544,15 @@ func TestGetActivationTimeForTask(t *testing.T) {
 	assert.NoError(t, versionWithoutTask.Insert())
 	assert.NoError(t, versionWithTask.Insert())
 
-	activationTime, err := projectRef.GetActivationTimeForTask(bvt)
+	currentTime := time.Now()
+	activationTime, err := projectRef.GetActivationTimeForTask(bvt, currentTime)
 	assert.NoError(t, err)
 	assert.True(t, activationTime.Equal(prevTime.Add(time.Hour)))
 
-	activationTime, err = projectRef.GetActivationTimeForTask(bvt2)
+	// Activation time should be the zero time, because this variant is disabled.
+	activationTime, err = projectRef.GetActivationTimeForTask(bvt2, currentTime)
 	assert.NoError(t, err)
-	assert.True(t, activationTime.Equal(utility.ZeroTime))
+	assert.True(t, utility.IsZeroTime(activationTime))
 }
 
 func TestGetActivationTimeWithCron(t *testing.T) {
@@ -3817,10 +3819,11 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	}
 	assert.Nil(projectRef.Insert())
 
-	// set based on last activation time when no version is found
-	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
+	// Set based on last activation time when no version is found
+	currentTime := time.Now().Add(-1 * time.Minute)
+	activationTime, err := projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
 	assert.NoError(err)
-	assert.NotZero(activationTime)
+	assert.Equal(activationTime, currentTime)
 
 	// set based on last activation time with a version
 	version := &Version{
@@ -3840,7 +3843,8 @@ func TestGetActivationTimeForVariant(t *testing.T) {
 	}
 	assert.Nil(version.Insert())
 
-	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"})
+	activationTime, err = projectRef.GetActivationTimeForVariant(&BuildVariant{Name: "bv"}, currentTime)
 	assert.NoError(err)
 	assert.NotZero(activationTime)
+	assert.Equal(activationTime, currentTime)
 }

--- a/model/version.go
+++ b/model/version.go
@@ -332,8 +332,6 @@ type VersionMetadata struct {
 var (
 	VersionBuildStatusVariantKey        = bsonutil.MustHaveTag(VersionBuildStatus{}, "BuildVariant")
 	VersionBuildStatusActivatedKey      = bsonutil.MustHaveTag(VersionBuildStatus{}, "Activated")
-	VersionBuildStatusActivateAtKey     = bsonutil.MustHaveTag(VersionBuildStatus{}, "ActivateAt")
-	VersionBuildStatusBuildIdKey        = bsonutil.MustHaveTag(VersionBuildStatus{}, "BuildId")
 	VersionBuildStatusBatchTimeTasksKey = bsonutil.MustHaveTag(VersionBuildStatus{}, "BatchTimeTasks")
 
 	BatchTimeTaskStatusTaskNameKey  = bsonutil.MustHaveTag(BatchTimeTaskStatus{}, "TaskName")

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -253,8 +253,9 @@ func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
 	return db.Query(q).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
-// VersionByMostRecentNonIgnored finds all non-ignored versions within a project,
-// ordered by most recently created to oldest, before a given time.
+// VersionByMostRecentNonIgnored finds all non-ignored mainline commit versions
+// within a project, ordered by most recently created to oldest, before a given
+// time.
 func VersionByMostRecentNonIgnored(projectId string, ts time.Time) db.Q {
 	return db.Query(
 		bson.M{

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -929,8 +929,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if v.Requester == evergreen.RepotrackerVersionRequester && evergreen.ShouldConsiderBatchtime(v.Requester) {
-			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant)
+		if evergreen.ShouldConsiderBatchtime(v.Requester) {
+			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime)
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
@@ -938,7 +938,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt)
+				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, v.CreateTime)
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 
 				taskStatuses = append(taskStatuses,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -930,7 +930,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
 		if evergreen.ShouldConsiderBatchtime(v.Requester) {
-			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime)
+			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime, time.Now())
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
@@ -938,7 +938,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, v.CreateTime)
+				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(&bvt, v.CreateTime, time.Now())
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 
 				taskStatuses = append(taskStatuses,

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -929,7 +929,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if evergreen.ShouldConsiderBatchtime(v.Requester) {
+		if v.Requester == evergreen.RepotrackerVersionRequester && evergreen.ShouldConsiderBatchtime(v.Requester) {
 			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime, time.Now())
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1094,7 +1094,7 @@ tasks:
 			s.InDelta(bv.ActivateAt.Unix(), now.Unix(), 1)
 			s.Require().Len(bv.BatchTimeTasks, 2)
 			for _, t := range bv.BatchTimeTasks {
-				if t.TaskName == "task1" { // activate time is now because their isn't a previous task
+				if t.TaskName == "task1" { // activate time is now because there isn't a previous task
 					s.InDelta(t.ActivateAt.Unix(), now.Unix(), 1)
 				} else {
 					// ensure that "daily" cron is set for the next day
@@ -1104,6 +1104,84 @@ tasks:
 					s.Equal(d, td)
 				}
 
+			}
+		}
+		if bv.BuildVariant == "bv2" {
+			s.False(bv.Activated)
+			s.Len(bv.BatchTimeTasks, 0)
+		}
+	}
+}
+
+func (s *CreateVersionFromConfigSuite) TestCreateVersionItemsBatchtime() {
+	// Test that we correctly use the version create time to determine task batchtimes, rather than the task create time.
+	configYml := `
+buildvariants:
+- name: bv
+  display_name: "bv_display"
+  run_on: d
+  tasks:
+  - name: task1
+    batchtime: 30
+  - name: task2
+    cron: "@daily"
+  - name: task3
+- name: bv2
+  batchtime: 15
+  display_name: bv2_display
+  run_on: d
+  tasks:
+  - name: task1
+tasks:
+- name: task1
+- name: task2
+- name: task3
+`
+	p := &model.Project{}
+	pp, err := model.LoadProjectInto(s.ctx, []byte(configYml), nil, s.ref.Id, p)
+	s.NoError(err)
+	projectInfo := &model.ProjectInfo{
+		Ref:                 s.ref,
+		IntermediateProject: pp,
+		Project:             p,
+	}
+	metadata := model.VersionMetadata{Revision: *s.rev}
+	versionCreateTime := time.Now().Add(time.Minute * -10)
+
+	v := &model.Version{
+		Id:                  "_abc",
+		CreateTime:          versionCreateTime,
+		Revision:            "abc",
+		Author:              "me",
+		RevisionOrderNumber: 12,
+		Owner:               "evergreen-ci",
+		Repo:                "evergreen",
+		Branch:              "main",
+		Requester:           evergreen.RepotrackerVersionRequester,
+	}
+
+	s.NoError(createVersionItems(s.ctx, v, metadata, projectInfo, nil))
+	tasks, err := task.FindAllTaskIDsFromVersion(v.Id)
+	s.NoError(err)
+	s.Len(tasks, 4)
+	tomorrow := versionCreateTime.Add(time.Hour * 24) // next day
+	y, m, d := tomorrow.Date()
+
+	s.Len(v.BuildVariants, 2)
+	for _, bv := range v.BuildVariants {
+		if bv.BuildVariant == "bv" {
+			s.Equal(versionCreateTime, bv.ActivateAt) // Build variant activate time should use the version create time
+			s.Require().Len(bv.BatchTimeTasks, 2)
+			for _, t := range bv.BatchTimeTasks {
+				if t.TaskName == "task1" { // activate time is the version create time because there isn't a previous task
+					s.Equal(versionCreateTime, t.ActivateAt)
+				} else {
+					// ensure that "daily" cron is set for the next day
+					ty, tm, td := t.ActivateAt.Date()
+					s.Equal(y, ty)
+					s.Equal(m, tm)
+					s.Equal(d, td)
+				}
 			}
 		}
 		if bv.BuildVariant == "bv2" {


### PR DESCRIPTION
DEVPROD-5857

### Description
This is #7888 with an improvement to handle a situation where versions are created really late.

If a commit is made almost at the same time as when the cron should activate (e.g. commit at 7:59 pm, next cron run is 8 pm), we should allow the cron to activate immediately, even if Evergreen starts processing the version a tiny bit late (e.g. at 8:01 pm). This is what #7888 fixes. 

_However_, as an additional consideration, the late cron can't activate immediately if there's a cron that's already scheduled to activate or is already activating right now. To deal with this, I limited the ability to schedule late crons so that they can only be scheduled to run immediately if they're only a few minutes late _and_ no other cron activation is currently going on/just happened. If there's another cron run already scheduled to run or the version is really late to be picked up, it'll schedule the cron to activate at a future time rather than immediately.

### Testing
Added unit tests.

### Documentation
N/A