### PR TITLE
DEVPROD-6539 Adapt kill spawned procs to work for macos 14

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -152,10 +152,11 @@ func newWithCommunicator(ctx context.Context, opts Options, comm client.Communic
 	}
 
 	a := &Agent{
-		opts:           opts,
-		comm:           comm,
-		jasper:         jpm,
-		setEndTaskResp: func(*triggerEndTaskResp) {},
+		opts:             opts,
+		comm:             comm,
+		jasper:           jpm,
+		setEndTaskResp:   func(*triggerEndTaskResp) {},
+		lastKillProcTime: time.Now(),
 	}
 
 	a.closers = append(a.closers, closerOp{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -55,6 +55,7 @@ type Agent struct {
 	tracer              trace.Tracer
 	otelGrpcConn        *grpc.ClientConn
 	closers             []closerOp
+	lastKillProcTime    time.Time
 }
 
 // Options contains startup options for an Agent.
@@ -1212,7 +1213,14 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 
 	if tc.task.ID != "" && tc.taskConfig != nil {
 		logger.Infof("Cleaning up processes for task: '%s'.", tc.task.ID)
-		if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, logger); err != nil {
+		defer func() {
+			a.lastKillProcTime = time.Now()
+		}()
+		if err := agentutil.KillSpawnedProcs(ctx, agentutil.KillSpawnedProcsOptions{
+			Key:              tc.task.ID,
+			WorkingDirectory: tc.taskConfig.WorkDir,
+			LastKillTime:     a.lastKillProcTime,
+		}, logger); err != nil {
 			// If the host is in a state where ps is timing out we need human intervention.
 			if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
 				disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -75,13 +75,11 @@ func getPIDsToKill(ctx context.Context, key, workingDir string, lastKillTime tim
 			continue
 		}
 
-		// If the command is not in the working directory, not marked by its environmental variables
-		// and started before the last kill time, we should skip it.
-		if !commandInWorkingDir(process.command, workingDir) && !envHasMarkers(key, process.env) && process.time.Before(lastKillTime) {
-			continue
+		// If the command is from the working directory, has the env markers, or was made after the last kill time
+		// we should kill it.
+		if commandInWorkingDir(process.command, workingDir) || envHasMarkers(key, process.env) && process.time.After(lastKillTime) {
+			pidsToKill = append(pidsToKill, process.pid)
 		}
-
-		pidsToKill = append(pidsToKill, process.pid)
 	}
 
 	return pidsToKill, nil

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -77,7 +77,7 @@ func getPIDsToKill(ctx context.Context, key, workingDir string, lastKillTime tim
 
 		// If the command is from the working directory, has the env markers, or was made after the last kill time
 		// we should kill it.
-		if commandInWorkingDir(process.command, workingDir) || envHasMarkers(key, process.env) && process.time.After(lastKillTime) {
+		if commandInWorkingDir(process.command, workingDir) || envHasMarkers(key, process.env) || process.time.After(lastKillTime) {
 			pidsToKill = append(pidsToKill, process.pid)
 		}
 	}


### PR DESCRIPTION
DEVPROD-6539

### Description
Macos 14 no longer prints environmental variables when running `ps`. This means we cannot rely on `ps` to kill environmental variables. This adds the time to the output and parses the time, and filters the processes that either are in 

### Testing
Unit testing 