### PR TITLE
DEVPROD-7739: remove host document from deco notify host job

### DIFF
--- a/units/deco_host_notify.go
+++ b/units/deco_host_notify.go
@@ -23,11 +23,8 @@ func init() {
 }
 
 type decoHostNotifyJob struct {
-	// TODO (DEVPROD-7739): remove Host field once commit has been deployed
-	// since it is not used anymore.
-	Host     *host.Host `bson:"host" json:"host" yaml:"host"`
-	HostID   string     `bson:"host_id" json:"host_id" yaml:"host_id"`
-	Message  string     `bson:"message" json:"message" yaml:"message"`
+	HostID   string `bson:"host_id" json:"host_id" yaml:"host_id"`
+	Message  string `bson:"message" json:"message" yaml:"message"`
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
 
 	host *host.Host
@@ -61,7 +58,6 @@ func NewDecoHostNotifyJob(env evergreen.Environment, hostID, message string) amb
 func (j *decoHostNotifyJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	j.host = j.Host
 	if j.host == nil {
 		h, err := host.FindOneId(ctx, j.HostID)
 		if err != nil {


### PR DESCRIPTION
DEVPROD-7739

### Description
Follow-up to #8321 - Remove the now-unused `Host` field from the deco host notify job doc. New deco host notify jobs use the host ID rather than storing the entire host doc in the job.

### Testing
Existing tests pass.

### Documentation
N/A