### PR TITLE
DEVPROD-4192: send notifications for system-timed-out tasks

### DIFF
--- a/trigger/task.go
+++ b/trigger/task.go
@@ -729,11 +729,11 @@ func (t *taskTriggers) taskRuntimeChange(sub *event.Subscription) (*notification
 	return t.generate(sub, fmt.Sprintf("changed in runtime by %.1f%% (over threshold of %s%%)", percentChange, percentString), "")
 }
 
-// isValidFailedTaskStatus only matches task statuses that should be triggered for failure.
-// For example, it excludes  setup failures.
+// isValidFailedTaskStatus only matches task display statuses that should
+// trigger failed task notifications. For example, it excludes setup
+// failures.
 func isValidFailedTaskStatus(status string) bool {
-	return status == evergreen.TaskFailed || status == evergreen.TaskSystemFailed ||
-		status == evergreen.TaskSystemUnresponse || status == evergreen.TaskTimedOut || status == evergreen.TaskTestTimedOut
+	return evergreen.IsFailedTaskStatus(status) && status != evergreen.TaskSetupFailed
 }
 
 func isTestStatusRegression(oldStatus, newStatus string) bool {

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -495,10 +495,16 @@ func (s *taskSuite) TestFailure() {
 	s.NoError(err)
 	s.Nil(n)
 
-	s.data.Status = evergreen.TaskFailed
-	n, err = s.t.taskFailure(&s.subs[2])
-	s.NoError(err)
-	s.NotNil(n)
+	for _, status := range evergreen.TaskFailureStatuses {
+		s.data.Status = status
+		n, err = s.t.taskFailure(&s.subs[2])
+		s.NoError(err)
+		if status == evergreen.TaskSetupFailed {
+			s.Nil(n, "should not notify for setup failure")
+		} else {
+			s.NotNil(n, "should notify for failed status '%s'", status)
+		}
+	}
 }
 
 func (s *taskSuite) TestOutcome() {
@@ -512,10 +518,16 @@ func (s *taskSuite) TestOutcome() {
 	s.NoError(err)
 	s.NotNil(n)
 
-	s.data.Status = evergreen.TaskFailed
-	n, err = s.t.taskOutcome(&s.subs[0])
-	s.NoError(err)
-	s.NotNil(n)
+	for _, status := range evergreen.TaskFailureStatuses {
+		s.data.Status = status
+		n, err = s.t.taskFailure(&s.subs[0])
+		s.NoError(err)
+		if status == evergreen.TaskSetupFailed {
+			s.Nil(n, "should not notify for setup failure")
+		} else {
+			s.NotNil(n, "should notify for failed status '%s'", status)
+		}
+	}
 }
 
 func (s *taskSuite) TestFailedOrBlocked() {


### PR DESCRIPTION
DEVPROD-4192

### Description
Task notifications currently can be sent for every task failure type except system-timed-out and setup-failed. I fixed it to send notifications for system-timed-out. (I'm not sure why setup-failed is a special case that doesn't warrant notification for task failure, but that wasn't part of the ticket.)

### Testing
Updated unit tests.

### Documentation
N/A