### PR TITLE
DEVPROD-9693 Remove tenancy option from host.create

### DIFF
--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -122,7 +121,6 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDistro", s.cmd.CreateHost.Distro)
 	s.Equal("task", s.cmd.CreateHost.Scope)
 	s.Equal("subnet-123456", s.cmd.CreateHost.Subnet)
-	s.Equal(evergreen.EC2TenancyDedicated, s.cmd.CreateHost.Tenancy)
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//test with both file and other params

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -37,7 +37,6 @@ func (s *createHostSuite) SetupSuite() {
 	s.conf = &internal.TaskConfig{
 		Expansions: util.Expansions{
 			"subnet_id": "subnet-123456",
-			"tenancy":   string(evergreen.EC2TenancyDedicated),
 		},
 		Task:    task.Task{Id: "mock_id", Secret: "mock_secret"},
 		Project: model.Project{}}
@@ -50,7 +49,6 @@ func (s *createHostSuite) SetupTest() {
 		"distro":    "myDistro",
 		"scope":     "task",
 		"subnet_id": "${subnet_id}",
-		"tenancy":   "${tenancy}",
 	}
 	s.cmd = createHost{}
 }
@@ -92,7 +90,6 @@ func (s *createHostSuite) TestParseFromFile() {
 		"scope":            "task",
 		"subnet_id":        "${subnet_id}",
 		"ebs_block_device": ebsDevice,
-		"tenancy":          "${tenancy}",
 	}
 	//parse from JSON file
 	s.NoError(utility.WriteJSONFile(path, fileContent))
@@ -108,7 +105,6 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDistro", s.cmd.CreateHost.Distro)
 	s.Equal("task", s.cmd.CreateHost.Scope)
 	s.Equal("subnet-123456", s.cmd.CreateHost.Subnet)
