### PR TITLE
DEVPROD-10392: make parameter manager available in global env

### DIFF
--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -48,23 +48,49 @@ type ParameterManager struct {
 	db        *mongo.Database
 }
 
-// NewParameterManager creates a new ParameterManager instance.
-func NewParameterManager(pathPrefix string, cachingEnabled bool, ssmClient SSMClient, db *mongo.Database) *ParameterManager {
-	if pathPrefix != "" {
+// ParameterManagerOptions represent options to create a parameter manager.
+type ParameterManagerOptions struct {
+	PathPrefix     string
+	CachingEnabled bool
+	SSMClient      SSMClient
+	DB             *mongo.Database
+}
+
+// Validate checks that the parameter manager options are valid and sets
+// defaults where possible.
+func (o *ParameterManagerOptions) Validate(ctx context.Context) error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(o.DB == nil, "DB cannot be nil")
+	if o.SSMClient == nil {
+		c, err := newSSMClient(ctx, "")
+		if err != nil {
+			return errors.Wrap(err, "creating default SSM client")
+		}
+		o.SSMClient = c
+	}
+	if o.PathPrefix != "" {
 		// Ensure the prefix has a leading slash to make it an absolute path in
 		// the hierarchy and a trailing slash to separate it from the remaining
 		// name.
-		pathPrefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(pathPrefix, "/"), "/"))
+		o.PathPrefix = fmt.Sprintf("/%s/", strings.TrimPrefix(strings.TrimSuffix(o.PathPrefix, "/"), "/"))
+	}
+	return catcher.Resolve()
+}
+
+// NewParameterManager creates a new ParameterManager instance.
+func NewParameterManager(ctx context.Context, opts ParameterManagerOptions) (*ParameterManager, error) {
+	if err := opts.Validate(ctx); err != nil {
+		return nil, errors.Wrap(err, "invalid parameter manager options")
 	}
 	pm := ParameterManager{
-		pathPrefix: pathPrefix,
-		ssmClient:  ssmClient,
-		db:         db,
+		pathPrefix: opts.PathPrefix,
+		ssmClient:  opts.SSMClient,
+		db:         opts.DB,
 	}
-	if cachingEnabled {
+	if opts.CachingEnabled {
 		pm.cache = newParameterCache()
 	}
-	return &pm
+	return &pm, nil
 }
 
 // Put adds or updates a parameter. This returns the created parameter.

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -36,8 +36,6 @@ type Parameter struct {
 // parameters in AWS Systems Manager Parameter Store. It supports caching to
 // optimize parameter retrieval.
 type ParameterManager struct {
-	// pathPrefix is the prefix path in the Parameter Store hierarchy. If set,
-	// all parameters should be stored under this prefix.
 	pathPrefix string
 	// cache holds the in-memory cache of parameters. If parameter caching is
 	// enabled, the cache will reduce the number of reads from Parameter Store
@@ -50,6 +48,8 @@ type ParameterManager struct {
 
 // ParameterManagerOptions represent options to create a parameter manager.
 type ParameterManagerOptions struct {
+	// PathPrefix is the prefix path in the Parameter Store hierarchy. If set,
+	// all parameters should be stored under this prefix.
 	PathPrefix     string
 	CachingEnabled bool
 	SSMClient      SSMClient

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -1,9 +1,12 @@
 package parameterstore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 // This tests basic functionality in the Parameter Manager.
@@ -20,7 +23,16 @@ func TestParameterManager(t *testing.T) {
 		"PathPrefixWithLeadingAndTrailingSlash":   "/prefix/",
 	} {
 		t.Run(prefixTestCase, func(t *testing.T) {
-			pm := NewParameterManager(prefix, false, nil, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			opts := ParameterManagerOptions{
+				PathPrefix: prefix,
+				DB:         &mongo.Database{},
+			}
+			require.NoError(t, opts.Validate(ctx))
+			pm := &ParameterManager{
+				pathPrefix: opts.PathPrefix,
+			}
 			t.Run("GetPrefixedName", func(t *testing.T) {
 				t.Run("PrefixesBasename", func(t *testing.T) {
 					assert.Equal(t, "/prefix/basename", pm.getPrefixedName("basename"))

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -1,4 +1,3 @@
-//nolint:unused
 package parameterstore
 
 import (

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -49,7 +49,7 @@ type ssmClientImpl struct {
 // region.
 var configCache map[string]*aws.Config = make(map[string]*aws.Config)
 
-func NewSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
+func newSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -50,7 +50,7 @@ type ssmClientImpl struct {
 // region.
 var configCache map[string]*aws.Config = make(map[string]*aws.Config)
 
-func newSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
+func NewSSMClient(ctx context.Context, region string) (*ssmClientImpl, error) {
 	if region == "" {
 		region = "us-east-1"
 	}

--- a/environment.go
+++ b/environment.go
@@ -923,12 +923,16 @@ func (e *envState) initParameterManager(ctx context.Context, tracer trace.Tracer
 	ctx, span := tracer.Start(ctx, "InitParameterManager")
 	defer span.End()
 
-	c, err := parameterstore.NewSSMClient(ctx, DefaultEC2Region)
+	pm, err := parameterstore.NewParameterManager(ctx, parameterstore.ParameterManagerOptions{
+		PathPrefix:     e.settings.Providers.AWS.ParameterStore.Prefix,
+		CachingEnabled: true,
+		DB:             e.client.Database(e.dbName),
+	})
 	if err != nil {
-		return errors.Wrap(err, "initializing SSM client")
+		return errors.Wrap(err, "creating parameter manager")
 	}
+	e.paramMgr = pm
 
-	e.paramMgr = parameterstore.NewParameterManager(e.settings.Providers.AWS.ParameterStore.Prefix, true, c, e.DB())
 	return nil
 }
 

--- a/environment.go
+++ b/environment.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/evergreen-ci/certdepot"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
@@ -136,6 +137,10 @@ type Environment interface {
 	// commands. Every process has a manager service.
 	JasperManager() jasper.Manager
 	CertificateDepot() certdepot.Depot
+	// ParameterManager returns the parameter manager that stores sensitive
+	// secrets.
+	ParameterManager() *parameterstore.ParameterManager
+	SetParameterManager(pm *parameterstore.ParameterManager)
 
 	// ClientConfig provides access to a list of the latest evergreen
 	// clients, that this server can serve to users
@@ -180,17 +185,17 @@ type Environment interface {
 	BuildVersion() string
 }
 
-// NewEnvironment constructs an Environment instance, establishing a
-// new connection to the database, and creating a new set of worker
-// queues.
+// NewEnvironment constructs an Environment instance and initializes all
+// essential global state, including establishing a new connection to the
+// database and creating a new set of worker queues.
 //
 // When NewEnvironment returns without an error, you should assume
 // that the queues have been started, there was no issue
 // establishing a connection to the database, and that the
 // local and remote queues have started.
 //
-// NewEnvironment requires that either the path or DB is sent so that
-// if both are specified, the settings are read from the file.
+// NewEnvironment requires that either the path or DB is set. If both are
+// specified, the settings are read from the file.
 func NewEnvironment(ctx context.Context, confPath, versionID, clientS3Bucket string, db *DBSettings, tp trace.TracerProvider) (Environment, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	tracer := tp.Tracer("github.com/evergreen-ci/evergreen/evergreen")
@@ -239,6 +244,7 @@ func NewEnvironment(ctx context.Context, confPath, versionID, clientS3Bucket str
 
 	catcher.Add(e.initJasper(ctx, tracer))
 	catcher.Add(e.initDepot(ctx, tracer))
+	catcher.Add(e.initParameterManager(ctx, tracer))
 	catcher.Add(e.initThirdPartySenders(ctx, tracer))
 	catcher.Add(e.initClientConfig(ctx, versionID, clientS3Bucket, tracer))
 	catcher.Add(e.createLocalQueue(ctx, tracer))
@@ -263,6 +269,7 @@ type envState struct {
 	ctx                     context.Context
 	jasperManager           jasper.Manager
 	depot                   certdepot.Depot
+	paramMgr                *parameterstore.ParameterManager
 	settings                *Settings
 	dbName                  string
 	client                  *mongo.Client
@@ -912,6 +919,19 @@ func (e *envState) initDepot(ctx context.Context, tracer trace.Tracer) error {
 	return nil
 }
 
+func (e *envState) initParameterManager(ctx context.Context, tracer trace.Tracer) error {
+	ctx, span := tracer.Start(ctx, "InitParameterManager")
+	defer span.End()
+
+	c, err := parameterstore.NewSSMClient(ctx, DefaultEC2Region)
+	if err != nil {
+		return errors.Wrap(err, "initializing SSM client")
+	}
+
+	e.paramMgr = parameterstore.NewParameterManager(e.settings.Providers.AWS.ParameterStore.Prefix, true, c, e.DB())
+	return nil
+}
+
 func (e *envState) initTracer(ctx context.Context, useInternalDNS bool, tracer trace.Tracer) error {
 	ctx, span := tracer.Start(ctx, "InitTracer")
 	defer span.End()
@@ -1251,6 +1271,20 @@ func (e *envState) CertificateDepot() certdepot.Depot {
 	defer e.mu.RUnlock()
 
 	return e.depot
+}
+
+func (e *envState) SetParameterManager(pm *parameterstore.ParameterManager) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.paramMgr = pm
+}
+
+func (e *envState) ParameterManager() *parameterstore.ParameterManager {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.paramMgr
 }
 
 func (e *envState) RoleManager() gimlet.RoleManager {

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/evergreen-ci/certdepot"
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/gimlet/rolemanager"
@@ -35,6 +36,7 @@ type Environment struct {
 	JasperProcessManager    jasper.Manager
 	RemoteGroup             amboy.QueueGroup
 	Depot                   certdepot.Depot
+	ParamManager            *parameterstore.ParameterManager
 	Closers                 map[string]func(context.Context) error
 	DBSession               db.Session
 	EvergreenSettings       *evergreen.Settings
@@ -247,6 +249,20 @@ func (e *Environment) CertificateDepot() certdepot.Depot {
 	defer e.mu.RUnlock()
 
 	return e.Depot
+}
+
+func (e *Environment) SetParameterManager(pm *parameterstore.ParameterManager) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.ParamManager = pm
+}
+
+func (e *Environment) ParameterManager() *parameterstore.ParameterManager {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.ParamManager
 }
 
 func (e *Environment) Settings() *evergreen.Settings {

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -504,7 +504,7 @@ tasks:
     tags: ["db"]
     name: test-cloud
   - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test"]
+    tags: ["nodb", "test"]
     name: test-cloud-parameterstore
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]


### PR DESCRIPTION
DEVPROD-10392

### Description
* Make it so that other packages can use the parameter manager to interact with Parameter Store by exposing it in the global env.
* Slightly refactor parameter manager constructor to use options struct and use the real SSM client implementation by default.

### Testing
* Added unit tests.
* Existing tests still pass, even those that initialize a test environment (this initialization indirectly creates a parameter manager).

### Documentation
N/A
