### PR TITLE
DEVPROD-2749 remove patch.DisplayNewUI

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -183,8 +183,6 @@ type Patch struct {
 	GithubPatchData      thirdparty.GithubPatch               `bson:"github_patch_data,omitempty"`
 	GithubMergeData      thirdparty.GithubMergeGroup          `bson:"github_merge_data,omitempty"`
 	GitInfo              *GitMetadata                         `bson:"git_info,omitempty"`
-	// DisplayNewUI is only used when roundtripping the patch via the CLI
-	DisplayNewUI bool `bson:"display_new_ui,omitempty"`
 	// MergeStatus is only used in gitServePatch to send the status of this
 	// patch on the commit queue to the agent
 	MergeStatus string `json:"merge_status"`
@@ -291,9 +289,7 @@ func (p *Patch) GetURL(uiHost string) string {
 		url = uiHost + "/patch/" + p.Id.Hex()
 	}
 
-	if p.DisplayNewUI {
-		url = url + "?redirect_spruce_users=true"
-	}
+	url = url + "?redirect_spruce_users=true"
 
 	return url
 }

--- a/units/github_status_refresh_test.go
+++ b/units/github_status_refresh_test.go
@@ -65,13 +65,12 @@ func (s *githubStatusRefreshSuite) SetupTest() {
 	startTime := time.Now().Truncate(time.Millisecond)
 	id := mgobson.NewObjectId()
 	s.patchDoc = &patch.Patch{
-		Id:           id,
-		Version:      id.Hex(),
-		Activated:    true,
-		DisplayNewUI: true,
-		Status:       evergreen.VersionStarted,
-		StartTime:    startTime,
-		FinishTime:   startTime.Add(10 * time.Minute),
+		Id:         id,
+		Version:    id.Hex(),
+		Activated:  true,
+		Status:     evergreen.VersionStarted,
+		StartTime:  startTime,
+		FinishTime: startTime.Add(10 * time.Minute),
 		GithubPatchData: thirdparty.GithubPatch{
 			BaseOwner: "evergreen-ci",
 			BaseRepo:  "evergreen",
@@ -153,7 +152,6 @@ func (s *githubStatusRefreshSuite) TestStatusPending() {
 		Triggers: patch.TriggerInfo{
 			ParentPatch: s.patchDoc.Id.Hex(),
 		},
-		DisplayNewUI: true,
 	}
 	s.NoError(childPatch.Insert())
 	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
@@ -359,7 +357,6 @@ func (s *githubStatusRefreshSuite) TestStatusSucceeded() {
 		Triggers: patch.TriggerInfo{
 			ParentPatch: s.patchDoc.Id.Hex(),
 		},
-		DisplayNewUI: true,
 	}
 	s.NoError(childPatch.Insert())
 	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}
@@ -425,7 +422,6 @@ func (s *githubStatusRefreshSuite) TestStatusFailed() {
 		Triggers: patch.TriggerInfo{
 			ParentPatch: s.patchDoc.Id.Hex(),
 		},
-		DisplayNewUI: true,
 	}
 	s.NoError(childPatch.Insert())
 	s.patchDoc.Triggers.ChildPatches = []string{childPatch.Id.Hex()}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -252,10 +252,6 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 	}
 
-	if j.user.Settings.UseSpruceOptions.SpruceV1 {
-		patchDoc.DisplayNewUI = true
-	}
-
 	pref, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version, true)
 	if err != nil {
 		return errors.Wrap(err, "finding project for patch")


### PR DESCRIPTION
DEVPROD-2749

### Description
The patch document contained a field called display_new_ui which was used as a flag to determine if we should show the redirect_spruce_users query param in the cli. We don't need this since redirect_spruce_users will already handle redirecting users who are opted into the new UI. 


