### PR TITLE
DEVPROD-7676 Filter set tasks scheduled time in memory

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1380,12 +1380,18 @@ func (t *Task) SetGeneratedTasksToActivate(buildVariantName, taskName string) er
 func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	ids := []string{}
 	for i := range tasks {
-		tasks[i].ScheduledTime = scheduledTime
-		ids = append(ids, tasks[i].Id)
+		// Skip tasks with scheduled time to prevent large updates
+		if tasks[i].ScheduledTime == utility.ZeroTime {
+			tasks[i].ScheduledTime = scheduledTime
+			ids = append(ids, tasks[i].Id)
+		}
 
 		// Display tasks are considered scheduled when their first exec task is scheduled
 		if tasks[i].IsPartOfDisplay() {
-			ids = append(ids, utility.FromStringPtr(tasks[i].DisplayTaskId))
+			displayTaskId := utility.FromStringPtr(tasks[i].DisplayTaskId)
+			if !utility.StringSliceContains(ids, displayTaskId) {
+				ids = append(ids, displayTaskId)
+			}
 		}
 	}
 	_, err := UpdateAll(

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1381,23 +1381,20 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	ids := []string{}
 	for i := range tasks {
 		// Skip tasks with scheduled time to prevent large updates
-		if tasks[i].ScheduledTime == utility.ZeroTime {
+		if utility.IsZeroTime(tasks[i].ScheduledTime) {
 			tasks[i].ScheduledTime = scheduledTime
 			ids = append(ids, tasks[i].Id)
 		}
 
 		// Display tasks are considered scheduled when their first exec task is scheduled
 		if tasks[i].IsPartOfDisplay() {
-			displayTaskId := utility.FromStringPtr(tasks[i].DisplayTaskId)
-			if !utility.StringSliceContains(ids, displayTaskId) {
-				ids = append(ids, displayTaskId)
-			}
+			ids = append(ids, utility.FromStringPtr(tasks[i].DisplayTaskId))
 		}
 	}
 	_, err := UpdateAll(
 		bson.M{
 			IdKey: bson.M{
-				"$in": ids,
+				"$in": utility.UniqueStrings(ids),
 			},
 			ScheduledTimeKey: bson.M{
 				"$lte": utility.ZeroTime,


### PR DESCRIPTION
DEVPROD-7676

### Description
this query was failing sometimes due to large document so we filter the tasks in memory before making the query 
I also thought that the cause of the large document error could be us putting in a massive amount of the same display task id for each execution task so I added a filter for that in memory as well

### Testing
current tests should pass