### PR TITLE
DEVPROD-9915 enable cgo on macos 

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -87,6 +87,10 @@ func main() {
 	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
 	if system == macGOOS {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+		// Specify the minimum OS version the build should target. This is necessary
+		// for clang to produce a binary that can run on older versions of macOS.
+		// This method for passing build arguments through cgo to clang is suggested
+		// at https://github.com/golang/go/issues/18400#issuecomment-270414574.
 		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_LDFLAGS=-mmacosx-version-min=%s", macMinVersion))
 		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_CFLAGS=-mmacosx-version-min=%s", macMinVersion))
 		cmd.Args = append(cmd.Args, "-installsuffix=evergreen")

--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const macGOOS = "darwin"
+
 func main() {
 	var (
 		arch      string
@@ -77,8 +79,14 @@ func main() {
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
 	}
-	// Disable cgo so that the compiled binary is statically linked.
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	// Disable cgo so that the compiled binary is statically linked. This is useful for systems lacking
+	// libc support. macOS is excluded because it will have libc support and cgo is needed for gopsutil on macOS.
+	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
+	if system == macGOOS {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+	} else {
+		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	}
 
 	goos := "GOOS=" + system
 	goarch := "GOARCH=" + arch

--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -9,7 +9,10 @@ import (
 	"strings"
 )
 
-const macGOOS = "darwin"
+const (
+	macGOOS       = "darwin"
+	macMinVersion = "10.14"
+)
 
 func main() {
 	var (
@@ -84,6 +87,9 @@ func main() {
 	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
 	if system == macGOOS {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
+		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_LDFLAGS=-mmacosx-version-min=%s", macMinVersion))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_CFLAGS=-mmacosx-version-min=%s", macMinVersion))
+		cmd.Args = append(cmd.Args, "-installsuffix=evergreen")
 	} else {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 	}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-15"
+	AgentVersion = "2024-08-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -752,9 +752,11 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin_amd64
     tags: ["build"]
+    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin_arm64
     tags: ["build"]
+    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets
     tags: ["build"]
@@ -768,6 +770,7 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-staging_amd64
     tags: ["build-staging"]
+    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets-staging
     tags: ["build-staging"]
@@ -775,9 +778,11 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-unsigned_amd64
     tags: ["build-unsigned"]
+    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
+    run_on: macos-14-arm64
 
 #######################################
 #            Buildvariants            #


### PR DESCRIPTION
[DEVPROD-9915](https://jira.mongodb.org/browse/DEVPROD-9915)

### Description
Trying again with #8186, which was reverted because the binary wouldn't start on macos versions less than the one it was built on. Apparently this is how it's supposed to work ([docs](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Configuring/configuring.html)). We need to set the `-mmacosx-version-min` flag (documented [here](https://clang.llvm.org/docs/CommandGuide/clang.html#cmdoption-mmacos-version-min)) to the minimum version we want to target. At the moment the oldest mac distros are on 10.14, but I tested setting it even older and that worked too (so we shouldn't feel that every time we retire a macOS version we need to come back here and update it right away).

The solution in this PR is from Russ Cox ([here](https://github.com/golang/go/issues/18400#issuecomment-270414574)) to pass the flag through to clang when it's compiling the C side of things.

### Testing
I built the agent in [a patch](https://spruce.mongodb.com/task/evergreen_build_and_push_display_build_and_push_darwin_unsigned_patch_061f0fbb010e51f27704e5b395cb4d72a8fb1d2a_66be7daad616030007a1e989_24_08_15_22_14_09?execution=0&sortBy=STATUS&sortDir=ASC) and `curl`ed the agent builds to mac hosts of all stripes (10.14, 11, and 14 for intel and 11 and 14 for arm) and the binary was able to run. Also confirmed the min os version on the binaries with [otool](https://www.unix.com/man-page/osx/1/otool/)
For intel
```
$ otool -l ./evergreen | grep minos
    minos 10.14
```

and for arm
```
$ otool -l ./evergreen | grep minos           
    minos 11.0
```

