### PR TITLE
DEVPROD-9401: set up parameter manager for testing

### DIFF
--- a/cloud/parameterstore/fakeparameter/parameter_record_db_test.go
+++ b/cloud/parameterstore/fakeparameter/parameter_record_db_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,8 +22,8 @@ func TestBumpParameterRecord(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(parameterstore.Collection))
 	}()
 
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment){
-		"CreatesNewParameterRecord": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment){
+		"CreatesNewParameterRecord": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			const name = "name"
 			lastUpdated := utility.BSONTime(time.Now())
 			require.NoError(t, parameterstore.BumpParameterRecord(ctx, env.DB(), name, lastUpdated))
@@ -33,7 +33,7 @@ func TestBumpParameterRecord(t *testing.T) {
 			assert.Equal(t, name, rec.Name)
 			assert.Equal(t, lastUpdated, rec.LastUpdated)
 		},
-		"UpdatesExistingParameterRecord": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+		"UpdatesExistingParameterRecord": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			const name = "name"
 			lastUpdated := utility.BSONTime(time.Now())
 			originalRec := parameterstore.ParameterRecord{
@@ -49,7 +49,7 @@ func TestBumpParameterRecord(t *testing.T) {
 			assert.Equal(t, name, rec.Name)
 			assert.Equal(t, lastUpdated, rec.LastUpdated, "last updated time should have been updated")
 		},
-		"DoesNotBumpNewerParameterRecord": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+		"DoesNotBumpNewerParameterRecord": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			const name = "name"
 			lastUpdated := utility.BSONTime(time.Now())
 			originalRec := parameterstore.ParameterRecord{
@@ -72,10 +72,7 @@ func TestBumpParameterRecord(t *testing.T) {
 
 			require.NoError(t, db.ClearCollections(parameterstore.Collection))
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			tCase(ctx, t, env)
+			tCase(ctx, t, evergreen.GetEnvironment())
 		})
 	}
 }
@@ -85,13 +82,13 @@ func TestParameterRecordFindOneName(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(parameterstore.Collection))
 	}()
 
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment){
-		"ReturnsNilWhenNotFound": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment){
+		"ReturnsNilWhenNotFound": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			rec, err := parameterstore.FindOneName(ctx, env.DB(), "nonexistent")
 			assert.NoError(t, err)
 			assert.Zero(t, rec)
 		},
-		"ReturnsFoundRecord": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+		"ReturnsFoundRecord": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			const name = "name"
 			expectedRec := parameterstore.ParameterRecord{
 				Name:        name,
@@ -109,10 +106,7 @@ func TestParameterRecordFindOneName(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			tCase(ctx, t, env)
+			tCase(ctx, t, evergreen.GetEnvironment())
 		})
 	}
 }
@@ -122,13 +116,13 @@ func TestParameterRecordFindByNames(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(parameterstore.Collection))
 	}()
 
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment){
-		"ReturnsNoResultsWhenNotFound": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env evergreen.Environment){
+		"ReturnsNoResultsWhenNotFound": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			foundParams, err := parameterstore.FindByNames(ctx, env.DB(), "nonexistent0", "nonexistent1")
 			assert.NoError(t, err)
 			assert.Empty(t, foundParams)
 		},
-		"ReturnsPartiallyFoundRecords": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+		"ReturnsPartiallyFoundRecords": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			const name = "name"
 			expectedRec := parameterstore.ParameterRecord{
 				Name:        name,
@@ -141,7 +135,7 @@ func TestParameterRecordFindByNames(t *testing.T) {
 			require.Len(t, recs, 1)
 			assert.Equal(t, expectedRec, recs[0])
 		},
-		"ReturnsNoResultsForNoNames": func(ctx context.Context, t *testing.T, env *mock.Environment) {
+		"ReturnsNoResultsForNoNames": func(ctx context.Context, t *testing.T, env evergreen.Environment) {
 			recs, err := parameterstore.FindByNames(ctx, env.DB())
 			assert.NoError(t, err)
 			assert.Empty(t, recs)
@@ -151,10 +145,7 @@ func TestParameterRecordFindByNames(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			tCase(ctx, t, env)
+			tCase(ctx, t, evergreen.GetEnvironment())
 		})
 	}
 }

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -340,5 +340,5 @@ type DockerConfig struct {
 // ParameterStoreConfig stores configuration for using SSM Parameter Store.
 type ParameterStoreConfig struct {
 	// Prefix is the Parameter Store path prefix for the Evergreen application.
-	Prefix string
+	Prefix string `bson:"prefix" json:"prefix" yaml:"prefix"`
 }

--- a/config_test/evg_settings.yml
+++ b/config_test/evg_settings.yml
@@ -45,6 +45,8 @@ providers:
         client_type: "mock"
       secrets_manager:
         client_type: "mock"
+    parameter_store:
+      prefix: "/evg-test"
   docker:
     api_version: 1.32
 

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
@@ -57,6 +59,15 @@ func Setup() {
 func NewEnvironment(ctx context.Context, t *testing.T) evergreen.Environment {
 	env, err := evergreen.NewEnvironment(ctx, filepath.Join(evergreen.FindEvergreenHome(), TestDir, TestSettings), "", "", nil, noop.NewTracerProvider())
 	require.NoError(t, err)
+	// For testing purposes, set up parameter manager so it's backed by the DB.
+	pm, err := parameterstore.NewParameterManager(ctx, parameterstore.ParameterManagerOptions{
+		PathPrefix:     env.Settings().Providers.AWS.ParameterStore.Prefix,
+		CachingEnabled: true,
+		SSMClient:      fakeparameter.NewFakeSSMClient(),
+		DB:             env.DB(),
+	})
+	require.NoError(t, err)
+	env.SetParameterManager(pm)
 	return env
 }
 


### PR DESCRIPTION
DEVPROD-9401

### Description
* Ensure testing environments use the fake Parameter Store implementation backed by the DB rather than actually using SSM Parameter Store. This will let us test functionality that uses parameters without relying on an external service for every single parameter-related functionality.
* Add some forgotten struct tags to the Parameter Store admin settings.

### Testing
Existing tests still run (which implicitly sets up the fake Parameter Store).

### Documentation
N/A