### PR TITLE
DEVPROD-9663 remove incorrect patch permission text and update superuser default

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1266,7 +1266,7 @@ var (
 		Value:       10,
 	}
 	PatchNone = PermissionLevel{
-		Description: "Not able to view or submit patches",
+		Description: "Not able to submit patches",
 		Value:       0,
 	}
 	LogsView = PermissionLevel{

--- a/testdata/local/roles.json
+++ b/testdata/local/roles.json
@@ -7,6 +7,6 @@
 {"_id":"superuser","name":"project_create","scope":"super","permissions":{"project_create":10,"admin_settings":10,"distro_create":10}}
 {"_id":"superuser_distro_access","name":"admin access","scope":"all_distros","permissions":{"distro_settings":30,"distro_hosts":20}}
 {"_id":"annotations_evergreen","name":"project_task_annotations","scope":"evergreen","permissions":{"project_task_annotations": 20}}
-{"_id":"admin_project_access","name":"project_settings","scope":"all_projects","permissions":{"project_logs":10,"project_patches":10,"project_tasks":30,"project_settings":20}}
+{"_id":"admin_project_access","name":"project_settings","scope":"all_projects","permissions":{"project_logs":10,"project_patches":0,"project_tasks":10,"project_settings":10}}
 {"_id":"basic_distro_access","name":"basic access","scope":"all_distros","permissions":{"distro_settings":10,"distro_hosts":10}}
 {"_id":"basic_project_access","name": "basic access","scope":"unrestricted_projects","permissions":{"project_tasks":20,"project_patches":10,"project_logs":10,"project_task_annotations":10}}

--- a/testdata/local/roles.json
+++ b/testdata/local/roles.json
@@ -7,6 +7,6 @@
 {"_id":"superuser","name":"project_create","scope":"super","permissions":{"project_create":10,"admin_settings":10,"distro_create":10}}
 {"_id":"superuser_distro_access","name":"admin access","scope":"all_distros","permissions":{"distro_settings":30,"distro_hosts":20}}
 {"_id":"annotations_evergreen","name":"project_task_annotations","scope":"evergreen","permissions":{"project_task_annotations": 20}}
-{"_id":"admin_project_access","name":"project_settings","scope":"all_projects","permissions":{"project_logs":10,"project_patches":0,"project_tasks":10,"project_settings":10}}
+{"_id":"admin_project_access","name":"project_settings","scope":"all_projects","permissions":{"project_logs":10,"project_patches":10,"project_tasks":30,"project_settings":20}}
 {"_id":"basic_distro_access","name":"basic access","scope":"all_distros","permissions":{"distro_settings":10,"distro_hosts":10}}
 {"_id":"basic_project_access","name": "basic access","scope":"unrestricted_projects","permissions":{"project_tasks":20,"project_patches":10,"project_logs":10,"project_task_annotations":10}}


### PR DESCRIPTION
DEVPROD-9663

### Description
This text says there's no permission to "view or edit patches", but we actually use task view permission for all viewing things, and we only use this for submission, so this shouldn't reference view.

Verified there's nothing to update for mana, since this already just says "unspecified".

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
