### PR TITLE
DEVPROD-9067 use correct execution for file logs

### DIFF
--- a/service/task.go
+++ b/service/task.go
@@ -643,8 +643,17 @@ func (uis *UIServer) taskFileRaw(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "file name not specified", http.StatusBadRequest)
 		return
 	}
+	executionNum := projCtx.Task.Execution
+	var err error
+	if execStr := gimlet.GetVars(r)["execution"]; execStr != "" {
+		executionNum, err = strconv.Atoi(execStr)
+		if err != nil {
+			http.Error(w, "invalid execution", http.StatusBadRequest)
+			return
+		}
+	}
 
-	taskFiles, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: projCtx.Task.Id, Execution: projCtx.Task.Execution}})
+	taskFiles, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: projCtx.Task.Id, Execution: executionNum}})
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "unable to find artifacts for task '%s'", projCtx.Task.Id))
 		return


### PR DESCRIPTION
DEVPROD-9067 
### Description
Use execution from URL to get logs for files.

### Testing
[first execution file](https://parsley-staging.corp.mongodb.com/taskFile/evg_ubuntu2204_upload_sample_log_patch_334c581a32d8d823020f8e5d93b96c7b10daf351_6500d3d3b237362f86002a15_23_09_12_21_11_07/0/samplelargefile )

[second execution file](https://parsley-staging.corp.mongodb.com/taskFile/evg_ubuntu2204_upload_sample_log_patch_334c581a32d8d823020f8e5d93b96c7b10daf351_6500d3d3b237362f86002a15_23_09_12_21_11_07/1/samplelargefile )

(first)
![image](https://github.com/user-attachments/assets/56e7902d-3f50-4369-a010-b10bed82c6d6)

(second)
<img width="539" alt="image" src="https://github.com/user-attachments/assets/e8f1b46f-40a2-494f-9eac-ba72d494cc1f">

After re-deploying head, confirmed that both links show the second image.
<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
