### PR TITLE
DEVPROD-6072 Implement degraded mode toggles

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -36,6 +36,9 @@ type TaskLimitsConfig struct {
 	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once.
 	MaxConcurrentLargeParserProjectTasks int `bson:"max_concurrent_large_parser_project_tasks" json:"max_concurrent_large_parser_project_tasks" yaml:"max_concurrent_large_parser_project_tasks"`
 
+	// MaxDegradedModeConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once during degraded mode.
+	MaxDegradedModeConcurrentLargeParserProjectTasks int `bson:"max_degraded_mode_concurrent_large_parser_project_tasks" json:"max_degraded_mode_concurrent_large_parser_project_tasks" yaml:"max_degraded_mode_concurrent_large_parser_project_tasks"`
+
 	// MaxDegradedModeParserProjectSize is the maximum parser project size during CPU degraded mode.
 	MaxDegradedModeParserProjectSize int `bson:"max_degraded_mode_parser_project_size" json:"max_degraded_mode_parser_project_size" yaml:"max_degraded_mode_parser_project_size"`
 
@@ -44,14 +47,15 @@ type TaskLimitsConfig struct {
 }
 
 var (
-	maxTasksPerVersionKey                = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
-	maxIncludesPerVersionKey             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
-	maxHourlyPatchTasksKey               = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
-	maxPendingGeneratedTasks             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
-	maxGenerateTaskJSONSize              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
-	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
-	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
-	maxParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
+	maxTasksPerVersionKey                            = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxIncludesPerVersionKey                         = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
+	maxHourlyPatchTasksKey                           = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
+	maxPendingGeneratedTasks                         = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
+	maxGenerateTaskJSONSize                          = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
+	maxConcurrentLargeParserProjectTasks             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
+	maxDegradedModeConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeConcurrentLargeParserProjectTasks")
+	maxDegradedModeParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
+	maxParserProjectSize                             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -76,14 +80,15 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey:                c.MaxTasksPerVersion,
-			maxIncludesPerVersionKey:             c.MaxIncludesPerVersion,
-			maxPendingGeneratedTasks:             c.MaxPendingGeneratedTasks,
-			maxHourlyPatchTasksKey:               c.MaxHourlyPatchTasks,
-			maxGenerateTaskJSONSize:              c.MaxGenerateTaskJSONSize,
-			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
-			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
-			maxParserProjectSize:                 c.MaxParserProjectSize,
+			maxTasksPerVersionKey:                            c.MaxTasksPerVersion,
+			maxIncludesPerVersionKey:                         c.MaxIncludesPerVersion,
+			maxPendingGeneratedTasks:                         c.MaxPendingGeneratedTasks,
+			maxHourlyPatchTasksKey:                           c.MaxHourlyPatchTasks,
+			maxGenerateTaskJSONSize:                          c.MaxGenerateTaskJSONSize,
+			maxConcurrentLargeParserProjectTasks:             c.MaxConcurrentLargeParserProjectTasks,
+			maxDegradedModeConcurrentLargeParserProjectTasks: c.MaxDegradedModeConcurrentLargeParserProjectTasks,
+			maxDegradedModeParserProjectSize:                 c.MaxDegradedModeParserProjectSize,
+			maxParserProjectSize:                             c.MaxParserProjectSize,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -33,16 +33,16 @@ type TaskLimitsConfig struct {
 	// MaxGenerateTaskJSONSize is the maximum size of a JSON file in MB that can be specified in the GenerateTasks command.
 	MaxGenerateTaskJSONSize int `bson:"max_generate_task_json_size" json:"max_generate_task_json_size" yaml:"max_generate_task_json_size"`
 
-	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once.
+	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once.
 	MaxConcurrentLargeParserProjectTasks int `bson:"max_concurrent_large_parser_project_tasks" json:"max_concurrent_large_parser_project_tasks" yaml:"max_concurrent_large_parser_project_tasks"`
 
-	// MaxDegradedModeConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once during degraded mode.
+	// MaxDegradedModeConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once during CPU degraded mode.
 	MaxDegradedModeConcurrentLargeParserProjectTasks int `bson:"max_degraded_mode_concurrent_large_parser_project_tasks" json:"max_degraded_mode_concurrent_large_parser_project_tasks" yaml:"max_degraded_mode_concurrent_large_parser_project_tasks"`
 
 	// MaxDegradedModeParserProjectSize is the maximum parser project size during CPU degraded mode.
 	MaxDegradedModeParserProjectSize int `bson:"max_degraded_mode_parser_project_size" json:"max_degraded_mode_parser_project_size" yaml:"max_degraded_mode_parser_project_size"`
 
-	// MaxParserProjectSize is the maximum allowed parser project size.
+	// MaxParserProjectSize is the maximum allowed size for parser projects that are stored in S3.
 	MaxParserProjectSize int `bson:"max_parser_project_size" json:"max_parser_project_size" yaml:"max_parser_project_size"`
 }
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1164,41 +1164,41 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 	}
 
 	t := &task.Task{
-		Id:                      id,
-		Secret:                  utility.RandomString(),
-		DisplayName:             buildVarTask.Name,
-		BuildId:                 creationInfo.Build.Id,
-		BuildVariant:            creationInfo.BuildVariant.Name,
-		BuildVariantDisplayName: creationInfo.BuildVariant.DisplayName,
-		CreateTime:              creationInfo.TaskCreateTime,
-		IngestTime:              time.Now(),
-		ScheduledTime:           utility.ZeroTime,
-		StartTime:               utility.ZeroTime, // Certain time fields must be initialized
-		FinishTime:              utility.ZeroTime, // to our own utility.ZeroTime value (which is
-		DispatchTime:            utility.ZeroTime, // Unix epoch 0, not Go's time.Time{})
-		LastHeartbeat:           utility.ZeroTime,
-		Status:                  evergreen.TaskUndispatched,
-		Activated:               activateTask,
-		ActivatedTime:           activatedTime,
-		RevisionOrderNumber:     creationInfo.Version.RevisionOrderNumber,
-		Requester:               creationInfo.Version.Requester,
-		ParentPatchID:           creationInfo.Build.ParentPatchID,
-		StepbackInfo:            &task.StepbackInfo{},
-		ParentPatchNumber:       creationInfo.Build.ParentPatchNumber,
-		Version:                 creationInfo.Version.Id,
-		Revision:                creationInfo.Version.Revision,
-		Project:                 creationInfo.Project.Identifier,
-		Priority:                buildVarTask.Priority,
-		GenerateTask:            creationInfo.Project.IsGenerateTask(buildVarTask.Name),
-		TriggerID:               creationInfo.Version.TriggerID,
-		TriggerType:             creationInfo.Version.TriggerType,
-		TriggerEvent:            creationInfo.Version.TriggerEvent,
-		CommitQueueMerge:        buildVarTask.CommitQueueMerge,
-		IsGithubCheck:           isGithubCheck,
-		ActivatedBy:             creationInfo.Version.AuthorID, // this will be overridden if the task was activated by stepback
-		DisplayTaskId:           utility.ToStringPtr(""),       // this will be overridden if the task is an execution task
-		IsEssentialToSucceed:    creationInfo.ActivatedTasksAreEssentialToSucceed && activateTask,
-		ProjectStorageMethod:    creationInfo.Version.ProjectStorageMethod,
+		Id:                         id,
+		Secret:                     utility.RandomString(),
+		DisplayName:                buildVarTask.Name,
+		BuildId:                    creationInfo.Build.Id,
+		BuildVariant:               creationInfo.BuildVariant.Name,
+		BuildVariantDisplayName:    creationInfo.BuildVariant.DisplayName,
+		CreateTime:                 creationInfo.TaskCreateTime,
+		IngestTime:                 time.Now(),
+		ScheduledTime:              utility.ZeroTime,
+		StartTime:                  utility.ZeroTime, // Certain time fields must be initialized
+		FinishTime:                 utility.ZeroTime, // to our own utility.ZeroTime value (which is
+		DispatchTime:               utility.ZeroTime, // Unix epoch 0, not Go's time.Time{})
+		LastHeartbeat:              utility.ZeroTime,
+		Status:                     evergreen.TaskUndispatched,
+		Activated:                  activateTask,
+		ActivatedTime:              activatedTime,
+		RevisionOrderNumber:        creationInfo.Version.RevisionOrderNumber,
+		Requester:                  creationInfo.Version.Requester,
+		ParentPatchID:              creationInfo.Build.ParentPatchID,
+		StepbackInfo:               &task.StepbackInfo{},
+		ParentPatchNumber:          creationInfo.Build.ParentPatchNumber,
+		Version:                    creationInfo.Version.Id,
+		Revision:                   creationInfo.Version.Revision,
+		Project:                    creationInfo.Project.Identifier,
+		Priority:                   buildVarTask.Priority,
+		GenerateTask:               creationInfo.Project.IsGenerateTask(buildVarTask.Name),
+		TriggerID:                  creationInfo.Version.TriggerID,
+		TriggerType:                creationInfo.Version.TriggerType,
+		TriggerEvent:               creationInfo.Version.TriggerEvent,
+		CommitQueueMerge:           buildVarTask.CommitQueueMerge,
+		IsGithubCheck:              isGithubCheck,
+		ActivatedBy:                creationInfo.Version.AuthorID, // this will be overridden if the task was activated by stepback
+		DisplayTaskId:              utility.ToStringPtr(""),       // this will be overridden if the task is an execution task
+		IsEssentialToSucceed:       creationInfo.ActivatedTasksAreEssentialToSucceed && activateTask,
+		CachedProjectStorageMethod: creationInfo.Version.ProjectStorageMethod,
 	}
 
 	if err := t.SetGenerateTasksEstimations(ctx); err != nil {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1198,6 +1198,7 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 		ActivatedBy:             creationInfo.Version.AuthorID, // this will be overridden if the task was activated by stepback
 		DisplayTaskId:           utility.ToStringPtr(""),       // this will be overridden if the task is an execution task
 		IsEssentialToSucceed:    creationInfo.ActivatedTasksAreEssentialToSucceed && activateTask,
+		ProjectStorageMethod:    creationInfo.Version.ProjectStorageMethod,
 	}
 
 	if err := t.SetGenerateTasksEstimations(ctx); err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -337,7 +337,7 @@ func GetPatchedProjectConfig(ctx context.Context, settings *evergreen.Settings, 
 	if p.ProjectStorageMethod != "" {
 		// If the patch has been created but not finalized, it has either
 		// already saved the project config as a string (if any) or stored
-		// the parser project document (i.e. CachedProjectStorageMethod). Since
+		// the parser project document (i.e. ProjectStorageMethod). Since
 		// the project config is optional, the patch may be created and have
 		// already evaluated the patched project config, but there simply
 		// was none. Therefore, this is a valid way to check and get the

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -617,24 +617,25 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	}
 
 	patchVersion := &Version{
-		Id:                  p.Id.Hex(),
-		CreateTime:          time.Now(),
-		Identifier:          p.Project,
-		Revision:            p.Githash,
-		Author:              p.Author,
-		Message:             p.Description,
-		BuildIds:            []string{},
-		BuildVariants:       []VersionBuildStatus{},
-		Status:              evergreen.VersionCreated,
-		Requester:           requester,
-		ParentPatchID:       p.Triggers.ParentPatch,
-		ParentPatchNumber:   parentPatchNumber,
-		Branch:              projectRef.Branch,
-		RevisionOrderNumber: p.PatchNumber,
-		AuthorID:            p.Author,
-		Parameters:          params,
-		Activated:           utility.TruePtr(),
-		AuthorEmail:         authorEmail,
+		Id:                   p.Id.Hex(),
+		CreateTime:           time.Now(),
+		Identifier:           p.Project,
+		Revision:             p.Githash,
+		Author:               p.Author,
+		Message:              p.Description,
+		BuildIds:             []string{},
+		BuildVariants:        []VersionBuildStatus{},
+		Status:               evergreen.VersionCreated,
+		Requester:            requester,
+		ParentPatchID:        p.Triggers.ParentPatch,
+		ParentPatchNumber:    parentPatchNumber,
+		ProjectStorageMethod: p.ProjectStorageMethod,
+		Branch:               projectRef.Branch,
+		RevisionOrderNumber:  p.PatchNumber,
+		AuthorID:             p.Author,
+		Parameters:           params,
+		Activated:            utility.TruePtr(),
+		AuthorEmail:          authorEmail,
 	}
 
 	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, githubOauthToken)
@@ -752,8 +753,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, numActivatedTasks, true); err != nil {
 		return nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
 	}
