### PR TITLE
DEVPROD-767 Warn if task exceeds max exec timeout

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -684,7 +684,6 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 
 	idleTimeoutCtx, idleTimeoutCancel := context.WithCancel(timeoutWatcherCtx)
 	go a.startIdleTimeoutWatcher(timeoutWatcherCtx, idleTimeoutCancel, tc)
-
 	execTimeoutCtx, execTimeoutCancel := context.WithCancel(idleTimeoutCtx)
 	defer execTimeoutCancel()
 	timeoutOpts := timeoutWatcherOptions{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -684,6 +684,7 @@ func (a *Agent) runPreAndMain(ctx context.Context, tc *taskContext) (status stri
 
 	idleTimeoutCtx, idleTimeoutCancel := context.WithCancel(timeoutWatcherCtx)
 	go a.startIdleTimeoutWatcher(timeoutWatcherCtx, idleTimeoutCancel, tc)
+
 	execTimeoutCtx, execTimeoutCancel := context.WithCancel(idleTimeoutCtx)
 	defer execTimeoutCancel()
 	timeoutOpts := timeoutWatcherOptions{

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -289,6 +289,7 @@ func (tc *taskContext) getTimeoutType() globals.TimeoutType {
 func (tc *taskContext) getExecTimeout() time.Duration {
 	tc.RLock()
 	defer tc.RUnlock()
+	// TODO DEVPROD-11204: Delete override to max exec timeout once this is enforced in project parsing
 	dynamicTimeout := math.Min(float64(tc.taskConfig.GetExecTimeout()), float64(tc.taskConfig.MaxExecTimeoutSecs))
 	if dynamicTimeout > 0 {
 		return time.Duration(dynamicTimeout) * time.Second

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -289,7 +289,6 @@ func (tc *taskContext) getTimeoutType() globals.TimeoutType {
 func (tc *taskContext) getExecTimeout() time.Duration {
 	tc.RLock()
 	defer tc.RUnlock()
-	// TODO DEVPROD-11204: Delete override to max exec timeout once this is enforced in project parsing
 	dynamicTimeout := math.Min(float64(tc.taskConfig.GetExecTimeout()), float64(tc.taskConfig.MaxExecTimeoutSecs))
 	if dynamicTimeout > 0 {
 		return time.Duration(dynamicTimeout) * time.Second

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"sync"
 	"time"
@@ -288,7 +289,8 @@ func (tc *taskContext) getTimeoutType() globals.TimeoutType {
 func (tc *taskContext) getExecTimeout() time.Duration {
 	tc.RLock()
 	defer tc.RUnlock()
-	if dynamicTimeout := tc.taskConfig.GetExecTimeout(); dynamicTimeout > 0 {
+	dynamicTimeout := math.Min(float64(tc.taskConfig.GetExecTimeout()), float64(tc.taskConfig.MaxExecTimeoutSecs))
+	if dynamicTimeout > 0 {
 		return time.Duration(dynamicTimeout) * time.Second
 	}
 	if pt := tc.taskConfig.Project.FindProjectTask(tc.taskConfig.Task.DisplayName); pt != nil && pt.ExecTimeoutSecs > 0 {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-05"
+	AgentVersion = "2024-09-10"
 )
 
 const (

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -989,9 +989,11 @@ func validateTimeoutLimits(_ context.Context, settings *evergreen.Settings, proj
 		for _, task := range project.Tasks {
 			if task.ExecTimeoutSecs > settings.TaskLimits.MaxExecTimeoutSecs {
 				errs = append(errs, ValidationError{
-					Message: fmt.Sprintf("task '%s' exec timeout (%d) exceeds maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxExecTimeoutSecs),
-					Level:   Error,
+					Message: fmt.Sprintf("task '%s' exec timeout (%d) is too high and will be set to maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxExecTimeoutSecs),
+					Level:   Warning,
 				})
+
+				task.ExecTimeoutSecs = settings.TaskLimits.MaxExecTimeoutSecs
 			}
 		}
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -990,10 +990,9 @@ func validateTimeoutLimits(_ context.Context, settings *evergreen.Settings, proj
 			if task.ExecTimeoutSecs > settings.TaskLimits.MaxExecTimeoutSecs {
 				errs = append(errs, ValidationError{
 					Message: fmt.Sprintf("task '%s' exec timeout (%d) is too high and will be set to maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxExecTimeoutSecs),
-					Level:   Warning,
+					// TODO DEVPROD-11204: Update to Error once the exec timeout limit can be enforced
+					Level: Warning,
 				})
-
-				task.ExecTimeoutSecs = settings.TaskLimits.MaxExecTimeoutSecs
 			}
 		}
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1757,8 +1757,8 @@ func TestValidateTimeoutLimits(t *testing.T) {
 		}
 		errs := validateTimeoutLimits(ctx, settings, project, &model.ProjectRef{}, false)
 		require.Len(t, errs, 1)
-		assert.Equal(t, Error, errs[0].Level)
-		assert.Contains(t, "task 'task' exec timeout (10) exceeds maximum limit (1)", errs[0].Message)
+		assert.Equal(t, Warning, errs[0].Level)
+		assert.Contains(t, "task 'task' exec timeout (10) is too high and will be set to maximum limit (1)", errs[0].Message)
 	})
 	t.Run("SucceedsWithNoMaxTimeoutLimit", func(t *testing.T) {
 		settings := &evergreen.Settings{}


### PR DESCRIPTION
DEVPROD-767

### Description
there are multiple tasks among multiple projects with a long exec timeout so we shouldn't error but warn and set the timeout to be lower. 

### Testing
unit test updated