### PR TITLE
DEVPROD-4971 Document that display task's execution task array can be tag or task name

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -984,7 +984,7 @@ tasks.
 
 To create a display task, list its name and its execution tasks in a
 `display_tasks` array in the variant definition. The execution tasks
-must be present in the `tasks` array.
+must be present in the `tasks` array in the form of a tag or task name.
 
 ``` yaml
 - name: lint-variant
@@ -993,10 +993,12 @@ must be present in the `tasks` array.
     - archlinux
   tasks:
     - name: ".lint"
+    - name: "lint-task"
   display_tasks:
     - name: lint
       execution_tasks:
       - ".lint"
+      - "lint-task
 ```
 
 ### Stepback


### PR DESCRIPTION
DEVPROD-4971

### Documentation
We already use a tag in the docs but we don't state explicitly that the 'execution_tasks' array can be a tag or task name. This adds a task name to it and explicitly says it