### PR TITLE
DEVPROD-10153 Log project identifier rather than whole project struct

### DIFF
--- a/service/version.go
+++ b/service/version.go
@@ -22,9 +22,9 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	project, err := projCtx.GetProject()
 
 	grip.DebugWhen(err != nil || project == nil || projCtx.Version == nil, message.Fields{
-		"message": "error getting project for version page",
-		"project": project,
-		"projCtx": projCtx,
+		"message":            "error getting project for version page",
+		"project_identifier": project.Identifier,
+		"projCtx":            projCtx,
 	})
 
 	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id)) {

--- a/service/version.go
+++ b/service/version.go
@@ -21,9 +21,14 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 	projCtx := MustHaveProjectContext(r)
 	project, err := projCtx.GetProject()
 
+	identifier := ""
+	if project != nil {
+		identifier = project.Identifier
+	}
+
 	grip.DebugWhen(err != nil || project == nil || projCtx.Version == nil, message.Fields{
 		"message":            "error getting project for version page",
-		"project_identifier": project.Identifier,
+		"project_identifier": identifier,
 		"projCtx":            projCtx,
 	})
 


### PR DESCRIPTION
DEVPROD-10153

### Description
Logging the whole project isn't secure and the identifier should be enough to trace from.
