### PR TITLE
DEVPROD-4971 Enable patch command to generate display tasks rather than execution for 'all' selector

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1908,9 +1908,11 @@ func (p *Project) extractDisplayTasks(pairs TaskVariantPairs) TaskVariantPairs {
 			for _, et := range dt.ExecTasks {
 				if len(et) > 0 && et[0] == '.' {
 					// If this execution task starts with a period, it is actually task tag.
-					for _, t := range p.findProjectTasksWithTag([]string{et}) {
-						execTaskToDisplayTask[TVPair{Variant: bv.Name, TaskName: t}] = displayTV
-						execTVPairs = append(execTVPairs, TVPair{Variant: bv.Name, TaskName: t})
+					tagToFind := et[1:]
+					for _, t := range p.findProjectTasksWithTag([]string{tagToFind}) {
+						execTV := TVPair{Variant: bv.Name, TaskName: t}
+						execTaskToDisplayTask[execTV] = displayTV
+						execTVPairs = append(execTVPairs, execTV)
 					}
 				} else {
 					// Otherwise, it is really an execution task.

--- a/model/project.go
+++ b/model/project.go
@@ -1728,7 +1728,8 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			bvs = append(bvs, p.findMatchingBuildVariants(bvRegex)...)
 		}
 	}
-	if len(tasks) == 1 && tasks[0] == "all" {
+	isAllTasks := len(tasks) == 1 && tasks[0] == "all"
+	if isAllTasks {
 		tasks = []string{}
 		for _, t := range p.Tasks {
 			tasks = append(tasks, t.Name)
@@ -1751,6 +1752,9 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 			tasks = append(tasks, p.findMatchingProjectTasks(tRegex)...)
 		}
 	}
+	// This is used to remove execution tasks that are part of a display task when
+	// the specified tasks is 'all'.
+	executionTasksToRemove := map[string][]string{}
 	var pairs TaskVariantPairs
 	for _, v := range bvs {
 		for _, t := range tasks {
@@ -1759,8 +1763,21 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 					continue
 				}
 				pairs.ExecTasks = append(pairs.ExecTasks, TVPair{Variant: v, TaskName: t})
-			} else if p.GetDisplayTask(v, t) != nil {
+			} else if dt := p.GetDisplayTask(v, t); dt != nil {
 				pairs.DisplayTasks = append(pairs.DisplayTasks, TVPair{Variant: v, TaskName: t})
+				if isAllTasks {
+					executionTasksToRemove[v] = append(executionTasksToRemove[v], dt.ExecTasks...)
+				}
+			}
+		}
+	}
+	for v, tasksToRemove := range executionTasksToRemove {
+		for _, t := range tasksToRemove {
+			for i, pair := range pairs.ExecTasks {
+				if pair.Variant == v && pair.TaskName == t {
+					pairs.ExecTasks = append(pairs.ExecTasks[:i], pairs.ExecTasks[i+1:]...)
+					break
+				}
 			}
 		}
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1760,7 +1760,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 					continue
 				}
 				pairs.ExecTasks = append(pairs.ExecTasks, TVPair{Variant: v, TaskName: t})
-			} else if dt := p.GetDisplayTask(v, t); dt != nil {
+			} else if p.GetDisplayTask(v, t) != nil {
 				pairs.DisplayTasks = append(pairs.DisplayTasks, TVPair{Variant: v, TaskName: t})
 			}
 		}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -958,6 +958,10 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 		"9001_task",
 		"very_task",
 		"another_disabled_task"}, patchDoc.Tasks)
+	s.Len(patchDoc.VariantsTasks, 0)
+	dts := patchDoc.VariantsTasks[0].DisplayTasks
+	s.Len(dts, 1)
+	s.Equal(dts[0].Name, "memes")
 	for _, vt := range patchDoc.VariantsTasks {
 		switch vt.Variant {
 		case "bv_1":

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -958,10 +958,6 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 		"9001_task",
 		"very_task",
 		"another_disabled_task"}, patchDoc.Tasks)
-	s.Len(patchDoc.VariantsTasks, 0)
-	dts := patchDoc.VariantsTasks[0].DisplayTasks
-	s.Len(dts, 1)
-	s.Equal(dts[0].Name, "memes")
 	for _, vt := range patchDoc.VariantsTasks {
 		switch vt.Variant {
 		case "bv_1":
@@ -974,6 +970,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 				"very_task",
 			}, vt.Tasks)
 			s.Len(vt.DisplayTasks, 1)
+			s.Equal("memes", vt.DisplayTasks[0].Name)
 		case "bv_2":
 			s.ElementsMatch([]string{
 				"a_task_1",


### PR DESCRIPTION
DEVPROD-4971

### Description
When doing `evergreen patch -t all -v all`, tasks are iterated through and the execution tasks are added rather than the display tasks. This leads to a patch that has all the execution tasks but not the display task bundling them.

This applies a fix at the (patchJob).finalizePatch(...) level where if it is 'all' passed through, it will go ahead and schedule the display tasks and remove the duplicated execution tasks.

This does not apply a fix for unfinalized tasks, as I think that's a bug with how the configure page works/interprets the 'all' option. I split a ticket for the ui team (in the linked tickets for this ticket).

### Testing
[Before patch](https://spruce-staging.corp.mongodb.com/version/66db298eb7934c0007752062/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and [After patch](https://spruce-staging.corp.mongodb.com/version/66e0661cf042bf00076dac6f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

[This](https://spruce-staging.corp.mongodb.com/version/66db296bb7934c000775205e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a patch manually selecting the three display tasks for comparison