### PR TITLE
docs: update task limits

### DIFF
--- a/docs/Reference/Limits.md
+++ b/docs/Reference/Limits.md
@@ -25,7 +25,7 @@ Evergreen does not have a limit on how large task timeouts can be. For different
 
 ## Include Limits
 
-We limit included files to 35 based on this [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) about GitHub usage. 
+We have a limit of 35 [included files](../Project-Configuration/Project-Configuration-Files/#Include) per project based on this [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) about GitHub usage. 
 
 ## YAML configuration size
 

--- a/docs/Reference/Limits.md
+++ b/docs/Reference/Limits.md
@@ -25,7 +25,7 @@ Evergreen does not have a limit on how large task timeouts can be. For different
 
 ## Include Limits
 
-We limit included files to 25 based on this [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) about GitHub usage. 
+We limit included files to 35 based on this [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) about GitHub usage. 
 
 ## YAML configuration size
 

--- a/docs/Reference/Limits.md
+++ b/docs/Reference/Limits.md
@@ -12,7 +12,7 @@ Exceptions can be requested on a case-by-case which will be granted based on [ou
 
 ## Task Limits
 
-Evergreen limits tasks per version to 40,000. This includes both selected and unselected tasks. 
+Evergreen limits tasks per version to 50,000. This includes both selected and unselected tasks. 
 
 ## Task Scheduling Limits
 
@@ -25,7 +25,7 @@ Evergreen does not have a limit on how large task timeouts can be. For different
 
 ## Include Limits
 
-There is an [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) to figure out how many include files we want to let users put in their project configuration. The current limit is 50.
+We limit included files to 25 based on this [investigation](https://jira.mongodb.org/browse/DEVPROD-3509) about GitHub usage. 
 
 ## YAML configuration size
 


### PR DESCRIPTION
It looks like these things were updated as part of the availability project. 

cc @hadjri @bynn if you'd meant to do this as part of [DEVPROD-6977](https://jira.mongodb.org/browse/DEVPROD-6977) but I think we should update docs as we make changes to keep things as up-to-date as possible, by using the "documentation" PR template section. 

