### PR TITLE
DEVPROD-9945 Connect AssumeRole project command and app route

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -97,7 +97,7 @@ func (r *ec2AssumeRole) execute(ctx context.Context, comm client.Communicator, l
 	conf.NewExpansions.PutAndRedact(globals.AWSAccessKeyId, creds.AccessKeyID)
 	conf.NewExpansions.PutAndRedact(globals.AWSSecretAccessKey, creds.SecretAccessKey)
 	conf.NewExpansions.PutAndRedact(globals.AWSSessionToken, creds.SessionToken)
-	conf.NewExpansions.PutAndRedact(globals.AWSRoleExpiration, creds.Expiration)
+	conf.NewExpansions.Put(globals.AWSRoleExpiration, creds.Expiration)
 
 	return nil
 }

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/globals"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mitchellh/mapstructure"
@@ -30,7 +31,7 @@ type ec2AssumeRole struct {
 
 	// The duration, in seconds, of the role session.
 	// Defaults to 900s (15 minutes).
-	DurationSeconds int `mapstructure:"duration_seconds"`
+	DurationSeconds int32 `mapstructure:"duration_seconds"`
 
 	// TemporaryFeatureFlag is a flag to flip between the new and old implementation.
 	// TODO (DEVPROD-9947): Remove this.
@@ -52,11 +53,9 @@ func (r *ec2AssumeRole) ParseParams(params map[string]interface{}) error {
 
 func (r *ec2AssumeRole) validate() error {
 	catcher := grip.NewSimpleCatcher()
-
 	catcher.NewWhen(r.RoleARN == "", "must specify role ARN")
 	// 0 will default duration time to 15 minutes.
 	catcher.NewWhen(r.DurationSeconds < 0, "cannot specify a non-positive duration")
-
 	return catcher.Resolve()
 }
 
@@ -79,8 +78,26 @@ func (r *ec2AssumeRole) Execute(ctx context.Context,
 
 func (r *ec2AssumeRole) execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
-	// TODO (DEVPROD-9945): Migration to new implementation.
-	return errors.New("temporary feature flag is enabled")
+	request := apimodels.AssumeRoleRequest{
+		RoleARN: r.RoleARN,
+	}
+	if r.DurationSeconds > 0 {
+		request.DurationSeconds = utility.ToInt32Ptr(r.DurationSeconds)
+	}
+	if r.Policy != "" {
+		request.Policy = utility.ToStringPtr(r.Policy)
+	}
+	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
+	creds, err := comm.AssumeRole(ctx, td, request)
+	if err != nil {
+		return errors.Wrap(err, "assuming role")
+	}
+	conf.NewExpansions.PutAndRedact(globals.AWSAccessKeyId, creds.AccessKeyID)
+	conf.NewExpansions.PutAndRedact(globals.AWSSecretAccessKey, creds.SecretAccessKey)
+	conf.NewExpansions.PutAndRedact(globals.AWSSessionToken, creds.SessionToken)
+	conf.NewExpansions.PutAndRedact(globals.AWSRoleExpiration, creds.Expiration)
+
+	return nil
 }
 
 func (r *ec2AssumeRole) legacyExecute(ctx context.Context,

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -104,7 +104,8 @@ func TestEC2AssumeRoleExecute(t *testing.T) {
 				assert.True(t, hasAccessKey)
 				assert.True(t, hasSecretAccessKey)
 				assert.True(t, hasSessionToken)
-				assert.True(t, hasExpiration)
+				// The expiration should not be redacted.
+				assert.False(t, hasExpiration)
 			})
 		},
 	} {

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/agent/globals"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,27 +44,75 @@ func TestEC2AssumeRoleParse(t *testing.T) {
 
 func TestEC2AssumeRoleExecute(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
-		"TemporaryFeatureFlagDisabled": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+		"OldMigration": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+			// TODO (DEVPROD-9947): Remove this.
 			c := &ec2AssumeRole{
 				RoleARN:         "randomRoleArn1234567890",
 				DurationSeconds: 10,
 			}
 			assert.EqualError(t, c.Execute(ctx, comm, logger, conf), "no EC2 keys in config")
 		},
-		"TemporaryFeatureFlagEnabled": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
-			// TODO (DEVPROD-9945): Migration to new implementation. That should include tests for the new implementations Execute method.
+		"BadAWSResponse": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+			comm.AssumeRoleResponse = nil
+
 			c := &ec2AssumeRole{
 				RoleARN:              "randomRoleArn1234567890",
 				DurationSeconds:      10,
 				TemporaryFeatureFlag: true,
 			}
-			assert.EqualError(t, c.Execute(ctx, comm, logger, conf), "temporary feature flag is enabled")
+			assert.EqualError(t, c.Execute(ctx, comm, logger, conf), "nil credentials returned")
+		},
+		"Success": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
+			comm.AssumeRoleResponse = &apimodels.AssumeRoleResponse{
+				AccessKeyID:     "access_key_id",
+				SecretAccessKey: "secret_access_key",
+				SessionToken:    "session_token",
+				Expiration:      "expiration",
+			}
+
+			c := &ec2AssumeRole{
+				RoleARN:              "randomRoleArn1234567890",
+				DurationSeconds:      10,
+				TemporaryFeatureFlag: true,
+			}
+			require.NoError(t, c.Execute(ctx, comm, logger, conf))
+
+			assert.Equal(t, "access_key_id", conf.NewExpansions.Get(globals.AWSAccessKeyId))
+			assert.Equal(t, "secret_access_key", conf.NewExpansions.Get(globals.AWSSecretAccessKey))
+			assert.Equal(t, "session_token", conf.NewExpansions.Get(globals.AWSSessionToken))
+			assert.Equal(t, "expiration", conf.NewExpansions.Get(globals.AWSRoleExpiration))
+
+			t.Run("KeysAreRedacted", func(t *testing.T) {
+				hasAccessKey := false
+				hasSecretAccessKey := false
+				hasSessionToken := false
+				hasExpiration := false
+
+				for _, redacted := range conf.NewExpansions.GetRedacted() {
+					switch redacted.Key {
+					case globals.AWSAccessKeyId:
+						hasAccessKey = true
+					case globals.AWSSecretAccessKey:
+						hasSecretAccessKey = true
+					case globals.AWSSessionToken:
+						hasSessionToken = true
+					case globals.AWSRoleExpiration:
+						hasExpiration = true
+					}
+				}
+
+				assert.True(t, hasAccessKey)
+				assert.True(t, hasSecretAccessKey)
+				assert.True(t, hasSessionToken)
+				assert.True(t, hasExpiration)
+			})
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
+			expansions := util.Expansions{}
 			conf := &internal.TaskConfig{
 				Task: task.Task{
 					Id:           "id",
@@ -78,6 +130,8 @@ func TestEC2AssumeRoleExecute(t *testing.T) {
 						ConfigEnabled: utility.TruePtr(),
 					},
 				},
+				Expansions:    expansions,
+				NewExpansions: agentutil.NewDynamicExpansions(expansions),
 			}
 
 			comm := client.NewMock("localhost")

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -1027,6 +1027,9 @@ func (c *baseCommunicator) AssumeRole(ctx context.Context, td TaskData, request 
 	if resp.StatusCode != http.StatusOK {
 		return nil, util.RespErrorf(resp, "trouble assuming role")
 	}
-	creds := apimodels.AssumeRoleResponse{}
-	return &creds, errors.Wrapf(utility.ReadJSON(resp.Body, &creds), "reading assume role response")
+	var creds apimodels.AssumeRoleResponse
+	if err := utility.ReadJSON(resp.Body, &creds); err != nil {
+		return nil, errors.Wrap(err, "reading assume role response")
+	}
+	return &creds, nil
 }

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -1012,3 +1012,21 @@ func (c *baseCommunicator) UpsertCheckRun(ctx context.Context, td TaskData, chec
 	defer resp.Body.Close()
 	return nil
 }
