### PR TITLE
DEVPROD-9473: decode parameters back to project variables

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -597,8 +597,7 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 }
 
 func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varName, varValue string, err error) {
-	// kim: TODO: use constant extension.
-	if !strings.HasSuffix(paramName, ".gz") {
+	if strings.HasSuffix(paramName, gzipCompressedParamExtension) {
 		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
 		if err != nil {
 			return "", "", errors.Wrap(err, "creating gzip reader for compressed project variable")
@@ -608,13 +607,15 @@ func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varN
 			return "", "", errors.Wrap(err, "decoding gzip-compressed parameter to project variable")
 		}
 		varValue = string(b)
+	} else {
+		varValue = paramValue
 	}
 
-	// kim: TODO: use exported helper from DEVPROD-9472.
-	varName, ok := pm.ParamNameMap()[paramName]
+	m, ok := pm.ParamNameMap()[paramName]
 	if !ok {
 		return "", "", errors.Errorf("cannot find project variable name corresponding to parameter '%s'", paramName)
 	}
+	varName = m.Name
 	if varName == "" {
 		return "", "", errors.Errorf("project variable name corresponding to parameter '%s' exists but is empty", paramName)
 	}

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -471,7 +471,8 @@ func (projectVars *ProjectVars) MergeWithRepoVars(repoVars *ProjectVars) {
 // name and value. In particular, it validates that the variable name and value
 // fits within parameter constraints and if the name or value doesn't fit in the
 // constraints, it attempts to fix minor issues where possible. The return value
-// is a valid parameter name and parameter value.
+// is a valid parameter name and parameter value. This is the inverse operation
+// of convertParamToVar.
 func convertVarToParam(projectID string, pm ParameterMappings, varName, varValue string) (paramName string, paramValue string, err error) {
 	if err := validateVarNameCharset(varName); err != nil {
 		return "", "", errors.Wrapf(err, "validating project variable name '%s'", varName)
@@ -596,6 +597,8 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 	return fmt.Sprintf("%s%s", varName, gzipCompressedParamExtension), compressedValue.String(), nil
 }
 
+// convertParamToVar converts a parameter back to its original project variable
+// name and value. This is the inverse operation of convertVarToParam.
 func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varName, varValue string, err error) {
 	if strings.HasSuffix(paramName, gzipCompressedParamExtension) {
 		gzr, err := gzip.NewReader(strings.NewReader(paramValue))

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -587,3 +587,19 @@ func TestShouldGetAdminOnlyVars(t *testing.T) {
 		assert.True(t, tested, fmt.Sprintf("requester '%s' not tested with non-admin", requester))
 	}
 }
+
+// kim: TODO: add tests
+func TestConvertParamToVar(t *testing.T) {
+	t.Run("ReturnsVarNameFromExistingParameterMapping", func(t *testing.T) {
+
+	})
+	t.Run("ReturnsErrorForVariableWithoutParameterMapping", func(t *testing.T) {
+
+	})
+	t.Run("ReturnsErrorForVariableWithEmptyParameterMapping", func(t *testing.T) {
+
+	})
+	t.Run("DecompressesParameterToOriginalVariable", func(t *testing.T) {
+
+	})
+}


### PR DESCRIPTION
DEVPROD-9473

### Description
Add helper that will convert an SSM parameter back to the original project var. The logic to convert a project var to a parameter already exists, this is the inverse operation.

### Testing
Added unit tests.

### Documentation
N/A