### PR TITLE
DEVPROD-10372: Remove unused fields from GraphQL Image object

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -535,14 +535,11 @@ type ComplexityRoot struct {
 		Distros         func(childComplexity int) int
 		Events          func(childComplexity int, limit int, page int) int
 		ID              func(childComplexity int) int
-		Kernel          func(childComplexity int) int
 		LastDeployed    func(childComplexity int) int
 		LatestTask      func(childComplexity int) int
-		Name            func(childComplexity int) int
 		OperatingSystem func(childComplexity int, opts thirdparty.OSInfoFilterOptions) int
 		Packages        func(childComplexity int, opts thirdparty.PackageFilterOptions) int
 		Toolchains      func(childComplexity int, opts thirdparty.ToolchainFilterOptions) int
-		VersionID       func(childComplexity int) int
 	}
 
 	ImageEvent struct {
@@ -1750,7 +1747,6 @@ type ImageResolver interface {
 	Events(ctx context.Context, obj *model.APIImage, limit int, page int) (*ImageEventsPayload, error)
 
 	LatestTask(ctx context.Context, obj *model.APIImage) (*model.APITask, error)
-
 	OperatingSystem(ctx context.Context, obj *model.APIImage, opts thirdparty.OSInfoFilterOptions) (*ImageOperatingSystemPayload, error)
 	Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*ImagePackagesPayload, error)
 	Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ImageToolchainsPayload, error)
@@ -3974,13 +3970,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Image.ID(childComplexity), true
 