+
+func (c *baseCommunicator) AssumeRole(ctx context.Context, td TaskData, request apimodels.AssumeRoleRequest) (*apimodels.AssumeRoleResponse, error) {
+	info := requestInfo{
+		method:   http.MethodPost,
+		taskData: &td,
+	}
+	info.setTaskPathSuffix("aws/assume_role")
+	resp, err := c.retryRequest(ctx, info, &request)
+	if err != nil {
+		return nil, util.RespErrorf(resp, errors.Wrap(err, "assuming role").Error())
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.RespErrorf(resp, "trouble assuming role")
+	}
+	creds := apimodels.AssumeRoleResponse{}
+	return &creds, errors.Wrapf(utility.ReadJSON(resp.Body, &creds), "reading assume role response")
+}

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -130,8 +130,11 @@ type SharedCommunicator interface {
 	// MarkFailedTaskToRestart marks the task as needing to be restarted
 	MarkFailedTaskToRestart(ctx context.Context, td TaskData) error
 
-	// UpsertCheckRun upserts a checkrun for a task
+	// UpsertCheckRun upserts a checkrun for a task.
 	UpsertCheckRun(ctx context.Context, td TaskData, checkRunOutput apimodels.CheckRunOutput) error
+
+	// AssumeRole assumes an AWS role and returns the credentials.
+	AssumeRole(ctx context.Context, td TaskData, request apimodels.AssumeRoleRequest) (*apimodels.AssumeRoleResponse, error)
 }
 
 // TaskData contains the taskData.ID and taskData.Secret. It must be set for

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -597,3 +597,7 @@ func (s *mockSender) Flush(_ context.Context) error { return nil }
 func (c *Mock) UpsertCheckRun(ctx context.Context, td TaskData, checkRunOutput apimodels.CheckRunOutput) error {
 	return nil
 }
