### PR TITLE
DEVPROD-8801 Limit container variant tasks

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -419,10 +419,10 @@ functions:
           set -o xtrace
           rm evergreen/bin/output.*
           rm evergreen/bin/jstests/*.xml
-  
+
   write-downstream-expansions-for-pine:
     - command: shell.exec
-      params: 
+      params:
         script: |
           touch downstream_expansions_pine.yaml
           echo "pine_repo_name: evergreen" | tee downstream_expansions_pine.yaml
@@ -528,7 +528,7 @@ tasks:
     tags: ["db", "test"]
     name: test-taskoutput
   - <<: *run-go-test-suite-with-mongodb
-    tags: ["db", "test", "skip-container"]
+    tags: ["db", "test"]
     name: test-thirdparty
   - <<: *run-go-test-suite-with-mongodb
     tags: ["db", "test"]
@@ -612,7 +612,7 @@ tasks:
     tags: ["db", "test"]
     name: test-plugin
   - <<: *run-go-test-suite-with-mongodb-useast
-    tags: ["db", "test", "skip-container"]
+    tags: ["db", "test"]
     name: test-graphql
   - name: test-repotracker
     tags: ["db", "test"]
@@ -646,7 +646,7 @@ tasks:
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
     disable: true # TODO: re-enable in DEVPROD-5453
-    tags: ["linter", "skip-container"]
+    tags: ["linter"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec
@@ -736,10 +736,10 @@ tasks:
           display_name: swagger.json (latest)
           patchable: false
   - name: write-downstream-expansions-for-pine
-    commands: 
+    commands:
       - func: write-downstream-expansions-for-pine
       - command: downstream_expansions.set
-        params: 
+        params:
           file: downstream_expansions_pine.yaml
   - <<: *build-and-push-client
     name: build-linux_amd64
@@ -842,9 +842,6 @@ buildvariants:
       decompress: tar zxvf
     tasks:
       - name: ".smoke"
-      - name: ".test !.skip-container"
-      - name: "js-test"
-      - name: ".linter !.skip-container"
 
   - name: lint
     display_name: Lint
@@ -918,14 +915,13 @@ buildvariants:
     display_tasks:
       - name: build-and-push
         execution_tasks:
-        - ".build"
+          - ".build"
       - name: build-and-push-staging
         execution_tasks:
-        - ".build-staging"
+          - ".build-staging"
       - name: build-and-push-darwin-unsigned
         execution_tasks:
-        - ".build-unsigned"
-
+          - ".build-unsigned"
 
 containers:
   - name: evg-container


### PR DESCRIPTION
DEVPROD-8801

### Description
We have not been using these task failures as a signal and they are causing our waterfall to consistently be red. This limits it to smoke test only so that we can still have some signal but eliminate the ones that are not being relied on. 

