### PR TITLE
DEVPROD-9393: add project-level flag for using Parameter Store

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -140,6 +140,10 @@ type ProjectRef struct {
 
 	// GitHubPermissionGroupByRequester is a mapping of requester type to the user defined GitHub permission groups above.
 	GitHubPermissionGroupByRequester map[string]string `bson:"github_token_permission_by_requester,omitempty" json:"github_token_permission_by_requester,omitempty" yaml:"github_token_permission_by_requester,omitempty"`
+
+	// ParameterStoreEnabled is a temporary feature flag to enable/disable
+	// Parameter Store for storing project secrets.
+	ParameterStoreEnabled bool `bson:"parameter_store_enabled,omitempty" json:"parameter_store_enabled,omitempty" yaml:"parameter_store_enabled,omitempty"`
 }
 
 // GitHubDynamicTokenPermissionGroup is a permission group for GitHub dynamic access tokens.


### PR DESCRIPTION
DEVPROD-9393

### Description
Add temporary feature flag to enable using Parameter Store per project. This is just to let us turn on Parameter Store in a more controlled way by setting it in the DB, users won't actually interact with this setting directly.

### Testing
Checked that the feature flag was preserved even if I saved the project settings page.

### Documentation
N/A
