### PR TITLE
DEVPROD-7885 Retry reading get project body

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -278,18 +278,14 @@ func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*
 	defer resp.Body.Close()
 
 	// Retry reading body since it may error on certain distros for certain go versions.
-	respBytes := []byte{}
 	for i := 0; i < c.retry.MaxAttempts; i++ {
-		respBytes, err = io.ReadAll(resp.Body)
+		respBytes, err := io.ReadAll(resp.Body)
 		if err == nil {
-			break
+			return model.GetProjectFromBSON(respBytes)
+
 		}
 	}
-	if err != nil {
-		return nil, errors.Wrap(err, "reading parser project from response")
-	}
-
-	return model.GetProjectFromBSON(respBytes)
+	return nil, errors.Wrap(err, "reading parser project from response")
 }
 
 func (c *baseCommunicator) GetExpansions(ctx context.Context, taskData TaskData) (util.Expansions, error) {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-15"
+	AgentVersion = "2024-08-19"
 )
 
 // ConfigSection defines a sub-document in the evergreen config


### PR DESCRIPTION
DEVPROD-7885

### Description
Tasks system fail without logs when we error *before* we set up loggers. 
I suspect that this happens because the macos 11 arm distro does not work well with certain golang version's io.ReadAll function and fails randomly because there is a history of that happening with certain goversions. 

The issue seemed to go away after a recent golang version update to the distros but I am adding a retry to this particular read because we would really want this to pass

will update the bf ticket with investigation update!