### PR TITLE
DEVPROD-4195 Don't unset priority field when enabling disabled task

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2726,8 +2726,8 @@ func enableDisabledTasks(taskIDs []string) error {
 			PriorityKey: evergreen.DisabledTaskPriority,
 		},
 		bson.M{
-			"$unset": bson.M{
-				PriorityKey: 1,
+			"$set": bson.M{
+				PriorityKey: 0,
 			},
 		})
 	return err

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2146,17 +2146,30 @@ func TestActivateTasksUpdate(t *testing.T) {
 	})
 
 	t.Run("DisabledTask", func(t *testing.T) {
-		require.NoError(t, db.Clear(Collection))
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		require.NoError(t, db.ClearCollections(Collection, distro.Collection))
 
 		t0 := Task{
-			Id:       "t0",
-			Priority: evergreen.DisabledTaskPriority,
+			Id:                "t0",
+			Status:            evergreen.TaskUndispatched,
+			Priority:          evergreen.DisabledTaskPriority,
+			ExecutionPlatform: ExecutionPlatformHost,
+			DistroId:          "d",
+		}
+		d := distro.Distro{
+			Id: "d",
 		}
 
+		require.NoError(t, d.Insert(ctx))
 		require.NoError(t, t0.Insert())
 		assert.NoError(t, activateTasks([]string{t0.Id}, caller, activationTime))
-		dbTask, err := FindOneId(t0.Id)
+
+		tasks, err := FindHostSchedulable(ctx, "d")
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
 		assert.NoError(t, err)
+		dbTask := tasks[0]
 		assert.True(t, dbTask.Activated)
 		assert.Equal(t, caller, dbTask.ActivatedBy)
 		assert.True(t, activationTime.Equal(dbTask.ActivatedTime))


### PR DESCRIPTION
DEVPROD-4195

### Description
Disabled tasks that have been enabled in `activateTasks` do not show up in the schedulable task query since [the priority field is unset](https://github.com/evergreen-ci/evergreen/blob/f5fff80846eebd27f1622a3eadece5eff5025203/model/task/db.go#L700), preventing them from ever getting added to the task queue
### Testing
Confirmed the issue no longer occurs in staging. Added a unit test.