+
+func (c *Mock) AssumeRole(ctx context.Context, td TaskData, request apimodels.AssumeRoleRequest) (*apimodels.AssumeRoleResponse, error) {
+	return nil, nil
+}

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -70,6 +70,7 @@ type Mock struct {
 	CreateGitHubDynamicAccessTokenResult string
 	CreateGitHubDynamicAccessTokenFail   bool
 	RevokeGitHubDynamicAccessTokenFail   bool
+	AssumeRoleResponse                   *apimodels.AssumeRoleResponse
 
 	CedarGRPCConn *grpc.ClientConn
 
@@ -599,5 +600,5 @@ func (c *Mock) UpsertCheckRun(ctx context.Context, td TaskData, checkRunOutput a
 }
 
 func (c *Mock) AssumeRole(ctx context.Context, td TaskData, request apimodels.AssumeRoleRequest) (*apimodels.AssumeRoleResponse, error) {
-	return nil, nil
+	return c.AssumeRoleResponse, nil
 }

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -200,9 +200,13 @@ type Token struct {
 
 // AssumeRoleRequest is the details of what role to assume.
 type AssumeRoleRequest struct {
-	RoleARN         string  `json:"role_arn"`
-	Policy          *string `json:"policy"`
-	DurationSeconds *int32  `json:"duration_seconds"`
+	// RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+	RoleARN string `json:"role_arn"`
+	// Policy is an optional field that can be used to restrict the permissions.
+	Policy *string `json:"policy"`
+	// DurationSeconds is an optional field of the duration of the role session.
+	// It defaults to 15 minutes.
+	DurationSeconds *int32 `json:"duration_seconds"`
 }
 
 // Validate checks that the request has valid values.

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -200,9 +200,9 @@ type Token struct {
 
 // AssumeRoleRequest is the details of what role to assume.
 type AssumeRoleRequest struct {
-	RoleARN         string `json:"role_arn"`
-	Policy          string `json:"policy"`
-	DurationSeconds *int32 `json:"duration_seconds"`
+	RoleARN         string  `json:"role_arn"`
+	Policy          *string `json:"policy"`
+	DurationSeconds *int32  `json:"duration_seconds"`
 }
 
 // Validate checks that the request has valid values.

--- a/apimodels/agent_models_test.go
+++ b/apimodels/agent_models_test.go
@@ -44,7 +44,7 @@ func TestAssumeRoleRequestValidate(t *testing.T) {
 			req: AssumeRoleRequest{
 				RoleARN:         "role",
 				DurationSeconds: utility.ToInt32Ptr(1),
-				Policy:          "policy",
+				Policy:          utility.ToStringPtr("policy"),
 			},
 		},
 	}

--- a/cloud/sts.go
+++ b/cloud/sts.go
@@ -41,8 +41,12 @@ type stsManagerImpl struct {
 // Some internal options are not present and are set by the manager
 // (e.g. ExternalID).
 type AssumeRoleOptions struct {
-	RoleARN         string
-	Policy          string
+	// RoleARN is the Amazon Resource Name (ARN) of the role to assume.
+	RoleARN string
+	// Policy is an optional field that can be used to restrict the permissions.
+	Policy *string
+	// DurationSeconds is an optional field of the duration of the role session.
+	// It defaults to 15 minutes.
 	DurationSeconds *int32
 }
 
@@ -70,7 +74,7 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 	}
 	output, err := s.client.AssumeRole(ctx, &sts.AssumeRoleInput{
 		RoleArn:         &opts.RoleARN,
-		Policy:          &opts.Policy,
+		Policy:          opts.Policy,
 		DurationSeconds: opts.DurationSeconds,
 		ExternalId:      aws.String(createExternalID(t)),
 		RoleSessionName: aws.String(strconv.Itoa(int(time.Now().Unix()))),

--- a/cloud/sts_test.go
+++ b/cloud/sts_test.go
@@ -26,7 +26,7 @@ func TestAssumeRole(t *testing.T) {
 		"InvalidTask": func(ctx context.Context, t *testing.T, manager STSManager, awsClientMock *awsClientMock) {
 			_, err := manager.AssumeRole(ctx, taskID, AssumeRoleOptions{
 				RoleARN: roleARN,
-				Policy:  policy,
+				Policy:  &policy,
 			})
 			require.ErrorContains(t, err, "task not found")
 		},
@@ -36,7 +36,7 @@ func TestAssumeRole(t *testing.T) {
 
 			creds, err := manager.AssumeRole(ctx, taskID, AssumeRoleOptions{
 				RoleARN: roleARN,
-				Policy:  policy,
+				Policy:  &policy,
 			})
 			require.NoError(t, err)
 			// Return credentials

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-25a"
+	AgentVersion = "2024-09-25b"
 )
 
 const (

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -932,7 +932,7 @@ func TestAWSAssumeRole(t *testing.T) {
 			require.NoError(t, handler.Parse(ctx, request))
 			assert.Equal(t, taskID, handler.taskID)
 			assert.Equal(t, roleARN, handler.body.RoleARN)
-			assert.Equal(t, policy, handler.body.Policy)
+			assert.Equal(t, policy, utility.FromStringPtr(handler.body.Policy))
 			assert.Equal(t, duration, utility.FromInt32Ptr(handler.body.DurationSeconds))
 
 			t.Run("RunErrorsOnNilTask", func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-9945

### Description
For the AssumeRole migration, we made the task app route to assume a role for a task. This migrates the command to use it if the feature flag is turned on.

### Testing
Deployed to staging, ran these patches [Mainline](https://spruce-staging.corp.mongodb.com/version/zackary_bisect_c23a8034170c677f2d756fa75c0d260c54efbe12/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=assume_role) and [Patch](https://spruce-staging.corp.mongodb.com/version/66f2d5daef10f50007fbc7db/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
Added some unit tests.

CLI Patch:
<img width="1378" alt="Screenshot 2024-09-24 at 11 11 27 AM" src="https://github.com/user-attachments/assets/4af89783-c251-4aa5-90d4-6bac614d0f5a">

Mainline Patch (I edited the title to match the same style as the above):
<img width="1382" alt="Screenshot 2024-09-24 at 11 11 52 AM" src="https://github.com/user-attachments/assets/ddbd84b6-461d-4336-983d-d06c31670f0c">

Note: The tasks with 'external id' means that the role they are trying to assume, had a policy set up with an external id that restricted it to *my* project + mainline commits (or gitter requester).

If you want to compare before, the [project ticket](https://jira.mongodb.org/browse/DEVPROD-5575?focusedCommentId=6690575&focusedId=6690575&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6690575) has some comments with screenshots before and after (the after are the same as the above).
