### PR TITLE
DEVPROD-9150: Incorporate Pine's Evergreen task into Evergreen

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -426,8 +426,8 @@ functions:
     - command: shell.exec
       params: 
         script: |
-          touch downstream_expansions.yaml
-          echo "pine_repo_name: evergreen" | tee downstream_expansions.yaml
+          touch downstream_expansions_pine.yaml
+          echo "pine_repo_name: evergreen" | tee downstream_expansions_pine.yaml
 
 #######################################
 #                Tasks                #
@@ -728,12 +728,12 @@ tasks:
           permissions: public-read
           display_name: swagger.json (latest)
           patchable: false
-  - name: write-downstream-expansions-pine
+  - name: write-downstream-expansions-for-pine
     commands: 
       - func: write-downstream-expansions-for-pine
       - command: downstream_expansions.set
         params: 
-          file: downstream_expansions.yaml
+          file: downstream_expansions_pine.yaml
   - <<: *build-and-push-client
     name: build-linux_amd64
     tags: ["build"]
@@ -804,7 +804,7 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
-      - name: write-downstream-expansions-pine
+      - name: write-downstream-expansions-for-pine
 
   - name: race-detector
     display_name: Race Detector

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -422,7 +422,7 @@ functions:
           rm evergreen/bin/output.*
           rm evergreen/bin/jstests/*.xml
   
-  write-repo-name-to-downstream_expansions.yaml-for-pine:
+  write-downstream-expansions-for-pine:
     - command: shell.exec
       params: 
         script: |
@@ -728,9 +728,9 @@ tasks:
           permissions: public-read
           display_name: swagger.json (latest)
           patchable: false
-  - name: write-and-set-downstream-expansions
+  - name: write-downstream-expansions-pine
     commands: 
-      - func: write-repo-name-to-downstream_expansions.yaml-for-pine
+      - func: write-downstream-expansions-for-pine
       - command: downstream_expansions.set
         params: 
           file: downstream_expansions.yaml
@@ -804,7 +804,7 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
-      - name: write-and-set-downstream-expansions
+      - name: write-downstream-expansions-pine
 
   - name: race-detector
     display_name: Race Detector

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -421,6 +421,13 @@ functions:
           set -o xtrace
           rm evergreen/bin/output.*
           rm evergreen/bin/jstests/*.xml
+  
+  write-repo-name-to-downstream_expansions.yaml-for-pine:
+    - command: shell.exec
+      params: 
+        script: |
+          touch downstream_expansions.yaml
+          echo "pine_repo_name: evergreen" | tee downstream_expansions.yaml
 
 #######################################
 #                Tasks                #
@@ -721,6 +728,12 @@ tasks:
           permissions: public-read
           display_name: swagger.json (latest)
           patchable: false
+  - name: write-and-set-downstream-expansions
+    commands: 
+      - func: write-repo-name-to-downstream_expansions.yaml-for-pine
+      - command: downstream_expansions.set
+        params: 
+          file: downstream_expansions.yaml
   - <<: *build-and-push-client
     name: build-linux_amd64
     tags: ["build"]
@@ -791,6 +804,7 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
+      - name: write-and-set-downstream-expansions
 
   - name: race-detector
     display_name: Race Detector


### PR DESCRIPTION
DEVPROD-9150

### Description
Pine now has the ability to automatically check whether any changes done to your repo's documentation will be rejected by Pine (and Docusaurus) as a result of bad Markdown. It does this through an Evergreen task that is automatically triggered when a parent patch (i.e a PR in your repo) is created. This will prevent you from merging changes that will cause issues in Pine. However, we do require some setup on your end to enable this functionality for your repo.

Instructions followed here: https://docs.devprod.prod.corp.mongodb.com/pine/onboarding/#incorporating-pines-evergreen-task 

### Testing
This [patch ](https://evergreen.mongodb.com/patch/66b0e254b83406000744f67b?redirect_spruce_users=true)shows the task write-downstream-expansions-for-pine.

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->