### PR TITLE
DEVPROD-9920 Block subsequent single host TG tasks if host gets terminated

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2661,6 +2661,9 @@ func FindAllDependencyTasksToModify(tasks []Task, isUnblocking, updateAllDepende
 			DependencyTaskIdKey:       t.Id,
 			DependencyUnattainableKey: isUnblocking,
 		}
+		// If the operation is unblocking, then we ignore the status the dependencies were waiting on,
+		// and unblock all of them. Similarly, if the operation is blocking and updateAllDependencies is set,
+		// we also want to ignore the status the dependencies were waiting on.
 		if !isUnblocking && !updateAllDependencies {
 			okStatusSet := []string{AllStatuses, t.Status}
 			elemMatchQuery[DependencyStatusKey] = bson.M{"$nin": okStatusSet}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1850,7 +1850,7 @@ func TestFindAllUnmarkedDependenciesToBlock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)
@@ -1889,7 +1889,7 @@ func TestFindAllUnattainableDependenciesToUnbock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1850,7 +1850,7 @@ func TestFindAllUnmarkedDependenciesToBlock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false, false)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)
@@ -1889,7 +1889,7 @@ func TestFindAllUnattainableDependenciesToUnbock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true, false)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -827,7 +827,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		return errors.Wrapf(err, "marking task '%s' finished", t.Id)
 	}
 
-	catcher.Wrap(UpdateBlockedDependencies(ctx, []task.Task{*t}), "updating blocked dependencies")
+	catcher.Wrap(UpdateBlockedDependencies(ctx, []task.Task{*t}, false), "updating blocked dependencies")
 	catcher.Wrap(t.MarkDependenciesFinished(ctx, true), "updating dependency finished status")
 
 	status := t.GetDisplayStatus()
