### PR TITLE
DEVPROD-10177: Add waterfall query pagination

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -80344,6 +80344,51 @@ func (ec *executionContext) _GeneralSubscription(ctx context.Context, sel ast.Se
 	return out
 }
 
+var generatedTaskCountResultsImplementors = []string{"GeneratedTaskCountResults"}
+
+func (ec *executionContext) _GeneratedTaskCountResults(ctx context.Context, sel ast.SelectionSet, obj *GeneratedTaskCountResults) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, generatedTaskCountResultsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GeneratedTaskCountResults")
+		case "buildVariantName":
+			out.Values[i] = ec._GeneratedTaskCountResults_buildVariantName(ctx, field, obj)
+		case "taskName":
+			out.Values[i] = ec._GeneratedTaskCountResults_taskName(ctx, field, obj)
+		case "taskId":
+			out.Values[i] = ec._GeneratedTaskCountResults_taskId(ctx, field, obj)
+		case "estimatedTasks":
+			out.Values[i] = ec._GeneratedTaskCountResults_estimatedTasks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var gitHubDynamicTokenPermissionGroupImplementors = []string{"GitHubDynamicTokenPermissionGroup"}
 
 func (ec *executionContext) _GitHubDynamicTokenPermissionGroup(ctx context.Context, sel ast.SelectionSet, obj *model.APIGitHubDynamicTokenPermissionGroup) graphql.Marshaler {
@@ -80493,51 +80538,6 @@ func (ec *executionContext) _GithubCheckSubscriber(ctx context.Context, sel ast.
 			}
 		case "repo":
 			out.Values[i] = ec._GithubCheckSubscriber_repo(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch(ctx)
-	if out.Invalids > 0 {
-		return graphql.Null
-	}
-
-	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
-
-	for label, dfs := range deferred {
-		ec.processDeferredGroup(graphql.DeferredGroup{
-			Label:    label,
-			Path:     graphql.GetPath(ctx),
-			FieldSet: dfs,
-			Context:  ctx,
-		})
-	}
-
-	return out
-}
-
-var generatedTaskCountResultsImplementors = []string{"GeneratedTaskCountResults"}
-
-func (ec *executionContext) _GeneratedTaskCountResults(ctx context.Context, sel ast.SelectionSet, obj *GeneratedTaskCountResults) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, generatedTaskCountResultsImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	deferred := make(map[string]*graphql.FieldSet)
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("GeneratedTaskCountResults")
-		case "buildVariantName":
-			out.Values[i] = ec._GeneratedTaskCountResults_buildVariantName(ctx, field, obj)
-		case "taskName":
-			out.Values[i] = ec._GeneratedTaskCountResults_taskName(ctx, field, obj)
-		case "taskId":
-			out.Values[i] = ec._GeneratedTaskCountResults_taskId(ctx, field, obj)
-		case "estimatedTasks":
-			out.Values[i] = ec._GeneratedTaskCountResults_estimatedTasks(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -49247,11 +49247,14 @@ func (ec *executionContext) _Query_waterfall(ctx context.Context, field graphql.
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*Waterfall)
 	fc.Result = res
-	return ec.marshalOWaterfall2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfall(ctx, field.Selections, res)
+	return ec.marshalNWaterfall2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfall(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_waterfall(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -87278,13 +87281,16 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 		case "waterfall":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Query_waterfall(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -98379,6 +98385,20 @@ func (ec *executionContext) unmarshalNVolumeHost2githubᚗcomᚋevergreenᚑci�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalNWaterfall2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfall(ctx context.Context, sel ast.SelectionSet, v Waterfall) graphql.Marshaler {
+	return ec._Waterfall(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNWaterfall2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfall(ctx context.Context, sel ast.SelectionSet, v *Waterfall) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Waterfall(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNWaterfallBuild2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuild(ctx context.Context, sel ast.SelectionSet, v model1.WaterfallBuild) graphql.Marshaler {
 	return ec._WaterfallBuild(ctx, sel, &v)
 }
@@ -101433,13 +101453,6 @@ func (ec *executionContext) marshalOVolume2ᚖgithubᚗcomᚋevergreenᚑciᚋev
 		return graphql.Null
 	}
 	return ec._Volume(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOWaterfall2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfall(ctx context.Context, sel ast.SelectionSet, v *Waterfall) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Waterfall(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOWebhookInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebHook(ctx context.Context, v interface{}) (model.APIWebHook, error) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1669,6 +1669,8 @@ type ComplexityRoot struct {
 
 	Waterfall struct {
 		BuildVariants func(childComplexity int) int
+		NextPageOrder func(childComplexity int) int
+		PrevPageOrder func(childComplexity int) int
 		Versions      func(childComplexity int) int
 	}
 
@@ -1690,6 +1692,11 @@ type ComplexityRoot struct {
 		DisplayName func(childComplexity int) int
 		Id          func(childComplexity int) int
 		Status      func(childComplexity int) int
+	}
+
+	WaterfallVersion struct {
+		InactiveVersions func(childComplexity int) int
+		Version          func(childComplexity int) int
 	}
 
 	Webhook struct {
@@ -10098,6 +10105,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Waterfall.BuildVariants(childComplexity), true
 
+	case "Waterfall.nextPageOrder":
+		if e.complexity.Waterfall.NextPageOrder == nil {
+			break
+		}
+
+		return e.complexity.Waterfall.NextPageOrder(childComplexity), true
+
+	case "Waterfall.prevPageOrder":
+		if e.complexity.Waterfall.PrevPageOrder == nil {
+			break
+		}
+
+		return e.complexity.Waterfall.PrevPageOrder(childComplexity), true
+
 	case "Waterfall.versions":
 		if e.complexity.Waterfall.Versions == nil {
 			break
@@ -10181,6 +10202,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.WaterfallTask.Status(childComplexity), true
+
+	case "WaterfallVersion.inactiveVersions":
+		if e.complexity.WaterfallVersion.InactiveVersions == nil {
+			break
+		}
+
+		return e.complexity.WaterfallVersion.InactiveVersions(childComplexity), true
+
+	case "WaterfallVersion.version":
+		if e.complexity.WaterfallVersion.Version == nil {
+			break
+		}
+
+		return e.complexity.WaterfallVersion.Version(childComplexity), true
 
 	case "Webhook.endpoint":
 		if e.complexity.Webhook.Endpoint == nil {
@@ -49229,6 +49264,10 @@ func (ec *executionContext) fieldContext_Query_waterfall(ctx context.Context, fi
 			switch field.Name {
 			case "buildVariants":
 				return ec.fieldContext_Waterfall_buildVariants(ctx, field)
+			case "nextPageOrder":
+				return ec.fieldContext_Waterfall_nextPageOrder(ctx, field)
+			case "prevPageOrder":
+				return ec.fieldContext_Waterfall_prevPageOrder(ctx, field)
 			case "versions":
 				return ec.fieldContext_Waterfall_versions(ctx, field)
 			}
@@ -69166,6 +69205,94 @@ func (ec *executionContext) fieldContext_Waterfall_buildVariants(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Waterfall_nextPageOrder(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Waterfall_nextPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Waterfall_nextPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Waterfall",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Waterfall_prevPageOrder(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Waterfall_prevPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrevPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Waterfall_prevPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Waterfall",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Waterfall_versions(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Waterfall_versions(ctx, field)
 	if err != nil {
@@ -69192,9 +69319,9 @@ func (ec *executionContext) _Waterfall_versions(ctx context.Context, field graph
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.APIVersion)
+	res := resTmp.([]*WaterfallVersion)
 	fc.Result = res
-	return ec.marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx, field.Selections, res)
+	return ec.marshalNWaterfallVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallVersionᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Waterfall_versions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -69205,86 +69332,12 @@ func (ec *executionContext) fieldContext_Waterfall_versions(_ context.Context, f
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "id":
-				return ec.fieldContext_Version_id(ctx, field)
-			case "activated":
-				return ec.fieldContext_Version_activated(ctx, field)
-			case "author":
-				return ec.fieldContext_Version_author(ctx, field)
-			case "authorEmail":
-				return ec.fieldContext_Version_authorEmail(ctx, field)
-			case "baseTaskStatuses":
-				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
-			case "baseVersion":
-				return ec.fieldContext_Version_baseVersion(ctx, field)
-			case "branch":
-				return ec.fieldContext_Version_branch(ctx, field)
-			case "buildVariants":
-				return ec.fieldContext_Version_buildVariants(ctx, field)
-			case "buildVariantStats":
-				return ec.fieldContext_Version_buildVariantStats(ctx, field)
-			case "childVersions":
-				return ec.fieldContext_Version_childVersions(ctx, field)
-			case "createTime":
-				return ec.fieldContext_Version_createTime(ctx, field)
-			case "errors":
-				return ec.fieldContext_Version_errors(ctx, field)
-			case "externalLinksForMetadata":
-				return ec.fieldContext_Version_externalLinksForMetadata(ctx, field)
-			case "finishTime":
-				return ec.fieldContext_Version_finishTime(ctx, field)
-			case "generatedTaskCounts":
-				return ec.fieldContext_Version_generatedTaskCounts(ctx, field)
-			case "gitTags":
-				return ec.fieldContext_Version_gitTags(ctx, field)
-			case "ignored":
-				return ec.fieldContext_Version_ignored(ctx, field)
-			case "isPatch":
-				return ec.fieldContext_Version_isPatch(ctx, field)
-			case "manifest":
-				return ec.fieldContext_Version_manifest(ctx, field)
-			case "message":
-				return ec.fieldContext_Version_message(ctx, field)
-			case "order":
-				return ec.fieldContext_Version_order(ctx, field)
-			case "parameters":
-				return ec.fieldContext_Version_parameters(ctx, field)
-			case "patch":
-				return ec.fieldContext_Version_patch(ctx, field)
-			case "previousVersion":
-				return ec.fieldContext_Version_previousVersion(ctx, field)
-			case "project":
-				return ec.fieldContext_Version_project(ctx, field)
-			case "projectIdentifier":
-				return ec.fieldContext_Version_projectIdentifier(ctx, field)
-			case "projectMetadata":
-				return ec.fieldContext_Version_projectMetadata(ctx, field)
-			case "repo":
-				return ec.fieldContext_Version_repo(ctx, field)
-			case "requester":
-				return ec.fieldContext_Version_requester(ctx, field)
-			case "revision":
-				return ec.fieldContext_Version_revision(ctx, field)
-			case "startTime":
-				return ec.fieldContext_Version_startTime(ctx, field)
-			case "status":
-				return ec.fieldContext_Version_status(ctx, field)
-			case "taskCount":
-				return ec.fieldContext_Version_taskCount(ctx, field)
-			case "tasks":
-				return ec.fieldContext_Version_tasks(ctx, field)
-			case "taskStatuses":
-				return ec.fieldContext_Version_taskStatuses(ctx, field)
-			case "taskStatusStats":
-				return ec.fieldContext_Version_taskStatusStats(ctx, field)
-			case "upstreamProject":
-				return ec.fieldContext_Version_upstreamProject(ctx, field)
-			case "versionTiming":
-				return ec.fieldContext_Version_versionTiming(ctx, field)
-			case "warnings":
-				return ec.fieldContext_Version_warnings(ctx, field)
+			case "inactiveVersions":
+				return ec.fieldContext_WaterfallVersion_inactiveVersions(ctx, field)
+			case "version":
+				return ec.fieldContext_WaterfallVersion_version(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type WaterfallVersion", field.Name)
 		},
 	}
 	return fc, nil
@@ -69786,6 +69839,248 @@ func (ec *executionContext) fieldContext_WaterfallTask_displayName(_ context.Con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallVersion_inactiveVersions(ctx context.Context, field graphql.CollectedField, obj *WaterfallVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallVersion_inactiveVersions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InactiveVersions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIVersion)
+	fc.Result = res
+	return ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallVersion_inactiveVersions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallVersion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Version_id(ctx, field)
+			case "activated":
+				return ec.fieldContext_Version_activated(ctx, field)
+			case "author":
+				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
+			case "baseTaskStatuses":
+				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
+			case "baseVersion":
+				return ec.fieldContext_Version_baseVersion(ctx, field)
+			case "branch":
+				return ec.fieldContext_Version_branch(ctx, field)
+			case "buildVariants":
+				return ec.fieldContext_Version_buildVariants(ctx, field)
+			case "buildVariantStats":
+				return ec.fieldContext_Version_buildVariantStats(ctx, field)
+			case "childVersions":
+				return ec.fieldContext_Version_childVersions(ctx, field)
+			case "createTime":
+				return ec.fieldContext_Version_createTime(ctx, field)
+			case "errors":
+				return ec.fieldContext_Version_errors(ctx, field)
+			case "externalLinksForMetadata":
+				return ec.fieldContext_Version_externalLinksForMetadata(ctx, field)
+			case "finishTime":
+				return ec.fieldContext_Version_finishTime(ctx, field)
+			case "generatedTaskCounts":
+				return ec.fieldContext_Version_generatedTaskCounts(ctx, field)
+			case "gitTags":
+				return ec.fieldContext_Version_gitTags(ctx, field)
+			case "ignored":
+				return ec.fieldContext_Version_ignored(ctx, field)
+			case "isPatch":
+				return ec.fieldContext_Version_isPatch(ctx, field)
+			case "manifest":
+				return ec.fieldContext_Version_manifest(ctx, field)
+			case "message":
+				return ec.fieldContext_Version_message(ctx, field)
+			case "order":
+				return ec.fieldContext_Version_order(ctx, field)
+			case "parameters":
+				return ec.fieldContext_Version_parameters(ctx, field)
+			case "patch":
+				return ec.fieldContext_Version_patch(ctx, field)
+			case "previousVersion":
+				return ec.fieldContext_Version_previousVersion(ctx, field)
+			case "project":
+				return ec.fieldContext_Version_project(ctx, field)
+			case "projectIdentifier":
+				return ec.fieldContext_Version_projectIdentifier(ctx, field)
+			case "projectMetadata":
+				return ec.fieldContext_Version_projectMetadata(ctx, field)
+			case "repo":
+				return ec.fieldContext_Version_repo(ctx, field)
+			case "requester":
+				return ec.fieldContext_Version_requester(ctx, field)
+			case "revision":
+				return ec.fieldContext_Version_revision(ctx, field)
+			case "startTime":
+				return ec.fieldContext_Version_startTime(ctx, field)
+			case "status":
+				return ec.fieldContext_Version_status(ctx, field)
+			case "taskCount":
+				return ec.fieldContext_Version_taskCount(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Version_tasks(ctx, field)
+			case "taskStatuses":
+				return ec.fieldContext_Version_taskStatuses(ctx, field)
+			case "taskStatusStats":
+				return ec.fieldContext_Version_taskStatusStats(ctx, field)
+			case "upstreamProject":
+				return ec.fieldContext_Version_upstreamProject(ctx, field)
+			case "versionTiming":
+				return ec.fieldContext_Version_versionTiming(ctx, field)
+			case "warnings":
+				return ec.fieldContext_Version_warnings(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallVersion_version(ctx context.Context, field graphql.CollectedField, obj *WaterfallVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallVersion_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Version, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.APIVersion)
+	fc.Result = res
+	return ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallVersion_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallVersion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Version_id(ctx, field)
+			case "activated":
+				return ec.fieldContext_Version_activated(ctx, field)
+			case "author":
+				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
+			case "baseTaskStatuses":
+				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
+			case "baseVersion":
+				return ec.fieldContext_Version_baseVersion(ctx, field)
+			case "branch":
+				return ec.fieldContext_Version_branch(ctx, field)
+			case "buildVariants":
+				return ec.fieldContext_Version_buildVariants(ctx, field)
+			case "buildVariantStats":
+				return ec.fieldContext_Version_buildVariantStats(ctx, field)
+			case "childVersions":
+				return ec.fieldContext_Version_childVersions(ctx, field)
+			case "createTime":
+				return ec.fieldContext_Version_createTime(ctx, field)
+			case "errors":
+				return ec.fieldContext_Version_errors(ctx, field)
+			case "externalLinksForMetadata":
+				return ec.fieldContext_Version_externalLinksForMetadata(ctx, field)
+			case "finishTime":
+				return ec.fieldContext_Version_finishTime(ctx, field)
+			case "generatedTaskCounts":
+				return ec.fieldContext_Version_generatedTaskCounts(ctx, field)
+			case "gitTags":
+				return ec.fieldContext_Version_gitTags(ctx, field)
+			case "ignored":
+				return ec.fieldContext_Version_ignored(ctx, field)
+			case "isPatch":
+				return ec.fieldContext_Version_isPatch(ctx, field)
+			case "manifest":
+				return ec.fieldContext_Version_manifest(ctx, field)
+			case "message":
+				return ec.fieldContext_Version_message(ctx, field)
+			case "order":
+				return ec.fieldContext_Version_order(ctx, field)
+			case "parameters":
+				return ec.fieldContext_Version_parameters(ctx, field)
+			case "patch":
+				return ec.fieldContext_Version_patch(ctx, field)
+			case "previousVersion":
+				return ec.fieldContext_Version_previousVersion(ctx, field)
+			case "project":
+				return ec.fieldContext_Version_project(ctx, field)
+			case "projectIdentifier":
+				return ec.fieldContext_Version_projectIdentifier(ctx, field)
+			case "projectMetadata":
+				return ec.fieldContext_Version_projectMetadata(ctx, field)
+			case "repo":
+				return ec.fieldContext_Version_repo(ctx, field)
+			case "requester":
+				return ec.fieldContext_Version_requester(ctx, field)
+			case "revision":
+				return ec.fieldContext_Version_revision(ctx, field)
+			case "startTime":
+				return ec.fieldContext_Version_startTime(ctx, field)
+			case "status":
+				return ec.fieldContext_Version_status(ctx, field)
+			case "taskCount":
+				return ec.fieldContext_Version_taskCount(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Version_tasks(ctx, field)
+			case "taskStatuses":
+				return ec.fieldContext_Version_taskStatuses(ctx, field)
+			case "taskStatusStats":
+				return ec.fieldContext_Version_taskStatusStats(ctx, field)
+			case "upstreamProject":
+				return ec.fieldContext_Version_upstreamProject(ctx, field)
+			case "versionTiming":
+				return ec.fieldContext_Version_versionTiming(ctx, field)
+			case "warnings":
+				return ec.fieldContext_Version_warnings(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
 	}
 	return fc, nil
@@ -77353,10 +77648,10 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 	}
 
 	if _, present := asMap["limit"]; !present {
-		asMap["limit"] = 7
+		asMap["limit"] = 5
 	}
 
-	fieldsInOrder := [...]string{"limit", "projectIdentifier", "requesters"}
+	fieldsInOrder := [...]string{"limit", "minOrder", "maxOrder", "projectIdentifier", "requesters"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -77370,6 +77665,20 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Limit = data
+		case "minOrder":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("minOrder"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MinOrder = data
+		case "maxOrder":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("maxOrder"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MaxOrder = data
 		case "projectIdentifier":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectIdentifier"))
 			directive0 := func(ctx context.Context) (interface{}, error) { return ec.unmarshalNString2string(ctx, v) }
@@ -92922,6 +93231,16 @@ func (ec *executionContext) _Waterfall(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "nextPageOrder":
+			out.Values[i] = ec._Waterfall_nextPageOrder(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "prevPageOrder":
+			out.Values[i] = ec._Waterfall_prevPageOrder(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "versions":
 			out.Values[i] = ec._Waterfall_versions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -93081,6 +93400,44 @@ func (ec *executionContext) _WaterfallTask(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var waterfallVersionImplementors = []string{"WaterfallVersion"}
+
+func (ec *executionContext) _WaterfallVersion(ctx context.Context, sel ast.SelectionSet, obj *WaterfallVersion) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, waterfallVersionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("WaterfallVersion")
+		case "inactiveVersions":
+			out.Values[i] = ec._WaterfallVersion_inactiveVersions(ctx, field, obj)
+		case "version":
+			out.Values[i] = ec._WaterfallVersion_version(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -97917,50 +98274,6 @@ func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋever
 	return ec._Version(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIVersion) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v *model.APIVersion) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -98219,6 +98532,60 @@ func (ec *executionContext) marshalNWaterfallTask2ᚕgithubᚗcomᚋevergreenᚑ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNWaterfallVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*WaterfallVersion) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNWaterfallVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallVersion(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNWaterfallVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallVersion(ctx context.Context, sel ast.SelectionSet, v *WaterfallVersion) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._WaterfallVersion(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNWebhook2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebHook(ctx context.Context, sel ast.SelectionSet, v model.APIWebHook) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -587,13 +587,24 @@ type VolumeHost struct {
 
 type Waterfall struct {
 	BuildVariants []*model1.WaterfallBuildVariant `json:"buildVariants"`
-	Versions      []*model.APIVersion             `json:"versions"`
+	NextPageOrder int                             `json:"nextPageOrder"`
+	PrevPageOrder int                             `json:"prevPageOrder"`
+	Versions      []*WaterfallVersion             `json:"versions"`
 }
 
 type WaterfallOptions struct {
-	Limit             *int     `json:"limit,omitempty"`
+	Limit *int `json:"limit,omitempty"`
+	// Return versions with an order greater than minOrder. Used for paginating backward.
+	MinOrder *int `json:"minOrder,omitempty"`
+	// Return versions with an order lower than maxOrder. Used for paginating forward.
+	MaxOrder          *int     `json:"maxOrder,omitempty"`
 	ProjectIdentifier string   `json:"projectIdentifier"`
 	Requesters        []string `json:"requesters,omitempty"`
+}
+
+type WaterfallVersion struct {
+	InactiveVersions []*model.APIVersion `json:"inactiveVersions,omitempty"`
+	Version          *model.APIVersion   `json:"version,omitempty"`
 }
 
 type AccessLevel string

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1025,7 +1025,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		activeVersionIds = append(activeVersionIds, v.Id)
 	}
 
-	waterfallVersions := groupInactiveVersions(ctx, activeVersionIds, allVersions)
+	waterfallVersions := groupInactiveVersions(activeVersionIds, allVersions)
 
 	buildVariants, err := model.GetWaterfallBuildVariants(ctx, activeVersionIds)
 	if err != nil {

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1018,9 +1018,14 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	// Something like this: https://github.com/evergreen-ci/evergreen/blob/bf8f12ec2eefe61f0cf9bcc594924c7be8f91d1b/graphql/query_resolver.go#L869-L938
 	// All other filters can be applied in the GetActiveWaterfallVersions pipeline, ensuring `limit` matching versions have been returned.
 
-	waterfallVersions := groupInactiveVersions(ctx, allVersions)
+	activeVersionIds := []string{}
+	for _, v := range activeVersions {
+		activeVersionIds = append(activeVersionIds, v.Id)
+	}
 
-	buildVariants, err := model.GetWaterfallBuildVariants(ctx, activeVersions)
+	waterfallVersions := groupInactiveVersions(ctx, activeVersionIds, allVersions)
+
+	buildVariants, err := model.GetWaterfallBuildVariants(ctx, activeVersionIds)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting waterfall build variants: %s", err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1000,12 +1000,14 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	// Since GetAllWaterfallVersions uses an inclusive order range ($gte instead of $gt), add 1 to our minimum range
 	minVersionOrder := minOrderOpt + 1
 	if minOrderOpt == 0 {
+		// Only use the last active version order number if no minOrder was provided. Using the activeVersions bounds may omit inactive versions between the min and the last active version found.
 		minVersionOrder = activeVersions[len(activeVersions)-1].RevisionOrderNumber
 	}
 
 	// Same as above, but subtract for max order
 	maxVersionOrder := maxOrderOpt - 1
 	if maxOrderOpt == 0 {
+		// Same as above: only use the first active version if no maxOrder was specified to avoid omitting inactive versions.
 		maxVersionOrder = activeVersions[0].RevisionOrderNumber
 	}
 

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1038,6 +1038,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		bv = append(bv, &bCopy)
 	}
 
+	// Return the min and max orders returned to be used as parameters for navigating to the next page
 	prevPageOrder := allVersions[0].RevisionOrderNumber
 	nextPageOrder := allVersions[len(allVersions)-1].RevisionOrderNumber
 

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1036,15 +1036,9 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		bv = append(bv, &bCopy)
 	}
 
-	// If a max order was specified, use this as the new min and vice versa. If not, take this value from the bounds of the returned versions.
 	prevPageOrder := allVersions[0].RevisionOrderNumber
-	if maxOrderOpt > prevPageOrder {
-		prevPageOrder = maxOrderOpt
-	}
 	nextPageOrder := allVersions[len(allVersions)-1].RevisionOrderNumber
-	if minOrderOpt != 0 && minOrderOpt < nextPageOrder {
-		nextPageOrder = minOrderOpt
-	}
+
 	// If loading base page, there's no prev page to navigate to regardless of max order
 	if maxOrderOpt == 0 && minOrderOpt == 0 {
 		prevPageOrder = 0

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1025,13 +1025,6 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting waterfall build variants: %s", err.Error()))
 	}
 
-	apiVersions := []*restModel.APIVersion{}
-	for _, v := range activeVersions {
-		apiVersion := restModel.APIVersion{}
-		apiVersion.BuildFromService(v)
-		apiVersions = append(apiVersions, &apiVersion)
-	}
-
 	bv := []*model.WaterfallBuildVariant{}
 	for _, b := range buildVariants {
 		bv = append(bv, &b)

--- a/graphql/schema/query.graphql
+++ b/graphql/schema/query.graphql
@@ -91,7 +91,7 @@ type Query {
   taskNamesForBuildVariant(projectIdentifier: String! @requireProjectAccess(permission: TASKS, access: VIEW), buildVariant: String!): [String!]
 
   # waterfall
-  waterfall(options: WaterfallOptions!): Waterfall 
+  waterfall(options: WaterfallOptions!): Waterfall!
 
   # version
   hasVersion(patchId: String!): Boolean!

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -1,5 +1,9 @@
 input WaterfallOptions {
-  limit: Int = 7
+  limit: Int = 5
+  "Return versions with an order greater than minOrder. Used for paginating backward."
+  minOrder: Int
+  "Return versions with an order lower than maxOrder. Used for paginating forward."
+  maxOrder: Int
   projectIdentifier: String! @requireProjectAccess(permission: TASKS, access: VIEW)
   requesters: [String!]
 }
@@ -24,7 +28,14 @@ type WaterfallBuildVariant {
   builds: [WaterfallBuild!]!
 }
 
+type WaterfallVersion {
+  inactiveVersions: [Version!]
+  version: Version
+}
+
 type Waterfall {
   buildVariants: [WaterfallBuildVariant!]!
-  versions: [Version!]!
+  nextPageOrder: Int!
+  prevPageOrder: Int!
+  versions: [WaterfallVersion!]!
 }

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -1,6 +1,31 @@
 {
   "versions": [
     {
+      "_id": "evergreen_version39",
+      "gitspec": "revision39",
+      "identifier": "spruce",
+      "r": "gitter_request",
+      "activated": true,
+      "author": "mohamed.khelif",
+      "status": "failed",
+      "order": 39
+    },
+    {
+      "_id": "evergreen_version0",
+      "gitspec": "revision0",
+      "identifier": "spruce",
+      "r": "gitter_request",
+      "activated": false,
+      "author": "mohamed.khelif",
+      "status": "failed",
+      "order": 40,
+      "build_variants_status": {
+        "activated": false,
+        "build_id": "evergreen_version1_build",
+        "build_variant": "enterprise-ubuntu1604-64"
+      }
+    },
+    {
       "_id": "evergreen_version1",
       "gitspec": "revision1",
       "identifier": "spruce",
@@ -8,7 +33,7 @@
       "activated": true,
       "author": "mohamed.khelif",
       "status": "success",
-      "order": 1,
+      "order": 41,
       "build_variants_status": {
         "activated": true,
         "build_id": "evergreen_version1_build",
@@ -23,7 +48,7 @@
       "activated": true,
       "author": "mohamed.khelif",
       "status": "success",
-      "order": 2,
+      "order": 42,
       "build_variants_status": {
         "activated": true,
         "build_id": "evergreen_version2_build",
@@ -38,7 +63,7 @@
       "activated": false,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 3
+      "order": 43
     },
     {
       "_id": "evergreen_version4",
@@ -48,7 +73,7 @@
       "activated": false,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 4
+      "order": 44
     },
     {
       "_id": "evergreen_version5",
@@ -58,7 +83,7 @@
       "activated": true,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 5
+      "order": 45
     }
   ],
   "tasks": [

--- a/graphql/tests/query/waterfall/queries/no_filters.graphql
+++ b/graphql/tests/query/waterfall/queries/no_filters.graphql
@@ -1,5 +1,7 @@
 {
   waterfall(options: { projectIdentifier: "spruce-identifier" }) {
+    nextPageOrder
+    prevPageOrder
     buildVariants {
       builds {
         activated
@@ -15,10 +17,18 @@
       id
     }
     versions {
-      activated
-      author
-      id
-      revision
+      version {
+        activated
+        author
+        id
+        order
+      }
+      inactiveVersions {
+        activated
+        author
+        id
+        order
+      }
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/pagination_backward.graphql
+++ b/graphql/tests/query/waterfall/queries/pagination_backward.graphql
@@ -1,0 +1,20 @@
+{
+  waterfall(options: { projectIdentifier: "spruce-identifier", minOrder: 42 }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        activated
+        author
+        id
+        order
+      }
+      inactiveVersions {
+        activated
+        author
+        id
+        order
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/queries/pagination_forward.graphql
+++ b/graphql/tests/query/waterfall/queries/pagination_forward.graphql
@@ -1,0 +1,20 @@
+{
+  waterfall(options: { projectIdentifier: "spruce-identifier", maxOrder: 45 }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        activated
+        author
+        id
+        order
+      }
+      inactiveVersions {
+        activated
+        author
+        id
+        order
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -5,6 +5,8 @@
       "result": {
         "data": {
           "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 0,
             "buildVariants": [
               {
                 "id": "enterprise-ubuntu1604-64",
@@ -49,34 +51,175 @@
             ],
             "versions": [
               {
-                "activated": true,
-                "author": "mohamed.khelif",
-                "id": "evergreen_version5",
-                "revision": "revision5"
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version5",
+                  "order": 45
+                }
               },
               {
-                "activated": false,
-                "author": "mohamed.khelif",
-                "id": "evergreen_version4",
-                "revision": "revision4"
+                "inactiveVersions": [
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version4",
+                    "order": 44
+                  },
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version3",
+                    "order": 43
+                  }
+                ],
+                "version": null
               },
               {
-                "activated": false,
-                "author": "mohamed.khelif",
-                "id": "evergreen_version3",
-                "revision": "revision3"
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version2",
+                  "order": 42
+                }
               },
               {
-                "activated": true,
-                "author": "mohamed.khelif",
-                "id": "evergreen_version2",
-                "revision": "2c9056df66d42fb1908d52eed096750a91f1f089"
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version1",
+                  "order": 41
+                }
               },
               {
-                "activated": true,
-                "author": "mohamed.khelif",
-                "id": "evergreen_version1",
-                "revision": "revision1"
+                "inactiveVersions": [
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version0",
+                    "order": 40
+                  }
+                ],
+                "version": null
+              },
+              {
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version39",
+                  "order": 39
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "pagination_forward.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 45,
+            "versions": [
+              {
+                "inactiveVersions": [
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version4",
+                    "order": 44
+                  },
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version3",
+                    "order": 43
+                  }
+                ],
+                "version": null
+              },
+              {
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version2",
+                  "order": 42
+                }
+              },
+              {
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version1",
+                  "order": 41
+                }
+              },
+              {
+                "inactiveVersions": [
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version0",
+                    "order": 40
+                  }
+                ],
+                "version": null
+              },
+              {
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version39",
+                  "order": 39
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "pagination_backward.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 42,
+            "prevPageOrder": 45,
+            "versions": [
+              {
+                "inactiveVersions": null,
+                "version": {
+                  "activated": true,
+                  "author": "mohamed.khelif",
+                  "id": "evergreen_version5",
+                  "order": 45
+                }
+              },
+              {
+                "inactiveVersions": [
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version4",
+                    "order": 44
+                  },
+                  {
+                    "activated": false,
+                    "author": "mohamed.khelif",
+                    "id": "evergreen_version3",
+                    "order": 43
+                  }
+                ],
+                "version": null
               }
             ]
           }

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -146,7 +146,7 @@
         "data": {
           "waterfall": {
             "nextPageOrder": 39,
-            "prevPageOrder": 45,
+            "prevPageOrder": 44,
             "versions": [
               {
                 "inactiveVersions": [
@@ -216,7 +216,7 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 42,
+            "nextPageOrder": 43,
             "prevPageOrder": 45,
             "versions": [
               {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1342,7 +1342,7 @@ func annotationPermissionHelper(ctx context.Context, taskID string, execution *i
 }
 
 // groupInactiveVersions partitions a slice of versions into a slice where each entry is either an active version or slice of inactive versions (i.e. versions that don't match filters; they may be technically activated).
-func groupInactiveVersions(ctx context.Context, activeVersionIds []string, versions []model.Version) []*WaterfallVersion {
+func groupInactiveVersions(activeVersionIds []string, versions []model.Version) []*WaterfallVersion {
 	waterfallVersions := []*WaterfallVersion{}
 	i := 0
 	for i < len(versions) {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1341,12 +1341,12 @@ func annotationPermissionHelper(ctx context.Context, taskID string, execution *i
 	return nil
 }
 
-// groupInactiveVersions partitions a slice of versions into a slice where each entry is either an active version or slice of inactive versions.
-func groupInactiveVersions(ctx context.Context, versions []model.Version) []*WaterfallVersion {
+// groupInactiveVersions partitions a slice of versions into a slice where each entry is either an active version or slice of inactive versions (i.e. versions that don't match filters; they may be technically activated).
+func groupInactiveVersions(ctx context.Context, activeVersionIds []string, versions []model.Version) []*WaterfallVersion {
 	waterfallVersions := []*WaterfallVersion{}
 	i := 0
 	for i < len(versions) {
-		if utility.FromBoolPtr(versions[i].Activated) == true {
+		if utility.StringSliceContains(activeVersionIds, versions[i].Id) {
 			apiVersion := restModel.APIVersion{}
 			apiVersion.BuildFromService(versions[i])
 			waterfallVersions = append(waterfallVersions, &WaterfallVersion{
@@ -1356,7 +1356,7 @@ func groupInactiveVersions(ctx context.Context, versions []model.Version) []*Wat
 			i++
 		} else {
 			inactiveGroup := []*restModel.APIVersion{}
-			for i < len(versions) && utility.FromBoolPtr(versions[i].Activated) == false {
+			for i < len(versions) && !utility.StringSliceContains(activeVersionIds, versions[i].Id) {
 				apiVersion := restModel.APIVersion{}
 				apiVersion.BuildFromService(versions[i])
 				inactiveGroup = append(inactiveGroup, &apiVersion)

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1340,3 +1340,33 @@ func annotationPermissionHelper(ctx context.Context, taskID string, execution *i
 	}
 	return nil
 }
+
+// groupInactiveVersions partitions a slice of versions into a slice where each entry is either an active version or slice of inactive versions.
+func groupInactiveVersions(ctx context.Context, versions []model.Version) []*WaterfallVersion {
+	waterfallVersions := []*WaterfallVersion{}
+	i := 0
+	for i < len(versions) {
+		if utility.FromBoolPtr(versions[i].Activated) == true {
+			apiVersion := restModel.APIVersion{}
+			apiVersion.BuildFromService(versions[i])
+			waterfallVersions = append(waterfallVersions, &WaterfallVersion{
+				InactiveVersions: nil,
+				Version:          &apiVersion,
+			})
+			i++
+		} else {
+			inactiveGroup := []*restModel.APIVersion{}
+			for i < len(versions) && utility.FromBoolPtr(versions[i].Activated) == false {
+				apiVersion := restModel.APIVersion{}
+				apiVersion.BuildFromService(versions[i])
+				inactiveGroup = append(inactiveGroup, &apiVersion)
+				i++
+			}
+			waterfallVersions = append(waterfallVersions, &WaterfallVersion{
+				InactiveVersions: inactiveGroup,
+				Version:          nil,
+			})
+		}
+	}
+	return waterfallVersions
+}

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -518,39 +518,20 @@ func TestGroupInactiveVersions(t *testing.T) {
 	ctx := context.Background()
 	assert.NoError(t, db.ClearCollections(model.VersionCollection))
 
-	v0 := model.Version{
-		Id:        "0",
-		Activated: utility.ToBoolPtr(false),
-	}
-	v1 := model.Version{
-		Id:        "1",
-		Activated: utility.ToBoolPtr(false),
-	}
+	v0 := model.Version{Id: "0"}
+	v1 := model.Version{Id: "1"}
 	assert.NoError(t, v1.Insert())
-	v2 := model.Version{
-		Id:        "2",
-		Activated: utility.ToBoolPtr(true),
-	}
+	v2 := model.Version{Id: "2"}
 	assert.NoError(t, v2.Insert())
-	v3 := model.Version{
-		Id:        "3",
-		Activated: utility.ToBoolPtr(true),
-	}
+	v3 := model.Version{Id: "3"}
 	assert.NoError(t, v3.Insert())
-	v4 := model.Version{
-		Id:        "4",
-		Activated: utility.ToBoolPtr(false),
-	}
+	v4 := model.Version{Id: "4"}
 	assert.NoError(t, v4.Insert())
-	v5 := model.Version{
-		Id:        "5",
-		Activated: utility.ToBoolPtr(true),
-	}
+	v5 := model.Version{Id: "5"}
 	assert.NoError(t, v5.Insert())
 
-	versions := []model.Version{v0, v1, v2, v3, v4, v5}
-
-	waterfallVersions := groupInactiveVersions(ctx, versions)
+	activeVersionIds := []string{v2.Id, v3.Id, v5.Id}
+	waterfallVersions := groupInactiveVersions(ctx, activeVersionIds, []model.Version{v0, v1, v2, v3, v4, v5})
 	assert.Len(t, waterfallVersions, 5)
 
 	assert.Nil(t, waterfallVersions[0].Version)

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -532,7 +532,7 @@ func TestGroupInactiveVersions(t *testing.T) {
 
 	activeVersionIds := []string{v2.Id, v3.Id, v5.Id}
 	waterfallVersions := groupInactiveVersions(ctx, activeVersionIds, []model.Version{v0, v1, v2, v3, v4, v5})
-	assert.Len(t, waterfallVersions, 5)
+	require.Len(t, waterfallVersions, 5)
 
 	assert.Nil(t, waterfallVersions[0].Version)
 	assert.Len(t, waterfallVersions[0].InactiveVersions, 2)

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -515,7 +515,6 @@ func TestHasAnnotationPermission(t *testing.T) {
 }
 
 func TestGroupInactiveVersions(t *testing.T) {
-	ctx := context.Background()
 	assert.NoError(t, db.ClearCollections(model.VersionCollection))
 
 	v0 := model.Version{Id: "0"}
@@ -531,7 +530,7 @@ func TestGroupInactiveVersions(t *testing.T) {
 	assert.NoError(t, v5.Insert())
 
 	activeVersionIds := []string{v2.Id, v3.Id, v5.Id}
-	waterfallVersions := groupInactiveVersions(ctx, activeVersionIds, []model.Version{v0, v1, v2, v3, v4, v5})
+	waterfallVersions := groupInactiveVersions(activeVersionIds, []model.Version{v0, v1, v2, v3, v4, v5})
 	require.Len(t, waterfallVersions, 5)
 
 	assert.Nil(t, waterfallVersions[0].Version)

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -102,7 +102,12 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 	return res, nil
 }
 
+/* GetAllWaterfallVersions returns all of a project's versions within an inclusive range of orders. */
 func GetAllWaterfallVersions(ctx context.Context, projectId string, minOrder int, maxOrder int) ([]Version, error) {
+	if minOrder >= maxOrder {
+		return nil, errors.New("minOrder must be greater than maxOrder")
+	}
+
 	match := bson.M{
 		VersionIdentifierKey: projectId,
 		VersionRequesterKey: bson.M{

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -133,14 +133,9 @@ func GetAllWaterfallVersions(ctx context.Context, projectId string, minOrder int
 }
 
 // GetWaterfallBuildVariants returns all build variants associated with the specified versions. Each build variant contains an array of builds sorted by revision and their tasks.
-func GetWaterfallBuildVariants(ctx context.Context, versions []Version) ([]WaterfallBuildVariant, error) {
-	if len(versions) == 0 {
-		return nil, errors.Errorf("no versions specified")
-	}
-
-	versionIds := []string{}
-	for _, version := range versions {
-		versionIds = append(versionIds, version.Id)
+func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]WaterfallBuildVariant, error) {
+	if len(versionIds) == 0 {
+		return nil, errors.Errorf("no version IDs specified")
 	}
 
 	pipeline := []bson.M{{"$match": bson.M{VersionIdKey: bson.M{"$in": versionIds}}}}

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -76,13 +76,15 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 	pipeline := []bson.M{{"$match": match}}
 
 	if pagingBackward {
+		// When querying with a $gt param, sort ascending so we can take `limit` versions nearest to the MinOrder param
 		pipeline = append(pipeline, bson.M{"$sort": bson.M{VersionRevisionOrderNumberKey: 1}})
-		pipeline = append(pipeline, bson.M{"$limit": DefaultWaterfallQueryCount})
+		pipeline = append(pipeline, bson.M{"$limit": opts.Limit})
+		// Then apply an acending sort so these versions are returned in the expected descending order
 		pipeline = append(pipeline, bson.M{"$sort": bson.M{VersionRevisionOrderNumberKey: -1}})
 
 	} else {
 		pipeline = append(pipeline, bson.M{"$sort": bson.M{VersionRevisionOrderNumberKey: -1}})
-		pipeline = append(pipeline, bson.M{"$limit": DefaultWaterfallQueryCount})
+		pipeline = append(pipeline, bson.M{"$limit": opts.Limit})
 
 	}
 
@@ -99,10 +101,10 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 	return res, nil
 }
 
-/* GetAllWaterfallVersions returns all of a project's versions within an inclusive range of orders. */
+// GetAllWaterfallVersions returns all of a project's versions within an inclusive range of orders.
 func GetAllWaterfallVersions(ctx context.Context, projectId string, minOrder int, maxOrder int) ([]Version, error) {
 	if minOrder >= maxOrder {
-		return nil, errors.New("minOrder must be greater than maxOrder")
+		return nil, errors.New("minOrder must be less than maxOrder")
 	}
 
 	match := bson.M{

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -61,11 +61,9 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 		VersionRequesterKey: bson.M{
 			"$in": opts.Requesters,
 		},
-		// TODO: Consider adding an index on requester, identifier, order, activated
 		VersionActivatedKey: true,
 	}
 
-	// Identify whether the operation is paginating. This affects how sort and limit is applied.
 	pagingForward := opts.MaxOrder != 0
 	pagingBackward := opts.MinOrder != 0
 
@@ -90,7 +88,6 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 
 	res := []Version{}
 	env := evergreen.GetEnvironment()
-	// TODO: We might consider adding SetMaxTime to this Aggregate operation
 	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating active versions")

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -700,7 +700,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	assert.NoError(t, tsk.Insert())
 
 	ctx := context.TODO()
-	buildVariants, err := GetWaterfallBuildVariants(ctx, []Version{v1, v2, v3, v4})
+	buildVariants, err := GetWaterfallBuildVariants(ctx, []string{v1.Id, v2.Id, v3.Id, v4.Id})
 	assert.NoError(t, err)
 	assert.Len(t, buildVariants, 3)
 

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -12,9 +12,13 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetActiveWaterfallVersions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
 	start := time.Now()
 	p := ProjectRef{
@@ -69,13 +73,12 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 
-	ctx := context.TODO()
 	versions, err := GetActiveWaterfallVersions(ctx, p.Id, WaterfallOptions{
 		Limit:      4,
 		Requesters: evergreen.SystemVersionRequesterTypes,
 	})
 	assert.NoError(t, err)
-	assert.Len(t, versions, 4)
+	require.Len(t, versions, 4)
 	assert.EqualValues(t, "v_1", versions[0].Id)
 	assert.EqualValues(t, "v_3", versions[1].Id)
 	assert.EqualValues(t, "v_4", versions[2].Id)
@@ -92,6 +95,9 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 }
 
 func TestGetAllWaterfallVersions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
 	start := time.Now()
 	p := ProjectRef{
@@ -146,10 +152,9 @@ func TestGetAllWaterfallVersions(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 
-	ctx := context.TODO()
 	versions, err := GetAllWaterfallVersions(ctx, p.Id, 7, 9)
 	assert.NoError(t, err)
-	assert.Len(t, versions, 3)
+	require.Len(t, versions, 3)
 	assert.EqualValues(t, "v_2", versions[0].Id)
 	assert.EqualValues(t, "v_3", versions[1].Id)
 	assert.EqualValues(t, "v_4", versions[2].Id)
@@ -160,10 +165,13 @@ func TestGetAllWaterfallVersions(t *testing.T) {
 
 	versions, err = GetAllWaterfallVersions(ctx, p.Id, 9, 8)
 	assert.Error(t, err)
-	assert.Nil(t, versions)
+	assert.Empty(t, versions)
 }
 
 func TestGetWaterfallBuildVariants(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
 	start := time.Now()
 	p := ProjectRef{
@@ -699,7 +707,6 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	tsk = task.Task{Id: "t_394", DisplayName: "Task 394", Status: evergreen.TaskSucceeded}
 	assert.NoError(t, tsk.Insert())
 
-	ctx := context.TODO()
 	buildVariants, err := GetWaterfallBuildVariants(ctx, []string{v1.Id, v2.Id, v3.Id, v4.Id})
 	assert.NoError(t, err)
 	assert.Len(t, buildVariants, 3)

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -84,6 +84,26 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 	assert.EqualValues(t, "v_4", versions[2].Id)
 	assert.EqualValues(t, "v_5", versions[3].Id)
 
+	versions, err = GetActiveWaterfallVersions(ctx, p.Id, WaterfallOptions{
+		Limit:      2,
+		Requesters: evergreen.SystemVersionRequesterTypes,
+		MaxOrder:   9,
+	})
+	assert.NoError(t, err)
+	require.Len(t, versions, 2)
+	assert.EqualValues(t, "v_3", versions[0].Id)
+	assert.EqualValues(t, "v_4", versions[1].Id)
+
+	versions, err = GetActiveWaterfallVersions(ctx, p.Id, WaterfallOptions{
+		Limit:      5,
+		Requesters: evergreen.SystemVersionRequesterTypes,
+		MinOrder:   7,
+	})
+	assert.NoError(t, err)
+	require.Len(t, versions, 2)
+	assert.EqualValues(t, "v_1", versions[0].Id)
+	assert.EqualValues(t, "v_3", versions[1].Id)
+
 	versions, err = GetActiveWaterfallVersions(ctx, p.Id,
 		WaterfallOptions{
 			Limit:      4,
@@ -166,6 +186,11 @@ func TestGetAllWaterfallVersions(t *testing.T) {
 	versions, err = GetAllWaterfallVersions(ctx, p.Id, 9, 8)
 	assert.Error(t, err)
 	assert.Empty(t, versions)
+
+	versions, err = GetAllWaterfallVersions(ctx, p.Id, 10, 12)
+	assert.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.EqualValues(t, "v_1", versions[0].Id)
 }
 
 func TestGetWaterfallBuildVariants(t *testing.T) {

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetWaterfallVersions(t *testing.T) {
+func TestGetActiveWaterfallVersions(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
 	start := time.Now()
 	p := ProjectRef{
@@ -70,7 +70,7 @@ func TestGetWaterfallVersions(t *testing.T) {
 	assert.NoError(t, v.Insert())
 
 	ctx := context.TODO()
-	versions, err := GetWaterfallVersions(ctx, p.Id, WaterfallOptions{
+	versions, err := GetActiveWaterfallVersions(ctx, p.Id, WaterfallOptions{
 		Limit:      4,
 		Requesters: evergreen.SystemVersionRequesterTypes,
 	})
@@ -81,7 +81,7 @@ func TestGetWaterfallVersions(t *testing.T) {
 	assert.EqualValues(t, "v_3", versions[2].Id)
 	assert.EqualValues(t, "v_4", versions[3].Id)
 
-	versions, err = GetWaterfallVersions(ctx, p.Id,
+	versions, err = GetActiveWaterfallVersions(ctx, p.Id,
 		WaterfallOptions{
 			Limit:      4,
 			Requesters: []string{"foo"},


### PR DESCRIPTION
DEVPROD-10177

### Description
- `GetActiveWaterfallVersions` returns at most `limit` active versions that satisfy order constraints related to pagination
- Using the min and max orders returned from these active versions, or the limit from the resolver request if provided, query for all versions within this range (inclusive). This fetches active and inactive versions. Inactive versions are then grouped for easy rendering by the front end
- Only use active versions to populate the `GetWaterfallBuildVariants` query
- Add fields to return to indicate order values that should be used for pagination to the client

### Testing
- Ensure `GetActiveWaterfallVersions` does not return inactive version
- GraphQL unit tests ensure pagination values returned to the client are correct
- Add unit test to ensure active/inactive versions are correctly grouped

### Documentation
N/A