### PR TITLE
DEVPROD-9920 Don't block single host TG deps if host terminates aftergroup finishes

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2634,18 +2634,22 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 }
 
 // FindAllDependencyTasksToModify finds tasks that depend on the
-// given tasks. The isUnblocking parameter indicates whether we are fetching
+// given tasks. The isBlocking parameter indicates whether we are fetching
 // tasks to unblock them, and if so, for each task, all dependencies
 // that have been marked unattainable will be retrieved. Otherwise, we are
 // fetching tasks to block them, and for each task, all dependencies
 // that have a status that that would block the task from running (i.e., it is
 // inconsistent with the task's Dependency.Status field) and have not been marked
-// unattainable will be retrieved.
+// unattainable will be retrieved. The ignoreDependencyStatusForBlocking parameter
+// indicates whether all tasks that depend on the given need to be updated for a
+// blocking operation (for example, if a single host task group host terminates
+// before completing the group and we need to block all later tasks regardless
+// of their Dependency.Status field).
 //
 // This must find tasks in smaller chunks to avoid the 16 MB query size limit -
 // if the number of tasks is large, a single query could be too large and the DB
 // will reject it.
-func FindAllDependencyTasksToModify(tasks []Task, isUnblocking bool) ([]Task, error) {
+func FindAllDependencyTasksToModify(tasks []Task, isBlocking, ignoreDependencyStatusForBlocking bool) ([]Task, error) {
 	if len(tasks) == 0 {
 		return nil, nil
 	}
@@ -2655,13 +2659,16 @@ func FindAllDependencyTasksToModify(tasks []Task, isUnblocking bool) ([]Task, er
 	allTasks := make([]Task, 0, len(tasks))
 
 	for i, t := range tasks {
-		elemMatchQuery := bson.M{DependencyTaskIdKey: t.Id}
-		if isUnblocking {
-			elemMatchQuery[DependencyUnattainableKey] = true
-		} else {
+		elemMatchQuery := bson.M{
+			DependencyTaskIdKey:       t.Id,
+			DependencyUnattainableKey: !isBlocking,
+		}
+		// If the operation is unblocking, then we ignore the status the dependencies were waiting on,
+		// and unblock all of them. Similarly, if the operation is blocking and ignoreDependencyStatusForBlocking
+		// is set, we also want to ignore the status the dependencies were waiting on.
+		if isBlocking && !ignoreDependencyStatusForBlocking {
 			okStatusSet := []string{AllStatuses, t.Status}
 			elemMatchQuery[DependencyStatusKey] = bson.M{"$nin": okStatusSet}
-			elemMatchQuery[DependencyUnattainableKey] = false
 		}
 		unmatchedDep = append(unmatchedDep, bson.M{
 			DependsOnKey: bson.M{"$elemMatch": elemMatchQuery},

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1850,7 +1850,7 @@ func TestFindAllUnmarkedDependenciesToBlock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)
@@ -1889,7 +1889,7 @@ func TestFindAllUnattainableDependenciesToUnbock(t *testing.T) {
 		assert.NoError(task.Insert())
 	}
 
-	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, true)
+	deps, err := FindAllDependencyTasksToModify([]Task{*t1}, false, false)
 	assert.NoError(err)
 	require.Len(t, deps, 1)
 	assert.Equal("t2", deps[0].Id)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7310,7 +7310,7 @@ func TestUpdateBlockedDependencies(t *testing.T) {
 	}
 	assert.NoError(execTask.Insert())
 
-	assert.NoError(UpdateBlockedDependencies(ctx, []task.Task{tasks[0]}))
+	assert.NoError(UpdateBlockedDependencies(ctx, []task.Task{tasks[0]}, false))
 
 	dbTask1, err := task.FindOneId(tasks[1].Id)
 	assert.NoError(err)

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -145,7 +145,7 @@ func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCac
 	if err == nil {
 		for _, blockingTask := range finishedBlockingTasks {
 			blockingTaskIds = append(blockingTaskIds, blockingTask.Id)
-			err = model.UpdateBlockedDependencies(ctx, []task.Task{blockingTask})
+			err = model.UpdateBlockedDependencies(ctx, []task.Task{blockingTask}, false)
 			catcher.Wrapf(err, "updating blocked dependencies for '%s'", blockingTask.Id)
 			if err != nil {
 				err = t.MarkDependenciesFinished(ctx, false)

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -225,11 +225,11 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 						lastActivatedTaskGroupTask = t
 					}
 				}
-				// If the host was in-between running a single host task group, the group should start from scratch.
-				// Since single host task groups only restart when the whole group is finished, we all block subsequent task group
-				// tasks from running regardless of what status they were waiting on, so that we can force the task group to restart immediately.
-				j.AddError(errors.Wrapf(model.UpdateBlockedDependencies(ctx, []task.Task{*latestTask}, true), "updating blocked dependencies for task '%s'", latestTask.Id))
 				if lastActivatedTaskGroupTask.Id != latestTask.Id {
+					// If the host was in-between running a single host task group, the group should start from scratch.
+					// Since single host task groups only restart when the whole group is finished, we all block subsequent task group
+					// tasks from running regardless of what status they were waiting on, so that we can force the task group to restart immediately.
+					j.AddError(errors.Wrapf(model.UpdateBlockedDependencies(ctx, []task.Task{*latestTask}, true), "updating blocked dependencies for task '%s'", latestTask.Id))
 					// If we aren't looking at the last task in the group, then we should mark the whole thing for restart,
 					// because later tasks in the group need to run on the same host as the earlier ones.
 					j.AddError(errors.Wrapf(model.TryResetTask(ctx, j.env.Settings(), latestTask.Id, evergreen.User, evergreen.MonitorPackage, nil), "resetting task '%s'", latestTask.Id))

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -526,10 +526,12 @@ func TestHostTerminationJob(t *testing.T) {
 			// Verify the task group has not been reset
 			resetTask, err := task.FindOneId("task2")
 			require.NoError(t, err)
+			require.NotNil(t, resetTask)
 			assert.Equal(t, evergreen.TaskSucceeded, resetTask.Status)
 
 			dbTask, err := task.FindOneId(nonTgTask.Id)
 			require.NoError(t, err)
+			require.NotNil(t, dbTask)
 			assert.False(t, dbTask.UnattainableDependency)
 		},
 	} {


### PR DESCRIPTION
DEVPROD-9920

### Description
The change in #8323 resolves the BFs, but it does not need to run the dependency blocking logic if the task group has ran its final task.
### Testing
Updated unit tests.
