### PR TITLE
DEVPROD-9623: add fake Parameter Store client

### DIFF
--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // ExecutionEnvironmentType is the type of environment in which the code is
@@ -40,5 +42,12 @@ type FakeParameter struct {
 // Insert inserts a single parameter into the fake parameter store.
 func (p *FakeParameter) Insert(ctx context.Context) error {
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertOne(ctx, p)
+	return err
+}
+
+// Upsert inserts a single parameter into the fake parameter store or replaces
+// an one if one with the same ID already exists.
+func (p *FakeParameter) Upsert(ctx context.Context) error {
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).ReplaceOne(ctx, bson.M{IDKey: p.ID}, p, options.Replace().SetUpsert(true))
 	return err
 }

--- a/cloud/parameterstore/fakeparameter/ssm_client.go
+++ b/cloud/parameterstore/fakeparameter/ssm_client.go
@@ -7,9 +7,9 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -39,7 +39,7 @@ func (c *FakeSSMClient) PutParameter(ctx context.Context, input *ssm.PutParamete
 		Value:       value,
 		LastUpdated: time.Now(),
 	}
-	if aws.BoolValue(input.Overwrite) {
+	if aws.ToBool(input.Overwrite) {
 		if err := p.Upsert(ctx); err != nil {
 			return nil, errors.Wrap(err, "upserting fake parameter")
 		}

--- a/cloud/parameterstore/fakeparameter/ssm_client.go
+++ b/cloud/parameterstore/fakeparameter/ssm_client.go
@@ -1,0 +1,136 @@
+package fakeparameter
+
+import (
+	"context"
+	"time"
+
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/evergreen-ci/utility"
+)
+
+// FakeSSMClient implements the parameterstore.SSMClient interface backed by the
+// fake parameters in the DB. This should only be used in testing.
+type FakeSSMClient struct{}
+
+// NewFakeSSMClient returns a fake SSM client implementation backed by the DB.
+// This should only be used in testing.
+func NewFakeSSMClient() *FakeSSMClient {
+	return &FakeSSMClient{}
+}
+
+// PutParameter inserts a parameter into the fake parameter store.
+func (c *FakeSSMClient) PutParameter(ctx context.Context, input *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+	name := utility.FromStringPtr(input.Name)
+	value := utility.FromStringPtr(input.Value)
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(name == "", "name is required")
+	catcher.NewWhen(value == "", "value is required")
+	if catcher.HasErrors() {
+		return nil, errors.Wrap(catcher.Resolve(), "invalid input")
+	}
+
+	p := FakeParameter{
+		ID:          name,
+		Value:       value,
+		LastUpdated: time.Now(),
+	}
+	if err := p.Insert(ctx); err != nil {
+		return nil, errors.Wrap(err, "inserting fake parameter")
+	}
+
+	return &ssm.PutParameterOutput{}, nil
+}
+
+// DeleteParametersSimple is the same as DeleteParameters but only returns the
+// deleted parameter names.
+func (c *FakeSSMClient) DeleteParametersSimple(ctx context.Context, input *ssm.DeleteParametersInput) ([]string, error) {
+	output, err := c.DeleteParameters(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, o := range output {
+		names = append(names, o.DeletedParameters...)
+	}
+	return names, nil
+}
+
+// DeleteParameters deletes the specified parameters from the fake parameter
+// store.
+func (c *FakeSSMClient) DeleteParameters(ctx context.Context, input *ssm.DeleteParametersInput) ([]*ssm.DeleteParametersOutput, error) {
+	names := input.Names
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	var output ssm.DeleteParametersOutput
+	for _, name := range names {
+		deleted, err := DeleteOneID(ctx, name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "deleting fake parameter '%s'", name)
+		}
+		if !deleted {
+			// AWS Parameter Store does not return an error if a parameter does
+			// not exist. Instead it returns it as an invalid parameter in the
+			// result.
+			output.InvalidParameters = append(output.InvalidParameters, name)
+			continue
+		}
+
+		output.DeletedParameters = append(output.DeletedParameters, name)
+	}
+
+	return []*ssm.DeleteParametersOutput{&output}, nil
+}
+
+// GetParametersSimple is the same as GetParameters but only returns the
+// parameters.
+func (c *FakeSSMClient) GetParametersSimple(ctx context.Context, input *ssm.GetParametersInput) ([]ssmTypes.Parameter, error) {
+	outputs, err := c.GetParameters(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	var params []ssmTypes.Parameter
+	for _, o := range outputs {
+		params = append(params, o.Parameters...)
+	}
+	return params, nil
+}
+
+// GetParameters retrieves the specified parameters from the fake parameter
+// store.
+func (c *FakeSSMClient) GetParameters(ctx context.Context, input *ssm.GetParametersInput) ([]*ssm.GetParametersOutput, error) {
+	names := input.Names
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	var output ssm.GetParametersOutput
+	for _, name := range names {
+		p, err := FindOneID(ctx, name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding parameter '%s'", name)
+		}
+		if p == nil {
+			// AWS Parameter Store does not return an error if a parameter does
+			// not exist. Instead it returns it as an invalid parameter in the
+			// result.
+			output.InvalidParameters = append(output.InvalidParameters, name)
+			continue
+		}
+
+		output.Parameters = append(output.Parameters, ssmTypes.Parameter{
+			Name:             utility.ToStringPtr(p.ID),
+			Value:            utility.ToStringPtr(p.Value),
+			LastModifiedDate: utility.ToTimePtr(p.LastUpdated),
+		})
+	}
+
+	return []*ssm.GetParametersOutput{&output}, nil
+}

--- a/cloud/parameterstore/fakeparameter/ssm_client.go
+++ b/cloud/parameterstore/fakeparameter/ssm_client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -38,8 +39,14 @@ func (c *FakeSSMClient) PutParameter(ctx context.Context, input *ssm.PutParamete
 		Value:       value,
 		LastUpdated: time.Now(),
 	}
-	if err := p.Insert(ctx); err != nil {
-		return nil, errors.Wrap(err, "inserting fake parameter")
+	if aws.BoolValue(input.Overwrite) {
+		if err := p.Upsert(ctx); err != nil {
+			return nil, errors.Wrap(err, "upserting fake parameter")
+		}
+	} else {
+		if err := p.Insert(ctx); err != nil {
+			return nil, errors.Wrap(err, "inserting fake parameter")
+		}
 	}
 
 	return &ssm.PutParameterOutput{}, nil

--- a/cloud/parameterstore/fakeparameter/ssm_client_test.go
+++ b/cloud/parameterstore/fakeparameter/ssm_client_test.go
@@ -1,0 +1,206 @@
+package fakeparameter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeSSMClient(t *testing.T) {
+	assert.Implements(t, (*parameterstore.SSMClient)(nil), NewFakeSSMClient())
+
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter){
+		"PutParameterSucceeds": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			p := params[0]
+			input := &ssm.PutParameterInput{
+				Name:      utility.ToStringPtr(p.ID),
+				Value:     utility.ToStringPtr(p.Value),
+				Overwrite: utility.ToBoolPtr(true),
+			}
+			output, err := c.PutParameter(ctx, input)
+			require.NoError(t, err)
+			require.NotZero(t, output)
+
+			dbParam, err := FindOneID(ctx, p.ID)
+			require.NoError(t, err)
+			require.NotZero(t, dbParam)
+			assert.Equal(t, p.ID, dbParam.ID)
+			assert.Equal(t, p.Value, dbParam.Value)
+			assert.WithinDuration(t, time.Now(), dbParam.LastUpdated, time.Second, "last updated time should be bumped")
+		},
+		"PutParameterFailsWithInvalidInput": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			input := &ssm.PutParameterInput{}
+			output, err := c.PutParameter(ctx, input)
+			assert.Error(t, err)
+			assert.Zero(t, output)
+		},
+		"DeleteParametersWithSingleParameterSucceeds": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				require.NoError(t, p.Insert(ctx))
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.DeleteParametersInput{
+				Names: paramNames[0:1],
+			}
+			outputs, err := c.DeleteParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			assert.ElementsMatch(t, paramNames[0:1], outputs[0].DeletedParameters)
+
+			dbParam, err := FindOneID(ctx, paramNames[0])
+			assert.NoError(t, err)
+			assert.Zero(t, dbParam)
+
+			dbParams, err := FindByIDs(ctx, paramNames[1:]...)
+			require.NoError(t, err)
+			require.NotZero(t, dbParams)
+			assert.Len(t, dbParams, len(paramNames[1:]))
+		},
+		"DeleteParametersWithMultipleParametersSucceeds": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				require.NoError(t, p.Insert(ctx))
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.DeleteParametersInput{
+				Names: paramNames[0:3],
+			}
+			outputs, err := c.DeleteParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			assert.ElementsMatch(t, paramNames[0:3], outputs[0].DeletedParameters)
+
+			dbDeletedParams, err := FindByIDs(ctx, paramNames[0:3]...)
+			assert.NoError(t, err)
+			assert.Empty(t, dbDeletedParams)
+
+			dbParams, err := FindByIDs(ctx, paramNames[3:]...)
+			require.NoError(t, err)
+			require.NotZero(t, dbParams)
+			assert.Len(t, dbParams, len(paramNames[3:]))
+		},
+		"DeleteParametersWithNonexistentParametersReturnsInvalidParameters": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.DeleteParametersInput{
+				Names: paramNames,
+			}
+			outputs, err := c.DeleteParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			assert.Empty(t, outputs[0].DeletedParameters, "should not return any deleted parameters because they are not present in fake parameter store")
+			assert.ElementsMatch(t, paramNames, outputs[0].InvalidParameters, "nonexistent parameters should appear in invalid parameters")
+		},
+		"DeleteParametersNoopsWithNoNames": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			input := &ssm.DeleteParametersInput{}
+			deletedNames, err := c.DeleteParametersSimple(ctx, input)
+			assert.NoError(t, err)
+			assert.Empty(t, deletedNames)
+		},
+		"GetParametersWithSingleParameterSucceeds": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				require.NoError(t, p.Insert(ctx))
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.GetParametersInput{
+				Names: paramNames[0:1],
+			}
+			outputs, err := c.GetParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			foundParams := outputs[0].Parameters
+			require.Len(t, foundParams, 1)
+			assert.Equal(t, params[0].ID, utility.FromStringPtr(foundParams[0].Name))
+			assert.Equal(t, params[0].Value, utility.FromStringPtr(foundParams[0].Value))
+			assert.Zero(t, utility.FromTimePtr(foundParams[0].LastModifiedDate), "should not bump last modified date for a get operation")
+		},
+		"GetParametersWithMultipleParametersSucceeds": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				require.NoError(t, p.Insert(ctx))
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.GetParametersInput{
+				Names: paramNames[0:3],
+			}
+			outputs, err := c.GetParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			foundParams := outputs[0].Parameters
+			require.Len(t, foundParams, 3)
+			for _, foundParam := range foundParams {
+				name := utility.FromStringPtr(foundParam.Name)
+				switch name {
+				case params[0].ID:
+					assert.Equal(t, utility.FromStringPtr(foundParam.Value), params[0].Value)
+				case params[1].ID:
+					assert.Equal(t, utility.FromStringPtr(foundParam.Value), params[1].Value)
+				case params[2].ID:
+					assert.Equal(t, utility.FromStringPtr(foundParam.Value), params[2].Value)
+				default:
+					assert.FailNow(t, "unexpected parameter '%s' returned in results", name)
+				}
+				assert.Zero(t, utility.FromTimePtr(foundParams[0].LastModifiedDate), "should not bump last modified date for a get operation")
+			}
+		},
+		"GetParametersWithNonexistentParametersReturnsInvalidParameters": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			paramNames := make([]string, 0, len(params))
+			for _, p := range params {
+				paramNames = append(paramNames, p.ID)
+			}
+
+			input := &ssm.GetParametersInput{
+				Names: paramNames,
+			}
+			outputs, err := c.GetParameters(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, outputs, 1)
+			assert.Empty(t, outputs[0].Parameters, "should not return any parameters because they are not present in fake parameter store")
+			assert.ElementsMatch(t, paramNames, outputs[0].InvalidParameters, "nonexistent parameters should appear in invalid parameters")
+		},
+		"GetParametersNoopsWithNoNames": func(ctx context.Context, t *testing.T, c *FakeSSMClient, params []FakeParameter) {
+			input := &ssm.GetParametersInput{}
+			outputs, err := c.GetParameters(ctx, input)
+			assert.NoError(t, err)
+			assert.Empty(t, outputs)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, db.ClearCollections(Collection))
+
+			var params []FakeParameter
+			for i := 0; i < 5; i++ {
+				params = append(params, FakeParameter{
+					ID:    fmt.Sprintf("name-%d", i),
+					Value: fmt.Sprintf("value-%d", i),
+				})
+			}
+
+			tCase(ctx, t, NewFakeSSMClient(), params)
+		})
+	}
+}

--- a/cloud/parameterstore/ssm_client_test.go
+++ b/cloud/parameterstore/ssm_client_test.go
@@ -1,0 +1,11 @@
+package parameterstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSMClientImpl(t *testing.T) {
+	assert.Implements(t, (*SSMClient)(nil), &ssmClientImpl{})
+}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -507,6 +507,9 @@ tasks:
     name: test-cloud
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
+    name: test-cloud-parameterstore
+  - <<: *run-go-test-suite-with-mongodb
+    tags: ["db", "test"]
     name: test-cloud-parameterstore-fakeparameter
   - <<: *run-go-test-suite
     tags: ["nodb", "test"]


### PR DESCRIPTION
DEVPROD-9623

### Description
Follow-up to #8194 to create an testing-only implementation of the SSMClient interface. Will be useful when testing code that relies on Parameter Store. This way, the unit tests can use an implementation backed by the DB rather than relying on an actual Parameter Store instance.

### Testing
Added unit tests.

### Documentation
N/A
