### PR TITLE
DEVPROD-3476 Create route that exposes task limits

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -46,7 +46,7 @@ type TaskLimitsConfig struct {
 	// MaxExecTimeoutSecs is the maximum number of seconds a task can run and set their timeout to.
 	MaxExecTimeoutSecs int `bson:"max_exec_timeout_secs" json:"max_exec_timeout_secs" yaml:"max_exec_timeout_secs"`
 
-	// MaxTaskExecution is the maximum task (zero based) execution number
+	// MaxTaskExecution is the maximum task (zero based) execution number.
 	MaxTaskExecution int `bson:"max_task_execution" json:"max_task_execution" yaml:"max_task_execution"`
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2744,17 +2744,32 @@ func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
 }
 
 type APITaskLimitsConfig struct {
-	MaxTasksPerVersion                               *int `json:"max_tasks_per_version"`
-	MaxIncludesPerVersion                            *int `json:"max_includes_per_version"`
-	MaxHourlyPatchTasks                              *int `json:"max_hourly_patch_tasks"`
-	MaxPendingGeneratedTasks                         *int `json:"max_pending_generated_tasks"`
-	MaxGenerateTaskJSONSize                          *int `json:"max_generate_task_json_size"`
-	MaxConcurrentLargeParserProjectTasks             *int `json:"max_concurrent_large_parser_project_tasks"`
-	MaxDegradedModeParserProjectSize                 *int `json:"max_degraded_mode_parser_project_size"`
-	MaxParserProjectSize                             *int `json:"max_parser_project_size"`
-	MaxExecTimeoutSecs                               *int `json:"max_exec_timeout_secs"`
+	// MaxTasksPerVersion is the maximum number of tasks that a single version
+	// can have.
+	MaxTasksPerVersion *int `json:"max_tasks_per_version"`
+	// MaxIncludesPerVersion is the maximum number of includes that a single
+	// version can have.
+	MaxIncludesPerVersion *int `json:"max_includes_per_version"`
+	// MaxHourlyPatchTasks is the maximum number of patch tasks a single user can
+	// schedule per hour.
+	MaxHourlyPatchTasks *int `json:"max_hourly_patch_tasks"`
+	// MaxPendingGeneratedTasks is the maximum number of tasks that can be created
+	// by all generated task at once.
+	MaxPendingGeneratedTasks *int `json:"max_pending_generated_tasks"`
+	// MaxGenerateTaskJSONSize is the maximum size of a JSON file in MB that can be specified in the GenerateTasks command.
+	MaxGenerateTaskJSONSize *int `json:"max_generate_task_json_size"`
+	// MaxConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once.
+	MaxConcurrentLargeParserProjectTasks *int `json:"max_concurrent_large_parser_project_tasks"`
+	// MaxDegradedModeConcurrentLargeParserProjectTasks is the maximum number of tasks with parser projects stored in S3 that can be running at once during CPU degraded mode.
 	MaxDegradedModeConcurrentLargeParserProjectTasks *int `json:"max_degraded_mode_concurrent_large_parser_project_tasks"`
-	MaxTaskExecution                                 *int `json:"max_task_execution"`
+	// MaxDegradedModeParserProjectSize is the maximum parser project size in MB during CPU degraded mode.
+	MaxDegradedModeParserProjectSize *int `json:"max_degraded_mode_parser_project_size"`
+	// MaxParserProjectSize is the maximum allowed size in MB for parser projects that are stored in S3.
+	MaxParserProjectSize *int `json:"max_parser_project_size"`
+	// MaxExecTimeoutSecs is the maximum number of seconds a task can run and set their timeout to.
+	MaxExecTimeoutSecs *int `json:"max_exec_timeout_secs"`
+	// MaxTaskExecution is the maximum task (zero based) execution number.
+	MaxTaskExecution *int `json:"max_task_execution"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {

--- a/rest/route/admin_settings.go
+++ b/rest/route/admin_settings.go
@@ -122,3 +122,37 @@ func (h *adminPostHandler) Run(ctx context.Context) gimlet.Responder {
 
 	return gimlet.NewJSONResponse(h.model)
 }
+
+func makeFetchTaskLimits() gimlet.RouteHandler {
+	return &taskLimitsGetHandler{}
+}
+
+type taskLimitsGetHandler struct{}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Get Evergreen's task limits
+//	@Description	Returns all of Evergreen's task-related limitations.
+//	@Tags			admin
+//	@Router			/admin/task_limits [get]
+//	@Security		Api-User || Api-Key
+//	@Success		200	{object}	model.APITaskLimitsConfig
+func (h *taskLimitsGetHandler) Factory() gimlet.RouteHandler {
+	return &taskLimitsGetHandler{}
+}
+
+func (h *taskLimitsGetHandler) Parse(ctx context.Context, r *http.Request) error {
+	return nil
+}
+
+func (h *taskLimitsGetHandler) Run(ctx context.Context) gimlet.Responder {
+	settings, err := evergreen.GetConfig(ctx)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting admin settings"))
+	}
+	taskLimits := &model.APITaskLimitsConfig{}
+	if err = taskLimits.BuildFromService(settings.TaskLimits); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "converting task limits to API model"))
+	}
+	return gimlet.NewJSONResponse(taskLimits)
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -127,6 +127,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/service_flags").Version(2).Post().Wrap(requireUser, adminSettings).RouteHandler(makeSetServiceFlagsRouteManager())
 	app.AddRoute("/admin/settings").Version(2).Get().Wrap(requireUser, adminSettings).RouteHandler(makeFetchAdminSettings())
 	app.AddRoute("/admin/settings").Version(2).Post().Wrap(requireUser, adminSettings).RouteHandler(makeSetAdminSettings())
+	app.AddRoute("/admin/task_limits").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchTaskLimits())
 	app.AddRoute("/admin/task_queue").Version(2).Delete().Wrap(requireUser, adminSettings).RouteHandler(makeClearTaskQueueHandler())
 	app.AddRoute("/admin/commit_queues").Version(2).Delete().Wrap(requireUser, adminSettings).RouteHandler(makeClearCommitQueuesHandler())
 	app.AddRoute("/admin/service_users").Version(2).Get().Wrap(requireUser, adminSettings).RouteHandler(makeGetServiceUsers())


### PR DESCRIPTION
DEVPROD-3476

### Description
External teams have requested that we expose our configurable task limits so they can make the necessary trade-off choices when scheduling versions. Created a route to support this.
### Testing
Tested locally
### Documentation
Added swaggo docs and tested locally