### PR TITLE
DEVPROD-9403: create parameter manager

### DIFF
--- a/cloud/parameterstore/db.go
+++ b/cloud/parameterstore/db.go
@@ -1,0 +1,14 @@
+package parameterstore
+
+import "time"
+
+const Collection = "parameter_metadata"
+
+// Parameter stores metadata about a parameter kept in Parameter Store. This
+// should only store metadata about the parameter, not the value itself.
+type parameterMetadata struct {
+	// Name is the unique full path identifier the parameter.
+	Name string `bson:"_id" json:"_id"`
+	// LastUpdated is the time the parameter was most recently updated.
+	LastUpdated time.Time `bson:"last_updated" json:"last_updated"`
+}

--- a/cloud/parameterstore/fakeparameter/parameter_manager_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_manager_test.go
@@ -1,0 +1,124 @@
+package fakeparameter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for ParameterManager are in this package to avoid a circular
+// dependency between the two packages.
+func TestParameterManager(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	checkParamInDB := func(ctx context.Context, t *testing.T, p *parameterstore.Parameter) {
+		dbParam, err := FindOneID(ctx, p.Name)
+		require.NoError(t, err)
+		require.NotZero(t, dbParam)
+		assert.Equal(t, p.Name, dbParam.ID, "full name should be used as fake parameter ID")
+		assert.Equal(t, p.Value, dbParam.Value)
+	}
+	checkParam := func(ctx context.Context, t *testing.T, p *parameterstore.Parameter, name, basename, value string) {
+		require.NotZero(t, p)
+		assert.Equal(t, name, p.Name)
+		assert.Equal(t, basename, p.Basename)
+		assert.Equal(t, value, p.Value)
+		checkParamInDB(ctx, t, p)
+	}
+
+	for managerTestName, makeParameterManager := range map[string]func() *parameterstore.ParameterManager{
+		"CachingDisabled": func() *parameterstore.ParameterManager {
+			return parameterstore.NewParameterManager("prefix", false, NewFakeSSMClient(), evergreen.GetEnvironment().DB())
+		},
+		// TODO (DEVPROD-9403): test same conditions work with caching enabled.
+	} {
+		t.Run(managerTestName, func(t *testing.T) {
+			for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager){
+				"PutAddsNewParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					for i := 0; i < 5; i++ {
+						name := fmt.Sprintf("name-%d", i)
+						value := fmt.Sprintf("value-%d", i)
+						p, err := pm.Put(ctx, name, value)
+						require.NoError(t, err)
+						checkParam(ctx, t, p, fmt.Sprintf("/prefix/%s", name), name, value)
+					}
+				},
+				"PutIncludesPrefixForPartialName": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					name := fmt.Sprintf("/path/to/name")
+					value := "value"
+					p, err := pm.Put(ctx, name, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/path/to/name", "name", value)
+				},
+				"PutOverwritesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					name := "name"
+					value := "old_value"
+					oldParam, err := pm.Put(ctx, name, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, oldParam, "/prefix/name", name, value)
+
+					newValue := "new_value"
+					newParam, err := pm.Put(ctx, name, newValue)
+					require.NoError(t, err)
+					checkParam(ctx, t, newParam, "/prefix/name", name, newValue)
+				},
+				// kim: TODO: add remaining tests.
+				"DeleteRemovesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"DeleteNoopsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetReturnsNoResultForNoParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetReturnsExistingSubsetForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetReturnsNoResultForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetStrictReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetStrictErrorsForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"GetStrictErrorsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+
+				},
+				"PutGetDeleteLifecycleWorks": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					name := "name"
+					value := "value"
+					p, err := pm.Put(ctx, name, value)
+					require.NoError(t, err)
+					assert.Equal(t, "/prefix/name", p.Name, "full name should include prefix")
+					assert.Equal(t, name, p.Basename)
+					assert.Equal(t, value, p.Value)
+				},
+			} {
+				t.Run(tName, func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+
+					require.NoError(t, db.ClearCollections(Collection))
+
+					pm := makeParameterManager()
+
+					tCase(ctx, t, pm)
+				})
+			}
+		})
+	}
+}

