### PR TITLE
DEVPROD-9403: use parameter cache

### DIFF
--- a/cloud/parameterstore/fakeparameter/parameter_manager_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_manager_test.go
@@ -3,11 +3,13 @@ package fakeparameter
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,17 +44,45 @@ func TestParameterManager(t *testing.T) {
 		"CachingDisabled": func() *parameterstore.ParameterManager {
 			return parameterstore.NewParameterManager("prefix", false, NewFakeSSMClient(), evergreen.GetEnvironment().DB())
 		},
-		// TODO (DEVPROD-9403): test same conditions pass with caching enabled.
+		"CachingEnabled": func() *parameterstore.ParameterManager {
+			return parameterstore.NewParameterManager("prefix", true, NewFakeSSMClient(), evergreen.GetEnvironment().DB())
+		},
 	} {
 		t.Run(managerTestName, func(t *testing.T) {
 			for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager){
 				"PutAddsNewParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-					for i := 0; i < 5; i++ {
-						basename := fmt.Sprintf("name-%d", i)
-						value := fmt.Sprintf("value-%d", i)
-						p, err := pm.Put(ctx, basename, value)
+					const numParams = 5
+					basenames := make([]string, 0, numParams)
+					expectedParams := make([]parameterstore.Parameter, 0, numParams)
+					for i := 0; i < numParams; i++ {
+						expectedParam := parameterstore.Parameter{
+							Name:     fmt.Sprintf("/prefix/basename-%d", i),
+							Basename: fmt.Sprintf("basename-%d", i),
+							Value:    fmt.Sprintf("value-%d", i),
+						}
+						p, err := pm.Put(ctx, expectedParam.Basename, expectedParam.Value)
 						require.NoError(t, err)
-						checkParam(ctx, t, p, fmt.Sprintf("/prefix/%s", basename), basename, value)
+						checkParam(ctx, t, p, expectedParam.Name, expectedParam.Basename, expectedParam.Value)
+
+						basenames = append(basenames, expectedParam.Basename)
+						expectedParams = append(expectedParams, expectedParam)
+					}
+
+					foundParams, err := pm.Get(ctx, basenames...)
+					require.NoError(t, err)
+					require.Len(t, foundParams, len(basenames))
+					for _, p := range foundParams {
+						var found bool
+						for i := 0; i < len(expectedParams); i++ {
+							if p.Basename == expectedParams[i].Basename {
+								checkParam(ctx, t, &p, expectedParams[i].Name, expectedParams[i].Basename, expectedParams[i].Value)
+								found = true
+								break
+							}
+						}
+						if !found {
+							assert.FailNow(t, "unexpected parameter", "found unexpected parameter with basename '%s'", p.Basename)
+						}
 					}
 				},
 				"PutIncludesPrefixForPartialName": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
@@ -61,18 +91,37 @@ func TestParameterManager(t *testing.T) {
 					p, err := pm.Put(ctx, partialName, value)
 					require.NoError(t, err)
 					checkParam(ctx, t, p, "/prefix/path/to/basename", "basename", value)
+
+					foundParams, err := pm.Get(ctx, partialName)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 1)
+					checkParam(ctx, t, &foundParams[0], "/prefix/path/to/basename", "basename", value)
 				},
 				"PutOverwritesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					const basename = "basename"
-					const value = "old_value"
-					oldParam, err := pm.Put(ctx, basename, value)
+					const oldValue = "old_value"
+					oldParam, err := pm.Put(ctx, basename, oldValue)
 					require.NoError(t, err)
-					checkParam(ctx, t, oldParam, "/prefix/basename", basename, value)
+					checkParam(ctx, t, oldParam, "/prefix/basename", basename, oldValue)
+
+					foundParams, err := pm.Get(ctx, basename, oldValue)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 1)
+					assert.Equal(t, basename, foundParams[0].Basename)
+					assert.Equal(t, oldValue, foundParams[0].Value)
+					assert.Equal(t, "/prefix/basename", foundParams[0].Name)
 
 					const newValue = "new_value"
 					newParam, err := pm.Put(ctx, basename, newValue)
 					require.NoError(t, err)
 					checkParam(ctx, t, newParam, "/prefix/basename", basename, newValue)
