### PR TITLE
DEVPROD-11617: Sort waterfall build variants alphabetically

### DIFF
--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -178,7 +178,7 @@
       "_id": "evergreen_version1_build",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
-      "display_name": "Ubuntu 16.04",
+      "display_name": "01 Ubuntu 16.04",
       "tasks": [
         {
           "id": "task_1"
@@ -193,7 +193,7 @@
       "_id": "evergreen_version2_build",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
-      "display_name": "Ubuntu 16.04",
+      "display_name": "02 Ubuntu 16.04",
       "tasks": [
         {
           "id": "task_3"
@@ -208,7 +208,7 @@
       "_id": "evergreen_version3_build",
       "activated": true,
       "build_variant": "lint",
-      "display_name": "Linter",
+      "display_name": "03 Linter",
       "tasks": [
         {
           "id": "task_5"

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -10,7 +10,7 @@
             "buildVariants": [
               {
                 "id": "enterprise-ubuntu1604-64",
-                "displayName": "Ubuntu 16.04",
+                "displayName": "01 Ubuntu 16.04",
                 "builds": [
                   {
                     "activated": true,
@@ -63,7 +63,7 @@
                     "version": "evergreen_version5"
                   }
                 ],
-                "displayName": "Linter",
+                "displayName": "03 Linter",
                 "id": "lint"
               }
             ],

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -195,7 +195,6 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 			},
 		},
 	})
-	pipeline = append(pipeline, bson.M{"$sort": bson.M{"_id": 1}})
 	pipeline = append(pipeline, bson.M{
 		"$project": bson.M{
 			build.DisplayNameKey: bson.M{
@@ -204,6 +203,7 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 			buildsKey: 1,
 		},
 	})
+	pipeline = append(pipeline, bson.M{"$sort": bson.M{build.DisplayNameKey: 1}})
 
 	res := []WaterfallBuildVariant{}
 	env := evergreen.GetEnvironment()

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -373,7 +373,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b := build.Build{
 		Id:          "b_a",
 		Activated:   true,
-		DisplayName: "Build A",
+		DisplayName: "02 Build C",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -394,7 +394,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_b",
 		Activated:   true,
-		DisplayName: "Build B",
+		DisplayName: "03 Build B",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -409,7 +409,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_c",
 		Activated:   true,
-		DisplayName: "Build C",
+		DisplayName: "01 Build A",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -427,7 +427,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_d",
 		Activated:   false,
-		DisplayName: "Build D",
+		DisplayName: "03 Build B",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -448,7 +448,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_e",
 		Activated:   false,
-		DisplayName: "Build E",
+		DisplayName: "01 Build A",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -463,7 +463,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_f",
 		Activated:   false,
-		DisplayName: "Build F",
+		DisplayName: "02 Build C",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -481,7 +481,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_g",
 		Activated:   true,
-		DisplayName: "Build G",
+		DisplayName: "01 Build A",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -502,7 +502,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_h",
 		Activated:   true,
-		DisplayName: "Build H",
+		DisplayName: "03 Build B",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -517,7 +517,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_i",
 		Activated:   true,
-		DisplayName: "Build I",
+		DisplayName: "02 Build C",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -535,7 +535,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_j",
 		Activated:   true,
-		DisplayName: "Build J",
+		DisplayName: "02 Build C",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -556,7 +556,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_k",
 		Activated:   true,
-		DisplayName: "Build K",
+		DisplayName: "01 Build A",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -571,7 +571,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_l",
 		Activated:   true,
-		DisplayName: "Build L",
+		DisplayName: "03 Build B",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -589,7 +589,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_m",
 		Activated:   true,
-		DisplayName: "Build M",
+		DisplayName: "03 Build B",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -610,7 +610,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_n",
 		Activated:   true,
-		DisplayName: "Build N",
+		DisplayName: "01 Build A",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -625,7 +625,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	b = build.Build{
 		Id:          "b_o",
 		Activated:   true,
-		DisplayName: "Build O",
+		DisplayName: "02 Build C",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
 			build.TaskCache{
@@ -737,9 +737,9 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	assert.Len(t, buildVariants, 3)
 
 	// Assert build variants are sorted alphabetically
-	assert.Equal(t, buildVariants[0].Id, "bv_1")
-	assert.Equal(t, buildVariants[1].Id, "bv_2")
-	assert.Equal(t, buildVariants[2].Id, "bv_3")
+	assert.Equal(t, buildVariants[0].DisplayName, "01 Build A")
+	assert.Equal(t, buildVariants[1].DisplayName, "02 Build C")
+	assert.Equal(t, buildVariants[2].DisplayName, "03 Build B")
 
 	// Each variant has 4 builds, corresponding to `limit`
 	assert.Len(t, buildVariants[0].Builds, 4)


### PR DESCRIPTION
DEVPROD-11617

### Description
- Fix previous implementation of waterfall sorting that sorted builds by their ID. We should sort by display name, especially since a lot of projects have their display names configured to render on the waterfall in a useful order.

### Testing
- Update test such that it would fail without display name sorting
