### PR TITLE
DEVPROD-9469: convert project var names to parameter names

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -448,8 +448,11 @@ var validParamName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 // generates one.
 func getParamNameForVar(varsToParams []ParameterMapping, varName string) (string, error) {
 	for _, varToParam := range varsToParams {
-		if varToParam.Name == varName && varToParam.ParameterName != "" {
-			return varToParam.ParameterName, nil
+		if varToParam.Name == varName {
+			if varToParam.ParameterName != "" {
+				return varToParam.ParameterName, nil
+			}
+			break
 		}
 	}
 


### PR DESCRIPTION
DEVPROD-9469

### Description
Add helper function (not used yet) to convert project var names to parameter names. We can't always use the project var name directly as the name of their corresponding Parameter Store parameter because [parameter names have some validation rules](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ssm@v1.52.3#PutParameterInput).

I checked the existing project var names and the only validation rule that's broken by existing project vars is that some project vars begin with `aws`/`ssm`. Since only that one rule is broken by the existing project vars, I wrote it to only make those existing project vars compatible with parameters and otherwise disallow other special characters to future-proof project var names in case someone tries to add an invalid character.

* Add helper to convert project var names into valid parameter names.
* Disallow special characters (except `_`, `-`, and `.`) in project var names.

### Testing
* Added unit tests.

### Documentation
N/A
