### PR TITLE
DEVPROD-6004 Send internal error instead of generic for invalid token generation

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1669,7 +1669,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
 	}
 	if token == "" {
-		return gimlet.MakeJSONErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))
 	}
 
 	return gimlet.NewJSONResponse(&apimodels.Token{


### PR DESCRIPTION
DEVPROD-6004

### Description
Some users care about the status code more, this would be an internal error (most likely on github's part)