### PR TITLE
DEVPROD-10099 Return 500 error for next task run request errors

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -202,7 +202,7 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		// assign the task to a host and retrieve the task
 		nextTask, shouldRunTeardown, err = assignNextAvailableTask(ctx, h.env, taskQueue, h.taskDispatcher, h.host, h.details)
 		if err != nil {
-			return gimlet.MakeJSONErrorResponder(err)
+			return gimlet.MakeJSONInternalErrorResponder(err)
 		}
 	}
 
@@ -219,7 +219,7 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		if secondaryQueue != nil {
 			nextTask, shouldRunTeardown, err = assignNextAvailableTask(ctx, h.env, secondaryQueue, h.taskAliasDispatcher, h.host, h.details)
 			if err != nil {
-				return gimlet.MakeJSONErrorResponder(err)
+				return gimlet.MakeJSONInternalErrorResponder(err)
 			}
 		}
 	}
@@ -236,7 +236,7 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 			})
 			err = h.host.SetTaskGroupTeardownStartTime(ctx)
 			if err != nil {
-				return gimlet.MakeJSONErrorResponder(err)
+				return gimlet.MakeJSONInternalErrorResponder(err)
 			}
 			nextTaskResponse.ShouldTeardownGroup = true
 		} else {


### PR DESCRIPTION
DEVPROD-10099

### Description
Correctly return 500 errors for the selected next task errors so they show up in the gimlet error logs.
### Testing
Existing tests