### PR TITLE
DEVPROD-5614 Add trace attributes to teardown group and task

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -896,8 +896,10 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 
 	if teardownGroup.commands != nil {
 		a.killProcs(ctx, tc, true, "teardown group commands are starting")
-
+		ctx = utility.ContextWithAttributes(ctx, tc.taskConfig.TaskAttributes())
+		ctx, span := a.tracer.Start(ctx, "teardown_group")
 		_ = a.runCommandsInBlock(ctx, tc, *teardownGroup)
+		span.End()
 		// Teardown groups should run all the remaining command cleanups.
 		tc.runTaskCommandCleanups(ctx, tc.logger, a.tracer)
 		tc.runSetupGroupCommandCleanups(ctx, tc.logger, a.tracer)

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -101,7 +101,7 @@ func (tc *taskContext) runTaskCommandCleanups(ctx context.Context, logger client
 	if len(tc.taskCleanups) == 0 {
 		return
 	}
-	ctx, span := trace.Start(ctx, "task_command_cleanups")
+	ctx, span := trace.Start(ctx, "task-command-cleanups")
 	defer span.End()
 
 	if err := errors.Wrap(runCommandCleanups(ctx, tc.taskCleanups, trace), "running setup group command cleanups"); err != nil {
@@ -115,7 +115,7 @@ func (tc *taskContext) runSetupGroupCommandCleanups(ctx context.Context, logger 
 	if len(tc.setupGroupCleanups) == 0 {
 		return
 	}
-	ctx, span := trace.Start(ctx, "setup_group_command_cleanups")
+	ctx, span := trace.Start(ctx, "setup-group-command-cleanups")
 	defer span.End()
 
 	if err := errors.Wrap(runCommandCleanups(ctx, tc.setupGroupCleanups, trace), "running setup group command cleanups"); err != nil {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-24"
+	AgentVersion = "2024-09-25"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-5614

### Description
This adds the task attributes to the teardown group traces (and gives it a parent span with a proper name). It also does a small rename for the cleanups to be consistent with the others.

### Testing
[Before](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen-agent/result/eRJdajDjkdV/trace/8HL89vCzvT1?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&source=query&span=0e6d051173c21c16):
<img width="1248" alt="Screenshot 2024-09-24 at 3 38 34 PM" src="https://github.com/user-attachments/assets/5f4344f1-ae0b-4c74-9524-baf8cffb7c32">

[After](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/result/CQ3h4iMDskc/trace/tDKy3FetuSv?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=ff7a2f9f3d94b1ca):
<img width="1242" alt="Screenshot 2024-09-24 at 3 38 05 PM" src="https://github.com/user-attachments/assets/6f2e2422-9248-4f29-a803-21a8976162c2">

(The difference in commands ran are not important, I just chose two random teardown group tasks. The difference is the attributes and the fact that the teardown group is the new named parent trace)