### PR TITLE
DEVPROD-11146: check nil response for update

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1741,10 +1741,12 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 			},
 		})
 		catcher.Wrap(err, "marking newly-added hosts as permanently exempt")
-		grip.InfoWhen(res.ModifiedCount > 0, message.Fields{
-			"message":   "marked newly-added hosts as permanently exempt",
-			"num_hosts": res.ModifiedCount,
-		})
+		if res != nil && res.ModifiedCount > 0 {
+			grip.Info(message.Fields{
+				"message":   "marked newly-added hosts as permanently exempt",
+				"num_hosts": res.ModifiedCount,
+			})
+		}
 	}
 
 	res, err := coll.UpdateMany(ctx, isSleepScheduleApplicable(bson.M{


### PR DESCRIPTION
DEVPROD-11146

### Description
If the `err` is non-nil from the driver, `res` might be nil, so check for nil before using it.

### Testing
Not really testable since it requires the driver to error, but it's not hard to reason about by inspection.