### PR TITLE
DEVPROD-6072 Implement degraded mode toggles with cached settings

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -33,25 +33,29 @@ type TaskLimitsConfig struct {
 	// MaxGenerateTaskJSONSize is the maximum size of a JSON file in MB that can be specified in the GenerateTasks command.
 	MaxGenerateTaskJSONSize int `bson:"max_generate_task_json_size" json:"max_generate_task_json_size" yaml:"max_generate_task_json_size"`
 
-	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with >16MB parser projects that can be running at once.
+	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once.
 	MaxConcurrentLargeParserProjectTasks int `bson:"max_concurrent_large_parser_project_tasks" json:"max_concurrent_large_parser_project_tasks" yaml:"max_concurrent_large_parser_project_tasks"`
+
+	// MaxDegradedModeConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once during CPU degraded mode.
+	MaxDegradedModeConcurrentLargeParserProjectTasks int `bson:"max_degraded_mode_concurrent_large_parser_project_tasks" json:"max_degraded_mode_concurrent_large_parser_project_tasks" yaml:"max_degraded_mode_concurrent_large_parser_project_tasks"`
 
 	// MaxDegradedModeParserProjectSize is the maximum parser project size during CPU degraded mode.
 	MaxDegradedModeParserProjectSize int `bson:"max_degraded_mode_parser_project_size" json:"max_degraded_mode_parser_project_size" yaml:"max_degraded_mode_parser_project_size"`
 
-	// MaxParserProjectSize is the maximum allowed parser project size.
+	// MaxParserProjectSize is the maximum allowed size for parser projects that are stored in S3.
 	MaxParserProjectSize int `bson:"max_parser_project_size" json:"max_parser_project_size" yaml:"max_parser_project_size"`
 }
 
 var (
-	maxTasksPerVersionKey                = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
-	maxIncludesPerVersionKey             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
-	maxHourlyPatchTasksKey               = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
-	maxPendingGeneratedTasks             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
-	maxGenerateTaskJSONSize              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
-	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
-	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
-	maxParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
+	maxTasksPerVersionKey                            = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTasksPerVersion")
+	maxIncludesPerVersionKey                         = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxIncludesPerVersion")
+	maxHourlyPatchTasksKey                           = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxHourlyPatchTasks")
+	maxPendingGeneratedTasks                         = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxPendingGeneratedTasks")
+	maxGenerateTaskJSONSize                          = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxGenerateTaskJSONSize")
+	maxConcurrentLargeParserProjectTasks             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
+	maxDegradedModeConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeConcurrentLargeParserProjectTasks")
+	maxDegradedModeParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
+	maxParserProjectSize                             = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -76,14 +80,15 @@ func (c *TaskLimitsConfig) Get(ctx context.Context) error {
 func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 	_, err := GetEnvironment().DB().Collection(ConfigCollection).UpdateOne(ctx, byId(c.SectionId()), bson.M{
 		"$set": bson.M{
-			maxTasksPerVersionKey:                c.MaxTasksPerVersion,
-			maxIncludesPerVersionKey:             c.MaxIncludesPerVersion,
-			maxPendingGeneratedTasks:             c.MaxPendingGeneratedTasks,
-			maxHourlyPatchTasksKey:               c.MaxHourlyPatchTasks,
-			maxGenerateTaskJSONSize:              c.MaxGenerateTaskJSONSize,
-			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
-			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
-			maxParserProjectSize:                 c.MaxParserProjectSize,
+			maxTasksPerVersionKey:                            c.MaxTasksPerVersion,
+			maxIncludesPerVersionKey:                         c.MaxIncludesPerVersion,
+			maxPendingGeneratedTasks:                         c.MaxPendingGeneratedTasks,
+			maxHourlyPatchTasksKey:                           c.MaxHourlyPatchTasks,
+			maxGenerateTaskJSONSize:                          c.MaxGenerateTaskJSONSize,
+			maxConcurrentLargeParserProjectTasks:             c.MaxConcurrentLargeParserProjectTasks,
+			maxDegradedModeConcurrentLargeParserProjectTasks: c.MaxDegradedModeConcurrentLargeParserProjectTasks,
+			maxDegradedModeParserProjectSize:                 c.MaxDegradedModeParserProjectSize,
+			maxParserProjectSize:                             c.MaxParserProjectSize,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1164,40 +1164,41 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 	}
 
 	t := &task.Task{
-		Id:                      id,
-		Secret:                  utility.RandomString(),
-		DisplayName:             buildVarTask.Name,
-		BuildId:                 creationInfo.Build.Id,
-		BuildVariant:            creationInfo.BuildVariant.Name,
-		BuildVariantDisplayName: creationInfo.BuildVariant.DisplayName,
-		CreateTime:              creationInfo.TaskCreateTime,
-		IngestTime:              time.Now(),
-		ScheduledTime:           utility.ZeroTime,
-		StartTime:               utility.ZeroTime, // Certain time fields must be initialized
-		FinishTime:              utility.ZeroTime, // to our own utility.ZeroTime value (which is
-		DispatchTime:            utility.ZeroTime, // Unix epoch 0, not Go's time.Time{})
-		LastHeartbeat:           utility.ZeroTime,
-		Status:                  evergreen.TaskUndispatched,
-		Activated:               activateTask,
-		ActivatedTime:           activatedTime,
-		RevisionOrderNumber:     creationInfo.Version.RevisionOrderNumber,
-		Requester:               creationInfo.Version.Requester,
-		ParentPatchID:           creationInfo.Build.ParentPatchID,
-		StepbackInfo:            &task.StepbackInfo{},
-		ParentPatchNumber:       creationInfo.Build.ParentPatchNumber,
-		Version:                 creationInfo.Version.Id,
-		Revision:                creationInfo.Version.Revision,
-		Project:                 creationInfo.Project.Identifier,
-		Priority:                buildVarTask.Priority,
-		GenerateTask:            creationInfo.Project.IsGenerateTask(buildVarTask.Name),
-		TriggerID:               creationInfo.Version.TriggerID,
-		TriggerType:             creationInfo.Version.TriggerType,
-		TriggerEvent:            creationInfo.Version.TriggerEvent,
-		CommitQueueMerge:        buildVarTask.CommitQueueMerge,
-		IsGithubCheck:           isGithubCheck,
-		ActivatedBy:             creationInfo.Version.AuthorID, // this will be overridden if the task was activated by stepback
-		DisplayTaskId:           utility.ToStringPtr(""),       // this will be overridden if the task is an execution task
-		IsEssentialToSucceed:    creationInfo.ActivatedTasksAreEssentialToSucceed && activateTask,
+		Id:                         id,
+		Secret:                     utility.RandomString(),
+		DisplayName:                buildVarTask.Name,
+		BuildId:                    creationInfo.Build.Id,
+		BuildVariant:               creationInfo.BuildVariant.Name,
+		BuildVariantDisplayName:    creationInfo.BuildVariant.DisplayName,
+		CreateTime:                 creationInfo.TaskCreateTime,
+		IngestTime:                 time.Now(),
+		ScheduledTime:              utility.ZeroTime,
+		StartTime:                  utility.ZeroTime, // Certain time fields must be initialized
+		FinishTime:                 utility.ZeroTime, // to our own utility.ZeroTime value (which is
+		DispatchTime:               utility.ZeroTime, // Unix epoch 0, not Go's time.Time{})
+		LastHeartbeat:              utility.ZeroTime,
+		Status:                     evergreen.TaskUndispatched,
+		Activated:                  activateTask,
+		ActivatedTime:              activatedTime,
+		RevisionOrderNumber:        creationInfo.Version.RevisionOrderNumber,
+		Requester:                  creationInfo.Version.Requester,
+		ParentPatchID:              creationInfo.Build.ParentPatchID,
+		StepbackInfo:               &task.StepbackInfo{},
+		ParentPatchNumber:          creationInfo.Build.ParentPatchNumber,
+		Version:                    creationInfo.Version.Id,
+		Revision:                   creationInfo.Version.Revision,
+		Project:                    creationInfo.Project.Identifier,
+		Priority:                   buildVarTask.Priority,
+		GenerateTask:               creationInfo.Project.IsGenerateTask(buildVarTask.Name),
+		TriggerID:                  creationInfo.Version.TriggerID,
+		TriggerType:                creationInfo.Version.TriggerType,
+		TriggerEvent:               creationInfo.Version.TriggerEvent,
+		CommitQueueMerge:           buildVarTask.CommitQueueMerge,
+		IsGithubCheck:              isGithubCheck,
+		ActivatedBy:                creationInfo.Version.AuthorID, // this will be overridden if the task was activated by stepback
+		DisplayTaskId:              utility.ToStringPtr(""),       // this will be overridden if the task is an execution task
+		IsEssentialToSucceed:       creationInfo.ActivatedTasksAreEssentialToSucceed && activateTask,
+		CachedProjectStorageMethod: creationInfo.Version.ProjectStorageMethod,
 	}
 
 	if err := t.SetGenerateTasksEstimations(ctx); err != nil {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -617,24 +617,25 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	}
 
 	patchVersion := &Version{
-		Id:                  p.Id.Hex(),
-		CreateTime:          time.Now(),
-		Identifier:          p.Project,
-		Revision:            p.Githash,
-		Author:              p.Author,
-		Message:             p.Description,
-		BuildIds:            []string{},
-		BuildVariants:       []VersionBuildStatus{},
-		Status:              evergreen.VersionCreated,
-		Requester:           requester,
-		ParentPatchID:       p.Triggers.ParentPatch,
-		ParentPatchNumber:   parentPatchNumber,
-		Branch:              projectRef.Branch,
-		RevisionOrderNumber: p.PatchNumber,
-		AuthorID:            p.Author,
-		Parameters:          params,
-		Activated:           utility.TruePtr(),
-		AuthorEmail:         authorEmail,
+		Id:                   p.Id.Hex(),
+		CreateTime:           time.Now(),
+		Identifier:           p.Project,
+		Revision:             p.Githash,
+		Author:               p.Author,
+		Message:              p.Description,
+		BuildIds:             []string{},
+		BuildVariants:        []VersionBuildStatus{},
+		Status:               evergreen.VersionCreated,
+		Requester:            requester,
+		ParentPatchID:        p.Triggers.ParentPatch,
+		ParentPatchNumber:    parentPatchNumber,
+		ProjectStorageMethod: p.ProjectStorageMethod,
+		Branch:               projectRef.Branch,
+		RevisionOrderNumber:  p.PatchNumber,
+		AuthorID:             p.Author,
+		Parameters:           params,
+		Activated:            utility.TruePtr(),
+		AuthorEmail:          authorEmail,
 	}
 
 	mfst, err := constructManifest(patchVersion, projectRef, project.Modules, githubOauthToken)
@@ -752,8 +753,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string, github
 	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, numActivatedTasks, true); err != nil {
 		return nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
 	}
-
-	patchVersion.ProjectStorageMethod = p.ProjectStorageMethod
 
 	env := evergreen.GetEnvironment()
 	mongoClient := env.Client()

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -124,6 +124,7 @@ var (
 	IsEssentialToSucceedKey                = bsonutil.MustHaveTag(Task{}, "IsEssentialToSucceed")
 	HasAnnotationsKey                      = bsonutil.MustHaveTag(Task{}, "HasAnnotations")
 	NumNextTaskDispatchesKey               = bsonutil.MustHaveTag(Task{}, "NumNextTaskDispatches")
+	CachedProjectStorageMethodKey          = bsonutil.MustHaveTag(Task{}, "CachedProjectStorageMethod")
 )
 
 var (
@@ -3062,6 +3063,16 @@ func GetPendingGenerateTasks(ctx context.Context) (int, error) {
 	} else {
 		return results[0].NumPendingGenerateTasks, nil
 	}
+}
+
+// CountLargeParserProjectTasks counts the number of tasks running with parser projects stored in s3.
+func CountLargeParserProjectTasks() (int, error) {
+	return Count(db.Query(bson.M{
+		StatusKey: bson.M{
+			"$in": evergreen.TaskInProgressStatuses,
+		},
+		CachedProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
+	}))
 }
 
 // GetLatestTaskFromImage retrieves the latest task from all the distros corresponding to the imageID.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -322,6 +322,10 @@ type Task struct {
 	// NumNextTaskDispatches is the number of times the task has been dispatched to run on a
 	// host or in a container. This is used to determine if the task seems to be stuck.
 	NumNextTaskDispatches int `bson:"num_next_task_dispatches" json:"num_next_task_dispatches"`
+
+	// CachedProjectStorageMethod is a cached value how the parser project for this task's version was
+	// stored at the time this task was created. If this is empty, the default storage method is StorageMethodDB.
+	CachedProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"cached_project_storage_method" json:"cached_project_storage_method,omitempty"`
 }
 
 // GeneratedJSONFiles represent files used by a task for generate.tasks to update the project YAML.

--- a/model/task_queue_service.go
+++ b/model/task_queue_service.go
@@ -17,7 +17,7 @@ type TaskQueueItemDispatcher interface {
 }
 
 type CachedDispatcher interface {
-	Refresh() error
+	Refresh(context.Context) error
 	FindNextTask(context.Context, TaskSpec, time.Time) *TaskQueueItem
 	Type() string
 	CreatedAt() time.Time
@@ -59,7 +59,7 @@ func (s *taskDispatchService) RefreshFindNextTask(ctx context.Context, distroID 
 		return nil, errors.WithStack(err)
 	}
 
-	if err := distroDispatchService.Refresh(); err != nil {
+	if err := distroDispatchService.Refresh(ctx); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return distroDispatchService.FindNextTask(ctx, spec, amiUpdatedTime), nil
@@ -71,7 +71,7 @@ func (s *taskDispatchService) Refresh(ctx context.Context, distroID string) erro
 		return errors.WithStack(err)
 	}
 
-	if err := distroDispatchService.Refresh(); err != nil {
+	if err := distroDispatchService.Refresh(ctx); err != nil {
 		return errors.WithStack(err)
 	}
 
@@ -111,7 +111,7 @@ func (s *taskDispatchService) ensureQueue(ctx context.Context, distroID string) 
 
 	switch d.DispatcherSettings.Version {
 	case evergreen.DispatcherVersionRevisedWithDependencies:
-		distroDispatchService, err = newDistroTaskDAGDispatchService(taskQueue, s.ttl)
+		distroDispatchService, err = newDistroTaskDAGDispatchService(ctx, taskQueue, s.ttl)
 		if err != nil {
 			return nil, err
 		}

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -276,6 +276,18 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 
 		item := d.getItemByNodeID(node.ID()) // item is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 
+		settings, err := evergreen.GetConfig(ctx)
+		if err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"dispatcher": DAGDispatcher,
+				"function":   "FindNextTask",
+				"message":    "problem getting evergreen settings",
+				"task_id":    item.Id,
+				"distro_id":  d.distroID,
+			}))
+			continue
+		}
+
 		// TODO Consider checking if the state of any task has changed, which could unblock later tasks in the queue.
 		// Currently, we just wait for the dispatcher's in-memory queue to refresh.
 
@@ -322,17 +334,6 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 			}
 
 			// Skip the task if it's estimated to create more tasks than the generate task limit.
-			settings, err := evergreen.GetConfig(ctx)
-			if err != nil {
-				grip.Warning(message.WrapError(err, message.Fields{
-					"dispatcher": DAGDispatcher,
-					"function":   "FindNextTask",
-					"message":    "problem getting evergreen settings",
-					"task_id":    item.Id,
-					"distro_id":  d.distroID,
-				}))
-				continue
-			}
 			generateTasksLimit := settings.TaskLimits.MaxPendingGeneratedTasks
 			tasksToGenerate := utility.FromIntPtr(nextTaskFromDB.EstimatedNumGeneratedTasks)
 			if generateTasksLimit > 0 && tasksToGenerate > 0 {
@@ -360,6 +361,14 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 					})
 					continue
 				}
+			}
+
+			shouldContinue, shouldReturn := checkMaxConcurrentLargeParserProjectTasks(settings, nextTaskFromDB, d.distroID)
+			if shouldReturn {
+				return nil
+			}
+			if shouldContinue {
+				continue
 			}
 
 			dependenciesMet, err := nextTaskFromDB.DependenciesMet(dependencyCaches)
@@ -423,6 +432,36 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 			d.taskGroups[taskGroupID] = taskGroupUnit
 			if taskGroupUnit.runningHosts < taskGroupUnit.maxHosts {
 				if next := d.nextTaskGroupTask(taskGroupUnit); next != nil {
+					nextTaskFromDB, err := task.FindOneId(next.Id)
+					if err != nil {
+						grip.Warning(message.WrapError(err, message.Fields{
+							"dispatcher": DAGDispatcher,
+							"function":   "FindNextTask",
+							"message":    "problem finding task in db",
+							"task_id":    item.Id,
+							"group":      item.Group,
+							"distro_id":  d.distroID,
+						}))
+						return nil
+					}
+					if nextTaskFromDB == nil {
+						grip.Warning(message.Fields{
+							"dispatcher": DAGDispatcher,
+							"function":   "FindNextTask",
+							"message":    "task from db not found",
+							"task_id":    item.Id,
+							"group":      item.Group,
+							"distro_id":  d.distroID,
+						})
+						return nil
+					}
+					shouldContinue, shouldReturn := checkMaxConcurrentLargeParserProjectTasks(settings, nextTaskFromDB, d.distroID)
+					if shouldReturn {
+						return nil
+					}
+					if shouldContinue {
+						continue
+					}
 					node := d.getNodeByItemID(next.Id)
 					taskGroupTask := d.getItemByNodeID(node.ID()) // *TaskQueueItem
 					taskGroupTask.IsDispatched = true
@@ -433,6 +472,68 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 		}
 	}
 	return nil
+}
+
+// checkMaxConcurrentLargeParserProjectTasks checks whether the task is allowed to be dispatched according to the current limitations
+// on how many concurrent large parser project tasks can be running. The first returned parameter indicates whether FindNextTask should
+// return on an error, and the second indicates whether FindNextTask should skip this task and continue its loop.
+func checkMaxConcurrentLargeParserProjectTasks(settings *evergreen.Settings, nextTaskFromDB *task.Task, distroId string) (bool, bool) {
+	taskVersion, err := VersionFindOneId(nextTaskFromDB.Version)
+	if err != nil {
+		grip.Warning(message.WrapError(err, message.Fields{
+			"dispatcher": DAGDispatcher,
+			"function":   "FindNextTask",
+			"message":    "problem finding version for task in db",
+			"version_id": nextTaskFromDB.Version,
+			"task_id":    nextTaskFromDB.Id,
+			"distro_id":  distroId,
+		}))
+		return false, true
+	}
+	if taskVersion == nil {
+		grip.Warning(message.Fields{
+			"dispatcher": DAGDispatcher,
+			"function":   "FindNextTask",
+			"message":    "version for task from db not found",
+			"task_id":    nextTaskFromDB.Id,
+			"version_id": nextTaskFromDB.Version,
+			"distro_id":  distroId,
+		})
+		return false, true
+	}
+
+	isDegradedMode := !settings.ServiceFlags.CPUDegradedModeDisabled
+	maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
+	if isDegradedMode {
+		maxConcurrentLargeParserProjTasks = settings.TaskLimits.MaxDegradedModeConcurrentLargeParserProjectTasks
+	}
+	if maxConcurrentLargeParserProjTasks > 0 && taskVersion.ProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
+		numLargeParserProjectTasks, err := task.CountLargeParserProjectTasks()
+		if err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"dispatcher": DAGDispatcher,
+				"function":   "FindNextTask",
+				"message":    "problem getting num large parser project tasks",
+				"task_id":    nextTaskFromDB.Id,
+				"distro_id":  distroId,
+			}))
+			return true, false
+		}
+		if numLargeParserProjectTasks >= maxConcurrentLargeParserProjTasks {
+			grip.Info(message.Fields{
+				"dispatcher":       DAGDispatcher,
+				"function":         "FindNextTask",
+				"message":          "skipping task because it would exceed the concurrent large parser project task limit",
+				"task_id":          nextTaskFromDB.Id,
+				"distro_id":        distroId,
+				"is_degraded_mode": isDegradedMode,
+				"max_concurrent_large_parser_project_tasks": maxConcurrentLargeParserProjTasks,
+				"num_large_parser_project_tasks":            numLargeParserProjectTasks,
+			})
+			return true, false
+		}
+	}
+	return false, false
 }
 
 func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *TaskQueueItem {

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -568,8 +568,7 @@ func (s *taskDAGDispatchServiceSuite) TestIntraTaskGroupDependencies() {
 }
 
 func (s *taskDAGDispatchServiceSuite) SetupTest() {
-	s.Require().NoError(db.ClearCollections(task.Collection))
-	s.Require().NoError(db.ClearCollections(host.Collection))
+	s.Require().NoError(db.ClearCollections(task.Collection, host.Collection, VersionCollection))
 	items := []TaskQueueItem{}
 	var group string
 	var variant string
@@ -620,9 +619,9 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 			maxHosts = 2
 		}
 
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         group,
 			BuildVariant:  variant,
 			Version:       version,
@@ -642,7 +641,7 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 		}
 
 		t := task.Task{
-			Id:                ID,
+			Id:                id,
 			DistroId:          distroID,
 			StartTime:         utility.ZeroTime,
 			TaskGroup:         group,
@@ -655,6 +654,31 @@ func (s *taskDAGDispatchServiceSuite) SetupTest() {
 		}
 		s.Require().NoError(t.Insert())
 	}
+	taskVersion1 := &Version{
+		Id:                   "version_1",
+		ProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+	}
+	taskVersion2 := &Version{
+		Id: "version_2",
+	}
+	taskVersion3 := &Version{
+		Id: "5d8cd23da4cf4747f4210333",
+	}
+	taskVersion4 := &Version{
+		Id: "5d88953e2a60ed61eefe9561",
+	}
+	taskVersion5 := &Version{
+		Id: "version",
+	}
+	taskVersion6 := &Version{
+		Id: "",
+	}
+	s.Require().NoError(taskVersion1.Insert())
+	s.Require().NoError(taskVersion2.Insert())
+	s.Require().NoError(taskVersion3.Insert())
+	s.Require().NoError(taskVersion4.Insert())
+	s.Require().NoError(taskVersion5.Insert())
+	s.Require().NoError(taskVersion6.Insert())
 
 	s.taskQueue = TaskQueue{
 		Distro: distroID,
@@ -1672,9 +1696,9 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 	groupIndexes := []int{2, 0, 4, 1, 3}
 
 	for i := 0; i < 5; i++ {
-		ID := fmt.Sprintf("%d", i)
+		id := fmt.Sprintf("%d", i)
 		items = append(items, TaskQueueItem{
-			Id:            ID,
+			Id:            id,
 			Group:         "group_1",
 			BuildVariant:  "variant_1",
 			Version:       "version_1",
@@ -1683,7 +1707,7 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 			GroupIndex:    groupIndexes[i],
 		})
 		t := task.Task{
-			Id:                ID,
+			Id:                id,
 			TaskGroup:         "group_1",
 			BuildVariant:      "variant_1",
 			Version:           "version_1",
@@ -1715,6 +1739,131 @@ func (s *taskDAGDispatchServiceSuite) TestSingleHostTaskGroupOrdering() {
 		next := service.FindNextTask(ctx, spec, utility.ZeroTime)
 		s.Require().NotNil(next)
 		s.Equal(expectedOrder[i], next.Id)
+	}
+}
+
+func (s *taskDAGDispatchServiceSuite) TestInProgressSingleHostTaskGroupLimits() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Require().NoError(db.ClearCollections(task.Collection, evergreen.ConfigCollection))
+
+	settings := evergreen.TaskLimitsConfig{
+		MaxDegradedModeConcurrentLargeParserProjectTasks: 1,
+	}
+	s.Require().NoError(settings.Set(ctx))
+
+	items := []TaskQueueItem{}
+
+	sampleS3Task := task.Task{
+		Id:                         "sample_s3_task",
+		Version:                    "version_1",
+		Project:                    "project_1",
+		Status:                     evergreen.TaskStarted,
+		CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+	}
+	s.Require().NoError(sampleS3Task.Insert())
+
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("%d", i)
+		items = append(items, TaskQueueItem{
+			Id:            id,
+			Group:         "group_1",
+			BuildVariant:  "variant_1",
+			Version:       "version_1",
+			Project:       "project_1",
+			GroupMaxHosts: 1,
+		})
+		t := task.Task{
+			Id:                         id,
+			TaskGroup:                  "group_1",
+			BuildVariant:               "variant_1",
+			Version:                    "version_1",
+			TaskGroupMaxHosts:          1,
+			Project:                    "project_1",
+			StartTime:                  utility.ZeroTime,
+			FinishTime:                 utility.ZeroTime,
+			CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+		}
+		s.Require().NoError(t.Insert())
+	}
+	s.taskQueue = TaskQueue{
+		Distro: "distro_1",
+		Queue:  items,
+	}
+
+	service, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
+	s.Require().NoError(err)
+
+	spec := TaskSpec{
+		Group:        "group_1",
+		BuildVariant: "variant_1",
+		Version:      "version_1",
+		Project:      "project_1",
+	}
+
+	for i := 0; i < 5; i++ {
+		next := service.FindNextTask(ctx, spec, utility.ZeroTime)
+		s.Require().NotNil(next)
+	}
+}
+
+func (s *taskDAGDispatchServiceSuite) TestNewSingleHostTaskGroupLimits() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s.Require().NoError(db.ClearCollections(task.Collection, evergreen.ConfigCollection))
+
+	settings := evergreen.TaskLimitsConfig{
+		MaxDegradedModeConcurrentLargeParserProjectTasks: 1,
+	}
+	s.Require().NoError(settings.Set(ctx))
+
+	items := []TaskQueueItem{}
+
+	sampleS3Task := task.Task{
+		Id:                         "sample_s3_task",
+		Version:                    "version_1",
+		Project:                    "project_1",
+		Status:                     evergreen.TaskStarted,
+		CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+	}
+	s.Require().NoError(sampleS3Task.Insert())
+
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("%d", i)
+		items = append(items, TaskQueueItem{
+			Id:            id,
+			Group:         "group_1",
+			BuildVariant:  "variant_1",
+			Version:       "version_1",
+			Project:       "project_1",
+			GroupMaxHosts: 1,
+		})
+		t := task.Task{
+			Id:                         id,
+			TaskGroup:                  "group_1",
+			BuildVariant:               "variant_1",
+			Version:                    "version_1",
+			TaskGroupMaxHosts:          1,
+			Project:                    "project_1",
+			StartTime:                  utility.ZeroTime,
+			FinishTime:                 utility.ZeroTime,
+			CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+		}
+		s.Require().NoError(t.Insert())
+	}
+	s.taskQueue = TaskQueue{
+		Distro: "distro_1",
+		Queue:  items,
+	}
+
+	service, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Minute)
+	s.Require().NoError(err)
+	spec := TaskSpec{}
+	for i := 0; i < 5; i++ {
+		next := service.FindNextTask(ctx, spec, utility.ZeroTime)
+		s.Require().Nil(next)
 	}
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2693,14 +2693,15 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion                   *int `json:"max_tasks_per_version"`
-	MaxIncludesPerVersion                *int `json:"max_includes_per_version"`
-	MaxHourlyPatchTasks                  *int `json:"max_hourly_patch_tasks"`
-	MaxPendingGeneratedTasks             *int `json:"max_pending_generated_tasks"`
-	MaxGenerateTaskJSONSize              *int `json:"max_generate_task_json_size"`
-	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
-	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
-	MaxParserProjectSize                 *int `json:"max_parser_project_size"`
+	MaxTasksPerVersion                               *int `json:"max_tasks_per_version"`
+	MaxIncludesPerVersion                            *int `json:"max_includes_per_version"`
+	MaxHourlyPatchTasks                              *int `json:"max_hourly_patch_tasks"`
+	MaxPendingGeneratedTasks                         *int `json:"max_pending_generated_tasks"`
+	MaxGenerateTaskJSONSize                          *int `json:"max_generate_task_json_size"`
+	MaxConcurrentLargeParserProjectTasks             *int `json:"max_concurrent_large_parser_project_tasks"`
+	MaxDegradedModeConcurrentLargeParserProjectTasks *int `json:"max_degraded_mode_concurrent_large_parser_project_tasks"`
+	MaxDegradedModeParserProjectSize                 *int `json:"max_degraded_mode_parser_project_size"`
+	MaxParserProjectSize                             *int `json:"max_parser_project_size"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2712,6 +2713,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxHourlyPatchTasks = utility.ToIntPtr(v.MaxHourlyPatchTasks)
 		c.MaxGenerateTaskJSONSize = utility.ToIntPtr(v.MaxGenerateTaskJSONSize)
 		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
+		c.MaxDegradedModeConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxDegradedModeConcurrentLargeParserProjectTasks)
 		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
 		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
 		return nil
@@ -2722,14 +2724,15 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 
 func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 	return evergreen.TaskLimitsConfig{
-		MaxTasksPerVersion:                   utility.FromIntPtr(c.MaxTasksPerVersion),
-		MaxIncludesPerVersion:                utility.FromIntPtr(c.MaxIncludesPerVersion),
-		MaxHourlyPatchTasks:                  utility.FromIntPtr(c.MaxHourlyPatchTasks),
-		MaxPendingGeneratedTasks:             utility.FromIntPtr(c.MaxPendingGeneratedTasks),
-		MaxGenerateTaskJSONSize:              utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
-		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
-		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
-		MaxParserProjectSize:                 utility.FromIntPtr(c.MaxParserProjectSize),
+		MaxTasksPerVersion:                               utility.FromIntPtr(c.MaxTasksPerVersion),
+		MaxIncludesPerVersion:                            utility.FromIntPtr(c.MaxIncludesPerVersion),
+		MaxHourlyPatchTasks:                              utility.FromIntPtr(c.MaxHourlyPatchTasks),
+		MaxPendingGeneratedTasks:                         utility.FromIntPtr(c.MaxPendingGeneratedTasks),
+		MaxGenerateTaskJSONSize:                          utility.FromIntPtr(c.MaxGenerateTaskJSONSize),
+		MaxConcurrentLargeParserProjectTasks:             utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
+		MaxDegradedModeConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxDegradedModeConcurrentLargeParserProjectTasks),
+		MaxDegradedModeParserProjectSize:                 utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
+		MaxParserProjectSize:                             utility.FromIntPtr(c.MaxParserProjectSize),
 	}, nil
 }
 

