### PR TITLE
DEVPROD-10343 Add note about git.get_project to github access token docs 

### DIFF
--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -177,7 +177,7 @@ The check run will include a `view more details` link which will link back to th
 
 Evergreen offers the [github.generate_token](Project-Commands#github_generate_token) project command that dynamically generates a short lived token from a user-provided GitHub app. Before you can use the command you will need to set up your github app in your project settings. This feature is not available as a [repo-level setting](Repo-Level-Settings), it will need to be set up separately for each project where the command will be used.
 
-> Note: Adding a GitHub app to your project setting will have no automatic affect on your tasks - `git.get_project` will not automatically start using it. It will simply enable you to use the `github.generate_token` if and when you choose to.
+> Note: Adding a GitHub app to your project setting won't automatically impact your tasks. The `git.get_project` command will not default to it. It will simply enable you to use the `github.generate_token` command if and when you choose to.
 
 If you run into any issues, please see our [FAQ](../FAQ.md#dynamic-github-access-tokens).
 

--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -173,9 +173,11 @@ The check run will include a `view more details` link which will link back to th
 - Check runs only apply to PR patches
 - There is a limit on how many check runs can be added per version. This limit is set by evergreen based on demand and available resources and is subject to change.
 
-## Dynamic Github Access Tokens
+## Dynamic GitHub Access Tokens
 
 Evergreen offers the [github.generate_token](Project-Commands#github_generate_token) project command that dynamically generates a short lived token from a user-provided GitHub app. Before you can use the command you will need to set up your github app in your project settings. This feature is not available as a [repo-level setting](Repo-Level-Settings), it will need to be set up separately for each project where the command will be used.
+
+> Note: Adding a GitHub app to your project setting will have no automatic affect on your tasks - `git.get_project` will not automatically start using it. It will simply enable you to use the `github.generate_token` if and when you choose to.
 
 If you run into any issues, please see our [FAQ](../FAQ.md#dynamic-github-access-tokens).
 


### PR DESCRIPTION
DEVPROD-10343

### Description
Add a note to git.get_project to avoid confusion 

### Documentation
yes 
