### PR TITLE
DEVPROD-9923: remove Evergreen client on MacOS task hosts

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -422,6 +422,10 @@ func (d *Distro) IsLinux() bool {
 	return strings.Contains(d.Arch, "linux")
 }
 
+func (d *Distro) IsMacOS() bool {
+	return strings.Contains(d.Arch, "darwin")
+}
+
 func (d *Distro) Platform() (string, string) {
 	osAndArch := strings.Split(d.Arch, "_")
 	return osAndArch[0], osAndArch[1]

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -412,20 +412,24 @@ func (d *Distro) IsPowerShellSetup() bool {
 	return strings.Contains(d.Setup[start:end], "powershell")
 }
 
+// IsWindows returns whether or not the distro's hosts run on Windows.
 func (d *Distro) IsWindows() bool {
 	// XXX: if this is-windows check is updated, make sure to also update
 	// public/static/js/spawned_hosts.js as well
 	return strings.Contains(d.Arch, "windows")
 }
 
+// IsWindows returns whether or not the distro's hosts run on Linux.
 func (d *Distro) IsLinux() bool {
 	return strings.Contains(d.Arch, "linux")
 }
 
+// IsMacOS returns whether or not the distro's hosts run on MacOS.
 func (d *Distro) IsMacOS() bool {
 	return strings.Contains(d.Arch, "darwin")
 }
 
+// Platform returns the distro's OS and architecture.
 func (d *Distro) Platform() (string, string) {
 	osAndArch := strings.Split(d.Arch, "_")
 	return osAndArch[0], osAndArch[1]

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -419,7 +419,7 @@ func (d *Distro) IsWindows() bool {
 	return strings.Contains(d.Arch, "windows")
 }
 
-// IsWindows returns whether or not the distro's hosts run on Linux.
+// IsLinux returns whether or not the distro's hosts run on Linux.
 func (d *Distro) IsLinux() bool {
 	return strings.Contains(d.Arch, "linux")
 }

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -101,7 +101,6 @@ func (h *Host) curlCommands(env evergreen.Environment, curlArgs string) ([]strin
 		fmt.Sprintf("cd %s", h.Distro.HomeDir()),
 	}
 	if h.Distro.IsMacOS() {
-		// kim: TODO: verify distro.arch is "darwin_amd64"/"darwin_arm64".
 		// Ensure the Evergreen client file is deleted on MacOS hosts before
 		// downloading it again. This is necessary to fix a MacOS-specific issue
 		// where if the host has System Integrity Protection (SIP) enabled and

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -64,7 +64,7 @@ func ChmodCommandWithSudo(script string, sudo bool) []string {
 	return append(args, "chmod", "+x", script)
 }
 
-// CurlCommand returns the command to curl the evergreen client.
+// CurlCommand returns the command to download the evergreen client.
 func (h *Host) CurlCommand(env evergreen.Environment) (string, error) {
 	cmds, err := h.curlCommands(env, "")
 	if err != nil {

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -33,24 +33,39 @@ import (
 )
 
 func TestCurlCommand(t *testing.T) {
-	assert := assert.New(t)
 	env := &mock.Environment{
 		EvergreenSettings: &evergreen.Settings{
 			ApiUrl: "www.example.com",
 		},
 		Clients: evergreen.ClientConfig{S3URLPrefix: "https://foo.com"},
 	}
-	h := &Host{
-		Distro: distro.Distro{
-			Arch: evergreen.ArchLinuxAmd64,
+
+	t.Run("Linux", func(t *testing.T) {
+		h := &Host{
+			Distro: distro.Distro{
+				Arch: evergreen.ArchLinuxAmd64,
+				User: "user",
+			},
 			User: "user",
-		},
-		User: "user",
-	}
-	expected := "cd /home/user && curl -fLO https://foo.com/linux_amd64/evergreen && chmod +x evergreen"
-	cmd, err := h.CurlCommand(env)
-	require.NoError(t, err)
-	assert.Equal(expected, cmd)
+		}
+		expected := "cd /home/user && curl -fLO https://foo.com/linux_amd64/evergreen && chmod +x evergreen"
+		cmd, err := h.CurlCommand(env)
+		require.NoError(t, err)
+		assert.Equal(t, expected, cmd)
+	})
+	t.Run("MacOS", func(t *testing.T) {
+		h := &Host{
+			Distro: distro.Distro{
+				Arch: evergreen.ArchDarwinArm64,
+				User: "user",
+			},
+			User: "user",
+		}
+		expected := "cd /Users/user && rm -f evergreen && curl -fLO https://foo.com/darwin_arm64/evergreen && chmod +x evergreen"
+		cmd, err := h.CurlCommand(env)
+		require.NoError(t, err)
+		assert.Equal(t, expected, cmd)
+	})
 }
 
 func TestSpawnHostGetTaskDataCommand(t *testing.T) {

--- a/units/provisioning_agent_monitor_deploy.go
+++ b/units/provisioning_agent_monitor_deploy.go
@@ -171,7 +171,7 @@ func (j *agentMonitorDeployJob) Run(ctx context.Context) {
 		return
 	}
 
-	if err = j.runSetupScript(ctx, &settings); err != nil {
+	if err = j.runSetupScript(ctx); err != nil {
 		j.AddError(err)
 		return
 	}
@@ -260,7 +260,7 @@ func (j *agentMonitorDeployJob) fetchClient(ctx context.Context) error {
 
 // runSetupScript runs the setup script on the host through the host's Jasper
 // service.
-func (j *agentMonitorDeployJob) runSetupScript(ctx context.Context, settings *evergreen.Settings) error {
+func (j *agentMonitorDeployJob) runSetupScript(ctx context.Context) error {
 	if j.host.Distro.Setup == "" {
 		return nil
 	}


### PR DESCRIPTION
DEVPROD-9923

### Description
The MacOS hosts have recently had trouble deploying new agent binaries. The suspected issue is that some of the MacOS hosts have SIP enabled, and those hosts are SIGKILL'ing the binary if it has some issue (such as running with CGO enabled or running an Evergreen binary that hasn't been signed by Apple). This problem persists even if a new version is downloaded that fixes the original issue - the binary still gets SIGKILL'd after redownloading a valid Evergreen agent to the file path. The workaround we found (that was found long ago during an identical outage) was to `rm` the binary, which seemed to fix the issue.

* Remove the Evergreen binary when downloading the agent monitor onto MacOS hosts.
* Remove the Evergreen binary when downloading the agent onto MacOS hosts.

### Testing
* Added unit tests.
* I can't test this in staging because there are no longer any MacOS static hosts available in staging (there used to be, but they don't work anymore). Instead, I'll be rolling this out incrementally to the MacOS hosts and manually checking that they're still able to run tasks.

### Documentation
N/A