-	s.Equal(evergreen.EC2TenancyDedicated, s.cmd.CreateHost.Tenancy)
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//parse from YAML file

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -150,16 +150,15 @@ type CreateHost struct {
 	Retries             int    `mapstructure:"retries" json:"retries" yaml:"retries"`
 
 	// EC2-related settings
-	AMI            string               `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
-	Distro         string               `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
-	EBSDevices     []EbsDevice          `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
-	InstanceType   string               `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
-	IPv6           bool                 `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
-	Region         string               `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
-	SecurityGroups []string             `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
-	Subnet         string               `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
-	Tenancy        evergreen.EC2Tenancy `mapstructure:"tenancy" json:"tenancy" yaml:"tenancy" plugin:"expand"`
-	UserdataFile   string               `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
+	AMI            string      `mapstructure:"ami" json:"ami" yaml:"ami" plugin:"expand"`
+	Distro         string      `mapstructure:"distro" json:"distro" yaml:"distro" plugin:"expand"`
+	EBSDevices     []EbsDevice `mapstructure:"ebs_block_device" json:"ebs_block_device" yaml:"ebs_block_device" plugin:"expand"`
+	InstanceType   string      `mapstructure:"instance_type" json:"instance_type" yaml:"instance_type" plugin:"expand"`
+	IPv6           bool        `mapstructure:"ipv6" json:"ipv6" yaml:"ipv6"`
+	Region         string      `mapstructure:"region" json:"region" yaml:"region" plugin:"expand"`
+	SecurityGroups []string    `mapstructure:"security_group_ids" json:"security_group_ids" yaml:"security_group_ids" plugin:"expand"`
+	Subnet         string      `mapstructure:"subnet_id" json:"subnet_id" yaml:"subnet_id" plugin:"expand"`
+	UserdataFile   string      `mapstructure:"userdata_file" json:"userdata_file" yaml:"userdata_file" plugin:"expand"`
 	// UserdataCommand is the content of the userdata file. Users can't actually
 	// set this directly, instead they pass in a userdata file.
 	UserdataCommand string `json:"userdata_command" yaml:"userdata_command" plugin:"expand"`
@@ -260,10 +259,6 @@ func (ch *CreateHost) validateEC2() error {
 			catcher.New("subnet ID must be set if AMI is set")
 		}
 	}
-	if ch.Tenancy != "" {
-		catcher.ErrorfWhen(!evergreen.IsValidEC2Tenancy(ch.Tenancy), "invalid tenancy '%s', allowed values are: %s", ch.Tenancy, evergreen.ValidEC2Tenancies)
-	}
-
 	return catcher.Resolve()
 }
 

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -52,10 +52,6 @@ type EC2ProviderSettings struct {
 	// SubnetId is only set in a VPC. Either subnet id or vpc name must set.
 	SubnetId string `mapstructure:"subnet_id" json:"subnet_id,omitempty" bson:"subnet_id,omitempty"`
 
-	// Tenancy, if set, determines how EC2 instances are distributed across
-	// physical hardware.
-	Tenancy evergreen.EC2Tenancy `mapstructure:"tenancy" json:"tenancy,omitempty" bson:"tenancy,omitempty"`
-
 	// VpcName is used to get the subnet ID automatically. Either subnet id or vpc name must set.
 	VpcName string `mapstructure:"vpc_name" json:"vpc_name,omitempty" bson:"vpc_name,omitempty"`
 
@@ -94,10 +90,6 @@ func (s *EC2ProviderSettings) Validate() error {
 
 	if s.IsVpc && s.SubnetId == "" {
 		catcher.New("must set a default subnet for a VPC")
-	}
-
-	if s.Tenancy != "" {
-		catcher.ErrorfWhen(!evergreen.IsValidEC2Tenancy(s.Tenancy), "invalid tenancy '%s', allowed values are: %s", s.Tenancy, evergreen.ValidEC2Tenancies)
 	}
 
 	_, err := makeBlockDeviceMappings(s.MountPoints)
@@ -283,9 +275,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		}
 	} else {
 		input.SecurityGroups = ec2Settings.SecurityGroupIDs
-	}
-	if ec2Settings.Tenancy != "" {
-		input.Placement = &types.Placement{Tenancy: types.Tenancy(ec2Settings.Tenancy)}
 	}
 
 	if ec2Settings.UserData != "" {

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -798,9 +798,6 @@ EC2 Parameters:
     set. May set if `distro` is set, which will override the value from
     the distro configuration.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
--   `tenancy` - If set, defines how the hosts are distributed across
-    physical hardware. Can be set to `default`, `dedicated`, or `host`. If not
-    set, it uses the `default` (i.e. shared) tenancy.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the
     distro configuration. May set if distro is not set.

--- a/globals.go
+++ b/globals.go
@@ -621,23 +621,6 @@ func IsDockerProvider(provider string) bool {
 		provider == ProviderNameDockerMock
 }
 
-// EC2Tenancy represents the physical hardware tenancy for EC2 hosts.
-type EC2Tenancy string
-
-const (
-	EC2TenancyDefault   EC2Tenancy = "default"
-	EC2TenancyDedicated EC2Tenancy = "dedicated"
-	EC2TenancyHost      EC2Tenancy = "host"
-)
-
-// ValidEC2Tenancies represents valid EC2 tenancy values.
-var ValidEC2Tenancies = []EC2Tenancy{EC2TenancyDefault, EC2TenancyDedicated, EC2TenancyHost}
-
-// IsValidEC2Tenancy returns if the given EC2 tenancy is valid.
-func IsValidEC2Tenancy(tenancy EC2Tenancy) bool {
-	return len(utility.FilterSlice(ValidEC2Tenancies, func(t EC2Tenancy) bool { return t == tenancy })) > 0
-}
-
 var (
 	// ProviderSpawnable includes all cloud provider types where hosts can be
 	// dynamically created and terminated according to need. This has no

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -376,10 +376,6 @@ func makeEC2IntentHost(ctx context.Context, env evergreen.Environment, taskID, u
 		ec2Settings.SecurityGroupIDs = append(ec2Settings.SecurityGroupIDs, evergreen.GetEnvironment().Settings().Providers.AWS.DefaultSecurityGroup)
 	}
 
-	if createHost.Tenancy != "" {
-		ec2Settings.Tenancy = createHost.Tenancy
-	}
-
 	ec2Settings.IPv6 = createHost.IPv6
 	ec2Settings.IsVpc = true // task-spawned hosts do not support ec2 classic
 

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -180,7 +180,6 @@ func TestMakeHost(t *testing.T) {
 		SetupTimeoutSecs:    600,
 		TeardownTimeoutSecs: 21600,
 		Subnet:              "subnet-123456",
-		Tenancy:             evergreen.EC2TenancyDedicated,
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -198,7 +197,6 @@ func TestMakeHost(t *testing.T) {
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings.AMI)
-	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings.Tenancy)
 	assert.Equal("subnet-123456", ec2Settings.SubnetId)
 	assert.Equal(true, ec2Settings.IsVpc)
 
@@ -207,7 +205,6 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-123456", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
-	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings2.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// bring your own ami
@@ -221,7 +218,6 @@ func TestMakeHost(t *testing.T) {
 		InstanceType:        "t1.micro",
 		Subnet:              "subnet-123456",
 		SecurityGroups:      []string{"1234"},
-		Tenancy:             evergreen.EC2TenancyDedicated,
 	}
 	handler.createHost = c
 	foundDistro, err = distro.GetHostCreateDistro(ctx, c)
@@ -240,7 +236,6 @@ func TestMakeHost(t *testing.T) {
 	assert.NoError(ec2Settings2.FromDistroSettings(h.Distro, ""))
 	assert.Equal("ami-654321", ec2Settings2.AMI)
 	assert.Equal("subnet-123456", ec2Settings2.SubnetId)
-	assert.Equal(evergreen.EC2TenancyDedicated, ec2Settings.Tenancy)
 	assert.Equal(true, ec2Settings2.IsVpc)
 
 	// with multiple regions


### PR DESCRIPTION
DEVPROD-9693

### Description

Remove EC2 tenancy, since we decided in the ticket not to support it anymore.

### Testing

This is just a removal of matching lines, so it should be covered in the existing tests.

### Documentation

Removed the mention of EC2 tenancy from the documentation.
