### PR TITLE
DEVPROD-8308 Update version status when unscheduling underwater tasks

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -249,6 +249,10 @@ const (
 	// responsible for monitoring container tasks that have not dispatched but
 	// have waiting for a long time since their activation.
 	StaleContainerTaskMonitor = "stale-container-task-monitor"
+	// UnderwaterTaskUnscheduler is the caller associated with unscheduling
+	// and disabling tasks older than the task.UnschedulableThreshold from
+	// their distro queue.
+	UnderwaterTaskUnscheduler = "underwater-task-unscheduler"
 
 	// Restart Types
 	RestartVersions = "versions"

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"strconv"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
+
+func init() { testutil.Setup() }
 
 var (
 	oneMs = time.Millisecond
@@ -1482,8 +1485,9 @@ func TestUnscheduleStaleUnderwaterHostTasksNoDistro(t *testing.T) {
 	}
 	assert.NoError(t2.Insert())
 
-	_, err := UnscheduleStaleUnderwaterHostTasks(ctx, "")
+	tasks, err := UnscheduleStaleUnderwaterHostTasks(ctx, "")
 	assert.NoError(err)
+	require.Len(t, tasks, 2)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(err)
 	assert.False(dbTask.Activated)
@@ -1619,8 +1623,9 @@ func TestUnscheduleStaleUnderwaterHostTasksWithDistro(t *testing.T) {
 	}
 	require.NoError(t, d.Insert(ctx))
 
-	_, err := UnscheduleStaleUnderwaterHostTasks(ctx, "d0")
+	tasks, err := UnscheduleStaleUnderwaterHostTasks(ctx, "d0")
 	assert.NoError(t, err)
+	require.Len(t, tasks, 1)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(t, err)
 	assert.False(t, dbTask.Activated)
@@ -1651,12 +1656,13 @@ func TestUnscheduleStaleUnderwaterHostTasksWithDistroAlias(t *testing.T) {
 	}
 	require.NoError(t, d.Insert(ctx))
 
-	_, err := UnscheduleStaleUnderwaterHostTasks(ctx, "d0")
+	tasks, err := UnscheduleStaleUnderwaterHostTasks(ctx, "d0")
 	assert.NoError(t, err)
 	dbTask, err := FindOneId("t1")
 	assert.NoError(t, err)
 	assert.False(t, dbTask.Activated)
 	assert.EqualValues(t, -1, dbTask.Priority)
+	require.Len(t, tasks, 1)
 }
 
 func TestGetRecentTaskStats(t *testing.T) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"strconv"
 	"testing"
 	"time"
@@ -29,8 +28,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
-
-func init() { testutil.Setup() }
 
 var (
 	oneMs = time.Millisecond

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -340,6 +340,11 @@ func underwaterUnschedule(ctx context.Context, distroID string) error {
 			if err = model.UpdateBuildAndVersionStatusForTask(ctx, &modifiedTask); err != nil {
 				return errors.Wrapf(err, "updating build and version status for task '%s'", modifiedTask.Id)
 			}
+			if modifiedTask.IsPartOfDisplay() {
+				if err = model.UpdateDisplayTaskForTask(&modifiedTask); err != nil {
+					return errors.Wrap(err, "updating parent display task")
+				}
+			}
 		}
 		grip.Info(message.Fields{
 			"message":  "unscheduled stale tasks",

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -328,17 +328,26 @@ func generateIntentHost(d distro.Distro, pool *evergreen.ContainerPool) (*host.H
 
 // pass the empty string to unschedule all distros.
 func underwaterUnschedule(ctx context.Context, distroID string) error {
-	num, err := task.UnscheduleStaleUnderwaterHostTasks(ctx, distroID)
+	modifiedTasks, err := task.UnscheduleStaleUnderwaterHostTasks(ctx, distroID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	grip.InfoWhen(num > 0, message.Fields{
-		"message": "unscheduled stale tasks",
-		"distro":  distroID,
-		"runner":  RunnerName,
-		"count":   num,
-	})
+	if len(modifiedTasks) > 0 {
+		taskIDs := make([]string, 0, len(modifiedTasks))
+		for _, modifiedTask := range modifiedTasks {
+			taskIDs = append(taskIDs, modifiedTask.Id)
+			if err = model.UpdateBuildAndVersionStatusForTask(ctx, &modifiedTask); err != nil {
+				return errors.Wrapf(err, "updating build and version status for task '%s'", modifiedTask.Id)
+			}
+		}
+		grip.Info(message.Fields{
+			"message":  "unscheduled stale tasks",
+			"distro":   distroID,
+			"runner":   RunnerName,
+			"task_ids": taskIDs,
+		})
+	}
 
 	return nil
 }

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type SchedulerSuite struct {
@@ -84,6 +85,8 @@ func TestUnderwaterUnschedule(t *testing.T) {
 	defer cancel()
 
 	require.NoError(t, db.ClearCollections(task.Collection, distro.Collection, build.Collection, model.VersionCollection))
+	require.NoError(t, db.EnsureIndex(task.Collection,
+		mongo.IndexModel{Keys: task.ActivatedTasksByDistroIndex}))
 
 	t1 := task.Task{
 		Id:            "t1",

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -2,11 +2,6 @@ package scheduler
 
 import (
 	"context"
-	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/evergreen/model/build"
-	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -14,9 +9,14 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 


### PR DESCRIPTION
DEVPROD-8308

### Description
The version in question in the ticket got stuck in running because one of the tasks that runs in it runs on a distro that is frequently at capacity (`rhel81-power8-small`). Because of this the task was stuck in the queue for so long that it eventually got marked unscheduled & disabled due to being [underwater](https://github.com/evergreen-ci/evergreen/blob/1204bb07a9d27073ce14db39c52900fdb2bbbbdd/model/task/task.go#L1483).

Made a few changes:
1. Update the underwater unscheduler to log priority change events because there were none when doing this investigation
2. Change the underwater unscheduling logic to log out task IDs instead of a count of updated tasks
3. Run `UpdateBuildAndVersionStatusForTask` for modified underwater tasks so that the build/version updates properly.
### Testing
Reproduced the issue in staging without the change. Confirmed the version completes with the change.