### PR TITLE
DEVPROD-5351: recreate task group working directory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -400,8 +400,6 @@ func (a *Agent) finishPrevTask(ctx context.Context, nextTask *apimodels.NextTask
 
 	if shouldRunSetupGroup(nextTask, tc) {
 		shouldSetupGroup = true
-		// kim: NOTE: this clears the task directory for the next task (either
-		// new task group or standalone task)
 		taskDirectory = ""
 		a.runTeardownGroupCommands(ctx, tc)
 	}
@@ -458,14 +456,14 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 
 	var recreateTaskDir bool
 	if tc.ranSetupGroup {
-		// kim: TODO: test task group manually
 		if _, err := os.Stat(taskDirectory); os.IsNotExist(err) {
 			recreateTaskDir = true
-			tc.logger.Execution().Info("Task directory was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a previous task group task), re-creating it.")
+			tc.logger.Execution().Infof("Task directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", taskDirectory)
 		}
-		if _, err := os.Stat(filepath.Join(taskDirectory, "tmp")); os.IsNotExist(err) {
+		tmpDir := filepath.Join(taskDirectory, "tmp")
+		if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
 			recreateTaskDir = true
-			tc.logger.Execution().Info("Task temporary directory was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a previous task group task), re-creating it.")
+			tc.logger.Execution().Infof("Task temporary directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", tmpDir)
 		}
 	}
 	if !tc.ranSetupGroup || recreateTaskDir {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -458,12 +458,12 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 	if tc.ranSetupGroup {
 		if _, err := os.Stat(taskDirectory); os.IsNotExist(err) {
 			recreateTaskDir = true
-			tc.logger.Execution().Infof("Task directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", taskDirectory)
+			tc.logger.Execution().Noticef("Task directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", taskDirectory)
 		}
 		tmpDir := filepath.Join(taskDirectory, "tmp")
 		if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
 			recreateTaskDir = true
-			tc.logger.Execution().Infof("Task temporary directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", tmpDir)
+			tc.logger.Execution().Noticef("Task temporary directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", tmpDir)
 		}
 	}
 	if !tc.ranSetupGroup || recreateTaskDir {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -454,19 +454,19 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "setting up logger producer"))
 	}
 
-	var recreateTaskDir bool
+	var taskGroupDirMissing bool
 	if tc.ranSetupGroup {
 		if _, err := os.Stat(taskDirectory); os.IsNotExist(err) {
-			recreateTaskDir = true
+			taskGroupDirMissing = true
 			tc.logger.Execution().Noticef("Task directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", taskDirectory)
 		}
 		tmpDir := filepath.Join(taskDirectory, "tmp")
 		if _, err := os.Stat(tmpDir); os.IsNotExist(err) {
-			recreateTaskDir = true
+			taskGroupDirMissing = true
 			tc.logger.Execution().Noticef("Task temporary directory '%s' was already created by a previous task group task, but is missing for this task group task (possibly because it was deleted by a command in a previous task group task), re-creating it.", tmpDir)
 		}
 	}
-	if !tc.ranSetupGroup || recreateTaskDir {
+	if !tc.ranSetupGroup || taskGroupDirMissing {
 		taskDirectory, err = a.createTaskDirectory(tc, taskDirectory)
 		if err != nil {
 			return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task directory"))

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -34,7 +34,7 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 		taskDir = filepath.Join(a.opts.WorkingDirectory, dirName)
 	}
 
-	tc.logger.Execution().Infof("Making new directory '%s' for task execution.", taskDir)
+	tc.logger.Execution().Infof("Making directory '%s' for task execution.", taskDir)
 
 	if err := os.MkdirAll(taskDir, 0777); err != nil {
 		tc.logger.Execution().Error(errors.Wrapf(err, "creating task directory '%s'", taskDir))
@@ -42,7 +42,7 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 	}
 
 	tmpDir := filepath.Join(taskDir, "tmp")
-	tc.logger.Execution().Infof("Making new temporary directory '%s' for task execution.", tmpDir)
+	tc.logger.Execution().Infof("Making temporary directory '%s' for task execution.", tmpDir)
 
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		tc.logger.Execution().Warning(errors.Wrapf(err, "creating task temporary directory '%s'", tmpDir))

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -34,7 +34,7 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 		taskDir = filepath.Join(a.opts.WorkingDirectory, dirName)
 	}
 
-	tc.logger.Execution().Infof("Making directory '%s' for task execution.", taskDir)
+	tc.logger.Execution().Infof("Making task directory '%s' for task execution.", taskDir)
 
 	if err := os.MkdirAll(taskDir, 0777); err != nil {
 		tc.logger.Execution().Error(errors.Wrapf(err, "creating task directory '%s'", taskDir))
@@ -42,7 +42,7 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 	}
 
 	tmpDir := filepath.Join(taskDir, "tmp")
-	tc.logger.Execution().Infof("Making temporary directory '%s' for task execution.", tmpDir)
+	tc.logger.Execution().Infof("Making task temporary directory '%s' for task execution.", tmpDir)
 
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		tc.logger.Execution().Warning(errors.Wrapf(err, "creating task temporary directory '%s'", tmpDir))

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -16,8 +16,9 @@ import (
 )
 
 // createTaskDirectory makes a directory for the agent to execute the current
-// task within. If taskDir is specified, it will create that task directory;
-// otherwise, it will generate a new task directory.
+// task within and a temporary directory within that new directory. If taskDir
+// is specified, it will create that task directory; otherwise, it will create
+// a new task directory based on the current task data.
 func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, error) {
 	if taskDir == "" {
 		h := md5.New()
@@ -41,6 +42,8 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 	}
 
 	tmpDir := filepath.Join(taskDir, "tmp")
+	tc.logger.Execution().Infof("Making new temporary directory '%s' for task execution.", tmpDir)
+
 	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		tc.logger.Execution().Warning(errors.Wrapf(err, "creating task temporary directory '%s'", tmpDir))
 	}

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -15,35 +15,37 @@ import (
 	"github.com/pkg/errors"
 )
 
