### PR TITLE
DEVPROD-9095: stagger sleep schedule jobs

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1624,7 +1624,7 @@ func FindHostsScheduledToStop(ctx context.Context) ([]Host, error) {
 
 // PreStartThreshold is how long in advance Evergreen can check for hosts that
 // are scheduled to start up soon.
-const PreStartThreshold = 5 * time.Minute
+const PreStartThreshold = 10 * time.Minute
 
 // FindHostsToSleep finds all unexpirable hosts that are due to start soon due
 // to their sleep schedule settings.

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -183,7 +183,12 @@ func StopSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUse
 	}
 
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	stopJob := units.NewSpawnhostStopJob(h, shouldKeepOff, evergreen.ModifySpawnHostManual, u.Id, ts)
+	stopJob := units.NewSpawnhostStopJob(units.SpawnHostModifyJobOptions{
+		Host:      h,
+		Source:    evergreen.ModifySpawnHostManual,
+		User:      u.Id,
+		Timestamp: ts,
+	}, shouldKeepOff)
 	if err := units.EnqueueSpawnHostModificationJob(ctx, env, stopJob); err != nil {
 		if amboy.IsDuplicateJobScopeError(err) {
 			err = errHostStatusChangeConflict
@@ -201,7 +206,12 @@ func StartSpawnHost(ctx context.Context, env evergreen.Environment, u *user.DBUs
 	}
 
 	ts := utility.RoundPartOfMinute(1).Format(units.TSFormat)
-	startJob := units.NewSpawnhostStartJob(h, evergreen.ModifySpawnHostManual, u.Id, ts)
+	startJob := units.NewSpawnhostStartJob(units.SpawnHostModifyJobOptions{
+		Host:      h,
+		Source:    evergreen.ModifySpawnHostManual,
+		User:      u.Id,
+		Timestamp: ts,
+	})
 	if err := units.EnqueueSpawnHostModificationJob(ctx, env, startJob); err != nil {
 		if amboy.IsDuplicateJobScopeError(err) {
 			err = errHostStatusChangeConflict

--- a/units/migrate_volume.go
+++ b/units/migrate_volume.go
@@ -151,7 +151,12 @@ func (j *volumeMigrationJob) Run(ctx context.Context) {
 // stopInitialHost inspects the initial host's status and stops it if the host is still running.
 func (j *volumeMigrationJob) stopInitialHost(ctx context.Context) {
 	ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-	stopJob := NewSpawnhostStopJob(j.initialHost, false, evergreen.ModifySpawnHostManual, evergreen.User, ts)
+	stopJob := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+		Host:      j.initialHost,
+		Source:    evergreen.ModifySpawnHostManual,
+		User:      j.ModifyOptions.UserName,
+		Timestamp: ts,
+	}, false)
 	err := amboy.EnqueueUniqueJob(ctx, j.env.RemoteQueue(), stopJob)
 	if err != nil {
 		j.AddRetryableError(err)

--- a/units/sleep_scheduler.go
+++ b/units/sleep_scheduler.go
@@ -252,6 +252,8 @@ func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergree
 		return nil, errors.Wrap(err, "checking if sleep schedule is enabled")
 	}
 
+	now := time.Now()
+
 	var stopJobs []amboy.Job
 	var hostIDsToStop []string
 	if !flags.SleepScheduleDisabled {
@@ -269,7 +271,17 @@ func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergree
 		hostIDsToStop = make([]string, 0, len(hostsToStop))
 		for i := range hostsToStop {
 			h := hostsToStop[i]
-			stopJobs = append(stopJobs, NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts.Format(TSFormat)))
+			stopJobs = append(stopJobs, NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:   &h,
+				Source: evergreen.ModifySpawnHostSleepSchedule,
+				User:   sleepScheduleUser,
+				// To reduce the likelihood that sleep schedule hosts
+				// collectively make a large burst of requests to AWS and hit
+				// rate limits, stagger the requests by adding a slight amount
+				// of delay to each job.
+				WaitUntil: now.Add(time.Duration(i) * time.Second),
+				Timestamp: ts.Format(TSFormat),
+			}, false))
 			hostIDsToStop = append(hostIDsToStop, h.Id)
 		}
 	}
@@ -282,7 +294,17 @@ func (j *sleepSchedulerJob) makeStopAndStartJobs(ctx context.Context, _ evergree
 	hostIDsToStart := make([]string, 0, len(hostsToStart))
 	for i := range hostsToStart {
 		h := hostsToStart[i]
-		startJobs = append(startJobs, NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts.Format(TSFormat)))
+		startJobs = append(startJobs, NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+			Host:   &h,
+			Source: evergreen.ModifySpawnHostSleepSchedule,
+			User:   sleepScheduleUser,
+			// To reduce the likelihood that sleep schedule hosts
+			// collectively make a large burst of requests to AWS and hit
+			// rate limits, stagger the requests by adding a slight amount
+			// of delay to each job.
+			WaitUntil: now.Add(time.Duration(i) * time.Second),
+			Timestamp: ts.Format(TSFormat),
+		}))
 		hostIDsToStart = append(hostIDsToStart, h.Id)
 	}
 

