### PR TITLE
DEVPROD-12051 Add ignore codes logic to github client

### DIFF
--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -141,6 +141,23 @@ func (s *githubSuite) TestGithubShouldRetry() {
 		}
 		s.False(retryFn(0, req, resp, nil))
 	})
+
+	s.Run("IgnoreCodes", func() {
+		code := http.StatusNotFound
+		resp := &http.Response{
+			StatusCode: code,
+			Header: http.Header{
+				"X-Ratelimit-Limit":     []string{"10"},
+				"X-Ratelimit-Remaining": []string{"10"},
+			},
+		}
+
+		retryFn := githubShouldRetry("", retryConfig{retry: true})
+		s.True(retryFn(0, req, resp, nil))
+
+		retryFn = githubShouldRetry("", retryConfig{retry: true, ignoreCodes: []int{code}})
+		s.False(retryFn(0, req, resp, nil))
+	})
 }
 
 func (s *githubSuite) TestCheckGithubAPILimit() {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -143,7 +143,7 @@ func (s *githubSuite) TestGithubShouldRetry() {
 	})
 
 	s.Run("IgnoreCodes", func() {
-		code := http.StatusNotFound
+		code := http.StatusBadGateway
 		resp := &http.Response{
 			StatusCode: code,
 			Header: http.Header{


### PR DESCRIPTION
DEVPROD-12051

### Description
We're getting a lot of extraneous logs in prod from trying to revoke tokens that are already revoked. (aka 401 responses)

This adds a config option to the client to ignore codes.

### Testing
Add unit test