### PR TITLE
DEVPROD-9302: fix spelling on error message

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -995,7 +995,7 @@ func (m *ec2Manager) StopInstance(ctx context.Context, h *host.Host, shouldKeepO
 			if info.Status == StatusStopped {
 				return false, nil
 			}
-			return true, errors.Errorf("host is not stopped, current status is '%s' becauase '%s'", info.Status, info.StateReason)
+			return true, errors.Errorf("host is not stopped, current status is '%s' because '%s'", info.Status, info.StateReason)
 		}, utility.RetryOptions{
 			MaxAttempts: checkSuccessAttempts,
 			MinDelay:    checkSuccessInitPeriod,
@@ -1045,7 +1045,7 @@ func (m *ec2Manager) StartInstance(ctx context.Context, h *host.Host, user strin
 			if info.Status == StatusRunning {
 				return false, nil
 			}
-			return true, errors.New("host is not started")
+			return true, errors.Errorf("host is not started, current status is '%s' because '%s'", info.Status, info.StateReason)
 		}, utility.RetryOptions{
 			MaxAttempts: checkSuccessAttempts,
 			MinDelay:    checkSuccessInitPeriod,


### PR DESCRIPTION
DEVPROD-9302

### Description
* I lost my 4th grade spelling bee because I apparently can't spell easy words.
* Made the error message for starting a host consistent with the one for stopping a host.

### Testing
N/A

### Documentation
N/A