--- a/units/sleep_scheduler_test.go
+++ b/units/sleep_scheduler_test.go
@@ -85,6 +85,7 @@ func TestSleepSchedulerJob(t *testing.T) {
 			for ji := range q.JobInfo(ctx) {
 				numJobs++
 				if ji.Type.Name == spawnhostStopName {
+					assert.False(t, utility.IsZeroTime(ji.Time.WaitUntil))
 					for hostID := range expectedHostsToStop {
 						if strings.Contains(ji.ID, hostID) {
 							expectedHostsToStop[hostID] = true
@@ -148,6 +149,7 @@ func TestSleepSchedulerJob(t *testing.T) {
 			for ji := range q.JobInfo(ctx) {
 				numJobs++
 				if ji.Type.Name == spawnhostStartName {
+					assert.False(t, utility.IsZeroTime(ji.Time.WaitUntil))
 					for hostID := range expectedHostsToStart {
 						if strings.Contains(ji.ID, hostID) {
 							expectedHostsToStart[hostID] = true

--- a/units/spawnhost_modify.go
+++ b/units/spawnhost_modify.go
@@ -52,7 +52,7 @@ func (m *CloudHostModification) modifyHost(ctx context.Context, op func(ctx cont
 	}
 
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(m.hostAttributes(m.host)...)
+	span.SetAttributes(m.hostAttributes()...)
 
 	mgrOpts, err := cloud.GetManagerOptions(m.host.Distro)
 	if err != nil {
@@ -66,7 +66,7 @@ func (m *CloudHostModification) modifyHost(ctx context.Context, op func(ctx cont
 	return op(ctx, cloudManager, m.host, m.UserID)
 }
 
-func (m *CloudHostModification) hostAttributes(h *host.Host) []attribute.KeyValue {
+func (m *CloudHostModification) hostAttributes() []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String(evergreen.HostIDOtelAttribute, m.host.Id),
 		attribute.String(evergreen.DistroIDOtelAttribute, m.host.Distro.Id),

--- a/units/spawnhost_start.go
+++ b/units/spawnhost_start.go
@@ -74,6 +74,12 @@ func (j *spawnhostStartJob) Run(ctx context.Context) {
 			// Only log an error if the final job attempt errors. Otherwise, it
 			// may retry and succeed on the next attempt.
 			event.LogHostStartError(j.HostID, string(j.Source), j.Error().Error())
+			grip.Error(message.WrapError(j.Error(), message.Fields{
+				"message": "no attempts remaining to start spawn host",
+				"host_id": j.HostID,
+				"source":  j.Source,
+				"job":     j.ID(),
+			}))
 		}
 	}()
 

--- a/units/spawnhost_start_test.go
+++ b/units/spawnhost_start_test.go
@@ -35,7 +35,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 				Provider: evergreen.ProviderNameMock,
 				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
 			}
-			j, ok := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts).(*spawnhostStartJob)
+			j, ok := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}).(*spawnhostStartJob)
 			require.True(t, ok)
 
 			assert.NotZero(t, j.RetryInfo().GetMaxAttempts(), "job should retry")
@@ -56,7 +61,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -85,7 +95,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -112,7 +127,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -137,7 +157,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			})
 			// Simulate the job running out of retry attempts, which should
 			// cause an event to be logged.
 			j.UpdateRetryInfo(amboy.JobRetryOptions{CurrentAttempt: utility.ToIntPtr(j.RetryInfo().GetMaxAttempts())})
@@ -175,7 +200,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -219,7 +249,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -255,7 +290,12 @@ func TestSpawnhostStartJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStartJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			})
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -58,7 +58,6 @@ type SpawnHostModifyJobOptions struct {
 }
 
 // NewSpawnhostStopJob returns a job to stop a running spawn host.
-// kim: TODO: refactor into common options
 func NewSpawnhostStopJob(opts SpawnHostModifyJobOptions, shouldKeepOff bool) amboy.Job {
 	j := makeSpawnhostStopJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s.%s", spawnhostStopName, opts.User, opts.Host.Id, opts.Timestamp))

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -86,6 +86,12 @@ func (j *spawnhostStopJob) Run(ctx context.Context) {
 			// Only log an error if the final job attempt errors. Otherwise, it
 			// may retry and succeed on the next attempt.
 			event.LogHostStopError(j.HostID, string(j.Source), j.Error().Error())
+			grip.Error(message.WrapError(j.Error(), message.Fields{
+				"message": "no attempts remaining to stop spawn host",
+				"host_id": j.HostID,
+				"source":  j.Source,
+				"job":     j.ID(),
+			}))
 		}
 	}()
 

--- a/units/spawnhost_stop.go
+++ b/units/spawnhost_stop.go
@@ -67,7 +67,6 @@ func NewSpawnhostStopJob(opts SpawnHostModifyJobOptions, shouldKeepOff bool) amb
 	j.CloudHostModification.UserID = opts.User
 	j.ShouldKeepOff = shouldKeepOff
 	j.CloudHostModification.Source = opts.Source
-	// kim: TODO: check if Amboy will behave fine if I set the zero time here.
 	j.SetTimeInfo(amboy.JobTimeInfo{
 		WaitUntil: opts.WaitUntil,
 	})

--- a/units/spawnhost_stop_test.go
+++ b/units/spawnhost_stop_test.go
@@ -35,7 +35,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 				Provider: evergreen.ProviderNameMock,
 				Distro:   distro.Distro{Provider: evergreen.ProviderNameMock},
 			}
-			j, ok := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts).(*spawnhostStopJob)
+			j, ok := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}, false).(*spawnhostStopJob)
 			require.True(t, ok)
 
 			assert.NotZero(t, j.RetryInfo().GetMaxAttempts(), "job should retry")
@@ -56,7 +61,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -83,7 +93,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, true, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}, true)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -111,7 +126,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -136,7 +156,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStartJob(&h, evergreen.ModifySpawnHostManual, "user", ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostManual,
+				User:      "user",
+				Timestamp: ts,
+			}, false)
 			// Simulate the job running out of retry attempts, which should
 			// cause an event to be logged.
 			j.UpdateRetryInfo(amboy.JobRetryOptions{CurrentAttempt: utility.ToIntPtr(j.RetryInfo().GetMaxAttempts())})
