### PR TITLE
DEVPROD-6732 Fix agent panic

### DIFF
--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -352,6 +352,9 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 
 	// Set AWS credentials for task output buckets.
 	awsCreds := pail.CreateAWSCredentials(taskConfig.TaskOutput.Key, taskConfig.TaskOutput.Secret, "")
+	if taskConfig.Task.TaskOutputInfo == nil {
+		return nil, errors.New("agent retrieved a task with no task output info")
+	}
 	taskConfig.Task.TaskOutputInfo.TaskLogs.AWSCredentials = awsCreds
 	taskConfig.Task.TaskOutputInfo.TestLogs.AWSCredentials = awsCreds
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-07"
+	AgentVersion = "2024-08-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-6732

### Description
Fixes a panic that occurred during DB instability where the agent was presumably retrieving empty task documents, causing the required task output info field to be nil.