### PR TITLE
DEVPROD-10509 Update git.clone project command to redact for modules

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -600,11 +600,8 @@ func (a *Agent) startLogging(ctx context.Context, tc *taskContext) error {
 	taskLogDir := filepath.Join(a.opts.WorkingDirectory, taskLogDirectory)
 	grip.Error(errors.Wrapf(os.RemoveAll(taskLogDir), "removing task log directory '%s'", taskLogDir))
 	tc.logger, err = a.makeLoggerProducer(ctx, tc, "")
-	if err != nil {
-		return errors.Wrap(err, "making the logger producer")
-	}
 
-	return nil
+	return errors.Wrap(err, "making the logger producer")
 }
 
 // runTask runs a task. It returns true if the agent should exit.

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -158,6 +158,10 @@ func getProjectMethodAndToken(ctx context.Context, comm client.Communicator, td 
 	owner := conf.ProjectRef.Owner
 	repo := conf.ProjectRef.Repo
 	appToken, err := comm.CreateInstallationToken(ctx, td, owner, repo)
+	if err == nil {
+		// Redact the token from the logs.
+		conf.NewExpansions.Redact("EVERGREEN_GENERATED_GITHUB_TOKEN", appToken)
+	}
 	// TODO EVG-21022: Remove fallback once we delete GitHub tokens as expansions.
 	grip.Warning(message.WrapError(err, message.Fields{
 		"message": "error creating GitHub app token, falling back to legacy clone methods",

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -42,6 +42,8 @@ const (
 	// Valid types of performing git clone
 	cloneMethodOAuth       = "oauth"
 	cloneMethodAccessToken = "access-token"
+
+	generatedTokenKey = "EVERGREEN_GENERATED_GITHUB_TOKEN"
 )
 
 var (
@@ -160,7 +162,7 @@ func getProjectMethodAndToken(ctx context.Context, comm client.Communicator, td 
 	appToken, err := comm.CreateInstallationToken(ctx, td, owner, repo)
 	if appToken != "" {
 		// Redact the token from the logs.
-		conf.NewExpansions.Redact("EVERGREEN_GENERATED_GITHUB_TOKEN", appToken)
+		conf.NewExpansions.Redact(generatedTokenKey, appToken)
 	}
 	// TODO EVG-21022: Remove fallback once we delete GitHub tokens as expansions.
 	grip.Warning(message.WrapError(err, message.Fields{
@@ -727,7 +729,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			opts.method = cloneMethodAccessToken
 
 			// After generating, redact the token from the logs.
-			conf.NewExpansions.Redact("EVERGREEN_GENERATED_GITHUB_TOKEN", appToken)
+			conf.NewExpansions.Redact(generatedTokenKey, appToken)
 		} else {
 			// If a token cannot be created, fallback to the legacy global token.
 			opts.method = cloneMethodOAuth

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -246,7 +247,7 @@ func (opts cloneOpts) buildHTTPCloneCommand(forApp bool) ([]string, error) {
 
 	return []string{
 		"set +o xtrace",
-		fmt.Sprintf(`echo %s`, clone),
+		fmt.Sprintf(`echo %s`, strconv.Quote(clone)),
 		clone,
 		"set -o xtrace",
 		fmt.Sprintf("cd %s", opts.dir),

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 
@@ -245,10 +244,9 @@ func (opts cloneOpts) buildHTTPCloneCommand(forApp bool) ([]string, error) {
 		clone = fmt.Sprintf("%s --branch '%s'", clone, opts.branch)
 	}
 
-	redactedClone := strings.Replace(clone, opts.token, "[redacted github token]", -1)
 	return []string{
 		"set +o xtrace",
-		fmt.Sprintf(`echo %s`, strconv.Quote(redactedClone)),
+		fmt.Sprintf(`echo %s`, clone),
 		clone,
 		"set -o xtrace",
 		fmt.Sprintf("cd %s", opts.dir),

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -158,7 +158,7 @@ func getProjectMethodAndToken(ctx context.Context, comm client.Communicator, td 
 	owner := conf.ProjectRef.Owner
 	repo := conf.ProjectRef.Repo
 	appToken, err := comm.CreateInstallationToken(ctx, td, owner, repo)
-	if err == nil {
+	if appToken != "" {
 		// Redact the token from the logs.
 		conf.NewExpansions.Redact("EVERGREEN_GENERATED_GITHUB_TOKEN", appToken)
 	}

--- a/agent/command/git_push_test.go
+++ b/agent/command/git_push_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -31,10 +32,12 @@ func TestGitPush(t *testing.T) {
 	}
 	comm := client.NewMock("http://localhost.com")
 	comm.CreateInstallationTokenResult = "token"
+	expansions := util.Expansions{}
 	conf := &internal.TaskConfig{
-		Task:       task.Task{},
-		ProjectRef: model.ProjectRef{Branch: "main"},
-		Expansions: util.Expansions{},
+		Task:          task.Task{},
+		ProjectRef:    model.ProjectRef{Branch: "main"},
+		Expansions:    expansions,
+		NewExpansions: agentutil.NewDynamicExpansions(expansions),
 	}
 	logger, err := comm.GetLoggerProducer(context.Background(), &conf.Task, nil)
 	require.NoError(t, err)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -344,17 +344,6 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 		}
 	}
 
-	redactedKeys := conf.NewExpansions.GetRedacted()
-	foundCloneTokenRedacted := false
-	for _, redactedKey := range redactedKeys {
-		if redactedKey.Key == "github_token" {
-			if redactedKey.Value == token {
-				foundCloneTokenRedacted = true
-			}
-		}
-	}
-	s.True(foundCloneTokenRedacted)
-
 	s.NoError(logger.Close())
 	foundCloneCommand := false
 	foundCloneErr := false

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -366,7 +366,9 @@ func (s *GitGetProjectSuite) TestTokenScrubbedFromLogger() {
 		if strings.Contains(line.Data, "Authentication failed for") {
 			foundCloneErr = true
 		}
-		fmt.Println(line.Data)
+		if strings.Contains(line.Data, token) {
+			s.FailNow("token was leaked")
+		}
 	}
 	s.False(foundCloneCommand)
 	s.True(foundCloneErr)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -357,10 +357,8 @@ func (s *GitGetProjectSuite) TestTokenIsRedactedWhenGenerated() {
 
 	findTokenInRedacted := func() bool {
 		for _, redacted := range conf.NewExpansions.GetRedacted() {
-			if redacted.Key == generatedTokenKey {
-				if redacted.Value == token {
-					return true
-				}
+			if redacted.Key == generatedTokenKey && redacted.Value == token {
+				return true
 			}
 		}
 		return false

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -994,14 +994,16 @@ func (s *GitGetProjectSuite) TestGetProjectMethodAndToken() {
 
 	td := client.TaskData{ID: s.taskConfig1.Task.Id, Secret: s.taskConfig1.Task.Secret}
 
+	expansions := map[string]string{
+		evergreen.GlobalGitHubTokenExpansion: globalGitHubToken,
+	}
 	conf := &internal.TaskConfig{
 		ProjectRef: model.ProjectRef{
 			Owner: "valid-owner",
 			Repo:  "valid-repo",
 		},
-		Expansions: map[string]string{
-			evergreen.GlobalGitHubTokenExpansion: globalGitHubToken,
-		},
+		Expansions:    expansions,
+		NewExpansions: agentutil.NewDynamicExpansions(expansions),
 	}
 
 	method, token, err = getProjectMethodAndToken(s.ctx, s.comm, td, conf, projectGitHubToken, true)

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -388,7 +388,7 @@ func (c *baseCommunicator) makeSender(ctx context.Context, tsk *task.Task, confi
 	levelInfo := send.LevelInfo{Default: level.Info, Threshold: level.Debug}
 	var senders []send.Sender
 	if config.SendToGlobalSender {
-		senders = append(senders, grip.GetSender())
+		senders = append(senders, redactor.NewRedactingSender(grip.GetSender(), config.RedactorOpts))
 	}
 
 	var sender send.Sender

--- a/agent/internal/client/client_test.go
+++ b/agent/internal/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,8 @@ func TestEvergreenCommunicatorConstructor(t *testing.T) {
 }
 
 func TestLoggerProducerRedactorOptions(t *testing.T) {
+	secret_key := "secret_key"
+	secret_key_redaction := fmt.Sprintf("<REDACTED:%s>", secret_key)
 	secret := "super_soccer_ball"
 	createTask := func() *task.Task {
 		return &task.Task{
@@ -78,6 +81,7 @@ func TestLoggerProducerRedactorOptions(t *testing.T) {
 
 		data := readLogs(t, task)
 		assert.Contains(t, data, secret)
+		assert.NotContains(t, data, secret_key_redaction)
 
 		// Make sure it has the other log lines.
 		assert.Contains(t, data, "Fluff 1")
@@ -98,7 +102,7 @@ func TestLoggerProducerRedactorOptions(t *testing.T) {
 			},
 		})
 		logger.Task().Alert("Fluff 1")
-		e.PutAndRedact("secret_key", secret)
+		e.PutAndRedact(secret_key, secret)
 		logger.Task().Alert("More fluff")
 		require.NoError(t, err)
 
@@ -108,7 +112,7 @@ func TestLoggerProducerRedactorOptions(t *testing.T) {
 
 		data := readLogs(t, task)
 		assert.NotContains(t, data, secret)
-		assert.Contains(t, data, "secret_key")
+		assert.Contains(t, data, secret_key_redaction)
 
 		// Make sure it has the other log lines.
 		assert.Contains(t, data, "Fluff 1")

--- a/agent/internal/client/client_test.go
+++ b/agent/internal/client/client_test.go
@@ -60,9 +60,12 @@ func TestLoggerProducerRedactorOptions(t *testing.T) {
 	}
 
 	t.Run("LeaksWithoutRedactor", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		task := createTask()
 		comm := newBaseCommunicator("whatever", map[string]string{})
-		logger, err := comm.GetLoggerProducer(context.Background(), task, nil)
+		logger, err := comm.GetLoggerProducer(ctx, task, nil)
 		require.NoError(t, err)
 
 		logger.Task().Alert("Fluff 1")
@@ -83,10 +86,13 @@ func TestLoggerProducerRedactorOptions(t *testing.T) {
 	})
 
 	t.Run("RedactsWhenAdded", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		task := createTask()
 		comm := newBaseCommunicator("whatever", map[string]string{})
 		e := agentutil.NewDynamicExpansions(util.Expansions{})
-		logger, err := comm.GetLoggerProducer(context.Background(), task, &LoggerConfig{
+		logger, err := comm.GetLoggerProducer(ctx, task, &LoggerConfig{
 			RedactorOpts: redactor.RedactionOptions{
 				Expansions: e,
 			},

--- a/agent/util/expansions.go
+++ b/agent/util/expansions.go
@@ -91,6 +91,15 @@ func (e *DynamicExpansions) PutAndRedact(key, value string) {
 	}
 }
 
+// Redact is used when the key and value shouldn't be an expansion,
+// but should be redacted like one.
+func (e *DynamicExpansions) Redact(key, value string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.redact = append(e.redact, RedactInfo{Key: key, Value: value})
+}
+
 // UpdateFromYamlAndRedact updates the expansions from the given yaml file
 // and then marks the expansions for redaction.
 func (e *DynamicExpansions) UpdateFromYamlAndRedact(filename string) ([]string, error) {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-25b"
+	AgentVersion = "2024-09-25c"
 )
 
 const (

--- a/model/project.go
+++ b/model/project.go
@@ -620,11 +620,6 @@ func (c *PluginCommandConf) unmarshalParams() error {
 	return nil
 }
 
-type ArtifactInstructions struct {
-	Include      []string `yaml:"include,omitempty" bson:"include"`
-	ExcludeFiles []string `yaml:"excludefiles,omitempty" bson:"exclude_files"`
-}
-
 type YAMLCommandSet struct {
 	SingleCommand *PluginCommandConf  `yaml:"single_command,omitempty" bson:"single_command,omitempty"`
 	MultiCommand  []PluginCommandConf `yaml:"multi_command,omitempty" bson:"multi_command,omitempty"`


### PR DESCRIPTION
DEVPROD-10509

### Description
This ticket cleans up some of the redacting logic and adds redaction to the generated tokens. 

It also fixes a bug where modules would still generate a token even if the user passed in an access token.

### Testing
Existing unit tests

[This](https://parsley-staging.corp.mongodb.com/evergreen/zackary_bisect_ubuntu_long_task_with_expansions_patch_75ff53fe6dcf210f4d5116e884abdd365150b4fd_66edb8e3decf1000077360c2_24_09_20_18_03_21/2/all?bookmarks=0,932&selectedLineRange=L686) task on staging after the fix, the token for `git clone ... github-merge-queue-sandbox` is redacted.