--- a/cloud/parameterstore/fakeparameter/parameter_manager_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_manager_test.go
@@ -29,7 +29,7 @@ func TestParameterManager(t *testing.T) {
 		assert.Equal(t, p.Value, dbParam.Value)
 	}
 	// checkParam checks that the input parameter matches the expected values
-	// and that it matches the document in the DB.
+	// and that it matches a corresponding document in the DB.
 	checkParam := func(ctx context.Context, t *testing.T, p *parameterstore.Parameter, name, basename, value string) {
 		require.NotZero(t, p)
 		assert.Equal(t, name, p.Name)

--- a/cloud/parameterstore/fakeparameter/parameter_manager_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_manager_test.go
@@ -12,20 +12,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Tests for ParameterManager are in this package to avoid a circular
-// dependency between the two packages.
+// Tests for the ParameterManager functionality are in this package to avoid a
+// circular dependency between the two packages.
 func TestParameterManager(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection))
 	}()
 
+	// checkParamInDB checks that the input parameter matches the document in
+	// the DB.
 	checkParamInDB := func(ctx context.Context, t *testing.T, p *parameterstore.Parameter) {
 		dbParam, err := FindOneID(ctx, p.Name)
 		require.NoError(t, err)
 		require.NotZero(t, dbParam)
-		assert.Equal(t, p.Name, dbParam.ID, "full name should be used as fake parameter ID")
+		assert.Equal(t, p.Name, dbParam.ID)
 		assert.Equal(t, p.Value, dbParam.Value)
 	}
+	// checkParam checks that the input parameter matches the expected values
+	// and that it matches the document in the DB.
 	checkParam := func(ctx context.Context, t *testing.T, p *parameterstore.Parameter, name, basename, value string) {
 		require.NotZero(t, p)
 		assert.Equal(t, name, p.Name)
@@ -38,74 +42,182 @@ func TestParameterManager(t *testing.T) {
 		"CachingDisabled": func() *parameterstore.ParameterManager {
 			return parameterstore.NewParameterManager("prefix", false, NewFakeSSMClient(), evergreen.GetEnvironment().DB())
 		},
-		// TODO (DEVPROD-9403): test same conditions work with caching enabled.
+		// TODO (DEVPROD-9403): test same conditions pass with caching enabled.
 	} {
 		t.Run(managerTestName, func(t *testing.T) {
 			for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager){
 				"PutAddsNewParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					for i := 0; i < 5; i++ {
+						basename := fmt.Sprintf("name-%d", i)
+						value := fmt.Sprintf("value-%d", i)
+						p, err := pm.Put(ctx, basename, value)
+						require.NoError(t, err)
+						checkParam(ctx, t, p, fmt.Sprintf("/prefix/%s", basename), basename, value)
+					}
+				},
+				"PutIncludesPrefixForPartialName": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const partialName = "/path/to/basename"
+					const value = "value"
+					p, err := pm.Put(ctx, partialName, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/path/to/basename", "basename", value)
+				},
+				"PutOverwritesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "old_value"
+					oldParam, err := pm.Put(ctx, basename, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, oldParam, "/prefix/basename", basename, value)
+
+					const newValue = "new_value"
+					newParam, err := pm.Put(ctx, basename, newValue)
+					require.NoError(t, err)
+					checkParam(ctx, t, newParam, "/prefix/basename", basename, newValue)
+				},
+				"DeleteRemovesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "value"
+					p, err := pm.Put(ctx, basename, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/basename", basename, value)
+
+					require.NoError(t, pm.Delete(ctx, basename))
+
+					dbParam, err := FindOneID(ctx, basename)
+					assert.NoError(t, err)
+					assert.Zero(t, dbParam)
+				},
+				"DeleteNoopsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					assert.NoError(t, pm.Delete(ctx, "nonexistent"))
+				},
+				"GetReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					precreatedParams := map[string]parameterstore.Parameter{}
+					var names []string
+					const numParams = 5
+					for i := 0; i < numParams; i++ {
 						name := fmt.Sprintf("name-%d", i)
 						value := fmt.Sprintf("value-%d", i)
 						p, err := pm.Put(ctx, name, value)
 						require.NoError(t, err)
 						checkParam(ctx, t, p, fmt.Sprintf("/prefix/%s", name), name, value)
+						precreatedParams[p.Name] = *p
+						names = append(names, p.Name)
+					}
+
+					foundParams, err := pm.Get(ctx, names...)
+					require.NoError(t, err)
+					require.Len(t, foundParams, numParams)
+					for _, foundParam := range foundParams {
+						expectedParam, ok := precreatedParams[foundParam.Name]
+						require.True(t, ok, "found unexpected param '%s'", foundParam.Name)
+						checkParam(ctx, t, &foundParam, expectedParam.Name, expectedParam.Basename, expectedParam.Value)
 					}
 				},
