### PR TITLE
DEVPROD-11768: Begin sending data to new perf endpoint in SPS

### DIFF
--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -72,9 +72,16 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 	if err != nil {
 		return errors.Wrap(err, "connecting to Cedar")
 	}
+	cedarConfig, err := comm.GetCedarConfig(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting Cedar config for performance results")
+	}
 	opts := rpc.UploadReportOptions{
-		Report:     report,
-		ClientConn: conn,
+		Report:          report,
+		CedarClientConn: conn,
+		SendToCedar:     !cedarConfig.SendToCedarDisabled,
+		SendRatioSPS:    cedarConfig.SendRatioSPS,
+		SPSURL:          cedarConfig.SPSURL,
 	}
 	return errors.Wrap(rpc.UploadReport(ctx, opts), "uploading report to Cedar")
 }

--- a/apimodels/cedar_models.go
+++ b/apimodels/cedar_models.go
@@ -19,12 +19,15 @@ import (
 )
 
 type CedarConfig struct {
-	BaseURL     string `json:"base_url"`
-	GRPCBaseURL string `json:"grpc_base_url"`
-	RPCPort     string `json:"rpc_port"`
-	Username    string `json:"username"`
-	APIKey      string `json:"api_key,omitempty"`
-	Insecure    bool   `json:"insecure"`
+	BaseURL             string `json:"base_url"`
+	GRPCBaseURL         string `json:"grpc_base_url"`
+	RPCPort             string `json:"rpc_port"`
+	Username            string `json:"username"`
+	APIKey              string `json:"api_key,omitempty"`
+	Insecure            bool   `json:"insecure"`
+	SendToCedarDisabled bool   `json:"send_to_cedar_disabled"`
+	SPSURL              string `json:"sps_url"`
+	SendRatioSPS        int    `json:"send_ratio_sps"`
 }
 
 // GetBuildloggerLogsOptions represents the arguments passed into the

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-10-14"
+	AgentVersion = "2024-10-16"
 )
 
 const (

--- a/config_cedar.go
+++ b/config_cedar.go
@@ -16,15 +16,24 @@ type CedarConfig struct {
 	APIKey      string `bson:"api_key" json:"api_key" yaml:"api_key"`
 	// Insecure disables TLS, this should only be used for testing.
 	Insecure bool `bson:"insecure" json:"insecure" yaml:"insecure"`
+	// SendToCedarDisabled disables sending perf results to cedar. This will be removed when Cedar no longer handles perf results.
+	SendToCedarDisabled bool `bson:"send_to_cedar_disabled" json:"send_to_cedar_disabled" yaml:"send_to_cedar_disabled"`
+	// SPSURL tells Evergreen where the SPS service is.
+	SPSURL string `bson:"sps_url" json:"sps_url" yaml:"sps_url"`
+	// SendRatioSPS is the ratio of perf results to send to SPS. This will be removed when Cedar no longer handles perf results as all results will go to SPS.
+	SendRatioSPS int `bson:"send_ratio_sps" json:"send_ratio_sps" yaml:"send_ratio_sps"`
 }
 
 var (
-	cedarConfigBaseURLKey     = bsonutil.MustHaveTag(CedarConfig{}, "BaseURL")
-	cedarConfigGRPCBaseURLKey = bsonutil.MustHaveTag(CedarConfig{}, "GRPCBaseURL")
-	cedarConfigRPCPortKey     = bsonutil.MustHaveTag(CedarConfig{}, "RPCPort")
-	cedarConfigUserKey        = bsonutil.MustHaveTag(CedarConfig{}, "User")
-	cedarConfigAPIKeyKey      = bsonutil.MustHaveTag(CedarConfig{}, "APIKey")
-	cedarConfigInsecureKey    = bsonutil.MustHaveTag(CedarConfig{}, "Insecure")
+	cedarConfigBaseURLKey       = bsonutil.MustHaveTag(CedarConfig{}, "BaseURL")
+	cedarConfigGRPCBaseURLKey   = bsonutil.MustHaveTag(CedarConfig{}, "GRPCBaseURL")
+	cedarConfigRPCPortKey       = bsonutil.MustHaveTag(CedarConfig{}, "RPCPort")
+	cedarConfigUserKey          = bsonutil.MustHaveTag(CedarConfig{}, "User")
+	cedarConfigAPIKeyKey        = bsonutil.MustHaveTag(CedarConfig{}, "APIKey")
+	cedarConfigInsecureKey      = bsonutil.MustHaveTag(CedarConfig{}, "Insecure")
+	cedarSendToCedarDisabledKey = bsonutil.MustHaveTag(CedarConfig{}, "SendToCedarDisabled")
+	cedarSPSURLKey              = bsonutil.MustHaveTag(CedarConfig{}, "SPSURL")
+	cedarSendRatioSPSKey        = bsonutil.MustHaveTag(CedarConfig{}, "SendRatioSPS")
 )
 
 func (*CedarConfig) SectionId() string { return "cedar" }
@@ -36,12 +45,15 @@ func (c *CedarConfig) Get(ctx context.Context) error {
 func (c *CedarConfig) Set(ctx context.Context) error {
 	return errors.Wrapf(setConfigSection(ctx, c.SectionId(), bson.M{
 		"$set": bson.M{
-			cedarConfigBaseURLKey:     c.BaseURL,
-			cedarConfigGRPCBaseURLKey: c.GRPCBaseURL,
-			cedarConfigRPCPortKey:     c.RPCPort,
-			cedarConfigUserKey:        c.User,
-			cedarConfigAPIKeyKey:      c.APIKey,
-			cedarConfigInsecureKey:    c.Insecure,
+			cedarConfigBaseURLKey:       c.BaseURL,
+			cedarConfigGRPCBaseURLKey:   c.GRPCBaseURL,
+			cedarConfigRPCPortKey:       c.RPCPort,
+			cedarConfigUserKey:          c.User,
+			cedarConfigAPIKeyKey:        c.APIKey,
+			cedarConfigInsecureKey:      c.Insecure,
+			cedarSendToCedarDisabledKey: c.SendToCedarDisabled,
+			cedarSPSURLKey:              c.SPSURL,
+			cedarSendRatioSPSKey:        c.SendRatioSPS,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/evergreen-ci/gimlet v0.0.0-20241003144629-4e8f8a178646
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
 	github.com/evergreen-ci/pail v0.0.0-20240812165850-4ccf32c50e99
-	github.com/evergreen-ci/poplar v0.0.0-20240809150814-63d58cd28568
+	github.com/evergreen-ci/poplar v0.0.0-20241014191612-891426af27cb
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20240509150854-9d66df03b40e
 	github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20211028170046-0999224b53df/go.mod h1:xiggfkrlxlu2C2e58tvk0WAYFetgNC7U9ONqcP29xZs=
 github.com/evergreen-ci/poplar v0.0.0-20220405164038-0cfe3198c320/go.mod h1:H4E1ha844o4VDsuJQQyB+HKHmz8gaXCRnukfWDPV/Zw=
-github.com/evergreen-ci/poplar v0.0.0-20240809150814-63d58cd28568 h1:0/URpnFJ540Iru/mjc5shY5XMvMmCnjvsVbw2VI3tgg=
-github.com/evergreen-ci/poplar v0.0.0-20240809150814-63d58cd28568/go.mod h1:6Ilzy/iipW39u9G9wwabSSU08A+l4b+q9KqaNDgEvDA=
+github.com/evergreen-ci/poplar v0.0.0-20241014191612-891426af27cb h1:OdsyxBcu52/w7/QKprEIL4dqnB1rvUo4rHj5Fvwn72E=
+github.com/evergreen-ci/poplar v0.0.0-20241014191612-891426af27cb/go.mod h1:6Ilzy/iipW39u9G9wwabSSU08A+l4b+q9KqaNDgEvDA=
 github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6 h1:LfvYiC/yIi91+6ykT8yaDfmzr67vcFUbQCbRg1ZbEj4=
 github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6/go.mod h1:r6YQr77CR37LMhBdWcFrxqu5V+UhO+SYloHfd9vO1go=
 github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826 h1:oViYb1lmJN1k9SExkF87VTess4JVR7Uvwr8AAKzJ864=

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -674,11 +674,14 @@ func (a *APIBucketsConfig) ToService() (interface{}, error) {
 }
 
 type APICedarConfig struct {
-	BaseURL     *string `json:"base_url"`
-	GRPCBaseURL *string `json:"grpc_base_url"`
-	RPCPort     *string `json:"rpc_port"`
-	User        *string `json:"user"`
-	APIKey      *string `json:"api_key"`
+	BaseURL             *string `json:"base_url"`
+	GRPCBaseURL         *string `json:"grpc_base_url"`
+	RPCPort             *string `json:"rpc_port"`
+	User                *string `json:"user"`
+	APIKey              *string `json:"api_key"`
+	SendToCedarDisabled *bool   `json:"send_to_cedar_disabled"`
+	SPSURL              *string `json:"sps_url"`
+	SendRatioSPS        *int    `json:"send_ratio_sps"`
 }
 
 func (a *APICedarConfig) BuildFromService(h interface{}) error {
@@ -689,6 +692,9 @@ func (a *APICedarConfig) BuildFromService(h interface{}) error {
 		a.RPCPort = utility.ToStringPtr(v.RPCPort)
 		a.User = utility.ToStringPtr(v.User)
 		a.APIKey = utility.ToStringPtr(v.APIKey)
+		a.SendToCedarDisabled = utility.ToBoolPtr(v.SendToCedarDisabled)
+		a.SPSURL = utility.ToStringPtr(v.SPSURL)
+		a.SendRatioSPS = utility.ToIntPtr(v.SendRatioSPS)
 	default:
 		return errors.Errorf("programmatic error: expected Cedar config but got type %T", h)
 	}
@@ -697,11 +703,14 @@ func (a *APICedarConfig) BuildFromService(h interface{}) error {
 
 func (a *APICedarConfig) ToService() (interface{}, error) {
 	return evergreen.CedarConfig{
-		BaseURL:     utility.FromStringPtr(a.BaseURL),
-		GRPCBaseURL: utility.FromStringPtr(a.GRPCBaseURL),
-		RPCPort:     utility.FromStringPtr(a.RPCPort),
-		User:        utility.FromStringPtr(a.User),
-		APIKey:      utility.FromStringPtr(a.APIKey),
+		BaseURL:             utility.FromStringPtr(a.BaseURL),
+		GRPCBaseURL:         utility.FromStringPtr(a.GRPCBaseURL),
+		RPCPort:             utility.FromStringPtr(a.RPCPort),
+		User:                utility.FromStringPtr(a.User),
+		APIKey:              utility.FromStringPtr(a.APIKey),
+		SendToCedarDisabled: utility.FromBoolPtr(a.SendToCedarDisabled),
+		SPSURL:              utility.FromStringPtr(a.SPSURL),
+		SendRatioSPS:        utility.FromIntPtr(a.SendRatioSPS),
 	}, nil
 }
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -54,12 +54,15 @@ func (*agentCedarConfig) Parse(_ context.Context, _ *http.Request) error { retur
 
 func (h *agentCedarConfig) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(apimodels.CedarConfig{
-		BaseURL:     h.config.BaseURL,
-		GRPCBaseURL: h.config.GRPCBaseURL,
-		RPCPort:     h.config.RPCPort,
-		Username:    h.config.User,
-		APIKey:      h.config.APIKey,
-		Insecure:    h.config.Insecure,
+		BaseURL:             h.config.BaseURL,
+		GRPCBaseURL:         h.config.GRPCBaseURL,
+		RPCPort:             h.config.RPCPort,
+		Username:            h.config.User,
+		APIKey:              h.config.APIKey,
+		Insecure:            h.config.Insecure,
+		SendToCedarDisabled: h.config.SendToCedarDisabled,
+		SPSURL:              h.config.SPSURL,
+		SendRatioSPS:        h.config.SendRatioSPS,
 	})
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1446,6 +1446,19 @@ Admin Settings
 										<input type="text" ng-model="Settings.cedar.rpc_port">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>SPS URL</label>
+										<input type="text" ng-model="Settings.cedar.sps_url">
+									</md-input-container>
+									<label>Disable Sending Performance Data to Cedar</label>
+									<md-radio-group data-ng-model="Settings.cedar.send_to_cedar_disabled" layout="row">
+										<md-radio-button data-ng-value="false">False</md-radio-button>
+										<md-radio-button data-ng-value="true">True</md-radio-button>
+									</md-radio-group>
+									<md-input-container class="control" style="width:45%;">
+										<label>Send Ratio to Cedar (1/x), 0 is off</label>
+										<input type="number" ng-model="Settings.cedar.send_ratio_sps">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>User</label>
 										<input type="text" ng-model="Settings.cedar.user">
 									</md-input-container>

--- a/smoke/internal/testdata/admin_settings.yml
+++ b/smoke/internal/testdata/admin_settings.yml
@@ -81,3 +81,6 @@ cedar:
   user: "user"
   api_key: "key"
   insecure: true
+  send_to_cedar_disabled: true
+  sps_url: "http://localhost:8080"
+  send_ratio_sps: 0


### PR DESCRIPTION
[DEVPROD-11768](https://jira.mongodb.org/browse/DEVPROD-11768)

### Description
This adds the configuration for being able to send Perf Results to SPS. It also bumps the Poplar version to be able to take advantage of the new options. I based these changes off of [this pr](https://github.com/evergreen-ci/evergreen/pull/7685/files).

### Testing
Likely the best way of testing this would be pushing this to Evergreen staging. I'll work with your team on doing that.
