### PR TITLE
DEVPROD-11199 Add git triggered info to version rest api

### DIFF
--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -49,7 +49,7 @@ type APIVersion struct {
 	Aborted   *bool `json:"aborted"`
 	// The git tag that triggered this version, if any.
 	TriggeredGitTag *APIGitTag `json:"triggered_by_git_tag"`
-	// The pushed git tags to this version.
+	// Git tags that were pushed to this version.
 	GitTags []APIGitTag `json:"git_tags"`
 	// Indicates if the version was ignored due to only making changes to ignored files.
 	Ignored *bool `json:"ignored"`
@@ -114,7 +114,6 @@ func (apiVersion *APIVersion) BuildFromService(v model.Version) {
 		})
 	}
 
-	// triggered by git tag
 	if v.TriggeredByGitTag.Tag != "" {
 		apiVersion.TriggeredGitTag = &APIGitTag{
 			Tag:    utility.ToStringPtr(v.TriggeredByGitTag.Tag),

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -45,9 +45,12 @@ type APIVersion struct {
 	Requester *string   `json:"requester"`
 	Errors    []*string `json:"errors"`
 	// Will be null for versions created before this field was added.
-	Activated *bool       `json:"activated"`
-	Aborted   *bool       `json:"aborted"`
-	GitTags   []APIGitTag `json:"git_tags"`
+	Activated *bool `json:"activated"`
+	Aborted   *bool `json:"aborted"`
+	// The git tag that triggered this version, if any.
+	TriggeredGitTag *APIGitTag `json:"triggered_by_git_tag"`
+	// The pushed git tags to this version.
+	GitTags []APIGitTag `json:"git_tags"`
 	// Indicates if the version was ignored due to only making changes to ignored files.
 	Ignored *bool `json:"ignored"`
 }
@@ -109,6 +112,14 @@ func (apiVersion *APIVersion) BuildFromService(v model.Version) {
 			Pusher: utility.ToStringPtr(gt.Pusher),
 			Tag:    utility.ToStringPtr(gt.Tag),
 		})
+	}
+
+	// triggered by git tag
+	if v.TriggeredByGitTag.Tag != "" {
+		apiVersion.TriggeredGitTag = &APIGitTag{
+			Tag:    utility.ToStringPtr(v.TriggeredByGitTag.Tag),
+			Pusher: utility.ToStringPtr(v.TriggeredByGitTag.Pusher),
+		}
 	}
 
 	if v.Identifier != "" {

--- a/rest/model/version_test.go
+++ b/rest/model/version_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestVersionBuildFromService tests that BuildFromService function completes
@@ -40,20 +41,32 @@ func TestVersionBuildFromService(t *testing.T) {
 			BuildId:      bi2,
 		},
 	}
+	gitTags := []model.GitTag{
+		{
+			Tag:    "tag",
+			Pusher: "pusher",
+		},
+	}
+	triggeredGitTag := model.GitTag{
+		Tag:    "my-triggered-tag",
+		Pusher: "pusher",
+	}
 	v := model.Version{
-		Id:            versionId,
-		CreateTime:    time,
-		StartTime:     time,
-		FinishTime:    time,
-		Revision:      revision,
-		Author:        author,
-		AuthorEmail:   authorEmail,
-		Message:       msg,
-		Status:        status,
-		Repo:          repo,
-		Branch:        branch,
-		BuildVariants: buildVariants,
-		Errors:        errors,
+		Id:                versionId,
+		CreateTime:        time,
+		StartTime:         time,
+		FinishTime:        time,
+		Revision:          revision,
+		Author:            author,
+		AuthorEmail:       authorEmail,
+		Message:           msg,
+		Status:            status,
+		Repo:              repo,
+		Branch:            branch,
+		BuildVariants:     buildVariants,
+		Errors:            errors,
+		GitTags:           gitTags,
+		TriggeredByGitTag: triggeredGitTag,
 	}
 
 	apiVersion := &APIVersion{}
@@ -78,4 +91,12 @@ func TestVersionBuildFromService(t *testing.T) {
 	assert.Equal(bvs[0].BuildId, utility.ToStringPtr(bi1))
 	assert.Equal(bvs[1].BuildVariant, utility.ToStringPtr(bv2))
 	assert.Equal(bvs[1].BuildId, utility.ToStringPtr(bi2))
+
+	gts := apiVersion.GitTags
+	require.Len(t, gts, 1)
+	assert.Equal(gts[0].Pusher, utility.ToStringPtr("pusher"))
+	assert.Equal(gts[0].Tag, utility.ToStringPtr("tag"))
+
+	require.NotNil(t, apiVersion.TriggeredGitTag)
+	assert.Equal(apiVersion.TriggeredGitTag.Tag, utility.ToStringPtr("my-triggered-tag"))
 }


### PR DESCRIPTION
DEVPROD-11199

### Description
This propagates the git triggered info in to the rest api.

### Testing
Added a unit test to make sure it propagates correctly. I didn't test in staging since it's a trivial change.
I did confirm via the version they provided that the git triggered by tag is populated (it just isn't propagated).
