### PR TITLE
DEVPROD-9472: handle long project vars and convert to parameter

### DIFF
--- a/cloud/parameterstore/parameter_cache.go
+++ b/cloud/parameterstore/parameter_cache.go
@@ -39,7 +39,7 @@ func newCachedParameter(name, value string, lastUpdated time.Time) cachedParamet
 func (cp *cachedParameter) export() Parameter {
 	return Parameter{
 		Name:     cp.name,
-		Basename: getBasename(cp.name),
+		Basename: GetBasename(cp.name),
 		Value:    cp.value,
 	}
 }

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -122,7 +122,7 @@ func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Param
 
 	return &Parameter{
 		Name:     fullName,
-		Basename: getBasename(fullName),
+		Basename: GetBasename(fullName),
 		Value:    value,
 	}, nil
 }
@@ -182,7 +182,7 @@ func (pm *ParameterManager) Get(ctx context.Context, names ...string) ([]Paramet
 		value := aws.ToString(p.Value)
 		params = append(params, Parameter{
 			Name:     name,
-			Basename: getBasename(name),
+			Basename: GetBasename(name),
 			Value:    value,
 		})
 		cachedParams = append(cachedParams, newCachedParameter(name, value, lastRetrieved))
@@ -284,8 +284,8 @@ func (pm *ParameterManager) getPrefixedName(basename string) string {
 	return fmt.Sprintf("/%s/%s", pathPrefix, strings.TrimPrefix(basename, "/"))
 }
 
-// getBasename returns the parameter basename without any intermediate paths.
-func getBasename(name string) string {
+// GetBasename returns the parameter basename without any intermediate paths.
+func GetBasename(name string) string {
 	idx := strings.LastIndex(name, "/")
 	if idx == -1 {
 		return name

--- a/cloud/parameterstore/parameter_manager_test.go
+++ b/cloud/parameterstore/parameter_manager_test.go
@@ -52,18 +52,18 @@ func TestParameterManager(t *testing.T) {
 				t.Run("ParsesBasenameFromFullNameWithPrefix", func(t *testing.T) {
 					fullName := pm.getPrefixedName("basename")
 					assert.Equal(t, "/prefix/basename", fullName)
-					assert.Equal(t, "basename", getBasename(fullName))
+					assert.Equal(t, "basename", GetBasename(fullName))
 				})
 				t.Run("ParsesBasenameFromFullNameWithoutPrefix", func(t *testing.T) {
 					fullName := "/some/other/path/basename"
-					assert.Equal(t, "basename", getBasename(fullName))
+					assert.Equal(t, "basename", GetBasename(fullName))
 				})
 				t.Run("ReturnsUnmodifiedBasenameThatIsAlreadyParsed", func(t *testing.T) {
-					assert.Equal(t, "basename", getBasename("basename"))
+					assert.Equal(t, "basename", GetBasename("basename"))
 				})
 				t.Run("ParsesBasenameWithoutLeadingSlash", func(t *testing.T) {
 					fullName := "/basename"
-					assert.Equal(t, "basename", getBasename(fullName))
+					assert.Equal(t, "basename", GetBasename(fullName))
 				})
 			})
 		})

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -17,7 +17,8 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
 )
 
-// ParamValueMaxLength is the maximum allowed length for an SSM parameter value.
+// ParamValueMaxLength is the maximum allowed length (in bytes) of an SSM
+// parameter value.
 const ParamValueMaxLength = 8192
 
 // SSMClient is an interface to interact with AWS Systems Manager (SSM)

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -17,6 +17,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
 )
 
