### PR TITLE
DEVPROD-8586 Propagate true weighted priority to task queue doc

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -86,9 +86,14 @@ type Task struct {
 
 	Version string `bson:"version" json:"version,omitempty"`
 	// Project is the project id of the task.
-	Project           string `bson:"branch" json:"branch,omitempty"`
-	Revision          string `bson:"gitspec" json:"gitspec"`
-	Priority          int64  `bson:"priority" json:"priority"`
+	Project  string `bson:"branch" json:"branch,omitempty"`
+	Revision string `bson:"gitspec" json:"gitspec"`
+	// Priority is a specifiable value that adds weight to the prioritization that task will be given in its
+	// corresponding distro task queue.
+	Priority int64 `bson:"priority" json:"priority"`
+	// PriorityRankValue is not persisted to the db, but stored in memory and passed to the task queue document.
+	// It is a mixture of Priority and the various task queue ranking factors that multiply on top of Priority.
+	PriorityRankValue int64  `bson:"priority_rank_value" json:"priority_rank_value"`
 	TaskGroup         string `bson:"task_group" json:"task_group"`
 	TaskGroupMaxHosts int    `bson:"task_group_max_hosts,omitempty" json:"task_group_max_hosts,omitempty"`
 	TaskGroupOrder    int    `bson:"task_group_order,omitempty" json:"task_group_order,omitempty"`

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -113,6 +113,7 @@ type TaskQueueItem struct {
 	Project             string        `bson:"project" json:"project"`
 	ExpectedDuration    time.Duration `bson:"exp_dur" json:"exp_dur"`
 	Priority            int64         `bson:"priority" json:"priority"`
+	PriorityRankValue   int64         `bson:"priority_rank_value" json:"priority_rank_value"`
 	Dependencies        []string      `bson:"dependencies" json:"dependencies"`
 	ActivatedBy         string        `bson:"activated_by" json:"activated_by"`
 }

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -425,7 +425,7 @@ func (tpl TaskPlan) Export() []task.Task {
 		rankValue := unit.RankValue()
 		tasks := unit.Export()
 		sort.Sort(tasks)
-		for i, _ := range tasks {
+		for i := range tasks {
 			if seen.Visit(tasks[i].Id) {
 				continue
 			}

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -355,15 +355,21 @@ func (tl TaskList) Less(i, j int) bool {
 		return t1.TaskGroupOrder < t2.TaskGroupOrder
 	}
 
-	if t1.NumDependents != t2.NumDependents {
-		return t1.NumDependents > t2.NumDependents
-	}
+	t1Max := maxPriorityAndNumDependents(t1.NumDependents, t1.Priority)
+	t2Max := maxPriorityAndNumDependents(t2.NumDependents, t2.Priority)
 
-	if t1.Priority != t2.Priority {
-		return t1.Priority > t2.Priority
+	if t1Max != t2Max {
+		return t1Max > t2Max
 	}
 
 	return t1.FetchExpectedDuration().Average > t2.FetchExpectedDuration().Average
+}
+
+func maxPriorityAndNumDependents(numDependents int, priority int64) int64 {
+	if int64(numDependents) > priority {
+		return int64(numDependents)
+	}
+	return priority
 }
 
 // TaskPlan provides a sortable interface on top of a slice of

--- a/scheduler/planner_test.go
+++ b/scheduler/planner_test.go
@@ -259,7 +259,7 @@ func TestPlanner(t *testing.T) {
 					unit.SetDistro(&distro.Distro{})
 					assert.EqualValues(t, 12, unit.RankValue())
 				})
-				t.Run("NumDeps", func(t *testing.T) {
+				t.Run("NumDependents", func(t *testing.T) {
 					unit := NewUnit(task.Task{Id: "foo", NumDependents: 2})
 					unit.SetDistro(&distro.Distro{})
 					assert.EqualValues(t, 182, unit.RankValue())
@@ -324,7 +324,7 @@ func TestPlanner(t *testing.T) {
 				assert.Equal(t, "first", plan[0].Id)
 				assert.Equal(t, "second", plan[1].Id)
 			})
-			t.Run("NumDeps", func(t *testing.T) {
+			t.Run("NumDependents", func(t *testing.T) {
 				plan := TaskList{{Id: "second"}, {Id: "first", NumDependents: 2}}
 				sort.Sort(plan)
 				assert.Equal(t, "first", plan[0].Id)

--- a/scheduler/task_queue_persister.go
+++ b/scheduler/task_queue_persister.go
@@ -29,6 +29,7 @@ func PersistTaskQueue(distro string, tasks []task.Task, distroQueueInfo model.Di
 			Project:             t.Project,
 			ExpectedDuration:    t.ExpectedDuration,
 			Priority:            t.Priority,
+			PriorityRankValue:   t.PriorityRankValue,
 			Group:               t.TaskGroup,
 			GroupMaxHosts:       t.TaskGroupMaxHosts,
 			GroupIndex:          t.TaskGroupOrder,


### PR DESCRIPTION
DEVPROD-8586

### Description
Currently there is an opacity of how priority + our planner admin settings compute an actual sorted queue, and these factors can overlap in complex ways. If we have a way to inspect what these values are in real-time in the DB, we can better determine what priority teams should bump their versions to, and what values we should tune our  [planning multipliers](https://github.com/evergreen-ci/evergreen/blob/38b298af5e49e6b2fb50a1715760c922dfb06d95/model/distro/distro.go#L255-L261) to.

Added a field in the task queue that tracks this true queue rank value.

### Testing

Ran multiple types of versions in staging (patches, mainline commits, generators) in staging and checked that this new field on the queue in the DB reflects priority * all matching planner setting factors.