### PR TITLE
DEVPROD-9997: fix enum configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -698,10 +698,10 @@ type DBSettings struct {
 type BannerTheme string
 
 const (
-	Announcement BannerTheme = "announcement"
-	Information              = "information"
-	Warning                  = "warning"
-	Important                = "important"
+	Announcement    BannerTheme = "announcement"
+	Information     BannerTheme = "information"
+	Warning         BannerTheme = "warning"
+	Important       BannerTheme = "important"
 )
 
 func IsValidBannerTheme(input string) (bool, BannerTheme) {

--- a/config.go
+++ b/config.go
@@ -698,10 +698,10 @@ type DBSettings struct {
 type BannerTheme string
 
 const (
-	Announcement    BannerTheme = "announcement"
-	Information     BannerTheme = "information"
-	Warning         BannerTheme = "warning"
-	Important       BannerTheme = "important"
+	Announcement BannerTheme = "announcement"
+	Information  BannerTheme = "information"
+	Warning      BannerTheme = "warning"
+	Important    BannerTheme = "important"
 )
 
 func IsValidBannerTheme(input string) (bool, BannerTheme) {

--- a/config_test.go
+++ b/config_test.go
@@ -150,7 +150,7 @@ func (s *AdminSuite) TestBanner() {
 	settings, err = GetConfig(ctx)
 	s.NoError(err)
 	s.NotNil(settings)
-	s.Equal(Important, string(settings.BannerTheme))
+	s.Equal(Important, settings.BannerTheme)
 }
 
 func (s *AdminSuite) TestBaseConfig() {

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -336,9 +336,9 @@ func (s *AdminDataSuite) TestGetBanner() {
 
 	u := &user.DBUser{Id: "me"}
 	s.NoError(evergreen.SetBanner(ctx, "banner text"))
-	s.NoError(SetBannerTheme(ctx, evergreen.Important, u))
+	s.NoError(SetBannerTheme(ctx, string(evergreen.Important), u))
 	text, theme, err := GetBanner(ctx)
 	s.NoError(err)
 	s.Equal("banner text", text)
-	s.Equal(evergreen.Important, theme)
+	s.Equal(string(evergreen.Important), theme)
 }


### PR DESCRIPTION
DEVPROD-9997

### Description
The Enum only generates a single entry in the generated openAPI client code.
that entry is "announcement", which is the only one that appears to be typed.

My assumption is that this causes the Enum to not generate the other possible values.

Once the OpenAPI gets a project result, it tries to validate the input, and finds that the value (in my test case, Information) does not exist as part of the Enum.

### Testing
add a description of how you tested it

### Documentation
remember to add or edit docs in the docs/ directory if relevant

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
