### PR TITLE
DEVPROD-9944 Add temporary feature flag for ec2.assume_role migration

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -54,7 +54,7 @@ func (r *ec2AssumeRole) validate() error {
 	catcher := grip.NewSimpleCatcher()
 
 	catcher.NewWhen(r.RoleARN == "", "must specify role ARN")
-	// 0 will default duration time to 15 minutes
+	// 0 will default duration time to 15 minutes.
 	catcher.NewWhen(r.DurationSeconds < 0, "cannot specify a non-positive duration")
 
 	return catcher.Resolve()
@@ -71,19 +71,20 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 	}
 
 	if r.TemporaryFeatureFlag {
-		return r.newExecution(ctx, comm, logger, conf)
+		return r.execute(ctx, comm, logger, conf)
 	}
 
 	return r.legacyExecute(ctx, comm, logger, conf)
 }
 
-func (r *ec2AssumeRole) newExecution(ctx context.Context,
+func (r *ec2AssumeRole) execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
-	// TODO (DEVPROD-9945): Migration to new implementation
+	// TODO (DEVPROD-9945): Migration to new implementation.
 	return errors.New("temporary feature flag is enabled")
 }
 
 func (r *ec2AssumeRole) legacyExecute(ctx context.Context,
+	// TODO (DEVPROD-9945): Remove this.
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	if len(conf.EC2Keys) == 0 {
 		return errors.New("no EC2 keys in config")

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-10"
+	AgentVersion = "2024-09-13"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-9944

### Description
This adds a temporary feature flag to the ec2.assume_role project command to support the migration from calling AWS on the agent --> calling AWS on the app servers.

### Testing
Staging tasks [here](https://spruce-staging.corp.mongodb.com/version/66e486db04ee5100070f7e2c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). Using config:

```yaml
tasks:
    - name: assume_role_legacy
      commands:
          - command: ec2.assume_role
            params:
                role_arn: ${AWS_ASSUME_ROLE_ARN}
    - name: assume_role_feature_flag
      commands:
          - command: ec2.assume_role
            params:
                role_arn: ${AWS_ASSUME_ROLE_ARN}
                temporary_feature_flag: true
```

The legacy task errors from an invalid ARN, while the feature one errors as expected stating it is the feature flag one.

Unit tests were refactored, since before we couldn't emulate the AWS logic since it was a hard dependency, while with the new implementation, a mock would be via the communicator.