### PR TITLE
DEVPROD-11733: ignore dependencies requiring go 1.21+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,5 @@ updates:
       - dependency-name: "*gonum*" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "*grpc*" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "github.com/aws/smithy-go" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
+      - dependency-name: "github.com/99designs/gqlgen" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.22. If it is not possible to upgrade to 1.22 in DEVPROD-3611, create a separate ticket from DEVPROD-6962 for this dependency.
       - dependency-name: "github.com/gorilla/sessions" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.23. If it is not possible to upgrade to 1.23 in DEVPROD-3611, create a separate ticket from DEVPROD-6962 for this dependency.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,5 @@ updates:
     ignore:
       - dependency-name: "*gonum*" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "*grpc*" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
+      - dependency-name: "github.com/aws/smithy-go" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
+      - dependency-name: "github.com/gorilla/sessions" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.23. If it is not possible to upgrade to 1.23 in DEVPROD-3611, create a separate ticket from DEVPROD-6962 for this dependency.


### PR DESCRIPTION
DEVPROD-11733

### Description
[smithy-go](https://github.com/evergreen-ci/evergreen/pull/8256), [sessions](https://github.com/evergreen-ci/evergreen/pull/8257), and [gqlgen](https://github.com/evergreen-ci/evergreen/pull/8332), cannot be upgraded further because they all require a higher go version than Evergreen currently runs. Adding to the ignore list until DEVPROD-3611 can upgrade Evergreen's go version, at which point DEVPROD-6962 can revisit upgrading them.