@@ -149,7 +174,7 @@ func TestSpawnhostStopJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostUninitialized, dbHost.Status)
 
-			checkSpawnHostModificationEvent(t, h.Id, event.EventHostStarted, false)
+			checkSpawnHostModificationEvent(t, h.Id, event.EventHostStopped, false)
 		},
 		"RunStopsHostAndSchedulesNextStopTime": func(ctx context.Context, t *testing.T, mock cloud.MockProvider) {
 			userTZ, err := time.LoadLocation("Antarctica/South_Pole")
@@ -174,7 +199,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -225,7 +255,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -262,7 +297,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())
@@ -298,7 +338,12 @@ func TestSpawnhostStopJob(t *testing.T) {
 			})
 
 			ts := utility.RoundPartOfMinute(1).Format(TSFormat)
-			j := NewSpawnhostStopJob(&h, false, evergreen.ModifySpawnHostSleepSchedule, sleepScheduleUser, ts)
+			j := NewSpawnhostStopJob(SpawnHostModifyJobOptions{
+				Host:      &h,
+				Source:    evergreen.ModifySpawnHostSleepSchedule,
+				User:      sleepScheduleUser,
+				Timestamp: ts,
+			}, false)
 
 			j.Run(ctx)
 			assert.NoError(t, j.Error())


### PR DESCRIPTION
DEVPROD-9095

### Description
* Stagger when the sleep schedule stop/start jobs can run. This is to avoid an issue where if lots of people just go with the default sleep schedule (8am-8pm Mon-Fri Eastern Time), there will be a burst of stop/start requests to AWS all at once right around those times, which triggers AWS to rate limit the requests. Spreading out the requests over a few minutes reduces the likelihood of rate limit issues.
* Start hosts a few minutes in advance of their actual startup time. We want the host to be up by the time it's supposed to wake up for its schedule, even if AWS temporarily rate limited us, so giving it more time to start up makes it more likely it'll be up at the scheduled time. Starting a few minutes earlier doesn't make a significant difference to the overall cost.
* Refactor spawn host stop/start jobs to use common struct for job creation parameters.

### Testing
* Added unit test.
* Tested in staging that when there were multiple sleep schedule jobs to run, they were all staggered by a few seconds of delay.

### Documentation
N/A