### PR TITLE
DEVPROD-10182: Add waterfall revision selector

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -78310,7 +78310,7 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 		asMap["limit"] = 5
 	}
 
-	fieldsInOrder := [...]string{"limit", "minOrder", "maxOrder", "projectIdentifier", "requesters"}
+	fieldsInOrder := [...]string{"limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -78373,6 +78373,13 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Requesters = data
+		case "revision":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revision"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Revision = data
 		}
 	}
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -623,6 +623,7 @@ type WaterfallOptions struct {
 	MaxOrder          *int     `json:"maxOrder,omitempty"`
 	ProjectIdentifier string   `json:"projectIdentifier"`
 	Requesters        []string `json:"requesters,omitempty"`
+	Revision          *string  `json:"revision,omitempty"`
 }
 
 type WaterfallVersion struct {

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -978,6 +978,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 
 		limit = limitOpt
 	}
+
 	requesters := options.Requesters
 	if len(requesters) == 0 {
 		requesters = evergreen.SystemVersionRequesterTypes
@@ -985,6 +986,23 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 
 	maxOrderOpt := utility.FromIntPtr(options.MaxOrder)
 	minOrderOpt := utility.FromIntPtr(options.MinOrder)
+	revision := utility.FromStringPtr(options.Revision)
+
+	if options.Revision != nil {
+		if len(revision) < minRevisionLength {
+			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("at least %d characters must be provided for the revision", minRevisionLength)))
+		} else {
+			found, err := model.VersionFindOne(model.VersionByProjectIdAndRevisionPrefix(projectId, revision))
+			if err != nil {
+				graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("getting version with revision '%s': %s", revision, err)))
+			} else if found == nil {
+				graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("version with revision '%s' not found", revision)))
+			} else {
+				// Offset the order number so the specified revision lands nearer to the center of the page.
+				maxOrderOpt = found.RevisionOrderNumber + limit/2 + 1
+			}
+		}
+	}
 
 	opts := model.WaterfallOptions{
 		Limit:      limit,
@@ -1024,10 +1042,6 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting waterfall versions: %s", err.Error()))
 	}
-
-	// TODO DEVPROD-10179: Add check to ensure each version has tasks that match filter...
-	// Something like this: https://github.com/evergreen-ci/evergreen/blob/bf8f12ec2eefe61f0cf9bcc594924c7be8f91d1b/graphql/query_resolver.go#L869-L938
-	// All other filters can be applied in the GetActiveWaterfallVersions pipeline, ensuring `limit` matching versions have been returned.
 
 	activeVersionIds := []string{}
 	for _, v := range activeVersions {

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -6,6 +6,7 @@ input WaterfallOptions {
   maxOrder: Int
   projectIdentifier: String! @requireProjectAccess(permission: TASKS, access: VIEW)
   requesters: [String!]
+  revision: String
 }
 
 type WaterfallTask {

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -2,7 +2,7 @@
   "versions": [
     {
       "_id": "evergreen_version39",
-      "gitspec": "revision39",
+      "gitspec": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
       "identifier": "spruce",
       "r": "gitter_request",
       "activated": true,

--- a/graphql/tests/query/waterfall/queries/revision.graphql
+++ b/graphql/tests/query/waterfall/queries/revision.graphql
@@ -1,0 +1,18 @@
+{
+  waterfall(options: { projectIdentifier: "spruce", revision: "da39a3e" }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        id
+        order
+        revision
+      }
+      inactiveVersions {
+        id
+        order
+        revision
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/queries/revision_nonexistent.graphql
+++ b/graphql/tests/query/waterfall/queries/revision_nonexistent.graphql
@@ -1,0 +1,18 @@
+{
+  waterfall(options: { projectIdentifier: "spruce", revision: "foobarbaz" }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        id
+        order
+        revision
+      }
+      inactiveVersions {
+        id
+        order
+        revision
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -300,6 +300,129 @@
           }
         }
       }
+    },
+    {
+      "query_file": "revision.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 41,
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "order": 41,
+                  "revision": "revision1"
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "id": "evergreen_version0",
+                    "order": 40,
+                    "revision": "revision0"
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version39",
+                  "order": 39,
+                  "revision": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                },
+                "inactiveVersions": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "revision_nonexistent.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 0,
+            "versions": [
+              {
+                "version": {
+                  "id": "evergreen_version5",
+                  "order": 45,
+                  "revision": "revision5"
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "id": "evergreen_version4",
+                    "order": 44,
+                    "revision": "revision4"
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version3",
+                  "order": 43,
+                  "revision": "revision3"
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version2",
+                  "order": 42,
+                  "revision": "2c9056df66d42fb1908d52eed096750a91f1f089"
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": {
+                  "id": "evergreen_version1",
+                  "order": 41,
+                  "revision": "revision1"
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "id": "evergreen_version0",
+                    "order": 40,
+                    "revision": "revision0"
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "id": "evergreen_version39",
+                  "order": 39,
+                  "revision": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+                },
+                "inactiveVersions": null
+              }
+            ]
+          }
+        },
+        "errors": [
+          {
+            "message": "version with revision 'foobarbaz' not found",
+            "path": [
+              "waterfall"
+            ],
+            "extensions": {
+              "code": "PARTIAL_ERROR"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1363,3 +1363,18 @@ func flattenOtelVariables(vars map[string]interface{}) map[string]interface{} {
 	}
 	return flattenedVars
 }
+
+func getRevisionOrder(revision string, projectId string, limit int) (int, error) {
+	if len(revision) < minRevisionLength {
+		return 0, errors.New(fmt.Sprintf("at least %d characters must be provided for the revision", minRevisionLength))
+	}
+
+	found, err := model.VersionFindOne(model.VersionByProjectIdAndRevisionPrefix(projectId, revision))
+	if err != nil {
+		return 0, errors.New(fmt.Sprintf("getting version with revision '%s': %s", revision, err))
+	} else if found == nil {
+		return 0, errors.New(fmt.Sprintf("version with revision '%s' not found", revision))
+	}
+	// Offset the order number so the specified revision lands nearer to the center of the page.
+	return found.RevisionOrderNumber + limit/2 + 1, nil
+}


### PR DESCRIPTION
DEVPROD-10182

### Description
- Accept an input for a revision hash in order to jump waterfall to a certain commit
- Uses basically the same logic as [mainline commits](https://github.com/evergreen-ci/evergreen/blob/ed6101e2f0ef85f8748910edc7de3065cabcb8f3/graphql/query_resolver.go#L814-L828)

### Testing
- Add GraphQL unit tests