### PR TITLE
DEVPROD-8797: stop agent monitor when host is unable to run tasks

### DIFF
--- a/operations/agent.go
+++ b/operations/agent.go
@@ -23,12 +23,12 @@ const defaultAgentStatusPort = 2285
 const (
 	agentAPIServerURLFlagName  = "api_server"
 	agentCloudProviderFlagName = "provider"
+	agentHostIDFlagName        = "host_id"
+	agentHostSecretFlagName    = "host_secret"
 )
 
 func Agent() cli.Command {
 	const (
-		hostIDFlagName                     = "host_id"
-		hostSecretFlagName                 = "host_secret"
 		workingDirectoryFlagName           = "working_directory"
 		logOutputFlagName                  = "log_output"
 		logPrefixFlagName                  = "log_prefix"
@@ -49,11 +49,11 @@ func Agent() cli.Command {
 		},
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  hostIDFlagName,
+				Name:  agentHostIDFlagName,
 				Usage: "the ID of the host the agent is running on (applies only to host mode)",
 			},
 			cli.StringFlag{
-				Name:  hostSecretFlagName,
+				Name:  agentHostSecretFlagName,
 				Usage: "secret for the current host (applies only to host mode)",
 			},
 			cli.StringFlag{
@@ -123,8 +123,8 @@ func Agent() cli.Command {
 				mode := c.String(modeFlagName)
 				switch mode {
 				case string(globals.HostMode):
-					catcher.Add(requireStringFlag(hostIDFlagName)(c))
-					catcher.Add(requireStringFlag(hostSecretFlagName)(c))
+					catcher.Add(requireStringFlag(agentHostIDFlagName)(c))
+					catcher.Add(requireStringFlag(agentHostSecretFlagName)(c))
 				case string(globals.PodMode):
 					catcher.Add(requireStringFlag(podIDFlagName)(c))
 					catcher.Add(requireStringFlag(podSecretFlagName)(c))
@@ -145,8 +145,8 @@ func Agent() cli.Command {
 			}
 
 			opts := agent.Options{
-				HostID:                     c.String(hostIDFlagName),
-				HostSecret:                 c.String(hostSecretFlagName),
+				HostID:                     c.String(agentHostIDFlagName),
+				HostSecret:                 c.String(agentHostSecretFlagName),
 				PodID:                      c.String(podIDFlagName),
 				PodSecret:                  c.String(podSecretFlagName),
 				Mode:                       globals.Mode(c.String(modeFlagName)),

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -76,8 +76,11 @@ func hostProvision() cli.Command {
 
 			hostID := c.String(hostIDFlagName)
 			hostSecret := c.String(hostSecretFlagName)
+			comm.SetHostID(hostID)
+			comm.SetHostSecret(hostSecret)
+
 			cloudProvider := c.String(cloudProviderFlagName)
-			h, err := postHostIsUp(ctx, comm, hostID, hostSecret, cloudProvider)
+			h, err := postHostIsUp(ctx, comm, hostID, cloudProvider)
 			if err != nil {
 				return errors.Wrap(err, "posting that the host is up")
 			}
@@ -90,7 +93,7 @@ func hostProvision() cli.Command {
 				}
 			}
 
-			opts, err := comm.GetHostProvisioningOptions(ctx, hostID, hostSecret)
+			opts, err := comm.GetHostProvisioningOptions(ctx)
 			if err != nil {
 				return errors.Wrap(err, "getting host provisioning script")
 			}
@@ -113,7 +116,7 @@ func hostProvision() cli.Command {
 	}
 }
 
-func postHostIsUp(ctx context.Context, comm client.Communicator, hostID, hostSecret, cloudProvider string) (*restmodel.APIHost, error) {
+func postHostIsUp(ctx context.Context, comm client.Communicator, hostID, cloudProvider string) (*restmodel.APIHost, error) {
 	var ec2InstanceID string
 	if cloud.IsEC2InstanceID(hostID) {
 		ec2InstanceID = hostID
@@ -129,7 +132,7 @@ func postHostIsUp(ctx context.Context, comm client.Communicator, hostID, hostSec
 		}
 	}
 
-	h, err := comm.PostHostIsUp(ctx, hostID, hostSecret, ec2InstanceID)
+	h, err := comm.PostHostIsUp(ctx, ec2InstanceID)
 	if err != nil {
 		return nil, errors.Wrap(err, "posting that the host is up")
 	}

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -94,7 +94,7 @@ func (c *communicatorImpl) SetHostID(hostID string) {
 	c.hostID = hostID
 }
 
-// SetHostID sets the host secret for authentication using host credentials
+// SetHostSecret sets the host secret for authentication using host credentials
 // instead of API keys.
 func (c *communicatorImpl) SetHostSecret(hostSecret string) {
 	c.hostSecret = hostSecret

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -27,6 +27,9 @@ type communicatorImpl struct {
 	// these fields have setters
 	apiUser string
 	apiKey  string
+
+	hostID     string
+	hostSecret string
 }
 
 // NewCommunicator returns a Communicator capable of making HTTP REST requests
@@ -83,4 +86,16 @@ func (c *communicatorImpl) SetAPIUser(apiUser string) {
 // SetAPIKey sets the API key.
 func (c *communicatorImpl) SetAPIKey(apiKey string) {
 	c.apiKey = apiKey
+}
+
+// SetHostID sets the host ID for authentication using host credentials instead
+// of API keys.
+func (c *communicatorImpl) SetHostID(hostID string) {
+	c.hostID = hostID
+}
+
+// SetHostID sets the host secret for authentication using host credentials
+// instead of API keys.
+func (c *communicatorImpl) SetHostSecret(hostSecret string) {
+	c.hostSecret = hostSecret
 }

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -23,10 +23,12 @@ type Communicator interface {
 	SetTimeoutMax(time.Duration)
 	// SetMaxAttempts sets the number of attempts a request will be made.
 	SetMaxAttempts(int)
-	// Client Configuration methods
-	//
+	// Client authentication methods (for users)
 	SetAPIUser(string)
 	SetAPIKey(string)
+	// Client authentication methods (for hosts)
+	SetHostID(string)
+	SetHostSecret(string)
 
 	// Method to release resources used by the communicator.
 	Close()
@@ -126,9 +128,9 @@ type Communicator interface {
 
 	// PostHostIsUp indicates to the app server that the task host is up and
 	// running.
-	PostHostIsUp(ctx context.Context, hostID, hostSecret, instanceID string) (*restmodel.APIHost, error)
+	PostHostIsUp(ctx context.Context, instanceID string) (*restmodel.APIHost, error)
 	// GetHostProvisioningOptions gets the options to provision a host.
-	GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error)
+	GetHostProvisioningOptions(ctx context.Context) (*restmodel.APIHostProvisioningOptions, error)
 
 	// CompareTasks returns the order that the given tasks would be scheduled, along with the scheduling logic.
 	CompareTasks(context.Context, []string, bool) ([]string, map[string]map[string]string, error)

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1489,32 +1489,30 @@ func (c *communicatorImpl) GetClientURLs(ctx context.Context, distroID string) (
 	return urls, nil
 }
 
-func (c *communicatorImpl) PostHostIsUp(ctx context.Context, hostID, hostSecret, ec2InstanceID string) (*restmodel.APIHost, error) {
+func (c *communicatorImpl) PostHostIsUp(ctx context.Context, ec2InstanceID string) (*restmodel.APIHost, error) {
 	info := requestInfo{
 		method: http.MethodPost,
-		path:   fmt.Sprintf("/hosts/%s/is_up", hostID),
+		path:   fmt.Sprintf("/hosts/%s/is_up", c.hostID),
 	}
 	opts := restmodel.APIHostIsUpOptions{
-		HostID:        hostID,
+		HostID:        c.hostID,
 		EC2InstanceID: ec2InstanceID,
 	}
 	r, err := c.createRequest(info, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
 	}
-	r.Header.Add(evergreen.HostHeader, hostID)
-	r.Header.Add(evergreen.HostSecretHeader, hostSecret)
 	resp, err := utility.RetryRequest(ctx, r, utility.RetryOptions{
 		MaxAttempts: c.maxAttempts,
 		MinDelay:    c.timeoutStart,
 		MaxDelay:    c.timeoutMax,
 	})
 	if err != nil {
-		return nil, util.RespErrorf(resp, "sending request to indicate host '%s' is up", hostID)
+		return nil, util.RespErrorf(resp, errors.Wrapf(err, "sending request to indicate host '%s' is up", c.hostID).Error())
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, util.RespErrorf(resp, "posting that host '%s' is up", hostID)
+		return nil, util.RespErrorf(resp, "posting that host '%s' is up", c.hostID)
 	}
 	var h restmodel.APIHost
 	if err = utility.ReadJSON(resp.Body, &h); err != nil {
@@ -1523,24 +1521,22 @@ func (c *communicatorImpl) PostHostIsUp(ctx context.Context, hostID, hostSecret,
 	return &h, nil
 }
 
-func (c *communicatorImpl) GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error) {
+func (c *communicatorImpl) GetHostProvisioningOptions(ctx context.Context) (*restmodel.APIHostProvisioningOptions, error) {
 	info := requestInfo{
 		method: http.MethodGet,
-		path:   fmt.Sprintf("/hosts/%s/provisioning_options", hostID),
+		path:   fmt.Sprintf("/hosts/%s/provisioning_options", c.hostID),
 	}
 	r, err := c.createRequest(info, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
 	}
-	r.Header.Add(evergreen.HostHeader, hostID)
-	r.Header.Add(evergreen.HostSecretHeader, hostSecret)
 	resp, err := utility.RetryRequest(ctx, r, utility.RetryOptions{
 		MaxAttempts: c.maxAttempts,
 		MinDelay:    c.timeoutStart,
 		MaxDelay:    c.timeoutMax,
 	})
 	if err != nil {
-		return nil, util.RespErrorf(resp, "sending request to get provisioning options for host '%s'", hostID)
+		return nil, util.RespErrorf(resp, errors.Wrapf(err, "sending request to get provisioning options for host '%s'", c.hostID).Error())
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -1726,7 +1722,6 @@ func (c *communicatorImpl) GetTestLogs(ctx context.Context, opts GetTestLogsOpti
 	if err != nil {
 		return nil, errors.Wrapf(err, "sending request to get test logs")
 	}
-	fmt.Println(resp.Request.URL)
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, util.RespErrorf(resp, AuthError)

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -52,6 +52,10 @@ func (c *communicatorImpl) newRequest(method, path string, data interface{}) (*h
 	if c.apiUser != "" {
 		r.Header.Add(evergreen.APIKeyHeader, c.apiKey)
 	}
+	if c.hostID != "" && c.hostSecret != "" {
+		r.Header.Add(evergreen.HostHeader, c.hostID)
+		r.Header.Add(evergreen.HostSecretHeader, c.hostSecret)
+	}
 	r.Header.Add(evergreen.ContentTypeHeader, evergreen.ContentTypeValue)
 
 	return r, nil

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -318,8 +318,6 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 		// If the host is an intent host but the agent does not send the EC2
 		// instance ID, there's nothing that can be done to fix it here.
 
-		// kim: TODO: verify that this does not log because when the agent
-		// monitor runs, it already has a real host ID.
 		msg := "intent host is up, but it did not provide an EC2 instance ID, which is required"
 		grip.Warning(message.Fields{
 			"message":     msg,

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -318,6 +318,8 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 		// If the host is an intent host but the agent does not send the EC2
 		// instance ID, there's nothing that can be done to fix it here.
 
+		// kim: TODO: verify that this does not log because when the agent
+		// monitor runs, it already has a real host ID.
 		msg := "intent host is up, but it did not provide an EC2 instance ID, which is required"
 		grip.Warning(message.Fields{
 			"message":     msg,

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -45,6 +45,7 @@ type APIHost struct {
 	AttachedVolumeIDs     []string    `json:"attached_volume_ids"`
 	// Contains options for spawn hosts.
 	ProvisionOptions APIProvisionOptions `json:"provision_options"`
+	NeedsReprovision *string             `json:"needs_reprovision"`
 }
 
 // APIProvisionOptions contains options for spawn hosts.
@@ -153,6 +154,7 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 		attachedVolumeIds = append(attachedVolumeIds, volAttachment.VolumeID)
 	}
 	apiHost.AttachedVolumeIDs = attachedVolumeIds
+	apiHost.NeedsReprovision = utility.ToStringPtr(string(h.NeedsReprovision))
 	if h.ProvisionOptions != nil {
 		apiHost.ProvisionOptions.BuildFromService(*h.ProvisionOptions)
 	}
@@ -176,26 +178,6 @@ func (apiHost *APIHost) buildFromHostStruct(h *host.Host) {
 		BootstrapMethod:      utility.ToStringPtr(h.Distro.BootstrapSettings.Method),
 	}
 	apiHost.Distro = di
-}
-
-// ToService returns a service layer host using the data from the APIHost.
-func (apiHost *APIHost) ToService() host.Host {
-	return host.Host{
-		Id:                    utility.FromStringPtr(apiHost.Id),
-		PersistentDNSName:     utility.FromStringPtr(apiHost.PersistentDNSName),
-		Tag:                   utility.FromStringPtr(apiHost.Tag),
-		Provisioned:           apiHost.Provisioned,
-		NoExpiration:          apiHost.NoExpiration,
-		StartedBy:             utility.FromStringPtr(apiHost.StartedBy),
-		Provider:              utility.FromStringPtr(apiHost.Provider),
-		InstanceType:          utility.FromStringPtr(apiHost.InstanceType),
-		User:                  utility.FromStringPtr(apiHost.User),
-		Status:                utility.FromStringPtr(apiHost.Status),
-		Zone:                  utility.FromStringPtr(apiHost.AvailabilityZone),
-		DisplayName:           utility.FromStringPtr(apiHost.DisplayName),
-		HomeVolumeID:          utility.FromStringPtr(apiHost.HomeVolumeID),
-		LastCommunicationTime: apiHost.LastCommunicationTime,
-	}
 }
 
 type APIVolume struct {


### PR DESCRIPTION
DEVPROD-8797

### Description
The agent monitor is a simple process on task hosts that repeatedly downloads and starts the agent. This is quite useful for agent deploys because when the agent needs a new binary version, the agent can just exit and the agent monitor will come in to download and run the newer agent version.

If the host is in a state where it can't run tasks anymore (e.g. it's quarantined or terminated), it should stop the agent startup cycle. This adds a check to the agent monitor to shut down if the host is not able to run tasks. For example, if the host is decommissioned, it'll terminate soon, so we can shut down the agent monitor early.

* Add check to agent monitor to see if host is still healthy before running the agent.
* Remove logic to manually shut down the agent monitor for quarantining/reprovisioning. The new logic should let the agent monitor shut down on its own, so the Evergreen apps don't need to do this.
* Slightly refactor agent monitor client to Evergreen so it can use host ID/secret to authenticate a little more easily.

### Testing
* Tested in staging that the agent monitor ran the agent and shut down when the host was quarantined/decommissioned.
* Agent monitor smoke test passes.

### Documentation
N/A