### PR TITLE
DEVPROD-9693 Remove host tenancy from host.create

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -799,7 +799,7 @@ EC2 Parameters:
     the distro configuration.
 -   `subnet_id` - Subnet ID for the VPC. Must be set if `ami` is set.
 -   `tenancy` - If set, defines how the hosts are distributed across
-    physical hardware. Can be set to `default`, `dedicated`, or `host`. If not
+    physical hardware. Can be set to `default` or `dedicated`. If not
     set, it uses the `default` (i.e. shared) tenancy.
 -   `userdata_file` - Path to file to load as EC2 user data on boot. May
     set if `distro` is set, which will override the value from the

--- a/globals.go
+++ b/globals.go
@@ -627,11 +627,10 @@ type EC2Tenancy string
 const (
 	EC2TenancyDefault   EC2Tenancy = "default"
 	EC2TenancyDedicated EC2Tenancy = "dedicated"
-	EC2TenancyHost      EC2Tenancy = "host"
 )
 
 // ValidEC2Tenancies represents valid EC2 tenancy values.
-var ValidEC2Tenancies = []EC2Tenancy{EC2TenancyDefault, EC2TenancyDedicated, EC2TenancyHost}
+var ValidEC2Tenancies = []EC2Tenancy{EC2TenancyDefault, EC2TenancyDedicated}
 
 // IsValidEC2Tenancy returns if the given EC2 tenancy is valid.
 func IsValidEC2Tenancy(tenancy EC2Tenancy) bool {


### PR DESCRIPTION
DEVPROD-9693

### Description

Remove tenancy: host option, as we determined in the ticket.

### Testing

This is a deletion so is covered by the existing tests.

### Documentation

Removed the tenancy: host option from the documentation.