### PR TITLE
DEVPROD-6908: remove sleep schedule beta test fields

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -97,7 +97,6 @@ var (
 	globalGitHubTokenDisabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "GlobalGitHubTokenDisabled")
 	unrecognizedPodCleanupDisabledKey  = bsonutil.MustHaveTag(ServiceFlags{}, "UnrecognizedPodCleanupDisabled")
 	sleepScheduleDisabledKey           = bsonutil.MustHaveTag(ServiceFlags{}, "SleepScheduleDisabled")
-	sleepScheduleBetaTestDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "SleepScheduleBetaTestDisabled")
 	systemFailedTaskRestartDisabledKey = bsonutil.MustHaveTag(ServiceFlags{}, "SystemFailedTaskRestartDisabled")
 	cpuDegradedModeDisabledKey         = bsonutil.MustHaveTag(ServiceFlags{}, "CPUDegradedModeDisabled")
 	parameterStoreDisabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "ParameterStoreDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -35,7 +35,6 @@ type ServiceFlags struct {
 	CloudCleanupDisabled            bool `bson:"cloud_cleanup_disabled" json:"cloud_cleanup_disabled"`
 	GlobalGitHubTokenDisabled       bool `bson:"global_github_token_disabled" json:"global_github_token_disabled"`
 	SleepScheduleDisabled           bool `bson:"sleep_schedule_disabled" json:"sleep_schedule_disabled"`
-	SleepScheduleBetaTestDisabled   bool `bson:"sleep_schedule_beta_test_disabled" json:"sleep_schedule_beta_test_disabled"`
 	SystemFailedTaskRestartDisabled bool `bson:"system_failed_task_restart_disabled" json:"system_failed_task_restart_disabled"`
 	CPUDegradedModeDisabled         bool `bson:"cpu_degraded_mode_disabled" json:"cpu_degraded_mode_disabled"`
 	ParameterStoreDisabled          bool `bson:"parameter_store_disabled" json:"parameter_store_disabled"`
@@ -90,7 +89,6 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			globalGitHubTokenDisabledKey:       c.GlobalGitHubTokenDisabled,
 			unrecognizedPodCleanupDisabledKey:  c.UnrecognizedPodCleanupDisabled,
 			sleepScheduleDisabledKey:           c.SleepScheduleDisabled,
