### PR TITLE
DEVPROD-10170 Use different sort key for estimated generated tasks

### DIFF
--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -135,7 +135,7 @@ func (r *patchResolver) GeneratedTaskCounts(ctx context.Context, obj *restModel.
 					task.BuildVariantKey: buildVariant.Name,
 					task.DisplayNameKey:  taskUnit.Name,
 					task.GenerateTaskKey: true,
-				}).Sort([]string{"-" + task.CreateTimeKey}))
+				}).Sort([]string{"-" + task.FinishTimeKey}))
 				if err != nil {
 					return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task with variant '%s' and name '%s': %s", buildVariant.Name, taskUnit.Name, err.Error()))
 				}

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -593,7 +593,7 @@ func (p *countEstimatedGeneratedTasksHandler) Run(ctx context.Context) gimlet.Re
 			task.BuildVariantKey: vt.Variant,
 			task.DisplayNameKey:  vt.TaskName,
 			task.GenerateTaskKey: true,
-		}).Sort([]string{"-" + task.CreateTimeKey}))
+		}).Sort([]string{"-" + task.FinishTimeKey}))
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting task with variant '%s' and name '%s'", vt.Variant, vt.TaskName))
 		}


### PR DESCRIPTION
DEVPROD-10170

### Description
These queries can be sped up by sorting on finish time key rather than create time key, since finish time is more friendly with the existing indexes that we have on the task collection.
### Testing
Tested by comparing explain plan results in shell.