### PR TITLE
DEVPROD-8746: include decommissioned hosts in global hosts limit

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -980,16 +980,31 @@ var (
 		HostStarting,
 	}
 
-	// Hosts in "initializing" status aren't actually running yet:
-	// they're just intents, so this list omits that value.
-	ActiveStatus = []string{
-		HostRunning,
+	// IsRunningOrWillRunStatuses includes all statuses for active hosts (see
+	// ActiveStatus) where the host is either currently running or is making
+	// progress towards running.
+	IsRunningOrWillRunStatuses = []string{
 		HostBuilding,
 		HostStarting,
 		HostProvisioning,
+		HostRunning,
+	}
+
+	// ActiveStatuses includes all where the host is alive in the cloud provider
+	// or could be alive (e.g. for building hosts, the host is in the process of
+	// starting up). Intent hosts have not requested a real host from the cloud
+	// provider, so they are omitted.
+	ActiveStatuses = []string{
+		HostBuilding,
+		HostBuildingFailed,
+		HostStarting,
+		HostProvisioning,
 		HostProvisionFailed,
+		HostRunning,
 		HostStopping,
 		HostStopped,
+		HostDecommissioned,
+		HostQuarantined,
 	}
 
 	// SleepScheduleStatuses are all host statuses for which the sleep schedule

--- a/model/host/stats.go
+++ b/model/host/stats.go
@@ -110,11 +110,9 @@ func statsByDistroPipeline() []bson.M {
 	return []bson.M{
 		{
 			"$match": bson.M{
-				// Don't count user-spawned hosts (EVG-15232).
-				// This also excludes hostcreate tasks (EVG-14363), as their started_by field is the task name.
 				StartedByKey: evergreen.User,
 				StatusKey: bson.M{
-					"$in": evergreen.ActiveStatus,
+					"$in": evergreen.IsRunningOrWillRunStatuses,
 				},
 			},
 		},
@@ -158,7 +156,7 @@ func statsByProviderPipeline() []bson.M {
 		{
 			"$match": bson.M{
 				StatusKey: bson.M{
-					"$in": evergreen.ActiveStatus,
+					"$in": evergreen.IsRunningOrWillRunStatuses,
 				},
 			},
 		},

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -215,7 +215,7 @@ func (sns *ec2SNS) handleInstanceInterruptionWarning(ctx context.Context, instan
 			instanceType = stringVal
 		}
 	}
-	existingHostCount, err := host.CountRunningHosts(ctx, h.Distro.Id)
+	existingHostCount, err := host.CountActiveHostsInDistro(ctx, h.Distro.Id)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":               "database error counting running hosts by distro_id",

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -73,8 +73,7 @@ func (j *hostDrawdownJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	// get currently existing hosts, in case some hosts have already been terminated elsewhere
-	existingHostCount, err := host.CountRunningHosts(ctx, j.DrawdownInfo.DistroID)
+	existingHostCount, err := host.CountHostsCanOrWillRunTasksInDistro(ctx, j.DrawdownInfo.DistroID)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "counting running hosts in distro '%s'", j.DrawdownInfo.DistroID))
 		return

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -139,15 +139,14 @@ func (j *createHostJob) Run(ctx context.Context) {
 	}
 
 	if j.host.IsSubjectToHostCreationThrottle() {
-		var numHosts int
-		numHosts, err = host.CountRunningHosts(ctx, j.host.Distro.Id)
+		distroActiveHosts, err := host.CountActiveHostsInDistro(ctx, j.host.Distro.Id)
 		if err != nil {
 			j.AddError(errors.Wrapf(err, "counting existing host pool size for distro '%s'", j.host.Distro.Id))
 			return
 		}
 
 		removeHostIntent := false
-		if numHosts > j.host.Distro.HostAllocatorSettings.MaximumHosts {
+		if distroActiveHosts > j.host.Distro.HostAllocatorSettings.MaximumHosts {
 			grip.Info(message.Fields{
 				"host_id":   j.HostID,
 				"attempt":   j.RetryInfo().CurrentAttempt,
@@ -158,18 +157,17 @@ func (j *createHostJob) Run(ctx context.Context) {
 				"max_hosts": j.host.Distro.HostAllocatorSettings.MaximumHosts,
 			})
 			removeHostIntent = true
-
 		}
 
-		allRunningDynamicHosts, err := host.CountAllRunningDynamicHosts(ctx)
+		allActiveDynamicHosts, err := host.CountActiveDynamicHosts(ctx)
 		j.AddError(err)
+
 		lowHostNumException := false
-		if numHosts < 10 {
+		if distroActiveHosts < 10 {
 			lowHostNumException = true
 		}
 
-		if allRunningDynamicHosts > hostInit.MaxTotalDynamicHosts && !lowHostNumException {
-
+		if allActiveDynamicHosts > hostInit.MaxTotalDynamicHosts && !lowHostNumException {
 			grip.Info(message.Fields{
 				"host_id":                 j.HostID,
 				"attempt":                 j.RetryInfo().CurrentAttempt,
@@ -177,11 +175,10 @@ func (j *createHostJob) Run(ctx context.Context) {
 				"job":                     j.ID(),
 				"provider":                j.host.Provider,
 				"message":                 "not provisioning host to respect max_total_dynamic_hosts",
-				"total_dynamic_hosts":     allRunningDynamicHosts,
+				"total_dynamic_hosts":     allActiveDynamicHosts,
 				"max_total_dynamic_hosts": hostInit.MaxTotalDynamicHosts,
 			})
 			removeHostIntent = true
-
 		}
 
 		if removeHostIntent {
@@ -242,19 +239,19 @@ func (j *createHostJob) selfThrottle(ctx context.Context, hostInit evergreen.Hos
 		return true
 	}
 
-	distroRunningHosts, err := host.CountRunningHosts(ctx, j.host.Distro.Id)
+	distroActiveHosts, err := host.CountActiveHostsInDistro(ctx, j.host.Distro.Id)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "counting host pool size for distro '%s'", j.host.Distro.Id))
 		return true
 	}
 
-	runningHosts, err := host.CountAllRunningDynamicHosts(ctx)
+	allActiveDynamicHosts, err := host.CountActiveDynamicHosts(ctx)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "counting size of entire host pool"))
 		return true
 	}
 
-	if distroRunningHosts < runningHosts/100 || distroRunningHosts < j.host.Distro.HostAllocatorSettings.MinimumHosts {
+	if distroActiveHosts < allActiveDynamicHosts/100 || distroActiveHosts < j.host.Distro.HostAllocatorSettings.MinimumHosts {
 		return false
 	} else if numProv >= hostInit.HostThrottle {
 		reason := "host creation throttle"

--- a/units/stats_host.go
+++ b/units/stats_host.go
@@ -113,7 +113,6 @@ func collectHostCountStats() (*hostCountStats, error) {
 }
 
 func (j *hostStatsCollector) statsByDistro() error {
-
 	stats, err := collectHostCountStats()
 
 	if err != nil {
@@ -143,9 +142,7 @@ func (j *hostStatsCollector) statsByProvider() error {
 	}
 
 	j.logger.Info(message.Fields{
-		"report": "host stats by provider",
-		// or we could make providers a map of provider names
-		// (string) to counts, by calling .Map() on the providers value.
+		"report":    "host stats by provider",
 		"providers": providers,
 	})
 


### PR DESCRIPTION
DEVPROD-8746

### Description
* Count decommissioned hosts towards distro and global hosts limits.
* Rename some DB functions and vars that had confusing or misleading names.
* Clean up some long-expired TODOs.

### Testing
Added unit test for decommissioned hosts and global hosts limit.

### Documentation
N/A