-			sleepScheduleBetaTestDisabledKey:   c.SleepScheduleBetaTestDisabled,
 			systemFailedTaskRestartDisabledKey: c.SystemFailedTaskRestartDisabled,
 			cpuDegradedModeDisabledKey:         c.CPUDegradedModeDisabled,
 			parameterStoreDisabledKey:          c.ParameterStoreDisabled,

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1220,7 +1220,6 @@ type ComplexityRoot struct {
 	SleepSchedule struct {
 		DailyStartTime         func(childComplexity int) int
 		DailyStopTime          func(childComplexity int) int
-		IsBetaTester           func(childComplexity int) int
 		NextStartTime          func(childComplexity int) int
 		NextStopTime           func(childComplexity int) int
 		PermanentlyExempt      func(childComplexity int) int
@@ -7806,13 +7805,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SleepSchedule.DailyStopTime(childComplexity), true
-
-	case "SleepSchedule.isBetaTester":
-		if e.complexity.SleepSchedule.IsBetaTester == nil {
-			break
-		}
-
-		return e.complexity.SleepSchedule.IsBetaTester(childComplexity), true
 
 	case "SleepSchedule.nextStartTime":
 		if e.complexity.SleepSchedule.NextStartTime == nil {
@@ -23492,8 +23484,6 @@ func (ec *executionContext) fieldContext_Host_sleepSchedule(_ context.Context, f
 				return ec.fieldContext_SleepSchedule_dailyStartTime(ctx, field)
 			case "dailyStopTime":
 				return ec.fieldContext_SleepSchedule_dailyStopTime(ctx, field)
-			case "isBetaTester":
-				return ec.fieldContext_SleepSchedule_isBetaTester(ctx, field)
 			case "nextStartTime":
 				return ec.fieldContext_SleepSchedule_nextStartTime(ctx, field)
 			case "nextStopTime":
@@ -53199,47 +53189,6 @@ func (ec *executionContext) fieldContext_SleepSchedule_dailyStopTime(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _SleepSchedule_isBetaTester(ctx context.Context, field graphql.CollectedField, obj *host.SleepScheduleInfo) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_SleepSchedule_isBetaTester(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.IsBetaTester, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_SleepSchedule_isBetaTester(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "SleepSchedule",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _SleepSchedule_nextStartTime(ctx context.Context, field graphql.CollectedField, obj *host.SleepScheduleInfo) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SleepSchedule_nextStartTime(ctx, field)
 	if err != nil {
@@ -76102,7 +76051,7 @@ func (ec *executionContext) unmarshalInputSleepScheduleInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"dailyStartTime", "dailyStopTime", "isBetaTester", "permanentlyExempt", "shouldKeepOff", "timeZone", "temporarilyExemptUntil", "wholeWeekdaysOff"}
+	fieldsInOrder := [...]string{"dailyStartTime", "dailyStopTime", "permanentlyExempt", "shouldKeepOff", "timeZone", "temporarilyExemptUntil", "wholeWeekdaysOff"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -76123,13 +76072,6 @@ func (ec *executionContext) unmarshalInputSleepScheduleInput(ctx context.Context
 				return it, err
 			}
 			it.DailyStopTime = data
-		case "isBetaTester":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("isBetaTester"))
-			data, err := ec.unmarshalOBoolean2bool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.IsBetaTester = data
 		case "permanentlyExempt":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("permanentlyExempt"))
 			data, err := ec.unmarshalNBoolean2bool(ctx, v)
@@ -87964,8 +87906,6 @@ func (ec *executionContext) _SleepSchedule(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "isBetaTester":
-			out.Values[i] = ec._SleepSchedule_isBetaTester(ctx, field, obj)
 		case "nextStartTime":
 			out.Values[i] = ec._SleepSchedule_nextStartTime(ctx, field, obj)
 		case "nextStopTime":

--- a/graphql/schema/types/host.graphql
+++ b/graphql/schema/types/host.graphql
@@ -22,7 +22,6 @@ enum TaskQueueItemType {
 type SleepSchedule {
   dailyStartTime: String!
   dailyStopTime: String!
-  isBetaTester: Boolean
   nextStartTime: Time
   nextStopTime: Time
   permanentlyExempt: Boolean!

--- a/graphql/schema/types/spawn.graphql
+++ b/graphql/schema/types/spawn.graphql
@@ -17,7 +17,6 @@ input VolumeHost {
 input SleepScheduleInput {
   dailyStartTime: String!
   dailyStopTime: String!
-  isBetaTester: Boolean
   permanentlyExempt: Boolean!
   shouldKeepOff: Boolean!
   timeZone: String!

--- a/graphql/tests/mutation/spawnHost/queries/spawn_host.graphql
+++ b/graphql/tests/mutation/spawnHost/queries/spawn_host.graphql
@@ -29,7 +29,6 @@ mutation {
     sleepSchedule {
       dailyStartTime
       dailyStopTime
-      isBetaTester
       permanentlyExempt
       shouldKeepOff
       timeZone

--- a/graphql/tests/mutation/spawnHost/results.json
+++ b/graphql/tests/mutation/spawnHost/results.json
@@ -14,7 +14,6 @@
                         "sleepSchedule": {
                           "dailyStartTime": "",
                           "dailyStopTime": "",
-                          "isBetaTester": false,
                           "permanentlyExempt": false,
                           "shouldKeepOff": false,
                           "timeZone": "America/New_York",

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -120,7 +120,6 @@ var (
 	SleepSchedulePermanentlyExemptKey      = bsonutil.MustHaveTag(SleepScheduleInfo{}, "PermanentlyExempt")
 	SleepScheduleTemporarilyExemptUntilKey = bsonutil.MustHaveTag(SleepScheduleInfo{}, "TemporarilyExemptUntil")
 	SleepScheduleShouldKeepOffKey          = bsonutil.MustHaveTag(SleepScheduleInfo{}, "ShouldKeepOff")
-	SleepScheduleIsBetaTesterKey           = bsonutil.MustHaveTag(SleepScheduleInfo{}, "IsBetaTester")
 )
 
 var (
@@ -1566,7 +1565,6 @@ func isSleepScheduleEnabledQuery(q bson.M, now time.Time) bson.M {
 	sleepSchedulePermanentlyExemptKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepSchedulePermanentlyExemptKey)
 	sleepScheduleTemporarilyExemptUntil := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleTemporarilyExemptUntilKey)
 	sleepScheduleShouldKeepOff := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleShouldKeepOffKey)
-	sleepScheduleIsBetaTesterKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleIsBetaTesterKey)
 
 	if _, ok := q[StatusKey]; !ok {
 		// Use all sleep schedule statuses if the query hasn't already specified
@@ -1576,18 +1574,6 @@ func isSleepScheduleEnabledQuery(q bson.M, now time.Time) bson.M {
 
 	q[sleepSchedulePermanentlyExemptKey] = bson.M{"$ne": true}
 	q[sleepScheduleShouldKeepOff] = bson.M{"$ne": true}
-
-	serviceFlagCtx, serviceFlagCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer serviceFlagCancel()
-	flags, err := evergreen.GetServiceFlags(serviceFlagCtx)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"message": "unable to check if sleep schedule beta test is enabled, falling back to assuming the beta test is enabled",
-		}))
-	}
-	if flags == nil || !flags.SleepScheduleBetaTestDisabled {
-		q[sleepScheduleIsBetaTesterKey] = true
-	}
 
 	notTemporarilyExempt := []bson.M{
 		{

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -562,7 +562,6 @@ func TestFindHostsScheduledToStop(t *testing.T) {
 			oldServiceFlags, err := evergreen.GetServiceFlags(ctx)
 			require.NoError(t, err)
 			newServiceFlags := *oldServiceFlags
-			newServiceFlags.SleepScheduleBetaTestDisabled = true
 			require.NoError(t, evergreen.SetServiceFlags(ctx, newServiceFlags))
 			defer func() {
 				assert.NoError(t, evergreen.SetServiceFlags(ctx, *oldServiceFlags))
@@ -785,7 +784,6 @@ func TestFindHostsScheduledToStart(t *testing.T) {
 			oldServiceFlags, err := evergreen.GetServiceFlags(ctx)
 			require.NoError(t, err)
 			newServiceFlags := *oldServiceFlags
-			newServiceFlags.SleepScheduleBetaTestDisabled = true
 			require.NoError(t, evergreen.SetServiceFlags(ctx, newServiceFlags))
 			defer func() {
 				assert.NoError(t, evergreen.SetServiceFlags(ctx, *oldServiceFlags))

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -382,10 +382,6 @@ type SleepScheduleInfo struct {
 	// NextStartTime is the next time that the host should start for its sleep
 	// schedule.
 	NextStartTime time.Time `bson:"next_start_time,omitempty" json:"next_start_time,omitempty"`
-
-	// IsBetaTester is a temporary flag to allow users to opt into beta testing
-	// the sleep schedule.
-	IsBetaTester bool `bson:"is_beta_tester,omitempty" json:"is_beta_tester,omitempty"`
 }
 
 // NewSleepScheduleInfo creates a new sleep schedule for a host that does not
@@ -464,8 +460,7 @@ func (i SleepScheduleInfo) IsZero() bool {
 		utility.IsZeroTime(i.NextStartTime) &&
 		utility.IsZeroTime(i.TemporarilyExemptUntil) &&
 		!i.PermanentlyExempt &&
-		!i.ShouldKeepOff &&
-		!i.IsBetaTester
+		!i.ShouldKeepOff
 }
 
 type newParentsNeededParams struct {
@@ -3753,32 +3748,6 @@ func (h *Host) UpdateSleepSchedule(ctx context.Context, schedule SleepScheduleIn
 		}
 	}
 	h.SleepSchedule = schedule
-
-	return nil
-}
-
-// SetSleepScheduleBetaTester enables or disables sleep schedule beta testing
-// for this host.
-func (h *Host) SetSleepScheduleBetaTester(ctx context.Context, isBetaTester bool) error {
-	if err := h.SleepSchedule.Validate(); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    errors.Wrap(err, "cannot opt into sleep schedule with invalid sleep schedule").Error(),
-		}
-	}
-
-	sleepScheduleIsBetaTesterKey := bsonutil.GetDottedKeyName(SleepScheduleKey, SleepScheduleIsBetaTesterKey)
-	if err := UpdateOne(ctx,
-		bson.M{IdKey: h.Id},
-		bson.M{"$set": bson.M{sleepScheduleIsBetaTesterKey: isBetaTester}},
-	); err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "enabling/disabling sleep schedule beta test").Error(),
-		}
-	}
-
-	h.SleepSchedule.IsBetaTester = isBetaTester
 
 	return nil
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2047,7 +2047,6 @@ type APIServiceFlags struct {
 	CloudCleanupDisabled            bool `json:"cloud_cleanup_disabled"`
 	GlobalGitHubTokenDisabled       bool `json:"global_github_token_disabled"`
 	SleepScheduleDisabled           bool `json:"sleep_schedule_disabled"`
-	SleepScheduleBetaTestDisabled   bool `json:"sleep_schedule_beta_test_disabled"`
 	SystemFailedTaskRestartDisabled bool `json:"system_failed_task_restart_disabled"`
 	DegradedModeDisabled            bool `json:"cpu_degraded_mode_disabled"`
 	ParameterStoreDisabled          bool `json:"parameter_store_disabled"`
@@ -2365,7 +2364,6 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 		as.CloudCleanupDisabled = v.CloudCleanupDisabled
 		as.GlobalGitHubTokenDisabled = v.GlobalGitHubTokenDisabled
 		as.SleepScheduleDisabled = v.SleepScheduleDisabled
-		as.SleepScheduleBetaTestDisabled = v.SleepScheduleBetaTestDisabled
 		as.SystemFailedTaskRestartDisabled = v.SystemFailedTaskRestartDisabled
 		as.DegradedModeDisabled = v.CPUDegradedModeDisabled
 		as.ParameterStoreDisabled = v.ParameterStoreDisabled
@@ -2410,7 +2408,6 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 		CloudCleanupDisabled:            as.CloudCleanupDisabled,
 		GlobalGitHubTokenDisabled:       as.GlobalGitHubTokenDisabled,
 		SleepScheduleDisabled:           as.SleepScheduleDisabled,
-		SleepScheduleBetaTestDisabled:   as.SleepScheduleBetaTestDisabled,
 		SystemFailedTaskRestartDisabled: as.SystemFailedTaskRestartDisabled,
 		CPUDegradedModeDisabled:         as.DegradedModeDisabled,
 		ParameterStoreDisabled:          as.ParameterStoreDisabled,

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -429,17 +429,6 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
-												<td>Unexpirable host sleep schedule beta test</td>
-												<td colspan="2">
-													<md-radio-group
-														data-ng-model="Settings.service_flags.sleep_schedule_beta_test_disabled"
-														layout="row">
-														<md-radio-button data-ng-value="false"></md-radio-button>
-														<md-radio-button data-ng-value="true"></md-radio-button>
-													</md-radio-group>
-												</td>
-											</tr>
-											<tr>
 												<td>Parameter Store</td>
 												<td colspan="2">
 													<md-radio-group

--- a/units/sleep_scheduler_test.go
+++ b/units/sleep_scheduler_test.go
@@ -494,7 +494,6 @@ func TestSleepSchedulerJob(t *testing.T) {
 			oldServiceFlags, err := evergreen.GetServiceFlags(ctx)
 			require.NoError(t, err)
 			newServiceFlags := *oldServiceFlags
-			newServiceFlags.SleepScheduleBetaTestDisabled = true
 			require.NoError(t, evergreen.SetServiceFlags(ctx, newServiceFlags))
 			defer func() {
 				assert.NoError(t, evergreen.SetServiceFlags(ctx, *oldServiceFlags))


### PR DESCRIPTION
DEVPROD-6908

### Description
The beta test for unexpirable host schedules has ended, so the beta test fields aren't needed. At this point, even if there were problems, we wouldn't revert back to the beta test; we would just disable the feature using the sleep schedule admin flag.

* Delete the feature flag for the beta test.
* Delete the beta test flag from the host model and GraphQL.

### Testing
Code compiles and existing tests pass.

### Documentation
N/A