-
-	patchVersion.ProjectStorageMethod = p.ProjectStorageMethod
 
 	env := evergreen.GetEnvironment()
 	mongoClient := env.Client()

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -337,7 +337,7 @@ func GetPatchedProjectConfig(ctx context.Context, settings *evergreen.Settings, 
 	if p.ProjectStorageMethod != "" {
 		// If the patch has been created but not finalized, it has either
 		// already saved the project config as a string (if any) or stored
-		// the parser project document (i.e. ProjectStorageMethod). Since
+		// the parser project document (i.e. CachedProjectStorageMethod). Since
 		// the project config is optional, the patch may be created and have
 		// already evaluated the patched project config, but there simply
 		// was none. Therefore, this is a valid way to check and get the

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -85,7 +85,7 @@ func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProjec
 	if isDegradedMode {
 		maxSize = config.TaskLimits.MaxDegradedModeParserProjectSize
 	}
-	if maxSize > 0 && parserProjectLen > maxSize {
+	if maxSize > 0 && parserProjectLen > maxSize*1024*1024 {
 		return errors.Errorf("parser project exceeds the system limit (%v > %v bytes).", parserProjectLen, maxSize)
 	}
 	return s.UpsertOneBSON(ctx, pp.Id, bsonPP)

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -80,7 +80,11 @@ func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProjec
 	if err != nil {
 		return errors.Wrap(err, "getting config")
 	}
+	isDegradedMode := !config.ServiceFlags.CPUDegradedModeDisabled
 	maxSize := config.TaskLimits.MaxParserProjectSize
+	if isDegradedMode {
+		maxSize = config.TaskLimits.MaxDegradedModeParserProjectSize
+	}
 	if maxSize > 0 && parserProjectLen > maxSize {
 		return errors.Errorf("parser project exceeds the system limit (%v > %v bytes).", parserProjectLen, maxSize)
 	}

--- a/model/project_parser_s3.go
+++ b/model/project_parser_s3.go
@@ -3,6 +3,7 @@ package model
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
@@ -86,7 +87,12 @@ func (s *ParserProjectS3Storage) UpsertOne(ctx context.Context, pp *ParserProjec
 		maxSize = config.TaskLimits.MaxDegradedModeParserProjectSize
 	}
 	if maxSize > 0 && parserProjectLen > maxSize*1024*1024 {
-		return errors.Errorf("parser project exceeds the system limit (%v > %v bytes).", parserProjectLen, maxSize)
+		serviceMode := "standard"
+		if isDegradedMode {
+			serviceMode = "degraded"
+		}
+		errMsg := fmt.Sprintf("parser project exceeds the %s system limit (%v > %v bytes).", serviceMode, parserProjectLen, maxSize)
+		return errors.New(errMsg)
 	}
 	return s.UpsertOneBSON(ctx, pp.Id, bsonPP)
 }

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -124,6 +124,7 @@ var (
 	IsEssentialToSucceedKey                = bsonutil.MustHaveTag(Task{}, "IsEssentialToSucceed")
 	HasAnnotationsKey                      = bsonutil.MustHaveTag(Task{}, "HasAnnotations")
 	NumNextTaskDispatchesKey               = bsonutil.MustHaveTag(Task{}, "NumNextTaskDispatches")
+	ProjectStorageMethodKey                = bsonutil.MustHaveTag(Task{}, "ProjectStorageMethod")
 )
 
 var (
@@ -3062,6 +3063,16 @@ func GetPendingGenerateTasks(ctx context.Context) (int, error) {
 	} else {
 		return results[0].NumPendingGenerateTasks, nil
 	}
+}
+
+// CountLargeParserProjectTasks counts the number of tasks running with parser projects stored in s3.
+func CountLargeParserProjectTasks() (int, error) {
+	return Count(db.Query(bson.M{
+		StatusKey: bson.M{
+			"$in": evergreen.TaskInProgressStatuses,
+		},
+		ProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
+	}))
 }
 
 // GetLatestTaskFromImage retrieves the latest task from all the distros corresponding to the imageID.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -124,7 +124,7 @@ var (
 	IsEssentialToSucceedKey                = bsonutil.MustHaveTag(Task{}, "IsEssentialToSucceed")
 	HasAnnotationsKey                      = bsonutil.MustHaveTag(Task{}, "HasAnnotations")
 	NumNextTaskDispatchesKey               = bsonutil.MustHaveTag(Task{}, "NumNextTaskDispatches")
-	ProjectStorageMethodKey                = bsonutil.MustHaveTag(Task{}, "ProjectStorageMethod")
+	CachedProjectStorageMethodKey          = bsonutil.MustHaveTag(Task{}, "CachedProjectStorageMethod")
 )
 
 var (
@@ -3071,7 +3071,7 @@ func CountLargeParserProjectTasks() (int, error) {
 		StatusKey: bson.M{
 			"$in": evergreen.TaskInProgressStatuses,
 		},
-		ProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
+		CachedProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
 	}))
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -322,6 +322,10 @@ type Task struct {
 	// NumNextTaskDispatches is the number of times the task has been dispatched to run on a
 	// host or in a container. This is used to determine if the task seems to be stuck.
 	NumNextTaskDispatches int `bson:"num_next_task_dispatches" json:"num_next_task_dispatches"`
+
+	// ProjectStorageMethod describes how the parser project for this task's version is
+	// stored. If this is empty, the default storage method is StorageMethodDB.
+	ProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"project_storage_method" json:"project_storage_method,omitempty"`
 }
 
 // GeneratedJSONFiles represent files used by a task for generate.tasks to update the project YAML.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -323,9 +323,9 @@ type Task struct {
 	// host or in a container. This is used to determine if the task seems to be stuck.
 	NumNextTaskDispatches int `bson:"num_next_task_dispatches" json:"num_next_task_dispatches"`
 
-	// ProjectStorageMethod describes how the parser project for this task's version is
-	// stored. If this is empty, the default storage method is StorageMethodDB.
-	ProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"project_storage_method" json:"project_storage_method,omitempty"`
+	// CachedProjectStorageMethod is a cached value how the parser project for this task's version was
+	// stored at the time this task was created. If this is empty, the default storage method is StorageMethodDB.
+	CachedProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"cached_project_storage_method" json:"cached_project_storage_method,omitempty"`
 }
 
 // GeneratedJSONFiles represent files used by a task for generate.tasks to update the project YAML.

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -385,9 +385,13 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 				})
 				return nil
 			}
-			maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
+
 			isDegradedMode := !settings.ServiceFlags.CPUDegradedModeDisabled
-			if isDegradedMode && maxConcurrentLargeParserProjTasks > 0 && taskVersion.ProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
+			maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
+			if isDegradedMode {
+				maxConcurrentLargeParserProjTasks = settings.TaskLimits.MaxDegradedModeConcurrentLargeParserProjectTasks
+			}
+			if maxConcurrentLargeParserProjTasks > 0 && taskVersion.ProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
 				numLargeParserProjectTasks, err := task.CountLargeParserProjectTasks()
 				if err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -439,6 +439,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 							"function":   "FindNextTask",
 							"message":    "problem finding task in db",
 							"task_id":    item.Id,
+							"group":      item.Group,
 							"distro_id":  d.distroID,
 						}))
 						return nil
@@ -449,6 +450,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 							"function":   "FindNextTask",
 							"message":    "task from db not found",
 							"task_id":    item.Id,
+							"group":      item.Group,
 							"distro_id":  d.distroID,
 						})
 						return nil

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -276,6 +276,18 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 
 		item := d.getItemByNodeID(node.ID()) // item is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 
+		settings, err := evergreen.GetConfig(ctx)
+		if err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"dispatcher": DAGDispatcher,
+				"function":   "FindNextTask",
+				"message":    "problem getting evergreen settings",
+				"task_id":    item.Id,
+				"distro_id":  d.distroID,
+			}))
+			continue
+		}
+
 		// TODO Consider checking if the state of any task has changed, which could unblock later tasks in the queue.
 		// Currently, we just wait for the dispatcher's in-memory queue to refresh.
 
@@ -322,17 +334,6 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 			}
 
 			// Skip the task if it's estimated to create more tasks than the generate task limit.
-			settings, err := evergreen.GetConfig(ctx)
-			if err != nil {
-				grip.Warning(message.WrapError(err, message.Fields{
-					"dispatcher": DAGDispatcher,
-					"function":   "FindNextTask",
-					"message":    "problem getting evergreen settings",
-					"task_id":    item.Id,
-					"distro_id":  d.distroID,
-				}))
-				continue
-			}
 			generateTasksLimit := settings.TaskLimits.MaxPendingGeneratedTasks
 			tasksToGenerate := utility.FromIntPtr(nextTaskFromDB.EstimatedNumGeneratedTasks)
 			if generateTasksLimit > 0 && tasksToGenerate > 0 {
@@ -362,59 +363,12 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 				}
 			}
 
-			taskVersion, err := VersionFindOneId(nextTaskFromDB.Version)
-			if err != nil {
-				grip.Warning(message.WrapError(err, message.Fields{
-					"dispatcher": DAGDispatcher,
-					"function":   "FindNextTask",
-					"message":    "problem finding version for task in db",
-					"version_id": nextTaskFromDB.Version,
-					"task_id":    nextTaskFromDB.Id,
-					"distro_id":  d.distroID,
-				}))
+			shouldContinue, shouldReturn := checkMaxConcurrentLargeParserProjectTasks(settings, nextTaskFromDB, d.distroID)
+			if shouldReturn {
 				return nil
 			}
-			if taskVersion == nil {
-				grip.Warning(message.Fields{
-					"dispatcher": DAGDispatcher,
-					"function":   "FindNextTask",
-					"message":    "version for task from db not found",
-					"task_id":    nextTaskFromDB.Id,
-					"version_id": nextTaskFromDB.Version,
-					"distro_id":  d.distroID,
-				})
-				return nil
-			}
-
-			isDegradedMode := !settings.ServiceFlags.CPUDegradedModeDisabled
-			maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
-			if isDegradedMode {
-				maxConcurrentLargeParserProjTasks = settings.TaskLimits.MaxDegradedModeConcurrentLargeParserProjectTasks
-			}
-			if maxConcurrentLargeParserProjTasks > 0 && taskVersion.ProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
-				numLargeParserProjectTasks, err := task.CountLargeParserProjectTasks()
-				if err != nil {
-					grip.Warning(message.WrapError(err, message.Fields{
-						"dispatcher": DAGDispatcher,
-						"function":   "FindNextTask",
-						"message":    "problem getting num large parser project tasks",
-						"task_id":    item.Id,
-						"distro_id":  d.distroID,
-					}))
-					continue
-				}
-				if numLargeParserProjectTasks >= maxConcurrentLargeParserProjTasks {
-					grip.Info(message.Fields{
-						"dispatcher": DAGDispatcher,
-						"function":   "FindNextTask",
-						"message":    "skipping task because it would exceed the concurrent large parser project task limit",
-						"task_id":    item.Id,
-						"distro_id":  d.distroID,
-						"max_concurrent_large_parser_project_tasks": maxConcurrentLargeParserProjTasks,
-						"num_large_parser_project_tasks":            numLargeParserProjectTasks,
-					})
-					continue
-				}
+			if shouldContinue {
+				continue
 			}
 
 			dependenciesMet, err := nextTaskFromDB.DependenciesMet(dependencyCaches)
@@ -478,6 +432,34 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 			d.taskGroups[taskGroupID] = taskGroupUnit
 			if taskGroupUnit.runningHosts < taskGroupUnit.maxHosts {
 				if next := d.nextTaskGroupTask(taskGroupUnit); next != nil {
+					nextTaskFromDB, err := task.FindOneId(next.Id)
+					if err != nil {
+						grip.Warning(message.WrapError(err, message.Fields{
+							"dispatcher": DAGDispatcher,
+							"function":   "FindNextTask",
+							"message":    "problem finding task in db",
+							"task_id":    item.Id,
+							"distro_id":  d.distroID,
+						}))
+						return nil
+					}
+					if nextTaskFromDB == nil {
+						grip.Warning(message.Fields{
+							"dispatcher": DAGDispatcher,
+							"function":   "FindNextTask",
+							"message":    "task from db not found",
+							"task_id":    item.Id,
+							"distro_id":  d.distroID,
+						})
+						return nil
+					}
+					shouldContinue, shouldReturn := checkMaxConcurrentLargeParserProjectTasks(settings, nextTaskFromDB, d.distroID)
+					if shouldReturn {
+						return nil
+					}
+					if shouldContinue {
+						continue
+					}
 					node := d.getNodeByItemID(next.Id)
 					taskGroupTask := d.getItemByNodeID(node.ID()) // *TaskQueueItem
 					taskGroupTask.IsDispatched = true
@@ -488,6 +470,68 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 		}
 	}
 	return nil
+}
+
+// checkMaxConcurrentLargeParserProjectTasks checks whether the task is allowed to be dispatched according to the current limitations
+// on how many concurrent large parser project tasks can be running. The first returned parameter indicates whether FindNextTask should
+// return on an error, and the second indicates whether FindNextTask should skip this task and continue its loop.
+func checkMaxConcurrentLargeParserProjectTasks(settings *evergreen.Settings, nextTaskFromDB *task.Task, distroId string) (bool, bool) {
+	taskVersion, err := VersionFindOneId(nextTaskFromDB.Version)
+	if err != nil {
+		grip.Warning(message.WrapError(err, message.Fields{
+			"dispatcher": DAGDispatcher,
+			"function":   "FindNextTask",
+			"message":    "problem finding version for task in db",
+			"version_id": nextTaskFromDB.Version,
+			"task_id":    nextTaskFromDB.Id,
+			"distro_id":  distroId,
+		}))
+		return false, true
+	}
+	if taskVersion == nil {
+		grip.Warning(message.Fields{
+			"dispatcher": DAGDispatcher,
+			"function":   "FindNextTask",
+			"message":    "version for task from db not found",
+			"task_id":    nextTaskFromDB.Id,
+			"version_id": nextTaskFromDB.Version,
+			"distro_id":  distroId,
+		})
+		return false, true
+	}
+
+	isDegradedMode := !settings.ServiceFlags.CPUDegradedModeDisabled
+	maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
+	if isDegradedMode {
+		maxConcurrentLargeParserProjTasks = settings.TaskLimits.MaxDegradedModeConcurrentLargeParserProjectTasks
+	}
+	if maxConcurrentLargeParserProjTasks > 0 && taskVersion.ProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
+		numLargeParserProjectTasks, err := task.CountLargeParserProjectTasks()
+		if err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"dispatcher": DAGDispatcher,
+				"function":   "FindNextTask",
+				"message":    "problem getting num large parser project tasks",
+				"task_id":    nextTaskFromDB.Id,
+				"distro_id":  distroId,
+			}))
+			return true, false
+		}
+		if numLargeParserProjectTasks >= maxConcurrentLargeParserProjTasks {
+			grip.Info(message.Fields{
+				"dispatcher":       DAGDispatcher,
+				"function":         "FindNextTask",
+				"message":          "skipping task because it would exceed the concurrent large parser project task limit",
+				"task_id":          nextTaskFromDB.Id,
+				"distro_id":        distroId,
+				"is_degraded_mode": isDegradedMode,
+				"max_concurrent_large_parser_project_tasks": maxConcurrentLargeParserProjTasks,
+				"num_large_parser_project_tasks":            numLargeParserProjectTasks,
+			})
+			return true, false
+		}
+	}
+	return false, false
 }
 
 func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *TaskQueueItem {

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -619,9 +619,9 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 			maxHosts = 2
 		}
 
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         group,
 			BuildVariant:  variant,
 			Version:       version,
@@ -641,7 +641,7 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 		}
 
 		t := task.Task{
-			Id:                ID,
+			Id:                id,
 			DistroId:          distroID,
 			StartTime:         utility.ZeroTime,
 			TaskGroup:         group,
@@ -1696,9 +1696,9 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 	groupIndexes := []int{2, 0, 4, 1, 3}
 
 	for i := 0; i < 5; i++ {
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         "group_1",
 			BuildVariant:  "variant_1",
 			Version:       "version_1",
@@ -1707,7 +1707,7 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 			GroupIndex:    groupIndexes[i],
 		})
 		t := task.Task{
-			Id:                ID,
+			Id:                id,
 			TaskGroup:         "group_1",
 			BuildVariant:      "variant_1",
 			Version:           "version_1",
@@ -1765,9 +1765,9 @@ func (s *taskDAGDispatchServiceSuite) TestInProgressSingleHostTaskGroupLimits() 
 	s.Require().NoError(sampleS3Task.Insert())
 
 	for i := 0; i < 5; i++ {
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         "group_1",
 			BuildVariant:  "variant_1",
 			Version:       "version_1",
@@ -1775,7 +1775,7 @@ func (s *taskDAGDispatchServiceSuite) TestInProgressSingleHostTaskGroupLimits() 
 			GroupMaxHosts: 1,
 		})
 		t := task.Task{
-			Id:                         ID,
+			Id:                         id,
 			TaskGroup:                  "group_1",
 			BuildVariant:               "variant_1",
 			Version:                    "version_1",
@@ -1831,9 +1831,9 @@ func (s *taskDAGDispatchServiceSuite) TestNewSingleHostTaskGroupLimits() {
 	s.Require().NoError(sampleS3Task.Insert())
 
 	for i := 0; i < 5; i++ {
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         "group_1",
 			BuildVariant:  "variant_1",
 			Version:       "version_1",
@@ -1841,7 +1841,7 @@ func (s *taskDAGDispatchServiceSuite) TestNewSingleHostTaskGroupLimits() {
 			GroupMaxHosts: 1,
 		})
 		t := task.Task{
-			Id:                         ID,
+			Id:                         id,
 			TaskGroup:                  "group_1",
 			BuildVariant:               "variant_1",
 			Version:                    "version_1",

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -568,8 +568,7 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 }
 
 func (s *taskDAGDispatchServiceSuite) SetupTest() {
-	s.Require().NoError(db.ClearCollections(task.Collection))
-	s.Require().NoError(db.ClearCollections(host.Collection))
+	s.Require().NoError(db.ClearCollections(task.Collection, host.Collection, VersionCollection))
 	items := []TaskQueueItem{}
 	var group string
 	var variant string
@@ -655,6 +654,26 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 		}
 		s.Require().NoError(t.Insert())
 	}
+	taskVersion1 := &Version{
+		Id: "version_1",
+	}
+	taskVersion2 := &Version{
+		Id: "5d8cd23da4cf4747f4210333",
+	}
+	taskVersion3 := &Version{
+		Id: "5d88953e2a60ed61eefe9561",
+	}
+	taskVersion4 := &Version{
+		Id: "version",
+	}
+	taskVersion5 := &Version{
+		Id: "",
+	}
+	s.Require().NoError(taskVersion1.Insert())
+	s.Require().NoError(taskVersion2.Insert())
+	s.Require().NoError(taskVersion3.Insert())
+	s.Require().NoError(taskVersion4.Insert())
+	s.Require().NoError(taskVersion5.Insert())
 
 	s.taskQueue = TaskQueue{
 		Distro: distroID,

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2693,14 +2693,15 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion                   *int `json:"max_tasks_per_version"`
-	MaxIncludesPerVersion                *int `json:"max_includes_per_version"`
-	MaxHourlyPatchTasks                  *int `json:"max_hourly_patch_tasks"`
-	MaxPendingGeneratedTasks             *int `json:"max_pending_generated_tasks"`
-	MaxGenerateTaskJSONSize              *int `json:"max_generate_task_json_size"`
-	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
-	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
-	MaxParserProjectSize                 *int `json:"max_parser_project_size"`
+	MaxTasksPerVersion                               *int `json:"max_tasks_per_version"`
+	MaxIncludesPerVersion                            *int `json:"max_includes_per_version"`
+	MaxHourlyPatchTasks                              *int `json:"max_hourly_patch_tasks"`
+	MaxPendingGeneratedTasks                         *int `json:"max_pending_generated_tasks"`
+	MaxGenerateTaskJSONSize                          *int `json:"max_generate_task_json_size"`
+	MaxConcurrentLargeParserProjectTasks             *int `json:"max_concurrent_large_parser_project_tasks"`
+	MaxDegradedModeConcurrentLargeParserProjectTasks *int `json:"max_degraded_mode_concurrent_large_parser_project_tasks"`
+	MaxDegradedModeParserProjectSize                 *int `json:"max_degraded_mode_parser_project_size"`
+	MaxParserProjectSize                             *int `json:"max_parser_project_size"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2712,6 +2713,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxHourlyPatchTasks = utility.ToIntPtr(v.MaxHourlyPatchTasks)
 		c.MaxGenerateTaskJSONSize = utility.ToIntPtr(v.MaxGenerateTaskJSONSize)
 		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
+		c.MaxDegradedModeConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxDegradedModeConcurrentLargeParserProjectTasks)
 		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
 		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
 		return nil
