### PR TITLE
DEVPROD-713 Reject requests from completed tasks and terminated hosts

### DIFF
--- a/model/validate.go
+++ b/model/validate.go
@@ -75,6 +75,9 @@ func ValidateHost(hostId string, r *http.Request) (*host.Host, int, error) {
 	if secret != h.Secret {
 		return nil, http.StatusUnauthorized, errors.Errorf("invalid host secret for host '%s'", hostId)
 	}
+	if h.Status == evergreen.HostTerminated {
+		return nil, http.StatusUnauthorized, errors.Errorf("host '%s' cannot make requests in a terminated state", hostId)
+	}
 
 	// if the task is attached to the context, check host-task relationship
 	var t *task.Task

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -364,7 +364,7 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 	switch h.Status {
 	case evergreen.HostBuilding:
 		return errors.Wrap(transitionIntentHostToStarting(ctx, env, h, instanceID), "starting intent host that actually succeeded")
-	case evergreen.HostBuildingFailed, evergreen.HostDecommissioned, evergreen.HostTerminated:
+	case evergreen.HostBuildingFailed, evergreen.HostDecommissioned:
 		return errors.Wrap(transitionIntentHostToDecommissioned(ctx, env, h, instanceID), "decommissioning intent host")
 	default:
 		return errors.Errorf("logical error: intent host is in state '%s', which should be impossible when host is up and provisioning", h.Status)

--- a/rest/data/task.go
+++ b/rest/data/task.go
@@ -78,9 +78,9 @@ func FindTasksByProjectAndCommit(opts task.GetTasksByProjectAndCommitOptions) ([
 	return res, nil
 }
 
-func CheckTaskSecret(taskID string, r *http.Request) (int, error) {
-	_, code, err := serviceModel.ValidateTask(taskID, true, r)
-	return code, errors.Wrapf(err, "invalid task '%s'", taskID)
+func CheckTaskSecret(taskID string, r *http.Request) (*task.Task, int, error) {
+	t, code, err := serviceModel.ValidateTask(taskID, true, r)
+	return t, code, errors.Wrapf(err, "invalid task '%s'", taskID)
 }
 
 func FindTask(taskID string) (*task.Task, error) {

--- a/rest/data/task_test.go
+++ b/rest/data/task_test.go
@@ -478,12 +478,15 @@ func TestCheckTaskSecret(t *testing.T) {
 			evergreen.TaskHeader: []string{"task1"},
 		},
 	}
-	code, err := CheckTaskSecret("task1", r)
+	dbTask, code, err := CheckTaskSecret("task1", r)
 	assert.Error(err)
 	assert.Equal(http.StatusConflict, code)
+	assert.Nil(dbTask)
 
 	r.Header.Set(evergreen.TaskSecretHeader, "abcdef")
-	code, err = CheckTaskSecret("task1", r)
+	dbTask, code, err = CheckTaskSecret("task1", r)
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, code)
+	assert.NotNil(dbTask)
+
 }

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -496,7 +496,7 @@ func (m *TaskAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, 
 		}))
 		return
 	}
-	if t.FinishTime.Before(time.Now().Add(-1*completedTaskValidityWindow)) && utility.StringSliceContains(evergreen.TaskCompletedStatuses, t.Status) {
+	if time.Since(t.FinishTime) > completedTaskValidityWindow && utility.StringSliceContains(evergreen.TaskCompletedStatuses, t.Status) {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusUnauthorized,
 			Message:    fmt.Sprintf("task '%s' cannot make requests in a completed state", taskID),

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -474,6 +475,13 @@ func TestTaskAuthMiddleware(t *testing.T) {
 	rw = httptest.NewRecorder()
 	m.ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {})
 	assert.NotEqual(http.StatusOK, rw.Code)
+
+	assert.NoError(task.UpdateOne(bson.M{"_id": "completedTask"}, bson.M{"$set": bson.M{"finish_time": time.Now().Add(-30 * time.Minute)}}))
+
+	r.Header.Set(evergreen.TaskHeader, "completedTask")
+	rw = httptest.NewRecorder()
+	m.ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {})
+	assert.Equal(http.StatusOK, rw.Code)
 
 }
 


### PR DESCRIPTION
DEVPROD-713

### Description
Completed tasks and terminated hosts shouldn't be able to make request to Evergreen, so updated the task / host middleware to reject the request in these cases. Also removed the check for the terminated host status when we fix an intent host that is mismatched with its true AWS state. 

This will cause these hosts that Evergreen believes are intent host but are actually genuine terminated EC2 instances to leak, leaving the reaper to clean them up. Since this mismatch condition is relatively rare, we can consider just allowing these hosts to leak for the sake of this change.
### Testing
Added unit tests.

