### PR TITLE
DEVPROD-1919: upgrade Jasper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -201,7 +201,7 @@ require (
 	github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1
 	github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826
 	github.com/gorilla/handlers v1.5.2
-	github.com/mongodb/jasper v0.0.0-20240424195530-4a5968d6fc0f
+	github.com/mongodb/jasper v0.0.0-20240903162551-472a0fcb2344
 	github.com/shirou/gopsutil/v3 v3.24.5
 	go.uber.org/automaxprocs v1.5.3
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -555,8 +555,8 @@ github.com/mongodb/grip v0.0.0-20211028155128-86e6e47bafdb/go.mod h1:0CTWxPoPDJP
 github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21/go.mod h1:QfF6CwbaTQx1Kgww77c6ROPBFN+JCiU2qBnk2SjKHyU=
 github.com/mongodb/grip v0.0.0-20240213223901-f906268d82b9 h1:e5CP54RuwTYts/MZk0JwuuG2RlKLh/Ujzf16/2ExupE=
 github.com/mongodb/grip v0.0.0-20240213223901-f906268d82b9/go.mod h1:6WpAGSIcNoH6zZuqr5y71TxqhwRT5vL8BRESXlgOzJk=
-github.com/mongodb/jasper v0.0.0-20240424195530-4a5968d6fc0f h1:WwA8iOWtwPa63v0sYXZYoBqNgfFVhf0LJ9GYLbDe4Sw=
-github.com/mongodb/jasper v0.0.0-20240424195530-4a5968d6fc0f/go.mod h1:HremM9A9I0F/SKvOcIbO+B4Zk1W1AKfRGYU891XMNmo=
+github.com/mongodb/jasper v0.0.0-20240903162551-472a0fcb2344 h1:ykm/c59BW1yn7AmE7K3U3KjyYLV47b1Mu2X9yKaw0Cc=
+github.com/mongodb/jasper v0.0.0-20240903162551-472a0fcb2344/go.mod h1:s8xrb54chID4zlsqi6nrFuTBRLf+cFtJ8VdPJOAXX00=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=


### PR DESCRIPTION
DEVPROD-1919

### Description
Upgrade Jasper for https://github.com/mongodb/jasper/pull/382. The SSH library code has never been used so nothing is affected by this.

### Testing
* Code compiles.
* Tested in staging to verify that a spawn host still provisions normally.

### Documentation
N/A