### PR TITLE
DEVPROD-8738: log final error for creating task hosts

### DIFF
--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -216,15 +216,18 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	defer func() {
-		if j.IsLastAttempt() && j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) && j.host.SpawnOptions.SpawnedByTask {
+		if j.IsLastAttempt() && j.HasErrors() && (j.host.Status == evergreen.HostUninitialized || j.host.Status == evergreen.HostBuilding) {
 			grip.Error(message.WrapError(j.Error(), message.Fields{
 				"message": "no attempts remaining to create host",
 				"outcome": "giving up on creating this host",
 				"host_id": j.HostID,
 				"distro":  j.host.Distro.Id,
 			}))
-			if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.host.SpawnOptions.TaskExecutionNumber, j.Error()); err != nil {
-				j.AddError(errors.Wrapf(err, "adding host create error details"))
+
+			if j.host.SpawnOptions.SpawnedByTask {
+				if err := task.AddHostCreateDetails(j.host.StartedBy, j.host.Id, j.host.SpawnOptions.TaskExecutionNumber, j.Error()); err != nil {
+					j.AddError(errors.Wrapf(err, "adding host create error details"))
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
DEVPROD-8738

### Description
Small amendment to #8103 - the if clause filters out hosts that aren't made by `host.create`, so I adjusted it so it logs the final attempt's error regardless of the type of host.

### Testing
Didn't seem worth testing a logging change.

### Documentation
N/A