### PR TITLE
DEVPROD-8228: update docs for end of beta test period

### DIFF
--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -164,7 +164,7 @@ Host <your_persistent_dns_name>
     Hostname <your_persistent_dns_name>
 ```
 
-Q: Can I have my host hibernate instead of shut down for the schedule?
+**Q: Can I have my host hibernate instead of shut down for the schedule?**
 
 A: Evergreen's hosts do not currently support hibernation, they can only shut down. This means that the host will lose
 current machine state (e.g. tmux sessions) when it turns off. Supporting hibernation may eventually be explored as

--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -69,14 +69,14 @@ long-lived hosts.
 Note that stopping the host during off hours means **shutting down the host**, not hibernating the host. If needed, see
 [the FAQ](#faq) for more info.
 
-**The beta test period for this feature has ended as of 11 am (Eastern Time) September 3, so all users who did not set a
-sleep schedule or request a permanent exemption have been assigned a default schedule. If you'd like your unexpirable
-host to use something other than the default settings, your options are:**
+**The beta test period for this feature has ended as of 11 am (Eastern Time) September 3 2024, so all users who did not
+set a sleep schedule or request a permanent exemption have been assigned a default schedule. If you'd like your
+unexpirable host to use something other than the default settings, your options are:**
 
-1. [Option 1](#sleep-schedule) (Recommended for most users): Set a sleep schedule for each of your existing
+1. [Set a sleep schedule](#sleep-schedule) (Recommended for most users): Set a sleep schedule for each of your existing
    unexpirable hosts on by [pressing the "edit" button on the spawn host page](https://spruce.mongodb.com/spawn/host).
-3. [Option 2](#permanent-exemption): If you have a reason that your host cannot use the sleep schedule, you can request
-   a permanent exemption for your host.
+2. [Permanently exempt your host](#permanent-exemption): If you have a reason that your host cannot use the sleep
+   schedule, you can request a permanent exemption for your host.
 
 ### Option 1: Sleep Schedule {#sleep-schedule}
 

--- a/docs/Hosts/Spawn-Hosts.md
+++ b/docs/Hosts/Spawn-Hosts.md
@@ -57,51 +57,30 @@ notification](../Project-Configuration/Notifications#spawn-host-expiration) for 
 
 ## Unexpirable Host Sleep Schedules
 
-Evergreen has introduced a new feature for unexpirable hosts called host sleep schedules, which allow you to control
-when you'd like your unexpirable host to be automatically turned on or off. A sleep schedule lets you choose recurring
-times of the week when you want your host to be on, and when it's okay for it to be turned off. For example, you could
-set a sleep schedule where your host is up and running during your work hours from 10 am to 6 pm between Monday and
-Friday and otherwise let it turn it off overnight and during weekends. Setting a sleep schedule ensures your host is on
-during your working hours, while also stopping the host when it's not being actively used. Powering down hosts when
-they're not being used is important to ensure that hosts are being efficiently utilized and to avoid over-spending on
-idle long-lived hosts.
+Unexpirable hosts have a feature (which is enabled by default) called a sleep schedule that allows you to control when
+you'd like your unexpirable host to be automatically turned on or off. A sleep schedule lets you choose recurring times
+of the week when you want your host to be on, and when it's okay for it to be turned off. For example, you could set a
+sleep schedule where your host is up and running during your work hours from 10 am to 6 pm between Monday and Friday and
+otherwise let it turn it off overnight and during weekends. Setting a sleep schedule ensures your host is on during your
+working hours, while also stopping the host when it's not being actively used. Powering down hosts when they're not
+being used is important to ensure that hosts are being efficiently utilized and to avoid over-spending on idle
+long-lived hosts.
 
 Note that stopping the host during off hours means **shutting down the host**, not hibernating the host. If needed, see
 [the FAQ](#faq) for more info.
 
-**While this feature is being rolled out, please [choose and complete one of the three options](#beta-testing) for your
-unexpirable host(s). You must complete one of the options before the beta test ends at 11 am (Eastern Time) on Tuesday
-September 3. If you do not take any action, a default schedule will be set on your behalf for your unexpirable host(s)
-at the end of the beta test period.**
-
-### ***Important Note***: This Feature is in Beta Testing! {#beta-testing}
-
-**This feature is currently available for beta testing until September 3.** While it's in beta testing, _using
-the sleep schedule is an opt-in feature_. During this beta testing period, you have the following options to choose from
-for your host, **please pick and complete one before the beta test period ends**:
+**The beta test period for this feature has ended as of 11 am (Eastern Time) September 3, so all users who did not set a
+sleep schedule or request a permanent exemption have been assigned a default schedule. If you'd like your unexpirable
+host to use something other than the default settings, your options are:**
 
 1. [Option 1](#sleep-schedule) (Recommended for most users): Set a sleep schedule for each of your existing
    unexpirable hosts on by [pressing the "edit" button on the spawn host page](https://spruce.mongodb.com/spawn/host).
-   After choosing a sleep schedule, it's also recommended (but not required) that you check the option to participate in
-   the sleep schedule beta test.
-2. [Option 2](#host-auto-sleep-script): Set up a local script on your host to automatically stop/start your host based
-   on your own activity within the host. This is a separate but accepted alternative to the sleep schedule.
-3. [Option 3](#permanent-exemption): If you have a reason that your host cannot use 1 or 2, you can request a permanent
-   exemption for your host.
-
-**The beta test period will end on September 3, at which point the sleep schedule will stop being an opt-in
-feature and will take effect on _all_ unexpirable hosts except those that have been granted a permanent exemption, so
-please make sure to complete one of the options above**. If you do not do any of the three options, a default sleep
-schedule will be automatically set for your unexpirable host when the beta test ends - the default is that the host will
-be set to a schedule where it'll be running 8am-8pm Mon-Fri in the time zone you've set in your Spruce preferences (or
-Eastern Time if you don't have any time zone set). Furthermore, if you have a host that's stopped and don't pick any
-sleep schedule for it by the end of the beta test period, it will still be assigned a sleep schedule. In addition, those
-hosts will be be [kept off](#keeping-a-host-off). Once you manually turn the host back on, the sleep schedule will begin
-taking effect.
+3. [Option 2](#permanent-exemption): If you have a reason that your host cannot use the sleep schedule, you can request
+   a permanent exemption for your host.
 
 ### Option 1: Sleep Schedule {#sleep-schedule}
 
-This is the new feature described [above](#unexpirable-host-sleep-schedules) to set times of the week when you want your
+This is the feature described [above](#unexpirable-host-sleep-schedules) to set times of the week when you want your
 host to be on or off. You can set a recurring sleep schedule on your host from [the
 UI](https://spruce.mongodb.com/spawn/host) by pressing the "edit" button your host.
 
@@ -114,23 +93,15 @@ The example sleep schedule above will automatically turn the host on from 8am to
 The host will be automatically turned off overnight from 8pm to 8am on Monday to Friday, and will be off for the entire
 weekend.
 
-From the create/edit host modal, you can pick which days you'd like the host to be on, and the time that you want your
-host to be on for those days. The time zone for the host sleep schedule will be based on the time zone you choose in
-your [Spruce preferences](https://spruce.mongodb.com/preferences/profile). You can edit this schedule whenever you want.
-
-When setting a sleep schedule in the UI, you also have the option to participate in the beta test. If you opt into the
-beta test, the sleep schedule that you set will take effect on your host, stopping and starting your host according to
-the schedule you configure; if you do not opt in, your sleep schedule will be set but will have no effect on your host
-during the beta test period (i.e. until September 3). You can opt in or out freely during the beta test for this
-feature. **It's highly recommend that when you set a sleep schedule for your unexpirable host(s), you also opt into the
-beta test to verify that your sleep schedule is working the way you want.**
+From the create/edit host modal, you can pick which days you'd like the host to be on, the time that you want your
+host to be on for those days, and the time zone of the schedule. You can edit this schedule whenever you want.
 
 #### Temporary Exemptions
 
 If you need your host to temporarily ignore its sleep schedule, you can request a temporary exemption for your host.
 During a temporary exemption, the sleep schedule will not take effect at all, so Evergreen will not stop/start your host
 unless you stop/start it manually. This is useful if you have a one-off need to keep your host on without interruption.
-For example, if you're running a test overnight on the host and you don't want the host to be stopped, you can request a
+For example, if you're running a test overnight on the host and you don't want the host to be stopped, you can use a
 temporary exemption until tomorrow to keep the host on. Another example is if it's outside your working hours (and the
 host has already automatically stopped for the night for its sleep schedule) but you want to check a file in your host,
 you can request a temporary exemption and then turn your host on. The sleep schedule will let your host stay on, and
@@ -201,67 +172,18 @@ future work in [DEVPROD-8579](https://jira.mongodb.org/browse/DEVPROD-8579). In 
 significantly impacted by the host shutting down and rebooting regularly on a schedule, you can [request a permanent
 exemption](#permanent-exemption).
 
-**Q: How do I choose the time zone when setting a sleep schedule?**
-
-A: You can pick a time zone from the edit host modal by selecting it from the dropdown.
-
 ---
 
-### Option 2: Host Auto-Sleep Script {#host-auto-sleep-script}
-
-The [host sleep script](https://github.com/evergreen-ci/host-sleep-script) is a standalone script-based option available
-to users that can be used alongside (or as a substitute for) the sleep schedule feature. The main benefit of the script
-over using the sleep schedule feature is that it will stop your host based on whether it detects activity in the host
-(such as active SSH sessions), rather than stopping and starting on a recurring weekly schedule. It will automatically
-turn off your host once there is no activity detected in it for some time. Later on, when you SSH into the host, it uses
-a proxy script on your local computer to turn it back on and SSH into your host.
-
-In order to use it, you must install the script into your local computer and unexpirable host by following the
-instructions in [this repo](https://github.com/evergreen-ci/host-sleep-script).
-
-***Caution: Use At Your Own Risk!***
-* This is not an Evergreen feature. It modifies your local computer SSH configuration and your unexpirable host's
-  systemd configuration to automatically start and stop the host.
-* The script may have bugs. It has been tested in only a handful of setups.
-* It may not work exactly as you'd like for your use case.
-
-If you choose to use the host sleep script, Evergreen can only provide limited assistance and is not responsible for
-debugging your setup. You're highly advised to read over the script and understand how it works before installing it.
-
-#### Requesting a Permanent Exemption with the Auto-Sleep Script
-
-Since the host auto-sleep script is a purely user-side script, the sleep schedule will still take effect alongside the
-auto-sleep script you've installed on your host. If you'd like to use the host sleep script _as a replacement_ for the
-Evergreen sleep schedule feature, you can [request a permanent exemption](#permanent-exemption). In the
-permanent exemption request, please:
-* Include the host ID.
-* Mention that you're using the host auto-sleep script instead of the sleep schedule.
-* Provide a text snippet of the script output.
-* Show an example in your host's event logs where the host sleep script successfully stopped your host due to
-  inactivity.
-
----
-
-### Option 3: Requesting a Permanent Exemption {#permanent-exemption}
+### Option 2: Requesting a Permanent Exemption {#permanent-exemption}
 
 If for some reason your host cannot use a sleep schedule at all or your regular workflow is impacted by using it, you
 can request that your host be permanently exempt from the sleep schedule feature. If your host is permanently exempt, it
 won't have any sleep schedule set and Evergreen will not stop/start your host according to a recurring sleep schedule. A
 permanent exemption from setting a sleep schedule would allow your host to be kept on 24/7.
 
-**If the sleep schedule feature does not impact your regular workflow, it's recommended to first try that out or set up
-[the auto-sleep script](#host-auto-sleep-script).** User who only occasionally need their host to stay on (e.g. to
-occasionally run a one-off test overnight) can set [temporary exemptions](#temporary-exemptions) when needed. If the
-feature negatively impacts your workflow on the host, you can request a permanent exemption.
-
 If you'd like to request a permanent exemption, please file a DEVPROD ticket with the title "Permanent Exemption
 Request" and set Evergreen App as the Dev Prod service. In it, please include your host ID and a brief description of
-why you'd like your host to be permanently exempt from the sleep schedule (and if relevant, why the other options are
-not suitable for your usage).
-
-If you're using the host auto-sleep script as a replacement for the sleep schedule and would like to get a permanent
-exemption for the host, please follow the instructions
-[here](#requesting-a-permanent-exemption-with-the-auto-sleep-script).
+why you'd like your host to be permanently exempt from the sleep schedule.
 
 ## Hosts Page
 


### PR DESCRIPTION
DEVPROD-8228

Update docs for the end of the beta period. Not going to merge this until the beta ends on Tuesday Sept 3.

* Remove beta period docs.
* Remove docs for option to use the user-owned script. I didn't see anyone mention that they used it, nor do the repo stats suggest anyone cloned it, so I assume it's unused. I think it's safe to remove given that there's not much interest.