### PR TITLE
DEVPROD-11778: Do not log warning messages for empty Evergreen test logs

### DIFF
--- a/agent/internal/taskoutput/test_log.go
+++ b/agent/internal/taskoutput/test_log.go
@@ -207,7 +207,7 @@ func (s testLogSpec) getParser() taskoutput.LogLineParser {
 
 			var data string
 			if len(lineParts) == 2 {
-				data = strings.TrimSuffix(lineParts[1], "\n")
+				data = lineParts[1]
 			}
 
 			return log.LogLine{

--- a/agent/internal/taskoutput/test_log.go
+++ b/agent/internal/taskoutput/test_log.go
@@ -197,20 +197,22 @@ const testLogSpecFilename = "log_spec.yaml"
 func (s testLogSpec) getParser() taskoutput.LogLineParser {
 	switch s.Format {
 	case testLogFormatTextTimestamp:
-		return func(data string) (log.LogLine, error) {
-			lineParts := strings.SplitN(strings.TrimSpace(data), " ", 2)
-			if len(lineParts) != 2 {
-				return log.LogLine{}, errors.Errorf("malformed text-timestamp log line: %s", data)
-			}
+		return func(line string) (log.LogLine, error) {
+			lineParts := strings.SplitN(strings.TrimSpace(line), " ", 2)
 
 			ts, err := strconv.ParseInt(lineParts[0], 10, 64)
 			if err != nil {
 				return log.LogLine{}, errors.Wrap(err, "invalid log timestamp prefix")
 			}
 
+			var data string
+			if len(lineParts) == 2 {
+				data = strings.TrimSuffix(lineParts[1], "\n")
+			}
+
 			return log.LogLine{
 				Timestamp: ts,
-				Data:      strings.TrimSuffix(lineParts[1], "\n"),
+				Data:      data,
 			}, nil
 		}
 	default:

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -333,6 +333,13 @@ func TestTestLogSpecGetParser(t *testing.T) {
 					_, err := parser(fmt.Sprintf("%v %s\n", time.Now(), data))
 					assert.Error(t, err)
 				})
+				t.Run("ParseRawLineWithJustTimestamp", func(t *testing.T) {
+					line, err := parser(fmt.Sprintf("%d\n", ts))
+					require.NoError(t, err)
+					assert.Zero(t, line.Priority)
+					assert.Equal(t, ts, line.Timestamp)
+					assert.Empty(t, line.Data)
+				})
 				t.Run("ParseRawLine", func(t *testing.T) {
 					line, err := parser(fmt.Sprintf("%d %s\n", ts, data))
 					require.NoError(t, err)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-09-25c"
+	AgentVersion = "2024-10-01"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-11778

### Description
Reduce noise in Evergreen logging warning messages.

If a log line is empty with just timestamp, the Evergreen agent should just ignore the line and move on rather than logging a warning. This is confusing for users and adds a lot of noise to the logs.

### Testing
Added new test to ensure empty lines are ok.

### Documentation
N/A

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