+
+					foundParams, err = pm.Get(ctx, basename, oldValue)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 1)
+					assert.Equal(t, basename, foundParams[0].Basename)
+					assert.Equal(t, newValue, foundParams[0].Value)
+					assert.Equal(t, "/prefix/basename", foundParams[0].Name)
 				},
 				"DeleteRemovesExistingParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					const basename = "basename"
@@ -86,9 +135,16 @@ func TestParameterManager(t *testing.T) {
 					dbParam, err := FindOneID(ctx, basename)
 					assert.NoError(t, err)
 					assert.Zero(t, dbParam)
+
+					foundParams, err := pm.Get(ctx, basename)
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
 				},
 				"DeleteNoopsForNonexistentParameter": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					assert.NoError(t, pm.Delete(ctx, "nonexistent"))
+					foundParams, err := pm.Get(ctx, "nonexistent")
+					assert.NoError(t, err)
+					assert.Empty(t, foundParams)
 				},
 				"GetReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					precreatedParams := map[string]parameterstore.Parameter{}
@@ -135,16 +191,70 @@ func TestParameterManager(t *testing.T) {
 					assert.Empty(t, foundParams)
 				},
 				"GetReturnsExistingSubsetForMixOfExistingAndNonexistentParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
-					const basename = "basename"
-					const value = "value"
-					p, err := pm.Put(ctx, basename, value)
+					p0 := parameterstore.Parameter{
+						Name:     "/prefix/basename-0",
+						Basename: "basename-0",
+						Value:    "value-0",
+					}
+					p, err := pm.Put(ctx, p0.Basename, p0.Value)
 					require.NoError(t, err)
-					checkParam(ctx, t, p, "/prefix/basename", basename, value)
+					checkParam(ctx, t, p, p0.Name, p0.Basename, p0.Value)
 
-					foundParams, err := pm.Get(ctx, "/prefix/basename", "nonexistent", "/prefix/also-nonexistent")
+					p1 := parameterstore.Parameter{
+						Name:     "/prefix/basename-1",
+						Basename: "basename-1",
+						Value:    "value-1",
+					}
+					p, err = pm.Put(ctx, p1.Basename, p1.Value)
 					require.NoError(t, err)
