### PR TITLE
DEVPROD-6652: use in-memory cache for internal installation tokens

### DIFF
--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -20,7 +20,10 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 
-	appToken, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, 30*time.Minute, nil)
+	// Arbitrarily pick a long lifetime for the app token so that it's valid for
+	// the entire test duration.
+	const appTokenLifetime = 30 * time.Minute
+	appToken, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, appTokenLifetime, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
@@ -19,7 +20,7 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 		return nil, errors.Wrap(err, "getting global GitHub OAuth token")
 	}
 
-	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, nil)
+	appToken, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, data.ProjectRef.Owner, data.ProjectRef.Repo, 30*time.Minute, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/environment.go
+++ b/environment.go
@@ -1128,7 +1128,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, MaxInstallationTokenLifetime, nil)
+	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, maxInstallationTokenLifetime, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/environment.go
+++ b/environment.go
@@ -297,6 +297,8 @@ type closerOp struct {
 // cachedGitHubSender stores a GitHub sender and the time it was created
 // because GitHub app tokens, and by extension, the senders, will expire
 // one hour after creation.
+// kim: TODO: generalize this to all GitHub requests rather than just GitHub
+// sender.
 type cachedGitHubSender struct {
 	sender send.Sender
 	time   time.Time
@@ -1148,6 +1150,8 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 		"repo":    repo,
 	}))
 
+	// kim: TODO: similar to the sender, may need an in-memory cache for GitHub
+	// installation tokens in general, not just for the GitHub sender.
 	e.githubSenders[owner] = cachedGitHubSender{
 		sender: sender,
 		time:   tokenCreatedAt,

--- a/environment.go
+++ b/environment.go
@@ -297,8 +297,6 @@ type closerOp struct {
 // cachedGitHubSender stores a GitHub sender and the time it was created
 // because GitHub app tokens, and by extension, the senders, will expire
 // one hour after creation.
-// kim: TODO: generalize this to all GitHub requests rather than just GitHub
-// sender.
 type cachedGitHubSender struct {
 	sender send.Sender
 	time   time.Time
@@ -1150,8 +1148,6 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 		"repo":    repo,
 	}))
 
-	// kim: TODO: similar to the sender, may need an in-memory cache for GitHub
-	// installation tokens in general, not just for the GitHub sender.
 	e.githubSenders[owner] = cachedGitHubSender{
 		sender: sender,
 		time:   tokenCreatedAt,

--- a/environment.go
+++ b/environment.go
@@ -1128,7 +1128,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, nil)
+	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, MaxInstallationTokenLifetime, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/environment.go
+++ b/environment.go
@@ -1126,7 +1126,7 @@ func (e *envState) GetGitHubSender(owner, repo string) (send.Sender, error) {
 	// If githubSender does not exist or has expired, create one, add it to the cache, then return it.
 
 	tokenCreatedAt := time.Now()
-	token, err := e.settings.CreateGitHubAppAuth().CreateInstallationToken(e.ctx, owner, repo, maxInstallationTokenLifetime, nil)
+	token, err := e.settings.CreateGitHubAppAuth().CreateCachedInstallationToken(e.ctx, owner, repo, maxInstallationTokenLifetime, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}

--- a/github_app.go
+++ b/github_app.go
@@ -123,7 +123,7 @@ func (g *GithubAppAuth) CreateInstallationToken(ctx context.Context, owner, repo
 		return "", errors.Wrapf(err, "getting installation id for '%s/%s'", owner, repo)
 	}
 
-	token, err := g.getInstallationTokenForID(ctx, installationID, lifetime, opts)
+	token, err := g.getInstallationToken(ctx, installationID, lifetime, opts)
 	if err != nil {
 		return "", errors.Wrapf(err, "getting installation token for '%s/%s'", owner, repo)
 	}
@@ -160,7 +160,7 @@ func getInstallationID(ctx context.Context, authFields *GithubAppAuth, owner, re
 
 }
 
-func (g *GithubAppAuth) getInstallationTokenForID(ctx context.Context, installationID int64, lifetime time.Duration, opts *github.InstallationTokenOptions) (string, error) {
+func (g *GithubAppAuth) getInstallationToken(ctx context.Context, installationID int64, lifetime time.Duration, opts *github.InstallationTokenOptions) (string, error) {
 	if cachedToken := ghInstallationTokenCache.get(installationID, lifetime); cachedToken != "" {
 		return cachedToken, nil
 	}

--- a/github_app_test.go
+++ b/github_app_test.go
@@ -3,6 +3,7 @@ package evergreen
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
@@ -91,4 +92,20 @@ func (s *installationSuite) TestGetInstallationID() {
 
 	_, err = getInstallationID(s.ctx, authFields, "", "")
 	s.Error(err)
+}
+
+func (s *installationSuite) TestGetInstallationToken() {
+	now := time.Now()
+	const (
+		installationID    = 1234
+		installationToken = "installation_token"
+		lifetime          = time.Minute
+	)
+
+	ghInstallationTokenCache.put(installationID, installationToken, now)
+
+	authFields := GithubAppAuth{}
+	token, err := authFields.getInstallationToken(s.ctx, installationID, lifetime, nil)
+	s.Require().NoError(err)
+	s.Equal(token, installationToken, "should return cached token since it is still valid for at least %s", lifetime)
 }

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,8 +191,8 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
-	// kim: TODO: determine what is a valid token lifetime.
-	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, evergreen.MaxInstallationTokenLifetime, nil)
+	const ghTokenLifetime = 59 * time.Minute
+	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,6 +191,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
+	// kim: TODO: determine what is a valid token lifetime.
 	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -192,7 +192,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 	}
 
 	const ghTokenLifetime = 59 * time.Minute
-	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
+	appToken, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -192,7 +192,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 	}
 
 	// kim: TODO: determine what is a valid token lifetime.
