### PR TITLE
DEVPROD-11203 Do not document the target field

### DIFF
--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -13,8 +13,11 @@ import (
 )
 
 type APISubscriber struct {
-	Type                *string                 `json:"type"`
-	Target              interface{}             `json:"target"`
+	Type *string `json:"type"`
+	// Target can be either a slice or a string. However, since swaggo does not
+	// support the OpenAPI `oneOf` keyword, we set `swaggerignore` and document
+	// the field manually in the "Fetch all projects" endpoint.
+	Target              interface{}             `json:"target" swaggerignore:"true"`
 	WebhookSubscriber   *APIWebhookSubscriber   `json:"-"`
 	JiraIssueSubscriber *APIJIRAIssueSubscriber `json:"-"`
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -43,7 +43,7 @@ func makeFetchProjectsRoute(url string) gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Fetch all projects
-//	@Description	Returns a paginated list of all projects. Any authenticated user can access this endpoint, so potentially sensitive information (variables, task annotation settings, workstation settings, and container secrets) is omitted.
+//	@Description	Returns a paginated list of all projects. Any authenticated user can access this endpoint, so potentially sensitive information (variables, task annotation settings, workstation settings, and container secrets) is omitted. subscriptions.subscriber.target is undocumented by the OpenAPI spec, and can be either a string or an object.
 //	@Tags			projects
 //	@Router			/projects [get]
 //	@Security		Api-User || Api-Key


### PR DESCRIPTION
DEVPROD-11203

### Description

The `Target` field can be either a slice or a string. However, since swaggo does not support the OpenAPI `oneOf` keyword, we set `swaggerignore` and document the field manually in the "Fetch all projects" endpoint.

### Testing

I generated swagger.json manually and checked that the field is missing.

### Documentation

Added to the "Fetch all projects" endpoint.