### PR TITLE
DEVPROD-8510 Document merge queue internals

### DIFF
--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -128,15 +128,16 @@ no changes to make on the Evergreen side.
 
 **Q:** Can I see the patch or patches associated with my merge attempt?
 
-**A:** GitHub abstracts the process of making builds from the queue. There might
-be many builds associated with your patch, and it might not be obvious when
-GitHub decided to make them. To see the behavior of the queue, you can look at
-the Activity page, accessible from under the About section of a repo, and limit
-the user to "GitHub Merge Queue[bot]", e.g.,
+**A:** GitHub abstracts the process of making builds from the queue. There might be
+many builds (which Evergreen calls versions) associated with your PR, and it
+might not be obvious when GitHub decided to make them. To see the behavior of
+the queue, you can look at the Activity page, accessible from under the About
+section of a repo, and limit the user to "GitHub Merge Queue[bot]", e.g.,
 <https://github.com/10gen/mongo/activity?actor=github-merge-queue%5Bbot%5D>. On
 the Evergreen side, you can click on More -> Project Patches, and look for
 patches prepended "GitHub Merge Queue:", e.g.,
-<https://spruce.mongodb.com/project/mongodb-mongo-master/patches>.
+<https://spruce.mongodb.com/project/mongodb-mongo-master/patches>. There is not
+a way, however, to map directly from a GitHub PR to its patches.
 
 **Q:** What does it mean if GitHub times out my merge queue request in my PR?
 

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -45,7 +45,7 @@ to pass before any changes can be merged into the protected branch.
 Alternatively, you can require a single or multiple variants to pass before
 merging, instead of all variants.
 
-## Concurrency
+## Merge Queue Behavior
 
 Concurrency is on by default for the GitHub merge queue. If there are multiple
 PRs in the queue, your PR might be tested with other commits. This means that
@@ -55,18 +55,11 @@ HEAD PR of a merge group, but the merge group could contain multiple PRs. Note
 that GitHub merges all commits from each PR before adding that PR to a version,
 so a given version has as many commits in it as there are PRs in it.
 
-See the [Merge Queue Behavior](#merge-queue-behavior) section for more details
-about how merge queue concurrency works.
-
-## Merge Queue Behavior
-
 The merge queue is not trying to merge individual PRs, but groups of PRs. This
-leads to some unintuitive behavior.
-
-Here is a typical sequence of events when a user adds 2 PRs to the merge queue.
-In this case we assume "Minimum pull requests to merge" is set to 1, "Maximum
-pull requests to merge" is set to 5, and "Maximum pull requests to build"
-("Build concurrency") is set to 5.
+leads to some unintuitive behavior. Here is a typical sequence of events when a
+user adds 2 PRs to the merge queue.  In this case we assume "Minimum pull
+requests to merge" is set to 1, "Maximum pull requests to merge" is set to 5,
+and "Maximum pull requests to build" ("Build concurrency") is set to 5.
 
 The diagram names its branches like "main/pr-1", but in reality they are named
 like "gh-readonly-queue/main/pr-1-\<hash\>".

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -231,3 +231,10 @@ version statuses.
 
 For more information on GitHub's merge queue feature and how to customize its
 settings, refer to the [official GitHub documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+
+## For Evergreen Developers
+
+To troubleshoot why a merge group version is not being created, find the `event
+= merge_group` message in Splunk. You can then search for the values of the
+`head_sha` and `msg_id` properties to track merge intent creation and the amboy
+job, as well as find the branch that Evergreen will clone for that project.

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -21,7 +21,7 @@ merge, like you would have to without the queue.
 
 1. From <https://spruce.mongodb.com/>, from the More drop down, select Project Settings.
 2. Select your project from the project dropdown.
-3. From the GitHub & Commit Queue section, set the Commit Queue to Enabled.
+3. From the GitHub section, set the Merge Queue to Enabled.
 4. Add variant and task tags or regexes for the variants and tasks you wish to run when a pull request is added to the queue.
 
 ### Turn on the GitHub merge queue
@@ -107,7 +107,10 @@ merge is set to 5, and, again, GitHub is testing the entire group.*
 If, in the branch protection rules, "only merge non-failing pull requests" is
 checked, then the merge will not happen if any of the PRs fail. Otherwise, if
 main/pr-1 is red and main/pr-2 is green, then the latter will be merged, which
-contains both PRs.
+contains both PRs. Note that, although this says "pull requests," it's really
+about merge queue behavior. All pull requests must pass the branch protection
+rules before they can be added to the merge queue. This setting is only about
+the behavior once they're in the merge queue.
 
 The temporary branch gets deleted only after the the PR is merged, or if the PR
 fails the check or is removed from the queue.

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -194,6 +194,6 @@ accurate. I've provided both in this table:
 
 Here are example links for the 10gen/mongo repository:
 
-* <https://github.com/10gen/mongo/activity?activity_type=merge_queue_merge> : View the branch creations and deletions by clicking the Activity link on the repository main page under the About section.
+* <https://github.com/10gen/mongo/activity?actor=github-merge-queue%5Bbot%5D> : View the branch creations and deletions by clicking the Activity link on the repository main page under the About section.
 * <https://github.com/10gen/mongo/queue/master> : View the queue itself.
 * <https://github.com/10gen/mongo/branches/all?query=gh-readonly> : View the gh-read-only branches.


### PR DESCRIPTION
DEVPROD-8510

### Description

This documents merge queue behavior more fully.

**Note for reviewers:** There are a couple ways to review this directly in GitHub

1. Click the rich diff button, which is in the upper right, looks like a piece of paper, and is to the right of the `< >` symbol. This will give you a diff that is of the actual rendered markdown.
2. In the diff view, click the three dots, then "View file", to see the markdown rendered.

### Testing

N/A

### Documentation

👀