-	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
+	appToken, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, evergreen.MaxInstallationTokenLifetime, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")
 	}

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -191,7 +191,7 @@ func makeProjectAndExpansionsFromTask(ctx context.Context, settings *evergreen.S
 		return nil, nil, errors.Errorf("project ref '%s' not found", t.Project)
 	}
 
-	const ghTokenLifetime = 59 * time.Minute
+	const ghTokenLifetime = 50 * time.Minute
 	appToken, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating GitHub app token")

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -424,7 +424,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 	}
 
 	const ghTokenLifetime = 50 * time.Minute
-	appToken, err := h.settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
+	appToken, err := h.settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
 	}
@@ -1405,7 +1405,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
 	const lifetime = 50 * time.Minute
-	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, lifetime, nil)
+	token, err := g.env.Settings().CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}
@@ -1659,8 +1659,10 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		})
 	}
 
-	const ghTokenLifetime = 59 * time.Minute
-	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, ghTokenLifetime, &github.InstallationTokenOptions{
+	// This cannot use a cached token because if the token was shared, it
+	// wouldn't be possible to revoke them without causing revoking tokens that
+	// other tasks could be using.
+	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -423,8 +423,8 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		})
 	}
 
-	// kim: TODO: determine what is a valid token lifetime.
-	appToken, err := h.settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
+	const ghTokenLifetime = 50 * time.Minute
+	appToken, err := h.settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, ghTokenLifetime, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
 	}
@@ -1404,8 +1404,8 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
-	// kim: TODO: determine what is a valid token lifetime.
-	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, nil)
+	const lifetime = 30 * time.Minute
+	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, lifetime, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}
@@ -1659,8 +1659,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		})
 	}
 
-	// kim: TODO: determine what is a valid token lifetime.
-	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
+	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, evergreen.MaxInstallationTokenLifetime, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1660,8 +1660,8 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	}
 
 	// This cannot use a cached token because if the token was shared, it
-	// wouldn't be possible to revoke them without causing revoking tokens that
-	// other tasks could be using.
+	// wouldn't be possible to revoke them without revoking tokens that other
+	// tasks could be using.
 	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1404,7 +1404,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
-	const lifetime = 30 * time.Minute
+	const lifetime = 50 * time.Minute
 	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, lifetime, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