-	case "Image.kernel":
-		if e.complexity.Image.Kernel == nil {
-			break
-		}
-
-		return e.complexity.Image.Kernel(childComplexity), true
-
 	case "Image.lastDeployed":
 		if e.complexity.Image.LastDeployed == nil {
 			break
@@ -3994,13 +3983,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Image.LatestTask(childComplexity), true
-
-	case "Image.name":
-		if e.complexity.Image.Name == nil {
-			break
-		}
-
-		return e.complexity.Image.Name(childComplexity), true
 
 	case "Image.operatingSystem":
 		if e.complexity.Image.OperatingSystem == nil {
@@ -4037,13 +4019,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Image.Toolchains(childComplexity, args["opts"].(thirdparty.ToolchainFilterOptions)), true
-
-	case "Image.versionId":
-		if e.complexity.Image.VersionID == nil {
-			break
-		}
-
-		return e.complexity.Image.VersionID(childComplexity), true
 
 	case "ImageEvent.amiAfter":
 		if e.complexity.ImageEvent.AMIAfter == nil {
@@ -25658,50 +25633,6 @@ func (ec *executionContext) fieldContext_Image_events(ctx context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Image_kernel(ctx context.Context, field graphql.CollectedField, obj *model.APIImage) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Image_kernel(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Kernel, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Image_kernel(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Image",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Image_lastDeployed(ctx context.Context, field graphql.CollectedField, obj *model.APIImage) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Image_lastDeployed(ctx, field)
 	if err != nil {
@@ -25939,50 +25870,6 @@ func (ec *executionContext) fieldContext_Image_latestTask(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Image_name(ctx context.Context, field graphql.CollectedField, obj *model.APIImage) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Image_name(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Image_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Image",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Image_operatingSystem(ctx context.Context, field graphql.CollectedField, obj *model.APIImage) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Image_operatingSystem(ctx, field)
 	if err != nil {
@@ -26168,50 +26055,6 @@ func (ec *executionContext) fieldContext_Image_toolchains(ctx context.Context, f
 	if fc.Args, err = ec.field_Image_toolchains_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Image_versionId(ctx context.Context, field graphql.CollectedField, obj *model.APIImage) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Image_versionId(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.VersionID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Image_versionId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Image",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
 	}
 	return fc, nil
 }
@@ -49398,22 +49241,16 @@ func (ec *executionContext) fieldContext_Query_image(ctx context.Context, field 
 				return ec.fieldContext_Image_distros(ctx, field)
 			case "events":
 				return ec.fieldContext_Image_events(ctx, field)
-			case "kernel":
-				return ec.fieldContext_Image_kernel(ctx, field)
 			case "lastDeployed":
 				return ec.fieldContext_Image_lastDeployed(ctx, field)
 			case "latestTask":
 				return ec.fieldContext_Image_latestTask(ctx, field)
-			case "name":
-				return ec.fieldContext_Image_name(ctx, field)
 			case "operatingSystem":
 				return ec.fieldContext_Image_operatingSystem(ctx, field)
 			case "packages":
 				return ec.fieldContext_Image_packages(ctx, field)
 			case "toolchains":
 				return ec.fieldContext_Image_toolchains(ctx, field)
-			case "versionId":
-				return ec.fieldContext_Image_versionId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Image", field.Name)
 		},
@@ -80575,11 +80412,6 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "kernel":
-			out.Values[i] = ec._Image_kernel(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "lastDeployed":
 			out.Values[i] = ec._Image_lastDeployed(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -80618,11 +80450,6 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "name":
-			out.Values[i] = ec._Image_name(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "operatingSystem":
 			field := field
 
@@ -80731,11 +80558,6 @@ func (ec *executionContext) _Image(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "versionId":
-			out.Values[i] = ec._Image_versionId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -72,6 +72,9 @@ func (r *imageResolver) LatestTask(ctx context.Context, obj *model.APIImage) (*m
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting latest task for image '%s': '%s'", imageID, err.Error()))
 	}
+	if latestTask == nil {
+		return nil, nil
+	}
 	apiLatestTask := &model.APITask{}
 	err = apiLatestTask.BuildFromService(ctx, latestTask, &model.APITaskArgs{
 		IncludeAMI: true,

--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -18,7 +18,7 @@ func (r *imageResolver) Distros(ctx context.Context, obj *model.APIImage) ([]*mo
 	imageID := utility.FromStringPtr(obj.ID)
 	distros, err := distro.GetDistrosForImage(ctx, imageID)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for image '%s': '%s'", imageID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for image '%s': %s", imageID, err.Error()))
 	}
 
 	userHasDistroCreatePermission := userHasDistroCreatePermission(usr)
@@ -40,7 +40,7 @@ func (r *imageResolver) Distros(ctx context.Context, obj *model.APIImage) ([]*mo
 func (r *imageResolver) Events(ctx context.Context, obj *model.APIImage, limit int, page int) (*ImageEventsPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: %s", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts := thirdparty.EventHistoryOptions{
@@ -50,7 +50,7 @@ func (r *imageResolver) Events(ctx context.Context, obj *model.APIImage, limit i
 	}
 	imageEvents, err := c.GetEvents(ctx, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting events for image '%s': '%s'", imageEvents, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting events for image '%s': %s", imageEvents, err.Error()))
 	}
 	apiImageEvents := []*model.APIImageEvent{}
 	for _, imageEvent := range imageEvents {
@@ -70,7 +70,7 @@ func (r *imageResolver) LatestTask(ctx context.Context, obj *model.APIImage) (*m
 	imageID := utility.FromStringPtr(obj.ID)
 	latestTask, err := task.GetLatestTaskFromImage(ctx, imageID)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting latest task for image '%s': '%s'", imageID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting latest task for image '%s': %s", imageID, err.Error()))
 	}
 	if latestTask == nil {
 		return nil, nil
@@ -89,13 +89,13 @@ func (r *imageResolver) LatestTask(ctx context.Context, obj *model.APIImage) (*m
 func (r *imageResolver) OperatingSystem(ctx context.Context, obj *model.APIImage, opts thirdparty.OSInfoFilterOptions) (*ImageOperatingSystemPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: %s", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
 	res, err := c.GetOSInfo(ctx, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting operating system information for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting operating system information for image '%s': %s", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiOSData := []*model.APIOSInfo{}
 	for _, osInfo := range res.Data {
@@ -114,13 +114,13 @@ func (r *imageResolver) OperatingSystem(ctx context.Context, obj *model.APIImage
 func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts thirdparty.PackageFilterOptions) (*ImagePackagesPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: %s", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
 	res, err := c.GetPackages(ctx, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting packages for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting packages for image '%s': %s", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiPackages := []*model.APIPackage{}
 	for _, pkg := range res.Data {
@@ -139,13 +139,13 @@ func (r *imageResolver) Packages(ctx context.Context, obj *model.APIImage, opts 
 func (r *imageResolver) Toolchains(ctx context.Context, obj *model.APIImage, opts thirdparty.ToolchainFilterOptions) (*ImageToolchainsPayload, error) {
 	config, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: '%s'", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting evergreen configuration: %s", err.Error()))
 	}
 	c := thirdparty.NewRuntimeEnvironmentsClient(config.RuntimeEnvironments.BaseURL, config.RuntimeEnvironments.APIKey)
 	opts.AMI = utility.FromStringPtr(obj.AMI)
 	res, err := c.GetToolchains(ctx, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting toolchains for image '%s': '%s'", utility.FromStringPtr(obj.ID), err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting toolchains for image '%s': %s", utility.FromStringPtr(obj.ID), err.Error()))
 	}
 	apiToolchains := []*model.APIToolchain{}
 	for _, toolchain := range res.Data {

--- a/graphql/image_test.go
+++ b/graphql/image_test.go
@@ -203,6 +203,11 @@ func TestLatestTask(t *testing.T) {
 		ImageID: "ubuntu1604",
 	}
 	require.NoError(t, d2.Insert(ctx))
+	d3 := &distro.Distro{
+		Id:      "ubuntu1804-small",
+		ImageID: "ubuntu1804",
+	}
+	require.NoError(t, d3.Insert(ctx))
 	taskA := &task.Task{
 		Id:         "task_a",
 		DistroId:   "ubuntu1604-small",
@@ -221,12 +226,20 @@ func TestLatestTask(t *testing.T) {
 		FinishTime: time.Date(2023, time.April, 1, 10, 30, 15, 0, time.UTC),
 	}
 	require.NoError(t, taskC.Insert())
-	imageID := "ubuntu1604"
 	image := model.APIImage{
-		ID: &imageID,
+		ID: utility.ToStringPtr("ubuntu1604"),
 	}
+	// Returns latest task that ran on the image.
 	res, err := config.Resolvers.Image().LatestTask(ctx, &image)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, "task_b", utility.FromStringPtr(res.Id))
+
+	// Returns nil if no task has ever ran on the image.
+	image = model.APIImage{
+		ID: utility.ToStringPtr("ubuntu1804"),
+	}
+	res, err = config.Resolvers.Image().LatestTask(ctx, &image)
+	require.NoError(t, err)
+	assert.Nil(t, res)
 }

--- a/graphql/schema/types/image.graphql
+++ b/graphql/schema/types/image.graphql
@@ -41,14 +41,11 @@ type Image {
   ami: String!
   distros: [Distro!]!
   events(limit: Int!, page: Int!): ImageEventsPayload!
-  kernel: String!
   lastDeployed: Time!
   latestTask: Task
-  name: String!
   operatingSystem(opts: OperatingSystemOpts!): ImageOperatingSystemPayload!
   packages(opts: PackageOpts!): ImagePackagesPayload!
   toolchains(opts: ToolchainOpts!): ImageToolchainsPayload!
-  versionId: String!
 }
 
 type ImageOperatingSystemPayload {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -3076,5 +3076,5 @@ func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) 
 		}
 		return &task, nil
 	}
-	return nil, errors.Errorf("no latest task found for image '%s'", imageID)
+	return nil, nil
 }

--- a/rest/model/image.go
+++ b/rest/model/image.go
@@ -162,20 +162,14 @@ func (apiImage *APIImageEvent) ToService() *thirdparty.ImageEvent {
 type APIImage struct {
 	ID           *string    `json:"id"`
 	AMI          *string    `json:"ami"`
-	Kernel       *string    `json:"kernel"`
 	LastDeployed *time.Time `json:"last_deployed"`
-	Name         *string    `json:"name"`
-	VersionID    *string    `json:"version_id"`
 }
 
 // BuildFromService converts from service level thirdparty.Image to an APIImage.
 func (apiImage *APIImage) BuildFromService(image thirdparty.Image) {
 	apiImage.ID = utility.ToStringPtr(image.ID)
 	apiImage.AMI = utility.ToStringPtr(image.AMI)
-	apiImage.Kernel = utility.ToStringPtr(image.Kernel)
 	apiImage.LastDeployed = utility.ToTimePtr(image.LastDeployed)
-	apiImage.Name = utility.ToStringPtr(image.Name)
-	apiImage.VersionID = utility.ToStringPtr(image.VersionID)
 }
 
 // ToService returns a service layer image using the data from APIImage.
@@ -183,10 +177,7 @@ func (apiImage *APIImage) ToService() *thirdparty.Image {
 	image := thirdparty.Image{
 		ID:           utility.FromStringPtr(apiImage.ID),
 		AMI:          utility.FromStringPtr(apiImage.AMI),
-		Kernel:       utility.FromStringPtr(apiImage.Kernel),
 		LastDeployed: utility.FromTimePtr(apiImage.LastDeployed),
-		Name:         utility.FromStringPtr(apiImage.Name),
-		VersionID:    utility.FromStringPtr(apiImage.VersionID),
 	}
 	return &image
 }

--- a/thirdparty/runtime_environments_test.go
+++ b/thirdparty/runtime_environments_test.go
@@ -279,9 +279,6 @@ func TestGetImageInfo(t *testing.T) {
 	result, err := c.GetImageInfo(ctx, "ubuntu2204")
 	require.NoError(t, err)
 	require.NotEmpty(t, result)
-	assert.NotEmpty(result.Name)
-	assert.NotEmpty(result.VersionID)
-	assert.NotEmpty(result.Kernel)
 	assert.NotEmpty(result.LastDeployed)
 	assert.NotEmpty(result.AMI)
 }


### PR DESCRIPTION
DEVPROD-10372

### Description
Remove these fields from the `Image` object because they aren't consistent across all images i.e. not all images, particularly Windows and Mac, have these properties.

Also fix a small issue with `latestTask` because it should be acceptable to return nil if a task has never ran on an image.
