### PR TITLE
DEVPROD-5670: Make isBetaTester field optional

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -53187,14 +53187,11 @@ func (ec *executionContext) _SleepSchedule_isBetaTester(ctx context.Context, fie
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SleepSchedule_isBetaTester(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -87176,9 +87173,6 @@ func (ec *executionContext) _SleepSchedule(ctx context.Context, sel ast.Selectio
 			}
 		case "isBetaTester":
 			out.Values[i] = ec._SleepSchedule_isBetaTester(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "nextStartTime":
 			out.Values[i] = ec._SleepSchedule_nextStartTime(ctx, field, obj)
 		case "nextStopTime":

--- a/graphql/schema/types/host.graphql
+++ b/graphql/schema/types/host.graphql
@@ -22,7 +22,7 @@ enum TaskQueueItemType {
 type SleepSchedule {
   dailyStartTime: String!
   dailyStopTime: String!
-  isBetaTester: Boolean!
+  isBetaTester: Boolean
   nextStartTime: Time
   nextStopTime: Time
   permanentlyExempt: Boolean!


### PR DESCRIPTION
DEVPROD-5670

### Description
- Ahead of removing the beta tester setting from the UI, make it non-required in the SleepSchedule type.
- In a followup PR once the updated UI has been deployed, I'll remove this field from GraphQL altogether

### Testing
- UI functions correctly with optional field