### PR TITLE
DEVPROD-10123 Consistently case admin and project banners

### DIFF
--- a/config.go
+++ b/config.go
@@ -721,23 +721,23 @@ func (s *DBSettings) mongoOptions(url string) *options.ClientOptions {
 type BannerTheme string
 
 const (
-	Announcement BannerTheme = "announcement"
-	Information  BannerTheme = "information"
-	Warning      BannerTheme = "warning"
-	Important    BannerTheme = "important"
+	Announcement BannerTheme = "ANNOUNCEMENT"
+	Information  BannerTheme = "INFORMATION"
+	Warning      BannerTheme = "WARNING"
+	Important    BannerTheme = "IMPORTANT"
 )
 
 func IsValidBannerTheme(input string) (bool, BannerTheme) {
 	switch input {
 	case "":
 		return true, ""
-	case "announcement":
+	case "ANNOUNCEMENT":
 		return true, Announcement
-	case "information":
+	case "INFORMATION":
 		return true, Information
-	case "warning":
+	case "WARNING":
 		return true, Warning
-	case "important":
+	case "IMPORTANT":
 		return true, Important
 	default:
 		return false, ""

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-08-20"
+	ClientVersion = "2024-08-26"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/admin.go
+++ b/operations/admin.go
@@ -82,7 +82,7 @@ func adminSetBanner() cli.Command {
 		),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().Parent().String(confFlagName)
-			themeName := c.String(themeFlagName)
+			themeName := strings.ToUpper(c.String(themeFlagName))
 			msgContent := c.String(messageFlagName)
 
 			var theme evergreen.BannerTheme

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -13,7 +13,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.restartRed = true;
     $scope.restartPurple = true;
     $scope.restartLavender = true;
-    $scope.ValidThemes = ["announcement", "information", "warning", "important"];
+    $scope.ValidThemes = ["ANNOUNCEMENT", "INFORMATION", "WARNING", "IMPORTANT", "announcement", "information", "warning", "important"];
     $scope.validAuthKinds = ["okta", "naive", "only_api", "allow_service_users", "github"];
     $scope.validECSOSes = ["linux", "windows"];
     $scope.validECSArches = ["amd64", "arm64"];

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -13,7 +13,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.restartRed = true;
     $scope.restartPurple = true;
     $scope.restartLavender = true;
-    $scope.ValidThemes = ["ANNOUNCEMENT", "INFORMATION", "WARNING", "IMPORTANT", "announcement", "information", "warning", "important"];
+    $scope.ValidThemes = ["ANNOUNCEMENT", "INFORMATION", "WARNING", "IMPORTANT"];
     $scope.validAuthKinds = ["okta", "naive", "only_api", "allow_service_users", "github"];
     $scope.validECSOSes = ["linux", "windows"];
     $scope.validECSArches = ["amd64", "arm64"];

--- a/public/static/js/menu.js
+++ b/public/static/js/menu.js
@@ -11,16 +11,19 @@ function setBanner() {
   $("#bannerText").html(jiraLinkify(text, window.JiraHost));
   switch (theme) {
     case "important":
+    case "IMPORTANT":
       $("#bannerIcon").append("<i class='fa fa-exclamation'></i>");
       $("#bannerIcon").addClass("banner-icon-important");
       $("#bannerBack").addClass("banner-text-important");
       break;
     case "warning":
+    case "WARNING":
       $("#bannerIcon").append("<i class='fa fa-exclamation-triangle'></i>");
       $("#bannerIcon").addClass("banner-icon-warning");
       $("#bannerBack").addClass("banner-text-warning");
       break;
     case "information":
+    case "INFORMATION":
       $("#bannerIcon").append("<i class='fa fa-info-circle'></i>");
       $("#bannerIcon").addClass("banner-icon-information");
       $("#bannerBack").addClass("banner-text-information");

--- a/rest/route/admin_banner_test.go
+++ b/rest/route/admin_banner_test.go
@@ -54,7 +54,7 @@ func TestSetBanner(t *testing.T) {
 	// test changing the theme
 	body = model.APIBanner{
 		Text:  utility.ToStringPtr("banner is changing again"),
-		Theme: utility.ToStringPtr("important"),
+		Theme: utility.ToStringPtr("IMPORTANT"),
 	}
 	jsonBody, err = json.Marshal(&body)
 	assert.NoError(err)

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -154,7 +154,7 @@ func MockConfig() *evergreen.Settings {
 		},
 		AWSInstanceRole: "role",
 		Banner:          "banner",
-		BannerTheme:     "important",
+		BannerTheme:     "IMPORTANT",
 		Buckets: evergreen.BucketsConfig{
 			LogBucket: evergreen.BucketConfig{
 				Name: "logs",


### PR DESCRIPTION
DEVPROD-10123

### Description

When we added project banners, we used uppercase for the GraphQL enum. But admin
banners use a lowercase type. This PR makes the admin banner also use an
uppercase type. It also ensures that both uppercase and lowercase have the same
behavior in the legacy JavaScript so that we can safely deploy this commit.

### Testing

Tested in staging.