-				"PutIncludesPrefixForPartialName": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-					name := fmt.Sprintf("/path/to/name")
-					value := "value"
-					p, err := pm.Put(ctx, name, value)
+				"GetReturnsMatchingFullNameParameterFromJustBasename": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "value"
+					p, err := pm.Put(ctx, basename, value)
 					require.NoError(t, err)
-					checkParam(ctx, t, p, "/prefix/path/to/name", "name", value)
-				},
-				"PutOverwritesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-					name := "name"
-					value := "old_value"
-					oldParam, err := pm.Put(ctx, name, value)
+					checkParam(ctx, t, p, "/prefix/basename", basename, value)
+
+					foundParams, err := pm.Get(ctx, basename)
 					require.NoError(t, err)
-					checkParam(ctx, t, oldParam, "/prefix/name", name, value)
-
-					newValue := "new_value"
-					newParam, err := pm.Put(ctx, name, newValue)
-					require.NoError(t, err)
-					checkParam(ctx, t, newParam, "/prefix/name", name, newValue)
+					checkParam(ctx, t, &foundParams[0], "/prefix/basename", basename, value)
 				},
-				// kim: TODO: add remaining tests.
-				"DeleteRemovesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-
-				},
-				"DeleteNoopsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-
-				},
-				"GetReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-
-				},
-				"GetReturnsNoResultForNoParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-
-				},
-				"GetReturnsExistingSubsetForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-
+				"GetReturnsNoResultForNoRequestedParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					foundParams, err := pm.Get(ctx)
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
 				},
 				"GetReturnsNoResultForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					foundParams, err := pm.Get(ctx, "nonexistent")
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
+				},
+				"GetReturnsExistingSubsetForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "value"
+					p, err := pm.Put(ctx, basename, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/basename", basename, value)
 
+					foundParams, err := pm.Get(ctx, "/prefix/basename", "nonexistent", "/prefix/also-nonexistent")
+					require.NoError(t, err)
+					require.Len(t, foundParams, 1)
+					checkParam(ctx, t, &foundParams[0], "/prefix/basename", basename, value)
 				},
 				"GetStrictReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					precreatedParams := map[string]parameterstore.Parameter{}
+					var names []string
+					const numParams = 5
+					for i := 0; i < numParams; i++ {
+						name := fmt.Sprintf("name-%d", i)
+						value := fmt.Sprintf("value-%d", i)
+						p, err := pm.Put(ctx, name, value)
+						require.NoError(t, err)
+						checkParam(ctx, t, p, fmt.Sprintf("/prefix/%s", name), name, value)
+						precreatedParams[p.Name] = *p
+						names = append(names, p.Name)
+					}
 
+					foundParams, err := pm.GetStrict(ctx, names...)
+					require.NoError(t, err)
+					require.Len(t, foundParams, numParams)
+					for _, foundParam := range foundParams {
+						expectedParam, ok := precreatedParams[foundParam.Name]
+						require.True(t, ok, "found unexpected param '%s'", foundParam.Name)
+						checkParam(ctx, t, &foundParam, expectedParam.Name, expectedParam.Basename, expectedParam.Value)
+					}
 				},
