### PR TITLE
DEVPROD-767 Add limit for exec timeout

### DIFF
--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -68,7 +68,7 @@ func (c *timeout) Execute(ctx context.Context, _ client.Communicator, logger cli
 	if c.ExecTimeoutSecs != 0 {
 		if conf.MaxExecTimeoutSecs > 0 && c.ExecTimeoutSecs > conf.MaxExecTimeoutSecs {
 			conf.SetExecTimeout(conf.MaxExecTimeoutSecs)
-			logger.Task().Errorf("Exec timeout %d seconds exceeds the limit of %d seconds. Set exec timeout to %d seconds.", c.ExecTimeoutSecs, conf.MaxExecTimeoutSecs, conf.MaxExecTimeoutSecs)
+			logger.Task().Warningf("Exec timeout %d seconds exceeds the limit of %d seconds. Set exec timeout to %d seconds.", c.ExecTimeoutSecs, conf.MaxExecTimeoutSecs, conf.MaxExecTimeoutSecs)
 		} else {
 			conf.SetExecTimeout(c.ExecTimeoutSecs)
 			logger.Execution().Infof("Set exec timeout to %d seconds.", c.ExecTimeoutSecs)

--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -66,8 +66,13 @@ func (c *timeout) Execute(ctx context.Context, _ client.Communicator, logger cli
 		logger.Execution().Infof("Set idle timeout to %d seconds.", c.TimeoutSecs)
 	}
 	if c.ExecTimeoutSecs != 0 {
-		conf.SetExecTimeout(c.ExecTimeoutSecs)
-		logger.Execution().Infof("Set exec timeout to %d seconds.", c.ExecTimeoutSecs)
+		if c.ExecTimeoutSecs > conf.ExecTimeoutLimit {
+			conf.SetExecTimeout(conf.ExecTimeoutLimit)
+			logger.Execution().Errorf("Exec timeout %d seconds exceeds the limit of %d seconds. Set exec timeout to %d seconds.", c.ExecTimeoutSecs, conf.ExecTimeoutLimit, conf.ExecTimeoutLimit)
+		} else {
+			conf.SetExecTimeout(c.ExecTimeoutSecs)
+			logger.Execution().Infof("Set exec timeout to %d seconds.", c.ExecTimeoutSecs)
+		}
 	}
 	return nil
 

--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -66,9 +66,9 @@ func (c *timeout) Execute(ctx context.Context, _ client.Communicator, logger cli
 		logger.Execution().Infof("Set idle timeout to %d seconds.", c.TimeoutSecs)
 	}
 	if c.ExecTimeoutSecs != 0 {
-		if c.ExecTimeoutSecs > conf.ExecTimeoutLimit {
-			conf.SetExecTimeout(conf.ExecTimeoutLimit)
-			logger.Execution().Errorf("Exec timeout %d seconds exceeds the limit of %d seconds. Set exec timeout to %d seconds.", c.ExecTimeoutSecs, conf.ExecTimeoutLimit, conf.ExecTimeoutLimit)
+		if conf.MaxExecTimeoutSecs > 0 && c.ExecTimeoutSecs > conf.MaxExecTimeoutSecs {
+			conf.SetExecTimeout(conf.MaxExecTimeoutSecs)
+			logger.Task().Errorf("Exec timeout %d seconds exceeds the limit of %d seconds. Set exec timeout to %d seconds.", c.ExecTimeoutSecs, conf.MaxExecTimeoutSecs, conf.MaxExecTimeoutSecs)
 		} else {
 			conf.SetExecTimeout(c.ExecTimeoutSecs)
 			logger.Execution().Infof("Set exec timeout to %d seconds.", c.ExecTimeoutSecs)

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -54,7 +54,7 @@ type TaskConfig struct {
 	CedarTestResultsID string
 	TaskGroup          *model.TaskGroup
 	CommandCleanups    []CommandCleanup
-	ExecTimeoutLimit   int
+	MaxExecTimeoutSecs int
 
 	mu sync.RWMutex
 }

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -54,6 +54,7 @@ type TaskConfig struct {
 	CedarTestResultsID string
 	TaskGroup          *model.TaskGroup
 	CommandCleanups    []CommandCleanup
+	ExecTimeoutLimit   int
 
 	mu sync.RWMutex
 }

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -351,6 +351,7 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.TaskOutput = a.opts.SetupData.TaskOutput
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
+	taskConfig.ExecTimeoutLimit = a.opts.SetupData.ExecTimeoutLimit
 
 	// Set AWS credentials for task output buckets.
 	awsCreds := pail.CreateAWSCredentials(taskConfig.TaskOutput.Key, taskConfig.TaskOutput.Secret, "")

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -351,7 +351,7 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.TaskOutput = a.opts.SetupData.TaskOutput
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
 	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
-	taskConfig.ExecTimeoutLimit = a.opts.SetupData.ExecTimeoutLimit
+	taskConfig.MaxExecTimeoutSecs = a.opts.SetupData.MaxExecTimeoutSecs
 
 	// Set AWS credentials for task output buckets.
 	awsCreds := pail.CreateAWSCredentials(taskConfig.TaskOutput.Key, taskConfig.TaskOutput.Secret, "")

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -120,6 +120,7 @@ type AgentSetupData struct {
 	TaskOutput             evergreen.S3Credentials `json:"task_output"`
 	EC2Keys                []evergreen.EC2Key      `json:"ec2_keys"`
 	TraceCollectorEndpoint string                  `json:"trace_collector_endpoint"`
+	ExecTimeoutLimit       int                     `json:"exec_timeout_limit"`
 }
 
 // NextTaskResponse represents the response sent back when an agent asks for a next task

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -120,7 +120,7 @@ type AgentSetupData struct {
 	TaskOutput             evergreen.S3Credentials `json:"task_output"`
 	EC2Keys                []evergreen.EC2Key      `json:"ec2_keys"`
 	TraceCollectorEndpoint string                  `json:"trace_collector_endpoint"`
-	ExecTimeoutLimit       int                     `json:"exec_timeout_limit"`
+	MaxExecTimeoutSecs     int                     `json:"max_exec_timeout_secs"`
 }
 
 // NextTaskResponse represents the response sent back when an agent asks for a next task

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-20a"
+	AgentVersion = "2024-08-23"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-23"
+	AgentVersion = "2024-08-26"
 )
 
 // ConfigSection defines a sub-document in the evergreen config

--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -41,6 +41,9 @@ type TaskLimitsConfig struct {
 
 	// MaxParserProjectSize is the maximum allowed parser project size.
 	MaxParserProjectSize int `bson:"max_parser_project_size" json:"max_parser_project_size" yaml:"max_parser_project_size"`
+
+	// MaxTaskSecs is the maximum number of seconds a task can run and set their timeout to.
+	MaxTaskSecs int `bson:"max_task_secs" json:"max_task_secs" yaml:"max_task_secs"`
 }
 
 var (
@@ -52,6 +55,7 @@ var (
 	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
 	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
 	maxParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
+	maxTaskSecs                          = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTaskSecs")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -84,6 +88,7 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
 			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
 			maxParserProjectSize:                 c.MaxParserProjectSize,
+			maxTaskSecs:                          c.MaxTaskSecs,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -42,8 +42,8 @@ type TaskLimitsConfig struct {
 	// MaxParserProjectSize is the maximum allowed parser project size.
 	MaxParserProjectSize int `bson:"max_parser_project_size" json:"max_parser_project_size" yaml:"max_parser_project_size"`
 
-	// MaxTaskSecs is the maximum number of seconds a task can run and set their timeout to.
-	MaxTaskSecs int `bson:"max_task_secs" json:"max_task_secs" yaml:"max_task_secs"`
+	// MaxExecTimeoutSecs is the maximum number of seconds a task can run and set their timeout to.
+	MaxExecTimeoutSecs int `bson:"max_exec_timeout_secs" json:"max_exec_timeout_secs" yaml:"max_exec_timeout_secs"`
 }
 
 var (
@@ -55,7 +55,7 @@ var (
 	maxConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxConcurrentLargeParserProjectTasks")
 	maxDegradedModeParserProjectSize     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeParserProjectSize")
 	maxParserProjectSize                 = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxParserProjectSize")
-	maxTaskSecs                          = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTaskSecs")
+	MaxExecTimeoutSecs                   = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxExecTimeoutSecs")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -88,7 +88,7 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			maxConcurrentLargeParserProjectTasks: c.MaxConcurrentLargeParserProjectTasks,
 			maxDegradedModeParserProjectSize:     c.MaxDegradedModeParserProjectSize,
 			maxParserProjectSize:                 c.MaxParserProjectSize,
-			maxTaskSecs:                          c.MaxTaskSecs,
+			MaxExecTimeoutSecs:                   c.MaxExecTimeoutSecs,
 		},
 	}, options.Update().SetUpsert(true))
 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -557,8 +557,8 @@ within an allotted time, set the key `exec_timeout_secs` on the overall project
 or on a specific task to set the maximum allowed length of execution time. Exec timeout only
 applies to commands that run in `pre`, `setup_group`, `setup_task`, and the main
 task commands; it does not apply to the `post`, `teardown_task`, and
-`teardown_group` blocks. This timeout defaults to 6 hours. `exec_timeout_secs`
-can only be set on the project or on a task as seen in below example. 
+`teardown_group` blocks. This timeout defaults to 6 hours, and cannot be set above 24 hours.
+`exec_timeout_secs` can only be set on the project or on a task as seen in below example. 
 It cannot be set on functions or build variant tasks.
 
 You can also set `exec_timeout_secs` using [timeout.update](Project-Commands#timeoutupdate).

--- a/docs/Project-Configuration/Task-Runtime-Behavior.md
+++ b/docs/Project-Configuration/Task-Runtime-Behavior.md
@@ -150,7 +150,8 @@ clean up the task directory.
 ## Task Timeouts
 
 Tasks are not allowed to run forever, so all commands that run for a task are
-subject to (configurable) timeouts. If a command hits a timeout, that command
+subject to (configurable) timeouts. However, tasks cannot be configured to have a timeout 
+greater than 86400 seconds (24 hours). If a command hits a timeout, that command
 will stop with an error. Furthermore, if that command can cause the task to fail
 and that command is in `pre`, `setup_task`, `setup_group`, or the main task
 block, it will skip forward to running the `timeout` block and will eventually

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2711,6 +2711,7 @@ type APITaskLimitsConfig struct {
 	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
 	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
 	MaxParserProjectSize                 *int `json:"max_parser_project_size"`
+	MaxTaskSecs                          *int `json:"max_task_secs"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2724,6 +2725,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
 		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
 		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
+		c.MaxTaskSecs = utility.ToIntPtr(v.MaxTaskSecs)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2740,6 +2742,7 @@ func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
 		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
 		MaxParserProjectSize:                 utility.FromIntPtr(c.MaxParserProjectSize),
+		MaxTaskSecs:                          utility.FromIntPtr(c.MaxTaskSecs),
 	}, nil
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2711,7 +2711,7 @@ type APITaskLimitsConfig struct {
 	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
 	MaxDegradedModeParserProjectSize     *int `json:"max_degraded_mode_parser_project_size"`
 	MaxParserProjectSize                 *int `json:"max_parser_project_size"`
-	MaxTaskSecs                          *int `json:"max_task_secs"`
+	MaxExecTimeoutSecs                   *int `json:"max_exec_timeout_secs"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2725,7 +2725,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxConcurrentLargeParserProjectTasks = utility.ToIntPtr(v.MaxConcurrentLargeParserProjectTasks)
 		c.MaxDegradedModeParserProjectSize = utility.ToIntPtr(v.MaxDegradedModeParserProjectSize)
 		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
-		c.MaxTaskSecs = utility.ToIntPtr(v.MaxTaskSecs)
+		c.MaxExecTimeoutSecs = utility.ToIntPtr(v.MaxExecTimeoutSecs)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2742,7 +2742,7 @@ func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 		MaxConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxConcurrentLargeParserProjectTasks),
 		MaxDegradedModeParserProjectSize:     utility.FromIntPtr(c.MaxDegradedModeParserProjectSize),
 		MaxParserProjectSize:                 utility.FromIntPtr(c.MaxParserProjectSize),
-		MaxTaskSecs:                          utility.FromIntPtr(c.MaxTaskSecs),
+		MaxExecTimeoutSecs:                   utility.FromIntPtr(c.MaxExecTimeoutSecs),
 	}, nil
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -84,13 +84,13 @@ func (h *agentSetup) Parse(ctx context.Context, r *http.Request) error {
 
 func (h *agentSetup) Run(ctx context.Context) gimlet.Responder {
 	data := apimodels.AgentSetupData{
-		SplunkServerURL:   h.settings.Splunk.SplunkConnectionInfo.ServerURL,
-		SplunkClientToken: h.settings.Splunk.SplunkConnectionInfo.Token,
-		SplunkChannel:     h.settings.Splunk.SplunkConnectionInfo.Channel,
-		TaskOutput:        h.settings.Providers.AWS.TaskOutput,
-		TaskSync:          h.settings.Providers.AWS.TaskSync,
-		EC2Keys:           h.settings.Providers.AWS.EC2Keys,
-		ExecTimeoutLimit:  h.settings.TaskLimits.MaxExecTimeoutSecs,
+		SplunkServerURL:    h.settings.Splunk.SplunkConnectionInfo.ServerURL,
+		SplunkClientToken:  h.settings.Splunk.SplunkConnectionInfo.Token,
+		SplunkChannel:      h.settings.Splunk.SplunkConnectionInfo.Channel,
+		TaskOutput:         h.settings.Providers.AWS.TaskOutput,
+		TaskSync:           h.settings.Providers.AWS.TaskSync,
+		EC2Keys:            h.settings.Providers.AWS.EC2Keys,
+		MaxExecTimeoutSecs: h.settings.TaskLimits.MaxExecTimeoutSecs,
 	}
 	if h.settings.Tracer.Enabled {
 		data.TraceCollectorEndpoint = h.settings.Tracer.CollectorEndpoint

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -90,6 +90,7 @@ func (h *agentSetup) Run(ctx context.Context) gimlet.Responder {
 		TaskOutput:        h.settings.Providers.AWS.TaskOutput,
 		TaskSync:          h.settings.Providers.AWS.TaskSync,
 		EC2Keys:           h.settings.Providers.AWS.EC2Keys,
+		ExecTimeoutLimit:  h.settings.TaskLimits.MaxExecTimeoutSecs,
 	}
 	if h.settings.Tracer.Enabled {
 		data.TraceCollectorEndpoint = h.settings.Tracer.CollectorEndpoint

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -380,6 +380,7 @@ func TestAgentSetup(t *testing.T) {
 			assert.Equal(t, data.SplunkChannel, s.Splunk.SplunkConnectionInfo.Channel)
 			assert.Equal(t, data.TaskSync, s.Providers.AWS.TaskSync)
 			assert.Equal(t, data.EC2Keys, s.Providers.AWS.EC2Keys)
+			assert.Equal(t, data.ExecTimeoutLimit, s.TaskLimits.MaxExecTimeoutSecs)
 		},
 		"ReturnsEmpty": func(ctx context.Context, t *testing.T, rh *agentSetup, s *evergreen.Settings) {
 			*s = evergreen.Settings{}
@@ -420,6 +421,9 @@ func TestAgentSetup(t *testing.T) {
 							},
 						},
 					},
+				},
+				TaskLimits: evergreen.TaskLimitsConfig{
+					MaxExecTimeoutSecs: 10,
 				},
 			}
 

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -380,7 +380,7 @@ func TestAgentSetup(t *testing.T) {
 			assert.Equal(t, data.SplunkChannel, s.Splunk.SplunkConnectionInfo.Channel)
 			assert.Equal(t, data.TaskSync, s.Providers.AWS.TaskSync)
 			assert.Equal(t, data.EC2Keys, s.Providers.AWS.EC2Keys)
-			assert.Equal(t, data.ExecTimeoutLimit, s.TaskLimits.MaxExecTimeoutSecs)
+			assert.Equal(t, data.MaxExecTimeoutSecs, s.TaskLimits.MaxExecTimeoutSecs)
 		},
 		"ReturnsEmpty": func(ctx context.Context, t *testing.T, rh *agentSetup, s *evergreen.Settings) {
 			*s = evergreen.Settings{}

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -655,7 +655,7 @@ Admin Settings
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
 										<label>Max Task Length (secs)</label>
-										<input type="number" ng-model="Settings.task_limits.max_task_secs">
+										<input type="number" ng-model="Settings.task_limits.max_exec_timeout_secs">
 									</md-input-container>
 								</md-card-content>
 							</md-card>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -653,6 +653,10 @@ Admin Settings
 										<label>Max Parser Project Size (MB)</label>
 										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Task Length (secs)</label>
+										<input type="number" ng-model="Settings.task_limits.max_task_secs">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -654,7 +654,7 @@ Admin Settings
 										<input type="number" ng-model="Settings.task_limits.max_parser_project_size">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Max Task Length (secs)</label>
+										<label>Max Task Exec Timeout (secs)</label>
 										<input type="number" ng-model="Settings.task_limits.max_exec_timeout_secs">
 									</md-input-container>
 								</md-card-content>

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1019,11 +1019,11 @@ func checkRunOn(runOnHasDistro, runOnHasContainer bool, runOn []string) []Valida
 
 func validateTimeoutLimits(_ context.Context, settings *evergreen.Settings, project *model.Project, _ *model.ProjectRef, _ bool) ValidationErrors {
 	errs := ValidationErrors{}
-	if settings.TaskLimits.MaxTaskSecs > 0 {
+	if settings.TaskLimits.MaxExecTimeoutSecs > 0 {
 		for _, task := range project.Tasks {
-			if task.ExecTimeoutSecs > settings.TaskLimits.MaxTaskSecs {
+			if task.ExecTimeoutSecs > settings.TaskLimits.MaxExecTimeoutSecs {
 				errs = append(errs, ValidationError{
-					Message: fmt.Sprintf("task '%s' exec timeout (%d) exceeds maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxTaskSecs),
+					Message: fmt.Sprintf("task '%s' exec timeout (%d) exceeds maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxExecTimeoutSecs),
 					Level:   Error,
 				})
 			}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -176,6 +176,7 @@ var projectSettingsValidators = []projectSettingsValidator{
 	validateContainers,
 	validateProjectLimits,
 	validateIncludeLimits,
+	validateTimeoutLimits,
 }
 
 // These validators have the potential to be very long, and may not be fully run unless specified.
@@ -1014,6 +1015,21 @@ func checkRunOn(runOnHasDistro, runOnHasContainer bool, runOn []string) []Valida
 		}}
 	}
 	return nil
+}
+
+func validateTimeoutLimits(_ context.Context, settings *evergreen.Settings, project *model.Project, _ *model.ProjectRef, _ bool) ValidationErrors {
+	errs := ValidationErrors{}
+	if settings.TaskLimits.MaxTaskSecs > 0 {
+		for _, task := range project.Tasks {
+			if task.ExecTimeoutSecs > settings.TaskLimits.MaxTaskSecs {
+				errs = append(errs, ValidationError{
+					Message: fmt.Sprintf("task '%s' exec timeout (%d) exceeds maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxTaskSecs),
+					Level:   Error,
+				})
+			}
+		}
+	}
+	return errs
 }
 
 func validateIncludeLimits(_ context.Context, settings *evergreen.Settings, project *model.Project, _ *model.ProjectRef, _ bool) ValidationErrors {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1745,7 +1745,7 @@ func TestValidateTimeoutLimits(t *testing.T) {
 	t.Run("SucceedsWithTimeoutBelowLimit", func(t *testing.T) {
 		settings := &evergreen.Settings{
 			TaskLimits: evergreen.TaskLimitsConfig{
-				MaxTaskSecs: 100,
+				MaxExecTimeoutSecs: 100,
 			},
 		}
 		assert.Empty(t, validateTimeoutLimits(ctx, settings, project, &model.ProjectRef{}, false))
@@ -1753,7 +1753,7 @@ func TestValidateTimeoutLimits(t *testing.T) {
 	t.Run("FailsWithTimeoutExceedingLimit", func(t *testing.T) {
 		settings := &evergreen.Settings{
 			TaskLimits: evergreen.TaskLimitsConfig{
-				MaxTaskSecs: 1,
+				MaxExecTimeoutSecs: 1,
 			},
 		}
 		errs := validateTimeoutLimits(ctx, settings, project, &model.ProjectRef{}, false)


### PR DESCRIPTION
DEVPROD-767

### Description
Looked through all the configs and found that the largest timeout is 24 hours so we will only let users specify a timeout up to 24 hours (the one 96 hour timeout task's project owner disabled his project and said it wasn't needed)

Also will be adding a splunk alert for any tasks that go over 8 hours like [this](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen%22%20%7C%20spath%20path%20%7C%20search%20path%3D%22/rest/v2/task/*/heartbeat%22%7C%20spath%20duration_ms%20%7C%20search%20duration_ms%3E28800000&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-24h@h&latest=now&display.page.search.tab=events&display.general.type=events&sid=1724358000.7550081) just so we know when there is a very long running task 

### Testing
unit test

### Documentation

added
