### PR TITLE
DEVPROD-9475: Update Packages and Toolchains resolvers to return total and filtered counts

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -759,8 +759,8 @@ type ComplexityRoot struct {
 	}
 
 	PackagesPayload struct {
+		Data          func(childComplexity int) int
 		FilteredCount func(childComplexity int) int
-		Packages      func(childComplexity int) int
 		TotalCount    func(childComplexity int) int
 	}
 
@@ -1504,8 +1504,8 @@ type ComplexityRoot struct {
 	}
 
 	ToolchainsPayload struct {
+		Data          func(childComplexity int) int
 		FilteredCount func(childComplexity int) int
-		Toolchains    func(childComplexity int) int
 		TotalCount    func(childComplexity int) int
 	}
 
@@ -5320,19 +5320,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Package.Version(childComplexity), true
 
+	case "PackagesPayload.data":
+		if e.complexity.PackagesPayload.Data == nil {
+			break
+		}
+
+		return e.complexity.PackagesPayload.Data(childComplexity), true
+
 	case "PackagesPayload.filteredCount":
 		if e.complexity.PackagesPayload.FilteredCount == nil {
 			break
 		}
 
 		return e.complexity.PackagesPayload.FilteredCount(childComplexity), true
-
-	case "PackagesPayload.packages":
-		if e.complexity.PackagesPayload.Packages == nil {
-			break
-		}
-
-		return e.complexity.PackagesPayload.Packages(childComplexity), true
 
 	case "PackagesPayload.totalCount":
 		if e.complexity.PackagesPayload.TotalCount == nil {
@@ -9214,19 +9214,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Toolchain.Version(childComplexity), true
 
+	case "ToolchainsPayload.data":
+		if e.complexity.ToolchainsPayload.Data == nil {
+			break
+		}
+
+		return e.complexity.ToolchainsPayload.Data(childComplexity), true
+
 	case "ToolchainsPayload.filteredCount":
 		if e.complexity.ToolchainsPayload.FilteredCount == nil {
 			break
 		}
 
 		return e.complexity.ToolchainsPayload.FilteredCount(childComplexity), true
-
-	case "ToolchainsPayload.toolchains":
-		if e.complexity.ToolchainsPayload.Toolchains == nil {
-			break
-		}
-
-		return e.complexity.ToolchainsPayload.Toolchains(childComplexity), true
 
 	case "ToolchainsPayload.totalCount":
 		if e.complexity.ToolchainsPayload.TotalCount == nil {
@@ -25910,8 +25910,8 @@ func (ec *executionContext) fieldContext_Image_packages(ctx context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "packages":
-				return ec.fieldContext_PackagesPayload_packages(ctx, field)
+			case "data":
+				return ec.fieldContext_PackagesPayload_data(ctx, field)
 			case "filteredCount":
 				return ec.fieldContext_PackagesPayload_filteredCount(ctx, field)
 			case "totalCount":
@@ -25973,8 +25973,8 @@ func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, f
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "toolchains":
-				return ec.fieldContext_ToolchainsPayload_toolchains(ctx, field)
+			case "data":
+				return ec.fieldContext_ToolchainsPayload_data(ctx, field)
 			case "filteredCount":
 				return ec.fieldContext_ToolchainsPayload_filteredCount(ctx, field)
 			case "totalCount":
@@ -35659,8 +35659,8 @@ func (ec *executionContext) fieldContext_Package_version(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _PackagesPayload_packages(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PackagesPayload_packages(ctx, field)
+func (ec *executionContext) _PackagesPayload_data(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackagesPayload_data(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -35673,7 +35673,7 @@ func (ec *executionContext) _PackagesPayload_packages(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Packages, nil
+		return obj.Data, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -35690,7 +35690,7 @@ func (ec *executionContext) _PackagesPayload_packages(ctx context.Context, field
 	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPackageᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_PackagesPayload_packages(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_PackagesPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "PackagesPayload",
 		Field:      field,
@@ -62829,8 +62829,8 @@ func (ec *executionContext) fieldContext_Toolchain_version(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _ToolchainsPayload_toolchains(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ToolchainsPayload_toolchains(ctx, field)
+func (ec *executionContext) _ToolchainsPayload_data(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ToolchainsPayload_data(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -62843,7 +62843,7 @@ func (ec *executionContext) _ToolchainsPayload_toolchains(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Toolchains, nil
+		return obj.Data, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -62860,7 +62860,7 @@ func (ec *executionContext) _ToolchainsPayload_toolchains(ctx context.Context, f
 	return ec.marshalNToolchain2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIToolchainᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ToolchainsPayload_toolchains(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ToolchainsPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ToolchainsPayload",
 		Field:      field,
@@ -81639,8 +81639,8 @@ func (ec *executionContext) _PackagesPayload(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PackagesPayload")
-		case "packages":
-			out.Values[i] = ec._PackagesPayload_packages(ctx, field, obj)
+		case "data":
+			out.Values[i] = ec._PackagesPayload_data(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -89561,8 +89561,8 @@ func (ec *executionContext) _ToolchainsPayload(ctx context.Context, sel ast.Sele
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ToolchainsPayload")
-		case "toolchains":
-			out.Values[i] = ec._ToolchainsPayload_toolchains(ctx, field, obj)
+		case "data":
+			out.Values[i] = ec._ToolchainsPayload_data(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -564,6 +564,18 @@ type ComplexityRoot struct {
 		EventLogEntries func(childComplexity int) int
 	}
 
+	ImagePackagesPayload struct {
+		Data          func(childComplexity int) int
+		FilteredCount func(childComplexity int) int
+		TotalCount    func(childComplexity int) int
+	}
+
+	ImageToolchainsPayload struct {
+		Data          func(childComplexity int) int
+		FilteredCount func(childComplexity int) int
+		TotalCount    func(childComplexity int) int
+	}
+
 	InstanceTag struct {
 		CanBeModified func(childComplexity int) int
 		Key           func(childComplexity int) int
@@ -761,12 +773,6 @@ type ComplexityRoot struct {
 		Manager func(childComplexity int) int
 		Name    func(childComplexity int) int
 		Version func(childComplexity int) int
-	}
-
-	PackagesPayload struct {
-		Data          func(childComplexity int) int
-		FilteredCount func(childComplexity int) int
-		TotalCount    func(childComplexity int) int
 	}
 
 	Parameter struct {
@@ -1508,12 +1514,6 @@ type ComplexityRoot struct {
 		Version func(childComplexity int) int
 	}
 
-	ToolchainsPayload struct {
-		Data          func(childComplexity int) int
-		FilteredCount func(childComplexity int) int
-		TotalCount    func(childComplexity int) int
-	}
-
 	TriggerAlias struct {
 		Alias                        func(childComplexity int) int
 		BuildVariantRegex            func(childComplexity int) int
@@ -1737,8 +1737,8 @@ type ImageResolver interface {
 
 	LatestTask(ctx context.Context, obj *model.APIImage) (*model.APITask, error)
 
-	Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*PackagesPayload, error)
-	Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ToolchainsPayload, error)
+	Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*ImagePackagesPayload, error)
+	Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ImageToolchainsPayload, error)
 }
 type IssueLinkResolver interface {
 	JiraTicket(ctx context.Context, obj *model.APIIssueLink) (*thirdparty.JiraTicket, error)
@@ -4092,6 +4092,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ImageEventsPayload.EventLogEntries(childComplexity), true
 
+	case "ImagePackagesPayload.data":
+		if e.complexity.ImagePackagesPayload.Data == nil {
+			break
+		}
+
+		return e.complexity.ImagePackagesPayload.Data(childComplexity), true
+
+	case "ImagePackagesPayload.filteredCount":
+		if e.complexity.ImagePackagesPayload.FilteredCount == nil {
+			break
+		}
+
+		return e.complexity.ImagePackagesPayload.FilteredCount(childComplexity), true
+
+	case "ImagePackagesPayload.totalCount":
+		if e.complexity.ImagePackagesPayload.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ImagePackagesPayload.TotalCount(childComplexity), true
+
+	case "ImageToolchainsPayload.data":
+		if e.complexity.ImageToolchainsPayload.Data == nil {
+			break
+		}
+
+		return e.complexity.ImageToolchainsPayload.Data(childComplexity), true
+
+	case "ImageToolchainsPayload.filteredCount":
+		if e.complexity.ImageToolchainsPayload.FilteredCount == nil {
+			break
+		}
+
+		return e.complexity.ImageToolchainsPayload.FilteredCount(childComplexity), true
+
+	case "ImageToolchainsPayload.totalCount":
+		if e.complexity.ImageToolchainsPayload.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ImageToolchainsPayload.TotalCount(childComplexity), true
+
 	case "InstanceTag.canBeModified":
 		if e.complexity.InstanceTag.CanBeModified == nil {
 			break
@@ -5338,27 +5380,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Package.Version(childComplexity), true
-
-	case "PackagesPayload.data":
-		if e.complexity.PackagesPayload.Data == nil {
-			break
-		}
-
-		return e.complexity.PackagesPayload.Data(childComplexity), true
-
-	case "PackagesPayload.filteredCount":
-		if e.complexity.PackagesPayload.FilteredCount == nil {
-			break
-		}
-
-		return e.complexity.PackagesPayload.FilteredCount(childComplexity), true
-
-	case "PackagesPayload.totalCount":
-		if e.complexity.PackagesPayload.TotalCount == nil {
-			break
-		}
-
-		return e.complexity.PackagesPayload.TotalCount(childComplexity), true
 
 	case "Parameter.key":
 		if e.complexity.Parameter.Key == nil {
@@ -9232,27 +9253,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Toolchain.Version(childComplexity), true
-
-	case "ToolchainsPayload.data":
-		if e.complexity.ToolchainsPayload.Data == nil {
-			break
-		}
-
-		return e.complexity.ToolchainsPayload.Data(childComplexity), true
-
-	case "ToolchainsPayload.filteredCount":
-		if e.complexity.ToolchainsPayload.FilteredCount == nil {
-			break
-		}
-
-		return e.complexity.ToolchainsPayload.FilteredCount(childComplexity), true
-
-	case "ToolchainsPayload.totalCount":
-		if e.complexity.ToolchainsPayload.TotalCount == nil {
-			break
-		}
-
-		return e.complexity.ToolchainsPayload.TotalCount(childComplexity), true
 
 	case "TriggerAlias.alias":
 		if e.complexity.TriggerAlias.Alias == nil {
@@ -25912,9 +25912,9 @@ func (ec *executionContext) _Image_packages(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*PackagesPayload)
+	res := resTmp.(*ImagePackagesPayload)
 	fc.Result = res
-	return ec.marshalNPackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx, field.Selections, res)
+	return ec.marshalNImagePackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImagePackagesPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_packages(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25926,13 +25926,13 @@ func (ec *executionContext) fieldContext_Image_packages(ctx context.Context, fie
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "data":
-				return ec.fieldContext_PackagesPayload_data(ctx, field)
+				return ec.fieldContext_ImagePackagesPayload_data(ctx, field)
 			case "filteredCount":
-				return ec.fieldContext_PackagesPayload_filteredCount(ctx, field)
+				return ec.fieldContext_ImagePackagesPayload_filteredCount(ctx, field)
 			case "totalCount":
-				return ec.fieldContext_PackagesPayload_totalCount(ctx, field)
+				return ec.fieldContext_ImagePackagesPayload_totalCount(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type PackagesPayload", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type ImagePackagesPayload", field.Name)
 		},
 	}
 	defer func() {
@@ -25975,9 +25975,9 @@ func (ec *executionContext) _Image_toolchains(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*ToolchainsPayload)
+	res := resTmp.(*ImageToolchainsPayload)
 	fc.Result = res
-	return ec.marshalNToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx, field.Selections, res)
+	return ec.marshalNImageToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImageToolchainsPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25989,13 +25989,13 @@ func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, f
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "data":
-				return ec.fieldContext_ToolchainsPayload_data(ctx, field)
+				return ec.fieldContext_ImageToolchainsPayload_data(ctx, field)
 			case "filteredCount":
-				return ec.fieldContext_ToolchainsPayload_filteredCount(ctx, field)
+				return ec.fieldContext_ImageToolchainsPayload_filteredCount(ctx, field)
 			case "totalCount":
-				return ec.fieldContext_ToolchainsPayload_totalCount(ctx, field)
+				return ec.fieldContext_ImageToolchainsPayload_totalCount(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type ToolchainsPayload", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type ImageToolchainsPayload", field.Name)
 		},
 	}
 	defer func() {
@@ -26554,6 +26554,286 @@ func (ec *executionContext) fieldContext_ImageEventsPayload_eventLogEntries(_ co
 				return ec.fieldContext_ImageEvent_amiAfter(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageEvent", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImagePackagesPayload_data(ctx context.Context, field graphql.CollectedField, obj *ImagePackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImagePackagesPayload_data(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Data, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIPackage)
+	fc.Result = res
+	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPackageᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImagePackagesPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImagePackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_Package_name(ctx, field)
+			case "manager":
+				return ec.fieldContext_Package_manager(ctx, field)
+			case "version":
+				return ec.fieldContext_Package_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImagePackagesPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *ImagePackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImagePackagesPayload_filteredCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilteredCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImagePackagesPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImagePackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImagePackagesPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *ImagePackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImagePackagesPayload_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImagePackagesPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImagePackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImageToolchainsPayload_data(ctx context.Context, field graphql.CollectedField, obj *ImageToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImageToolchainsPayload_data(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Data, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIToolchain)
+	fc.Result = res
+	return ec.marshalNToolchain2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIToolchainᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImageToolchainsPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImageToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_Toolchain_name(ctx, field)
+			case "path":
+				return ec.fieldContext_Toolchain_path(ctx, field)
+			case "version":
+				return ec.fieldContext_Toolchain_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Toolchain", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImageToolchainsPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *ImageToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImageToolchainsPayload_filteredCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilteredCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImageToolchainsPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImageToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ImageToolchainsPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *ImageToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImageToolchainsPayload_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImageToolchainsPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImageToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -35767,146 +36047,6 @@ func (ec *executionContext) fieldContext_Package_version(_ context.Context, fiel
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PackagesPayload_data(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PackagesPayload_data(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Data, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.APIPackage)
-	fc.Result = res
-	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPackageᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PackagesPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PackagesPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "name":
-				return ec.fieldContext_Package_name(ctx, field)
-			case "manager":
-				return ec.fieldContext_Package_manager(ctx, field)
-			case "version":
-				return ec.fieldContext_Package_version(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PackagesPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PackagesPayload_filteredCount(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.FilteredCount, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PackagesPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PackagesPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PackagesPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PackagesPayload_totalCount(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TotalCount, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PackagesPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PackagesPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -62942,146 +63082,6 @@ func (ec *executionContext) fieldContext_Toolchain_version(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _ToolchainsPayload_data(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ToolchainsPayload_data(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Data, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.APIToolchain)
-	fc.Result = res
-	return ec.marshalNToolchain2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIToolchainᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ToolchainsPayload_data(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ToolchainsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "name":
-				return ec.fieldContext_Toolchain_name(ctx, field)
-			case "path":
-				return ec.fieldContext_Toolchain_path(ctx, field)
-			case "version":
-				return ec.fieldContext_Toolchain_version(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Toolchain", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ToolchainsPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ToolchainsPayload_filteredCount(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.FilteredCount, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ToolchainsPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ToolchainsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ToolchainsPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ToolchainsPayload_totalCount(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TotalCount, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ToolchainsPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ToolchainsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _TriggerAlias_alias(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TriggerAlias_alias(ctx, field)
 	if err != nil {
@@ -80327,6 +80327,104 @@ func (ec *executionContext) _ImageEventsPayload(ctx context.Context, sel ast.Sel
 	return out
 }
 
+var imagePackagesPayloadImplementors = []string{"ImagePackagesPayload"}
+
+func (ec *executionContext) _ImagePackagesPayload(ctx context.Context, sel ast.SelectionSet, obj *ImagePackagesPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, imagePackagesPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ImagePackagesPayload")
+		case "data":
+			out.Values[i] = ec._ImagePackagesPayload_data(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "filteredCount":
+			out.Values[i] = ec._ImagePackagesPayload_filteredCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCount":
+			out.Values[i] = ec._ImagePackagesPayload_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var imageToolchainsPayloadImplementors = []string{"ImageToolchainsPayload"}
+
+func (ec *executionContext) _ImageToolchainsPayload(ctx context.Context, sel ast.SelectionSet, obj *ImageToolchainsPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, imageToolchainsPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ImageToolchainsPayload")
+		case "data":
+			out.Values[i] = ec._ImageToolchainsPayload_data(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "filteredCount":
+			out.Values[i] = ec._ImageToolchainsPayload_filteredCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCount":
+			out.Values[i] = ec._ImageToolchainsPayload_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var instanceTagImplementors = []string{"InstanceTag"}
 
 func (ec *executionContext) _InstanceTag(ctx context.Context, sel ast.SelectionSet, obj *host.Tag) graphql.Marshaler {
@@ -81759,55 +81857,6 @@ func (ec *executionContext) _Package(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "version":
 			out.Values[i] = ec._Package_version(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
-var packagesPayloadImplementors = []string{"PackagesPayload"}
-
-func (ec *executionContext) _PackagesPayload(ctx context.Context, sel ast.SelectionSet, obj *PackagesPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, packagesPayloadImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PackagesPayload")
-		case "data":
-			out.Values[i] = ec._PackagesPayload_data(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "filteredCount":
-			out.Values[i] = ec._PackagesPayload_filteredCount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "totalCount":
-			out.Values[i] = ec._PackagesPayload_totalCount(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -89707,55 +89756,6 @@ func (ec *executionContext) _Toolchain(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
-var toolchainsPayloadImplementors = []string{"ToolchainsPayload"}
-
-func (ec *executionContext) _ToolchainsPayload(ctx context.Context, sel ast.SelectionSet, obj *ToolchainsPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, toolchainsPayloadImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("ToolchainsPayload")
-		case "data":
-			out.Values[i] = ec._ToolchainsPayload_data(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "filteredCount":
-			out.Values[i] = ec._ToolchainsPayload_filteredCount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "totalCount":
-			out.Values[i] = ec._ToolchainsPayload_totalCount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
 var triggerAliasImplementors = []string{"TriggerAlias"}
 
 func (ec *executionContext) _TriggerAlias(ctx context.Context, sel ast.SelectionSet, obj *model.APITriggerDefinition) graphql.Marshaler {
@@ -93385,6 +93385,34 @@ func (ec *executionContext) marshalNImageEventsPayload2ᚖgithubᚗcomᚋevergre
 	return ec._ImageEventsPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNImagePackagesPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImagePackagesPayload(ctx context.Context, sel ast.SelectionSet, v ImagePackagesPayload) graphql.Marshaler {
+	return ec._ImagePackagesPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNImagePackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImagePackagesPayload(ctx context.Context, sel ast.SelectionSet, v *ImagePackagesPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ImagePackagesPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNImageToolchainsPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImageToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v ImageToolchainsPayload) graphql.Marshaler {
+	return ec._ImageToolchainsPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNImageToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐImageToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v *ImageToolchainsPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ImageToolchainsPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNInstanceTag2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋhostᚐTag(ctx context.Context, sel ast.SelectionSet, v host.Tag) graphql.Marshaler {
 	return ec._InstanceTag(ctx, sel, &v)
 }
@@ -94064,20 +94092,6 @@ func (ec *executionContext) marshalNPackage2ᚖgithubᚗcomᚋevergreenᚑciᚋe
 func (ec *executionContext) unmarshalNPackageOpts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐPackageFilterOptions(ctx context.Context, v interface{}) (thirdparty.PackageFilterOptions, error) {
 	res, err := ec.unmarshalInputPackageOpts(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNPackagesPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx context.Context, sel ast.SelectionSet, v PackagesPayload) graphql.Marshaler {
-	return ec._PackagesPayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNPackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx context.Context, sel ast.SelectionSet, v *PackagesPayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._PackagesPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNParameter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameter(ctx context.Context, sel ast.SelectionSet, v model.APIParameter) graphql.Marshaler {
@@ -95933,20 +95947,6 @@ func (ec *executionContext) marshalNToolchain2ᚖgithubᚗcomᚋevergreenᚑci�
 func (ec *executionContext) unmarshalNToolchainOpts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐToolchainFilterOptions(ctx context.Context, v interface{}) (thirdparty.ToolchainFilterOptions, error) {
 	res, err := ec.unmarshalInputToolchainOpts(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNToolchainsPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v ToolchainsPayload) graphql.Marshaler {
-	return ec._ToolchainsPayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v *ToolchainsPayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._ToolchainsPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNTriggerAlias2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITriggerDefinition(ctx context.Context, sel ast.SelectionSet, v model.APITriggerDefinition) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -758,6 +758,12 @@ type ComplexityRoot struct {
 		Version func(childComplexity int) int
 	}
 
+	PackagesPayload struct {
+		FilteredCount func(childComplexity int) int
+		Packages      func(childComplexity int) int
+		TotalCount    func(childComplexity int) int
+	}
+
 	Parameter struct {
 		Key   func(childComplexity int) int
 		Value func(childComplexity int) int
@@ -1497,6 +1503,12 @@ type ComplexityRoot struct {
 		Version func(childComplexity int) int
 	}
 
+	ToolchainsPayload struct {
+		FilteredCount func(childComplexity int) int
+		Toolchains    func(childComplexity int) int
+		TotalCount    func(childComplexity int) int
+	}
+
 	TriggerAlias struct {
 		Alias                        func(childComplexity int) int
 		BuildVariantRegex            func(childComplexity int) int
@@ -1720,8 +1732,8 @@ type ImageResolver interface {
 
 	LatestTask(ctx context.Context, obj *model.APIImage) (*model.APITask, error)
 
-	Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) ([]*model.APIPackage, error)
-	Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) ([]*model.APIToolchain, error)
+	Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*PackagesPayload, error)
+	Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ToolchainsPayload, error)
 }
 type IssueLinkResolver interface {
 	JiraTicket(ctx context.Context, obj *model.APIIssueLink) (*thirdparty.JiraTicket, error)
@@ -5307,6 +5319,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Package.Version(childComplexity), true
+
+	case "PackagesPayload.filteredCount":
+		if e.complexity.PackagesPayload.FilteredCount == nil {
+			break
+		}
+
+		return e.complexity.PackagesPayload.FilteredCount(childComplexity), true
+
+	case "PackagesPayload.packages":
+		if e.complexity.PackagesPayload.Packages == nil {
+			break
+		}
+
+		return e.complexity.PackagesPayload.Packages(childComplexity), true
+
+	case "PackagesPayload.totalCount":
+		if e.complexity.PackagesPayload.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.PackagesPayload.TotalCount(childComplexity), true
 
 	case "Parameter.key":
 		if e.complexity.Parameter.Key == nil {
@@ -9180,6 +9213,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Toolchain.Version(childComplexity), true
+
+	case "ToolchainsPayload.filteredCount":
+		if e.complexity.ToolchainsPayload.FilteredCount == nil {
+			break
+		}
+
+		return e.complexity.ToolchainsPayload.FilteredCount(childComplexity), true
+
+	case "ToolchainsPayload.toolchains":
+		if e.complexity.ToolchainsPayload.Toolchains == nil {
+			break
+		}
+
+		return e.complexity.ToolchainsPayload.Toolchains(childComplexity), true
+
+	case "ToolchainsPayload.totalCount":
+		if e.complexity.ToolchainsPayload.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.ToolchainsPayload.TotalCount(childComplexity), true
 
 	case "TriggerAlias.alias":
 		if e.complexity.TriggerAlias.Alias == nil {
@@ -25843,9 +25897,9 @@ func (ec *executionContext) _Image_packages(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.APIPackage)
+	res := resTmp.(*PackagesPayload)
 	fc.Result = res
-	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPackageᚄ(ctx, field.Selections, res)
+	return ec.marshalNPackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_packages(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25856,14 +25910,14 @@ func (ec *executionContext) fieldContext_Image_packages(ctx context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "name":
-				return ec.fieldContext_Package_name(ctx, field)
-			case "manager":
-				return ec.fieldContext_Package_manager(ctx, field)
-			case "version":
-				return ec.fieldContext_Package_version(ctx, field)
+			case "packages":
+				return ec.fieldContext_PackagesPayload_packages(ctx, field)
+			case "filteredCount":
+				return ec.fieldContext_PackagesPayload_filteredCount(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_PackagesPayload_totalCount(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type PackagesPayload", field.Name)
 		},
 	}
 	defer func() {
@@ -25906,9 +25960,9 @@ func (ec *executionContext) _Image_toolchains(ctx context.Context, field graphql
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.APIToolchain)
+	res := resTmp.(*ToolchainsPayload)
 	fc.Result = res
-	return ec.marshalNToolchain2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIToolchainᚄ(ctx, field.Selections, res)
+	return ec.marshalNToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -25919,14 +25973,14 @@ func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, f
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "name":
-				return ec.fieldContext_Toolchain_name(ctx, field)
-			case "path":
-				return ec.fieldContext_Toolchain_path(ctx, field)
-			case "version":
-				return ec.fieldContext_Toolchain_version(ctx, field)
+			case "toolchains":
+				return ec.fieldContext_ToolchainsPayload_toolchains(ctx, field)
+			case "filteredCount":
+				return ec.fieldContext_ToolchainsPayload_filteredCount(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_ToolchainsPayload_totalCount(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Toolchain", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type ToolchainsPayload", field.Name)
 		},
 	}
 	defer func() {
@@ -35600,6 +35654,146 @@ func (ec *executionContext) fieldContext_Package_version(_ context.Context, fiel
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackagesPayload_packages(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackagesPayload_packages(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Packages, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIPackage)
+	fc.Result = res
+	return ec.marshalNPackage2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIPackageᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackagesPayload_packages(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_Package_name(ctx, field)
+			case "manager":
+				return ec.fieldContext_Package_manager(ctx, field)
+			case "version":
+				return ec.fieldContext_Package_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Package", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackagesPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackagesPayload_filteredCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilteredCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackagesPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackagesPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *PackagesPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackagesPayload_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackagesPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackagesPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -62635,6 +62829,146 @@ func (ec *executionContext) fieldContext_Toolchain_version(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _ToolchainsPayload_toolchains(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ToolchainsPayload_toolchains(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Toolchains, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIToolchain)
+	fc.Result = res
+	return ec.marshalNToolchain2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIToolchainᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ToolchainsPayload_toolchains(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_Toolchain_name(ctx, field)
+			case "path":
+				return ec.fieldContext_Toolchain_path(ctx, field)
+			case "version":
+				return ec.fieldContext_Toolchain_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Toolchain", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolchainsPayload_filteredCount(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ToolchainsPayload_filteredCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilteredCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ToolchainsPayload_filteredCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ToolchainsPayload_totalCount(ctx context.Context, field graphql.CollectedField, obj *ToolchainsPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ToolchainsPayload_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ToolchainsPayload_totalCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ToolchainsPayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TriggerAlias_alias(ctx context.Context, field graphql.CollectedField, obj *model.APITriggerDefinition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TriggerAlias_alias(ctx, field)
 	if err != nil {
@@ -81294,6 +81628,55 @@ func (ec *executionContext) _Package(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var packagesPayloadImplementors = []string{"PackagesPayload"}
+
+func (ec *executionContext) _PackagesPayload(ctx context.Context, sel ast.SelectionSet, obj *PackagesPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, packagesPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("PackagesPayload")
+		case "packages":
+			out.Values[i] = ec._PackagesPayload_packages(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "filteredCount":
+			out.Values[i] = ec._PackagesPayload_filteredCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCount":
+			out.Values[i] = ec._PackagesPayload_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var parameterImplementors = []string{"Parameter"}
 
 func (ec *executionContext) _Parameter(ctx context.Context, sel ast.SelectionSet, obj *model.APIParameter) graphql.Marshaler {
@@ -89167,6 +89550,55 @@ func (ec *executionContext) _Toolchain(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
+var toolchainsPayloadImplementors = []string{"ToolchainsPayload"}
+
+func (ec *executionContext) _ToolchainsPayload(ctx context.Context, sel ast.SelectionSet, obj *ToolchainsPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, toolchainsPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ToolchainsPayload")
+		case "toolchains":
+			out.Values[i] = ec._ToolchainsPayload_toolchains(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "filteredCount":
+			out.Values[i] = ec._ToolchainsPayload_filteredCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "totalCount":
+			out.Values[i] = ec._ToolchainsPayload_totalCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var triggerAliasImplementors = []string{"TriggerAlias"}
 
 func (ec *executionContext) _TriggerAlias(ctx context.Context, sel ast.SelectionSet, obj *model.APITriggerDefinition) graphql.Marshaler {
@@ -93463,6 +93895,20 @@ func (ec *executionContext) unmarshalNPackageOpts2githubᚗcomᚋevergreenᚑci�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNPackagesPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx context.Context, sel ast.SelectionSet, v PackagesPayload) graphql.Marshaler {
+	return ec._PackagesPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPackagesPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPackagesPayload(ctx context.Context, sel ast.SelectionSet, v *PackagesPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PackagesPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNParameter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameter(ctx context.Context, sel ast.SelectionSet, v model.APIParameter) graphql.Marshaler {
 	return ec._Parameter(ctx, sel, &v)
 }
@@ -95316,6 +95762,20 @@ func (ec *executionContext) marshalNToolchain2ᚖgithubᚗcomᚋevergreenᚑci�
 func (ec *executionContext) unmarshalNToolchainOpts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐToolchainFilterOptions(ctx context.Context, v interface{}) (thirdparty.ToolchainFilterOptions, error) {
 	res, err := ec.unmarshalInputToolchainOpts(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNToolchainsPayload2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v ToolchainsPayload) graphql.Marshaler {
+	return ec._ToolchainsPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNToolchainsPayload2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐToolchainsPayload(ctx context.Context, sel ast.SelectionSet, v *ToolchainsPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ToolchainsPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNTriggerAlias2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITriggerDefinition(ctx context.Context, sel ast.SelectionSet, v model.APITriggerDefinition) graphql.Marshaler {

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -78,20 +78,20 @@ func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts 
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
-	data, err := c.GetPackages(ctx, opts)
+	res, err := c.GetPackages(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting packages for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiPackages := []*model.APIPackage{}
-	for _, pkg := range data.Packages {
+	for _, pkg := range res.Data {
 		apiPackage := model.APIPackage{}
 		apiPackage.BuildFromService(pkg)
 		apiPackages = append(apiPackages, &apiPackage)
 	}
 	return &PackagesPayload{
-		Packages:      apiPackages,
-		FilteredCount: data.FilteredCount,
-		TotalCount:    data.TotalCount,
+		Data:          apiPackages,
+		FilteredCount: res.FilteredCount,
+		TotalCount:    res.TotalCount,
 	}, nil
 }
 
@@ -103,20 +103,20 @@ func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opt
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
-	data, err := c.GetToolchains(ctx, opts)
+	res, err := c.GetToolchains(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting toolchains for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiToolchains := []*model.APIToolchain{}
-	for _, toolchain := range data.Toolchains {
+	for _, toolchain := range res.Data {
 		apiToolchain := model.APIToolchain{}
 		apiToolchain.BuildFromService(toolchain)
 		apiToolchains = append(apiToolchains, &apiToolchain)
 	}
 	return &ToolchainsPayload{
-		Toolchains:    apiToolchains,
-		FilteredCount: data.FilteredCount,
-		TotalCount:    data.TotalCount,
+		Data:          apiToolchains,
+		FilteredCount: res.FilteredCount,
+		TotalCount:    res.TotalCount,
 	}, nil
 }
 

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -83,7 +83,7 @@ func (r *imageResolver) LatestTask(ctx context.Context, obj *model.APIImage) (*m
 }
 
 // Packages is the resolver for the packages field.
-func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*PackagesPayload, error) {
+func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*ImagePackagesPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
@@ -100,7 +100,7 @@ func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts 
 		apiPackage.BuildFromService(pkg)
 		apiPackages = append(apiPackages, &apiPackage)
 	}
-	return &PackagesPayload{
+	return &ImagePackagesPayload{
 		Data:          apiPackages,
 		FilteredCount: res.FilteredCount,
 		TotalCount:    res.TotalCount,
@@ -108,7 +108,7 @@ func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts 
 }
 
 // Toolchains is the resolver for the toolchains field.
-func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ToolchainsPayload, error) {
+func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ImageToolchainsPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
@@ -125,7 +125,7 @@ func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opt
 		apiToolchain.BuildFromService(toolchain)
 		apiToolchains = append(apiToolchains, &apiToolchain)
 	}
-	return &ToolchainsPayload{
+	return &ImageToolchainsPayload{
 		Data:          apiToolchains,
 		FilteredCount: res.FilteredCount,
 		TotalCount:    res.TotalCount,

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -71,45 +71,53 @@ func (r *imageResolver) LatestTask(ctx context.Context, obj *model.APIImage) (*m
 }
 
 // Packages is the resolver for the packages field.
-func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) ([]*model.APIPackage, error) {
+func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*PackagesPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
-	packages, err := c.GetPackages(ctx, opts)
+	data, err := c.GetPackages(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting packages for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiPackages := []*model.APIPackage{}
-	for _, pkg := range packages {
+	for _, pkg := range data.Packages {
 		apiPackage := model.APIPackage{}
 		apiPackage.BuildFromService(pkg)
 		apiPackages = append(apiPackages, &apiPackage)
 	}
-	return apiPackages, nil
+	return &PackagesPayload{
+		Packages:      apiPackages,
+		FilteredCount: data.FilteredCount,
+		TotalCount:    data.TotalCount,
+	}, nil
 }
 
 // Toolchains is the resolver for the toolchains field.
-func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) ([]*model.APIToolchain, error) {
+func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ToolchainsPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
-	toolchains, err := c.GetToolchains(ctx, opts)
+	data, err := c.GetToolchains(ctx, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting toolchains for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiToolchains := []*model.APIToolchain{}
-	for _, toolchain := range toolchains {
+	for _, toolchain := range data.Toolchains {
 		apiToolchain := model.APIToolchain{}
 		apiToolchain.BuildFromService(toolchain)
 		apiToolchains = append(apiToolchains, &apiToolchain)
 	}
-	return apiToolchains, nil
+	return &ToolchainsPayload{
+		Toolchains:    apiToolchains,
+		FilteredCount: data.FilteredCount,
+		TotalCount:    data.TotalCount,
+	}, nil
 }
 
 // Image returns ImageResolver implementation.

--- a/graphql/image_test.go
+++ b/graphql/image_test.go
@@ -35,9 +35,9 @@ func TestPackages(t *testing.T) {
 	}
 	res, err := config.Resolvers.Image().Packages(ctx, &image, opts)
 	require.NoError(t, err)
-	require.Len(t, res.Packages, 1)
-	require.NotNil(t, res.Packages[0])
-	assert.Equal(t, utility.FromStringPtr(res.Packages[0].Name), "python3-automat")
+	require.Len(t, res.Data, 1)
+	require.NotNil(t, res.Data[0])
+	assert.Equal(t, utility.FromStringPtr(res.Data[0].Name), "python3-automat")
 	assert.Equal(t, res.FilteredCount, 1)
 	assert.Equal(t, res.TotalCount, 1618)
 }
@@ -59,9 +59,9 @@ func TestToolchains(t *testing.T) {
 	}
 	res, err := config.Resolvers.Image().Toolchains(ctx, &image, opts)
 	require.NoError(t, err)
-	require.Len(t, res.Toolchains, 1)
-	require.NotNil(t, res.Toolchains[0])
-	assert.Equal(t, utility.FromStringPtr(res.Toolchains[0].Name), "golang")
+	require.Len(t, res.Data, 1)
+	require.NotNil(t, res.Data[0])
+	assert.Equal(t, utility.FromStringPtr(res.Data[0].Name), "golang")
 	assert.Equal(t, res.FilteredCount, 33)
 	assert.Equal(t, res.TotalCount, 49)
 }

--- a/graphql/image_test.go
+++ b/graphql/image_test.go
@@ -25,22 +25,21 @@ func TestPackages(t *testing.T) {
 	testConfig := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestPackages")
 	require.NoError(t, testConfig.RuntimeEnvironments.Set(ctx))
-	manager := "pip"
-	testPackage := "Automat"
 	ami := "ami-0f6b89500372d4a06"
 	image := model.APIImage{
 		AMI: &ami,
 	}
 	opts := thirdparty.PackageFilterOptions{
-		AMI:     ami,
-		Manager: manager,
-		Name:    testPackage,
+		AMI:  ami,
+		Name: "python3-automat",
 	}
 	res, err := config.Resolvers.Image().Packages(ctx, &image, opts)
 	require.NoError(t, err)
-	require.Len(t, res, 1)
-	require.NotNil(t, res[0])
-	assert.Equal(t, testPackage, utility.FromStringPtr(res[0].Name))
+	require.Len(t, res.Packages, 1)
+	require.NotNil(t, res.Packages[0])
+	assert.Equal(t, utility.FromStringPtr(res.Packages[0].Name), "python3-automat")
+	assert.Equal(t, res.FilteredCount, 1)
+	assert.Equal(t, res.TotalCount, 1618)
 }
 
 func TestToolchains(t *testing.T) {
@@ -49,20 +48,22 @@ func TestToolchains(t *testing.T) {
 	testConfig := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, testConfig, "TestToolchains")
 	require.NoError(t, testConfig.RuntimeEnvironments.Set(ctx))
-	testToolchain := "golang"
 	ami := "ami-0f6b89500372d4a06"
 	image := model.APIImage{
 		AMI: &ami,
 	}
 	opts := thirdparty.ToolchainFilterOptions{
 		AMI:   ami,
-		Limit: 5,
+		Name:  "golang",
+		Limit: 1,
 	}
 	res, err := config.Resolvers.Image().Toolchains(ctx, &image, opts)
 	require.NoError(t, err)
-	require.Len(t, res, 5)
-	require.NotNil(t, res[0])
-	assert.Equal(t, testToolchain, utility.FromStringPtr(res[0].Name))
+	require.Len(t, res.Toolchains, 1)
+	require.NotNil(t, res.Toolchains[0])
+	assert.Equal(t, utility.FromStringPtr(res.Toolchains[0].Name), "golang")
+	assert.Equal(t, res.FilteredCount, 33)
+	assert.Equal(t, res.TotalCount, 49)
 }
 
 func TestEvents(t *testing.T) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -234,6 +234,12 @@ type NewDistroPayload struct {
 	NewDistroID string `json:"newDistroId"`
 }
 
+type PackagesPayload struct {
+	Packages      []*model.APIPackage `json:"packages"`
+	FilteredCount int                 `json:"filteredCount"`
+	TotalCount    int                 `json:"totalCount"`
+}
+
 // PatchConfigure is the input to the schedulePatch mutation.
 // It contains information about how a user has configured their patch (e.g. name, tasks to run, etc).
 type PatchConfigure struct {
@@ -491,6 +497,12 @@ type TestFilterOptions struct {
 type TestSortOptions struct {
 	SortBy    TestSortCategory `json:"sortBy"`
 	Direction SortDirection    `json:"direction"`
+}
+
+type ToolchainsPayload struct {
+	Toolchains    []*model.APIToolchain `json:"toolchains"`
+	FilteredCount int                   `json:"filteredCount"`
+	TotalCount    int                   `json:"totalCount"`
 }
 
 type UpdateParsleySettingsInput struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -189,6 +189,18 @@ type ImageEventsPayload struct {
 	EventLogEntries []*model.APIImageEvent `json:"eventLogEntries"`
 }
 
+type ImagePackagesPayload struct {
+	Data          []*model.APIPackage `json:"data"`
+	FilteredCount int                 `json:"filteredCount"`
+	TotalCount    int                 `json:"totalCount"`
+}
+
+type ImageToolchainsPayload struct {
+	Data          []*model.APIToolchain `json:"data"`
+	FilteredCount int                   `json:"filteredCount"`
+	TotalCount    int                   `json:"totalCount"`
+}
+
 type MainlineCommitVersion struct {
 	RolledUpVersions []*model.APIVersion `json:"rolledUpVersions,omitempty"`
 	Version          *model.APIVersion   `json:"version,omitempty"`
@@ -237,12 +249,6 @@ type Mutation struct {
 // Return type representing whether a distro was created and any validation errors
 type NewDistroPayload struct {
 	NewDistroID string `json:"newDistroId"`
-}
-
-type PackagesPayload struct {
-	Data          []*model.APIPackage `json:"data"`
-	FilteredCount int                 `json:"filteredCount"`
-	TotalCount    int                 `json:"totalCount"`
 }
 
 // PatchConfigure is the input to the schedulePatch mutation.
@@ -502,12 +508,6 @@ type TestFilterOptions struct {
 type TestSortOptions struct {
 	SortBy    TestSortCategory `json:"sortBy"`
 	Direction SortDirection    `json:"direction"`
-}
-
-type ToolchainsPayload struct {
-	Data          []*model.APIToolchain `json:"data"`
-	FilteredCount int                   `json:"filteredCount"`
-	TotalCount    int                   `json:"totalCount"`
 }
 
 type UpdateParsleySettingsInput struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -235,7 +235,7 @@ type NewDistroPayload struct {
 }
 
 type PackagesPayload struct {
-	Packages      []*model.APIPackage `json:"packages"`
+	Data          []*model.APIPackage `json:"data"`
 	FilteredCount int                 `json:"filteredCount"`
 	TotalCount    int                 `json:"totalCount"`
 }
@@ -500,7 +500,7 @@ type TestSortOptions struct {
 }
 
 type ToolchainsPayload struct {
-	Toolchains    []*model.APIToolchain `json:"toolchains"`
+	Data          []*model.APIToolchain `json:"data"`
 	FilteredCount int                   `json:"filteredCount"`
 	TotalCount    int                   `json:"totalCount"`
 }

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -38,12 +38,12 @@ type Image {
   lastDeployed: Time!
   latestTask: Task
   name: String!
-  packages(opts: PackageOpts!): PackagesPayload!
-  toolchains(opts: ToolchainOpts!): ToolchainsPayload!
+  packages(opts: PackageOpts!): ImagePackagesPayload!
+  toolchains(opts: ToolchainOpts!): ImageToolchainsPayload!
   versionId: String!
 }
 
-type PackagesPayload {
+type ImagePackagesPayload {
   data: [Package!]!
   filteredCount: Int!
   totalCount: Int!
@@ -55,7 +55,7 @@ type Package {
   version: String!
 }
 
-type ToolchainsPayload {
+type ImageToolchainsPayload {
   data: [Toolchain!]!
   filteredCount: Int!
   totalCount: Int!

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -24,7 +24,6 @@ input ToolchainOpts {
   page: Int
 }
 
-
 ###### TYPES ######
 """
 Image is returned by the image query.
@@ -39,15 +38,27 @@ type Image {
   lastDeployed: Time!
   latestTask: Task
   name: String!
-  packages(opts: PackageOpts!): [Package!]!
-  toolchains(opts: ToolchainOpts!): [Toolchain!]!
+  packages(opts: PackageOpts!): PackagesPayload!
+  toolchains(opts: ToolchainOpts!): ToolchainsPayload!
   versionId: String!
+}
+
+type PackagesPayload {
+  packages: [Package!]!
+  filteredCount: Int!
+  totalCount: Int!
 }
 
 type Package {
   name: String!
   manager: String!
   version: String!
+}
+
+type ToolchainsPayload {
+  toolchains: [Toolchain!]!
+  filteredCount: Int!
+  totalCount: Int!
 }
 
 type Toolchain {

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -44,7 +44,7 @@ type Image {
 }
 
 type PackagesPayload {
-  packages: [Package!]!
+  data: [Package!]!
   filteredCount: Int!
   totalCount: Int!
 }
@@ -56,7 +56,7 @@ type Package {
 }
 
 type ToolchainsPayload {
-  toolchains: [Toolchain!]!
+  data: [Toolchain!]!
   filteredCount: Int!
   totalCount: Int!
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -89,7 +89,7 @@ func (c *RuntimeEnvironmentsClient) GetImageNames(ctx context.Context) ([]string
 
 // APIPackageResponse represents a response from the /rest/api/v1/ami/packages route.
 type APIPackageResponse struct {
-	Packages      []Package `json:"data"`
+	Data          []Package `json:"data"`
 	FilteredCount int       `json:"filtered_count"`
 	TotalCount    int       `json:"total_count"`
 }
@@ -247,7 +247,7 @@ func (c *RuntimeEnvironmentsClient) getImageDiff(ctx context.Context, opts Image
 
 // APIPackageResponse represents a response from the /rest/api/v1/ami/toolchains route.
 type APIToolchainResponse struct {
-	Toolchains    []Toolchain `json:"data"`
+	Data          []Toolchain `json:"data"`
 	FilteredCount int         `json:"filtered_count"`
 	TotalCount    int         `json:"total_count"`
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -245,7 +245,7 @@ func (c *RuntimeEnvironmentsClient) getImageDiff(ctx context.Context, opts Image
 	return filteredChanges, nil
 }
 
-// APIPackageResponse represents a response from the /rest/api/v1/ami/toolchains route.
+// APIToolchainResponse represents a response from the /rest/api/v1/ami/toolchains route.
 type APIToolchainResponse struct {
 	Data          []Toolchain `json:"data"`
 	FilteredCount int         `json:"filtered_count"`

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -83,7 +83,7 @@ func TestGetPackages(t *testing.T) {
 	result, err := c.GetPackages(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Len(t, result.Packages, 10)
+	require.Len(t, result.Data, 10)
 	assert.Equal(result.FilteredCount, 1538)
 	assert.Equal(result.TotalCount, 1538)
 
@@ -97,8 +97,8 @@ func TestGetPackages(t *testing.T) {
 	result, err = c.GetPackages(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Len(t, result.Packages, 1)
-	assert.Equal(result.Packages[0].Name, "Automat")
+	require.Len(t, result.Data, 1)
+	assert.Equal(result.Data[0].Name, "Automat")
 	assert.Equal(result.FilteredCount, 1)
 	assert.Equal(result.TotalCount, 1538)
 
@@ -112,7 +112,7 @@ func TestGetPackages(t *testing.T) {
 	result, err = c.GetPackages(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Empty(result.Packages)
+	assert.Empty(result.Data)
 	assert.Equal(result.FilteredCount, 0)
 	assert.Equal(result.TotalCount, 1538)
 
@@ -174,7 +174,7 @@ func TestGetToolchains(t *testing.T) {
 	result, err := c.GetToolchains(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Len(result.Toolchains, 10)
+	assert.Len(result.Data, 10)
 	assert.Equal(result.FilteredCount, 41)
 	assert.Equal(result.TotalCount, 41)
 
@@ -189,10 +189,10 @@ func TestGetToolchains(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
 	require.NotNil(t, result)
-	require.Len(t, result.Toolchains, 3)
-	assert.Equal(result.Toolchains[0].Name, "nodejs")
-	assert.Equal(result.Toolchains[1].Name, "nodejs")
-	assert.Equal(result.Toolchains[2].Name, "nodejs")
+	require.Len(t, result.Data, 3)
+	assert.Equal(result.Data[0].Name, "nodejs")
+	assert.Equal(result.Data[1].Name, "nodejs")
+	assert.Equal(result.Data[2].Name, "nodejs")
 	assert.Equal(result.FilteredCount, 3)
 	assert.Equal(result.TotalCount, 41)
 
@@ -206,7 +206,7 @@ func TestGetToolchains(t *testing.T) {
 	result, err = c.GetToolchains(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Empty(result.Toolchains)
+	assert.Empty(result.Data)
 	assert.Equal(result.FilteredCount, 0)
 	assert.Equal(result.TotalCount, 41)
 

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -125,37 +125,6 @@ func TestGetPackages(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetImageDiff(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	assert := assert.New(t)
-	config := testutil.TestConfig()
-	testutil.ConfigureIntegrationTest(t, config, "TestGetImageDiff")
-	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
-
-	// Verify that getImageDiff correctly returns Toolchain/Package changes for a pair of sample AMIs.
-	opts := ImageDiffOptions{
-		AMIBefore: "ami-029ab576546a58916",
-		AMIAfter:  "ami-02b25f680ad574d33",
-	}
-	result, err := c.getImageDiff(ctx, opts)
-	require.NoError(t, err)
-	assert.NotEmpty(result)
-	for _, change := range result {
-		assert.True(change.Type == "Toolchains" || change.Type == "Packages")
-	}
-
-	// Verify that getImageDiff finds no differences between the same AMI.
-	opts = ImageDiffOptions{
-		AMIBefore: "ami-016662ab459a49e9d",
-		AMIAfter:  "ami-016662ab459a49e9d",
-	}
-	result, err = c.getImageDiff(ctx, opts)
-	require.NoError(t, err)
-	assert.Empty(result)
-}
-
 func TestGetToolchains(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -213,6 +182,37 @@ func TestGetToolchains(t *testing.T) {
 	// Verify that we receive an error when an AMI is not provided.
 	_, err = c.GetToolchains(ctx, ToolchainFilterOptions{})
 	require.Error(t, err)
+}
+
+func TestGetImageDiff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert := assert.New(t)
+	config := testutil.TestConfig()
+	testutil.ConfigureIntegrationTest(t, config, "TestGetImageDiff")
+	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
+
+	// Verify that getImageDiff correctly returns Toolchain/Package changes for a pair of sample AMIs.
+	opts := ImageDiffOptions{
+		AMIBefore: "ami-029ab576546a58916",
+		AMIAfter:  "ami-02b25f680ad574d33",
+	}
+	result, err := c.getImageDiff(ctx, opts)
+	require.NoError(t, err)
+	assert.NotEmpty(result)
+	for _, change := range result {
+		assert.True(change.Type == "Toolchains" || change.Type == "Packages")
+	}
+
+	// Verify that getImageDiff finds no differences between the same AMI.
+	opts = ImageDiffOptions{
+		AMIBefore: "ami-016662ab459a49e9d",
+		AMIAfter:  "ami-016662ab459a49e9d",
+	}
+	result, err = c.getImageDiff(ctx, opts)
+	require.NoError(t, err)
+	assert.Empty(result)
 }
 
 func TestGetHistory(t *testing.T) {

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -73,46 +73,48 @@ func TestGetPackages(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, config, "TestGetPackages")
 	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 
-	// Verify that we filter correctly by limit and manager.
-	manager := "pip"
+	// Verify that there are no errors with ToolchainFilterOptions including the AMI and limit.
 	ami := "ami-0e12ef25a5f7712a4"
-	limit := 10
 	opts := PackageFilterOptions{
-		AMI:     ami,
-		Page:    0,
-		Limit:   limit,
-		Manager: manager,
+		AMI:   ami,
+		Page:  0,
+		Limit: 10,
 	}
 	result, err := c.GetPackages(ctx, opts)
 	require.NoError(t, err)
-	require.Len(t, result, limit)
-	for i := 0; i < limit; i++ {
-		assert.Contains(result[i].Manager, manager)
-	}
+	require.NotNil(t, result)
+	require.Len(t, result.Packages, 10)
+	assert.Equal(result.FilteredCount, 1538)
+	assert.Equal(result.TotalCount, 1538)
 
-	// Verify that we filter correctly by both manager and name.
-	name := "Automat"
+	// Verify that we filter correctly by name.
 	opts = PackageFilterOptions{
-		AMI:     ami,
-		Page:    0,
-		Limit:   5,
-		Name:    "Automat",
-		Manager: manager,
+		AMI:   ami,
+		Page:  0,
+		Limit: 5,
+		Name:  "Automat",
 	}
 	result, err = c.GetPackages(ctx, opts)
 	require.NoError(t, err)
-	require.Len(t, result, 1)
-	assert.Equal(result[0].Name, name)
-	assert.Contains(result[0].Manager, manager)
+	require.NotNil(t, result)
+	require.Len(t, result.Packages, 1)
+	assert.Equal(result.Packages[0].Name, "Automat")
+	assert.Equal(result.FilteredCount, 1)
+	assert.Equal(result.TotalCount, 1538)
 
-	// Verify that there are no results for fake package name.
+	// Verify that there are no results for a nonexistent package.
 	opts = PackageFilterOptions{
-		AMI:  ami,
-		Name: "blahblahblah",
+		AMI:   ami,
+		Page:  0,
+		Limit: 5,
+		Name:  "xyz",
 	}
 	result, err = c.GetPackages(ctx, opts)
 	require.NoError(t, err)
-	assert.Empty(result)
+	require.NotNil(t, result)
+	assert.Empty(result.Packages)
+	assert.Equal(result.FilteredCount, 0)
+	assert.Equal(result.TotalCount, 1538)
 
 	// Verify that there are no errors with PackageFilterOptions only including the AMI.
 	_, err = c.GetPackages(ctx, PackageFilterOptions{AMI: ami})
@@ -171,35 +173,42 @@ func TestGetToolchains(t *testing.T) {
 	}
 	result, err := c.GetToolchains(ctx, opts)
 	require.NoError(t, err)
-	assert.Len(result, 10)
+	require.NotNil(t, result)
+	assert.Len(result.Toolchains, 10)
+	assert.Equal(result.FilteredCount, 41)
+	assert.Equal(result.TotalCount, 41)
 
-	// Verify that we filter correctly by name and version.
-	name := "nodejs"
-	version := "toolchain_version_v16.17.0"
-	opts = ToolchainFilterOptions{
-		AMI:     ami,
-		Page:    0,
-		Limit:   5,
-		Name:    name,
-		Version: version,
-	}
-	result, err = c.GetToolchains(ctx, opts)
-	require.NoError(t, err)
-	require.NotEmpty(t, result)
-	require.Len(t, result, 1)
-	assert.Equal(result[0].Name, name)
-	assert.Equal(result[0].Version, version)
-
-	// Verify that we receive no results for a fake toolchain.
+	// Verify that we filter correctly by name.
 	opts = ToolchainFilterOptions{
 		AMI:   ami,
 		Page:  0,
 		Limit: 5,
-		Name:  "blahblahblah",
+		Name:  "nodejs",
 	}
 	result, err = c.GetToolchains(ctx, opts)
 	require.NoError(t, err)
-	assert.Empty(result)
+	require.NotEmpty(t, result)
+	require.NotNil(t, result)
+	require.Len(t, result.Toolchains, 3)
+	assert.Equal(result.Toolchains[0].Name, "nodejs")
+	assert.Equal(result.Toolchains[1].Name, "nodejs")
+	assert.Equal(result.Toolchains[2].Name, "nodejs")
+	assert.Equal(result.FilteredCount, 3)
+	assert.Equal(result.TotalCount, 41)
+
+	// Verify that we receive no results for a nonexistent toolchain.
+	opts = ToolchainFilterOptions{
+		AMI:   ami,
+		Page:  0,
+		Limit: 5,
+		Name:  "xyz",
+	}
+	result, err = c.GetToolchains(ctx, opts)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(result.Toolchains)
+	assert.Equal(result.FilteredCount, 0)
+	assert.Equal(result.TotalCount, 41)
 
 	// Verify that we receive an error when an AMI is not provided.
 	_, err = c.GetToolchains(ctx, ToolchainFilterOptions{})

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -73,7 +73,7 @@ func TestGetPackages(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, config, "TestGetPackages")
 	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 
-	// Verify that there are no errors with ToolchainFilterOptions including the AMI and limit.
+	// Verify that we can get package data with limit and page.
 	ami := "ami-0e12ef25a5f7712a4"
 	opts := PackageFilterOptions{
 		AMI:   ami,
@@ -165,7 +165,7 @@ func TestGetToolchains(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, config, "TestGetToolchains")
 	c := NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 
-	// Verify that there are no errors with ToolchainFilterOptions including the AMI and limit.
+	// Verify that we can get toolchain data with limit and page.
 	ami := "ami-016662ab459a49e9d"
 	opts := ToolchainFilterOptions{
 		AMI:   ami,


### PR DESCRIPTION
DEVPROD-9475

### Description
In order to be able to paginate on the frontend, we need to know the total number of items available. The API has been updated with a new route which is what this PR uses.

500 lines from this PR were added automatically by code generation.

### Testing
- Updated existing tests