### PR TITLE
Docs: alowed organizations

### DIFF
--- a/docs/Project-Configuration/Create-a-Project.md
+++ b/docs/Project-Configuration/Create-a-Project.md
@@ -14,7 +14,8 @@ Note that that projects can only be created in spruce as it has been deprecated 
 ![create_project_modal.png](../images/create_project_modal.png)
 1. Visit the projects page in the new UI https://spruce.mongodb.com/projects/.
 2. Click New Project. If you want to copy the current project, click Duplicate Current Project. Otherwise, click Create New Project.
-3. Enter the project name, repo org ("Owner"), and repo name ("Repo").
+3. Enter the project name, repo org ("Owner"), and repo name ("Repo"). Note that only creating projects that track
+MongoDB owned organizations is supported.
 4. **Do not set a Project ID unless you want to use the performance plugin.**
 5. If this project needs AWS credentials for S3 bucket access, click the check mark to open a JIRA ticket. (You should see the JIRA ticket under "reported by me.")
 6. Click "Create New Project".


### PR DESCRIPTION
### Documentation
There was a recent users thread where the question came up if it's allowed to create projects that track repos external to the company. The answer is no, so documenting that in the create project docs.