### PR TITLE
DEVPROD-5739 Only return GitHub Checks Aliases when enabled

### DIFF
--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -252,6 +252,12 @@ func ConstructMergedAliasesByPrecedence(projectRef *ProjectRef, projectConfig *P
 	aliasesToReturn := map[string]ProjectAliases{}
 	for _, alias := range projectAliases {
 		aliasName := alias.Alias
+
+		// Don't include github checks aliases if github checks are disabled
+		if !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
+			continue
+		}
+
 		if IsPatchAlias(aliasName) {
 			aliasName = patchAliasKey
 		}
@@ -268,6 +274,12 @@ func ConstructMergedAliasesByPrecedence(projectRef *ProjectRef, projectConfig *P
 		}
 		for _, alias := range repoAliases {
 			aliasName := alias.Alias
+
+			// Don't include github checks aliases if github checks are disabled
+			if !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
+				continue
+			}
+
 			if IsPatchAlias(aliasName) {
 				aliasName = patchAliasKey
 			}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -254,7 +254,7 @@ func ConstructMergedAliasesByPrecedence(projectRef *ProjectRef, projectConfig *P
 		aliasName := alias.Alias
 
 		// Don't include github checks aliases if github checks are disabled
-		if !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
+		if projectRef != nil && !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
 			continue
 		}
 
@@ -276,7 +276,7 @@ func ConstructMergedAliasesByPrecedence(projectRef *ProjectRef, projectConfig *P
 			aliasName := alias.Alias
 
 			// Don't include github checks aliases if github checks are disabled
-			if !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
+			if projectRef != nil && !utility.FromBoolPtr(projectRef.GithubChecksEnabled) && aliasName == evergreen.GithubChecksAlias {
 				continue
 			}
 

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -317,6 +317,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 		Id:                    "p1",
 		RepoRefId:             "r1",
 		VersionControlEnabled: utility.TruePtr(),
+		GithubChecksEnabled:   utility.TruePtr(),
 	}
 	cqAliases := []ProjectAlias{
 		{
@@ -346,6 +347,11 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			Alias: "something dastardly",
 		},
 	}
+	githubChecksAlias := []ProjectAlias{
+		{
+			Alias: evergreen.GithubChecksAlias,
+		},
+	}
 	projectConfig := ProjectConfig{ProjectConfigFields: ProjectConfigFields{
 		PatchAliases: []ProjectAlias{
 			{
@@ -362,6 +368,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 	for testName, testCase := range map[string]func(t *testing.T){
 		"nothing enabled": func(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(githubChecksAlias, pRef.Id))
 			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
 			tempRef := ProjectRef{ // This ref has nothing else enabled so merging should only return project aliases
 				Id: pRef.Id,
@@ -376,10 +383,11 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
 			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.RepoRefId))
 			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(githubChecksAlias, pRef.RepoRefId))
 			res, err := ConstructMergedAliasesByPrecedence(&pRef, &projectConfig, pRef.RepoRefId)
 			assert.NoError(t, err)
 			// Uses aliases from project, repo, and config
-			require.Len(t, res, 5)
+			require.Len(t, res, 6)
 			cqCount := 0
 			// There should only be two commit queue aliases, and they should all be from the project
 			for _, a := range res {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -398,6 +398,8 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 				} else if a.Alias == evergreen.GitTagAlias {
 					assert.Equal(t, a.ProjectID, pRef.RepoRefId)
 					assert.Equal(t, a.Source, AliasSourceRepo)
+				} else if a.Alias == evergreen.GithubChecksAlias {
+					assert.Equal(t, a.Source, AliasSourceRepo)
 				} else {
 					assert.Equal(t, a.Source, AliasSourceConfig)
 				}


### PR DESCRIPTION
DEVPROD-5739

### Description
github checks aliases being returned was causing things to fail validation silently so now they only return when it is enabled

### Testing
unit test