### PR TITLE
DEVPROD-9092: Send GitHub error when merge queue is not enabled

### DIFF
--- a/rest/data/patch_intent.go
+++ b/rest/data/patch_intent.go
@@ -6,14 +6,12 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	"github.com/pkg/errors"
 )
 
 // AddPRPatchIntent inserts the intent and adds it to the queue if PR testing is enabled for the branch.
@@ -55,19 +53,6 @@ func AddPRPatchIntent(intent patch.Intent, queue amboy.Queue) error {
 }
 
 func AddGithubMergeIntent(intent patch.Intent, queue amboy.Queue) error {
-	patchDoc := intent.NewPatch()
-	projectRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(patchDoc.GithubMergeData.Org,
-		patchDoc.GithubMergeData.Repo, patchDoc.GithubMergeData.BaseBranch)
-	if err != nil {
-		return gimlet.ErrorResponse{
-			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrap(err, "finding project ref for GitHub merge group").Error(),
-		}
-	}
-	if projectRef == nil {
-		return nil
-	}
-
 	if err := intent.Insert(); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "couldn't insert GitHub merge group intent",

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -592,15 +592,6 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 			assert.Contains(t, str, "message ID cannot be empty")
 			assert.NotContains(t, str, "200")
 		},
-		"evergreenMergeQueueSelected": func(t *testing.T) {
-			p.CommitQueue.MergeQueue = model.MergeQueueEvergreen
-			require.NoError(t, p.Insert())
-			response := gh.handleMergeGroupChecksRequested(event)
-			// check for 200 returned in noop case
-			str := fmt.Sprintf("%#v", response)
-			assert.Contains(t, str, "200")
-			assert.NotContains(t, str, "message ID cannot be empty")
-		},
 	} {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
 		t.Run(testCase, test)

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -37,7 +37,7 @@ const (
 	// GitHub intent processing errors
 	ProjectDisabled             = "project was disabled"
 	PatchingDisabled            = "patching was disabled"
-	commitQueueDisabled         = "commit queue was disabled"
+	commitQueueDisabled         = "merge queue disabled for project"
 	ignoredFiles                = "all patched files are ignored"
 	PatchTaskSyncDisabled       = "task sync was disabled for patches"
 	invalidAlias                = "alias not found"

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1071,7 +1071,8 @@ func (j *patchIntentProcessor) buildGithubMergeDoc(ctx context.Context, patchDoc
 		)
 	}
 	if projectRef == nil {
-		return errors.Errorf("project ref for repo '%s/%s' with branch '%s' not found",
+		j.gitHubError = commitQueueDisabled
+		return errors.Errorf("project ref for repo '%s/%s' with branch '%s' and merge queue enabled not found",
 			patchDoc.GithubMergeData.Org, patchDoc.GithubMergeData.Repo, patchDoc.GithubMergeData.BaseBranch)
 	}
 	j.user, err = findEvergreenUserForGithubMergeGroup(patchDoc.GithubPatchData.AuthorUID)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -336,6 +336,52 @@ func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVari
 	s.Equal("patch has no build variants or tasks", err.Error())
 }
 
+func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithDisabledCommitQueue() {
+	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings(), s.T().Name())
+	headRef := "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+	orgName := "evergreen-ci"
+	repoName := "commit-queue-sandbox"
+	headSHA := "foo"
+	baseSHA := "bar"
+
+	disabledMergeQueueProject := model.ProjectRef{
+		Id: repoName,
+		CommitQueue: model.CommitQueueParams{
+			Enabled: utility.FalsePtr(),
+		},
+	}
+	s.Require().NoError(disabledMergeQueueProject.Upsert())
+
+	org := github.Organization{
+		Login: &orgName,
+	}
+	repo := github.Repository{
+		Name: &repoName,
+	}
+	mg := github.MergeGroup{
+		HeadSHA: &headSHA,
+		HeadRef: &headRef,
+		BaseSHA: &baseSHA,
+	}
+	mge := github.MergeGroupEvent{
+		MergeGroup: &mg,
+		Org:        &org,
+		Repo:       &repo,
+	}
+	intent, err := patch.NewGithubMergeIntent("id", "auto", &mge)
+
+	s.NoError(err)
+	s.Require().NotNil(intent)
+	s.NoError(intent.Insert())
+
+	j := NewPatchIntentProcessor(s.env, mgobson.NewObjectId(), intent).(*patchIntentProcessor)
+
+	patchDoc := intent.NewPatch()
+	s.Error(j.finishPatch(s.ctx, patchDoc))
+	s.NotEmpty(j.gitHubError)
+	s.Equal(j.gitHubError, commitQueueDisabled)
+}
+
 func (s *PatchIntentUnitsSuite) TestSetToPreviousPatchDefinition() {
 	patchId := mgobson.NewObjectId().Hex()
 	previousPatchDoc := &patch.Patch{


### PR DESCRIPTION
DEVPROD-9092

### Description
For projects with the merge queue enabled on GitHub but not Evergreen, we were not sending a response to the merge queue because of a few superfluous `FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch` that would fail and block the patch intent from being created.

Instead, always create the intent and respond with an appropriate error

### Testing
- Tested in github-merge-queue-sandbox repo [here](https://github.com/evergreen-ci/github-merge-queue-sandbox/pull/22#event-14204590972)
- Add unit test for intent with disabled merge queue
- Remove test to noop when a project is encountered with an Evergreen merge queue since these have all been removed from production

### Documentation
N/A

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->