### PR TITLE
DEVPROD-7739: auto-quarantine and alert for static hosts

### DIFF
--- a/api/host.go
+++ b/api/host.go
@@ -100,6 +100,9 @@ func ModifyHostStatus(ctx context.Context, env evergreen.Environment, h *host.Ho
 	}
 
 	if newStatus == evergreen.HostQuarantined {
+		if notes == "" {
+			notes = fmt.Sprintf("quarantined by user '%s'", u.Username())
+		}
 		if err := units.DisableAndNotifyPoisonedHost(ctx, env, h, false, notes); err != nil {
 			return "", http.StatusInternalServerError, errors.Wrap(err, HostUpdateError)
 		}

--- a/config_jira.go
+++ b/config_jira.go
@@ -14,7 +14,6 @@ type JiraConfig struct {
 	Host            string              `yaml:"host" bson:"host" json:"host"`
 	BasicAuthConfig JiraBasicAuthConfig `yaml:"basic_auth" bson:"basic_auth" json:"basic_auth"`
 	OAuth1Config    JiraOAuth1Config    `yaml:"oauth1" bson:"oauth1" json:"oauth1"`
-	DefaultProject  string              `yaml:"default_project" bson:"default_project" json:"default_project"`
 	Email           string              `yaml:"email" bson:"email" json:"email"`
 }
 
@@ -39,11 +38,10 @@ func (c *JiraConfig) Get(ctx context.Context) error {
 func (c *JiraConfig) Set(ctx context.Context) error {
 	return errors.Wrapf(setConfigSection(ctx, c.SectionId(), bson.M{
 		"$set": bson.M{
-			"host":            c.Host,
-			"basic_auth":      c.BasicAuthConfig,
-			"oauth1":          c.OAuth1Config,
-			"default_project": c.DefaultProject,
-			"email":           c.Email,
+			"host":       c.Host,
+			"basic_auth": c.BasicAuthConfig,
+			"oauth1":     c.OAuth1Config,
+			"email":      c.Email,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -325,8 +325,7 @@ func (s *AdminSuite) TestJiraConfig() {
 			PrivateKey:  "asdf",
 			AccessToken: "fdsa",
 		},
-		DefaultProject: "proj",
-		Email:          "a@mail.com",
+		Email: "a@mail.com",
 	}
 
 	err := config.Set(ctx)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -956,7 +956,6 @@ func (a *APIJiraConfig) BuildFromService(h interface{}) error {
 	switch v := h.(type) {
 	case evergreen.JiraConfig:
 		a.Host = utility.ToStringPtr(v.Host)
-		a.DefaultProject = utility.ToStringPtr(v.DefaultProject)
 		a.Email = utility.ToStringPtr(v.Email)
 		a.BasicAuthConfig = &APIJiraBasicAuth{}
 		a.BasicAuthConfig.BuildFromService(v.BasicAuthConfig)
@@ -970,9 +969,8 @@ func (a *APIJiraConfig) BuildFromService(h interface{}) error {
 
 func (a *APIJiraConfig) ToService() (interface{}, error) {
 	c := evergreen.JiraConfig{
-		Host:           utility.FromStringPtr(a.Host),
-		DefaultProject: utility.FromStringPtr(a.DefaultProject),
-		Email:          utility.FromStringPtr(a.Email),
+		Host:  utility.FromStringPtr(a.Host),
+		Email: utility.FromStringPtr(a.Email),
 	}
 	if a.BasicAuthConfig != nil {
 		c.BasicAuthConfig = a.BasicAuthConfig.ToService()

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -84,7 +84,7 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 		case evergreen.HostTerminated:
 			err = errors.WithStack(cloud.TerminateSpawnHost(ctx, evergreen.GetEnvironment(), foundHost, user.Id, "terminated via REST API"))
 		case evergreen.HostQuarantined:
-			err = units.DisableAndNotifyPoisonedHost(ctx, evergreen.GetEnvironment(), foundHost, false, "quarantined via REST API")
+			err = units.DisableAndNotifyPoisonedHost(ctx, evergreen.GetEnvironment(), foundHost, false, fmt.Sprintf("quarantined via REST API by user '%s'", user.Id))
 		default:
 			err = foundHost.SetStatus(ctx, status.Status, user.Id, fmt.Sprintf("changed by %s from API", user.Id))
 		}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1241,7 +1241,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	// Disable hosts and prevent them from performing more work if they have
 	// system failed many tasks in a row.
 	if event.AllRecentHostEventsMatchStatus(ctx, currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
-		msg := "host encountered consecutive system failures"
+		msg := fmt.Sprintf("host encountered %d consecutive system failures", consecutiveSystemFailureThreshold)
 		grip.Error(message.WrapError(units.HandlePoisonedHost(ctx, h.env, currentHost, msg), message.Fields{
 			"message": "unable to disable poisoned host",
 			"host":    currentHost.Id,

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1241,10 +1241,6 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	// Disable hosts and prevent them from performing more work if they have
 	// system failed many tasks in a row.
 	if event.AllRecentHostEventsMatchStatus(ctx, currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
-		// kim: TODO: add test to verify that this quarantines the host after
-		// the task is marked system-failed. Need to simulate the host event
-		// log, possibly by looking at what a real static host event log looks
-		// like.
 		msg := "host encountered consecutive system failures"
 		grip.Error(message.WrapError(units.HandlePoisonedHost(ctx, h.env, currentHost, msg), message.Fields{
 			"message": "unable to disable poisoned host",

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1213,8 +1213,8 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 	// the active state should be inactive.
 	if h.details.Status == evergreen.TaskUndispatched {
 		if t.Activated {
-			grip.Warningf("task %s is active and undispatched after being marked as finished", t.Id)
-			return gimlet.NewJSONResponse(struct{}{})
+			grip.Warningf("task '%s' is active and undispatched after being marked as finished", t.Id)
+			return gimlet.NewJSONResponse(&apimodels.EndTaskResponse{})
 		}
 		abortMsg := fmt.Sprintf("task '%s' has been aborted and will not run", t.Id)
 		grip.Infof(abortMsg)

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -92,13 +92,13 @@ func TestHostNextTask(t *testing.T) {
 		"ShouldSucceedAndSetAgentStartTime": func(ctx context.Context, t *testing.T, rh *hostAgentNextTask) {
 			resp := rh.Run(ctx)
 			assert.NotNil(t, resp)
-			assert.Equal(t, resp.Status(), http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.Status())
 			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 			require.True(t, ok, resp.Data())
 			assert.NotNil(t, taskResp)
 			assert.Equal(t, "task1", taskResp.TaskId)
 			assert.Equal(t, 5, taskResp.TaskExecution)
-			nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
+			nextTask, err := task.FindOneId(taskResp.TaskId)
 			require.NoError(t, err)
 			require.NotNil(t, nextTask)
 			assert.Equal(t, nextTask.Status, evergreen.TaskDispatched)
@@ -120,7 +120,7 @@ func TestHostNextTask(t *testing.T) {
 			resp := rh.Run(ctx)
 			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 			require.True(t, ok, resp.Data())
-			assert.Equal(t, resp.Status(), http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.Status())
 			assert.False(t, taskResp.ShouldExit)
 		},
 		"SetsAndUnsetsIsTearingDown": func(ctx context.Context, t *testing.T, rh *hostAgentNextTask) {
@@ -132,7 +132,7 @@ func TestHostNextTask(t *testing.T) {
 			resp := rh.Run(ctx)
 			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 			require.True(t, ok, resp.Data())
-			assert.Equal(t, resp.Status(), http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.Status())
 			assert.False(t, taskResp.ShouldExit)
 			assert.True(t, taskResp.ShouldTeardownGroup)
 
@@ -146,7 +146,7 @@ func TestHostNextTask(t *testing.T) {
 			resp = rh.Run(ctx)
 			taskResp, ok = resp.Data().(apimodels.NextTaskResponse)
 			require.True(t, ok, resp.Data())
-			assert.Equal(t, resp.Status(), http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.Status())
 			assert.False(t, taskResp.ShouldExit)
 			assert.False(t, taskResp.ShouldTeardownGroup)
 
@@ -166,7 +166,7 @@ func TestHostNextTask(t *testing.T) {
 					rh.host = h
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
@@ -193,7 +193,7 @@ func TestHostNextTask(t *testing.T) {
 					rh.taskDispatcher = model.NewTaskDispatchService(time.Hour)
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
@@ -270,7 +270,7 @@ func TestHostNextTask(t *testing.T) {
 				rh.host = &nonLegacyHost
 				resp := rh.Run(ctx)
 				assert.NotNil(t, resp)
-				assert.Equal(t, resp.Status(), http.StatusOK)
+				assert.Equal(t, http.StatusOK, resp.Status())
 				taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 				require.True(t, ok, resp.Data())
 				assert.True(t, taskResp.ShouldExit)
@@ -296,7 +296,7 @@ func TestHostNextTask(t *testing.T) {
 			resp := rh.Run(ctx)
 
 			assert.NotNil(t, resp)
-			assert.Equal(t, resp.Status(), http.StatusOK)
+			assert.Equal(t, http.StatusOK, resp.Status())
 			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 			require.True(t, ok, resp.Data())
 			assert.True(t, taskResp.ShouldExit)
@@ -348,7 +348,7 @@ func TestHostNextTask(t *testing.T) {
 					rh.host = nonLegacyHost
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					resp := rh.Run(ctx)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
 					assert.False(t, taskResp.ShouldExit)
@@ -406,12 +406,12 @@ func TestHostNextTask(t *testing.T) {
 					rh.host = h2
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
 					assert.Equal(t, "existingTask", taskResp.TaskId)
 					assert.Equal(t, 8, taskResp.TaskExecution)
-					nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
+					nextTask, err := task.FindOneId(taskResp.TaskId)
 					require.NoError(t, err)
 					require.NotZero(t, nextTask)
 					assert.Equal(t, nextTask.Status, evergreen.TaskDispatched)
@@ -444,12 +444,13 @@ func TestHostNextTask(t *testing.T) {
 					assert.NotNil(t, resp)
 					assert.Equal(t, resp.Status(), http.StatusInternalServerError)
 
-					h, err := host.FindOne(ctx, host.ById(anotherHost.Id))
+					h, err := host.FindOneId(ctx, anotherHost.Id)
 					require.NoError(t, err)
 					assert.Equal(t, h.RunningTask, "")
 
-					previouslyStuckTask, err := task.FindOne(db.Query(task.ById(stuckTask.Id)))
+					previouslyStuckTask, err := task.FindOneId(stuckTask.Id)
 					require.NoError(t, err)
+					require.NotZero(t, previouslyStuckTask)
 					assert.Equal(t, previouslyStuckTask.Status, evergreen.TaskFailed)
 
 				},
@@ -476,11 +477,11 @@ func TestHostNextTask(t *testing.T) {
 					rh.host = &anotherHost
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
 					assert.Equal(t, taskResp.TaskId, t1.Id)
-					nextTask, err := task.FindOne(db.Query(task.ById(taskResp.TaskId)))
+					nextTask, err := task.FindOneId(taskResp.TaskId)
 					require.NoError(t, err)
 					require.NotZero(t, nextTask)
 					assert.Equal(t, nextTask.Status, evergreen.TaskDispatched)
@@ -505,10 +506,10 @@ func TestHostNextTask(t *testing.T) {
 					rh.host = &h3
 					resp = rh.Run(ctx)
 					assert.NotNil(t, resp)
-					assert.Equal(t, resp.Status(), http.StatusOK)
+					assert.Equal(t, http.StatusOK, resp.Status())
 					taskResp = resp.Data().(apimodels.NextTaskResponse)
 					assert.Equal(t, "", taskResp.TaskId)
-					h, err := host.FindOne(ctx, host.ById(h3.Id))
+					h, err := host.FindOneId(ctx, h3.Id)
 					require.NoError(t, err)
 					require.NotZero(t, h)
 					assert.Equal(t, "", h.RunningTask)
@@ -554,8 +555,9 @@ func TestHostNextTask(t *testing.T) {
 			require.NoError(t, newServiceFlags.Set(ctx))
 			resp := rh.Run(ctx)
 			assert.NotNil(t, resp)
-			assert.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := resp.Data().(apimodels.NextTaskResponse)
+			assert.Equal(t, http.StatusOK, resp.Status())
+			taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
+			require.True(t, ok)
 			assert.NotNil(t, taskResp)
 			assert.Equal(t, taskResp.TaskId, "")
 			assert.False(t, taskResp.ShouldExit)
@@ -635,19 +637,22 @@ func TestHostNextTask(t *testing.T) {
 	}
 }
 
-func TestTaskLifecycleEndpoints(t *testing.T) {
-	hostId := "h1"
-	projectId := "proj"
-	buildID := "b1"
-	versionId := "v1"
+func TestHostEndTask(t *testing.T) {
+	const (
+		hostId    = "h1"
+		projectId = "proj"
+		buildID   = "b1"
+		versionId = "v1"
+		taskId    = "task1"
+	)
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *hostAgentEndTask, env *mock.Environment){
 		"TestTaskShouldShowHostRunningTask": func(ctx context.Context, t *testing.T, handler *hostAgentEndTask, env *mock.Environment) {
 			startTaskHandler := makeStartTask(env).(*startTaskHandler)
-			startTaskHandler.hostID = "h1"
-			startTaskHandler.taskID = "task1"
+			startTaskHandler.hostID = hostId
+			startTaskHandler.taskID = taskId
 			resp := startTaskHandler.Run(ctx)
-			require.Equal(t, resp.Status(), http.StatusOK)
+			require.Equal(t, http.StatusOK, resp.Status())
 			require.NotNil(t, resp)
 
 			h, err := host.FindOneId(ctx, hostId)
@@ -662,15 +667,16 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			handler.details = *details
 			resp := handler.Run(ctx)
 			require.NotNil(t, resp)
-			require.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := apimodels.EndTaskResponse{}
+			require.Equal(t, http.StatusOK, resp.Status())
+			taskResp, ok := resp.Data().(*apimodels.EndTaskResponse)
+			require.True(t, ok)
 			require.False(t, taskResp.ShouldExit)
-			h, err := host.FindOne(ctx, host.ById(hostId))
+			h, err := host.FindOneId(ctx, hostId)
 			require.NoError(t, err)
 			require.NotZero(t, h)
 			require.Equal(t, h.RunningTask, "")
 
-			foundTask, err := task.FindOne(db.Query(task.ById("task1")))
+			foundTask, err := task.FindOneId(taskId)
 			require.NoError(t, err)
 			require.NotZero(t, foundTask)
 			require.Equal(t, evergreen.TaskSucceeded, foundTask.Status)
@@ -680,23 +686,24 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			details := &apimodels.TaskEndDetail{
 				Status: evergreen.TaskFailed,
 			}
-			testTask, err := task.FindOne(db.Query(task.ById("task1")))
+			testTask, err := task.FindOneId(taskId)
 			require.NoError(t, err)
 			require.NotZero(t, testTask)
 			require.Equal(t, evergreen.TaskStarted, testTask.Status)
 			handler.details = *details
 			resp := handler.Run(ctx)
 			require.NotNil(t, resp)
-			require.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := apimodels.EndTaskResponse{}
+			require.Equal(t, http.StatusOK, resp.Status())
+			taskResp, ok := resp.Data().(*apimodels.EndTaskResponse)
+			require.True(t, ok)
 			require.False(t, taskResp.ShouldExit)
 
-			h, err := host.FindOne(ctx, host.ById(hostId))
+			h, err := host.FindOneId(ctx, hostId)
 			require.NoError(t, err)
 			require.NotZero(t, h)
 			require.Equal(t, "", h.RunningTask)
 
-			foundTask, err := task.FindOne(db.Query(task.ById("task1")))
+			foundTask, err := task.FindOneId(taskId)
 			require.NoError(t, err)
 			require.NotZero(t, foundTask)
 			require.Equal(t, evergreen.TaskFailed, foundTask.Status)
@@ -727,7 +734,7 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			details := &apimodels.TaskEndDetail{
 				Status: evergreen.TaskUndispatched,
 			}
-			testTask, err := task.FindOne(db.Query(task.ById("task1")))
+			testTask, err := task.FindOneId(taskId)
 			require.NoError(t, err)
 			require.NotZero(t, testTask)
 			require.Equal(t, evergreen.TaskStarted, testTask.Status)
@@ -735,8 +742,9 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			handler.details = *details
 			resp := handler.Run(ctx)
 			require.NotNil(t, resp)
-			require.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := apimodels.EndTaskResponse{}
+			require.Equal(t, http.StatusOK, resp.Status())
+			taskResp, ok := resp.Data().(*apimodels.EndTaskResponse)
+			require.True(t, ok)
 			require.False(t, taskResp.ShouldExit)
 		},
 		"WithTasksHostsBuildAndTaskQueue": func(ctx context.Context, t *testing.T, handler *hostAgentEndTask, env *mock.Environment) {
@@ -784,14 +792,79 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			handler.details = *details
 			resp := handler.Run(ctx)
 			require.NotNil(t, resp)
-			require.Equal(t, resp.Status(), http.StatusOK)
-			taskResp := apimodels.EndTaskResponse{}
+			require.Equal(t, http.StatusOK, resp.Status())
+			taskResp, ok := resp.Data().(*apimodels.EndTaskResponse)
+			require.True(t, ok)
 			require.False(t, taskResp.ShouldExit)
 
-			dbTask, err := task.FindOne(db.Query(task.ById(displayTask.Id)))
+			dbTask, err := task.FindOneId(displayTask.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbTask)
 			require.Equal(t, evergreen.TaskFailed, dbTask.Status)
+		},
+		"QuarantinesStaticHostWithRepeatedSystemFailedTasks": func(ctx context.Context, t *testing.T, handler *hostAgentEndTask, env *mock.Environment) {
+			h, err := host.FindOneId(ctx, hostId)
+			require.NoError(t, err)
+			require.NotZero(t, h)
+			require.NoError(t, host.UpdateOne(ctx, host.ById(hostId), bson.M{
+				"$set": bson.M{
+					host.ProviderKey: evergreen.ProviderNameStatic,
+				},
+			}))
+
+			for i := 0; i < 10; i++ {
+				event.LogHostTaskFinished(fmt.Sprintf("some-system-failed-task-%d", i), 0, hostId, evergreen.TaskSystemFailed)
+			}
+
+			details := &apimodels.TaskEndDetail{
+				Status: evergreen.TaskFailed,
+				Type:   evergreen.CommandTypeSystem,
+			}
+			handler.details = *details
+			resp := handler.Run(ctx)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusOK, resp.Status())
+			h, err = host.FindOneId(ctx, hostId)
+			require.NoError(t, err)
+			require.NotZero(t, h)
+			assert.Equal(t, evergreen.HostQuarantined, h.Status, "static host should be quarantined for consecutive system failed tasks")
+
+			foundTask, err := task.FindOneId(handler.taskID)
+			require.NoError(t, err)
+			require.NotZero(t, foundTask)
+			require.Equal(t, evergreen.TaskSystemFailed, foundTask.GetDisplayStatus())
+		},
+		"DecommissionsDynamicHostWithRepeatedSystemFailedTasks": func(ctx context.Context, t *testing.T, handler *hostAgentEndTask, env *mock.Environment) {
+			h, err := host.FindOneId(ctx, hostId)
+			require.NoError(t, err)
+			require.NotZero(t, h)
+			require.NoError(t, host.UpdateOne(ctx, host.ById(hostId), bson.M{
+				"$set": bson.M{
+					host.ProviderKey: evergreen.ProviderNameEc2Fleet,
+				},
+			}))
+
+			for i := 0; i < 10; i++ {
+				event.LogHostTaskFinished(fmt.Sprintf("some-system-failed-task-%d", i), 0, hostId, evergreen.TaskSystemFailed)
+			}
+
+			details := &apimodels.TaskEndDetail{
+				Status: evergreen.TaskFailed,
+				Type:   evergreen.CommandTypeSystem,
+			}
+			handler.details = *details
+			resp := handler.Run(ctx)
+			require.NotNil(t, resp)
+			require.Equal(t, http.StatusOK, resp.Status())
+			h, err = host.FindOneId(ctx, hostId)
+			require.NoError(t, err)
+			require.NotZero(t, h)
+			assert.Equal(t, evergreen.HostDecommissioned, h.Status, "dynamic host should be decommissioned for consecutive system failed tasks")
+
+			foundTask, err := task.FindOneId(handler.taskID)
+			require.NoError(t, err)
+			require.NotZero(t, foundTask)
+			require.Equal(t, evergreen.TaskSystemFailed, foundTask.GetDisplayStatus())
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
@@ -822,7 +895,7 @@ func TestTaskLifecycleEndpoints(t *testing.T) {
 			require.NoError(t, proj.Insert())
 
 			task1 := task.Task{
-				Id:        "task1",
+				Id:        taskId,
 				Status:    evergreen.TaskStarted,
 				Activated: true,
 				HostId:    hostId,

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -217,7 +217,6 @@ func MockConfig() *evergreen.Settings {
 				Username: "username",
 				Password: "password",
 			},
-			DefaultProject: "proj",
 		},
 		TaskLimits: evergreen.TaskLimitsConfig{
 			MaxTasksPerVersion: 1000,

--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -13,26 +12,29 @@ import (
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 const decoHostNotifyJobName = "deco-host-notify"
 
 func init() {
-	registry.AddJobType(decoHostNotifyJobName, func() amboy.Job { return makeDecoHostsNotifyJob() })
+	registry.AddJobType(decoHostNotifyJobName, func() amboy.Job { return makeDecoHostNotifyJob() })
 }
 
 type decoHostNotifyJob struct {
+	// TODO (DEVPROD-7739): remove Host field once commit has been deployed
+	// since it is not used anymore.
 	Host     *host.Host `bson:"host" json:"host" yaml:"host"`
+	HostID   string     `bson:"host_id" json:"host_id" yaml:"host_id"`
 	Message  string     `bson:"message" json:"message" yaml:"message"`
-	OpError  string     `bson:"error" json:"error" yaml:"error"`
-	HasError bool       `bson:"errorp" json:"errorp" yaml:"errorp"`
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
-	env      evergreen.Environment
+
+	host *host.Host
+	env  evergreen.Environment
 }
 
-func makeDecoHostsNotifyJob() *decoHostNotifyJob {
+func makeDecoHostNotifyJob() *decoHostNotifyJob {
 	j := &decoHostNotifyJob{
 		Base: job.Base{
 			JobType: amboy.JobType{
@@ -44,104 +46,46 @@ func makeDecoHostsNotifyJob() *decoHostNotifyJob {
 	return j
 }
 
-// NewDecoHostNotifyJob notifies the relevant team that a static host has been
-// quarantined and needs investigation.
-func NewDecoHostNotifyJob(env evergreen.Environment, h *host.Host, err error, message string) amboy.Job {
-	j := makeDecoHostsNotifyJob()
+// NewDecoHostNotifyJob notifies the relevant team that a host has been
+// decommissioned/quarantined and needs investigation.
+func NewDecoHostNotifyJob(env evergreen.Environment, hostID, message string) amboy.Job {
+	j := makeDecoHostNotifyJob()
 	j.env = env
-	j.Host = h
+	j.HostID = hostID
 	j.Message = message
-	if err != nil {
-		j.OpError = err.Error()
-		j.HasError = true
-	}
 
-	j.SetID(fmt.Sprintf("%s.%s.%s", decoHostNotifyJobName, h.Id, utility.RoundPartOfHour(10)))
+	j.SetID(fmt.Sprintf("%s.%s.%s", decoHostNotifyJobName, hostID, utility.RoundPartOfHour(10)))
 	return j
 }
 
-func (j *decoHostNotifyJob) Run(_ context.Context) {
+func (j *decoHostNotifyJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	hostUptime := time.Since(j.Host.CreationTime)
-
-	if j.Host.Provider != evergreen.HostTypeStatic {
-		// if this isn't a static host
-		m := message.Fields{
-			"operation":   decoHostNotifyJobName,
-			"message":     j.Message,
-			"distro":      j.Host.Distro.Id,
-			"provider":    j.Host.Provider,
-			"uptime":      hostUptime,
-			"uptime_span": hostUptime.String(),
-			"host_id":     j.Host.Id,
+	j.host = j.Host
+	if j.host == nil {
+		h, err := host.FindOneId(ctx, j.HostID)
+		if err != nil {
+			j.AddError(errors.Wrapf(err, "finding host '%s'", j.HostID))
 		}
-
-		if j.HasError {
-			m["error"] = j.OpError
+		if h == nil {
+			j.AddError(errors.Errorf("host '%s' not found", j.HostID))
 		}
-
-		grip.Error(m)
-		return
+		j.host = h
 	}
 
-	// otherwise, it was a static host and we should create jira tickets for this.
-	client := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(client)
-
-	if j.env == nil {
-		j.env = evergreen.GetEnvironment()
+	m := message.Fields{
+		"operation": decoHostNotifyJobName,
+		"message":   j.Message,
+		"distro":    j.host.Distro.Id,
+		"provider":  j.host.Provider,
+		"host_id":   j.host.Id,
+	}
+	if j.host.Provider != evergreen.ProviderNameStatic {
+		uptime := time.Since(j.host.CreationTime)
+		m["time_since_creation_secs"] = int(uptime.Seconds())
+		m["time_since_creation_str"] = uptime.String()
 	}
 
-	conf := j.env.Settings()
-	sender, err := j.env.GetSender(evergreen.SenderJIRAIssue)
-	if err != nil {
-		j.AddError(err)
-
-		m := message.Fields{
-			"operation":   decoHostNotifyJobName,
-			"message":     j.Message,
-			"state":       "host disabled, jira ticket creation failed",
-			"distro":      j.Host.Distro.Id,
-			"provider":    j.Host.Provider,
-			"uptime":      hostUptime,
-			"uptime_span": hostUptime.String(),
-			"host_id":     j.Host.Id,
-			"jira_error":  err.Error(),
-		}
-
-		if j.HasError {
-			m["error"] = j.OpError
-		}
-
-		grip.Alert(m)
-
-		return
-	}
-
-	descParts := []string{
-		fmt.Sprintf("Distro: [%s|%s/distros##%s]", j.Host.Distro.Id, conf.Ui.Url, j.Host.Distro.Id),
-		fmt.Sprintf("Host: [%s|%s/host/%s]", j.Host.Id, conf.Ui.Url, j.Host.Id),
-		fmt.Sprintln("Provider:", j.Host.Provider),
-		fmt.Sprintf("Target: %s@%s", j.Host.Distro.User, j.Host.Host),
-	}
-
-	if j.HasError {
-		descParts = append(descParts, fmt.Sprintln("Error:", j.OpError))
-	}
-
-	issue := message.JiraIssue{
-		Project:     conf.Jira.DefaultProject,
-		Summary:     fmt.Sprintf("investigate automatically decommissioned host '%s'", j.Host.Id),
-		Type:        "Bug",
-		Description: strings.Join(descParts, "\n"),
-		Fields: map[string]interface{}{
-			evergreen.DevProdServiceFieldName: evergreen.DevProdJiraServiceField,
-		},
-	}
-
-	msg := message.MakeJiraMessage(&issue)
-	grip.Warning(msg.SetPriority(level.Notice))
-
-	sender.Send(msg)
+	grip.Notice(m)
+	return
 }

--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -93,5 +93,4 @@ func (j *decoHostNotifyJob) Run(ctx context.Context) {
 	}
 
 	grip.Notice(m)
-	return
 }

--- a/units/util.go
+++ b/units/util.go
@@ -65,7 +65,7 @@ func DisableAndNotifyPoisonedHost(ctx context.Context, env evergreen.Environment
 		return errors.Wrap(err, "clearing stranded task from host")
 	}
 
-	return errors.Wrapf(amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewDecoHostNotifyJob(env, h, nil, reason)), "enqueueing decohost notify job for host '%s'", h.Id)
+	return errors.Wrapf(amboy.EnqueueUniqueJob(ctx, env.RemoteQueue(), NewDecoHostNotifyJob(env, h.Id, reason)), "enqueueing decohost notify job for host '%s'", h.Id)
 }
 
 // EnqueueHostReprovisioningJob enqueues a job to reprovision a host. For hosts


### PR DESCRIPTION
DEVPROD-7739

### Description
* Automatically quarantine a static host if it system-fails three tasks in a row. (This behavior already used to exist but EVG-2742 mysteriously removed it for unknown reasons. I think it's fine to reintroduce.)
* Send a Splunk log when a static host is quarantined. I refactored the job so that it's less weird and more in line with how we typically write jobs (i.e. not persisting an entire copy of the host doc in the job). When this logs, [an alert will ping `#devprod-runtime-environment-alerts`](https://mongodb.splunkcloud.com/en-US/app/search/alert?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2FEvergreen%253A%2520Static%2520Host%2520Quarantined) that a static host is quarantined.
* Clean up some old next/end task tests so they're more in line with current coding style standards. While fixing the tests, I also drive-by fixed a tiny issue where the end task route returns the wrong type of payload in one case.

### Testing
* Added unit tests.
* Tested in staging that quarantining a host created the Splunk log.
* After the deploy, will verify that static host quarantine alerts go through.

### Documentation
N/A