@@ -2722,14 +2724,15 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion:                   utility.FromIntPtr(c.MaxTasksPerVersion),
-		MaxIncludesPerVersion:                utility.FromIntPtr(c.MaxIncludesPerVersion),
-		MaxHourlyPatchTasks:                  utility.FromIntPtr(c.MaxHourlyPatchTasks),
-		MaxPendingGeneratedTasks:             utility.FromIntPtr(c.MaxPendingGeneratedTasks),
-		MaxGenerateTaskJSONSize:              utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
-		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
-		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
-		MaxParserProjectSize:                 utility.FromIntPtr(c.MaxParserProjectSize),
+		MaxTasksPerVersion:                               utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxIncludesPerVersion:                            utility.FromIntPtr(c.MaxIncludesPerVersion),
+		MaxHourlyPatchTasks:                              utility.FromIntPtr(c.MaxHourlyPatchTasks),
+		MaxPendingGeneratedTasks:                         utility.FromIntPtr(c.MaxPendingGeneratedTasks),
+		MaxGenerateTaskJSONSize:                          utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
+		MaxConcurrentLargeParserProjectTasks:             utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
+		MaxDegradedModeConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxDegradedModeConcurrentLargeParserProjectTasks),
+		MaxDegradedModeParserProjectSize:                 utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
+		MaxParserProjectSize:                             utility.FromIntPtr(c.MaxParserProjectSize),
 	}, nil
 }
 

