### PR TITLE
DEVPROD-11692 Protect static content from public web

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/certdepot v0.0.0-20220408180137-e70afe67cc1b
 	github.com/evergreen-ci/cocoa v0.0.0-20240523192623-2e730fcd1784
-	github.com/evergreen-ci/gimlet v0.0.0-20240926182641-240c2d86e7cb
+	github.com/evergreen-ci/gimlet v0.0.0-20241003144629-4e8f8a178646
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
 	github.com/evergreen-ci/pail v0.0.0-20240812165850-4ccf32c50e99
 	github.com/evergreen-ci/poplar v0.0.0-20240809150814-63d58cd28568

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57/go.mod h1:lb
 github.com/evergreen-ci/gimlet v0.0.0-20211018155143-ebbbff34990a/go.mod h1:F2dAoc1x1+JwZH9ylB9tpeOnztafEx2IbZjEz8GQzOM=
 github.com/evergreen-ci/gimlet v0.0.0-20220401150826-5898de01dbd8/go.mod h1:LfnJ3oYEVFUHwIPoAotvn9bbtAT+lAaCpH5YYnyxluk=
 github.com/evergreen-ci/gimlet v0.0.0-20220401151443-33c830c51cee/go.mod h1:NqXYQ2lPMU7dY33a4ZrqXJKQ3ZY8IZru8H/rpY0hrxs=
-github.com/evergreen-ci/gimlet v0.0.0-20240926182641-240c2d86e7cb h1:F19O3LxRTiMzbXrb1IJUYW2/Q/KA6sLwEVx86QfP+ZY=
-github.com/evergreen-ci/gimlet v0.0.0-20240926182641-240c2d86e7cb/go.mod h1:K6lg/s69fDkoijB96GUJPCUA3siqI7XJGNueOtFPx2Q=
+github.com/evergreen-ci/gimlet v0.0.0-20241003144629-4e8f8a178646 h1:HDTyxRAZoP6IHsB2J/UHQqZTXj2In/HsNxw9nilvxVQ=
+github.com/evergreen-ci/gimlet v0.0.0-20241003144629-4e8f8a178646/go.mod h1:K6lg/s69fDkoijB96GUJPCUA3siqI7XJGNueOtFPx2Q=
 github.com/evergreen-ci/juniper v0.0.0-20210624185208-0fd21a88954c/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
 github.com/evergreen-ci/juniper v0.0.0-20220118233332-0813edc78908/go.mod h1:LewZWRe1jV5XJhNksoB0rpvlwsg+D6M3yvzIFJZ8OJs=
 github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa h1:42kGqVm2tQOVtB/gj7AgOPPq3lBiuGUgLA0NOSpd2EM=

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -144,7 +144,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/commit_queue/{patch_id}").Version(2).Delete().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeDeleteCommitQueueItems(env))
 	app.AddRoute("/commit_queue/{patch_id}").Version(2).Put().Wrap(requireUser, addProject, requireCommitQueueItemOwner, editTasks).RouteHandler(makeCommitQueueEnqueueItem())
 	app.AddRoute("/commit_queue/{patch_id}/message").Version(2).Get().Wrap(requireUser).RouteHandler(makecqMessageForPatch())
-	app.AddRoute("/degraded_mode").Version(2).Post().Wrap(requireUser, requireAlertmanager).RouteHandler(makeSetDegradedMode())
+	// degraded_mode is used by Kanopy's alertmanager instance, which is only able to perform basic auth for REST, so it does not pass in user info
+	app.AddRoute("/degraded_mode").Version(2).Post().Wrap(requireAlertmanager).RouteHandler(makeSetDegradedMode())
 	app.AddRoute("/distros").Version(2).Get().Wrap(requireUser).RouteHandler(makeDistroRoute())
 	app.AddRoute("/distros/{distro_id}").Version(2).Get().Wrap(requireUser, editDistroSettings).RouteHandler(makeGetDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Patch().Wrap(requireUser, editDistroSettings).RouteHandler(makePatchDistroByID())

--- a/service/service.go
+++ b/service/service.go
@@ -46,7 +46,7 @@ func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler,
 	app.AddMiddleware(gimlet.MakeRecoveryLogger())
 	app.AddMiddleware(gimlet.UserMiddleware(ctx, uis.env.UserManager(), uis.umconf))
 	app.AddMiddleware(gimlet.NewAuthenticationHandler(gimlet.NewBasicAuthenticator(nil, nil), uis.env.UserManager()))
-	app.AddMiddleware(gimlet.NewStatic("", http.Dir(filepath.Join(uis.Home, "public"))))
+	app.AddMiddleware(gimlet.NewStaticAuth("", http.Dir(filepath.Join(uis.Home, "public"))))
 
 	clients := gimlet.NewApp()
 	if uis.env.ClientConfig().S3URLPrefix != "" {

--- a/service/ui.go
+++ b/service/ui.go
@@ -276,7 +276,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/login/key").Handler(uis.userGetKey).Post()
 	app.AddRoute("/logout").Wrap(allowsCORS).Handler(uis.logout).Get()
 
-	app.AddRoute("/robots.txt").Get().Handler(func(rw http.ResponseWriter, r *http.Request) {
+	app.AddRoute("/robots.txt").Get().Wrap(needsLogin).Handler(func(rw http.ResponseWriter, r *http.Request) {
 		_, err := rw.Write([]byte(strings.Join([]string{
 			"User-agent: *",
 			"Disallow: /",
@@ -317,7 +317,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/task_log_raw/{task_id}/{execution}").Wrap(needsLogin, needsContext, allowsCORS, viewLogs).Handler(uis.taskLogRaw).Get()
 
 	// Proxy downloads for task uploaded files via S3
-	app.AddRoute(("/task_file_raw/{task_id}/{execution}/{file_name}")).Wrap(needsLogin, needsContext, allowsCORS, viewLogs).Handler(uis.taskFileRaw).Get()
+	app.AddRoute("/task_file_raw/{task_id}/{execution}/{file_name}").Wrap(needsLogin, needsContext, allowsCORS, viewLogs).Handler(uis.taskFileRaw).Get()
 	// Test Logs
 	app.AddRoute("/test_log/{task_id}/{task_execution}").Wrap(needsLogin, needsContext, allowsCORS, viewLogs).Handler(uis.testLog).Get()
 	// TODO: We are keeping this route temporarily for backwards


### PR DESCRIPTION
DEVPROD-11692

### Description
Upgrade to include recent gimlet change. Include a driveby change to remove the user auth from the Alertmanager route that was added in DEVPROD-667 and added auth to one more unauthed route I found.
### Testing
Tested content is not available publicly anymore