### PR TITLE
DEVPROD-11385 OTel process counters

### DIFF
--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -1,13 +1,19 @@
 package agent
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -120,5 +126,71 @@ func TestBatchSpans(t *testing.T) {
 				assert.Len(t, batch, testCase.spansLen/testCase.batchSize)
 			}
 		})
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for testName, testCase := range map[string]func(t *testing.T, meter metric.Meter, reader sdk.Reader){
+		"CPUMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addCPUMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
+			assert.Equal(t, fmt.Sprintf("%s.idle", cpuTimeInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints[0].Value)
+
+			assert.Equal(t, cpuUtilInstrument, metrics.ScopeMetrics[0].Metrics[5].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints[0].Value)
+		},
+		"MemoryMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addMemoryMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 3)
+			assert.Equal(t, fmt.Sprintf("%s.available", memoryUsageInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"DiskMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addDiskMetrics(ctx, meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics)
+			assert.Regexp(t, `system\.disk\.io\.\w+\.read`, metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"NetworkMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addNetworkMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 2)
+			assert.Equal(t, fmt.Sprintf("%s.transmit", networkIOInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"ProcessMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addProcessMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 4)
+			assert.Equal(t, fmt.Sprintf("%s.sleeping", processCountPrefix), metrics.ScopeMetrics[0].Metrics[1].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+	} {
+		reader := sdk.NewManualReader()
+		meter := sdk.NewMeterProvider(sdk.WithReader(reader)).Meter(packageName)
+		t.Run(testName, func(t *testing.T) { testCase(t, meter, reader) })
 	}
 }

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-13"
+	AgentVersion = "2024-09-16"
 )
 
 const (


### PR DESCRIPTION
[DEVPROD-11385](https://jira.mongodb.org/browse/DEVPROD-11385)

### Description
In https://github.com/evergreen-ci/evergreen/pull/8303 it was raised that we don't have visibility into the number of processes that are running. This PR adds process counts in accordance with the spec [here](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/#metric-systemprocesscount).

### Testing
[Works on staging](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/jWZ9Bkkmztq?omitMissingValues)™️ 
