### PR TITLE
DEVPROD-9928: Return GraphQL enum values for ImageEventEntry.Type field

### DIFF
--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -1,5 +1,6 @@
 ###### ENUMS ######
 enum ImageEventType {
+  OPERATING_SYSTEM
   PACKAGE
   TOOLCHAIN
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -489,13 +489,14 @@ func buildImageEventEntry(diff ImageDiffChange) (*ImageEventEntry, error) {
 	}
 
 	var eventType ImageEventType
-	if diff.Type == APITypeOS {
+	switch diff.Type {
+	case APITypeOS:
 		eventType = ImageEventTypeOperatingSystem
-	} else if diff.Type == APITypePackages {
+	case APITypePackages:
 		eventType = ImageEventTypePackage
-	} else if diff.Type == APITypeToolchains {
+	case APITypeToolchains:
 		eventType = ImageEventTypeToolchain
-	} else {
+	default:
 		return nil, errors.New(fmt.Sprintf("item '%s' has unrecognized event type '%s'", diff.Name, diff.Type))
 	}
 

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -264,17 +264,17 @@ func (c *RuntimeEnvironmentsClient) GetToolchains(ctx context.Context, opts Tool
 
 // ImageDiffOptions represents the arguments for getImageDiff. AMIBefore is the starting AMI, and AMIAfter is the ending AMI.
 type ImageDiffOptions struct {
-	AMIBefore string
-	AMIAfter  string
+	AMIBefore string `json:"-"`
+	AMIAfter  string `json:"-"`
 }
 
 // ImageDiffChange represents a change between two AMIs.
 type ImageDiffChange struct {
-	Name    string
-	Manager string
-	Type    string
-	Removed string
-	Added   string
+	Name    string `json:"name"`
+	Manager string `json:"manager"`
+	Type    string `json:"type"`
+	Removed string `json:"removed"`
+	Added   string `json:"added"`
 }
 
 // getImageDiff returns a list of package and toolchain changes that occurred between the provided AMIs.

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -25,11 +25,16 @@ const (
 type ImageEventType string
 
 const (
-	ImageEventTypePackages   ImageEventType = "Packages"
-	ImageEventTypeToolchains ImageEventType = "Toolchains"
+	ImageEventTypeOperatingSystem ImageEventType = "OPERATING_SYSTEM"
+	ImageEventTypePackage         ImageEventType = "PACKAGE"
+	ImageEventTypeToolchain       ImageEventType = "TOOLCHAIN"
 )
 
 const (
+	APITypeOS         = "OS"
+	APITypePackages   = "Packages"
+	APITypeToolchains = "Toolchains"
+
 	OSNameField      = "PRETTY_NAME"
 	OSKernelField    = "Kernel"
 	OSVersionIDField = "VERSION_ID"
@@ -267,7 +272,7 @@ type ImageDiffOptions struct {
 type ImageDiffChange struct {
 	Name    string
 	Manager string
-	Type    ImageEventType
+	Type    string
 	Removed string
 	Added   string
 }
@@ -300,7 +305,7 @@ func (c *RuntimeEnvironmentsClient) getImageDiff(ctx context.Context, opts Image
 	}
 	filteredChanges := []ImageDiffChange{}
 	for _, c := range changes {
-		if c.Type == ImageEventTypePackages || c.Type == ImageEventTypeToolchains {
+		if c.Type == APITypeOS || c.Type == APITypePackages || c.Type == APITypeToolchains {
 			filteredChanges = append(filteredChanges, c)
 		}
 	}
@@ -472,22 +477,34 @@ func (c *RuntimeEnvironmentsClient) GetImageInfo(ctx context.Context, imageID st
 
 // buildImageEventEntry make an ImageEventEntry given an ImageDiffChange.
 func buildImageEventEntry(diff ImageDiffChange) (*ImageEventEntry, error) {
-	var action ImageEventEntryAction
+	var eventAction ImageEventEntryAction
 	if diff.Added != "" && diff.Removed != "" {
-		action = ImageEventEntryActionUpdated
+		eventAction = ImageEventEntryActionUpdated
 	} else if diff.Added != "" {
-		action = ImageEventEntryActionAdded
+		eventAction = ImageEventEntryActionAdded
 	} else if diff.Removed != "" {
-		action = ImageEventEntryActionDeleted
+		eventAction = ImageEventEntryActionDeleted
 	} else {
-		return nil, errors.New("neither added nor removed")
+		return nil, errors.New(fmt.Sprintf("item '%s' was neither added nor removed", diff.Name))
 	}
+
+	var eventType ImageEventType
+	if diff.Type == APITypePackages {
+		eventType = ImageEventTypePackage
+	} else if diff.Type == APITypeToolchains {
+		eventType = ImageEventTypeToolchain
+	} else if diff.Type == APITypeOS {
+		eventType = ImageEventTypeOperatingSystem
+	} else {
+		return nil, errors.New(fmt.Sprintf("item '%s' has unrecognized event type '%s'", diff.Name, diff.Type))
+	}
+
 	entry := ImageEventEntry{
 		Name:   diff.Name,
 		After:  diff.Added,
 		Before: diff.Removed,
-		Type:   diff.Type,
-		Action: action,
+		Type:   eventType,
+		Action: eventAction,
 	}
 	return &entry, nil
 }

--- a/thirdparty/runtime_environments.go
+++ b/thirdparty/runtime_environments.go
@@ -489,12 +489,12 @@ func buildImageEventEntry(diff ImageDiffChange) (*ImageEventEntry, error) {
 	}
 
 	var eventType ImageEventType
-	if diff.Type == APITypePackages {
+	if diff.Type == APITypeOS {
+		eventType = ImageEventTypeOperatingSystem
+	} else if diff.Type == APITypePackages {
 		eventType = ImageEventTypePackage
 	} else if diff.Type == APITypeToolchains {
 		eventType = ImageEventTypeToolchain
-	} else if diff.Type == APITypeOS {
-		eventType = ImageEventTypeOperatingSystem
 	} else {
 		return nil, errors.New(fmt.Sprintf("item '%s' has unrecognized event type '%s'", diff.Name, diff.Type))
 	}

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -320,7 +320,7 @@ func TestGetEvents(t *testing.T) {
 		assert.Greater(result[i].Timestamp, result[i+1].Timestamp)
 	}
 
-	// Verify that entry fields have been correctly transformed to use our custom enums.
+	// Verify that entries have been correctly transformed to use our custom enums.
 	for _, r := range result {
 		for _, entry := range r.Entries {
 			assert.True(entry.Action == ImageEventEntryActionAdded || entry.Action == ImageEventEntryActionDeleted || entry.Action == ImageEventEntryActionUpdated)


### PR DESCRIPTION
DEVPROD-9928

### Description
Fixes a bug where we were returning incorrect values for the `Type` field on these events. The `Type` field should be equal to the values of our custom GraphQL enums (`"PACKAGE"`, `"TOOLCHAIN"`) but instead they were equal to the values returned directly from the API (e.g. `"Packages"`, `"Toolchains"`).

Also, although we were originally only returning package and toolchain changes, I introduced a new enum `"OPERATING_SYSTEM"` and started to additionally return OS changes since Winston said these should be included.

### Testing
- Updated existing tests and wrote more tests