### PR TITLE
DEVPROD-11385  OTel process counters

### DIFF
--- a/agent/otel_default.go
+++ b/agent/otel_default.go
@@ -1,0 +1,64 @@
+//go:build !windows
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"github.com/shirou/gopsutil/v3/process"
+	"go.opentelemetry.io/otel/metric"
+)
+
+func addProcessMetrics(meter metric.Meter) error {
+	processCountRunning, err := meter.Int64ObservableUpDownCounter(fmt.Sprintf("%s.running", processCountPrefix), metric.WithUnit("{process}"), metric.WithDescription("Total number of running processes"))
+	if err != nil {
+		return errors.Wrap(err, "making running process counter")
+	}
+	processCountSleeping, err := meter.Int64ObservableUpDownCounter(fmt.Sprintf("%s.sleeping", processCountPrefix), metric.WithUnit("{process}"), metric.WithDescription("Total number of sleeping processes"))
+	if err != nil {
+		return errors.Wrap(err, "making sleeping process counter")
+	}
+	processCountZombie, err := meter.Int64ObservableUpDownCounter(fmt.Sprintf("%s.zombie", processCountPrefix), metric.WithUnit("{process}"), metric.WithDescription("Total number of zombie processes"))
+	if err != nil {
+		return errors.Wrap(err, "making zombie process counter")
+	}
+	processCountStopped, err := meter.Int64ObservableUpDownCounter(fmt.Sprintf("%s.stopped", processCountPrefix), metric.WithUnit("{process}"), metric.WithDescription("Total number of stopped processes"))
+	if err != nil {
+		return errors.Wrap(err, "making stopped process counter")
+	}
+
+	_, err = meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+		processes, err := process.ProcessesWithContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, "getting processes")
+		}
+		var running, sleeping, zombie, stopped int
+		for _, p := range processes {
+			statuses, err := p.StatusWithContext(ctx)
+			if err != nil {
+				continue
+			}
+			switch {
+			case utility.StringSliceContains(statuses, process.Running):
+				running++
+			case utility.StringSliceContains(statuses, process.Sleep):
+				sleeping++
+			case utility.StringSliceContains(statuses, process.Zombie):
+				zombie++
+			case utility.StringSliceContains(statuses, process.Stop):
+				stopped++
+			}
+		}
+
+		observer.ObserveInt64(processCountRunning, int64(running))
+		observer.ObserveInt64(processCountSleeping, int64(sleeping))
+		observer.ObserveInt64(processCountZombie, int64(zombie))
+		observer.ObserveInt64(processCountStopped, int64(stopped))
+
+		return nil
+	}, processCountRunning, processCountSleeping, processCountZombie, processCountStopped)
+	return errors.Wrap(err, "registering process count callback")
+}

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -1,13 +1,19 @@
 package agent
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -120,5 +126,71 @@ func TestBatchSpans(t *testing.T) {
 				assert.Len(t, batch, testCase.spansLen/testCase.batchSize)
 			}
 		})
