### PR TITLE
DEVPROD-10086 Add nil pointer check inside of task queue dispatcher

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -269,6 +269,9 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 		}
 
 		item := d.getItemByNodeID(node.ID()) // item is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
+		if item == nil {
+			continue
+		}
 
 		// TODO Consider checking if the state of any task has changed, which could unblock later tasks in the queue.
 		// Currently, we just wait for the dispatcher's in-memory queue to refresh.


### PR DESCRIPTION
DEVPROD-10086

### Description
This adds a nil pointer check inside of the task queue dispatcher logic. I don't think we've ever hit it, but I imagine if we did it would be bad.
