### PR TITLE
DEVPROD-8323 Set socket timeout for DB client

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -372,6 +372,7 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings, tracer trace
 	opts := options.Client().ApplyURI(settings.Url).SetWriteConcern(settings.WriteConcernSettings.Resolve()).
 		SetReadConcern(settings.ReadConcernSettings.Resolve()).
 		SetTimeout(5 * time.Minute).
+		SetSocketTimeout(5 * time.Minute).
 		SetConnectTimeout(5 * time.Second).
 		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeDisabled(false), apm.WithCommandAttributeTransformer(redactSensitiveCollections)))
 

--- a/environment.go
+++ b/environment.go
@@ -372,6 +372,9 @@ func (e *envState) initDB(ctx context.Context, settings DBSettings, tracer trace
 	opts := options.Client().ApplyURI(settings.Url).SetWriteConcern(settings.WriteConcernSettings.Resolve()).
 		SetReadConcern(settings.ReadConcernSettings.Resolve()).
 		SetTimeout(5 * time.Minute).
+		// SetSocketTimeout will be deprecated in future Go driver releases, though at the time being there
+		// isn't any other way to enforce a time limit on how long the client waits when trying to R/W data
+		// over a connection, so we are including it until Go driver finalizes their timeout API.
 		SetSocketTimeout(5 * time.Minute).
 		SetConnectTimeout(5 * time.Second).
 		SetMonitor(apm.NewMonitor(apm.WithCommandAttributeDisabled(false), apm.WithCommandAttributeTransformer(redactSensitiveCollections)))


### PR DESCRIPTION
DEVPROD-8323

### Description
Since #8148 deployed we've seen a drop in long-hanging Amboy jobs, but we did just observe one occur today ([Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?sid=1724079942.6814920)). Based on the error message the issue seems to be that the client hangs while trying to read the DB server response, so it may be that the socket was open for too long without receiving a full message. 

There is a separate [socket timeout configuration](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connections/connection-guide/#connection-options) that we aren't currently using that will control how long the client waits when trying to R/W data over a connection, rather than waiting indefinitely (as it supposedly does right now).

The go driver [docs](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connections/connection-guide/#single-timeout-setting) give a deprecation warning mentioning that  when using SocketTimeout and Timeout together, while both fields will be respected, it may result in "undefined behavior":
<img width="809" alt="image" src="https://github.com/user-attachments/assets/337ea16e-3674-4062-ac7c-a4a9da79ff37">

I'm skeptical that `Timeout` actually sufficiently covers `SocketTimeout`, though, because if that were the case I wouldn't expect that we'd find any operations hanging for 60+ minutes like in the above Splunk link, because we already have `Timeout` set to 5 minutes. This is why I've added `SocketTimeout` despite the deprecation warning, but open to discuss here.
