### PR TITLE
docs: clarify REST v2 URL prefix

### DIFF
--- a/docs/API/REST-V2-Usage.mdx
+++ b/docs/API/REST-V2-Usage.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: true
 # REST v2 API
 
 To use Evergreen's REST v2 API, all URLs should be prefixed with `https://evergreen.mongodb.com/rest/v2`. For
-example, to [get a single task](#tag/tasks/paths/~1tasks~1{task_id}/get), make a GET request to `https://evergreen.mongodb.com/rest/v2/tasks/<TASK_ID>`.
+example, to [get a single task](#tag/tasks/paths/~1tasks~1{task_id}/get), make a GET request to `https://evergreen.mongodb.com/rest/v2/tasks/{task_id}`.
 
 ## General Functionality
 

--- a/docs/API/REST-V2-Usage.mdx
+++ b/docs/API/REST-V2-Usage.mdx
@@ -4,6 +4,9 @@ hide_table_of_contents: true
 
 # REST v2 API
 
+To use Evergreen's REST v2 API, all URLs should be prefixed with `https://evergreen.mongodb.com/rest/v2`. For
+example, to [get a single task](#tag/tasks/paths/~1tasks~1{task_id}/get), make a GET request to `https://evergreen.mongodb.com/rest/v2/tasks/<TASK_ID>`.
+
 ## General Functionality
 
 ### Errors


### PR DESCRIPTION
Noticed a new user was confused about how to use the REST v2 API. It seems like the docs don't mention anywhere on the page that the REST v2 URL format is always in the form `https://evergreen.mongodb.com/rest/v2/<ROUTE>`.