### PR TITLE
DEVPROD-3968 Validate number of hosts for create.host command

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2620,7 +2620,7 @@ func FindAllHostsSpawnedByTasks(ctx context.Context) ([]Host, error) {
 	return hosts, nil
 }
 
-// FindHostsSpawnedByTask finds hosts spawned by the `createhost` command scoped to a given task.
+// FindHostsSpawnedByTask finds hosts spawned by the `create.host` command scoped to a given task.
 func FindHostsSpawnedByTask(ctx context.Context, taskID string, execution int) ([]Host, error) {
 	taskIDKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskIDKey)
 	taskExecutionNumberKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskExecutionNumberKey)
@@ -2632,6 +2632,22 @@ func FindHostsSpawnedByTask(ctx context.Context, taskID string, execution int) (
 	hosts, err := Find(ctx, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding hosts spawned by task '%s' for execution %d", taskID, execution)
+	}
+	return hosts, nil
+}
+
+// NumHostIntentsByTask returns the number of host intents created by `create.host` command for a given task.
+func FindHostIntentsByTask(ctx context.Context, taskID string, execution int) ([]Host, error) {
+	taskIDKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskIDKey)
+	taskExecutionNumberKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskExecutionNumberKey)
+	query := bson.M{
+		StatusKey:              bson.M{"$in": evergreen.IsRunningOrWillRunStatuses},
+		taskIDKey:              taskID,
+		taskExecutionNumberKey: execution,
+	}
+	hosts, err := Find(ctx, query)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding host intents created by task '%s' for execution %d", taskID, execution)
 	}
 	return hosts, nil
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2620,34 +2620,18 @@ func FindAllHostsSpawnedByTasks(ctx context.Context) ([]Host, error) {
 	return hosts, nil
 }
 
-// FindHostsSpawnedByTask finds hosts spawned by the `create.host` command scoped to a given task.
-func FindHostsSpawnedByTask(ctx context.Context, taskID string, execution int) ([]Host, error) {
+// FindHostsSpawnedByTask finds hosts spawned by the `host.create` command scoped to a given task.
+func FindHostsSpawnedByTask(ctx context.Context, taskID string, execution int, statuses []string) ([]Host, error) {
 	taskIDKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskIDKey)
 	taskExecutionNumberKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskExecutionNumberKey)
 	query := bson.M{
-		StatusKey:              evergreen.HostRunning,
+		StatusKey:              bson.M{"$in": statuses},
 		taskIDKey:              taskID,
 		taskExecutionNumberKey: execution,
 	}
 	hosts, err := Find(ctx, query)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding hosts spawned by task '%s' for execution %d", taskID, execution)
