### PR TITLE
DEVPROD-11330 Pass request through to ui context for legacy ui plugin system

### DIFF
--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -4,8 +4,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -40,41 +38,21 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 				PanelHTML: "<div ng-include=\"'/static/plugins/attach/partials/task_files_panel.html'\" " +
 					"ng-init='entries=plugins.attach' ng-show='plugins.attach.length'></div>",
 				DataFunc: func(uiCtx UIContext) (interface{}, error) {
-					myTaskId := "zackary_bisect_ubuntu_s3put_test_patch_c23a8034170c677f2d756fa75c0d260c54efbe12_66fea63acd3f3b000d2e3c0d_24_10_03_14_12_17"
 					if uiCtx.Task == nil {
 						return nil, nil
 					}
 					var err error
 					taskId := uiCtx.Task.Id
-					isMyTask := taskId == myTaskId
-					grip.InfoWhen(isMyTask, message.Fields{
-						"message": "zackary message",
-						"second":  "1",
-						"task":    *uiCtx.Task,
-					})
 					t := uiCtx.Task
 					if uiCtx.Task.OldTaskId != "" {
-						grip.InfoWhen(isMyTask, message.Fields{
-							"message": "zackary message",
-							"second":  "1.1",
-						})
 						taskId = uiCtx.Task.OldTaskId
 						t, err = task.FindOneId(taskId)
 						if err != nil {
-							grip.InfoWhen(isMyTask, message.Fields{
-								"message": "zackary message",
-								"second":  "1.2",
-								"error":   err,
-							})
 							return nil, errors.Wrap(err, "error retrieving task")
 						}
 					}
 
 					if t.DisplayOnly {
-						grip.InfoWhen(isMyTask, message.Fields{
-							"message": "zackary message",
-							"second":  "1.3",
-						})
 						files := []displayTaskFiles{}
 						for _, execTaskID := range t.ExecutionTasks {
 							var execTaskFiles []artifact.File
@@ -108,47 +86,16 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 						return files, nil
 					}
 
-					grip.InfoWhen(isMyTask, message.Fields{
-						"message": "zackary message",
-						"second":  "2",
-					})
 					files, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: taskId, Execution: uiCtx.Task.Execution}})
 					if err != nil {
-						grip.InfoWhen(isMyTask, message.Fields{
-							"message": "zackary message",
-							"second":  "2.1",
-							"error":   err,
-						})
 						return nil, err
 					}
 					hasUser := uiCtx.User.(*user.DBUser) != nil
-					grip.InfoWhen(isMyTask, message.Fields{
-						"message": "zackary message",
-						"second":  "3",
-						"hasUser": hasUser,
-						"files":   files,
-						"uiCtx":   uiCtx,
-						"request": uiCtx.Request,
-					})
 
 					strippedFiles, err := artifact.StripHiddenFiles(uiCtx.Request.Context(), files, hasUser)
-					grip.InfoWhen(isMyTask, message.Fields{
-						"message": "zackary message",
-						"second":  "3-half?",
-					})
 					if err != nil {
-						grip.InfoWhen(isMyTask, message.Fields{
-							"message": "zackary message",
-							"second":  "3.1",
-							"error":   err,
-						})
 						return nil, errors.Wrap(err, "signing urls")
 					}
-					grip.InfoWhen(isMyTask, message.Fields{
-						"message":       "zackary message",
-						"second":        "4",
-						"strippedFiles": strippedFiles,
-					})
 					return strippedFiles, nil
 				},
 			},

--- a/service/build.go
+++ b/service/build.go
@@ -125,6 +125,7 @@ func (uis *UIServer) buildPage(w http.ResponseWriter, r *http.Request) {
 
 	// set data for plugin data function injection
 	pluginContext := projCtx.ToPluginContext(uis.Settings, user)
+	pluginContext.Request = r
 	pluginContent := getPluginDataAndHTML(uis, plugin.BuildPage, pluginContext)
 
 	uis.render.WriteResponse(w, http.StatusOK, struct {

--- a/service/task.go
+++ b/service/task.go
@@ -372,6 +372,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 	usr := gimlet.GetUser(ctx)
 	pluginContext := projCtx.ToPluginContext(uis.Settings, usr)
+	pluginContext.Request = r
 	pluginContent := getPluginDataAndHTML(uis, plugin.TaskPage, pluginContext)
 	permissions := gimlet.Permissions{}
 	if usr != nil {

--- a/service/version.go
+++ b/service/version.go
@@ -225,6 +225,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 
 	canEdit := (currentUser != nil) && (projCtx.Version.Requester != evergreen.MergeTestRequester)
 	pluginContext := projCtx.ToPluginContext(uis.Settings, currentUser)
+	pluginContext.Request = r
 	pluginContent := getPluginDataAndHTML(uis, plugin.VersionPage, pluginContext)
 	newUILink := ""
 	if len(uis.Settings.Ui.UIv2Url) > 0 {


### PR DESCRIPTION
DEVPROD-11330

### Description
We recently had an issue where the files plugin (or tab) on the legacy ui was panicing because of a nil pointer exception when accessing the `request` field. This propogates the request object through to the plugin system.

I was also considering adding logging [here](https://github.com/ZackarySantana/evergreen/blob/ad7105b64c4cd53f7f7d05982fc484fe73534261/plugin/plugin_ui.go#L269) but decided not to since this is our legacy ui, but it would've caught this and prevented the regression. It was a bit of a pain to find out what was happening but looking at what plugins we have, there's not much and they're at a low risk of regressing (at least by the time we fully migrate to new ui)

### Testing
Deployed to staging and tested. Didn't add unit tests since this is hard to test and it's our legacy page.