-				"GetStrictErrorsForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+				"GetStrictReturnsMatchingParameterFromJustBasename": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "value"
+					p, err := pm.Put(ctx, basename, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/basename", basename, value)
 
+					foundParams, err := pm.Get(ctx, basename)
+					require.NoError(t, err)
+					checkParam(ctx, t, &foundParams[0], "/prefix/basename", basename, value)
+				},
+				"GetStrictReturnsNoResultForNoRequestedParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					foundParams, err := pm.Get(ctx)
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
 				},
 				"GetStrictErrorsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					foundParams, err := pm.GetStrict(ctx, "nonexistent")
+					assert.Error(t, err)
+					assert.Empty(t, foundParams)
+				},
+				"GetStrictErrorsForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
+					const basename = "basename"
+					const value = "value"
+					p, err := pm.Put(ctx, basename, value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, "/prefix/basename", basename, value)
 
+					foundParams, err := pm.GetStrict(ctx, "/prefix/basename", "nonexistent", "/prefix/also-nonexistent")
+					assert.Error(t, err)
+					assert.Empty(t, foundParams)
 				},
 				"PutGetDeleteLifecycleWorks": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-					name := "name"
+					name := "basename"
 					value := "value"
 					p, err := pm.Put(ctx, name, value)
 					require.NoError(t, err)
