### PR TITLE
DEVPROD-9403: add parameter cache

### DIFF
--- a/cloud/parameterstore/fakeparameter/parameter_record_db_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_record_db_test.go
@@ -80,7 +80,7 @@ func TestBumpParameterRecord(t *testing.T) {
 	}
 }
 
-func TestParameterRecordFindOneID(t *testing.T) {
+func TestParameterRecordFindOneName(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(parameterstore.Collection))
 	}()
@@ -117,7 +117,7 @@ func TestParameterRecordFindOneID(t *testing.T) {
 	}
 }
 
-func TestParameterRecordFindByIDs(t *testing.T) {
+func TestParameterRecordFindByNames(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(parameterstore.Collection))
 	}()

--- a/cloud/parameterstore/parameter_cache.go
+++ b/cloud/parameterstore/parameter_cache.go
@@ -1,3 +1,4 @@
+//nolint:unused
 package parameterstore
 
 import (

--- a/cloud/parameterstore/parameter_cache.go
+++ b/cloud/parameterstore/parameter_cache.go
@@ -1,0 +1,83 @@
+package parameterstore
+
+import (
+	"sync"
+	"time"
+
+	"github.com/evergreen-ci/utility"
+)
+
+// parameterCache is a thread-safe cache for parameter values.
+type parameterCache struct {
+	cache map[string]cachedParameter
+	mu    sync.RWMutex
+}
+
+func newParameterCache() *parameterCache {
+	return &parameterCache{
+		cache: map[string]cachedParameter{},
+	}
+}
+
+type cachedParameter struct {
+	// name is the full name of the parameter.
+	name string
+	// value is the plaintext value of the parameter.
+	value string
+	// lastUpdated is the time the parameter was last updated.
+	lastUpdated time.Time
+}
+
+func newCachedParameter(name, value string, lastUpdated time.Time) cachedParameter {
+	return cachedParameter{
+		name:        name,
+		value:       value,
+		lastUpdated: lastUpdated,
+	}
+}
+
+func (cp *cachedParameter) export() Parameter {
+	return Parameter{
+		Name:     cp.name,
+		Basename: getBasename(cp.name),
+		Value:    cp.value,
+	}
+}
+
+// get gets the cached parameters for the given parameter records. It returns
+// the cached parameter only if the parameter record indicates that the cached
+// parameter is up-to-date.
+func (pc *parameterCache) get(records ...ParameterRecord) (found []cachedParameter, notFound []string) {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+
+	var cachedParams []cachedParameter
+	for _, r := range records {
+		p, ok := pc.cache[r.Name]
+		isStaleEntry := !utility.IsZeroTime(r.LastUpdated) && r.LastUpdated.After(p.lastUpdated)
+		if !ok || isStaleEntry {
+			notFound = append(notFound, r.Name)
+			continue
+		}
+		cachedParams = append(cachedParams, p)
+	}
+	return cachedParams, notFound
+}
+
+// put adds the given cached parameters to the cache. If the cached parameter
+// already exists and the one being newly cached is more up-to-date than the one
+// in the cache, it is overwritten.
+func (pc *parameterCache) put(cachedParams ...cachedParameter) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	for _, cachedParam := range cachedParams {
+		existingCachedParam, ok := pc.cache[cachedParam.name]
+		if ok && existingCachedParam.lastUpdated.After(cachedParam.lastUpdated) {
+			// A more up-to-date parameter is already in the cache.
+			continue
+		}
+
+		pc.cache[cachedParam.name] = cachedParam
+	}
+}