--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -43,9 +45,15 @@ func (h *degradedModeHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "retrieving service flags"))
 	}
-	flags.CPUDegradedModeDisabled = false
-	if err = flags.Set(ctx); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
+	if flags.CPUDegradedModeDisabled {
+		flags.CPUDegradedModeDisabled = false
+		if err = flags.Set(ctx); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting service flags"))
+		}
+		grip.Info(message.Fields{
+			"message": "CPU degraded mode has been triggered",
+			"route":   "/degraded_mode",
+		})
 	}
 	return gimlet.NewJSONResponse(struct{}{})
 }

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -639,6 +639,10 @@ Admin Settings
 										<input type="number" ng-model="Settings.task_limits.max_concurrent_large_parser_project_tasks">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>Max CPU Degraded Mode Concurrent Large Parser Project Tasks</label>
+										<input type="number" ng-model="Settings.task_limits.max_degraded_mode_concurrent_large_parser_project_tasks">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>Max Parser Project Size (MB)</label>
 										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
 									</md-input-container>


### PR DESCRIPTION
DEVPROD-6072

### Description
#8130 Was reverted because it resulted in a large number of calls to `GetConfig`, maxing out our Splunk limits.

The first commit in this PR is a re-staging of the changes in #8130 . Subsequent commits are to cache the evergreen settings in the task dispatcher, updating it every time the dispatcher refreshes itself
### Testing
Tested in staging and confirmed the number of calls to `GetConfig` reduced significantly.