-					assert.Equal(t, "/prefix/name", p.Name, "full name should include prefix")
-					assert.Equal(t, name, p.Basename)
-					assert.Equal(t, value, p.Value)
+					checkParam(ctx, t, p, "/prefix/basename", name, value)
+
+					foundParams, err := pm.Get(ctx, name)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 1)
+					checkParam(ctx, t, &foundParams[0], "/prefix/basename", name, value)
+
+					require.NoError(t, pm.Delete(ctx, name))
+
+					foundParams, err = pm.Get(ctx, name)
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
 				},
 			} {
 				t.Run(tName, func(t *testing.T) {

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -37,7 +37,6 @@ type ParameterManager struct {
 }
 
 // NewParameterManager creates a new ParameterManager instance.
-// kim: TODO: add test
 func NewParameterManager(prefix string, cachingEnabled bool, ssmClient SSMClient, db *mongo.Database) *ParameterManager {
 	prefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(prefix, "/"), "/"))
 	return &ParameterManager{
@@ -100,11 +99,11 @@ func (pm *ParameterManager) Get(ctx context.Context, names ...string) ([]Paramet
 
 	params := make([]Parameter, 0, len(ssmParams))
 	for _, p := range ssmParams {
-		name := aws.StringValue(p.Name)
+		name := aws.ToString(p.Name)
 		params = append(params, Parameter{
 			Name:     name,
 			Basename: pm.getBasename(name),
-			Value:    aws.StringValue(p.Value),
+			Value:    aws.ToString(p.Value),
 		})
 	}
 

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -1,0 +1,195 @@
+package parameterstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Parameter represents a parameter kept in Parameter Store.
+type Parameter struct {
+	// Name is the full name of the parameter, including its path. This is a
+	// unique identifier.
+	Name string `bson:"-" json:"-" yaml:"-"`
+	// Basename is the parameter's name without any hierarchical paths. For
+	// example, if the full name including the path is
+	// /evergreen/prefix/my-parameter, the basename is my-parameter.
+	Basename string `bson:"-" json:"-" yaml:"-"`
+	// Value is the parameter's plaintext value.
+	Value string `bson:"-" json:"-" yaml:"-"`
+}
+
+// ParameterManager is an intermediate abstraction layer for interacting with
+// parameters in AWS Systems Manager Parameter Store. It supports caching to
+// optimize parameter retrieval.
+type ParameterManager struct {
+	prefix         string
+	cachingEnabled bool
+	ssmClient      SSMClient
+	db             *mongo.Database
+}
+
+// NewParameterManager creates a new ParameterManager instance.
+// kim: TODO: add test
+func NewParameterManager(prefix string, cachingEnabled bool, ssmClient SSMClient, db *mongo.Database) *ParameterManager {
+	prefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(prefix, "/"), "/"))
+	return &ParameterManager{
+		prefix:         prefix,
+		cachingEnabled: cachingEnabled,
+		ssmClient:      ssmClient,
+		db:             db,
+	}
+}
+
+// Put adds or updates a parameter. This returns the created parameter.
+// kim: TODO: test in fakeparameters package once fake PS client is available
+// (to avoid cyclical dependency).
+func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Parameter, error) {
+	fullName := pm.getPrefixedName(name)
+	if _, err := pm.ssmClient.PutParameter(ctx, &ssm.PutParameterInput{
+		Name:      aws.String(fullName),
+		Value:     aws.String(value),
+		Overwrite: aws.Bool(true),
+		Type:      ssmTypes.ParameterTypeSecureString,
+		Tier:      ssmTypes.ParameterTierIntelligentTiering,
+	}); err != nil {
+		return nil, errors.Wrapf(err, "putting parameter '%s'", name)
+	}
+
+	// TODO (DEVPROD-9403): update cache as needed.
+
+	return &Parameter{
+		Name:     fullName,
+		Basename: pm.getBasename(fullName),
+		Value:    value,
+	}, nil
+}
+
+// Get retrieves the parameters given by the provided name(s). If some
+// parameters cannot be found, they will not be returned. Use GetStrict to both
+// get the parameters and validate that all the requested parameters were found.
+// kim: TODO: test in fakeparameters package once fake PS client is available
+// (to avoid cyclical dependency).
+func (pm *ParameterManager) Get(ctx context.Context, names ...string) ([]Parameter, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	// TODO (DEVPROD-9403): use caching if possible before retrieving value from
+	// Parameter Store.
+
+	fullNames := make([]string, 0, len(names))
+	for _, name := range names {
+		fullNames = append(fullNames, pm.getPrefixedName(name))
+	}
+
+	ssmParams, err := pm.ssmClient.GetParametersSimple(ctx, &ssm.GetParametersInput{
+		Names:          fullNames,
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "getting %d parameters", len(names))
+	}
+
+	params := make([]Parameter, 0, len(ssmParams))
+	for _, p := range ssmParams {
+		name := aws.StringValue(p.Name)
+		params = append(params, Parameter{
+			Name:     name,
+			Basename: pm.getBasename(name),
+			Value:    aws.StringValue(p.Value),
+		})
+	}
+
+	return params, nil
+}
+
+// GetStrict is the same as Get but verifies that all the requested parameter
+// names were found before returning the result.
+// kim: TODO: test in fakeparameters package once fake PS client is available
+// (to avoid cyclical dependency).
+func (pm *ParameterManager) GetStrict(ctx context.Context, names ...string) ([]Parameter, error) {
+	fullNames := make([]string, 0, len(names))
+	for _, name := range names {
+		fullNames = append(fullNames, pm.getPrefixedName(name))
+	}
+
+	params, err := pm.Get(ctx, names...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params) != len(fullNames) {
+		foundNames := make(map[string]struct{}, len(params))
+		for _, p := range params {
+			foundNames[p.Name] = struct{}{}
+		}
+
+		var missingNames []string
+		for _, name := range fullNames {
+			if _, ok := foundNames[name]; !ok {
+				missingNames = append(missingNames, name)
+			}
+		}
+
+		if len(missingNames) > 0 {
+			return nil, errors.Errorf("parameter(s) not found: %s", missingNames)
+		}
+	}
+
+	return params, nil
+}
+
+// Delete deletes the parameters given by the provided name(s).
+// kim: TODO: test in fakeparameters package once fake PS client is available
+// (to avoid cyclical dependency).
+func (pm *ParameterManager) Delete(ctx context.Context, names ...string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	fullNames := make([]string, 0, len(names))
+	for _, name := range names {
+		fullNames = append(fullNames, pm.getPrefixedName(name))
+	}
+
+	_, err := pm.ssmClient.DeleteParameters(ctx, &ssm.DeleteParametersInput{
+		Names: fullNames,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "deleting %d parameters", len(names))
+	}
+
+	// TODO (DEVPROD-9403): update cache as needed.
+
+	return nil
+}
+
+// getPrefixedName returns the parameter name with the common parameter prefix
+// to ensure it is a full path rather than a basename.
+func (pm *ParameterManager) getPrefixedName(basename string) string {
+	if pm.prefix == "" {
+		return basename
+	}
+	if strings.HasPrefix(basename, pm.prefix) {
+		return basename
+	}
+	prefix := strings.TrimSuffix(strings.TrimPrefix(pm.prefix, "/"), "/")
+	return fmt.Sprintf("/%s/%s", prefix, strings.TrimPrefix(basename, "/"))
+}
+
+// getBasename returns the parameter basename without any intermediate paths.
+func (pm *ParameterManager) getBasename(name string) string {
+	idx := strings.LastIndex(name, "/")
+	if idx == -1 {
+		return name
+	}
+	return name[idx+1:]
+}

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -30,17 +30,17 @@ type Parameter struct {
 // parameters in AWS Systems Manager Parameter Store. It supports caching to
 // optimize parameter retrieval.
 type ParameterManager struct {
-	prefix         string
+	pathPrefix     string
 	cachingEnabled bool
 	ssmClient      SSMClient
 	db             *mongo.Database
 }
 
 // NewParameterManager creates a new ParameterManager instance.
-func NewParameterManager(prefix string, cachingEnabled bool, ssmClient SSMClient, db *mongo.Database) *ParameterManager {
-	prefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(prefix, "/"), "/"))
+func NewParameterManager(pathPrefix string, cachingEnabled bool, ssmClient SSMClient, db *mongo.Database) *ParameterManager {
+	pathPrefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(pathPrefix, "/"), "/"))
 	return &ParameterManager{
-		prefix:         prefix,
+		pathPrefix:     pathPrefix,
 		cachingEnabled: cachingEnabled,
 		ssmClient:      ssmClient,
 		db:             db,
@@ -174,14 +174,14 @@ func (pm *ParameterManager) Delete(ctx context.Context, names ...string) error {
 // getPrefixedName returns the parameter name with the common parameter prefix
 // to ensure it is a full path rather than a basename.
 func (pm *ParameterManager) getPrefixedName(basename string) string {
-	if pm.prefix == "" {
+	if pm.pathPrefix == "" {
 		return basename
 	}
-	if strings.HasPrefix(basename, pm.prefix) {
+	if strings.HasPrefix(basename, pm.pathPrefix) {
 		return basename
 	}
-	prefix := strings.TrimSuffix(strings.TrimPrefix(pm.prefix, "/"), "/")
-	return fmt.Sprintf("/%s/%s", prefix, strings.TrimPrefix(basename, "/"))
+	pathPrefix := strings.TrimSuffix(strings.TrimPrefix(pm.pathPrefix, "/"), "/")
+	return fmt.Sprintf("/%s/%s", pathPrefix, strings.TrimPrefix(basename, "/"))
 }
 
 // getBasename returns the parameter basename without any intermediate paths.

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -1,0 +1,41 @@
+package parameterstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This tests basic functionality in the Parameter Manager.
+// It's not possible to integration test directly with an SSM client in this
+// package because tests do not have a real Parameter Store instance to use.
+// Furthermore, using the fake Parameter Store client implementation in this
+// package would produce a circular package dependency.
+func TestParameterManager(t *testing.T) {
+	pm := NewParameterManager("prefix", false, nil, nil)
+	t.Run("GetPrefixedName", func(t *testing.T) {
+		t.Run("PrefixesBasenames", func(t *testing.T) {
+			assert.Equal(t, "/prefix/basename", pm.getPrefixedName("basename"))
+		})
+		t.Run("PrefixesPartialFullNames", func(t *testing.T) {
+			assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/path/to/basename"))
+		})
+		t.Run("NoopsForAlreadyPrefixedName", func(t *testing.T) {
+			assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/prefix/path/to/basename"))
+		})
+	})
+	t.Run("GetBasename", func(t *testing.T) {
+		t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
+			fullName := pm.getPrefixedName("basename")
+			assert.Equal(t, "/prefix/basename", fullName)
+			assert.Equal(t, "basename", pm.getBasename(fullName))
+		})
+		t.Run("ParsesBasenameFromFullNameWithoutPrefix", func(t *testing.T) {
+			fullName := "/some/other/path/basename"
+			assert.Equal(t, "basename", pm.getBasename(fullName))
+		})
+		t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
+			assert.Equal(t, "basename", pm.getBasename("basename"))
+		})
+	})
+}

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -12,30 +12,43 @@ import (
 // Furthermore, using the fake Parameter Store client implementation in this
 // package would produce a circular package dependency.
 func TestParameterManager(t *testing.T) {
-	pm := NewParameterManager("prefix", false, nil, nil)
-	t.Run("GetPrefixedName", func(t *testing.T) {
-		t.Run("PrefixesBasenames", func(t *testing.T) {
-			assert.Equal(t, "/prefix/basename", pm.getPrefixedName("basename"))
+	for prefixTestCase, prefix := range map[string]string{
+		// Check resiliency against various possible slashes in the path prefix.
+		"PathPrefixWithoutLeadingOrTrailingSlash": "prefix",
+		"PathPrefixWithLeadingSlash":              "/prefix",
+		"PathPrefixWithTrailingSlash":             "prefix/",
+		"PathPrefixWithLeadingAndTrailingSlash":   "/prefix/",
+	} {
+		t.Run(prefixTestCase, func(t *testing.T) {
+			pm := NewParameterManager(prefix, false, nil, nil)
+			t.Run("GetPrefixedName", func(t *testing.T) {
+				t.Run("PrefixesBasename", func(t *testing.T) {
+					assert.Equal(t, "/prefix/basename", pm.getPrefixedName("basename"))
+				})
+				t.Run("PrefixesPartialName", func(t *testing.T) {
+					assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/path/to/basename"))
+				})
+				t.Run("PrefixesPartialNamesWithoutLeadingSlash", func(t *testing.T) {
+					assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("path/to/basename"))
+				})
+				t.Run("NoopsForAlreadyPrefixedName", func(t *testing.T) {
+					assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/prefix/path/to/basename"))
+				})
+			})
+			t.Run("GetBasename", func(t *testing.T) {
+				t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
+					fullName := pm.getPrefixedName("basename")
+					assert.Equal(t, "/prefix/basename", fullName)
+					assert.Equal(t, "basename", pm.getBasename(fullName))
+				})
+				t.Run("ParsesBasenameFromFullNameWithoutPrefix", func(t *testing.T) {
+					fullName := "/some/other/path/basename"
+					assert.Equal(t, "basename", pm.getBasename(fullName))
+				})
+				t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
+					assert.Equal(t, "basename", pm.getBasename("basename"))
+				})
+			})
 		})
-		t.Run("PrefixesPartialFullNames", func(t *testing.T) {
-			assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/path/to/basename"))
-		})
-		t.Run("NoopsForAlreadyPrefixedName", func(t *testing.T) {
-			assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/prefix/path/to/basename"))
-		})
-	})
-	t.Run("GetBasename", func(t *testing.T) {
-		t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
-			fullName := pm.getPrefixedName("basename")
-			assert.Equal(t, "/prefix/basename", fullName)
-			assert.Equal(t, "basename", pm.getBasename(fullName))
-		})
-		t.Run("ParsesBasenameFromFullNameWithoutPrefix", func(t *testing.T) {
-			fullName := "/some/other/path/basename"
-			assert.Equal(t, "basename", pm.getBasename(fullName))
-		})
-		t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
-			assert.Equal(t, "basename", pm.getBasename("basename"))
-		})
-	})
+	}
 }


### PR DESCRIPTION
DEVPROD-9403

### Description
This sets up some scaffolding to both use Parameter Store and support a cache. The caching part isn't implemented yet, so I left some TODOs and will add it in a follow-up PR.

* Create a middle layer ParameterManager to sit in between the raw SSM client and application logic. This is to support some common operations like using a shared prefix for parameters parameters and using the cache if enabled.

### Testing
Added unit tests for Parameter Manager and some integration tests for using it with the fake SSM client implementation that's used for testing.

### Documentation
N/A
