### PR TITLE
DEVPROD-10231 Re-enable code signing to error out when it fails

### DIFF
--- a/cmd/sign-executable/sign-executable.go
+++ b/cmd/sign-executable/sign-executable.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -176,8 +175,7 @@ func signExecutable(ctx context.Context, opts signOpts) error {
 
 	signedZipPath := path.Join(tempDir, "evergreen_signed.zip")
 	if err = signWithNotaryClient(ctx, toSignPath, signedZipPath, opts); err != nil {
-		fmt.Fprintf(os.Stderr, "code signing failed: %s", err.Error())
-		return nil
+		return errors.Wrap(err, "code signing failed")
 	}
 
 	signedZip, err := os.ReadFile(signedZipPath)

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -117,8 +117,6 @@ variables:
       - func: run-make
         vars: { target: "${task_name}" }
 
-  - &version-constants
-    nodejs_version: "6.11.1"
   - &run-generate-lint
     name: generate-lint
     commands:


### PR DESCRIPTION
DEVPROD-10231

### Description
This re-enables code signing to error out rather than just print to std err.

This was caused by EVG-16589.