### PR TITLE
DEVPROD-9908 GitHub token route should account for requester / intersection having no permissions

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -273,6 +273,27 @@ func (p *GitHubDynamicTokenPermissionGroup) Intersection(other GitHubDynamicToke
 	return intersectionGroup, nil
 }
 
+// HasNoPermissions tests if the group has no permissions.
+func (p *GitHubDynamicTokenPermissionGroup) HasNoPermissions() bool {
+	if p.AllPermissions {
+		return false
+	}
+
+	perms := reflect.ValueOf(&p.Permissions).Elem()
+	for i := 0; i < perms.NumField(); i++ {
+		permPtr, ok := perms.Field(i).Interface().(*string)
+		if !ok {
+			continue
+		}
+		perm := utility.FromStringPtr(permPtr)
+		if perm != "" {
+			return false
+		}
+	}
+
+	return true
+}
+
 type ProjectHealthView string
 
 const (

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2071,8 +2071,7 @@ func TestGithubPermissionGroups(t *testing.T) {
 		require.NoError(err)
 		assert.Equal(orgGroup[0].Name, intersection.Name)
 
-		// Fields that were set on orgGroup[0].
-		assert.Nil(intersection.Permissions)
+		assert.True(intersection.HasNoPermissions())
 	})
 
 	t.Run("Intersection of two no permissions should return no permissions", func(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1998,6 +1998,12 @@ func TestGithubPermissionGroups(t *testing.T) {
 			Name:           "all-permissions-2",
 			AllPermissions: true,
 		},
+		{
+			Name: "other-permissions",
+			Permissions: github.InstallationPermissions{
+				Contents: utility.ToStringPtr("read"),
+			},
+		},
 	}
 	orgRequesters := map[string]string{
 		evergreen.PatchVersionRequester: "some-group",
@@ -2125,6 +2131,20 @@ func TestGithubPermissionGroups(t *testing.T) {
 
 		// An unspecified field.
 		assert.Nil(intersection.Permissions.Emails)
+	})
+
+	t.Run("Intersection of permissions that result in no permissions should return no permissions", func(t *testing.T) {
+		intersection, err := orgGroup[1].Intersection(orgGroup[6])
+		require.NoError(err)
+		assert.True(intersection.HasNoPermissions())
+
+		assert.Nil(intersection.Permissions.Administration)
+		assert.Nil(intersection.Permissions.Actions)
+		assert.Nil(intersection.Permissions.Contents)
+		assert.Nil(intersection.Permissions.Followers)
+		assert.Nil(intersection.Permissions.Checks)
+		assert.Nil(intersection.Permissions.Metadata)
+		assert.Nil(intersection.Permissions.OrganizationAdministration)
 	})
 
 	t.Run("Intersection of permissions with invalid permissions should return an error", func(t *testing.T) {

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2072,6 +2072,50 @@ func TestGithubPermissionGroups(t *testing.T) {
 		assert.Equal(orgGroup[0].Name, intersection.Name)
 
 		// Fields that were set on orgGroup[0].
+		assert.Nil(intersection.Permissions)
+	})
+
+	t.Run("Intersection of two no permissions should return no permissions", func(t *testing.T) {
+		intersection, err := orgGroup[2].Intersection(orgGroup[2])
+		require.NoError(err)
+		assert.Equal(orgGroup[2].Name, intersection.Name)
+		assert.True(intersection.HasNoPermissions())
+
+		// Specified fields.
+		assert.Nil(intersection.Permissions.Administration)
+		assert.Nil(intersection.Permissions.Actions)
+		assert.Nil(intersection.Permissions.Contents)
+		assert.Nil(intersection.Permissions.Followers)
+		assert.Nil(intersection.Permissions.Checks)
+		assert.Nil(intersection.Permissions.Metadata)
+		assert.Nil(intersection.Permissions.OrganizationAdministration)
+
+		// An unspecified field.
+		assert.Nil(intersection.Permissions.Emails)
+
+		intersection, err = noPermissionsGitHubTokenPermissionGroup.Intersection(orgGroup[2])
+		require.NoError(err)
+		assert.Equal(noPermissionsGitHubTokenPermissionGroup.Name, intersection.Name)
+		assert.True(intersection.HasNoPermissions())
+
+		// Specified fields.
+		assert.Nil(intersection.Permissions.Administration)
+		assert.Nil(intersection.Permissions.Actions)
+		assert.Nil(intersection.Permissions.Contents)
+		assert.Nil(intersection.Permissions.Followers)
+		assert.Nil(intersection.Permissions.Checks)
+		assert.Nil(intersection.Permissions.Metadata)
+		assert.Nil(intersection.Permissions.OrganizationAdministration)
+
+		// An unspecified field.
+		assert.Nil(intersection.Permissions.Emails)
+
+		intersection, err = noPermissionsGitHubTokenPermissionGroup.Intersection(noPermissionsGitHubTokenPermissionGroup)
+		require.NoError(err)
+		assert.Equal(noPermissionsGitHubTokenPermissionGroup.Name, intersection.Name)
+		assert.True(intersection.HasNoPermissions())
+
+		// Specified fields.
 		assert.Nil(intersection.Permissions.Administration)
 		assert.Nil(intersection.Permissions.Actions)
 		assert.Nil(intersection.Permissions.Contents)
@@ -2109,6 +2153,21 @@ func TestGithubPermissionGroups(t *testing.T) {
 		intersection, err := orgGroup[4].Intersection(orgGroup[5])
 		require.NoError(err)
 		assert.True(intersection.AllPermissions)
+	})
+
+	t.Run("Group defined with no permissions should return true for has no permissions", func(t *testing.T) {
+		assert.True(orgGroup[2].HasNoPermissions())
+	})
+
+	t.Run("Group defined with some permissions should return false for has no permissions", func(t *testing.T) {
+		assert.False(orgGroup[0].HasNoPermissions())
+		assert.False(orgGroup[1].HasNoPermissions())
+		assert.False(orgGroup[3].HasNoPermissions())
+		assert.False(orgGroup[4].HasNoPermissions())
+	})
+
+	t.Run("No permission group should return true for has no permissions", func(t *testing.T) {
+		assert.True(noPermissionsGitHubTokenPermissionGroup.HasNoPermissions())
 	})
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1634,6 +1634,8 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		})
 	}
 	requesterPermissionGroup, _ := p.GetGitHubPermissionGroup(t.Requester)
+	// If the requester has no permissions, they should not be able to create a token.
+	// GitHub interprets an empty token as having all permissions.
 	if requesterPermissionGroup.HasNoPermissions() {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusUnauthorized,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1592,8 +1592,7 @@ func (h *createGitHubDynamicAccessToken) Parse(ctx context.Context, r *http.Requ
 	if err != nil {
 		return errors.Wrap(err, "reading body")
 	}
-	// If the body is an empty json object or a null json object, we want to set allPermissions to true.
-	if string(body) == "{}" || string(body) == "null" {
+	if len(body) == 0 || string(body) == "{}" {
 		h.allPermissions = true
 		return nil
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1656,7 +1656,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	} else if intersection.HasNoPermissions() {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusUnauthorized,
-			Message:    "the intersection of the requester's permissions and provided permissions does not have permission to create a token",
+			Message:    "the intersection of the project setting's requester permissions and provided permissions does not have any permissions to create a token",
 		})
 	}
 


### PR DESCRIPTION
DEVPROD-9908

### Description
Since GitHub interprets an empty permissions as all permissions, we need to manually check if what we are sending is empty permissions.

### Testing
Unit testing and deployed to staging

### Documentation
Added a comment since it's niche