--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -51,7 +51,8 @@ func (h *degradedModeHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
 		}
 		grip.Info(message.Fields{
-			"message": "degraded mode has been triggered",
+			"message": "CPU degraded mode has been triggered",
+			"route":   "/degraded_mode",
 		})
 	}
 	return gimlet.NewJSONResponse(struct{}{})

--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -2,11 +2,12 @@ package route
 
 import (
 	"context"
-	"net/http"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"net/http"
 )
 
 const firingStatus = "firing"
@@ -48,6 +49,9 @@ func (h *degradedModeHandler) Run(ctx context.Context) gimlet.Responder {
 		if err = flags.Set(ctx); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
 		}
+		grip.Info(message.Fields{
+			"message": "degraded mode has been triggered",
+		})
 	}
 	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -2,12 +2,13 @@ package route
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 const firingStatus = "firing"

--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -43,9 +43,11 @@ func (h *degradedModeHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "retrieving service flags"))
 	}
-	flags.CPUDegradedModeDisabled = false
-	if err = flags.Set(ctx); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
+	if flags.CPUDegradedModeDisabled {
+		flags.CPUDegradedModeDisabled = false
+		if err = flags.Set(ctx); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
+		}
 	}
 	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -34,6 +34,7 @@ const hostSecret = "secret"
 func TestHostNextTask(t *testing.T) {
 	distroID := "testDistro"
 	buildID := "buildId"
+	versionID := "versionId"
 	task1 := task.Task{
 		Id:        "task1",
 		Execution: 5,
@@ -42,6 +43,7 @@ func TestHostNextTask(t *testing.T) {
 		BuildId:   buildID,
 		Project:   "exists",
 		StartTime: utility.ZeroTime,
+		Version:   versionID,
 	}
 	task2 := task.Task{
 		Id:        "task2",
@@ -50,6 +52,7 @@ func TestHostNextTask(t *testing.T) {
 		Project:   "exists",
 		BuildId:   buildID,
 		StartTime: utility.ZeroTime,
+		Version:   versionID,
 	}
 	task3 := task.Task{
 		Id:        "task3",
@@ -58,6 +61,7 @@ func TestHostNextTask(t *testing.T) {
 		Project:   "exists",
 		BuildId:   buildID,
 		StartTime: utility.ZeroTime,
+		Version:   versionID,
 	}
 	task4 := task.Task{
 		Id:        "another",
@@ -66,6 +70,7 @@ func TestHostNextTask(t *testing.T) {
 		Project:   "exists",
 		StartTime: utility.ZeroTime,
 		BuildId:   buildID,
+		Version:   versionID,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -203,7 +208,7 @@ func TestHostNextTask(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					require.NoError(t, db.ClearCollections(host.Collection, distro.Collection))
+					require.NoError(t, db.ClearCollections(host.Collection, distro.Collection, model.VersionCollection))
 					h := host.Host{
 						Id: "id",
 						Distro: distro.Distro{
@@ -222,8 +227,12 @@ func TestHostNextTask(t *testing.T) {
 						Status:           evergreen.HostRunning,
 						NeedsReprovision: host.ReprovisionToNew,
 					}
+					v := model.Version{
+						Id: versionID,
+					}
 					require.NoError(t, h.Insert(ctx))
 					require.NoError(t, h.Distro.Insert(ctx))
+					require.NoError(t, v.Insert())
 					handler := hostAgentNextTask{
 						env: env,
 					}
@@ -868,7 +877,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 		settings := distro.DispatcherSettings{
 			Version: evergreen.DispatcherVersionRevisedWithDependencies,
 		}
-		colls := []string{distro.Collection, host.Collection, task.Collection, model.TaskQueuesCollection, model.ProjectRefCollection}
+		colls := []string{distro.Collection, host.Collection, task.Collection, model.TaskQueuesCollection, model.ProjectRefCollection, model.VersionCollection}
 		require.NoError(t, db.ClearCollections(colls...))
 		defer func() {
 			assert.NoError(t, db.ClearCollections(colls...))
@@ -880,6 +889,11 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			DispatcherSettings: settings,
 		}
 		So(d.Insert(ctx), ShouldBeNil)
+
+		v := model.Version{
+			Id: versionId,
+		}
+		So(v.Insert(), ShouldBeNil)
 
 		taskGroupInfo := model.TaskGroupInfo{
 			Name:  "",
@@ -916,6 +930,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			Activated: true,
 			Project:   "exists",
 			StartTime: utility.ZeroTime,
+			Version:   versionId,
 		}
 		task2 := task.Task{
 			Id:        "task2",
@@ -923,6 +938,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 			Activated: true,
 			Project:   "exists",
 			StartTime: utility.ZeroTime,
+			Version:   versionId,
 		}
 		pref := &model.ProjectRef{
 			Id:      "exists",
@@ -1044,6 +1060,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Project:   "exists",
 				Activated: true,
 				StartTime: utility.ZeroTime,
+				Version:   versionId,
 			}
 			So(t1.Insert(), ShouldBeNil)
 			t2 := task.Task{
@@ -1052,6 +1069,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Project:   "exists",
 				Activated: true,
 				StartTime: utility.ZeroTime,
+				Version:   versionId,
 			}
 			So(t2.Insert(), ShouldBeNil)
 
@@ -1082,7 +1100,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				RunningTask:             "task1",
 				RunningTaskGroup:        "group1",
 				RunningTaskBuildVariant: "variant1",
-				RunningTaskVersion:      "version1",
+				RunningTaskVersion:      versionId,
 				RunningTaskProject:      "exists",
 				Distro: distro.Distro{
 					Id: "d1",
@@ -1098,7 +1116,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				RunningTask:             "",
 				RunningTaskGroup:        "",
 				RunningTaskBuildVariant: "",
-				RunningTaskVersion:      "",
+				RunningTaskVersion:      versionId,
 				RunningTaskProject:      "",
 				Distro: distro.Distro{
 					Id: d.Id,
@@ -1114,7 +1132,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Activated:         true,
 				TaskGroup:         "group1",
 				BuildVariant:      "variant1",
-				Version:           "version1",
+				Version:           versionId,
 				Project:           "exists",
 				TaskGroupMaxHosts: 1,
 			}
@@ -1125,7 +1143,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Activated:         true,
 				TaskGroup:         "group2",
 				BuildVariant:      "variant1",
-				Version:           "version1",
+				Version:           versionId,
 				Project:           "exists",
 				TaskGroupMaxHosts: 1,
 			}

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -565,7 +565,7 @@ func TestHostNextTask(t *testing.T) {
 			defer cancel()
 
 			colls := []string{model.ProjectRefCollection, host.Collection, task.Collection, model.TaskQueuesCollection, build.Collection,
-				evergreen.ConfigCollection, distro.Collection}
+				evergreen.ConfigCollection, distro.Collection, model.VersionCollection}
 			require.NoError(t, db.ClearCollections(colls...))
 			defer func() {
 				assert.NoError(t, db.ClearCollections(colls...))
@@ -608,6 +608,9 @@ func TestHostNextTask(t *testing.T) {
 				Id:      "exists",
 				Enabled: true,
 			}
+			v := model.Version{
+				Id: versionID,
+			}
 
 			require.NoError(t, d.Insert(ctx))
 			require.NoError(t, task1.Insert())
@@ -618,6 +621,7 @@ func TestHostNextTask(t *testing.T) {
 			require.NoError(t, pref.Insert())
 			require.NoError(t, sampleHost.Insert(ctx))
 			require.NoError(t, tq.Save())
+			require.NoError(t, v.Insert())
 
 			r, ok := makeHostAgentNextTask(env, nil, nil).(*hostAgentNextTask)
 			require.True(t, ok)
@@ -890,6 +894,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 		}
 		So(d.Insert(ctx), ShouldBeNil)
 
+		versionId = "versionId"
 		v := model.Version{
 			Id: versionId,
 		}
@@ -1003,6 +1008,7 @@ func TestAssignNextAvailableTaskWithDispatcherSettingsVersionTunable(t *testing.
 				Id:        "undispatchedTask",
 				Status:    evergreen.TaskStarted,
 				StartTime: utility.ZeroTime,
+				Version:   versionId,
 			}
 			So(undispatchedTask.Insert(), ShouldBeNil)
 			t, shouldTeardown, err := assignNextAvailableTask(ctx, env, taskQueue, model.NewTaskDispatchService(time.Minute), &theHostWhoCanBoastTheMostRoast, details)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -639,6 +639,10 @@ Admin Settings
 										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>Max Degraded Mode Concurrent Large Parser Project Tasks</label>
+										<input type="number" ng-model="Settings.task_limits.max_degraded_mode_concurrent_large_parser_project_tasks">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>Max Parser Project Size (MB)</label>
 										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
 									</md-input-container>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -639,7 +639,7 @@ Admin Settings
 										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Max Degraded Mode Concurrent Large Parser Project Tasks</label>
+										<label>Max CPU Degraded Mode Concurrent Large Parser Project Tasks</label>
 										<input type="number" ng-model="Settings.task_limits.max_degraded_mode_concurrent_large_parser_project_tasks">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">


### PR DESCRIPTION
DEVPROD-6072

### Description
Implements degraded mode.

- Reduces the maximum allowed parser project size
- Reduces the number of tasks in s3 versions that can be running concurrently.

### Testing
Added CPU alert in staging to fire to the alertmanager webhook at 10% CPU (to trigger it immediately). Confirmed that degraded mode turned on, and upon scheduling a bunch of tasks in s3 versions, tasks got throttled once the limit of concurrent s3 tasks were hit ([splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?sid=1721928863.1192603))