### PR TITLE
DEVPROD-11414 Fix panic in FindNextTask accessing out of bounds slice

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -253,8 +253,7 @@ func (d *basicCachedDAGDispatcherImpl) FindNextTask(ctx context.Context, spec Ta
 
 	settings := evergreen.GetEnvironment().Settings()
 	dependencyCaches := make(map[string]task.Task)
-	for i := range d.sorted {
-		node := d.sorted[i]
+	for _, node := range d.sorted {
 		// topo.SortStabilized represents nodes in a dependency cycle with a nil Node.
 		if node == nil {
 			continue


### PR DESCRIPTION
DEVPROD-11414

### Description
This fixes a panic in prod that happened where FindNextTask tried accessing out of bounds on a slice.

I _feel_ like this fix was too easy, when someone reviews this please double check this is intended!
