### PR TITLE
DEVPROD-9348: revert to legacy agent monitor logic for old static hosts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/evergreen-ci/certdepot"
@@ -960,6 +961,35 @@ func (h *Host) CheckTaskDataFetched(ctx context.Context, env evergreen.Environme
 func (h *Host) WithAgentMonitor(ctx context.Context, env evergreen.Environment, handleAgentMonitor func(procs []jasper.Process) error) error {
 	return h.withTaggedProcs(ctx, env, evergreen.AgentMonitorTag, func(procs []jasper.Process) error {
 		return handleAgentMonitor(procs)
+	})
+}
+
+// StopAgentMonitor stops the agent monitor (if it is running) on the host via
+// its Jasper service. On legacy hosts, this is a no-op.
+// TODO (DEVPROD-9348): this can be removed once all agent monitors have rolled
+// over to the newest version since on the new version, they stop themselves
+// when they're not in a healthy state.
+func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) error {
+	if (h.Distro.LegacyBootstrap() && h.NeedsReprovision != ReprovisionToLegacy) || h.NeedsReprovision == ReprovisionToNew {
+		return nil
+	}
+
+	return h.WithAgentMonitor(ctx, env, func(procs []jasper.Process) error {
+		catcher := grip.NewBasicCatcher()
+		var numRunning int
+		for _, proc := range procs {
+			if proc.Running(ctx) {
+				numRunning++
+				catcher.Wrapf(proc.Signal(ctx, syscall.SIGTERM), "signalling agent monitor process with ID '%s'", proc.ID())
+			}
+		}
+		grip.WarningWhen(numRunning > 1, message.Fields{
+			"message": fmt.Sprintf("host should be running at most one agent monitor, but found %d", len(procs)),
+			"host_id": h.Id,
+			"distro":  h.Distro.Id,
+		})
+
+		return catcher.Resolve()
 	})
 }
 

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -966,9 +966,14 @@ func (h *Host) WithAgentMonitor(ctx context.Context, env evergreen.Environment, 
 
 // StopAgentMonitor stops the agent monitor (if it is running) on the host via
 // its Jasper service. On legacy hosts, this is a no-op.
-// TODO (DEVPROD-9348): this can be removed once all agent monitors have rolled
-// over to the newest version since on the new version, they stop themselves
-// when they're not in a healthy state.
+// Stopping the agent monitor manually like this is only necessary for legacy
+// reasons. There are some static hosts that have been quarantined for a long
+// time, and they could have very old versions of the agent monitor running on
+// them. Newer versions of the agent monitor shut themselves down when
+// appropriate, making this operation unnecessary. However, we have no guarantee
+// on how long ago hosts were quarantined and when they might be unquarantined,
+// meaning we can't get rid of this unless we know every single static host has
+// is running a relatively recent version of the agent monitor.
 func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) error {
 	if (h.Distro.LegacyBootstrap() && h.NeedsReprovision != ReprovisionToLegacy) || h.NeedsReprovision == ReprovisionToNew {
 		return nil

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -887,6 +888,103 @@ func TestStartAgentMonitorRequest(t *testing.T) {
 	assert.Contains(t, cmd, string(expectedCmd))
 
 	assert.Contains(t, cmd, evergreen.AgentMonitorTag)
+}
+
+func TestStopAgentMonitor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment, manager *jmock.Manager, h *Host){
+		"SendsKillToTaggedRunningProcesses": func(ctx context.Context, t *testing.T, env evergreen.Environment, manager *jmock.Manager, h *Host) {
+			proc, err := manager.CreateProcess(ctx, &options.Create{
+				Args: []string{"agent", "monitor", "command"},
+			})
+			require.NoError(t, err)
+			proc.Tag(evergreen.AgentMonitorTag)
+
+			mockProc, ok := proc.(*jmock.Process)
+			require.True(t, ok)
+			mockProc.ProcInfo.IsRunning = true
+
+			require.NoError(t, h.StopAgentMonitor(ctx, env))
+
+			require.Len(t, mockProc.Signals, 1)
+			assert.Equal(t, syscall.SIGTERM, mockProc.Signals[0])
+		},
+		"DoesNotKillProcessesWithoutCorrectTag": func(ctx context.Context, t *testing.T, env evergreen.Environment, manager *jmock.Manager, h *Host) {
+			proc, err := manager.CreateProcess(ctx, &options.Create{
+				Args: []string{"some", "other", "command"}},
+			)
+			require.NoError(t, err)
+
+			mockProc, ok := proc.(*jmock.Process)
+			require.True(t, ok)
+			mockProc.ProcInfo.IsRunning = true
+
+			require.NoError(t, h.StopAgentMonitor(ctx, env))
+
+			assert.Empty(t, mockProc.Signals)
+		},
+		"DoesNotKillFinishedAgentMonitors": func(ctx context.Context, t *testing.T, env evergreen.Environment, manager *jmock.Manager, h *Host) {
+			proc, err := manager.CreateProcess(ctx, &options.Create{
+				Args: []string{"agent", "monitor", "command"},
+			})
+			require.NoError(t, err)
+			proc.Tag(evergreen.AgentMonitorTag)
+
+			require.NoError(t, h.StopAgentMonitor(ctx, env))
+
+			mockProc, ok := proc.(*jmock.Process)
+			require.True(t, ok)
+			assert.Empty(t, mockProc.Signals)
+		},
+		"NoopsOnLegacyHost": func(ctx context.Context, t *testing.T, env evergreen.Environment, manager *jmock.Manager, h *Host) {
+			h.Distro = distro.Distro{
+				BootstrapSettings: distro.BootstrapSettings{
+					Method:        distro.BootstrapMethodLegacySSH,
+					Communication: distro.CommunicationMethodLegacySSH,
+				},
+			}
+
+			proc, err := manager.CreateProcess(ctx, &options.Create{
+				Args: []string{"agent", "monitor", "command"},
+			})
+			require.NoError(t, err)
+			proc.Tag(evergreen.AgentMonitorTag)
+
+			mockProc, ok := proc.(*jmock.Process)
+			require.True(t, ok)
+			mockProc.ProcInfo.IsRunning = true
+
+			require.NoError(t, h.StopAgentMonitor(ctx, env))
+
+			assert.Empty(t, mockProc.Signals)
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			tctx, tcancel := context.WithTimeout(ctx, 10*time.Second)
+			defer tcancel()
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(tctx))
+			manager := &jmock.Manager{}
+
+			h := &Host{
+				Id:   "id",
+				Host: "localhost",
+				Distro: distro.Distro{
+					BootstrapSettings: distro.BootstrapSettings{
+						Method:        distro.BootstrapMethodUserData,
+						Communication: distro.CommunicationMethodRPC,
+					},
+				},
+			}
+
+			assert.NoError(t, withJasperServiceSetupAndTeardown(tctx, env, manager, h, func() {
+				testCase(tctx, t, env, manager, h)
+			}))
+		})
+	}
 }
 
 func TestSpawnHostSetupCommands(t *testing.T) {

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -134,10 +134,10 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	if checkHostHealth(h.host) {
-		shouldExit, err := h.prepareHostForAgentExit(ctx, agentExitParams{
+		shouldExit, err := prepareHostForAgentExit(ctx, agentExitParams{
 			host:       h.host,
 			remoteAddr: h.remoteAddr,
-		})
+		}, h.env)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":       "could not prepare host for agent to exit",
@@ -253,58 +253,6 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 
 	setNextTask(nextTask, &nextTaskResponse)
 	return gimlet.NewJSONResponse(nextTaskResponse)
-}
-
-// prepareHostForAgentExit prepares a host to stop running tasks on the host.
-// For a quarantined host, it shuts down the agent and agent monitor to prevent
-// it from running further tasks. This is especially important for quarantining
-// hosts, as the host may continue running, but it must stop all agent-related
-// activity for now. For a terminated host, the host should already have been
-// terminated but is nonetheless alive, so terminate it again.
-func (h *hostAgentNextTask) prepareHostForAgentExit(ctx context.Context, params agentExitParams) (shouldExit bool, err error) {
-	switch params.host.Status {
-	case evergreen.HostQuarantined:
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-
-		if err := params.host.SetNeedsAgentDeploy(ctx, true); err != nil {
-			return true, errors.Wrap(err, "marking host as needing agent or agent monitor deploy")
-		}
-
-		return true, nil
-	case evergreen.HostTerminated:
-		// The host should already be terminated but somehow the agent is still
-		// alive in the cloud. If the host was terminated very recently, it may
-		// simply need time for the cloud instance to actually be terminated and
-		// fully cleaned up. If this message logs, that means there is a
-		// mismatch between either:
-		// 1. What Evergreen believes is this host's state (terminated) and the
-		//    cloud instance's actual state (not terminated). This is a bug.
-		// 2. The cloud instance's status and the actual liveliness of the host.
-		//    There are some cases where the agent is still checking in for a
-		//    long time after the cloud provider says the instance is already
-		//    terminated. There's no bug on our side, so this log is harmless.
-		if time.Since(params.host.TerminationTime) > 10*time.Minute {
-			msg := message.Fields{
-				"message":    "DB-cloud state mismatch - host has been marked terminated in the DB but the host's agent is still running",
-				"host_id":    params.host.Id,
-				"distro":     params.host.Distro.Id,
-				"remote":     params.remoteAddr,
-				"request_id": gimlet.GetRequestID(ctx),
-			}
-			grip.Warning(msg)
-		}
-		return true, nil
-	case evergreen.HostDecommissioned:
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
-type agentExitParams struct {
-	host       *host.Host
-	remoteAddr string
 }
 
 // assignNextAvailableTask gets the next task from the queue and sets the running task field
@@ -805,9 +753,6 @@ func handleReprovisioning(ctx context.Context, env evergreen.Environment, h *hos
 		return apimodels.NextTaskResponse{}, nil
 	}
 
-	// TODO (DEVPROD-9348): this can be removed once all agent monitors have
-	// rolled over to the newest version since on the new version, they stop
-	// themselves when they're not in a healthy state.
 	stopCtx, stopCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer stopCancel()
 	if err := h.StopAgentMonitor(stopCtx, env); err != nil {
@@ -816,7 +761,7 @@ func handleReprovisioning(ctx context.Context, env evergreen.Environment, h *hos
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":       "problem stopping agent monitor for reprovisioning",
 			"host_id":       h.Id,
-			"operation":     "next_task",
+			"host_status":   h.Status,
 			"revision":      evergreen.BuildRevision,
 			"agent":         evergreen.AgentVersion,
 			"current_agent": h.AgentRevision,
@@ -1327,6 +1272,11 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(endTaskResp)
 }
 
+type agentExitParams struct {
+	host       *host.Host
+	remoteAddr string
+}
+
 // prepareHostForAgentExit prepares a host to stop running tasks on the host.
 // For a quarantined host, it shuts down the agent and agent monitor to prevent
 // it from running further tasks. This is especially important for quarantining
@@ -1336,11 +1286,15 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 func prepareHostForAgentExit(ctx context.Context, params agentExitParams, env evergreen.Environment) (shouldExit bool, err error) {
 	switch params.host.Status {
 	case evergreen.HostQuarantined:
-		// TODO (DEVPROD-9348): this can be removed once all agent monitors have
-		// rolled over to the newest version since on the new version, they stop
-		// themselves when they're not in a healthy state.
-		if err := params.host.StopAgentMonitor(ctx, h.env); err != nil {
-			return true, errors.Wrap(err, "stopping agent monitor")
+		if err := params.host.StopAgentMonitor(ctx, env); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":       "problem stopping agent monitor for quarantine",
+				"host_id":       params.host.Id,
+				"host_status":   params.host.Status,
+				"revision":      evergreen.BuildRevision,
+				"agent":         evergreen.AgentVersion,
+				"current_agent": params.host.AgentRevision,
+			}))
 		}
 		if err := params.host.SetNeedsAgentDeploy(ctx, true); err != nil {
 			return true, errors.Wrap(err, "marking host as needing agent or agent monitor deploy")

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -805,6 +805,24 @@ func handleReprovisioning(ctx context.Context, env evergreen.Environment, h *hos
 		return apimodels.NextTaskResponse{}, nil
 	}
 
+	// TODO (DEVPROD-9348): this can be removed once all agent monitors have
+	// rolled over to the newest version since on the new version, they stop
+	// themselves when they're not in a healthy state.
+	stopCtx, stopCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer stopCancel()
+	if err := h.StopAgentMonitor(stopCtx, env); err != nil {
+		// Stopping the agent monitor should not stop reprovisioning as long as
+		// the host is not currently running a task.
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":       "problem stopping agent monitor for reprovisioning",
+			"host_id":       h.Id,
+			"operation":     "next_task",
+			"revision":      evergreen.BuildRevision,
+			"agent":         evergreen.AgentVersion,
+			"current_agent": h.AgentRevision,
+		}))
+	}
+
 	if err := prepareForReprovision(ctx, env, h); err != nil {
 		return apimodels.NextTaskResponse{}, err
 	}
@@ -1318,6 +1336,12 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 func prepareHostForAgentExit(ctx context.Context, params agentExitParams, env evergreen.Environment) (shouldExit bool, err error) {
 	switch params.host.Status {
 	case evergreen.HostQuarantined:
+		// TODO (DEVPROD-9348): this can be removed once all agent monitors have
+		// rolled over to the newest version since on the new version, they stop
+		// themselves when they're not in a healthy state.
+		if err := params.host.StopAgentMonitor(ctx, h.env); err != nil {
+			return true, errors.Wrap(err, "stopping agent monitor")
+		}
 		if err := params.host.SetNeedsAgentDeploy(ctx, true); err != nil {
 			return true, errors.Wrap(err, "marking host as needing agent or agent monitor deploy")
 		}


### PR DESCRIPTION
DEVPROD-9348

### Description
Split from #8188.

Some static hosts are still running old versions of the agent monitor (old versions need to manually be stopped by the app server). Furthermore, some static hosts were quarantined a long time ago, so they may be running very old versions of the agent monitor. Very old versions of the agent monitor create some backward compatibility issues with the changes in https://github.com/evergreen-ci/evergreen/pull/8115 because that PR assumes that hosts will eventually roll over to the new agent monitor version. Unfortunately, we can't force them to run on the newer agent monitor version since we can't operate on a quarantined host, and it's the responsibility of the runtime environments team to bring them out of quarantine (so we could wait a very long time before they come out of quarantine). To fix this backward compatibility issue with very old quarantined static hosts, I reinstated the logic to stop the agent monitor that https://github.com/evergreen-ci/evergreen/pull/8115 removed. Maybe one day we can remove this legacy logic, but unfortunately not today.

* Re-add the logic to manually stop the agent monitor that was removed in https://github.com/evergreen-ci/evergreen/pull/8115. This is just reinstating the old logic that was there for the sake of old quarantined static hosts.

### Testing
Tested in staging that the reprovision button worked. No real easy way to test this on an old quarantined hosts since we don't have any old quarantined hosts in staging.

### Documentation
N/A