### PR TITLE
DEVPROD-11303 Add empty bannertheme

### DIFF
--- a/config.go
+++ b/config.go
@@ -725,6 +725,7 @@ const (
 	Information  BannerTheme = "INFORMATION"
 	Warning      BannerTheme = "WARNING"
 	Important    BannerTheme = "IMPORTANT"
+	Empty        BannerTheme = ""
 )
 
 func IsValidBannerTheme(input string) (bool, BannerTheme) {


### PR DESCRIPTION
DEVPROD-11303

### Description

`IsValidBannerTheme` supports empty banner themes, and there are existing empty banner themes. A team is attempting to use Evergreen's OpenAPI spec, and the missing empty enum value is causing errors. This PR adds that as a legal value.

### Testing

Existing tests should cover this. I validated by hand that the swagger.json generated by `make swaggo` looks correct.

### Documentation

N/A