@@ -1659,7 +1659,8 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		})
 	}
 
-	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, evergreen.MaxInstallationTokenLifetime, &github.InstallationTokenOptions{
+	const ghTokenLifetime = 59 * time.Minute
+	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, ghTokenLifetime, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})
 	if err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -423,6 +423,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		})
 	}
 
+	// kim: TODO: determine what is a valid token lifetime.
 	appToken, err := h.settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, pRef.Owner, pRef.Repo, nil)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "creating GitHub app token"))
@@ -1403,6 +1404,7 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
+	// kim: TODO: determine what is a valid token lifetime.
 	token, err := g.env.Settings().CreateGitHubAppAuth().CreateInstallationToken(ctx, g.owner, g.repo, nil)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
@@ -1657,6 +1659,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		})
 	}
 
+	// kim: TODO: determine what is a valid token lifetime.
 	token, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
 	})

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -332,7 +332,9 @@ func getGithubClient(token, caller string, config retryConfig) *evergreen.GitHub
 	return &githubClient
 }
 
-const defaultGitHubAPIRequestLifetime = 10 * time.Minute
+// defaultGitHubAPIRequestLifetime is the default amount of time that an
+// installation token is valid for a single GitHub API request.
+const defaultGitHubAPIRequestLifetime = 15 * time.Minute
 
 // getInstallationToken creates an installation token using Github app auth.
 // If creating a token fails it will return the legacyToken.

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -340,6 +340,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
+	// kim: TODO: determine what is a valid token lifetime.
 	token, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, owner, repo, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -344,7 +344,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	token, err := settings.CreateGitHubAppAuth().CreateInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, opts)
+	token, err := settings.CreateGitHubAppAuth().CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"message": "error creating token",
@@ -362,7 +362,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 	return token, nil
 }
 