--- a/cloud/parameterstore/parameter_cache_test.go
+++ b/cloud/parameterstore/parameter_cache_test.go
@@ -1,0 +1,213 @@
+package parameterstore
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParameterCache(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, pc *parameterCache){
+		"PutAndGetSucceeds": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			cp := cachedParameter{
+				name:        "name",
+				value:       "value",
+				lastUpdated: now,
+			}
+			pc.put(cp)
+			rec := ParameterRecord{
+				Name:        cp.name,
+				LastUpdated: now,
+			}
+			found, notFound := pc.get(rec)
+			assert.ElementsMatch(t, []cachedParameter{cp}, found)
+			assert.Empty(t, notFound)
+		},
+		"PutOverwritesOlderRecord": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			olderCachedParam := cachedParameter{
+				name:        "name",
+				value:       "older-value",
+				lastUpdated: now.Add(-time.Minute),
+			}
+			pc.put(olderCachedParam)
+			newerCachedParam := cachedParameter{
+				name:        "name",
+				value:       "newer-value",
+				lastUpdated: now,
+			}
+			pc.put(newerCachedParam)
+
+			rec := ParameterRecord{
+				Name:        "name",
+				LastUpdated: now.Add(-time.Hour),
+			}
+			found, notFound := pc.get(rec)
+			assert.ElementsMatch(t, []cachedParameter{newerCachedParam}, found, "should return latest cached param")
+			assert.Empty(t, notFound)
+		},
+		"PutDoesNotOverwriteNewerRecord": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			newerCachedParam := cachedParameter{
+				name:        "name",
+				value:       "newer-value",
+				lastUpdated: now,
+			}
+			pc.put(newerCachedParam)
+			olderCachedParam := cachedParameter{
+				name:        "name",
+				value:       "older-value",
+				lastUpdated: now.Add(-time.Minute),
+			}
+			pc.put(olderCachedParam)
+
+			rec := ParameterRecord{
+				Name:        "name",
+				LastUpdated: now.Add(-time.Hour),
+			}
+			found, notFound := pc.get(rec)
+			assert.ElementsMatch(t, []cachedParameter{newerCachedParam}, found, "should return latest cached param")
+			assert.Empty(t, notFound)
+		},
+		"GetReturnsNotFoundForOutdatedEntry": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			cp := cachedParameter{
+				name:        "name",
+				value:       "value",
+				lastUpdated: now,
+			}
+			pc.put(cp)
+			rec := ParameterRecord{
+				Name:        cp.name,
+				LastUpdated: now.Add(time.Hour),
+			}
+			found, notFound := pc.get(rec)
+			assert.Empty(t, found)
+			assert.ElementsMatch(t, []string{cp.name}, notFound)
+		},
+		"GetReturnsOnlyFoundSubsetOfEntries": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			cps := []cachedParameter{
+				{
+					name:        "name-0",
+					value:       "value-0",
+					lastUpdated: now,
+				},
+				{
+					name:        "name-1",
+					value:       "value-1",
+					lastUpdated: now,
+				},
+				{
+					name:        "name-2",
+					value:       "value-2",
+					lastUpdated: now,
+				},
+			}
+			recs := make([]ParameterRecord, 0, len(cps))
+			for i := 0; i < len(cps); i++ {
+				recs = append(recs, ParameterRecord{
+					Name:        fmt.Sprintf(cps[i].name),
+					LastUpdated: now,
+				})
+			}
+
+			for i, cp := range cps {
+				pc.put(cp)
+
+				found, notFound := pc.get(recs...)
+				assert.Len(t, found, i+1)
+				assert.Len(t, notFound, len(cps)-(i+1))
+			}
+		},
+		"GetReturnsOnlyUpToDateSubsetOfEntries": func(t *testing.T, pc *parameterCache) {
+			now := time.Now()
+			cp0 := cachedParameter{
+				name:        "name-0",
+				value:       "value-0",
+				lastUpdated: now,
+			}
+			cp1 := cachedParameter{
+				name:        "name-1",
+				value:       "value-1",
+				lastUpdated: now,
+			}
+			pc.put(cp0)
+			pc.put(cp1)
+
+			found, notFound := pc.get(ParameterRecord{
+				Name:        cp0.name,
+				LastUpdated: now.Add(time.Hour),
+			}, ParameterRecord{
+				Name:        cp1.name,
+				LastUpdated: now,
+			})
+			assert.ElementsMatch(t, []cachedParameter{cp1}, found, "should not return an entry when parameter record indicates that it's outdated")
+			assert.ElementsMatch(t, []string{cp0.name}, notFound, "should return an entry when parameter record indicates it's up-to-date")
+		},
+		"GetParameterNotInCacheReturnsNotFound": func(t *testing.T, pc *parameterCache) {
+			found, notFound := pc.get(ParameterRecord{
+				Name:        "nonexistent",
+				LastUpdated: time.Now(),
+			})
+			assert.Empty(t, found)
+			assert.ElementsMatch(t, []string{"nonexistent"}, notFound)
+		},
+		"ConcurrentReadAndWritesAreSafeAndReachEventualConsistency": func(t *testing.T, pc *parameterCache) {
+			const name = "name"
+
+			var wg sync.WaitGroup
+			startOps := make(chan struct{})
+			now := time.Now()
+
+			for i := 0; i < 100; i++ {
+				workerNum := i + 1
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-startOps
+					pc.put(cachedParameter{
+						name:        name,
+						value:       fmt.Sprintf("value-%d", workerNum),
+						lastUpdated: now.Add(time.Duration(workerNum) * time.Millisecond),
+					})
+				}()
+
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-startOps
+					found, notFound := pc.get(ParameterRecord{
+						Name:        name,
+						LastUpdated: now.Add(100 * time.Hour),
+					})
+					assert.Empty(t, found)
+					assert.Len(t, notFound, 1)
+				}()
+			}
+
+			close(startOps)
+
+			wg.Wait()
+
+			found, notFound := pc.get(ParameterRecord{
+				Name:        name,
+				LastUpdated: now,
+			})
+			assert.Empty(t, notFound)
+			require.Len(t, found, 1)
+			assert.Equal(t, name, found[0].name)
+			assert.Equal(t, "value-100", found[0].value, "expected the most recent updated entry's value to be stored as the final value")
+			assert.Equal(t, now.Add(100*time.Millisecond), found[0].lastUpdated, "expected the most recent entry timestamp")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tCase(t, newParameterCache())
+		})
+	}
+}

