### PR TITLE
DEVPROD-2527: fix handling of reset failed for display task

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2868,11 +2868,16 @@ func abortAndMarkResetTasks(ctx context.Context, filter bson.M, taskIDs []string
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateMany(
 		ctx,
 		filter,
-		bson.M{"$set": bson.M{
-			AbortedKey:           true,
-			AbortInfoKey:         AbortInfo{User: caller},
-			ResetWhenFinishedKey: true,
-		}},
+		bson.M{
+			"$set": bson.M{
+				AbortedKey:           true,
+				AbortInfoKey:         AbortInfo{User: caller},
+				ResetWhenFinishedKey: true,
+			},
+			"$unset": bson.M{
+				ResetFailedWhenFinishedKey: 1,
+			},
+		},
 	)
 
 	return err

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3339,9 +3339,10 @@ func CheckUsersPatchTaskLimit(requester, username string, includeDisplayAndTaskG
 }
 
 func FindExecTasksToReset(t *Task) ([]string, error) {
-	if !t.ResetFailedWhenFinished {
+	if t.ResetWhenFinished || !t.ResetFailedWhenFinished {
 		return t.ExecutionTasks, nil
 	}
+
 	failedExecTasks, err := FindWithFields(FailedTasksByIds(t.ExecutionTasks), IdKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving failed execution tasks")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3339,7 +3339,7 @@ func CheckUsersPatchTaskLimit(requester, username string, includeDisplayAndTaskG
 }
 
 func FindExecTasksToReset(t *Task) ([]string, error) {
-	if t.ResetWhenFinished || !t.ResetFailedWhenFinished {
+	if !t.IsRestartFailedOnly() {
 		return t.ExecutionTasks, nil
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -254,7 +254,11 @@ type Task struct {
 	// ResetWhenFinished indicates that a task should be reset once it is
 	// finished running. This is typically to deal with tasks that should be
 	// reset but cannot do so yet because they're currently running.
-	ResetWhenFinished       bool `bson:"reset_when_finished,omitempty" json:"reset_when_finished,omitempty"`
+	ResetWhenFinished bool `bson:"reset_when_finished,omitempty" json:"reset_when_finished,omitempty"`
+	// ResetWhenFinished indicates that a task should be reset once it is
+	// finished running and only reset if it fails. This is typically to deal
+	// with tasks that should be reset on failure but cannot do so yet because
+	// they're currently running.
 	ResetFailedWhenFinished bool `bson:"reset_failed_when_finished,omitempty" json:"reset_failed_when_finished,omitempty"`
 	// NumAutomaticRestarts is the number of times the task has been programmatically restarted via a failed agent command.
 	NumAutomaticRestarts int `bson:"num_automatic_restarts,omitempty" json:"num_automatic_restarts,omitempty"`

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2122,6 +2122,10 @@ func MarkTasksReset(ctx context.Context, taskIds []string, caller string) error 
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	// kim: NOTE: this just adds the execution task's parent DisplayTaskId, it
+	// doesn't actually add the display task itself to the list. See if this
+	// potentially causes a bug if we maybe only reset the execution task and
+	// not the display task.
 	tasks, err = task.AddParentDisplayTasks(tasks)
 	if err != nil {
 		return errors.WithStack(err)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2502,7 +2502,6 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 
 		updatedDisplayTask, err = tryUpdateDisplayTaskAtomically(*originalDisplayTask)
 		if err == nil {
-			t.DisplayTask = updatedDisplayTask
 			break
 		}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2768,7 +2768,6 @@ func TestTryResetTask(t *testing.T) {
 				So(testTask.Status, ShouldNotEqual, evergreen.TaskUndispatched)
 			})
 			Convey("system failed tasks should reset if they haven't reached the admin setting limit", func() {
-				fmt.Println("START OF TEST")
 				detail.Type = evergreen.CommandTypeSystem
 				So(TryResetTask(ctx, settings, systemFailedTask.Id, userName, "", detail), ShouldBeNil)
 				systemFailedTask, err = task.FindOne(db.Query(task.ById(systemFailedTask.Id)))
@@ -2776,7 +2775,6 @@ func TestTryResetTask(t *testing.T) {
 				So(systemFailedTask.Status, ShouldEqual, evergreen.TaskUndispatched)
 			})
 			Convey("system failed tasks should not reset if they've reached the admin setting limit", func() {
-				fmt.Println("SHOULD NOT RESET")
 				detail.Type = evergreen.CommandTypeSystem
 				So(TryResetTask(ctx, settings, anotherSystemFailedTask.Id, userName, "", detail), ShouldBeNil)
 				anotherSystemFailedTask, err = task.FindOne(db.Query(task.ById(systemFailedTask.Id)))

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -19,6 +19,8 @@ import (
 // fetches the needed task and project and calls the service function to
 // set the proper fields when reseting the task.
 type taskRestartHandler struct {
+	// If set for a display task, restarts only failed execution tasks. When
+	// used with a non-display task, this parameter has no effect.
 	FailedOnly bool `json:"failed_only"`
 
 	taskId   string
@@ -36,8 +38,8 @@ func makeTaskRestartHandler() gimlet.RouteHandler {
 //	@Tags			tasks
 //	@Router			/tasks/{task_id}/restart [post]
 //	@Security		Api-User || Api-Key
-//	@Param			task_id		path		string	true	"task ID"
-//	@Param			failed_only	query		string	false	"For a display task, restarts only failed execution tasks. When used with a non-display task, this parameter has no effect."
+//	@Param			task_id		path		string				true	"task ID"
+//	@Param			{object}	body		taskRestartHandler	false "parameters"
 //	@Success		200			{object}	model.APITask
 func (trh *taskRestartHandler) Factory() gimlet.RouteHandler {
 	return &taskRestartHandler{}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -766,6 +766,47 @@ tasks:
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
 
+  - name: kim-et0
+    tags: ["kim-ets"]
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            sleep 1
+            echo "hello ${task_name} ${execution}"
+            exit 0
+  - name: kim-et1
+    tags: ["kim-ets"]
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            sleep 10
+            echo "hello ${task_name} ${execution}"
+            exit 0
+  - name: kim-et2
+    tags: ["kim-ets"]
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            sleep 20
+            echo "hello ${task_name} ${execution}"
+            exit 0
+  - name: kim-et3
+    tags: ["kim-ets"]
+    commands:
+      - command: shell.exec
+        params:
+          shell: bash
+          script: |
+            sleep 30
+            echo "hello ${task_name} ${execution}"
+            exit 0
+
 #######################################
 #            Buildvariants            #
 #######################################
@@ -791,6 +832,11 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
+      - name: ".kim-ets"
+    display_tasks:
+      - name: kim-dt
+        execution_tasks:
+        - ".kim-ets"
 
   - name: race-detector
     display_name: Race Detector

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -766,47 +766,6 @@ tasks:
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
 
-  - name: kim-et0
-    tags: ["kim-ets"]
-    commands:
-      - command: shell.exec
-        params:
-          shell: bash
-          script: |
-            sleep 1
-            echo "hello ${task_name} ${execution}"
-            exit 0
-  - name: kim-et1
-    tags: ["kim-ets"]
-    commands:
-      - command: shell.exec
-        params:
-          shell: bash
-          script: |
-            sleep 10
-            echo "hello ${task_name} ${execution}"
-            exit 0
-  - name: kim-et2
-    tags: ["kim-ets"]
-    commands:
-      - command: shell.exec
-        params:
-          shell: bash
-          script: |
-            sleep 20
-            echo "hello ${task_name} ${execution}"
-            exit 0
-  - name: kim-et3
-    tags: ["kim-ets"]
-    commands:
-      - command: shell.exec
-        params:
-          shell: bash
-          script: |
-            sleep 30
-            echo "hello ${task_name} ${execution}"
-            exit 0
-
 #######################################
 #            Buildvariants            #
 #######################################
@@ -832,11 +791,6 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
-      - name: ".kim-ets"
-    display_tasks:
-      - name: kim-dt
-        execution_tasks:
-        - ".kim-ets"
 
   - name: race-detector
     display_name: Race Detector


### PR DESCRIPTION
DEVPROD-2527

### Description
The original report is hard to investigate because there's no logs or other tracing available, but I did manage to reproduce the same symptoms. (There's actually three bugs, I'm going to open a follow-up PR for the last one.) The two bugs are:

1. When a user restarts a version that's still running to restart failed tasks, the display task can still be running. It's supposed to wait until all the execution tasks finish, then conditionally restart the failed ones. However, if all the execution tasks succeeded, the display task would restart but none of the execution tasks would restart. I fixed it to check if any execution tasks failed before restarting.
2. When using the REST route to restart tasks, the route gives a `failed_only` option to choose whether to restart all or restart just the failed subset of execution tasks. Unfortunately, the back-end logic allowed marking a display task to both reset when finished _and_ reset failed tasks when finished if you made two requests (one with `failed_only: false` and one with `failed_only: true`. If both were set, the same symptoms as bug 1 happened. I made the settings mutually exclusive.

### Testing
* Added unit tests.
* Ran test patches in staging using the task restart route.

### Documentation
N/A