### PR TITLE
Revert "DEVPROD-9915 enable cgo on macos  (#8207)"

### DIFF
--- a/cmd/build-cross-compile/build-cross-compile.go
+++ b/cmd/build-cross-compile/build-cross-compile.go
@@ -9,11 +9,6 @@ import (
 	"strings"
 )
 
-const (
-	macGOOS       = "darwin"
-	macMinVersion = "10.14"
-)
-
 func main() {
 	var (
 		arch      string
@@ -82,21 +77,8 @@ func main() {
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
 		cmd.Env = append(cmd.Env, "TMPDIR="+strings.Replace(tmpdir, `\`, `\\`, -1))
 	}
-	// Disable cgo so that the compiled binary is statically linked. This is useful for systems lacking
-	// libc support. macOS is excluded because it will have libc support and cgo is needed for gopsutil on macOS.
-	// Always set it explicitly because the default varies. See https://pkg.go.dev/cmd/cgo#hdr-Using_cgo_with_the_go_command.
-	if system == macGOOS {
-		cmd.Env = append(cmd.Env, "CGO_ENABLED=1")
-		// Specify the minimum OS version the build should target. This is necessary
-		// for clang to produce a binary that can run on older versions of macOS.
-		// This method for passing build arguments through cgo to clang is suggested
-		// at https://github.com/golang/go/issues/18400#issuecomment-270414574.
-		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_LDFLAGS=-mmacosx-version-min=%s", macMinVersion))
-		cmd.Env = append(cmd.Env, fmt.Sprintf("CGO_CFLAGS=-mmacosx-version-min=%s", macMinVersion))
-		cmd.Args = append(cmd.Args, "-installsuffix=evergreen")
-	} else {
-		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
-	}
+	// Disable cgo so that the compiled binary is statically linked.
+	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 
 	goos := "GOOS=" + system
 	goarch := "GOARCH=" + arch

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-26"
+	AgentVersion = "2024-08-27"
 )
 
 const (

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -758,11 +758,9 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin_amd64
     tags: ["build"]
-    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin_arm64
     tags: ["build"]
-    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets
     tags: ["build"]
@@ -776,7 +774,6 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-staging_amd64
     tags: ["build-staging"]
-    run_on: macos-14-arm64
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets-staging
     tags: ["build-staging"]
@@ -784,11 +781,9 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin-unsigned_amd64
     tags: ["build-unsigned"]
-    run_on: macos-14-arm64
   - <<: *build-and-push-client
     name: build-darwin-unsigned_arm64
     tags: ["build-unsigned"]
-    run_on: macos-14-arm64
 
 #######################################
 #            Buildvariants            #


### PR DESCRIPTION
This reverts commit 6445c354664c04362ce567703053262f33df13f8.

