### PR TITLE
DEVPROD-9738: Surface the command that set the user defined task failure status

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1179,10 +1179,15 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 	detail.Status = status
 	detail.Description = description
 	if status != evergreen.TaskSucceeded {
-		detail.FailingCommand = currCmd.FullDisplayName()
+		if tc.userEndTaskRespOriginatingCommand != nil {
+			detail.FailingCommand = (*tc.userEndTaskRespOriginatingCommand).FullDisplayName()
+			tc.setFailingCommand(*tc.userEndTaskRespOriginatingCommand)
+		} else {
+			detail.FailingCommand = currCmd.FullDisplayName()
+			tc.setFailingCommand(currCmd)
+		}
 		detail.Type = failureType
 		detail.FailureMetadataTags = utility.UniqueStrings(append(currCmd.FailureMetadataTags(), failureMetadataTagsToAdd...))
-		tc.setFailingCommand(currCmd)
 	}
 
 	detail.OtherFailingCommands = tc.getOtherFailingCommands()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1180,8 +1180,8 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 	detail.Description = description
 	if status != evergreen.TaskSucceeded {
 		if tc.userEndTaskRespOriginatingCommand != nil {
-			detail.FailingCommand = (*tc.userEndTaskRespOriginatingCommand).FullDisplayName()
-			tc.setFailingCommand(*tc.userEndTaskRespOriginatingCommand)
+			detail.FailingCommand = tc.userEndTaskRespOriginatingCommand.FullDisplayName()
+			tc.setFailingCommand(tc.userEndTaskRespOriginatingCommand)
 		} else {
 			detail.FailingCommand = currCmd.FullDisplayName()
 			tc.setFailingCommand(currCmd)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1819,7 +1819,11 @@ tasks:
 		Description:            "task failed",
 		AddFailureMetadataTags: []string{"failure_tag0", "failure_tag1", "failure_tag2"},
 	}
+
+	s.Nil(s.tc.userEndTaskResp)
 	s.tc.setUserEndTaskResponse(resp)
+	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
+	s.Equal((*s.tc.userEndTaskRespOriginatingCommand).FullDisplayName(), "initial task setup")
 
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
@@ -1831,8 +1835,6 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
-	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
-	s.Equal((*s.tc.userEndTaskRespOriginatingCommand).FullDisplayName(), "initial task setup")
 	s.ElementsMatch([]string{"failure_tag0", "failure_tag1", "failure_tag2"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set the failing command's metadata tags along with the additional tags")
 
 	s.NoError(s.tc.logger.Close())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1245,8 +1245,8 @@ func (s *AgentSuite) TestEndTaskResponse() {
 		}
 		factory, ok := command.GetCommandFactory("command.mock")
 		s.Require().True(ok)
-		command := factory()
-		s.tc.userEndTaskRespOriginatingCommand = &command
+		cmd := factory()
+		s.tc.userEndTaskRespOriginatingCommand = cmd
 		defer func() {
 			s.tc.userEndTaskResp = nil
 			s.tc.userEndTaskRespOriginatingCommand = nil
@@ -1254,7 +1254,7 @@ func (s *AgentSuite) TestEndTaskResponse() {
 		detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskSucceeded, systemFailureDescription)
 		s.Equal(s.tc.userEndTaskResp.Status, detail.Status)
 		s.Equal(s.tc.userEndTaskResp.Description, detail.Description)
-		s.Equal(detail.FailingCommand, command.FullDisplayName())
+		s.Equal(detail.FailingCommand, cmd.FullDisplayName())
 	})
 	s.T().Run("TaskHitsIdleTimeoutAndFailsResultsInFailureWithTimeout", func(t *testing.T) {
 		s.tc.setTimedOut(true, globals.IdleTimeout)
@@ -1829,7 +1829,7 @@ tasks:
 	s.Nil(s.tc.userEndTaskResp)
 	s.tc.setUserEndTaskResponse(resp)
 	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
-	s.Equal((*s.tc.userEndTaskRespOriginatingCommand).FullDisplayName(), "initial task setup")
+	s.Equal(s.tc.userEndTaskRespOriginatingCommand.FullDisplayName(), "initial task setup")
 
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1831,6 +1831,8 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
+	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
+	s.Equal((*s.tc.userEndTaskRespOriginatingCommand).FullDisplayName(), "initial task setup")
 	s.ElementsMatch([]string{"failure_tag0", "failure_tag1", "failure_tag2"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set the failing command's metadata tags along with the additional tags")
 
 	s.NoError(s.tc.logger.Close())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1831,6 +1831,11 @@ tasks:
 	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
 	s.Equal(s.tc.userEndTaskRespOriginatingCommand.FullDisplayName(), "initial task setup")
 
+	// Set the current command to show that the command containing the user-defined resp has precedence.
+	factory, ok := command.GetCommandFactory("command.mock")
+	s.Require().True(ok)
+	s.tc.setCurrentCommand(factory())
+
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
 		TaskSecret: s.tc.task.Secret,
@@ -1841,6 +1846,7 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
+	s.Equal("initial task setup", s.mockCommunicator.EndTaskResult.Detail.FailingCommand, "should set the failing command's display name to the user-defined resp's originating command")
 	s.ElementsMatch([]string{"failure_tag0", "failure_tag1", "failure_tag2"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set the failing command's metadata tags along with the additional tags")
 
 	s.NoError(s.tc.logger.Close())

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1829,7 +1829,7 @@ tasks:
 	s.Nil(s.tc.userEndTaskResp)
 	s.tc.setUserEndTaskResponse(resp)
 	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
-	s.Equal(s.tc.userEndTaskRespOriginatingCommand.FullDisplayName(), "initial task setup")
+	s.Equal("initial task setup", s.tc.userEndTaskRespOriginatingCommand.FullDisplayName())
 
 	// Set the current command to show that the command containing the user-defined resp has precedence.
 	factory, ok := command.GetCommandFactory("command.mock")

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -51,7 +51,7 @@ type taskContext struct {
 	// userEndTaskResp is the end task response that the user can define, which
 	// will overwrite the default end task response.
 	userEndTaskResp                   *triggerEndTaskResp
-	userEndTaskRespOriginatingCommand *command.Command
+	userEndTaskRespOriginatingCommand command.Command
 	sync.RWMutex
 }
 
@@ -609,8 +609,7 @@ func (tc *taskContext) setUserEndTaskResponse(resp *triggerEndTaskResp) {
 	defer tc.Unlock()
 
 	tc.userEndTaskResp = resp
-	currCmd := tc.currentCommand
-	tc.userEndTaskRespOriginatingCommand = &currCmd
+	tc.userEndTaskRespOriginatingCommand = tc.currentCommand
 }
 
 // getUserEndTaskResponse gets the user-defined end task response data.

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -50,7 +50,8 @@ type taskContext struct {
 	setupGroupCleanups []internal.CommandCleanup
 	// userEndTaskResp is the end task response that the user can define, which
 	// will overwrite the default end task response.
-	userEndTaskResp *triggerEndTaskResp
+	userEndTaskResp                   *triggerEndTaskResp
+	userEndTaskRespOriginatingCommand *command.Command
 	sync.RWMutex
 }
 
@@ -608,6 +609,8 @@ func (tc *taskContext) setUserEndTaskResponse(resp *triggerEndTaskResp) {
 	defer tc.Unlock()
 
 	tc.userEndTaskResp = resp
+	currCmd := tc.currentCommand
+	tc.userEndTaskRespOriginatingCommand = &currCmd
 }
 
 // getUserEndTaskResponse gets the user-defined end task response data.

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-10"
+	AgentVersion = "2024-09-16"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-9738

### Description
Currently, tasks that report a failed status with the task_status API endpoint misrepresent the command that set the failure by always saving the last command ran. These code change take into the current command when the user defined task end response is processed.