-					require.Len(t, foundParams, 1)
-					checkParam(ctx, t, &foundParams[0], "/prefix/basename", basename, value)
+					checkParam(ctx, t, p, p1.Name, p1.Basename, p1.Value)
+
+					p2 := parameterstore.Parameter{
+						Name:     "/prefix/basename-2",
+						Basename: "basename-2",
+						Value:    "value-2",
+					}
+					p, err = pm.Put(ctx, p2.Basename, p2.Value)
+					require.NoError(t, err)
+					checkParam(ctx, t, p, p2.Name, p2.Basename, p2.Value)
+
+					// If caching is enabled, get a subset of the created
+					// parameters to pre-populate the cache.
+					// If caching is disabled, this should still return
+					// correct results.
+					foundParams, err := pm.Get(ctx, "nonexistent", p0.Basename, p1.Basename)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 2)
+					for _, p := range foundParams {
+						switch p.Basename {
+						case p0.Basename:
+							checkParam(ctx, t, &p, p0.Name, p0.Basename, p0.Value)
+						case p1.Basename:
+							checkParam(ctx, t, &p, p1.Name, p1.Basename, p1.Value)
+						default:
+							assert.FailNow(t, "unexpected parameter", "found unexpected parameter with basename '%s'", p.Basename)
+						}
+					}
+
+					// Check the returned parameters more than once to
+					// ensure caching returns consistent results. If caching is
+					// disabled, this is also expected to return the same
+					// results.
+					foundParams, err = pm.Get(ctx, "nonexistent", p0.Basename, p1.Basename, p2.Basename)
+					require.NoError(t, err)
+					require.Len(t, foundParams, 3)
+					for _, p := range foundParams {
+						switch p.Basename {
+						case p0.Basename:
+							checkParam(ctx, t, &p, p0.Name, p0.Basename, p0.Value)
+						case p1.Basename:
+							checkParam(ctx, t, &p, p1.Name, p1.Basename, p1.Value)
+						case p2.Basename:
+							checkParam(ctx, t, &p, p2.Name, p2.Basename, p2.Value)
+						default:
+							assert.FailNow(t, "unexpected parameter", "found unexpected parameter with basename '%s'", p.Basename)
+						}
+					}
 				},
 				"GetStrictReturnsAllExistingParameters": func(ctx context.Context, t *testing.T, pm *parameterstore.ParameterManager) {
 					precreatedParams := map[string]parameterstore.Parameter{}
@@ -233,4 +343,66 @@ func TestParameterManager(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ConcurrentReadsAndWritesAreSafeAndLastWriteWins", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		pm := parameterstore.NewParameterManager("prefix", true, NewFakeSSMClient(), evergreen.GetEnvironment().DB())
+		const basename = "basename"
+		const fullName = "/prefix/basename"
+
+		var wg sync.WaitGroup
+		startOps := make(chan struct{})
+
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-startOps
+				// Each writer puts a new random string in the DB. One of these
+				// will eventually be the last write, and that's the persistent
+				// value in a steady state.
+				_, err := pm.Put(ctx, basename, utility.RandomString())
+				assert.NoError(t, err)
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-startOps
+				for j := 0; j < 10; j++ {
+					// Each reader reads the random strings from the DB and they
+					// get cached. While this is happening, the value will be
+					// fluctuating because there are concurrent writes, so the
+					// cached value for the parameter will be fluctuating as
+					// well.
+					_, err := pm.Get(ctx, basename)
+					assert.NoError(t, err)
+				}
+			}()
+		}
+
+		close(startOps)
+
+		wg.Wait()
+
+		dbParam, err := FindOneID(ctx, fullName)
+		require.NoError(t, err)
+		require.NotZero(t, dbParam)
+
+		params, err := pm.Get(ctx, basename)
+		require.NoError(t, err)
+		require.Len(t, params, 1)
+		assert.Equal(t, params[0].Name, dbParam.Name)
+		assert.Equal(t, params[0].Basename, basename)
+		// After the readers and writers are all finished and there's no more
+		// modifications being made to the parameter, the parameter returned
+		// from the ParameterManager must match the final value that was last
+		// written to the DB. This is necessary to prove that, even with a
+		// cache, it eventually reflects the most up-to-date value from the DB.
+		// If this is ever flaky, that means the caching logic is faulty because
+		// it returned a stale value.
+		assert.Equal(t, params[0].Value, dbParam.Value, "value returned from Get should agree with the latest written value, even after several concurrent reads/writes")
+	})
 }

--- a/cloud/parameterstore/parameter_cache.go
+++ b/cloud/parameterstore/parameter_cache.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package parameterstore
 
 import (

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,13 +39,13 @@ type ParameterManager struct {
 	// pathPrefix is the prefix path in the Parameter Store hierarchy. If set,
 	// all parameters should be stored under this prefix.
 	pathPrefix string
-	// cachingEnabled indicates whether parameter caching is enabled. If
+	// cache holds the in-memory cache of parameters. If parameter caching is
 	// enabled, the cache will reduce the number of reads from Parameter Store
 	// by only fetching directly from Parameter Store if the value is missing
 	// from the cache or is stale.
-	cachingEnabled bool
-	ssmClient      SSMClient
-	db             *mongo.Database
+	cache     *parameterCache
+	ssmClient SSMClient
+	db        *mongo.Database
 }
 
 // NewParameterManager creates a new ParameterManager instance.
@@ -52,16 +56,23 @@ func NewParameterManager(pathPrefix string, cachingEnabled bool, ssmClient SSMCl
 		// name.
 		pathPrefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(pathPrefix, "/"), "/"))
 	}
