### PR TITLE
DEVPROD-8877: Fix redaction logic for githubAppAuth field

### DIFF
--- a/graphql/tests/query/projectEvents/data.json
+++ b/graphql/tests/query/projectEvents/data.json
@@ -3,6 +3,10 @@
     {
       "_id": "sandbox_project_id",
       "identifier": "sandbox"
+    },
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
     }
   ],
   "project_vars": [
@@ -65,6 +69,49 @@
               "hello": "universe"
             }
           }
+        }
+      }
+    },
+    {
+      "_id": "2a3b7bb857e85a21ceb53cf9",
+      "r_type": "PROJECT",
+      "processed_at": {
+        "$date": "2020-03-03T15:46:29.961Z"
+      },
+      "ts": {
+        "$date": "2020-03-03T15:46:00.709Z"
+      },
+      "r_id": "spruce",
+      "e_type": "PROJECT_MODIFIED",
+      "data": {
+        "user": "bob.smith",
+        "before": {
+          "proj_ref": {
+            "_id": "spruce",
+            "identifier": "spruce",
+            "owner_name": "evergreen-ci",
+            "repo_name": "spruce",
+            "branch_name": "main"
+          },
+          "github_app_auth": {
+            "app_id": 11111,
+            "private_key": "secret"
+          },
+          "github_hooks_enabled": false
+        },
+        "after": {
+          "proj_ref": {
+            "_id": "spruce",
+            "identifier": "spruce",
+            "owner_name": "evergreen-ci",
+            "repo_name": "spruce",
+            "branch_name": "main"
+          },
+          "github_app_auth": {
+            "app_id": 11111,
+            "private_key": "secret"
+          },
+          "github_hooks_enabled": false
         }
       }
     }

--- a/graphql/tests/query/projectEvents/queries/no_changes.graphql
+++ b/graphql/tests/query/projectEvents/queries/no_changes.graphql
@@ -1,0 +1,29 @@
+query {
+  projectEvents(projectIdentifier: "spruce") {
+    eventLogEntries {
+      user
+      timestamp
+      before {
+        projectRef {
+          branch
+        }
+        githubAppAuth {
+          appId
+          privateKey
+        }
+        githubWebhooksEnabled
+      }
+      after {
+        projectRef {
+          branch
+        }
+        githubAppAuth {
+          appId
+          privateKey
+        }
+        githubWebhooksEnabled
+      }
+    }
+    count
+  }
+}

--- a/graphql/tests/query/projectEvents/results.json
+++ b/graphql/tests/query/projectEvents/results.json
@@ -45,6 +45,42 @@
           }
         }
       }
+    },
+    {
+      "query_file": "no_changes.graphql",
+      "result": {
+        "data": {
+          "projectEvents": {
+            "eventLogEntries": [
+              {
+                "user": "bob.smith",
+                "timestamp": "2020-03-03T10:46:00.709-05:00",
+                "before": {
+                  "projectRef": {
+                    "branch": "main"
+                  },
+                  "githubAppAuth": {
+                    "appId": 11111,
+                    "privateKey": "{REDACTED}"
+                  },
+                  "githubWebhooksEnabled": false
+                },
+                "after": {
+                  "projectRef": {
+                    "branch": "main"
+                  },
+                  "githubAppAuth": {
+                    "appId": 11111,
+                    "privateKey": "{REDACTED}"
+                  },
+                  "githubWebhooksEnabled": false
+                }
+              }
+            ],
+            "count": 1
+          }
+        }
+      }
     }
   ]
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -111,8 +111,13 @@ func (p *ProjectChangeEvents) RedactGitHubPrivateKey() {
 			continue
 		}
 		if len(changeEvent.After.GitHubAppAuth.PrivateKey) > 0 && len(changeEvent.Before.GitHubAppAuth.PrivateKey) > 0 {
-			changeEvent.After.GitHubAppAuth.PrivateKey = []byte(evergreen.RedactedAfterValue)
-			changeEvent.Before.GitHubAppAuth.PrivateKey = []byte(evergreen.RedactedBeforeValue)
+			if string(changeEvent.After.GitHubAppAuth.PrivateKey) == string(changeEvent.Before.GitHubAppAuth.PrivateKey) {
+				changeEvent.After.GitHubAppAuth.RedactPrivateKey()
+				changeEvent.Before.GitHubAppAuth.RedactPrivateKey()
+			} else {
+				changeEvent.After.GitHubAppAuth.PrivateKey = []byte(evergreen.RedactedAfterValue)
+				changeEvent.Before.GitHubAppAuth.PrivateKey = []byte(evergreen.RedactedBeforeValue)
+			}
 		} else if len(changeEvent.After.GitHubAppAuth.PrivateKey) > 0 {
 			changeEvent.After.GitHubAppAuth.RedactPrivateKey()
 		} else if len(changeEvent.Before.GitHubAppAuth.PrivateKey) > 0 {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -479,6 +479,9 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		privateKeyRedacted := utility.FromStringPtr(changes.GithubAppAuth.PrivateKey) == evergreen.RedactedValue
 
 		if appIDChanged || privateKeyChanged {
+			// The UI only ever sees the private key as the {REDACTED} string and will include it in calls to
+			// this function. To avoid overwriting the actual private key, we should not update the credentials
+			// if the private key is equal to the {REDACTED} placeholder.
 			if !privateKeyRedacted {
 				if err = mergedSection.SetGithubAppCredentials(int64(changes.GithubAppAuth.AppID), []byte(utility.FromStringPtr(changes.GithubAppAuth.PrivateKey))); err != nil {
 					return nil, errors.Wrap(err, "updating GitHub app credentials")

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -503,6 +503,23 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
 			assert.Equal(t, githubAppFromDB.PrivateKey, []byte("my_new_secret"))
 
+			// Should not update if the private key string is {REDACTED}.
+			apiChanges = &restModel.APIProjectSettings{
+				GithubAppAuth: restModel.APIGithubAppAuth{
+					AppID:      67890,
+					PrivateKey: utility.ToStringPtr(evergreen.RedactedValue),
+				},
+			}
+			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageGithubAppSettingsSection, false, "me")
+			assert.NoError(t, err)
+			assert.NotNil(t, settings)
+
+			githubAppFromDB, err = model.FindOneGithubAppAuth(ref.Id)
+			assert.NoError(t, err)
+			require.NotNil(t, githubAppFromDB)
+			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
+			assert.Equal(t, githubAppFromDB.PrivateKey, []byte("my_new_secret"))
+
 			// Should be able to clear GitHub app credentials.
 			apiChanges = &restModel.APIProjectSettings{
 				GithubAppAuth: restModel.APIGithubAppAuth{

--- a/testdata/local/github_app_auth.json
+++ b/testdata/local/github_app_auth.json
@@ -1,0 +1,1 @@
+{ "_id": "spruce", "app_id": 12345, "private_key": { "$binary": { "base64": "c2VjcmV0", "subType": "00" } } }


### PR DESCRIPTION
DEVPROD-8877

### Description
As I was writing the frontend code for this component, I realized I missed an edge case when checking for
```
len(changeEvent.After.GitHubAppAuth.PrivateKey) > 0 && len(changeEvent.Before.GitHubAppAuth.PrivateKey) > 0
```
I was setting the before value to `{REDACTED_BEFORE}` and the after value to `{REDACTED_AFTER}` even if they were actually the same value (unchanged).

### Testing
- Added GraphQL test that does not pass without the changes in this PR
