### PR TITLE
DEVPROD-7677: renotify for spawn host and volume expiration

### DIFF
--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -121,13 +121,16 @@ func shouldNotifyForSpawnhostExpiration(h *host.Host, numHours int) (bool, error
 	if err != nil {
 		return false, err
 	}
+	if rec == nil {
+		return true, nil
+	}
 
-	return rec == nil, nil
+	return time.Since(rec.AlertTime) > hostRenotificationInterval, nil
 }
 
-// temporaryExemptionRenotificationInterval is how frequently a notification can
-// be re-sent for a temporary exemption that's expring.
-const temporaryExemptionRenotificationInterval = utility.Day
+// hostRenotificationInterval is how frequently a host-related notification can
+// be re-sent after one has already been sent.
+const hostRenotificationInterval = utility.Day
 
 func shouldNotifyForHostTemporaryExemptionExpiration(h *host.Host, numHours int) (bool, error) {
 	if utility.IsZeroTime(h.SleepSchedule.TemporarilyExemptUntil) || time.Until(h.SleepSchedule.TemporarilyExemptUntil) > time.Duration(numHours)*time.Hour {
@@ -141,7 +144,7 @@ func shouldNotifyForHostTemporaryExemptionExpiration(h *host.Host, numHours int)
 		return true, nil
 	}
 
-	return time.Since(rec.AlertTime) > temporaryExemptionRenotificationInterval, nil
+	return time.Since(rec.AlertTime) > hostRenotificationInterval, nil
 }
 
 func trySpawnHostExpirationNotification(h *host.Host, numHours int) error {

--- a/units/volume_expiration_warning.go
+++ b/units/volume_expiration_warning.go
@@ -145,6 +145,9 @@ func shouldNotifyForVolumeExpiration(v host.Volume, numHours int) (bool, error) 
 	if err != nil {
 		return false, err
 	}
+	if rec == nil {
+		return true, err
+	}
 
-	return rec == nil, nil
+	return time.Since(rec.AlertTime) > hostRenotificationInterval, nil
 }


### PR DESCRIPTION
DEVPROD-7677

### Description
If a user receives a notification that their spawn host/volume is about to expire and they extend it, currently they won't get another notification when their extended expiration is close to expiring. This change allows the user to be re-notified again after extending the expiration.

### Testing
Added unit tests.

### Documentation
N/A