-// revokeInstallationToken revokes an installation token.
+// RevokeInstallationToken revokes an installation token.
 func RevokeInstallationToken(ctx context.Context, token string) error {
 	caller := "RevokeInstallationToken"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
@@ -441,7 +441,6 @@ func getCommits(ctx context.Context, token, owner, repo, ref string, until time.
 		if err != nil {
 			return nil, 0, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -526,7 +525,6 @@ func getFile(ctx context.Context, token, owner, repo, path, ref string) (*github
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -688,7 +686,6 @@ func getCommitComparison(ctx context.Context, token, owner, repo, baseRevision, 
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -752,7 +749,6 @@ func commitEvent(ctx context.Context, token, owner, repo, githash string) (*gith
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -834,7 +830,6 @@ func commitDiff(ctx context.Context, token, owner, repo, sha string) (string, er
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -895,7 +890,6 @@ func branchEvent(ctx context.Context, token, owner, repo, branch string) (*githu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1092,7 +1086,6 @@ func taggedCommit(ctx context.Context, token, owner, repo, tag string) (string, 
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1147,7 +1140,6 @@ func getObjectTag(ctx context.Context, token, owner, repo, sha string) (*github.
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1201,7 +1193,6 @@ func userInTeam(ctx context.Context, token string, teams []string, org, user, ow
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1312,7 +1303,6 @@ func apiLimit(ctx context.Context, token string) (int64, error) {
 		if err != nil {
 			return 0, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1367,7 +1357,6 @@ func getUser(ctx context.Context, token, loginName string) (*github.User, error)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1421,7 +1410,6 @@ func userInOrganization(ctx context.Context, token, requiredOrganization, userna
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1467,7 +1455,6 @@ func authorizedForOrg(ctx context.Context, token, requiredOrganization, name str
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -1539,7 +1526,6 @@ func userHasWritePermission(ctx context.Context, token, owner, repo, username st
 		if err != nil {
 			return false, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
@@ -1620,7 +1606,6 @@ func getPRMergeBase(ctx context.Context, token string, data GithubPatch) (string
 		if err != nil {
 			return "", errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
@@ -1671,7 +1656,6 @@ func getCommit(ctx context.Context, token, owner, repo, sha string) (*github.Rep
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
@@ -1725,7 +1709,6 @@ func getPullRequest(ctx context.Context, token, baseOwner, baseRepo string, prNu
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
@@ -1776,7 +1759,6 @@ func pullRequestDiff(ctx context.Context, token string, gh GithubPatch) (string,
 		if err != nil {
 			return "", nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
@@ -2006,7 +1988,6 @@ func postComment(ctx context.Context, token, owner, repo string, prNum int, comm
 		if err != nil {
 			return errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 	defer githubClient.Close()
@@ -2064,7 +2045,6 @@ func GetBranchProtectionRules(ctx context.Context, token, owner, repo, branch st
 		if err != nil {
 			return nil, errors.Wrap(err, "getting installation token")
 		}
-		defer func() { _ = RevokeInstallationToken(ctx, token) }()
 	}
 	githubClient := getGithubClient(token, caller, retryConfig{})
 	defer githubClient.Close()
@@ -2124,7 +2104,6 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -2183,7 +2162,6 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -2250,7 +2228,6 @@ func ListCheckRunCheckSuite(ctx context.Context, owner, repo string, checkSuiteI
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
@@ -2283,7 +2260,6 @@ func GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*gi
 	if err != nil {
 		return nil, errors.Wrap(err, "getting installation token")
 	}
-	defer func() { _ = RevokeInstallationToken(ctx, token) }()
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -161,6 +161,18 @@ func (s *githubSuite) TestGetGithubCommitsUntil() {
 	s.Len(githubCommits, 4)
 }
 
+func (s *githubSuite) TestGetInstallationTokenCached() {
+	token, err := getInstallationToken(s.ctx, "evergreen-ci", "sample", nil)
+	s.NoError(err)
+	s.NotZero(token)
+
+	for i := 0; i < 10; i++ {
+		cachedToken, err := getInstallationToken(s.ctx, "evergreen-ci", "sample", nil)
+		s.NoError(err)
+		s.Equal(token, cachedToken, "should return same exact cached token since it is still valid")
+	}
+}
+
 func (s *githubSuite) TestRevokeInstallationToken() {
 	token, err := getInstallationToken(s.ctx, "evergreen-ci", "sample", nil)
 	s.NoError(err)


### PR DESCRIPTION
DEVPROD-6652

### Description
The requests that get a secondary rate limit from GitHub appear to be requesting an installation token, which means we're requesting installation tokens from GitHub too frequently. To avoid getting a new token for every single task run and every single GH API request, I added a cache to reuse tokens for Evergreen's own internal operations. However, to accommodate caching, I had to adjust a few things about how tokens are used:

* I had to remove the logic that defer revokes tokens at the end of each GitHub API call. Revoking a token after one use defeats the purpose of caching the token.
* When getting a cached token, callers now have to specify how long they need the token to be valid. This is necessary to figure out if the cached token is going to be valid for long enough to perform the operation. For example, a quick GitHub request may only need to use the token for a minute, whereas a git clone of a large repo might need 10+ minutes.
* For tokens from Evergreen's global GitHub app, tasks currently get a fresh token that's valid for a full hour. I elected to make a token valid to reuse if it still had >=59 minutes left, which I think is close enough to a fresh 1 hour token, while still letting Evergreen cache tokens for a brief time. [git clones that succeed seem to finish in well under an hour](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen-agent/result/5RRx4SJ63GN), so I think it's fine if they potentially lose up to a minute on the token validity.
     * The only tad bit scary asterisk here is that if any task command for some reason _revokes_ `${github_app_token}`, it'll revoke that token for any other task that's reusing it. I consider this not a big deal because I can't imagine why users would revoke it themselves and we're supposed to be getting rid of that expansion soon.
* GitHub dynamic access tokens for projects need to always receive a fresh token because they revoke the token at the end of the task (which would invalidate all other shared usages of that token). To accommodate this, I had to split the cached/uncached method variants to make sure we only cache for Evergreen's internal operations and never cache tokens for tasks using their own project's GitHub app.

### Testing
* Added unit tests.
* Existing tests that use GitHub operations still pass.
* Tested with a log in staging to verify that the cache reused the token as long as it was still valid.

### Documentation
N/A