### PR TITLE
DEVPROD-9510 include everything in static_assets dependencies

### DIFF
--- a/makefile
+++ b/makefile
@@ -92,9 +92,8 @@ windowsBinaries := $(foreach platform,$(windowsPlatforms),$(clientBuildDir)/$(pl
 clientBinaries := $(macOSBinaries) $(linuxBinaries) $(windowsBinaries)
 
 clientSource := cmd/evergreen/evergreen.go
-uiFiles := $(shell find public/static -not -path "./public/static/app" -name "*.js" -o -name "*.css" -o -name "*.html")
 
-staticArtifacts :=  ./public ./service/templates
+staticArtifacts := ./public ./service/templates
 srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
 testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 currentHash := $(shell git rev-parse HEAD)
@@ -243,8 +242,8 @@ $(buildDir)/macnotary:$(buildDir)/sign-executable
 $(clientBuildDir)/%/.signed:$(buildDir)/sign-executable $(clientBuildDir)/%/$(unixBinaryBasename) $(buildDir)/macnotary
 	./$< sign --client $(buildDir)/macnotary --executable $(@D)/$(unixBinaryBasename) --server-url $(NOTARY_SERVER_URL) --bundle-id $(EVERGREEN_BUNDLE_ID)
 	touch $@
-$(buildDir)/static_assets.tgz:$(buildDir)/make-tarball $(uiFiles)
-	./$< --name $@ --prefix static_assets $(foreach item,$(staticArtifacts),--item $(item)) --exclude "public/node_modules" --exclude "clients/.cache"
+$(buildDir)/static_assets.tgz:$(buildDir)/make-tarball $(staticArtifacts)
+	./$< --name $@ --prefix static_assets $(foreach item,$(staticArtifacts),--item $(item)) --exclude "public/node_modules"
 local: $(buildDir)/static_assets.tgz $(clientBinaries)
 # end main build
 


### PR DESCRIPTION
[DEVPROD-9510](https://jira.mongodb.org/browse/DEVPROD-9510)

### Description
`static_assets.tgz` doesn't only depend on the `./public/static` files, but rather on everything in `public` and `service/templates`.

### Testing
The new tarball is exactly the same as the old (equivalent hashes). It rebuilds now when I make a change to a template.
