### PR TITLE
DEVPROD-9133 only run maxprocs for the app servers

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -8,7 +8,6 @@ import (
 	// this *must* be included in the binary so that the legacy
 	// plugins are built into the binary.
 	_ "github.com/evergreen-ci/evergreen/plugin"
-	"github.com/pkg/errors"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/operations"
@@ -17,13 +16,9 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"
 	"github.com/urfave/cli"
-	"go.uber.org/automaxprocs/maxprocs"
 )
 
 func main() {
-	_, err := maxprocs.Set()
-	grip.EmergencyFatal(errors.Wrap(err, "setting max procs"))
-
 	// this is where the main action of the program starts. The
 	// command line interface is managed by the cli package and
 	// its objects/structures. This, plus the basic configuration

--- a/config.go
+++ b/config.go
@@ -34,11 +34,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-07-19a"
+	ClientVersion = "2024-07-23"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-07-17"
+	AgentVersion = "2024-07-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -31,6 +31,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 func startWebService() cli.Command {
@@ -47,6 +48,9 @@ func startWebService() cli.Command {
 		),
 		Action: func(c *cli.Context) error {
 			ctx, cancel := context.WithCancel(context.Background())
+
+			_, err := maxprocs.Set()
+			grip.EmergencyFatal(errors.Wrap(err, "setting max procs"))
 
 			var tp trace.TracerProvider
 			sdkTracerProvider, err := startupTracerProvider(ctx, c.String(traceEndpointFlagName))

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -49,6 +49,8 @@ func startWebService() cli.Command {
 		Action: func(c *cli.Context) error {
 			ctx, cancel := context.WithCancel(context.Background())
 
+			// When running within a container, detect the number of CPUs available to the container
+			// and set GOMAXPROCS. This noops when running outside of a container.
 			_, err := maxprocs.Set()
 			grip.EmergencyFatal(errors.Wrap(err, "setting max procs"))
 


### PR DESCRIPTION
[DEVPROD-9133](https://jira.mongodb.org/browse/DEVPROD-9133)

### Description
It looks like maxprocs assumes `cfs_quota_us` and `cfs_period_us` are set, which in turn depend on the `CONFIG_CFS_BANDWIDTH` kernel configuration option. This was [added to modern versions of Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=789019), but not Jessie.

This PR moves setting GOMAXPROCS into `startWebService()` so it'll only happen in the app servers (and smoke tests and whatever), which should only be running on modern versions of Linux.

### Testing
The app server started successfully in staging, and GOMAXPROCS was set appropriately.
