### PR TITLE
DEVPROD-7853: Remove status calculation in patch resolver

### DIFF
--- a/graphql/tests/query/patch/data.json
+++ b/graphql/tests/query/patch/data.json
@@ -6,7 +6,8 @@
       },
       "githash": "123",
       "branch": "spruce",
-      "author": "bob.smith"
+      "author": "bob.smith",
+      "status": "failed"
     },
     {
       "_id": {


### PR DESCRIPTION
DEVPROD-7853

### Description
This resolver was throwing an error whenever the patch had tasks deleted due to TTL. Currently, the resolver tries to determine if the patch status is aborted by querying for its tasks, and errors when it finds no tasks in the database.

I think the code in this resolver is 1. weird (status should be resolved by a `patch.Status` resolver if anything) and 2. not necessary, as it is a remnant of when Spruce wasn't able to distinguish between patches and versions. 

I deployed this on staging and verified that the versions and child patches still showed up as aborted properly:
<img width="377" alt="Screenshot 2024-08-01 at 2 38 43 PM" src="https://github.com/user-attachments/assets/5d15b04d-2e04-4737-aad0-e8680ec818c9">

<img width="184" alt="Screenshot 2024-08-01 at 2 38 36 PM" src="https://github.com/user-attachments/assets/9fa9e8fb-ec8c-4787-959d-8b88cc0b09d0">

### Testing
- On staging
- Edited GraphQL test which does not pass without this patch's changes
