### PR TITLE
DEVPROD-8950: fix ambiguous task route

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-07-16"
+	ClientVersion = "2024-07-19"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1399,7 +1399,7 @@ func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, proj
 func (c *communicatorImpl) GetTaskSyncReadCredentials(ctx context.Context) (*evergreen.S3Credentials, error) {
 	info := requestInfo{
 		method: http.MethodGet,
-		path:   "/task/sync_read_credentials",
+		path:   "/tasks/sync/read_credentials",
 	}
 
 	resp, err := c.request(ctx, info, nil)

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -244,7 +244,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/generated_tasks").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetGeneratedTasks())
 	app.AddRoute("/tasks/{task_id}/build/TaskLogs").Version(2).Get().Wrap(requireUser, viewTasks, compress).RouteHandler(makeGetTaskLogs(opts.URL))
 	app.AddRoute("/tasks/{task_id}/build/TestLogs/{path}").Version(2).Get().Wrap(requireUser, viewTasks, compress).RouteHandler(makeGetTestLogs(opts.URL))
-	app.AddRoute("/task/sync_read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())
+	app.AddRoute("/tasks/sync/read_credentials").Version(2).Get().Wrap(requireUser).RouteHandler(makeTaskSyncReadCredentialsGetHandler())
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(requireUser).RouteHandler(makeSetUserConfig())
 	app.AddRoute("/users/{user_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetUserHandler())

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -315,7 +315,7 @@ func (rh *taskSyncPathGetHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewTextResponse(t.S3Path(t.BuildVariant, t.DisplayName))
 }
 
-// GET /task/sync_read_credentials
+// GET /tasks/sync/read_credentials
 
 type taskSyncReadCredentialsGetHandler struct{}
 


### PR DESCRIPTION
DEVPROD-8950

### Description
The route pattern was ambiguous because the router treated `/task/sync_read_credentials` as matching `/task/{task_id}` (i.e. get one task), but it's really a standalone, unrelated route. I changed the route name so it's not ambiguous.

### Testing
Tested in staging that I can GET the route and it returns a valid result.

### Documentation
N/A
