### PR TITLE
DEVPROD-10176 bugfix: Correctly convert slice to slice of pointers

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1013,7 +1013,8 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 
 	bv := []*model.WaterfallBuildVariant{}
 	for _, b := range buildVariants {
-		bv = append(bv, &b)
+		bCopy := b
+		bv = append(bv, &bCopy)
 	}
 
 	return &Waterfall{

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -38,7 +38,12 @@
       "activated": false,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 3
+      "order": 3,
+      "build_variants_status": {
+        "activated": true,
+        "build_id": "evergreen_version3_build",
+        "build_variant": "lint"
+      }
     },
     {
       "_id": "evergreen_version4",
@@ -122,11 +127,11 @@
       "_id": "task_5",
       "version": "evergreen_version5",
       "status": "success",
-      "display_name": "Some Other Task",
+      "display_name": "Task Number 5",
       "activated": true,
-      "build_variant": "enterprise-ubuntu1604-64",
-      "build_variant_display_name": "Ubuntu 16.04",
-      "build_id": "evergreen_version5_build",
+      "build_variant": "lint",
+      "build_variant_display_name": "Linter",
+      "build_id": "evergreen_version3_build",
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
@@ -175,9 +180,15 @@
       "version": "evergreen_version2"
     },
     {
-      "_id": "evergreen_version5_build",
-      "build_variant": "enterprise-ubuntu1604-64",
-      "display_name": "Ubuntu 16.04"
+      "_id": "evergreen_version3_build",
+      "build_variant": "lint",
+      "display_name": "Linter",
+      "tasks": [
+        {
+          "id": "task_5"
+        }
+      ],
+      "version": "evergreen_version5"
     }
   ]
 }

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -45,6 +45,24 @@
                     "version": "evergreen_version2"
                   }
                 ]
+              },
+              {
+                "builds": [
+                  {
+                    "activated": false,
+                    "id": "evergreen_version3_build",
+                    "tasks": [
+                      {
+                        "displayName": "Task Number 5",
+                        "id": "task_5",
+                        "status": "success"
+                      }
+                    ],
+                    "version": "evergreen_version5"
+                  }
+                ],
+                "displayName": "Linter",
+                "id": "lint"
               }
             ],
             "versions": [


### PR DESCRIPTION
DEVPROD-10176 - #8254 followup

### Description
- Fix bug where converting `[]WaterfallBuildVariant` to `[]*WaterfallBuildVariant` was creating an array of pointers to the same address (I think), resulting in this type of response:
  <img width="333" alt="image" src="https://github.com/user-attachments/assets/5f3a18bb-b11d-4cc9-b5ae-3b62bc7abd0e">

If there's a more Go/more efficient way to do this I'd love to know!

### Testing
- Updated resolver test so that it fails without these changes