### PR TITLE
DEVPROD-10509 Module cloning should always generate new token unless oauth

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -684,7 +684,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		return errors.Wrap(err, "setting location to clone from")
 	}
 
-	if opts.method == cloneMethodOAuth || opts.method == cloneMethodAccessToken {
+	if opts.method == cloneMethodOAuth {
 		// If user provided a token, use that token.
 		opts.token = projectToken
 	} else {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-10-02"
+	AgentVersion = "2024-10-03"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-10509

### Description
This reverts a small portion of https://github.com/evergreen-ci/evergreen/commit/dc993be1a6db2fe65aa8e0ba1d157d4c9f2b797d#diff-1e8d12ae20a5922169a78aaae96aab11adb323b77baf8910c3cbfba80b1d0012R720

which was causing issues for modules from a different org than the repository
