### PR TITLE
DEVPROD-9377 hold on to the HTTP client

### DIFF
--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -109,6 +109,7 @@ func (w *EvergreenWebhook) request() (*http.Request, error) {
 }
 
 type evergreenWebhookLogger struct {
+	client *http.Client
 	*send.Base
 }
 
@@ -142,9 +143,11 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 		minDelay = time.Duration(raw.MinDelayMS) * time.Millisecond
 	}
 
-	client := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(client)
-
+	client := w.client
+	if client == nil {
+		client = utility.GetHTTPClient()
+		defer utility.PutHTTPClient(client)
+	}
 	return utility.Retry(context.Background(), func() (bool, error) {
 		req, err := raw.request()
 		if err != nil {


### PR DESCRIPTION
[DEVPROD-9377](https://jira.mongodb.org/browse/DEVPROD-9377)

### Description
This is an exotic bug...
In the case where the webhook sender needs to retry it puts the client back in the pool but still holds on to a pointer to the client for the next round. In the meantime, the GitHub app [requests a client from the pool and modifies its Transport](https://github.com/evergreen-ci/evergreen/blob/3bfa042ffdf3422155ddc84c63272e302d7293db/github_app.go#L243-L244) to [overwrite the Authorization header with a new bearer token](https://github.com/bradleyfalzon/ghinstallation/blob/d680810648e94347929da00376d1e7067f3572dd/appsTransport.go#L89-L102). Subsequently the webhook sender makes the http call using the modified transport that overwrites its Authorization header.

This PR makes the webhook sender hold on to the http client until it's done with it.

### Testing
N/A
