### PR TITLE
DEVPROD-9826: remove unused top-level batchtime

### DIFF
--- a/config_dev/project/sample.yml
+++ b/config_dev/project/sample.yml
@@ -1,5 +1,4 @@
 enabled: true
-batchtime: 120
 identifier: sample
 
 functions:

--- a/docs/Project-Configuration/Controlling-when-tasks-run.md
+++ b/docs/Project-Configuration/Controlling-when-tasks-run.md
@@ -50,7 +50,7 @@ Batchtime sets an interval of time in minutes that Evergreen should wait before 
 
 A default batch time can be set on the project page [under general settings](../Project-Configuration/Project-and-Distro-Settings/#general-project-settings) for the interval of time (in minutes) that Evergreen should wait in between activating the latest version.
 
-Batchtime can also be specified at the top level of the project configuration file or in the buildvariants section in the project configuration file on a build variant or task level.
+Batchtime can also be specified in the buildvariants section in the project configuration file on an entire build variant or for a single task in the build variant task list.
 
 #### Example
 

--- a/model/project.go
+++ b/model/project.go
@@ -46,7 +46,6 @@ type Project struct {
 	PreErrorFailsTask  bool                       `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask bool                       `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
 	OomTracker         bool                       `yaml:"oom_tracker,omitempty" bson:"oom_tracker"`
-	BatchTime          int                        `yaml:"batchtime,omitempty" bson:"batch_time"`
 	Identifier         string                     `yaml:"identifier,omitempty" bson:"identifier"`
 	DisplayName        string                     `yaml:"display_name,omitempty" bson:"display_name"`
 	CommandType        string                     `yaml:"command_type,omitempty" bson:"command_type"`

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -83,7 +83,6 @@ type ParserProject struct {
 	PreErrorFailsTask  *bool                      `yaml:"pre_error_fails_task,omitempty" bson:"pre_error_fails_task,omitempty"`
 	PostErrorFailsTask *bool                      `yaml:"post_error_fails_task,omitempty" bson:"post_error_fails_task,omitempty"`
 	OomTracker         *bool                      `yaml:"oom_tracker,omitempty" bson:"oom_tracker,omitempty"`
-	BatchTime          *int                       `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
 	Owner              *string                    `yaml:"owner,omitempty" bson:"owner,omitempty"`
 	Repo               *string                    `yaml:"repo,omitempty" bson:"repo,omitempty"`
 	RemotePath         *string                    `yaml:"remote_path,omitempty" bson:"remote_path,omitempty"`
@@ -1009,7 +1008,6 @@ func TranslateProject(pp *ParserProject) (*Project, error) {
 		PreErrorFailsTask:  utility.FromBoolPtr(pp.PreErrorFailsTask),
 		PostErrorFailsTask: utility.FromBoolPtr(pp.PostErrorFailsTask),
 		OomTracker:         utility.FromBoolTPtr(pp.OomTracker), // oom tracker is true by default
-		BatchTime:          utility.FromIntPtr(pp.BatchTime),
 		Identifier:         utility.FromStringPtr(pp.Identifier),
 		DisplayName:        utility.FromStringPtr(pp.DisplayName),
 		CommandType:        utility.FromStringPtr(pp.CommandType),

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -18,7 +18,6 @@ var (
 	ParserProjectStepbackKey          = bsonutil.MustHaveTag(ParserProject{}, "Stepback")
 	ParserProjectPreErrorFailsTaskKey = bsonutil.MustHaveTag(ParserProject{}, "PreErrorFailsTask")
 	ParserProjectOomTracker           = bsonutil.MustHaveTag(ParserProject{}, "OomTracker")
-	ParserProjectBatchTimeKey         = bsonutil.MustHaveTag(ParserProject{}, "BatchTime")
 	ParserProjectOwnerKey             = bsonutil.MustHaveTag(ParserProject{}, "Owner")
 	ParserProjectRepoKey              = bsonutil.MustHaveTag(ParserProject{}, "Repo")
 	ParserProjectRemotePathKey        = bsonutil.MustHaveTag(ParserProject{}, "RemotePath")

--- a/model/project_parser_merge_functions.go
+++ b/model/project_parser_merge_functions.go
@@ -139,12 +139,6 @@ func (pp *ParserProject) mergeUnique(toMerge *ParserProject) error {
 		pp.Stepback = toMerge.Stepback
 	}
 
-	if pp.BatchTime != nil && toMerge.BatchTime != nil {
-		catcher.New("batch time can only be defined in one YAML")
-	} else if toMerge.BatchTime != nil {
-		pp.BatchTime = toMerge.BatchTime
-	}
-
 	if pp.PreTimeoutSecs != nil && toMerge.PreTimeoutSecs != nil {
 		catcher.New("pre timeout secs can only be defined in one YAML")
 	} else if toMerge.PreTimeoutSecs != nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2550,7 +2550,6 @@ func TestMergeOrderedUniqueFail(t *testing.T) {
 func TestMergeUnique(t *testing.T) {
 	main := &ParserProject{
 		Stepback:    utility.ToBoolPtr(true),
-		BatchTime:   utility.ToIntPtr(1),
 		OomTracker:  utility.ToBoolPtr(false),
 		DisplayName: utility.ToStringPtr("name"),
 	}
@@ -2568,7 +2567,6 @@ func TestMergeUnique(t *testing.T) {
 	err := main.mergeUnique(add)
 	assert.NoError(t, err)
 	assert.NotNil(t, main.Stepback)
-	assert.NotNil(t, main.BatchTime)
 	assert.NotNil(t, main.OomTracker)
 	assert.NotNil(t, main.DisplayName)
 	assert.NotNil(t, main.PreTimeoutSecs)
@@ -2583,7 +2581,6 @@ func TestMergeUnique(t *testing.T) {
 func TestMergeUniqueFail(t *testing.T) {
 	main := &ParserProject{
 		Stepback:          utility.ToBoolPtr(true),
-		BatchTime:         utility.ToIntPtr(1),
 		OomTracker:        utility.ToBoolPtr(true),
 		PreTimeoutSecs:    utility.ToIntPtr(1),
 		PostTimeoutSecs:   utility.ToIntPtr(1),
@@ -2596,7 +2593,6 @@ func TestMergeUniqueFail(t *testing.T) {
 
 	add := &ParserProject{
 		Stepback:          utility.ToBoolPtr(true),
-		BatchTime:         utility.ToIntPtr(1),
 		OomTracker:        utility.ToBoolPtr(true),
 		PreTimeoutSecs:    utility.ToIntPtr(1),
 		PostTimeoutSecs:   utility.ToIntPtr(1),
@@ -2610,7 +2606,6 @@ func TestMergeUniqueFail(t *testing.T) {
 
 	err := main.mergeUnique(add)
 	assert.Contains(t, err.Error(), "stepback can only be defined in one YAML")
-	assert.Contains(t, err.Error(), "batch time can only be defined in one YAML")
 	assert.Contains(t, err.Error(), "OOM tracker can only be defined in one YAML")
 	assert.Contains(t, err.Error(), "pre timeout secs can only be defined in one YAML")
 	assert.Contains(t, err.Error(), "post timeout secs can only be defined in one YAML")

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -81,12 +81,11 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{
-		Id:        project.DisplayName,
-		Owner:     "evergreen-ci",
-		Repo:      "sample",
-		Branch:    "main",
-		Enabled:   true,
-		BatchTime: project.BatchTime,
+		Id:      project.DisplayName,
+		Owner:   "evergreen-ci",
+		Repo:    "sample",
+		Branch:  "main",
+		Enabled: true,
 	}
 	if err = projectRef.Insert(); err != nil {
 		return nil, errors.Wrap(err, "inserting project ref")

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -158,7 +157,6 @@ var projectConfigErrorValidators = []projectConfigValidator{
 // a level of Warning ValidationLevel or Notice ValidationLevel.
 var projectWarningValidators = []projectValidator{
 	checkTaskGroups,
-	checkProjectFields,
 	checkTaskRuns,
 	checkModules,
 	checkTasks,
@@ -819,15 +817,6 @@ func validateBVFields(project *model.Project) ValidationErrors {
 func validateProjectFields(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 
-	if project.BatchTime < 0 {
-		errs = append(errs,
-			ValidationError{
-				Level:   Error,
-				Message: "'batchtime' must be non-negative",
-			},
-		)
-	}
-
 	if project.CommandType != "" {
 		if !utility.StringSliceContains(evergreen.ValidCommandTypes, project.CommandType) {
 			errs = append(errs,
@@ -838,24 +827,6 @@ func validateProjectFields(project *model.Project) ValidationErrors {
 			)
 		}
 	}
-	return errs
-}
-
-func checkProjectFields(project *model.Project) ValidationErrors {
-	errs := ValidationErrors{}
-
-	if project.BatchTime > math.MaxInt32 {
-		// Error level is warning for backwards compatibility with
-		// existing projects. This value will be capped at MaxInt32
-		// in ProjectRef.getBatchTime()
-		errs = append(errs,
-			ValidationError{
-				Message: fmt.Sprintf("'batchtime' should not exceed %d", math.MaxInt32),
-				Level:   Warning,
-			},
-		)
-	}
-
 	return errs
 }
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"math"
 	"reflect"
 	"runtime"
 	"strings"
@@ -3834,17 +3833,7 @@ func (s *validateProjectFieldSuite) SetupTest() {
 	s.project = model.Project{
 		Identifier:  "identifier",
 		DisplayName: "test",
-		BatchTime:   10,
 	}
-}
-
-func (s *validateProjectFieldSuite) TestBatchTimeValueMustNonNegative() {
-	s.project.BatchTime = -10
-	validationError := validateProjectFields(&s.project)
-
-	s.Len(validationError, 1)
-	s.Contains(validationError[0].Message, "'batchtime' must be non-negative",
-		"Project 'batchtime' must not be negative")
 }
 
 func (s *validateProjectFieldSuite) TestCommandTypes() {
@@ -3872,15 +3861,6 @@ func (s *validateProjectFieldSuite) TestFailOnInvalidCommandType() {
 	s.Len(validationError, 1)
 	s.Contains(validationError[0].Message, "invalid command type: random",
 		"Project 'CommandType' must be valid")
-}
-
-func (s *validateProjectFieldSuite) TestWarnOnLargeBatchTimeValue() {
-	s.project.BatchTime = math.MaxInt32 + 1
-	validationError := checkProjectFields(&s.project)
-
-	s.Len(validationError, 1)
-	s.Equal(validationError[0].Level, Warning,
-		"Large batch time validation error should be a warning")
 }
 
 func TestValidateBVFields(t *testing.T) {


### PR DESCRIPTION
DEVPROD-9826

### Description
The top-level batchtime doesn't have any effect right now, so it can be removed. If any remaining YAMLs have it defined, `evergreen validate` produces a warning.

### Testing
* Existing tests pass.
* Ran `evergreen validate` on project YAMLs and verified that for the few projects that define top-level batchtime, it emits a warning. (Those that have it just set it to 0)

### Documentation
Removed docs about top-level batchtime.