### PR TITLE
DEVPROD-11144 Add options handler to logout route

### DIFF
--- a/service/ui.go
+++ b/service/ui.go
@@ -436,7 +436,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.PrefixRoute("/plugin").Route("/buildbaron/note/{task_id}").Wrap(needsLogin, needsContext, editTasks).Handler(bbSaveNote).Put()
 	app.PrefixRoute("/plugin").Route("/buildbaron/file_ticket").Wrap(needsLogin, needsContext).Handler(uis.bbFileTicket).Post()
 
-	// Add an OPTIONS method to every POST request to handle preflight OPTIONS requests.
+	// Add an OPTIONS method to every POST request to handle preflight OPTIONS requests, and also for logging out.
 	// These requests must not check for credentials. They exist to validate whether a route exists, and to
 	// allow requests from specific origins.
 	for _, r := range app.Routes() {

--- a/service/ui.go
+++ b/service/ui.go
@@ -440,7 +440,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	// These requests must not check for credentials. They exist to validate whether a route exists, and to
 	// allow requests from specific origins.
 	for _, r := range app.Routes() {
-		if r.HasMethod(http.MethodPost) {
+		if r.HasMethod(http.MethodPost) || r.GetRoute() == "/logout" {
 			app.AddRoute(r.GetRoute()).Wrap(allowsCORS).Handler(func(w http.ResponseWriter, _ *http.Request) { gimlet.WriteJSON(w, "") }).Options()
 		}
 	}

--- a/service/ui.go
+++ b/service/ui.go
@@ -436,11 +436,11 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.PrefixRoute("/plugin").Route("/buildbaron/note/{task_id}").Wrap(needsLogin, needsContext, editTasks).Handler(bbSaveNote).Put()
 	app.PrefixRoute("/plugin").Route("/buildbaron/file_ticket").Wrap(needsLogin, needsContext).Handler(uis.bbFileTicket).Post()
 
-	// Add an OPTIONS method to every POST request to handle preflight OPTIONS requests, and also for logging out.
+	// Add an OPTIONS method to every POST and GET request to handle preflight OPTIONS requests.
 	// These requests must not check for credentials. They exist to validate whether a route exists, and to
 	// allow requests from specific origins.
 	for _, r := range app.Routes() {
-		if r.HasMethod(http.MethodPost) || r.GetRoute() == "/logout" {
+		if r.HasMethod(http.MethodPost) || r.HasMethod(http.MethodGet) {
 			app.AddRoute(r.GetRoute()).Wrap(allowsCORS).Handler(func(w http.ResponseWriter, _ *http.Request) { gimlet.WriteJSON(w, "") }).Options()
 		}
 	}


### PR DESCRIPTION
DEVPROD-11144

### Description
When making CORS request to the `/logout` endpoint of Evergreen, the browser pings `/logout` with an OPTIONS method, which was returning a CORS error because Evergreen doesn't have a route for this type of request on the `/logout` path.

Added an OPTIONS method to the logout path that adds CORS headers, just like we do for all POST methods currently.

### Testing
Tested in staging and confirmed that in incognito, visiting Spruce no longer gives an indefinite LOADING screen, but redirects to the login flow.