### PR TITLE
DEVPROD-9134 Add agent start time and isEC2 to provisioning failure logs

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -340,14 +340,16 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	if utility.StringSliceContains(evergreen.ProvisioningHostStatus, prevStatus) && j.host.TaskCount == 0 {
 		event.LogHostProvisionFailed(j.HostID, fmt.Sprintf("terminating host in status '%s'", prevStatus))
 		grip.Info(message.Fields{
-			"message":     "provisioning failure",
-			"status":      prevStatus,
-			"host_id":     j.HostID,
-			"host_tag":    j.host.Tag,
-			"distro":      j.host.Distro.Id,
-			"uptime_secs": time.Since(j.host.StartTime).Seconds(),
-			"provider":    j.host.Provider,
-			"spawn_host":  j.host.StartedBy != evergreen.User,
+			"message":          "provisioning failure",
+			"status":           prevStatus,
+			"host_id":          j.HostID,
+			"host_tag":         j.host.Tag,
+			"distro":           j.host.Distro.Id,
+			"uptime_secs":      time.Since(j.host.StartTime).Seconds(),
+			"provider":         j.host.Provider,
+			"spawn_host":       j.host.StartedBy != evergreen.User,
+			"is_ec2_host":      cloud.IsEC2InstanceID(j.HostID),
+			"agent_start_time": j.host.AgentStartTime,
 		})
 	}
 }


### PR DESCRIPTION
DEVPROD-9134

### Description
With these new logs, we can create an alert to tell if we are consistently wasting host compute time by failing to provision hosts over and over, while actually creating them on the EC2 side.