### PR TITLE
DEVPROD-11290: Fix logic for fetching task's imageID field

### DIFF
--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -439,7 +439,7 @@ func (r *taskResolver) ImageID(ctx context.Context, obj *restModel.APITask) (str
 	}
 	imageID, err := distro.GetImageIDFromDistro(ctx, utility.FromStringPtr(obj.DistroId))
 	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("error finding imageID from distro '%s': %s", utility.FromStringPtr(obj.DistroId), err.Error()))
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("finding imageID from distro '%s': %s", utility.FromStringPtr(obj.DistroId), err.Error()))
 	}
 	return imageID, nil
 }

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -433,15 +433,15 @@ func (r *taskResolver) GeneratedByName(ctx context.Context, obj *restModel.APITa
 
 // ImageID is the resolver for the imageId field.
 func (r *taskResolver) ImageID(ctx context.Context, obj *restModel.APITask) (string, error) {
-	// Display tasks don't have any associated distro information.
-	if obj.DisplayOnly {
+	// Don't try to look up image ID if there's no associated distro information.
+	if utility.FromStringPtr(obj.DistroId) == "" {
 		return "", nil
 	}
-	imageId, err := distro.GetImageIDFromDistro(ctx, *obj.DistroId)
+	imageID, err := distro.GetImageIDFromDistro(ctx, utility.FromStringPtr(obj.DistroId))
 	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("error finding imageID from distro: %s", err.Error()))
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("error finding imageID from distro '%s': %s", utility.FromStringPtr(obj.DistroId), err.Error()))
 	}
-	return imageId, nil
+	return imageID, nil
 }
 
 // IsPerfPluginEnabled is the resolver for the isPerfPluginEnabled field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -433,13 +433,14 @@ func (r *taskResolver) GeneratedByName(ctx context.Context, obj *restModel.APITa
 
 // ImageID is the resolver for the imageId field.
 func (r *taskResolver) ImageID(ctx context.Context, obj *restModel.APITask) (string, error) {
-	// Don't try to look up image ID if there's no associated distro information.
-	if utility.FromStringPtr(obj.DistroId) == "" {
+	distroID := utility.FromStringPtr(obj.DistroId)
+	// Don't try to look up image ID if the task has no associated distro.
+	if distroID == "" {
 		return "", nil
 	}
-	imageID, err := distro.GetImageIDFromDistro(ctx, utility.FromStringPtr(obj.DistroId))
+	imageID, err := distro.GetImageIDFromDistro(ctx, distroID)
 	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("finding imageID from distro '%s': %s", utility.FromStringPtr(obj.DistroId), err.Error()))
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("finding imageID from distro '%s': %s", distroID, err.Error()))
 	}
 	return imageID, nil
 }

--- a/graphql/tests/task/imageId/data.json
+++ b/graphql/tests/task/imageId/data.json
@@ -1,26 +1,31 @@
 {
-    "tasks": [
-      {
-        "_id": "task-1",
-        "distro": "ubuntu1604-large",
-        "branch": "spruce"
-      },
-      {
-        "_id": "display-task",
-        "branch": "spruce",
-        "display_only": true
-      }
-    ], 
-    "distro": [
-        {
-          "_id": "ubuntu1604-large",
-          "image_id": "ubuntu1604"
-        }
-    ],
-    "project_ref": [
-        {
-          "_id": "spruce",
-          "identifier": "spruce"
-        }
-    ]
-  }
+  "tasks": [
+    {
+      "_id": "regular-task",
+      "distro": "ubuntu1604-large",
+      "branch": "spruce"
+    },
+    {
+      "_id": "display-task",
+      "branch": "spruce",
+      "display_only": true
+    },
+    {
+      "_id": "container-task",
+      "branch": "spruce",
+      "container": "ubuntu1604-test"
+    }
+  ],
+  "distro": [
+    {
+      "_id": "ubuntu1604-large",
+      "image_id": "ubuntu1604"
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ]
+}

--- a/graphql/tests/task/imageId/data.json
+++ b/graphql/tests/task/imageId/data.json
@@ -13,7 +13,7 @@
     {
       "_id": "container-task",
       "branch": "spruce",
-      "container": "ubuntu1604-test"
+      "container": "ubuntu1604-container"
     }
   ],
   "distro": [

--- a/graphql/tests/task/imageId/queries/container_task.graphql
+++ b/graphql/tests/task/imageId/queries/container_task.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "container-task") {
+    imageId
+  }
+}

--- a/graphql/tests/task/imageId/queries/regular_task.graphql
+++ b/graphql/tests/task/imageId/queries/regular_task.graphql
@@ -1,5 +1,5 @@
 {
-  task(taskId: "task-1") {
+  task(taskId: "regular-task") {
     imageId
   }
 }

--- a/graphql/tests/task/imageId/results.json
+++ b/graphql/tests/task/imageId/results.json
@@ -1,24 +1,34 @@
 {
-    "tests": [
-      {
-        "query_file": "regular_task.graphql",
-        "result": {
-          "data": {
-            "task": {
-              "imageId": "ubuntu1604"
-            }
-          }
-        }
-      },
-      {
-        "query_file": "display_task.graphql",
-        "result": {
-          "data": {
-            "task": {
-              "imageId": ""
-            }
+  "tests": [
+    {
+      "query_file": "regular_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "imageId": "ubuntu1604"
           }
         }
       }
-    ]
-  }
+    },
+    {
+      "query_file": "display_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "imageId": ""
+          }
+        }
+      }
+    },
+    {
+      "query_file": "container_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "imageId": ""
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
DEVPROD-11290

### Description
The `ImageID` resolver requires the existence of `DistroID`. I thought I had covered everything by checking for display tasks, but I missed container tasks. I decided to just make this resolver a bit more broad and allow it to return an empty string if `DistroID` is not defined.

### Testing
- Added GraphQL tests