### PR TITLE
DEVPROD-9646 Replace usage of standalone pail function to use bucket construction instead

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -114,9 +114,6 @@ type s3put struct {
 	base
 }
 
-// NotFound is returned by S3 when an object does not exist.
-const notFoundError = "NotFound"
-
 func s3PutFactory() Command      { return &s3put{} }
 func (s3pc *s3put) Name() string { return "s3.put" }
 

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -563,16 +563,16 @@ func (s3pc *s3put) isPublic() bool {
 }
 
 func (s3pc *s3put) remoteFileExists(ctx context.Context, remoteName string) (bool, error) {
-	requestParams2 := pail.S3Options{
+	opts := pail.S3Options{
 		Name:        s3pc.Bucket,
 		Credentials: pail.CreateAWSCredentials(s3pc.AwsKey, s3pc.AwsSecret, s3pc.AwsSessionToken),
 		Region:      s3pc.Region,
 	}
-	bucket, err := pail.NewS3Bucket(ctx, requestParams2)
+	bucket, err := pail.NewS3Bucket(ctx, opts)
 	if err != nil {
 		return false, errors.Wrap(err, "creating S3 bucket")
 	}
-	_, err = bucket.Get(ctx, remoteName)
+	ok, err := bucket.Exists(ctx, remoteName)
 	if err != nil {
 		var smithyErr smithy.APIError
 		if errors.As(err, &smithyErr) {
@@ -581,6 +581,9 @@ func (s3pc *s3put) remoteFileExists(ctx context.Context, remoteName string) (boo
 			}
 		}
 		return false, errors.Wrapf(err, "getting head object for remote file '%s'", remoteName)
+	}
+	if !ok {
+		return false, nil
 	}
 	return true, nil
 }

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/smithy-go"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -572,18 +571,5 @@ func (s3pc *s3put) remoteFileExists(ctx context.Context, remoteName string) (boo
 	if err != nil {
 		return false, errors.Wrap(err, "creating S3 bucket")
 	}
-	ok, err := bucket.Exists(ctx, remoteName)
-	if err != nil {
-		var smithyErr smithy.APIError
-		if errors.As(err, &smithyErr) {
-			if smithyErr.ErrorCode() == notFoundError {
-				return false, nil
-			}
-		}
-		return false, errors.Wrapf(err, "getting head object for remote file '%s'", remoteName)
-	}
-	if !ok {
-		return false, nil
-	}
-	return true, nil
+	return bucket.Exists(ctx, remoteName)
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-08-27a"
+	AgentVersion = "2024-08-29"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-9646

### Description
This replaces the usage of a standalone pail function that is misleading in what it does (it accepts options to presign, but doesn't) to instead use the same constructs we usually use, which is creating a bucket then calling a method on it.

The change this really does is when a user does s3.put and provides the option "skip_existing".

Here is the example task I was running:

```
    - name: s3put-test
      commands:
          - func: clone-project
          - command: s3.put
            params:
                aws_key: ${AWS_ACCESS_KEY_ID}
                aws_secret: ${AWS_SECRET_ACCESS_KEY}
                aws_session_token: ${AWS_SESSION_TOKEN}
                local_file: src/evergreen.yml
                remote_file: mciuploads/zackary.santana/evergreen.yml
                bucket: mciuploads
                region: us-east-1
                permissions: public-read
                content_type: ${content_type|application/x-gzip}
                display_name: Binaries
                skip_existing: true
```

### Testing
TBA patch [before](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_ubuntu_s3put_test_patch_f9ccf280a6ad5111cc6261e913724a3832a9483f_66d0940c050fca0007b0df6b_24_08_29_15_30_25/logs?execution=1) which has execution 1 (passing) and execution 2 (fails because it exists) vs [after](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_ubuntu_s3put_test_patch_f9ccf280a6ad5111cc6261e913724a3832a9483f_66d0984a6c68e400073c9abb_24_08_29_15_48_32/logs?execution=0) which has only 1 execution to replicate failing deployed to staging.

EDIT: [new patch](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_ubuntu_s3put_test_patch_f9ccf280a6ad5111cc6261e913724a3832a9483f_66d0c71b725202000706bf34_24_08_29_19_08_18/logs?execution=0) with new changes
