### PR TITLE
DEVPROD-752 Remove ssh fallback

### DIFF
--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -312,7 +312,7 @@ func FormGitURL(host, owner, repo, token string) string {
 		return fmt.Sprintf("https://%s:x-oauth-basic@%s/%s/%s.git", token, host, owner, repo)
 	}
 
-	return fmt.Sprintf("git@%s:%s/%s.git", host, owner, repo)
+	return fmt.Sprintf("https://%s/%s/%s.git", host, owner, repo)
 }
 
 func FormGitURLForApp(host, owner, repo, token string) string {
@@ -320,5 +320,5 @@ func FormGitURLForApp(host, owner, repo, token string) string {
 		return fmt.Sprintf("https://x-access-token:%s@%s/%s/%s.git", token, host, owner, repo)
 	}
 
-	return fmt.Sprintf("git@%s:%s/%s.git", host, owner, repo)
+	return fmt.Sprintf("https://%s/%s/%s.git", host, owner, repo)
 }


### PR DESCRIPTION
DEVPROD-752

### Description
Instead of falling back to ssh cloning, fall back to an https url without a token which will work for public repos. 
The rest of the cleanup specified in the ticket has already been done at some point. 
