### PR TITLE
DEVPROD-9526 clarify that evaluate command excludes module includes

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-08-26"
+	ClientVersion = "2024-09-04"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -265,7 +265,8 @@ The validation step will check for
 
 Note: validation is server-side and requires a valid evergreen configuration file (by default located at ~/.evergreen.yml). If the configuration file exists but is not valid (malformed, references invalid hosts, invalid api key, etc.) the `evergreen validate` command [will exit with code 0, indicating success, even when the project file is invalid](https://jira.mongodb.org/browse/EVG-6417). The validation is likely not performed at all in this scenario. To check whether a project file is valid, verify that the process exited with code 0 and produced the output "\<project file path\> is valid".
 
-Additionally the `evaluate` command can be used to locally expand task tags and return a fully evaluated version of a project file.
+Additionally, the `evaluate` command can be used to locally expand task tags and return a fully evaluated version of a project file.
+(Note that this command doesn't support evaluating included files from modules.)
 
 ```
 evergreen evaluate <path-to-yaml-project-file>

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -21,7 +21,7 @@ func Evaluate() cli.Command {
 
 	return cli.Command{
 		Name:  "evaluate",
-		Usage: "reads a project configuration and expands tags and matrix definitions, printing the expanded definitions",
+		Usage: "reads a project configuration and expands tags and included files (excluding module includes), printing the expanded definitions",
 		Flags: addPathFlag(
 			cli.BoolFlag{
 				Name:  taskFlagName,

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -21,7 +21,7 @@ func Evaluate() cli.Command {
 
 	return cli.Command{
 		Name:  "evaluate",
-		Usage: "reads a project configuration and expands tags and included files (excluding module includes), printing the expanded definitions",
+		Usage: "prints the given project configuration with tags and included files expanded (excluding files included from a separate module)",
 		Flags: addPathFlag(
 			cli.BoolFlag{
 				Name:  taskFlagName,


### PR DESCRIPTION
DEVPROD-9526
### Description
Updating some documentation to be clear about us not supporting this right now. (Removed a matrices reference to keep the description shorter, and because we've deprecated this.)

