### PR TITLE
DEVPROD-7647: Resolve Distros From GraphQL Image Type

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -56,6 +56,7 @@ type ResolverRoot interface {
 	FinderSettings() FinderSettingsResolver
 	Host() HostResolver
 	HostAllocatorSettings() HostAllocatorSettingsResolver
+	Image() ImageResolver
 	IssueLink() IssueLinkResolver
 	LogkeeperBuild() LogkeeperBuildResolver
 	Mutation() MutationResolver
@@ -527,6 +528,7 @@ type ComplexityRoot struct {
 
 	Image struct {
 		AMI          func(childComplexity int) int
+		Distros      func(childComplexity int) int
 		Kernel       func(childComplexity int) int
 		LastDeployed func(childComplexity int) int
 		Name         func(childComplexity int) int
@@ -1672,6 +1674,9 @@ type HostAllocatorSettingsResolver interface {
 
 	RoundingRule(ctx context.Context, obj *model.APIHostAllocatorSettings) (RoundingRule, error)
 	Version(ctx context.Context, obj *model.APIHostAllocatorSettings) (HostAllocatorVersion, error)
+}
+type ImageResolver interface {
+	Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error)
 }
 type IssueLinkResolver interface {
 	JiraTicket(ctx context.Context, obj *model.APIIssueLink) (*thirdparty.JiraTicket, error)
@@ -3854,6 +3859,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Image.AMI(childComplexity), true
+
+	case "Image.distros":
+		if e.complexity.Image.Distros == nil {
+			break
+		}
+
+		return e.complexity.Image.Distros(childComplexity), true
 
 	case "Image.kernel":
 		if e.complexity.Image.Kernel == nil {
@@ -25084,6 +25096,114 @@ func (ec *executionContext) fieldContext_Image_versionId(_ context.Context, fiel
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Image_distros(ctx context.Context, field graphql.CollectedField, obj *thirdparty.Image) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Image_distros(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Image().Distros(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIDistro)
+	fc.Result = res
+	return ec.marshalNDistro2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIDistroᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Image_distros(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Image",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "adminOnly":
+				return ec.fieldContext_Distro_adminOnly(ctx, field)
+			case "aliases":
+				return ec.fieldContext_Distro_aliases(ctx, field)
+			case "arch":
+				return ec.fieldContext_Distro_arch(ctx, field)
+			case "authorizedKeysFile":
+				return ec.fieldContext_Distro_authorizedKeysFile(ctx, field)
+			case "bootstrapSettings":
+				return ec.fieldContext_Distro_bootstrapSettings(ctx, field)
+			case "containerPool":
+				return ec.fieldContext_Distro_containerPool(ctx, field)
+			case "disabled":
+				return ec.fieldContext_Distro_disabled(ctx, field)
+			case "disableShallowClone":
+				return ec.fieldContext_Distro_disableShallowClone(ctx, field)
+			case "dispatcherSettings":
+				return ec.fieldContext_Distro_dispatcherSettings(ctx, field)
+			case "expansions":
+				return ec.fieldContext_Distro_expansions(ctx, field)
+			case "finderSettings":
+				return ec.fieldContext_Distro_finderSettings(ctx, field)
+			case "homeVolumeSettings":
+				return ec.fieldContext_Distro_homeVolumeSettings(ctx, field)
+			case "hostAllocatorSettings":
+				return ec.fieldContext_Distro_hostAllocatorSettings(ctx, field)
+			case "iceCreamSettings":
+				return ec.fieldContext_Distro_iceCreamSettings(ctx, field)
+			case "imageId":
+				return ec.fieldContext_Distro_imageId(ctx, field)
+			case "isCluster":
+				return ec.fieldContext_Distro_isCluster(ctx, field)
+			case "isVirtualWorkStation":
+				return ec.fieldContext_Distro_isVirtualWorkStation(ctx, field)
+			case "name":
+				return ec.fieldContext_Distro_name(ctx, field)
+			case "note":
+				return ec.fieldContext_Distro_note(ctx, field)
+			case "warningNote":
+				return ec.fieldContext_Distro_warningNote(ctx, field)
+			case "plannerSettings":
+				return ec.fieldContext_Distro_plannerSettings(ctx, field)
+			case "provider":
+				return ec.fieldContext_Distro_provider(ctx, field)
+			case "providerSettingsList":
+				return ec.fieldContext_Distro_providerSettingsList(ctx, field)
+			case "setup":
+				return ec.fieldContext_Distro_setup(ctx, field)
+			case "setupAsSudo":
+				return ec.fieldContext_Distro_setupAsSudo(ctx, field)
+			case "sshOptions":
+				return ec.fieldContext_Distro_sshOptions(ctx, field)
+			case "user":
+				return ec.fieldContext_Distro_user(ctx, field)
+			case "userSpawnAllowed":
+				return ec.fieldContext_Distro_userSpawnAllowed(ctx, field)
+			case "validProjects":
+				return ec.fieldContext_Distro_validProjects(ctx, field)
+			case "workDir":
+				return ec.fieldContext_Distro_workDir(ctx, field)
+			case "mountpoints":
+				return ec.fieldContext_Distro_mountpoints(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Distro", field.Name)
 		},
 	}
 	return fc, nil
@@ -46959,6 +47079,8 @@ func (ec *executionContext) fieldContext_Query_image(ctx context.Context, field 
 				return ec.fieldContext_Image_name(ctx, field)
 			case "versionId":
 				return ec.fieldContext_Image_versionId(ctx, field)
+			case "distros":
+				return ec.fieldContext_Image_distros(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Image", field.Name)
 		},
@@ -77594,28 +77716,64 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 		case "ami":
 			out.Values[i] = ec._Image_ami(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "kernel":
 			out.Values[i] = ec._Image_kernel(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "lastDeployed":
 			out.Values[i] = ec._Image_lastDeployed(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "name":
 			out.Values[i] = ec._Image_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "versionId":
 			out.Values[i] = ec._Image_versionId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "distros":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Image_distros(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -4,31 +4,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/thirdparty"
-	"github.com/mongodb/grip"
 )
 
 // Distros is the resolver for the distros field.
 func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error) {
-	config, err := evergreen.GetConfig(ctx)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
-	}
-	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
-	OSInfo, err := c.GetOSInfo(ctx, thirdparty.OSInfoFilterOptions{AMI: obj.AMI})
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding OSInfo from AMI: '%s'", err.Error()))
-	}
-	if len(OSInfo) == 0 {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find OSInfo from AMI '%s'", obj.AMI))
-	}
-	grip.Debug(OSInfo[0].ImageID)
-	distros, err := distro.GetDistrosForImage(ctx, OSInfo[0].ImageID)
-	grip.Debug(distros)
+	distros, err := distro.GetDistrosForImage(ctx, obj.ImageID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding distros from imageID: '%s'", err.Error()))
 	}

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -4,17 +4,33 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/mongodb/grip"
 )
 
 // Distros is the resolver for the distros field.
 func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error) {
-	distros, err := distro.GetDistrosForImage(ctx, obj.Name)
+	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding imageID from distro: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
+	}
+	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
+	OSInfo, err := c.GetOSInfo(ctx, thirdparty.OSInfoFilterOptions{AMI: obj.AMI})
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding OSInfo from AMI: '%s'", err.Error()))
+	}
+	if len(OSInfo) == 0 {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("could not find OSInfo from AMI '%s'", obj.AMI))
+	}
+	grip.Debug(OSInfo[0].ImageID)
+	distros, err := distro.GetDistrosForImage(ctx, OSInfo[0].ImageID)
+	grip.Debug(distros)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding distros from imageID: '%s'", err.Error()))
 	}
 	apiDistros := []*restModel.APIDistro{}
 	for _, d := range distros {

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -12,12 +12,12 @@ import (
 
 // Distros is the resolver for the distros field.
 func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error) {
-	if obj.ImageID == "" {
-		return nil, ResourceNotFound.Send(ctx, "unable to find imageID from provided Image")
+	if obj == nil {
+		return nil, InternalServerError.Send(ctx, "image undefined when attempting to find corresponding distros")
 	}
-	distros, err := distro.GetDistrosForImage(ctx, obj.ImageID)
+	distros, err := distro.GetDistrosForImage(ctx, obj.ID)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding distros from imageID '%s': '%s'", obj.ImageID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for imageID '%s': '%s'", obj.ID, err.Error()))
 	}
 	apiDistros := []*restModel.APIDistro{}
 	for _, d := range distros {

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -17,7 +17,7 @@ func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*
 	}
 	distros, err := distro.GetDistrosForImage(ctx, obj.ID)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for imageID '%s': '%s'", obj.ID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for image '%s': '%s'", obj.ID, err.Error()))
 	}
 	apiDistros := []*restModel.APIDistro{}
 	for _, d := range distros {

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -12,9 +12,12 @@ import (
 
 // Distros is the resolver for the distros field.
 func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error) {
+	if obj.ImageID == "" {
+		return nil, ResourceNotFound.Send(ctx, "unable to find imageID from provided Image")
+	}
 	distros, err := distro.GetDistrosForImage(ctx, obj.ImageID)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding distros from imageID: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding distros from imageID '%s': '%s'", obj.ImageID, err.Error()))
 	}
 	apiDistros := []*restModel.APIDistro{}
 	for _, d := range distros {

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -1,0 +1,31 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+)
+
+// Distros is the resolver for the distros field.
+func (r *imageResolver) Distros(ctx context.Context, obj *thirdparty.Image) ([]*model.APIDistro, error) {
+	distros, err := distro.GetDistrosForImage(ctx, obj.Name)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("error finding imageID from distro: '%s'", err.Error()))
+	}
+	apiDistros := []*restModel.APIDistro{}
+	for _, d := range distros {
+		apiDistro := restModel.APIDistro{}
+		apiDistro.BuildFromService(d)
+		apiDistros = append(apiDistros, &apiDistro)
+	}
+	return apiDistros, nil
+}
+
+// Image returns ImageResolver implementation.
+func (r *Resolver) Image() ImageResolver { return &imageResolver{r} }
+
+type imageResolver struct{ *Resolver }

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -9,4 +9,5 @@ type Image {
   lastDeployed: Time!
   name: String!
   versionId: String!
+  distros: [Distro!]!
 }

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -4,10 +4,11 @@ Image is returned by the image query.
 It contains information about an image.
 """
 type Image {
+  id: String!
   ami: String!
+  distros: [Distro!]!
   kernel: String!
   lastDeployed: Time!
   name: String!
   versionId: String!
-  distros: [Distro!]!
 }

--- a/graphql/tests/image/distros/data.json
+++ b/graphql/tests/image/distros/data.json
@@ -1,0 +1,28 @@
+{
+    "image": [
+      {
+        "_id": "image-1",
+        "ami": "ami-0f6b89500372d4a06"
+      }
+    ], 
+    "distro": [
+        {
+          "_id": "ubuntu1604-large",
+          "image_id": "ubuntu1604"
+        },
+        {
+            "_id": "ubuntu1604-small",
+            "image_id": "ubuntu1604"
+        },
+        {
+            "_id": "rhel82-small",
+            "image_id": "rhel82"
+        }
+    ],
+    "project_ref": [
+        {
+          "_id": "spruce",
+          "identifier": "spruce"
+        }
+    ]
+  }

--- a/graphql/tests/image/distros/data.json
+++ b/graphql/tests/image/distros/data.json
@@ -1,13 +1,13 @@
 {
     "image": [
-      {
-        "_id": "ubuntu1604"
-      }
-    ], 
+        {
+            "_id": "ubuntu1604"
+        }
+    ],
     "distro": [
         {
-          "name": "ubuntu1604-large",
-          "image_id": "ubuntu1604"
+            "name": "ubuntu1604-large",
+            "image_id": "ubuntu1604"
         },
         {
             "name": "ubuntu1604-small",
@@ -20,8 +20,8 @@
     ],
     "project_ref": [
         {
-          "_id": "spruce",
-          "identifier": "spruce"
+            "_id": "spruce",
+            "identifier": "spruce"
         }
     ]
-  }
+}

--- a/graphql/tests/image/distros/data.json
+++ b/graphql/tests/image/distros/data.json
@@ -1,21 +1,20 @@
 {
     "image": [
       {
-        "_id": "image-1",
-        "ami": "ami-0f6b89500372d4a06"
+        "_id": "ubuntu1604"
       }
     ], 
     "distro": [
         {
-          "_id": "ubuntu1604-large",
+          "name": "ubuntu1604-large",
           "image_id": "ubuntu1604"
         },
         {
-            "_id": "ubuntu1604-small",
+            "name": "ubuntu1604-small",
             "image_id": "ubuntu1604"
         },
         {
-            "_id": "rhel82-small",
+            "name": "rhel82-small",
             "image_id": "rhel82"
         }
     ],

--- a/graphql/tests/image/distros/data.json
+++ b/graphql/tests/image/distros/data.json
@@ -1,9 +1,4 @@
 {
-    "image": [
-        {
-            "_id": "ubuntu1604"
-        }
-    ],
     "distro": [
         {
             "name": "ubuntu1604-large",

--- a/graphql/tests/image/distros/queries/distros.graphql
+++ b/graphql/tests/image/distros/queries/distros.graphql
@@ -1,5 +1,7 @@
 {
-  image(imageId: "image-1") {
-    distros
+  image(imageId: "ubuntu1604") {
+    distros {
+        name
+    }
   }
 }

--- a/graphql/tests/image/distros/queries/distros.graphql
+++ b/graphql/tests/image/distros/queries/distros.graphql
@@ -1,0 +1,5 @@
+{
+  image(imageId: "image-1") {
+    distros
+  }
+}

--- a/graphql/tests/image/distros/results.json
+++ b/graphql/tests/image/distros/results.json
@@ -1,0 +1,21 @@
+{
+    "tests": [
+      {
+        "query_file": "distros.graphql",
+        "result": {
+          "data": {
+            "image": {
+                "distros": [
+                    {
+                        "_id": "ubuntu2204-large"
+                    },
+                    {
+                        "_id": "ubuntu2204-small"
+                    }
+                ]
+            }
+          }
+        }
+      }
+    ]
+}

--- a/graphql/tests/image/distros/results.json
+++ b/graphql/tests/image/distros/results.json
@@ -1,21 +1,14 @@
 {
-    "tests": [
-      {
-        "query_file": "distros.graphql",
-        "result": {
-          "data": {
-            "image": {
-                "distros": [
-                    {
-                        "_id": "ubuntu2204-large"
-                    },
-                    {
-                        "_id": "ubuntu2204-small"
-                    }
-                ]
-            }
+    "data": {
+      "image": {
+        "distros": [
+          {
+            "name": "ubuntu1604-large"
+          },
+          {
+            "name": "ubuntu1604-small"
           }
-        }
+        ]
       }
-    ]
-}
+    }
+  }

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -896,6 +896,9 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 
 // GetDistrosForImage returns the distros for a given image.
 func GetDistrosForImage(ctx context.Context, imageID string) ([]Distro, error) {
+	if imageID == "" {
+		return nil, errors.Errorf("imageID not found")
+	}
 	return Find(ctx, bson.M{ImageIDKey: imageID})
 }
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -897,7 +897,7 @@ func GetHostCreateDistro(ctx context.Context, createHost apimodels.CreateHost) (
 // GetDistrosForImage returns the distros for a given image.
 func GetDistrosForImage(ctx context.Context, imageID string) ([]Distro, error) {
 	if imageID == "" {
-		return nil, errors.Errorf("imageID not found")
+		return nil, errors.Errorf("imageID not provided")
 	}
 	return Find(ctx, bson.M{ImageIDKey: imageID})
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -368,11 +368,12 @@ func stringToTime(timeInitial string) (time.Time, error) {
 
 // Image stores information about an image including its name, version ID, kernel, AMI, and its last deployed time.
 type Image struct {
-	Name         string
-	VersionID    string
+	AMI          string
+	ImageID      string
 	Kernel       string
 	LastDeployed time.Time
-	AMI          string
+	Name         string
+	VersionID    string
 }
 
 // getNameFromOSInfo uses the provided AMI and name (exact match) arguments to filter the image information.
@@ -437,9 +438,9 @@ func (c *RuntimeEnvironmentsClient) GetImageInfo(ctx context.Context, imageID st
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting OSInfo '%s' field for image: '%s'", OSVersionIDField, imageID)
 	}
-
 	return &Image{
 		AMI:          latestImageHistory.AMI,
+		ImageID:      imageID,
 		Kernel:       kernel,
 		LastDeployed: timestamp,
 		Name:         name,

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -143,6 +143,7 @@ type OSInfoFilterOptions struct {
 type OSInfo struct {
 	Version string `json:"version"`
 	Name    string `json:"name"`
+	ImageID string `json:"distro"`
 }
 
 // GetOSInfo returns a list of operating system information for an AMI.

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -139,11 +139,10 @@ type OSInfoFilterOptions struct {
 	Limit int
 }
 
-// OSInfo stores operating system information. Distro field from runtime environments API corresponds to our definition of ImageID.
+// OSInfo stores operating system information.
 type OSInfo struct {
 	Version string `json:"version"`
 	Name    string `json:"name"`
-	ImageID string `json:"distro"`
 }
 
 // GetOSInfo returns a list of operating system information for an AMI.
@@ -368,8 +367,8 @@ func stringToTime(timeInitial string) (time.Time, error) {
 
 // Image stores information about an image including its AMI, imageID, kernel, last deployed time, name, and versionID.
 type Image struct {
+	ID           string
 	AMI          string
-	ImageID      string
 	Kernel       string
 	LastDeployed time.Time
 	Name         string
@@ -439,8 +438,8 @@ func (c *RuntimeEnvironmentsClient) GetImageInfo(ctx context.Context, imageID st
 		return nil, errors.Wrapf(err, "getting OSInfo '%s' field for image: '%s'", OSVersionIDField, imageID)
 	}
 	return &Image{
+		ID:           imageID,
 		AMI:          latestImageHistory.AMI,
-		ImageID:      imageID,
 		Kernel:       kernel,
 		LastDeployed: timestamp,
 		Name:         name,

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -139,7 +139,7 @@ type OSInfoFilterOptions struct {
 	Limit int
 }
 
-// OSInfo stores operating system information.
+// OSInfo stores operating system information. Distro field from runtime environments API corresponds to our definition of ImageID.
 type OSInfo struct {
 	Version string `json:"version"`
 	Name    string `json:"name"`
@@ -366,7 +366,7 @@ func stringToTime(timeInitial string) (time.Time, error) {
 	return time.Unix(timestamp, 0), nil
 }
 
-// Image stores information about an image including its name, version ID, kernel, AMI, and its last deployed time.
+// Image stores information about an image including its AMI, imageID, kernel, last deployed time, name, and versionID.
 type Image struct {
 	AMI          string
 	ImageID      string

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -365,7 +365,7 @@ func stringToTime(timeInitial string) (time.Time, error) {
 	return time.Unix(timestamp, 0), nil
 }
 
-// Image stores information about an image including its AMI, imageID, kernel, last deployed time, name, and versionID.
+// Image stores information about an image including its AMI, ID, kernel, last deployed time, name, and version ID.
 type Image struct {
 	ID           string
 	AMI          string


### PR DESCRIPTION
DEVPROD-7647

### Description
Added GraphQL support for the field: distros: [Distro!]!
Used the getDistrosForImage method to fetch the associated distros for an image.
CodeQL failing, but I did not modify the file, so will ignore. 

### Testing
Added GraphQL test

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
