### PR TITLE
DEVPROD-7489 Allow get project aliases route to return config aliases

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-10-04"
+	ClientVersion = "2024-10-09"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/list.go
+++ b/operations/list.go
@@ -24,7 +24,7 @@ func List() cli.Command {
 		tasksFlagName                = "tasks"
 		distrosFlagName              = "distros"
 		spawnableFlagName            = "spawnable"
-		includeProjectConfigFlagName = "include-config"
+		includeConfigAliasesFlagName = "include-config-aliases"
 		parametersFlagName           = "parameters"
 		patchAliasesFlagName         = "patch-aliases"
 		triggerAliasesFlagName       = "trigger-aliases"
@@ -59,6 +59,10 @@ func List() cli.Command {
 				Usage: "list all patch aliases for a project",
 			},
 			cli.BoolFlag{
+				Name:  includeConfigAliasesFlagName,
+				Usage: "include YAML defined aliases when listing patch aliases",
+			},
+			cli.BoolFlag{
 				Name:  triggerAliasesFlagName,
 				Usage: "list all trigger aliases for a project",
 			},
@@ -72,7 +76,7 @@ func List() cli.Command {
 			project := c.String(projectFlagName)
 			filename := c.String(pathFlagName)
 			onlyUserSpawnable := c.Bool(spawnableFlagName)
-			includeProjectConfig := c.Bool(includeProjectConfigFlagName)
+			includeProjectConfig := c.Bool(includeConfigAliasesFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/operations/list.go
+++ b/operations/list.go
@@ -19,14 +19,15 @@ import (
 
 func List() cli.Command {
 	const (
-		projectsFlagName       = "projects"
-		variantsFlagName       = "variants"
-		tasksFlagName          = "tasks"
-		distrosFlagName        = "distros"
-		spawnableFlagName      = "spawnable"
-		parametersFlagName     = "parameters"
-		patchAliasesFlagName   = "patch-aliases"
-		triggerAliasesFlagName = "trigger-aliases"
+		projectsFlagName             = "projects"
+		variantsFlagName             = "variants"
+		tasksFlagName                = "tasks"
+		distrosFlagName              = "distros"
+		spawnableFlagName            = "spawnable"
+		includeProjectConfigFlagName = "include-config"
+		parametersFlagName           = "parameters"
+		patchAliasesFlagName         = "patch-aliases"
+		triggerAliasesFlagName       = "trigger-aliases"
 	)
 
 	return cli.Command{
@@ -71,6 +72,7 @@ func List() cli.Command {
 			project := c.String(projectFlagName)
 			filename := c.String(pathFlagName)
 			onlyUserSpawnable := c.Bool(spawnableFlagName)
+			includeProjectConfig := c.Bool(includeProjectConfigFlagName)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -85,7 +87,7 @@ func List() cli.Command {
 			case c.Bool(parametersFlagName):
 				return listParameters(ctx, confPath, project, filename)
 			case c.Bool(patchAliasesFlagName):
-				return listPatchAliases(ctx, confPath, project)
+				return listPatchAliases(ctx, confPath, project, includeProjectConfig)
 			case c.Bool(triggerAliasesFlagName):
 				return listTriggerAliases(ctx, confPath, project)
 			case c.Bool(distrosFlagName), onlyUserSpawnable:
@@ -302,7 +304,7 @@ func listTriggerAliases(ctx context.Context, confPath, project string) error {
 	return nil
 }
 
-func listPatchAliases(ctx context.Context, confPath, project string) error {
+func listPatchAliases(ctx context.Context, confPath, project string, includeProjectConfig bool) error {
 	conf, err := NewClientSettings(confPath)
 	if err != nil {
 		return errors.Wrap(err, "loading configuration")
@@ -317,7 +319,7 @@ func listPatchAliases(ctx context.Context, confPath, project string) error {
 		return errors.New("no project specified")
 	}
 
-	aliases, err := comm.ListAliases(ctx, project)
+	aliases, err := comm.ListAliases(ctx, project, includeProjectConfig)
 	if err != nil {
 		return err
 	}

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -83,7 +83,7 @@ type Communicator interface {
 	DeletePublicKey(context.Context, string) error
 
 	// List variant/task aliases
-	ListAliases(context.Context, string) ([]model.ProjectAlias, error)
+	ListAliases(context.Context, string, bool) ([]model.ProjectAlias, error)
 	ListPatchTriggerAliases(context.Context, string) ([]string, error)
 	GetDistroByName(context.Context, string) (*restmodel.APIDistro, error)
 

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -82,7 +82,7 @@ type Communicator interface {
 	// Delete a key with specified name from the current authenticated user
 	DeletePublicKey(context.Context, string) error
 
-	// List variant/task aliases
+	// List variant/task aliases, with bool parameter to optionally include YAML-defined aliases.
 	ListAliases(context.Context, string, bool) ([]model.ProjectAlias, error)
 	ListPatchTriggerAliases(context.Context, string) ([]string, error)
 	GetDistroByName(context.Context, string) (*restmodel.APIDistro, error)

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -900,11 +900,14 @@ func (c *communicatorImpl) DeletePublicKey(ctx context.Context, keyName string) 
 	return nil
 }
 
-func (c *communicatorImpl) ListAliases(ctx context.Context, project string) ([]serviceModel.ProjectAlias, error) {
+func (c *communicatorImpl) ListAliases(ctx context.Context, project string, includeProjectConfig bool) ([]serviceModel.ProjectAlias, error) {
 	path := fmt.Sprintf("alias/%s", project)
 	info := requestInfo{
 		method: http.MethodGet,
 		path:   path,
+	}
+	if includeProjectConfig {
+		info.path += "?includeProjectConfig=true"
 	}
 	resp, err := c.request(ctx, info, "")
 	if err != nil {

--- a/rest/route/alias.go
+++ b/rest/route/alias.go
@@ -22,7 +22,7 @@ func makeFetchAliases() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Get a project's aliases
-//	@Description	Returns the the project's aliases. This endpoint serves the data returned by the "evergreen list --patch-aliases" command.
+//	@Description	Returns the project's aliases. This endpoint serves the data returned by the "evergreen list --patch-aliases" command.
 //	@Tags			projects
 //	@Router			/alias/{project_id} [get]
 //	@Security		Api-User || Api-Key

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -1,0 +1,137 @@
+package route
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/db"
+	dbModel "github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAliasesHandler(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, h *aliasGetHandler){
+		"ReturnsProjectLevelAliases": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
+			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref", nil)
+			assert.NoError(t, err)
+			assert.NoError(t, h.Parse(ctx, r))
+
+			resp := h.Run(ctx)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			payload := resp.Data().([]interface{})
+			require.Len(t, payload, 1)
+			foundAlias := payload[0].(model.APIProjectAlias)
+			assert.Equal(t, utility.FromStringPtr(foundAlias.Alias), "project_alias")
+		},
+		"ReturnsRepoLevelAliases": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
+			projectAliases, err := dbModel.FindAliasesForProjectFromDb("project_ref")
+			require.NoError(t, err)
+			require.Len(t, projectAliases, 1)
+			require.NoError(t, dbModel.RemoveProjectAlias(projectAliases[0].ID.Hex()))
+
+			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref", nil)
+			assert.NoError(t, err)
+			assert.NoError(t, h.Parse(ctx, r))
+
+			resp := h.Run(ctx)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			payload := resp.Data().([]interface{})
+			require.Len(t, payload, 1)
+			foundAlias := payload[0].(model.APIProjectAlias)
+			assert.Equal(t, utility.FromStringPtr(foundAlias.Alias), "repo_alias")
+		},
+		"ReturnsNoAliasesWithoutProjectConfigURLParam": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
+			require.NoError(t, db.Clear(dbModel.ProjectAliasCollection))
+
+			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref", nil)
+			assert.NoError(t, err)
+			assert.NoError(t, h.Parse(ctx, r))
+
+			resp := h.Run(ctx)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			payload := resp.Data().([]interface{})
+			require.Len(t, payload, 0)
+		},
+		"ReturnsConfigLevelAliases": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
+			require.NoError(t, db.Clear(dbModel.ProjectAliasCollection))
+
+			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref?includeProjectConfig=true", nil)
+			assert.NoError(t, err)
+			assert.NoError(t, h.Parse(ctx, r))
+
+			resp := h.Run(ctx)
+			assert.Equal(t, resp.Status(), http.StatusOK)
+
+			payload := resp.Data().([]interface{})
+			require.Len(t, payload, 1)
+			foundAlias := payload[0].(model.APIProjectAlias)
+			assert.Equal(t, utility.FromStringPtr(foundAlias.Alias), "project_config_alias")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(
+				dbModel.RepoRefCollection,
+				dbModel.ProjectRefCollection,
+				dbModel.ProjectAliasCollection,
+				dbModel.ProjectConfigCollection,
+			))
+
+			repoRef := &dbModel.RepoRef{
+				ProjectRef: dbModel.ProjectRef{
+					Id:    "repo_ref",
+					Repo:  "repo",
+					Owner: "mongodb",
+				},
+			}
+			projectRef := &dbModel.ProjectRef{
+				Id:                    "project_ref",
+				Repo:                  "repo",
+				Owner:                 "mongodb",
+				RepoRefId:             "repo_ref",
+				VersionControlEnabled: utility.TruePtr(),
+			}
+			require.NoError(t, repoRef.Upsert())
+			require.NoError(t, projectRef.Upsert())
+
+			repoAlias := &dbModel.ProjectAlias{
+				ProjectID: repoRef.Id,
+				Alias:     "repo_alias",
+				Variant:   "test_variant",
+			}
+			projectAlias := &dbModel.ProjectAlias{
+				ProjectID: projectRef.Id,
+				Alias:     "project_alias",
+				Variant:   "test_variant",
+			}
+			require.NoError(t, repoAlias.Upsert())
+			require.NoError(t, projectAlias.Upsert())
+
+			projectConfig := &dbModel.ProjectConfig{
+				Id:      "project-1",
+				Project: "project_ref",
+				ProjectConfigFields: dbModel.ProjectConfigFields{
+					PatchAliases: []dbModel.ProjectAlias{
+						{
+							Alias:       "project_config_alias",
+							Description: "from project config",
+						},
+					},
+				}}
+			require.NoError(t, projectConfig.Insert())
+
+			rh, ok := makeFetchAliases().(*aliasGetHandler)
+			require.True(t, ok)
+
+			tCase(ctx, t, rh)
+		})
+	}
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -132,7 +132,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/service_users").Version(2).Get().Wrap(requireUser, adminSettings).RouteHandler(makeGetServiceUsers())
 	app.AddRoute("/admin/service_users").Version(2).Post().Wrap(requireUser, adminSettings).RouteHandler(makeUpdateServiceUser())
 	app.AddRoute("/admin/service_users").Version(2).Delete().Wrap(requireUser, adminSettings).RouteHandler(makeDeleteServiceUser())
-	app.AddRoute("/alias/{name}").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchAliases())
+	app.AddRoute("/alias/{project_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchAliases())
 	app.AddRoute("/auth").Version(2).Get().Wrap(requireUser).RouteHandler(&authPermissionGetHandler{})
 	app.AddRoute("/builds/{build_id}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetBuildByID(env))
 	app.AddRoute("/builds/{build_id}").Version(2).Patch().Wrap(requireUser, editTasks).RouteHandler(makeChangeStatusForBuild())


### PR DESCRIPTION
DEVPROD-7489

### Description
Add functionality to the get project aliases route to also optionally retrieve YAML aliases.
### Testing
Added unit testing for the whole route, and tested this in staging.
