### PR TITLE
DEVPROD-8877: Support showing changes to GitHub app credentials in event logs

### DIFF
--- a/github_app.go
+++ b/github_app.go
@@ -299,6 +299,6 @@ func createInstallationTokenForID(ctx context.Context, authFields *GithubAppAuth
 
 // RedactPrivateKey redacts the GitHub app's private key so that it's not exposed via the UI or GraphQL.
 func (g *GithubAppAuth) RedactPrivateKey() *GithubAppAuth {
-	g.PrivateKey = []byte("{REDACTED}")
+	g.PrivateKey = []byte(RedactedValue)
 	return g
 }

--- a/globals.go
+++ b/globals.go
@@ -380,7 +380,9 @@ const (
 	HostServicePasswordExpansion = "host_service_password"
 
 	// RedactedValue is the value that is shown in the REST API and UI for redacted values.
-	RedactedValue = "<REDACTED>"
+	RedactedValue       = "{REDACTED}"
+	RedactedAfterValue  = "{REDACTED_AFTER}"
+	RedactedBeforeValue = "{REDACTED_BEFORE}"
 )
 
 var VersionSucceededStatuses = []string{

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -966,6 +966,7 @@ type ComplexityRoot struct {
 
 	ProjectEventSettings struct {
 		Aliases               func(childComplexity int) int
+		GithubAppAuth         func(childComplexity int) int
 		GithubWebhooksEnabled func(childComplexity int) int
 		ProjectRef            func(childComplexity int) int
 		Subscriptions         func(childComplexity int) int
@@ -6334,6 +6335,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ProjectEventSettings.Aliases(childComplexity), true
+
+	case "ProjectEventSettings.githubAppAuth":
+		if e.complexity.ProjectEventSettings.GithubAppAuth == nil {
+			break
+		}
+
+		return e.complexity.ProjectEventSettings.GithubAppAuth(childComplexity), true
 
 	case "ProjectEventSettings.githubWebhooksEnabled":
 		if e.complexity.ProjectEventSettings.GithubWebhooksEnabled == nil {
@@ -42391,6 +42399,8 @@ func (ec *executionContext) fieldContext_ProjectEventLogEntry_after(_ context.Co
 			switch field.Name {
 			case "aliases":
 				return ec.fieldContext_ProjectEventSettings_aliases(ctx, field)
+			case "githubAppAuth":
+				return ec.fieldContext_ProjectEventSettings_githubAppAuth(ctx, field)
 			case "githubWebhooksEnabled":
 				return ec.fieldContext_ProjectEventSettings_githubWebhooksEnabled(ctx, field)
 			case "projectRef":
@@ -42444,6 +42454,8 @@ func (ec *executionContext) fieldContext_ProjectEventLogEntry_before(_ context.C
 			switch field.Name {
 			case "aliases":
 				return ec.fieldContext_ProjectEventSettings_aliases(ctx, field)
+			case "githubAppAuth":
+				return ec.fieldContext_ProjectEventSettings_githubAppAuth(ctx, field)
 			case "githubWebhooksEnabled":
 				return ec.fieldContext_ProjectEventSettings_githubWebhooksEnabled(ctx, field)
 			case "projectRef":
@@ -42605,6 +42617,53 @@ func (ec *executionContext) fieldContext_ProjectEventSettings_aliases(_ context.
 				return ec.fieldContext_ProjectAlias_parameters(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProjectAlias", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProjectEventSettings_githubAppAuth(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectEventSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProjectEventSettings_githubAppAuth(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GithubAppAuth, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(model.APIGithubAppAuth)
+	fc.Result = res
+	return ec.marshalOGithubAppAuth2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ProjectEventSettings_githubAppAuth(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectEventSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "appId":
+				return ec.fieldContext_GithubAppAuth_appId(ctx, field)
+			case "privateKey":
+				return ec.fieldContext_GithubAppAuth_privateKey(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GithubAppAuth", field.Name)
 		},
 	}
 	return fc, nil
@@ -81312,6 +81371,8 @@ func (ec *executionContext) _ProjectEventSettings(ctx context.Context, sel ast.S
 			out.Values[i] = graphql.MarshalString("ProjectEventSettings")
 		case "aliases":
 			out.Values[i] = ec._ProjectEventSettings_aliases(ctx, field, obj)
+		case "githubAppAuth":
+			out.Values[i] = ec._ProjectEventSettings_githubAppAuth(ctx, field, obj)
 		case "githubWebhooksEnabled":
 			out.Values[i] = ec._ProjectEventSettings_githubWebhooksEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -94105,6 +94166,10 @@ func (ec *executionContext) marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋev
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOGithubAppAuth2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx context.Context, sel ast.SelectionSet, v model.APIGithubAppAuth) graphql.Marshaler {
+	return ec._GithubAppAuth(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalOGithubAppAuth2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubAppAuth(ctx context.Context, sel ast.SelectionSet, v *model.APIGithubAppAuth) graphql.Marshaler {

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -28,10 +28,10 @@ func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restMo
 	if app == nil {
 		return nil, nil
 	}
-	return &restModel.APIGithubAppAuth{
-		AppID:      int(app.AppID),
-		PrivateKey: utility.ToStringPtr(""),
-	}, nil
+	res := &restModel.APIGithubAppAuth{}
+	app = app.RedactPrivateKey()
+	res.BuildFromService(*app)
+	return res, nil
 }
 
 // GithubWebhooksEnabled is the resolver for the githubWebhooksEnabled field.

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -175,6 +175,7 @@ type ProjectEventLogEntry {
 
 type ProjectEventSettings {
   aliases: [ProjectAlias!]
+  githubAppAuth: GithubAppAuth
   githubWebhooksEnabled: Boolean!
   projectRef: Project
   subscriptions: [GeneralSubscription!]

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -220,7 +220,7 @@
           "saveProjectSettingsForSection": {
             "githubAppAuth": {
               "appId": 12345,
-              "privateKey": ""
+              "privateKey": "{REDACTED}"
             },
             "projectRef": {
               "id": "sandbox_project_id",

--- a/graphql/tests/query/projectEvents/data.json
+++ b/graphql/tests/query/projectEvents/data.json
@@ -34,6 +34,10 @@
             "repo_name": "evergreen",
             "branch_name": "master"
           },
+          "github_app_auth": {
+            "app_id": 12345,
+            "private_key": "secret_before"
+          },
           "github_hooks_enabled": false,
           "vars": {
             "_id": "sandbox_project_id",
@@ -49,6 +53,10 @@
             "owner_name": "evergreen-ci",
             "repo_name": "evergreen",
             "branch_name": "main"
+          },
+          "github_app_auth": {
+            "app_id": 67890,
+            "private_key": "secret_after"
           },
           "github_hooks_enabled": true,
           "vars": {

--- a/graphql/tests/query/projectEvents/queries/get_branch.graphql
+++ b/graphql/tests/query/projectEvents/queries/get_branch.graphql
@@ -1,27 +1,35 @@
 query {
-    projectEvents(projectIdentifier: "sandbox") {
-        eventLogEntries {
-            user
-            timestamp
-            before {
-                projectRef {
-                    branch
-                }
-                githubWebhooksEnabled
-                 vars{
-                    vars
-                }
-            }
-            after {
-                projectRef {
-                    branch
-                }
-                githubWebhooksEnabled  
-                vars{
-                    vars
-                }
-            }
+  projectEvents(projectIdentifier: "sandbox") {
+    eventLogEntries {
+      user
+      timestamp
+      before {
+        projectRef {
+          branch
         }
-        count
+        githubAppAuth {
+          appId
+          privateKey
+        }
+        githubWebhooksEnabled
+        vars {
+          vars
+        }
+      }
+      after {
+        projectRef {
+          branch
+        }
+        githubAppAuth {
+          appId
+          privateKey
+        }
+        githubWebhooksEnabled
+        vars {
+          vars
+        }
+      }
     }
+    count
+  }
 }

--- a/graphql/tests/query/projectEvents/results.json
+++ b/graphql/tests/query/projectEvents/results.json
@@ -13,8 +13,12 @@
                   "projectRef": {
                     "branch": "master"
                   },
+                  "githubAppAuth": {
+                    "appId": 12345,
+                    "privateKey": "{REDACTED_BEFORE}"
+                  },
                   "githubWebhooksEnabled": false,
-                   "vars": {
+                  "vars": {
                     "vars": {
                       "hello": "world"
                     }
@@ -23,6 +27,10 @@
                 "after": {
                   "projectRef": {
                     "branch": "main"
+                  },
+                  "githubAppAuth": {
+                    "appId": 67890,
+                    "privateKey": "{REDACTED_AFTER}"
                   },
                   "githubWebhooksEnabled": true,
                   "vars": {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -351,6 +351,7 @@ func GetEventsById(id string, before time.Time, n int) ([]restModel.APIProjectEv
 	if err != nil {
 		return nil, err
 	}
+	events.RedactGitHubPrivateKey()
 	events.RedactPrivateVars()
 	events.ApplyDefaults()
 

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -76,6 +76,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 		var loggedProjectEvents model.ProjectChangeEvents
 		loggedProjectEvents, err = model.MostRecentProjectEvents(resourceID, 200)
 		loggedProjectEvents.RedactPrivateVars()
+		loggedProjectEvents.RedactGitHubPrivateKey()
 		for _, event := range loggedProjectEvents {
 			loggedEvents = append(loggedEvents, event.EventLogEntry)
 		}


### PR DESCRIPTION
DEVPROD-8877

### Description
Show event log changes for the `githubAppAuth` field, making sure to redact the `PrivateKey` field.

### Testing
- GraphQL and unit tests
