### PR TITLE
DEVPROD-2527: do not system fail display task that is marked to reset

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2502,6 +2502,8 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 
 		updatedDisplayTask, err = tryUpdateDisplayTaskAtomically(*originalDisplayTask)
 		if err == nil {
+			// Update the cached display task in case it's used later on.
+			t.DisplayTask = updatedDisplayTask
 			break
 		}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2532,6 +2532,80 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 	}
 }
 
+func TestMarkEndWithDisplayTaskResetWhenFinished(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, host.Collection))
+
+	const (
+		etID      = "execution_task_id"
+		dtID      = "display_task_id"
+		buildID   = "build_id"
+		versionID = "version_id"
+		hostID    = "host_id"
+	)
+	et := task.Task{
+		Id:            etID,
+		DisplayTaskId: utility.ToStringPtr(dtID),
+		Status:        evergreen.TaskStarted,
+		BuildId:       buildID,
+		Version:       versionID,
+		HostId:        hostID,
+	}
+	assert.NoError(t, et.Insert())
+	dt := task.Task{
+		Id:                dtID,
+		DisplayOnly:       true,
+		ExecutionTasks:    []string{etID},
+		BuildId:           buildID,
+		Version:           versionID,
+		Status:            evergreen.TaskStarted,
+		ResetWhenFinished: true,
+	}
+	assert.NoError(t, dt.Insert())
+	b := build.Build{
+		Id:     buildID,
+		Status: evergreen.BuildStarted,
+	}
+	assert.NoError(t, b.Insert())
+	v := Version{
+		Id:     versionID,
+		Status: evergreen.VersionStarted,
+	}
+	assert.NoError(t, v.Insert())
+	h := host.Host{
+		Id:     hostID,
+		Status: evergreen.HostRunning,
+	}
+	assert.NoError(t, h.Insert(ctx))
+
+	assert.NoError(t, MarkEnd(ctx, &evergreen.Settings{}, &et, "", time.Now(), &apimodels.TaskEndDetail{Status: evergreen.TaskSucceeded}, false))
+
+	restartedDisplayTask, err := task.FindOneId(dtID)
+	assert.NoError(t, err)
+	require.NotZero(t, restartedDisplayTask)
+	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status, "display task should restart when execution task finishes")
+	assert.Equal(t, 1, restartedDisplayTask.Execution, "execution number should have incremented")
+
+	originalDisplayTask, err := task.FindOneOldByIdAndExecution(dtID, 0)
+	assert.NoError(t, err)
+	require.NotZero(t, originalDisplayTask)
+	assert.Equal(t, evergreen.TaskSucceeded, originalDisplayTask.Status, "original display task should be successful")
+
+	restartedExecTask, err := task.FindOneId(etID)
+	assert.NoError(t, err)
+	require.NotZero(t, restartedExecTask)
+	assert.Equal(t, evergreen.TaskUndispatched, restartedExecTask.Status, "execution task should restart when it finishes")
+	assert.Equal(t, 1, restartedExecTask.Execution, "execution number should have incremented")
+
+	originalExecTask, err := task.FindOneOldByIdAndExecution(etID, 0)
+	assert.NoError(t, err)
+	require.NotZero(t, originalExecTask)
+	assert.Equal(t, evergreen.TaskSucceeded, originalExecTask.Status, "original execution task should be successful")
+
+}
+
 func TestTryResetTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
DEVPROD-2527

### Description
Follow-up to #8152 - this fixes one last bug where the display task wasn't restarting properly when the last execution task finished. On the first execution where it's marked to restart when the execution tasks finish (e.g. by restarting all tasks in a patch), it would end up system failing the display task, and then on execution 1+, the display task would refuse to restart at all (because there's a limit on the number of system failure restarts).

This was because the restarting logic used `t.GetDisplayTask()`, which caches the display task after an initial lookup. If the cached display task isn't kept up-to-date, then it'll have stale data of the parent display task. This caused problems when restarting the display task because when the execution task finishes, it [updated the display task's final status](https://github.com/evergreen-ci/evergreen/blob/53ca7a8b0eb83e8eff13cefaecee9c5e0ec25e51/model/task_lifecycle.go#L887-L889), but only in the DB. The cached display task in `t.GetDisplayTask()` didn't get that update, so [when it restarted the display task](https://github.com/evergreen-ci/evergreen/blob/53ca7a8b0eb83e8eff13cefaecee9c5e0ec25e51/model/task_lifecycle.go#L890-L894), the restart logic would see the stale display task wasn't finished and system-fail it before restarting it.

### Testing
* Added unit test for restarting display task when the last execution task finishes. As expected, it fails before this change and succeeds afterwards.
* Tested in staging that the first execution sets the correct final display task status (i.e. not system-failing) and restarts.

### Documentation
N/A