### PR TITLE
DEVPROD-9714 cgo on macOS

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const macGOOS = "darwin"
+
 func main() {
 	var (
 		arch      string
@@ -77,8 +79,14 @@ func main() {
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
 	}
-	// Disable cgo so that the compiled binary is statically linked.
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	// Disable cgo so that the compiled binary is statically linked. This is useful for systems lacking
+	// libc support. macOS is excluded because it will have libc support and cgo is needed for gopsutil on macOS.
+	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
+	if system == macGOOS {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+	} else {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	}
 
 	goos := "GOOS=" + system
 	goarch := "GOARCH=" + arch

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -752,9 +752,11 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin_amd64
     tags: ["build"]
+    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin_arm64
     tags: ["build"]
+    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets
     tags: ["build"]
@@ -768,6 +770,7 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-staging_amd64
     tags: ["build-staging"]
+    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets-staging
     tags: ["build-staging"]
@@ -775,9 +778,11 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-unsigned_amd64
     tags: ["build-unsigned"]
+    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
+    run_on: macos-14-arm64
 
 #######################################
 #            Buildvariants            #


### PR DESCRIPTION
[DEVPROD-9714](https://jira.mongodb.org/browse/DEVPROD-9714)

### Description
#8175 was reverted because the macOS build was failing. Apparently building with cgo invokes the local C compiler (makes sense) which is missing flags that are provided by go when building for macOS (see [this issue](https://github.com/golang/go/issues/59544)). This PR cherry-picks the now-reverted changes from #8175 and builds the mac executables on mac instances.

### Testing
[build-and-push succeeded](https://spruce.mongodb.com/task/evergreen_build_and_push_display_build_and_push_darwin_unsigned_patch_72f23265d19097bd5f7acc7146a4c80d380bd9bc_66ba2d0dc323d700078e3254_24_08_12_15_41_13?execution=0&sortBy=STATUS&sortDir=ASC).

