### PR TITLE
DEVPROD-9663 allow removing roles from route and log usage

### DIFF
--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -585,7 +585,7 @@ func removeHiddenProjects(permissions []rolemanager.PermissionSummary) error {
 
 type rolesPostRequest struct {
 	// the list of roles to add for the user
-	Roles []string `json:"roles"`
+	AddRoles []string `json:"roles"` // the JSON here is "roles" instead of "add_roles" for backwards compatibility.
 	// The list of roles to remove for the user
 	RemoveRoles []string `json:"remove_roles"`
 	// if true, will also create a shell user document for the user. By default, specifying a user that does not exist will error
@@ -631,10 +631,10 @@ func (h *userRolesPostHandler) Parse(ctx context.Context, r *http.Request) error
 	if err := utility.ReadJSON(r.Body, &request); err != nil {
 		return errors.Wrap(err, "reading role modification request from JSON request body")
 	}
-	if len(request.Roles) == 0 && len(request.RemoveRoles) == 0 {
+	if len(request.AddRoles) == 0 && len(request.RemoveRoles) == 0 {
 		return errors.New("must specify at least 1 role to add/remove")
 	}
-	h.rolesToAdd = request.Roles
+	h.rolesToAdd = request.AddRoles
 	h.rolesToRemove = request.RemoveRoles
 	h.createUser = request.CreateUser
 	vars := gimlet.GetVars(r)

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -702,7 +702,7 @@ func (h *userRolesPostHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	for _, toRemove := range h.rolesToRemove {
 		if err = u.RemoveRole(toRemove); err != nil {
-			catcher.Wrapf(err, "removing the role '%s' from user '%s'", toRemove, u.Username()))
+			catcher.Wrapf(err, "removing the role '%s' from user '%s'", toRemove, u.Username())
 		}
 	}
 
@@ -712,7 +712,7 @@ func (h *userRolesPostHandler) Run(ctx context.Context) gimlet.Responder {
 		"roles_removed": h.rolesToRemove,
 		"user_modified": u.Username(),
 		"caller":        h.caller,
-		"errors": catcher.Resolve(),
+		"errors":        catcher.Resolve(),
 	})
 
 	if catcher.HasErrors() {


### PR DESCRIPTION
DEVPROD-9663 
### Description
1. Allow removing roles via route. (This would just be convenient, since needing to do things via DB is annoying, and has potential to be un-logged).
2. Add log for usage of the route. (I'm logging even if there are errors, because regardless I think we want to know if this happened, and this will tell us what was changed.) Will create a splunk alert for this.

### Testing
Added a unit test.

### Documentation
Will add to the rotation playbook (i.e. ignore it if it's not intended, escalate if it seems fishy)

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