-	return &ParameterManager{
-		pathPrefix:     pathPrefix,
-		cachingEnabled: cachingEnabled,
-		ssmClient:      ssmClient,
-		db:             db,
+	pm := ParameterManager{
+		pathPrefix: pathPrefix,
+		ssmClient:  ssmClient,
+		db:         db,
 	}
+	if cachingEnabled {
+		pm.cache = newParameterCache()
+	}
+	return &pm
 }
 
 // Put adds or updates a parameter. This returns the created parameter.
 func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Parameter, error) {
+	if name == "" {
+		return nil, errors.New("cannot put a parameter with an empty name")
+	}
+
 	fullName := pm.getPrefixedName(name)
 	if _, err := pm.ssmClient.PutParameter(ctx, &ssm.PutParameterInput{
 		Name:      aws.String(fullName),
@@ -73,7 +84,15 @@ func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Param
 		return nil, errors.Wrapf(err, "putting parameter '%s'", name)
 	}
 
-	// TODO (DEVPROD-9403): update cache as needed.
+	// Regardless of whether caching is enabled or not, still record that the
+	// parameter was changed in case caching gets enabled or a different
+	// ParameterManager instance has caching enabled.
+	if err := BumpParameterRecord(ctx, pm.db, fullName, time.Now()); err != nil {
+		grip.Warning(message.WrapError(err, message.Fields{
+			"message": "could not bump parameter update timestamp, possibly because it is being concurrently updated",
+			"name":    fullName,
+		}))
+	}
 
 	return &Parameter{
 		Name:     fullName,
@@ -90,30 +109,61 @@ func (pm *ParameterManager) Get(ctx context.Context, names ...string) ([]Paramet
 		return nil, nil
 	}
 
-	// TODO (DEVPROD-9403): use caching if possible before retrieving value from
-	// Parameter Store.
-
 	fullNames := make([]string, 0, len(names))
 	for _, name := range names {
 		fullNames = append(fullNames, pm.getPrefixedName(name))
 	}
 
+	fullNamesToFind := fullNames
+	params := make([]Parameter, 0, len(fullNamesToFind))
+	if pm.isCachingEnabled() {
+		paramRecords, err := FindByNames(ctx, pm.db, fullNames...)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding parameter records for %d parameters", len(fullNamesToFind))
+		}
+		cachedParams, namesNotFound := pm.cache.get(paramRecords...)
+		for _, cachedParam := range cachedParams {
+			params = append(params, cachedParam.export())
+		}
+		fullNamesToFind = namesNotFound
+	}
+
+	if len(fullNamesToFind) == 0 {
+		// Cache found all the parameters.
+		return params, nil
+	}
+
+	// It's important to set the time of retrieval for the cache before actually
+	// retrieving the value from Parameter Store. This is to be on the
+	// conservative side and ensure the cache doesn't return outdated values. If
+	// a parameter is updated in between getting the parameter from Parameter
+	// Store and caching it, the cache will be updated to an already-stale
+	// value, so it should evict the outdated value on the next read, thus
+	// ensuring that the cache reaches eventual consistency with the most
+	// up-to-date value.
+	lastRetrieved := utility.BSONTime(time.Now())
 	ssmParams, err := pm.ssmClient.GetParametersSimple(ctx, &ssm.GetParametersInput{
-		Names:          fullNames,
+		Names:          fullNamesToFind,
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting %d parameters", len(names))
+		return nil, errors.Wrapf(err, "getting %d parameters", len(fullNames))
 	}
 
-	params := make([]Parameter, 0, len(ssmParams))
+	cachedParams := make([]cachedParameter, 0, len(ssmParams))
 	for _, p := range ssmParams {
 		name := aws.ToString(p.Name)
+		value := aws.ToString(p.Value)
 		params = append(params, Parameter{
 			Name:     name,
 			Basename: getBasename(name),
-			Value:    aws.ToString(p.Value),
+			Value:    value,
 		})
+		cachedParams = append(cachedParams, newCachedParameter(name, value, lastRetrieved))
+	}
+
+	if pm.isCachingEnabled() {
+		pm.cache.put(cachedParams...)
 	}
 
 	return params, nil
@@ -131,7 +181,7 @@ func (pm *ParameterManager) GetStrict(ctx context.Context, names ...string) ([]P
 		fullNames = append(fullNames, pm.getPrefixedName(name))
 	}
 
-	params, err := pm.Get(ctx, names...)
+	params, err := pm.Get(ctx, fullNames...)
 	if err != nil {
 		return nil, err
 	}
@@ -172,12 +222,27 @@ func (pm *ParameterManager) Delete(ctx context.Context, names ...string) error {
 		Names: fullNames,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "deleting %d parameters", len(names))
+		return errors.Wrapf(err, "deleting %d parameters", len(fullNames))
 	}
 
-	// TODO (DEVPROD-9403): update cache as needed.
+	for _, fullName := range fullNames {
+		// Regardless of whether caching is enabled or not, still record that
+		// the parameter was changed in case caching gets enabled or a different
+		// ParameterManager instance has caching enabled.
+		if err := BumpParameterRecord(ctx, pm.db, fullName, time.Now()); err != nil {
+			grip.Warning(message.WrapError(err, message.Fields{
+				"message": "could not bump parameter record last updated timestamp, possibly because it is being concurrently updated",
+				"name":    fullName,
+			}))
+		}
+	}
 
 	return nil
+}
+
+// isCachingEnabled returns whether parameter caching is enabled.
+func (pm *ParameterManager) isCachingEnabled() bool {
+	return pm.cache != nil
 }
 
 // getPrefixedName returns the parameter name with the common parameter prefix

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -35,6 +35,7 @@ func TestParameterManager(t *testing.T) {
 					assert.Equal(t, "/prefix/path/to/basename", pm.getPrefixedName("/prefix/path/to/basename"))
 				})
 			})