@@ -1032,8 +1032,9 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string) (c
 // UpdateBlockedDependencies traverses the dependency graph and recursively sets
 // each parent dependency in dependencies as unattainable in depending tasks. It
 // updates the status of builds as well, in case they change due to blocking
-// dependencies.
-func UpdateBlockedDependencies(ctx context.Context, dependencies []task.Task) error {
+// dependencies. The updateAllDependencies indicates whether all tasks that depend
+// on the given tasks will be updated (i.e., whether the task's Dependency.Status will be ignored).
+func UpdateBlockedDependencies(ctx context.Context, dependencies []task.Task, updateAllDependencies bool) error {
 	ctx, span := tracer.Start(ctx, "update-blocked-dependencies")
 	defer span.End()
 
@@ -1042,7 +1043,7 @@ func UpdateBlockedDependencies(ctx context.Context, dependencies []task.Task) er
 		dependencyIDs = append(dependencyIDs, dep.Id)
 	}
 
-	dependentTasks, err := task.FindAllDependencyTasksToModify(dependencies, false)
+	dependentTasks, err := task.FindAllDependencyTasksToModify(dependencies, false, updateAllDependencies)
 	if err != nil {
 		return errors.Wrapf(err, "getting all tasks depending on tasks")
 	}
@@ -1055,7 +1056,7 @@ func UpdateBlockedDependencies(ctx context.Context, dependencies []task.Task) er
 		return errors.Wrap(err, "marking unattainable dependencies for tasks")
 	}
 
-	if err := UpdateBlockedDependencies(ctx, dependentTasks); err != nil {
+	if err := UpdateBlockedDependencies(ctx, dependentTasks, true); err != nil {
 		return errors.Wrap(err, "updating many blocked dependencies recursively")
 	}
 
@@ -1080,6 +1081,8 @@ func UpdateBlockedDependencies(ctx context.Context, dependencies []task.Task) er
 }
 
 // UpdateUnblockedDependencies recursively marks all unattainable dependencies as attainable.
+// The updateAllDependencies indicates whether all tasks that depend on the given tasks will
+// be updated (i.e., whether the task's Dependency.Status will be ignored).
 func UpdateUnblockedDependencies(ctx context.Context, dependencies []task.Task) error {
 	ctx, span := tracer.Start(ctx, "update-unblocked-dependencies")
 	defer span.End()
@@ -1089,7 +1092,7 @@ func UpdateUnblockedDependencies(ctx context.Context, dependencies []task.Task) 
 		dependencyIDs = append(dependencyIDs, dep.Id)
 	}
 
-	tasksToUnblock, err := task.FindAllDependencyTasksToModify(dependencies, true)
+	tasksToUnblock, err := task.FindAllDependencyTasksToModify(dependencies, true, false)
 	if err != nil {
 		return errors.Wrapf(err, "getting all tasks depending on tasks")
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7310,7 +7310,7 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	}
 	assert.NoError(execTask.Insert())
 
-	assert.NoError(UpdateBlockedDependencies(ctx, []task.Task{tasks[0]}))
+	assert.NoError(UpdateBlockedDependencies(ctx, []task.Task{tasks[0]}, false))
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -145,7 +145,7 @@ func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCac
 	if err == nil {
 		for _, blockingTask := range finishedBlockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			err = model.UpdateBlockedDependencies(ctx, []task.Task{blockingTask})
+			err = model.UpdateBlockedDependencies(ctx, []task.Task{blockingTask}, false)
 			catcher.Wrapf(err, "updating blocked dependencies for '%s'", blockingTask.Id)
 			if err != nil {
 				err = t.MarkDependenciesFinished(ctx, false)

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -205,6 +205,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			latestTask, err := task.FindOneId(j.host.LastTask)
 			if err != nil {
 				j.AddError(errors.Wrapf(err, "finding last task '%s'", j.host.LastTask))
+				return
 			}
 			// Only try to restart the task group if it was successful and should have continued executing.
 			if latestTask != nil && latestTask.IsPartOfSingleHostTaskGroup() && latestTask.Status == evergreen.TaskSucceeded {
@@ -218,13 +219,14 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 					return
 				}
 				// Check for the last task in the task group that we have activated, running, or completed.
-				var lastTaskGroupTask task.Task
+				var lastActivatedTaskGroupTask task.Task
 				for _, t := range tasks {
 					if t.Activated {
-						lastTaskGroupTask = t
+						lastActivatedTaskGroupTask = t
 					}
 				}
-				if lastTaskGroupTask.Id != latestTask.Id {
+				j.AddError(errors.Wrapf(model.UpdateBlockedDependencies(ctx, []task.Task{*latestTask}, true), "updating blocked dependencies for task '%s'", latestTask.Id))
+				if lastActivatedTaskGroupTask.Id != latestTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,
 					// because later tasks in the group need to run on the same host as the earlier ones.
 					j.AddError(errors.Wrapf(model.TryResetTask(ctx, j.env.Settings(), latestTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", latestTask.Id))

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -225,6 +225,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 						lastActivatedTaskGroupTask = t
 					}
 				}
+				// We want to block all subsequent tasks from running, regardless of what status the dependencies are waiting on.
 				j.AddError(errors.Wrapf(model.UpdateBlockedDependencies(ctx, []task.Task{*latestTask}, true), "updating blocked dependencies for task '%s'", latestTask.Id))
 				if lastActivatedTaskGroupTask.Id != latestTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -225,7 +225,9 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 						lastActivatedTaskGroupTask = t
 					}
 				}
-				// We want to block all subsequent tasks from running, regardless of what status the dependencies are waiting on.
+				// If the host was in-between running a single host task group, the group should start from scratch.
+				// Since single host task groups only restart when the whole group is finished, we all block subsequent task group
+				// tasks from running regardless of what status they were waiting on, so that we can force the task group to restart immediately.
 				j.AddError(errors.Wrapf(model.UpdateBlockedDependencies(ctx, []task.Task{*latestTask}, true), "updating blocked dependencies for task '%s'", latestTask.Id))
 				if lastActivatedTaskGroupTask.Id != latestTask.Id {
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -310,7 +310,7 @@ func TestHostTerminationJob(t *testing.T) {
 				assert.False(t, dbTask.ResetWhenFinished)
 			}
 		},
-		"TaskInTaskGroupDoesNotRestartIfFinished2": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
+		"TaskInSingleHostTaskGroupBlocksAndRestartsTasks": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			h.LastGroup = "taskgroup"
 			h.LastTask = "task2"
 			require.NoError(t, h.Insert(ctx))


### PR DESCRIPTION
DEVPROD-9920

### Description
Currently, if a host gets terminated midway through a single host task group, the group gets marked to automatically reset (which is correct), but it won't do that until the subsequent tasks run, which creates unnecessary failures.

This change is to block those tasks immediately so the task group can immediately reset. Also cleaned up `TestHostTerminationJob` a bit.
### Testing
Reproduced the bug in staging and confirmed it went away with this change. Added unit tests.
