### PR TITLE
DEVPROD-11817 Don't apply secondary _id sort if sort is by _id on hosts query

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3520,9 +3520,11 @@ func GetPaginatedRunningHosts(ctx context.Context, opts HostsFilterOptions) ([]H
 	if len(opts.SortBy) > 0 {
 		sorters = append(sorters, bson.E{Key: opts.SortBy, Value: opts.SortDir})
 	}
-	// _id must be the last item in the sort array to ensure a consistent sort
-	// order when previous sort keys result in a tie.
-	sorters = append(sorters, bson.E{Key: IdKey, Value: 1})
+
+	// If we're not sorting by ID, we need to sort by ID as a tiebreaker to ensure a consistent sort order.
+	if opts.SortBy != IdKey {
+		sorters = append(sorters, bson.E{Key: IdKey, Value: 1})
+	}
 	runningHostsPipeline = append(runningHostsPipeline, bson.M{
 		"$sort": sorters,
 	})


### PR DESCRIPTION
DEVPROD-11817

### Description
After upgrading to MongoDB 8.0 this query broke due to a duplicate sort key error. I've flagged this with the query team since it didn't seem to be documented in the 8.0 release notes. 

### Testing
Tested on staging and the 8.0 tests upgrade should be unblocked
