### PR TITLE
DEVPROD-11629: log test selection inputs

### DIFF
--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -73,5 +74,10 @@ func (t *selectTestsHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (t *selectTestsHandler) Run(ctx context.Context) gimlet.Responder {
+	grip.Info(message.Fields{
+		"message": "received test selection request",
+		"route":   "/rest/v2/select/tests",
+		"request": t.selectTests,
+	})
 	return gimlet.NewJSONResponse(t.selectTests)
 }


### PR DESCRIPTION
DEVPROD-11629

### Description
Log the inputs to the test selection route so that we can have an idea of what a sample input looks like. This info will be helpful while creating the test selection service.