-// createTaskDirectory makes a directory for the agent to execute
-// the current task within. It changes the necessary variables
-// so that all of the agent's operations will use this folder.
-func (a *Agent) createTaskDirectory(tc *taskContext) (string, error) {
-	h := md5.New()
+// createTaskDirectory makes a directory for the agent to execute the current
+// task within. If taskDir is specified, it will create that task directory;
+// otherwise, it will generate a new task directory.
+func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, error) {
+	if taskDir == "" {
+		h := md5.New()
 
-	_, err := h.Write([]byte(
-		fmt.Sprintf("%s_%d_%d", tc.taskConfig.Task.Id, tc.taskConfig.Task.Execution, os.Getpid())))
-	if err != nil {
-		tc.logger.Execution().Error(errors.Wrap(err, "creating task directory name"))
+		_, err := h.Write([]byte(
+			fmt.Sprintf("%s_%d_%d", tc.taskConfig.Task.Id, tc.taskConfig.Task.Execution, os.Getpid())))
+		if err != nil {
+			tc.logger.Execution().Error(errors.Wrap(err, "creating task directory name"))
+			return "", err
+		}
+
+		dirName := hex.EncodeToString(h.Sum(nil))
+		taskDir = filepath.Join(a.opts.WorkingDirectory, dirName)
+	}
+
+	tc.logger.Execution().Infof("Making new directory '%s' for task execution.", taskDir)
+
+	if err := os.MkdirAll(taskDir, 0777); err != nil {
+		tc.logger.Execution().Error(errors.Wrapf(err, "creating task directory '%s'", taskDir))
 		return "", err
 	}
 
-	dirName := hex.EncodeToString(h.Sum(nil))
-	newDir := filepath.Join(a.opts.WorkingDirectory, dirName)
-
-	tc.logger.Execution().Infof("Making new directory '%s' for task execution.", newDir)
-
-	if err = os.MkdirAll(newDir, 0777); err != nil {
-		tc.logger.Execution().Error(errors.Wrapf(err, "creating task directory '%s'", newDir))
-		return "", err
-	}
-
-	tmpDir := filepath.Join(newDir, "tmp")
-	if err = os.MkdirAll(tmpDir, 0777); err != nil {
+	tmpDir := filepath.Join(taskDir, "tmp")
+	if err := os.MkdirAll(tmpDir, 0777); err != nil {
 		tc.logger.Execution().Warning(errors.Wrapf(err, "creating task temporary directory '%s'", tmpDir))
 	}
 
-	return newDir, nil
+	return taskDir, nil
 }
 
 // removeTaskDirectory removes the folder the agent created for the task it

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -36,12 +36,14 @@ type taskContext struct {
 	postErrored          bool
 	logger               client.LoggerProducer
 	task                 client.TaskData
-	ranSetupGroup        bool
-	taskConfig           *internal.TaskConfig
-	timeout              timeoutInfo
-	oomTracker           jasper.OOMTracker
-	traceID              string
-	diskDevices          []string
+	// ranSetupGroup is true during task setup if the task is a new standalone
+	// task or if it's the first task in a task group.
+	ranSetupGroup bool
+	taskConfig    *internal.TaskConfig
+	timeout       timeoutInfo
+	oomTracker    jasper.OOMTracker
+	traceID       string
+	diskDevices   []string
 	// taskCleanups and taskGroupCleanups store the cleanup commands for the
 	// task and setup group, respectively.
 	taskCleanups       []internal.CommandCleanup

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-15"
+	AgentVersion = "2024-08-16"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-5351

### Description
The task working directory and its temporary directory are currently made only when the first task in the task group runs. However, if a task deletes one (or both) of them, they'll be missing in later tasks. I modified it to ensure the directories are recreated if they're missing at the beginning of each task in the task group.

### Testing
* Updated unit tests.
* Tested in staging by deleting the temporary directory in a task group task, then checking in a later task group task that it was recreated.