+
 			t.Run("GetBasename", func(t *testing.T) {
 				t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
 					fullName := pm.getPrefixedName("basename")
@@ -47,6 +48,10 @@ func TestParameterManager(t *testing.T) {
 				})
 				t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
 					assert.Equal(t, "basename", getBasename("basename"))
+				})
+				t.Run("ParsesBasenameWithoutLeadingSlash", func(t *testing.T) {
+					fullName := "/basename"
+					assert.Equal(t, "basename", getBasename(fullName))
 				})
 			})
 		})

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -50,7 +50,7 @@ type ssmClientImpl struct {
 // region.
 var configCache map[string]*aws.Config = make(map[string]*aws.Config)
 
-func newSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
+func NewSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -50,7 +50,7 @@ type ssmClientImpl struct {
 // region.
 var configCache map[string]*aws.Config = make(map[string]*aws.Config)
 
-func NewSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
+func newSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -8,9 +8,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// kim: TODO: since this is the same data model as GitHub App Auth, should
-// probably go into the model/githubapp directory.
-
 var (
 	ghAuthIdKey         = bsonutil.MustHaveTag(githubapp.GithubAppAuth{}, "Id")
 	ghAuthAppIdKey      = bsonutil.MustHaveTag(githubapp.GithubAppAuth{}, "AppID")


### PR DESCRIPTION
DEVPROD-9403

### Description
This is the last PR to get parameter caching to work with Parameter Store. The previous PRs (#8231 and #8262) introduced the parameter cache and the parameter records collection that contains info on when parameter were last updated. This PR integrates those two into the parameter manager so that it uses the cache when it's possible to get the parameter's value.

* Bump the parameter record when updating/deleting a new parameter.
* When reading a parameter, use the cache if possible.
    * Use the parameter record to decide if the cached value is sufficiently up-to-date or not.
    * Fall back to reading from Parameter Manager directly (and caching the value) if the cache doesn't have the parameter or the cache is outdated.

### Testing
* Existing tests also test with caching enabled/disabled.
* Added unit tests to ensure caching always returns the most up-to-date value available.

### Documentation
N/A