-	}
-	return hosts, nil
-}
-
-// NumHostIntentsByTask returns the number of host intents created by `create.host` command for a given task.
-func FindHostIntentsByTask(ctx context.Context, taskID string, execution int) ([]Host, error) {
-	taskIDKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskIDKey)
-	taskExecutionNumberKey := bsonutil.GetDottedKeyName(SpawnOptionsKey, SpawnOptionsTaskExecutionNumberKey)
-	query := bson.M{
-		StatusKey:              bson.M{"$in": evergreen.IsRunningOrWillRunStatuses},
-		taskIDKey:              taskID,
-		taskExecutionNumberKey: execution,
-	}
-	hosts, err := Find(ctx, query)
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding host intents created by task '%s' for execution %d", taskID, execution)
 	}
 	return hosts, nil
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -3094,12 +3094,12 @@ func TestFindHostsSpawnedByTasks(t *testing.T) {
 	assert.Equal(found[1].Id, "4")
 	assert.Equal(found[2].Id, "7")
 
-	found, err = FindHostsSpawnedByTask(ctx, "task_1", 0)
+	found, err = FindHostsSpawnedByTask(ctx, "task_1", 0, []string{evergreen.HostRunning})
 	assert.NoError(err)
 	assert.Len(found, 1)
 	assert.Equal(found[0].Id, "1")
 
-	found, err = FindHostsSpawnedByTask(ctx, "task_1", 1)
+	found, err = FindHostsSpawnedByTask(ctx, "task_1", 1, []string{evergreen.HostRunning})
 	assert.NoError(err)
 	assert.Len(found, 1)
 	assert.Equal(found[0].Id, "7")

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -43,7 +43,7 @@ func ListHostsForTask(ctx context.Context, taskID string) ([]host.Host, error) {
 	}
 
 	catcher := grip.NewBasicCatcher()
-	hostsSpawnedByTask, err := host.FindHostsSpawnedByTask(ctx, t.Id, t.Execution)
+	hostsSpawnedByTask, err := host.FindHostsSpawnedByTask(ctx, t.Id, t.Execution, []string{evergreen.HostRunning})
 	catcher.Add(err)
 	hostsSpawnedByBuild, err := host.FindHostsSpawnedByBuild(ctx, t.BuildId)
 	catcher.Add(err)

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var createdOrCreatingHostStatuses = append(evergreen.IsRunningOrWillRunStatuses, evergreen.HostUninitialized)
+var createdOrCreatingHostStatuses = append([]string{evergreen.HostUninitialized}, evergreen.IsRunningOrWillRunStatuses...)
 
 type hostCreateHandler struct {
 	taskID     string

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -375,11 +375,6 @@ func TestHostCreateDocker(t *testing.T) {
 	assert.NoError(err)
 	require.Len(hosts, 3)
 	assert.Equal(h.DockerOptions.Command, hosts[1].DockerOptions.Command)
-
-	// assert.Equal(http.StatusOK, handler.Run(ctx).Status())
-	// hosts, err = host.Find(ctx, bson.M{})
-	// assert.NoError(err)
-	// require.Len(hosts, 3)
 }
 
 func TestGetDockerLogs(t *testing.T) {

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -336,7 +336,7 @@ func TestHostCreateDocker(t *testing.T) {
 	require.NoError(d.Insert(ctx))
 
 	sampleTask := &task.Task{
-		Id: "task-id",
+		Id: handler.taskID,
 	}
 	require.NoError(sampleTask.Insert())
 
@@ -353,7 +353,6 @@ func TestHostCreateDocker(t *testing.T) {
 	}
 	c.Registry.Name = "myregistry"
 	handler.createHost = c
-	handler.taskID = sampleTask.Id
 
 	foundDistro, err := distro.GetHostCreateDistro(ctx, c)
 	require.NoError(err)

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -284,6 +284,16 @@ func TestMakeHost(t *testing.T) {
 	ec2Settings2 = &cloud.EC2ProviderSettings{}
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, "us-west-1"))
 	assert.Equal(ec2Settings2.AMI, "ami-987654")
+
+	hosts, err := host.Find(ctx, bson.M{})
+	assert.NoError(err)
+	require.Len(hosts, 7)
+
+	assert.Equal(http.StatusOK, handler.Run(ctx).Status())
+
+	hosts, err = host.Find(ctx, bson.M{})
+	assert.NoError(err)
+	require.Len(hosts, 7)
 }
 
 func TestHostCreateDocker(t *testing.T) {
@@ -326,7 +336,7 @@ func TestHostCreateDocker(t *testing.T) {
 	require.NoError(d.Insert(ctx))
 
 	sampleTask := &task.Task{
-		Id: handler.taskID,
+		Id: "task-id",
 	}
 	require.NoError(sampleTask.Insert())
 
@@ -343,6 +353,7 @@ func TestHostCreateDocker(t *testing.T) {
 	}
 	c.Registry.Name = "myregistry"
 	handler.createHost = c
+	handler.taskID = sampleTask.Id
 
 	foundDistro, err := distro.GetHostCreateDistro(ctx, c)
 	require.NoError(err)
@@ -364,6 +375,11 @@ func TestHostCreateDocker(t *testing.T) {
 	assert.NoError(err)
 	require.Len(hosts, 3)
 	assert.Equal(h.DockerOptions.Command, hosts[1].DockerOptions.Command)
+
+	// assert.Equal(http.StatusOK, handler.Run(ctx).Status())
+	// hosts, err = host.Find(ctx, bson.M{})
+	// assert.NoError(err)
+	// require.Len(hosts, 3)
 }
 
 func TestGetDockerLogs(t *testing.T) {

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -296,15 +296,8 @@ func TestHostCreateHandler(t *testing.T) {
 
 	env := &mock.Environment{}
 	assert.NoError(env.Configure(ctx))
-	var err error
-	env.RemoteGroup, err = queue.NewLocalQueueGroup(ctx, queue.LocalQueueGroupOptions{
-		DefaultQueue: queue.LocalQueueOptions{Constructor: func(context.Context) (amboy.Queue, error) {
-			return queue.NewLocalLimitedSize(2, 1048), nil
-		}}})
-	assert.NoError(err)
 
 	handler := hostCreateHandler{}
-
 	d := distro.Distro{
 		Id:       "archlinux-test",
 		Aliases:  []string{"archlinux-alias"},

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -340,8 +340,10 @@ func TestCreateHostRoute(t *testing.T) {
 	// Calling create host route multiple times should not create more hosts than number requested.
 	hosts, err := host.FindHostIntentsByTask(ctx, sampleTask.Id, sampleTask.Execution)
 	assert.NoError(err)
-	assert.Len(hosts, 5)
+	assert.Len(hosts, 0)
 
+	assert.Equal(http.StatusOK, handler.Run(ctx).Status())
+	assert.Equal(http.StatusOK, handler.Run(ctx).Status())
 	assert.Equal(http.StatusOK, handler.Run(ctx).Status())
 
 	hosts, err = host.FindHostIntentsByTask(ctx, sampleTask.Id, sampleTask.Execution)

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -370,6 +370,10 @@ func TestHostCreateHandler(t *testing.T) {
 	hosts, err = host.FindHostsSpawnedByTask(ctx, sampleTask.Id, sampleTask.Execution, createdOrCreatingHostStatuses)
 	assert.NoError(err)
 	assert.Len(hosts, 5)
+
+	// Error if there are more hosts than initially requested.
+	handler.createHost.NumHosts = "1"
+	assert.Equal(http.StatusBadRequest, handler.Run(ctx).Status())
 }
 
 func TestHostCreateDocker(t *testing.T) {


### PR DESCRIPTION
DEVPROD-3968

### Description
There was a bug with `create.host` creating more hosts than it was told to create probably due to the command retrying due to failure, but the host was still created during the failure. This double checks that the number of host intents created for each command will be the same each time.

No test because this would only happen if something went wrong in a strange way