+// ParamValueMaxLength is the maximum allowed length for an SSM parameter value.
+const ParamValueMaxLength = 8192
+
 // SSMClient is an interface to interact with AWS Systems Manager (SSM)
 // Parameter Store.
 type SSMClient interface {

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -66,21 +66,22 @@ type ProjectVars struct {
 
 type ParameterMappings []ParameterMapping
 
-// NameMap returns a map from each name to the full parameter mapping.
-func (pms ParameterMappings) NameMap() map[string]ParameterMapping {
-	res := make(map[string]ParameterMapping, len(pms))
-	for i, pm := range pms {
-		res[pm.Name] = pms[i]
+// NameMap returns a map from each name to the full parameter mapping
+// information.
+func (pm ParameterMappings) NameMap() map[string]ParameterMapping {
+	res := make(map[string]ParameterMapping, len(pm))
+	for i, m := range pm {
+		res[m.Name] = pm[i]
 	}
 	return res
 }
 
 // ParamNameMap returns a map from each parameter name to the full parameter
-// mapping.
-func (pms ParameterMappings) ParamNameMap() map[string]ParameterMapping {
-	res := make(map[string]ParameterMapping, len(pms))
-	for i, pm := range pms {
-		res[pm.ParameterName] = pms[i]
+// mapping information.
+func (pm ParameterMappings) ParamNameMap() map[string]ParameterMapping {
+	res := make(map[string]ParameterMapping, len(pm))
+	for i, m := range pm {
+		res[m.ParameterName] = pm[i]
 	}
 	return res
 }

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -511,14 +511,21 @@ func convertVarToParam(projectID string, pm ParameterMappings, varName, varValue
 var validParamBasename = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // validateVarNameCharset verifies that a project variable name is not empty and
-// contains only valid characters. It returns an error if it it's empty or
-// contains invalid characters that are not allowed in a parameter name.
+// contains only valid characters. It returns an error if it's empty or contains
+// invalid characters that are not allowed in a parameter name.
 func validateVarNameCharset(varName string) error {
 	if len(varName) == 0 {
 		return errors.Errorf("project variable name cannot be empty")
 	}
 	if !validParamBasename.MatchString(varName) {
-		return errors.Errorf("project variable '%s' contains invalid characters - can only contain alphanumerics, underscores, periods, and dashes", varName)
+		return errors.Errorf("project variable name '%s' contains invalid characters - can only contain alphanumerics, underscores, periods, and dashes", varName)
+	}
+	if strings.HasSuffix(varName, gzipCompressedParamExtension) {
+		// Project variable names should not end in ".gz" to avoid ambiguity
+		// over whether the variable value had to be compressed. The ".gz"
+		// extension is reserved for project variables where the value had to be
+		// compressed to fit within the parameter length limit.
+		return errors.Errorf("project variable name '%s' cannot end with '%s'", varName, gzipCompressedParamExtension)
 	}
 	return nil
 }

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -521,10 +521,11 @@ func validateVarNameCharset(varName string) error {
 		return errors.Errorf("project variable name '%s' contains invalid characters - can only contain alphanumerics, underscores, periods, and dashes", varName)
 	}
 	if strings.HasSuffix(varName, gzipCompressedParamExtension) {
-		// Project variable names should not end in ".gz" to avoid ambiguity
-		// over whether the variable value had to be compressed. The ".gz"
-		// extension is reserved for project variables where the value had to be
-		// compressed to fit within the parameter length limit.
+		// Project variable names should not end in a gzip extension to avoid
+		// ambiguity over whether the variable value had to be compressed. The
+		// extension is reserved for internal Evergreen use in case there's a
+		// project variable that's long enough to require compression to fit
+		// within the parameter length limit.
 		return errors.Errorf("project variable name '%s' cannot end with '%s'", varName, gzipCompressedParamExtension)
 	}
 	return nil

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -327,7 +327,7 @@ func TestAWSVars(t *testing.T) {
 
 func TestGetParamNameForVar(t *testing.T) {
 	t.Run("ReturnsNewlyGeneratedParameterNameBasedOnProjectVarName", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name:          "my_var",
 				ParameterName: "my_parameter_name",
@@ -337,7 +337,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Equal(t, "my_new_var", paramName)
 	})
 	t.Run("ReturnsAlreadyGeneratedParamName", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name:          "my_var",
 				ParameterName: "my_parameter_name",
@@ -347,7 +347,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Equal(t, "my_parameter_name", paramName)
 	})
 	t.Run("ReturnsNewlyGeneratedParameterNameThatDoesNotStartWithAWS", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name:          "my_var",
 				ParameterName: "my_parameter_name",
@@ -360,7 +360,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Equal(t, "_aws_key", paramName)
 	})
 	t.Run("ReturnsNewlyGeneratedParameterNameThatDoesNotStartWithSSM", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name:          "my_var",
 				ParameterName: "my_parameter_name",
@@ -373,7 +373,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Equal(t, "_ssm_key", paramName)
 	})
 	t.Run("ReturnsNewlyGeneratedParameterNameIfParameterMappingDoesNotYetHaveParameterName", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name: "aws_key",
 			},
@@ -382,7 +382,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Equal(t, "_aws_key", paramName)
 	})
 	t.Run("ErrorsIfConflictingParameterNameWouldBeGenerated", func(t *testing.T) {
-		paramName, err := getParamNameForVar([]ParameterMapping{
+		paramName, err := createParamBasenameForVar([]ParameterMapping{
 			{
 				Name:          "_aws_key",
 				ParameterName: "_aws_key",
@@ -395,7 +395,7 @@ func TestGetParamNameForVar(t *testing.T) {
 		assert.Zero(t, paramName)
 	})
 	t.Run("DoesNotAllowEmptyParameterName", func(t *testing.T) {
-		paramName, err := getParamNameForVar(nil, "")
+		paramName, err := createParamBasenameForVar(nil, "")
 		assert.Error(t, err)
 		assert.Zero(t, paramName)
 	})

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -437,6 +437,14 @@ func TestConvertVarToParam(t *testing.T) {
 		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
 		assert.Error(t, err, "should not allow variable with empty name")
 	})
+	t.Run("ReturnsErrorForVariableNameEndingInGzipExtension", func(t *testing.T) {
+		const (
+			varName  = "var_name.gz"
+			varValue = "var_value"
+		)
+		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		assert.Error(t, err, "should not allow variable with gzip extension")
+	})
 	t.Run("ReturnsErrorForVarValueThatExceedsMaxLengthAfterCompression", func(t *testing.T) {
 		const varName = "var_name"
 		// Since this is a purely random string, there's no realistic way to

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -5,10 +5,8 @@ import (
 	"testing"
 
 	"strings"
-	"testing"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
@@ -409,7 +407,7 @@ func TestGetParamValueForVar(t *testing.T) {
 			varName  = "var_name"
 			varValue = "var_value"
 		)
-		paramName, paramValue, err := getParamValueForVar(varName, varValue)
+		paramName, paramValue, err := getCompressedParamValueForVar(varName, varValue)
 		assert.NoError(t, err)
 		assert.Equal(t, varName, paramName)
 		assert.Equal(t, varValue, paramValue)
@@ -419,7 +417,7 @@ func TestGetParamValueForVar(t *testing.T) {
 			varName  = "var_name"
 			varValue = ""
 		)
-		paramName, paramValue, err := getParamValueForVar(varName, varValue)
+		paramName, paramValue, err := getCompressedParamValueForVar(varName, varValue)
 		assert.NoError(t, err)
 		assert.Equal(t, varName, paramName)
 		assert.Equal(t, varValue, paramValue)
@@ -429,7 +427,7 @@ func TestGetParamValueForVar(t *testing.T) {
 		varValue := strings.Repeat("abc", parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(varValue), parameterstore.ParamValueMaxLength)
 
-		paramName, paramValue, err := getParamValueForVar(varName, varValue)
+		paramName, paramValue, err := getCompressedParamValueForVar(varName, varValue)
 		assert.NoError(t, err)
 		assert.Equal(t, fmt.Sprintf("%s%s", varName, gzipCompressedParamExtension), paramName)
 		assert.Less(t, len(paramValue), parameterstore.ParamValueMaxLength)
@@ -439,7 +437,7 @@ func TestGetParamValueForVar(t *testing.T) {
 		varValue := utility.MakeRandomString(10 * parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(varValue), parameterstore.ParamValueMaxLength)
 
-		_, _, err := getParamValueForVar(varName, varValue)
+		_, _, err := getCompressedParamValueForVar(varName, varValue)
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
DEVPROD-9472

### Description
This is a follow-up to #8329 to further handle and try fixing more special cases with existing project vars to fit within SSM's parameter name/value constraints.

* If a project var value is longer than the 8 KB SSM parameter length limit, try compressing it to get it within the length limit. Add `.gz` to the end of the parameter name to indicate the value was compressed with gzip. (Adding the extension will make it easier to determine that a project var needs to be decompressed when reading the parameter out of Parameter Store.)
* Refactor logic from #8329 to validate parameter name constraints after adding the `.gz` extension for compressed vars.
* Include project ID as prefix in the parameter name. This ensures that parameters are unique across projects (e.g. `aws_key` in projectA and `aws_key` in projectB are unique).

### Testing
* Added unit tests and consolidated existing tests from #8329.
* Tested in staging that the 8 KB limit is exactly 8192 bytes (8 KB).
* Manually tested the compression logic on a long project var in production to verify it compressed the var to stay within the 8 KB limit.

### Documentation
N/A