+	}
+}
+
+func TestMetrics(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for testName, testCase := range map[string]func(t *testing.T, meter metric.Meter, reader sdk.Reader){
+		"CPUMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addCPUMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
+			assert.Equal(t, fmt.Sprintf("%s.idle", cpuTimeInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints[0].Value)
+
+			assert.Equal(t, cpuUtilInstrument, metrics.ScopeMetrics[0].Metrics[5].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints[0].Value)
+		},
+		"MemoryMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addMemoryMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 3)
+			assert.Equal(t, fmt.Sprintf("%s.available", memoryUsageInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"DiskMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addDiskMetrics(ctx, meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics)
+			assert.Regexp(t, `system\.disk\.io\.\w+\.read`, metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"NetworkMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addNetworkMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 2)
+			assert.Equal(t, fmt.Sprintf("%s.transmit", networkIOInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+		"ProcessMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addProcessMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 4)
+			assert.Equal(t, fmt.Sprintf("%s.sleeping", processCountPrefix), metrics.ScopeMetrics[0].Metrics[1].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		},
+	} {
+		reader := sdk.NewManualReader()
+		meter := sdk.NewMeterProvider(sdk.WithReader(reader)).Meter(packageName)
+		t.Run(testName, func(t *testing.T) { testCase(t, meter, reader) })
 	}
 }

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -133,21 +134,7 @@ func TestMetrics(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	for testName, testCase := range map[string]func(t *testing.T, meter metric.Meter, reader sdk.Reader){
-		"CPUMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addCPUMetrics(meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
-			assert.Equal(t, fmt.Sprintf("%s.idle", cpuTimeInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints)
-			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints[0].Value)
-
-			assert.Equal(t, cpuUtilInstrument, metrics.ScopeMetrics[0].Metrics[5].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints)
-			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints[0].Value)
-		},
+	testCases := map[string]func(t *testing.T, meter metric.Meter, reader sdk.Reader){
 		"MemoryMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
 			assert.NoError(t, addMemoryMetrics(meter))
 			var metrics metricdata.ResourceMetrics
@@ -155,16 +142,6 @@ func TestMetrics(t *testing.T) {
 			require.NotEmpty(t, metrics.ScopeMetrics)
 			require.Len(t, metrics.ScopeMetrics[0].Metrics, 3)
 			assert.Equal(t, fmt.Sprintf("%s.available", memoryUsageInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
-			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-		},
-		"DiskMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addDiskMetrics(ctx, meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics)
-			assert.Regexp(t, `system\.disk\.io\.\w+\.read`, metrics.ScopeMetrics[0].Metrics[0].Name)
 			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
 			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
 		},
@@ -178,7 +155,37 @@ func TestMetrics(t *testing.T) {
 			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
 			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
 		},
-		"ProcessMetrics": func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+	}
+
+	if runtime.GOOS != "darwin" {
+		testCases["CPUMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addCPUMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
+			assert.Equal(t, fmt.Sprintf("%s.idle", cpuTimeInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[float64]).DataPoints[0].Value)
+
+			assert.Equal(t, cpuUtilInstrument, metrics.ScopeMetrics[0].Metrics[5].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[5].Data.(metricdata.Gauge[float64]).DataPoints[0].Value)
+		}
+		testCases["DiskMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addDiskMetrics(ctx, meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics)
+			assert.Regexp(t, `system\.disk\.io\.\w+\.read`, metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		}
+	}
+
+	if runtime.GOOS != "windows" {
+		testCases["ProcessMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
 			assert.NoError(t, addProcessMetrics(meter))
 			var metrics metricdata.ResourceMetrics
 			assert.NoError(t, reader.Collect(ctx, &metrics))
@@ -187,8 +194,21 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("%s.sleeping", processCountPrefix), metrics.ScopeMetrics[0].Metrics[1].Name)
 			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints)
 			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-		},
-	} {
+		}
+	} else {
+		testCases["ProcessMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+			assert.NoError(t, addProcessMetrics(meter))
+			var metrics metricdata.ResourceMetrics
+			assert.NoError(t, reader.Collect(ctx, &metrics))
+			require.NotEmpty(t, metrics.ScopeMetrics)
+			require.Len(t, metrics.ScopeMetrics[0].Metrics, 1)
+			assert.Equal(t, processCountPrefix, metrics.ScopeMetrics[0].Metrics[0].Name)
+			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+		}
+	}
+
+	for testName, testCase := range testCases {
 		reader := sdk.NewManualReader()
 		meter := sdk.NewMeterProvider(sdk.WithReader(reader)).Meter(packageName)
 		t.Run(testName, func(t *testing.T) { testCase(t, meter, reader) })

--- a/agent/otel_windows.go
+++ b/agent/otel_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/shirou/gopsutil/v3/process"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// addProcessMetrics tallies the total number of processes in any state. This is because on Windows gopsutil doesn't support
+// checking process state.
+func addProcessMetrics(meter metric.Meter) error {
+	processCount, err := meter.Int64ObservableUpDownCounter(processCountPrefix, metric.WithUnit("{process}"), metric.WithDescription("Total number of processes"))
+	if err != nil {
+		return errors.Wrap(err, "making process counter")
+	}
+
+	_, err = meter.RegisterCallback(func(ctx context.Context, observer metric.Observer) error {
+		processes, err := process.ProcessesWithContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, "getting processes")
+		}
+
+		observer.ObserveInt64(processCount, int64(len(processes)))
+
+		return nil
+	}, processCount)
+	return errors.Wrap(err, "registering process count callback")
+}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-16"
+	AgentVersion = "2024-09-20"
 )
 
 const (


### PR DESCRIPTION
[DEVPROD-11385](https://jira.mongodb.org/browse/DEVPROD-11385)

### Description
#8317 added process counters to the task OTel metrics. It also added a test that revealed which metrics weren't working. Although it doesn't hurt to call the functions and get the error, it makes more sense to be explicit about which ones are working.

This PR cherry-picks #8317 which was reverted because of the failing tests and fixes the tests. As an added bonus, it fixes disk metrics on Windows, which were failing because the disk names included colons (e.g. C:) and you can't have a colon in an instrument name. Also, process metrics were adjusted so they'd work on Windows.

### Testing
The `test-agent`s are passing now.
