### PR TITLE
DEVPROD-7824 ensure no error when retrieving branch protection rules

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -483,7 +483,7 @@ func addGithubCheckSubscriptions(ctx context.Context, v *model.Version) error {
 		Ref:       v.Revision,
 		Desc:      "version created",
 		Caller:    RunnerName,
-		Context:   "evergreen",
+		Context:   thirdparty.GithubStatusDefaultContext,
 	}
 	err := thirdparty.SendPendingStatusToGithub(ctx, input, "")
 	if err != nil {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -39,6 +39,7 @@ const (
 
 	GithubInvestigation        = "Github API Limit Investigation"
 	PRDiffTooLargeErrorMessage = "the diff exceeded the maximum"
+	GithubStatusDefaultContext = "evergreen"
 )
 
 const (
@@ -2028,7 +2029,7 @@ func GetEvergreenBranchProtectionRules(ctx context.Context, token, owner, repo, 
 func getRulesWithEvergreenPrefix(rules []string) []string {
 	rulesWithEvergreenPrefix := []string{}
 	for _, rule := range rules {
-		if strings.HasPrefix(rule, "evergreen") {
+		if strings.HasPrefix(rule, GithubStatusDefaultContext) {
 			rulesWithEvergreenPrefix = append(rulesWithEvergreenPrefix, rule)
 		}
 	}

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -243,7 +244,7 @@ func (t *patchTriggers) makeData(sub *event.Subscription) (*commonTemplateData, 
 			},
 		)
 	} else {
-		data.githubContext = "evergreen"
+		data.githubContext = thirdparty.GithubStatusDefaultContext
 		data.URL = versionLink(
 			versionLinkInput{
 				uiBase:    t.uiConfig.Url,

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -151,7 +152,7 @@ func (t *versionTriggers) makeData(sub *event.Subscription, pastTenseOverride st
 		PastTenseStatus:   versionStatus,
 		apiModel:          &api,
 		githubState:       message.GithubStatePending,
-		githubContext:     "evergreen",
+		githubContext:     thirdparty.GithubStatusDefaultContext,
 		githubDescription: evergreen.PRTasksRunningDescription,
 	}
 	if t.data.GithubCheckStatus != "" {

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -30,8 +30,6 @@ const (
 	githubUpdateTypePushToCommitQueue     = "commit-queue-push"
 	githubUpdateTypeDeleteFromCommitQueue = "commit-queue-delete"
 	githubUpdateTypeProcessingError       = "processing-error"
-
-	evergreenContext = "evergreen"
 )
 
 const (
@@ -206,13 +204,13 @@ func (j *githubStatusUpdateJob) fetch() (*message.GithubStatus, error) {
 
 	} else if j.UpdateType == githubUpdateTypeNewPatch {
 		status.URL = fmt.Sprintf("%s/version/%s?redirect_spruce_users=true", j.urlBase, j.FetchID)
-		status.Context = evergreenContext
+		status.Context = thirdparty.GithubStatusDefaultContext
 		status.State = message.GithubStatePending
 		status.Description = "preparing to run tasks"
 
 	} else if j.UpdateType == githubUpdateTypeRequestAuth {
 		status.URL = fmt.Sprintf("%s/patch/%s", j.urlBase, j.FetchID)
-		status.Context = evergreenContext
+		status.Context = thirdparty.GithubStatusDefaultContext
 		status.Description = "patch must be manually authorized"
 		status.State = message.GithubStateFailure
 

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -195,7 +195,7 @@ func (j *githubStatusRefreshJob) sendBuildStatuses() {
 		Ref:   j.patch.GithubPatchData.HeadHash,
 	}
 	for _, b := range j.builds {
-		status.Context = fmt.Sprintf("%s/%s", evergreenContext, b.BuildVariant)
+		status.Context = fmt.Sprintf("%s/%s", thirdparty.GithubStatusDefaultContext, b.BuildVariant)
 		status.URL = b.GetURL(j.urlBase)
 
 		switch b.Status {
@@ -235,7 +235,7 @@ func (j *githubStatusRefreshJob) Run(ctx context.Context) {
 
 	status := &message.GithubStatus{
 		URL:     j.patch.GetURL(j.urlBase),
-		Context: evergreenContext,
+		Context: thirdparty.GithubStatusDefaultContext,
 		Owner:   j.patch.GithubPatchData.BaseOwner,
 		Repo:    j.patch.GithubPatchData.BaseRepo,
 		Ref:     j.patch.GithubPatchData.HeadHash,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1317,7 +1317,7 @@ func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchD
 	var update amboy.Job
 	if j.IntentType == patch.GithubIntentType {
 		update = NewGithubStatusUpdateJobForProcessingError(
-			evergreenContext,
+			thirdparty.GithubStatusDefaultContext,
 			patchDoc.GithubPatchData.BaseOwner,
 			patchDoc.GithubPatchData.BaseRepo,
 			patchDoc.GithubPatchData.HeadHash,
@@ -1325,7 +1325,7 @@ func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchD
 		)
 	} else if j.IntentType == patch.GithubMergeIntentType {
 		update = NewGithubStatusUpdateJobForProcessingError(
-			evergreenContext,
+			thirdparty.GithubStatusDefaultContext,
 			patchDoc.GithubMergeData.Org,
 			patchDoc.GithubMergeData.Repo,
 			patchDoc.GithubMergeData.HeadSHA,
@@ -1358,7 +1358,7 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 }
 
 // getEvergreenBranchProtectionRulesForStatuses returns the rules we want to send Evergreen statuses for.
-// If we don't find rules, we'll send the status default "evergreen" context. We log the error but don't
+// If we don't find rules, we'll send the status default context. We log the error but don't
 // return it, because we might have permission to send statuses but not to get branch protection rules.
 func (j *patchIntentProcessor) getEvergreenBranchProtectionRulesForStatuses(ctx context.Context, owner, repo, branch string) []string {
 	rules, err := thirdparty.GetEvergreenBranchProtectionRules(ctx, "", owner, repo, branch)
@@ -1369,7 +1369,8 @@ func (j *patchIntentProcessor) getEvergreenBranchProtectionRulesForStatuses(ctx 
 		"org":      owner,
 		"repo":     repo,
 		"branch":   branch,
+		"patch":    j.PatchID.Hex(),
 	}))
 
-	return utility.UniqueStrings(append(rules, evergreenContext))
+	return utility.UniqueStrings(append(rules, thirdparty.GithubStatusDefaultContext))
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -566,39 +566,14 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 		Caller:    j.Name,
 	}
 
-	rules, err := thirdparty.GetEvergreenBranchProtectionRules(ctx, "", p.GithubMergeData.Org, p.GithubMergeData.Repo, p.GithubMergeData.BaseBranch)
-	// We might have permission to send statuses but not to get branch
-	// protection rules, so log the error, but don't return it.
-	grip.Error(message.WrapError(err, message.Fields{
-		"job":      j.ID(),
-		"job_type": j.Type,
-		"message":  "failed to get branch protection rules",
-		"org":      p.GithubMergeData.Org,
-		"repo":     p.GithubMergeData.Repo,
-		"branch":   p.GithubMergeData.BaseBranch,
-	}))
-	// If we don't find any rules, send the default.
-	if len(rules) == 0 {
-		grip.Debug(message.Fields{
-			"job":      j.ID(),
-			"job_type": j.Type,
-			"message":  "could not find branch protection rules, sending default status",
-			"org":      p.GithubMergeData.Org,
-			"repo":     p.GithubMergeData.Repo,
-			"branch":   p.GithubMergeData.BaseBranch,
-			"project":  p.Project,
-		})
-		input.Context = "evergreen"
-		catcher.Wrap(thirdparty.SendPendingStatusToGithub(ctx, input, j.env.Settings().Ui.Url), "failed to send pending status to GitHub")
-	} else {
-		for i, rule := range rules {
-			// Limit statuses to 10
-			if i >= 10 {
-				break
-			}
-			input.Context = rule
-			catcher.Wrap(thirdparty.SendPendingStatusToGithub(ctx, input, j.env.Settings().Ui.Url), "failed to send pending status to GitHub")
+	rules := j.getEvergreenBranchProtectionRulesForStatuses(ctx, p.GithubMergeData.Org, p.GithubMergeData.Repo, p.GithubMergeData.BaseBranch)
+	for i, rule := range rules {
+		// Limit statuses to 10
+		if i >= 10 {
+			break
 		}
+		input.Context = rule
+		catcher.Wrap(thirdparty.SendPendingStatusToGithub(ctx, input, j.env.Settings().Ui.Url), "failed to send pending status to GitHub")
 	}
 
 	return catcher.Resolve()
@@ -1365,17 +1340,11 @@ func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchD
 	j.AddError(update.Error())
 }
 
-// sendGitHubSuccessMessages sends a successful status to Github with the given message for all
+// sendGitHubSuccessMessages sends a successful status to GitHub with the given message for all
 // branch protection rules configured for the given project.
 func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, patchDoc *patch.Patch, projectRef *model.ProjectRef, msg string) {
-	rules, err := thirdparty.GetEvergreenBranchProtectionRules(ctx, "", projectRef.Owner, projectRef.Repo, projectRef.Branch)
-	if err != nil {
-		j.AddError(errors.Wrapf(err, "getting branch protection rules for %s/%s/%s", projectRef.Owner, projectRef.Repo, projectRef.Branch))
-		return
-	}
-	// If the base evergreen context is not one of the rules, add it.
-	uniqueRules := utility.UniqueStrings(append(rules, evergreenContext))
-	for _, rule := range uniqueRules {
+	rules := j.getEvergreenBranchProtectionRulesForStatuses(ctx, patchDoc.GithubPatchData.BaseOwner, projectRef.Repo, projectRef.Branch)
+	for _, rule := range rules {
 		update := NewGithubStatusUpdateJobWithSuccessMessage(
 			rule,
 			patchDoc.GithubPatchData.BaseOwner,
@@ -1386,4 +1355,21 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 		update.Run(ctx)
 		j.AddError(update.Error())
 	}
+}
+
+// getEvergreenBranchProtectionRulesForStatuses returns the rules we want to send Evergreen statuses for.
+// If we don't find rules, we'll send the status default "evergreen" context. We log the error but don't
+// return it, because we might have permission to send statuses but not to get branch protection rules.
+func (j *patchIntentProcessor) getEvergreenBranchProtectionRulesForStatuses(ctx context.Context, owner, repo, branch string) []string {
+	rules, err := thirdparty.GetEvergreenBranchProtectionRules(ctx, "", owner, repo, branch)
+	grip.Error(message.WrapError(err, message.Fields{
+		"job":      j.ID(),
+		"job_type": j.Type,
+		"message":  "failed to get branch protection rules",
+		"org":      owner,
+		"repo":     repo,
+		"branch":   branch,
+	}))
+
+	return utility.UniqueStrings(append(rules, evergreenContext))
 }


### PR DESCRIPTION
DEVPROD-7824 

### Description
When sending pending statuses we don't error if there's a branch protection problem, but we do for successful statuses, which is inconsistent. Refactored this out to a helper function for simplicity.
