### PR TITLE
DEVPROD-10040 Activate dependencies in new builds too 

### DIFF
--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1282,7 +1282,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependenciesInNewBuilds() {
 	g.Task = &generator
 	p, pp, err := FindAndTranslateProjectForVersion(s.ctx, s.env.Settings(), v, false)
 	s.Require().NoError(err)
-	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
+	p, pp, v, err = g.NewVersion(s.ctx, p, pp, v)
 	s.NoError(err)
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 


### PR DESCRIPTION
DEVPROD-10040

### Description
When adding generated tasks, we add the ones in existing builds and the ones in new builds separately. When adding tasks to existing builds we would also find and dependencies and activate them. However, when adding tasks to new builds we skipped this step. This would cause tasks generated with dependencies in new builds to not activate dependencies and therefore block the task from running.  

### Testing
Added a unit test and tested on staging. 
[patch before changes ](https://spruce-staging.corp.mongodb.com/version/66db352f7ac0800007d64fac/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
[patch after changes ](https://spruce-staging.corp.mongodb.com/version/66db6da8d9ad170007246cb1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)


