### PR TITLE
DEVPROD-9623: add data model for fake parameters

### DIFF
--- a/cloud/parameterstore/fakeparameter/db.go
+++ b/cloud/parameterstore/fakeparameter/db.go
@@ -1,0 +1,34 @@
+package fakeparameter
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/mongodb/anser/bsonutil"
+	adb "github.com/mongodb/anser/db"
+	"github.com/pkg/errors"
+)
+
+// Collection is the name of the collection in the DB holding the fake
+// parameters. This is for testing only.
+const Collection = "fake_parameters"
+
+var (
+	IDKey          = bsonutil.MustHaveTag(FakeParameter{}, "ID")
+	ValueKey       = bsonutil.MustHaveTag(FakeParameter{}, "Value")
+	LastUpdatedKey = bsonutil.MustHaveTag(FakeParameter{}, "LastUpdated")
+)
+
+// FindOneID finds a single parameter by its name.
+func FindOneID(ctx context.Context, id string) (*FakeParameter, error) {
+	var p FakeParameter
+	err := evergreen.GetEnvironment().DB().Collection(Collection).FindOne(ctx, bson.M{IDKey: id}).Decode(&p)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "finding parameter by ID")
+	}
+	return &p, nil
+}

--- a/cloud/parameterstore/fakeparameter/db_test.go
+++ b/cloud/parameterstore/fakeparameter/db_test.go
@@ -1,0 +1,48 @@
+package fakeparameter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindOneID(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, p *FakeParameter){
+		"FindsExistingParameter": func(ctx context.Context, t *testing.T, p *FakeParameter) {
+			require.NoError(t, p.Insert(ctx))
+
+			dbParam, err := FindOneID(ctx, p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbParam)
+			assert.Equal(t, p, dbParam)
+		},
+		"ReturnsNilForNonexistentParameter": func(ctx context.Context, t *testing.T, p *FakeParameter) {
+			dbParam, err := FindOneID(ctx, "nonexistent")
+			assert.NoError(t, err)
+			assert.Zero(t, dbParam)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(Collection))
+
+			p := FakeParameter{
+				ID:          "id",
+				Value:       "value",
+				LastUpdated: utility.BSONTime(time.Now()),
+			}
+
+			tCase(ctx, t, &p)
+		})
+	}
+}

