### PR TITLE
docs: fix controlling when a task run links

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,4 +4,4 @@ This FAQ is in progress. If there is anything you'd like to see added, please re
 
 ##### What is the difference between cron, batchtime, and periodic build?
 
-The main difference is that cron and batchtime are tied to activating builds for existing commits and periodic builds creates new builds on a schedule regardless of commit activity. For more on their differences and examples, see [controlling when tasks run](Project-Configuration/#controlling-when-tasks-run).
+The main difference is that cron and batchtime are tied to activating builds for existing commits and periodic builds creates new builds on a schedule regardless of commit activity. For more on their differences and examples, see [controlling when tasks run](Project-Configuration/controlling-when-tasks-run).

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -308,7 +308,7 @@ Fields:
     commits. For example, if you specify a task with `cron: '@daily'`, Evergreen
     will check that task once per day. If the most recent mainline commit is
     inactive, Evergreen will activate it. In this way, cron is tied more closely
-    to project commit activity. For more on the differences between cron, batchtime and [periodic builds](Project-and-Distro-Settings#periodic-builds), see [controlling when tasks run](../Project-Configuration/#controlling-when-tasks-run).
+    to project commit activity. For more on the differences between cron, batchtime and [periodic builds](Project-and-Distro-Settings#periodic-builds), see [controlling when tasks run](../Project-Configuration/controlling-when-tasks-run).
 -   `task_group`: a [task group](#task-groups)
     may be defined directly inline or using YAML aliases on a build
     variant task. This is an alternative to referencing a task group
@@ -629,7 +629,7 @@ To cause a task to not run at all, set `disable: true`.
 
 Can also set activate, batchtime or cron on tasks or build variants, detailed
 [here](#build-variants). For more on controlling scheduling of tasks, see 
-[controlling when tasks run](../Project-Configuration/#controlling-when-tasks-run)
+[controlling when tasks run](../Project-Configuration/controlling-when-tasks-run)
 
 If there are conflicting settings defined at different levels, the order of
 priority is defined [here](#task-fields-override-hierarchy).

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -66,7 +66,7 @@ to have Evergreen run tests using a different project file located
 elsewhere, or if they move the config file. The batch time corresponds
 to the interval of time (in minutes) that Evergreen should wait in
 between activating the latest version. For more on batch time and how 
-it differs from cron and [periodic builds](Project-and-Distro-Settings#periodic-builds), see [controlling when tasks run](../Project-Configuration/#controlling-when-tasks-run).
+it differs from cron and [periodic builds](Project-and-Distro-Settings#periodic-builds), see [controlling when tasks run](../Project-Configuration/controlling-when-tasks-run).
 
 Admins can modify which GitHub repository the project points to and
 change the owner, repository name, or branch that is to be tracked by
@@ -397,7 +397,7 @@ what should be run periodically, and how often. **This is different than build v
 a build variant cron activates build variants on _existing waterfall commits_ based on the cron you specify
 (so if you want it to run daily, it’ll activate the most recent build variant at that time daily),
 whereas a new periodic build will be created each interval regardless of whether there are new commits. For 
-more on those differences, see [controlling when tasks run](../Project-Configuration/#controlling-when-tasks-run). 
+more on those differences, see [controlling when tasks run](../Project-Configuration/controlling-when-tasks-run). 
 
 Options:
 


### PR DESCRIPTION
these links don't work right now since they use # for a section, where they're actually a fresh page (see https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Controlling-when-tasks-run)