--- a/cloud/parameterstore/parameter_cache_test.go
+++ b/cloud/parameterstore/parameter_cache_test.go
@@ -158,7 +158,7 @@ func TestParameterCache(t *testing.T) {
 			assert.Empty(t, found)
 			assert.ElementsMatch(t, []string{"nonexistent"}, notFound)
 		},
-		"ConcurrentReadAndWritesAreSafeAndReachEventualConsistency": func(t *testing.T, pc *parameterCache) {
+		"ConcurrentReadAndWritesAreSafeAndLastWriteWins": func(t *testing.T, pc *parameterCache) {
 			const name = "name"
 
 			var wg sync.WaitGroup

--- a/cloud/parameterstore/parameter_cache_test.go
+++ b/cloud/parameterstore/parameter_cache_test.go
@@ -112,7 +112,7 @@ func TestParameterCache(t *testing.T) {
 			recs := make([]ParameterRecord, 0, len(cps))
 			for i := 0; i < len(cps); i++ {
 				recs = append(recs, ParameterRecord{
-					Name:        fmt.Sprintf(cps[i].name),
+					Name:        cps[i].name,
 					LastUpdated: now,
 				})
 			}

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -77,7 +77,7 @@ func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Param
 
 	return &Parameter{
 		Name:     fullName,
-		Basename: pm.getBasename(fullName),
+		Basename: getBasename(fullName),
 		Value:    value,
 	}, nil
 }
@@ -111,7 +111,7 @@ func (pm *ParameterManager) Get(ctx context.Context, names ...string) ([]Paramet
 		name := aws.ToString(p.Name)
 		params = append(params, Parameter{
 			Name:     name,
-			Basename: pm.getBasename(name),
+			Basename: getBasename(name),
 			Value:    aws.ToString(p.Value),
 		})
 	}
@@ -194,7 +194,7 @@ func (pm *ParameterManager) getPrefixedName(basename string) string {
 }
 
 // getBasename returns the parameter basename without any intermediate paths.
-func (pm *ParameterManager) getBasename(name string) string {
+func getBasename(name string) string {
 	idx := strings.LastIndex(name, "/")
 	if idx == -1 {
 		return name

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -39,14 +39,14 @@ func TestParameterManager(t *testing.T) {
 				t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
 					fullName := pm.getPrefixedName("basename")
 					assert.Equal(t, "/prefix/basename", fullName)
-					assert.Equal(t, "basename", pm.getBasename(fullName))
+					assert.Equal(t, "basename", getBasename(fullName))
 				})
 				t.Run("ParsesBasenameFromFullNameWithoutPrefix", func(t *testing.T) {
 					fullName := "/some/other/path/basename"
-					assert.Equal(t, "basename", pm.getBasename(fullName))
+					assert.Equal(t, "basename", getBasename(fullName))
 				})
 				t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
-					assert.Equal(t, "basename", pm.getBasename("basename"))
+					assert.Equal(t, "basename", getBasename("basename"))
 				})
 			})
 		})


### PR DESCRIPTION
DEVPROD-9403

### Description
Follow-up to #8231. This adds the in-memory parameter cache that will hold the parameter values that have already been retrieved during Evergreen app runtime. Reading values from the cache instead of reading directly from Parameter Store each time will reduce our API calls and keep Evergreen's usage within the Parameter Store rate limits.

To reduce the size of the PRs, this isn't used yet. A follow-up PR will actually integrate the cache with the parameter manager so that the caching and real Parameter Store all work as intended.

### Testing
Added unit tests.

### Documentation
N/A