--- a/cloud/parameterstore/fakeparameter/doc.go
+++ b/cloud/parameterstore/fakeparameter/doc.go
@@ -1,0 +1,5 @@
+// Package fakeparameter contains the data model and helpers for testing code
+// that uses Parameter Store. Because this stores parameter values in plaintext
+// in the DB, this is only meant as a helper to facilitate testing and should
+// never be used in production code.
+package fakeparameter

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -1,0 +1,51 @@
+package fakeparameter
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+)
+
+// ExecutionEnvironmentType is the type of environment in which the code is
+// running. This exists a safety mechanism against accidentally calling this
+// logic in non-testing environment. For tests, this should always be overridden
+// to "test".
+// kim: NOTE: can't do ClientType trick like for Secrets Manager because the
+// production code will still import this package. May have to manually set PS
+// implementation somehow. May be annoying to have to pass in PS implementation
+// to all dependent code though. Possibly can have a compromise with something
+// like Amboy queues pluggable implementations. Can set fake implementation in
+// mock.Environment.Configure() (which is called manually in tests) and
+// testutil.NewEnvironment() (which is init'd by _test.go files).
+var ExecutionEnvironmentType = "production"
+
+func init() {
+	if ExecutionEnvironmentType != "test" {
+		grip.EmergencyFatal(message.Fields{
+			"message":     "fake Parameter Store testing code called in a non-testing environment",
+			"environment": ExecutionEnvironmentType,
+			"args":        flag.Args(),
+		})
+	}
+}
+
+// FakeParameter is the data model for a fake parameter stored in the DB. This
+// is for testing only.
+type FakeParameter struct {
+	// ID is the unique identifying name for the parameter.
+	ID string `bson:"_id,omitempty"`
+	// Value is the parameter value.
+	Value string `bson:"value,omitempty"`
+	// LastUpdated is the last time the parameter was updated.
+	LastUpdated time.Time `bson:"last_updated,omitempty"`
+}
+
+// Insert inserts a single parameter into the fake parameter store.
+func (p *FakeParameter) Insert(ctx context.Context) error {
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertOne(ctx, p)
+	return err
+}

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -14,13 +14,6 @@ import (
 // running. This exists a safety mechanism against accidentally calling this
 // logic in non-testing environment. For tests, this should always be overridden
 // to "test".
-// kim: NOTE: can't do ClientType trick like for Secrets Manager because the
-// production code will still import this package. May have to manually set PS
-// implementation somehow. May be annoying to have to pass in PS implementation
-// to all dependent code though. Possibly can have a compromise with something
-// like Amboy queues pluggable implementations. Can set fake implementation in
-// mock.Environment.Configure() (which is called manually in tests) and
-// testutil.NewEnvironment() (which is init'd by _test.go files).
 var ExecutionEnvironmentType = "production"
 
 func init() {

--- a/cloud/parameterstore/fakeparameter/fake_parameter_test.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter_test.go
@@ -1,0 +1,9 @@
+package fakeparameter
+
+import (
+	"github.com/evergreen-ci/evergreen/testutil"
+)
+
+func init() {
+	testutil.Setup()
+}

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ packages += db util plugin units graphql thirdparty thirdparty-docker auth sched
 packages += model-annotations model-patch model-artifact model-host model-pod model-pod-definition model-pod-dispatcher model-build model-event model-task model-user model-distro model-manifest model-testresult model-log model-testlog model-parsley
 packages += model-commitqueue model-cache
 packages += rest-client rest-data rest-route rest-model trigger model-alertrecord model-notification model-taskstats model-reliability
-packages += taskoutput cloud-parameterstore
+packages += taskoutput cloud-parameterstore cloud-parameterstore-fakeparameter
 lintOnlyPackages := api apimodels testutil model-manifest model-testutil service-testutil service-graphql db-mgo db-mgo-bson db-mgo-internal-json rest
 lintOnlyPackages += smoke-internal smoke-internal-host smoke-internal-container smoke-internal-agentmonitor smoke-internal-endpoint
 testOnlyPackages := service-graphql smoke-internal-host smoke-internal-container smoke-internal-agentmonitor smoke-internal-endpoint # has only test files so can't undergo all operations
@@ -319,7 +319,7 @@ testArgs += -timeout=$(TEST_TIMEOUT)
 else
 testArgs += -timeout=10m
 endif
-testArgs += -ldflags="$(ldFlags) -X=github.com/evergreen-ci/evergreen/testutil.ExecutionEnvironmentType=test"
+testArgs += -ldflags="$(ldFlags) -X=github.com/evergreen-ci/evergreen/testutil.ExecutionEnvironmentType=test -X=github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter.ExecutionEnvironmentType=test"
 #  targets to run any tests in the top-level package
 $(buildDir):
 	mkdir -p $@

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -505,6 +505,9 @@ tasks:
   - <<: *run-go-test-suite-with-docker
     tags: ["db"]
     name: test-cloud
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
+    name: test-cloud-parameterstore-fakeparameter
   - <<: *run-go-test-suite
     tags: ["nodb", "test"]
     name: test-cloud-userdata


### PR DESCRIPTION
DEVPROD-9623

### Description
Add a DB-backed fake model of Parameter Store. This exists to make it easy and convenient for tests that use Parameter Store for secrets to set up testing conditions without relying on direct access to a real instance of AWS Parameter Store. There will be a follow-up PR to create an SSM client implementation that uses this fake implementation.

* Add data model for testing-only implementation of Parameter Store client.
* Add guard to ensure that the fake Parameter Store code is never called in production code. It can only be called in `_test.go` files and testing-specific utility files (like `testutil/config.go` and `mock/environment.go`).

### Testing
* Added unit tests.
* Tested that not setting the execution environment type to "test" (which is only set for tests) caused Go to log and exit.

### Documentation
N/A