### PR TITLE
DEVPROD-10088 Remove unused methods on task queue interface

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -69,12 +69,6 @@ func (d *basicCachedDAGDispatcherImpl) Type() string {
 	return evergreen.DispatcherVersionRevisedWithDependencies
 }
 
-func (d *basicCachedDAGDispatcherImpl) CreatedAt() time.Time {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-	return d.lastUpdated
-}
-
 func (d *basicCachedDAGDispatcherImpl) Refresh() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()


### PR DESCRIPTION
DEVPROD-10088

### Description
These methods were unused in the task queue interface. 