### PR TITLE
DEVPROD-9714 use cgo on macOS

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -80,9 +80,11 @@ func main() {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
 	}
 	// Disable cgo so that the compiled binary is statically linked. This is useful for systems lacking
-	// libc support.
-	// macOS is excluded because it will have libc support cgo is needed for gopsutil on macOS.
-	if system != macGOOS {
+	// libc support. macOS is excluded because it will have libc support and cgo is needed for gopsutil on macOS.
+	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
+	if system == macGOOS {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+	} else {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 	}
 

--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const macGOOS = "darwin"
+
 func main() {
 	var (
 		arch      string
@@ -77,8 +79,12 @@ func main() {
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
 	}
-	// Disable cgo so that the compiled binary is statically linked.
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	// Disable cgo so that the compiled binary is statically linked. This is useful for systems lacking
+	// libc support.
+	// macOS is excluded because it will have libc support cgo is needed for gopsutil on macOS.
+	if system != macGOOS {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	}
 
 	goos := "GOOS=" + system
 	goarch := "GOARCH=" + arch

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-07"
+	AgentVersion = "2024-08-08"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
[DEVPROD-9714](https://jira.mongodb.org/browse/DEVPROD-9714)

### Description
gopsutil on macOS relies on cgo for CPU metrics ([here](https://github.com/shirou/gopsutil/blob/1e6b445a8ad4ffe097ccdb97a2f365a4e6287325/cpu/cpu_darwin_nocgo.go#L13)). In order to collect those metrics [here](https://github.com/evergreen-ci/evergreen/blob/6b7aa96e5256f9ef28f0dd65122b0ea8fe7a01b8/agent/otel.go#L179) and [here](https://github.com/evergreen-ci/evergreen/blob/6b7aa96e5256f9ef28f0dd65122b0ea8fe7a01b8/agent/otel.go#L199) we need to have cgo enabled. Although we turned it off on purpose ([here](https://github.com/evergreen-ci/evergreen/pull/5095#issue-1022996625)), it should be okay to turn cgo back on specifically for macOS which definitely has libc support.

### Testing
Ran [a task](https://spruce-staging.corp.mongodb.com/task/evg_osx_test_agent_patch_8f3341c54f8430a9be6e5ae817c81a1a65f0e9b2_66b518df2ad0350007e11289_24_08_08_19_14_17/logs?execution=1) on staging. For the second execution, `CGO_ENABLED=1` was set and [metrics were sent to Honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/qtgFUcBwNLG?omitMissingValues). 
For the first execution, CGO_ENABLED was unset and CGO was disabled by default.

