### PR TITLE
DEVPROD-12086 Add queue sorting factor for number of dependent tasks

### DIFF
--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,13 +2,10 @@ package fakeparameter
 
 import (
 	"context"
-	"flag"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -19,13 +16,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	if ExecutionEnvironmentType != "test" {
-		grip.EmergencyFatal(message.Fields{
-			"message":     "fake Parameter Store testing code called in a non-testing environment",
-			"environment": ExecutionEnvironmentType,
-			"args":        flag.Args(),
-		})
-	}
+	//if ExecutionEnvironmentType != "test" {
+	//	grip.EmergencyFatal(message.Fields{
+	//		"message":     "fake Parameter Store testing code called in a non-testing environment",
+	//		"environment": ExecutionEnvironmentType,
+	//		"args":        flag.Args(),
+	//	})
+	//}
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,6 +2,9 @@ package fakeparameter
 
 import (
 	"context"
+	"flag"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -16,13 +19,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	//if ExecutionEnvironmentType != "test" {
-	//	grip.EmergencyFatal(message.Fields{
-	//		"message":     "fake Parameter Store testing code called in a non-testing environment",
-	//		"environment": ExecutionEnvironmentType,
-	//		"args":        flag.Args(),
-	//	})
-	//}
+	if ExecutionEnvironmentType != "test" {
+		grip.EmergencyFatal(message.Fields{
+			"message":     "fake Parameter Store testing code called in a non-testing environment",
+			"environment": ExecutionEnvironmentType,
+			"args":        flag.Args(),
+		})
+	}
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -3,12 +3,12 @@ package fakeparameter
 import (
 	"context"
 	"flag"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 

--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -27,7 +27,7 @@ type SchedulerConfig struct {
 	MainlineTimeInQueueFactor     int64   `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 	GenerateTaskFactor            int64   `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
-	NumDependentsFactor           int64   `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
+	NumDependentsFactor           float64 `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
 	StepbackTaskFactor            int64   `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 }
 

--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -27,6 +27,7 @@ type SchedulerConfig struct {
 	MainlineTimeInQueueFactor     int64   `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 	GenerateTaskFactor            int64   `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
+	NumDependentsFactor           int64   `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
 	StepbackTaskFactor            int64   `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 }
 
@@ -56,6 +57,7 @@ func (c *SchedulerConfig) Set(ctx context.Context) error {
 			"mainline_time_in_queue_factor":     c.MainlineTimeInQueueFactor,
 			"expected_runtime_factor":           c.ExpectedRuntimeFactor,
 			"generate_task_factor":              c.GenerateTaskFactor,
+			"num_dependents_factor":             c.NumDependentsFactor,
 			"stepback_task_factor":              c.StepbackTaskFactor,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
@@ -161,7 +163,9 @@ func (c *SchedulerConfig) ValidateAndDefault() error {
 	if c.GenerateTaskFactor < 0 || c.GenerateTaskFactor > 100 {
 		return errors.New("generate task factor must be between 0 and 100")
 	}
-
+	if c.NumDependentsFactor < 0 || c.NumDependentsFactor > 100 {
+		return errors.New("num dependents factor must be between 0 and 100")
+	}
 	if c.StepbackTaskFactor < 0 || c.StepbackTaskFactor > 100 {
 		return errors.New("stepback task factor must be between 0 and 100")
 	}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -40619,14 +40619,11 @@ func (ec *executionContext) _PlannerSettings_numDependentsFactor(ctx context.Con
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+	return ec.marshalOFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlannerSettings_numDependentsFactor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -75670,7 +75667,7 @@ func (ec *executionContext) unmarshalInputPlannerSettingsInput(ctx context.Conte
 			it.GenerateTaskFactor = data
 		case "numDependentsFactor":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("numDependentsFactor"))
-			data, err := ec.unmarshalNFloat2float64(ctx, v)
+			data, err := ec.unmarshalOFloat2float64(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -85815,9 +85812,6 @@ func (ec *executionContext) _PlannerSettings(ctx context.Context, sel ast.Select
 			}
 		case "numDependentsFactor":
 			out.Values[i] = ec._PlannerSettings_numDependentsFactor(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "groupVersions":
 			out.Values[i] = ec._PlannerSettings_groupVersions(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -40624,9 +40624,9 @@ func (ec *executionContext) _PlannerSettings_numDependentsFactor(ctx context.Con
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int64)
+	res := resTmp.(float64)
 	fc.Result = res
-	return ec.marshalNInt2int64(ctx, field.Selections, res)
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_PlannerSettings_numDependentsFactor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -40636,7 +40636,7 @@ func (ec *executionContext) fieldContext_PlannerSettings_numDependentsFactor(_ c
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -75670,7 +75670,7 @@ func (ec *executionContext) unmarshalInputPlannerSettingsInput(ctx context.Conte
 			it.GenerateTaskFactor = data
 		case "numDependentsFactor":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("numDependentsFactor"))
-			data, err := ec.unmarshalNInt2int64(ctx, v)
+			data, err := ec.unmarshalNFloat2float64(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -908,6 +908,7 @@ type ComplexityRoot struct {
 		GenerateTaskFactor        func(childComplexity int) int
 		GroupVersions             func(childComplexity int) int
 		MainlineTimeInQueueFactor func(childComplexity int) int
+		NumDependentsFactor       func(childComplexity int) int
 		PatchFactor               func(childComplexity int) int
 		PatchTimeInQueueFactor    func(childComplexity int) int
 		TargetTime                func(childComplexity int) int
@@ -6075,6 +6076,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PlannerSettings.MainlineTimeInQueueFactor(childComplexity), true
+
+	case "PlannerSettings.numDependentsFactor":
+		if e.complexity.PlannerSettings.NumDependentsFactor == nil {
+			break
+		}
+
+		return e.complexity.PlannerSettings.NumDependentsFactor(childComplexity), true
 
 	case "PlannerSettings.patchFactor":
 		if e.complexity.PlannerSettings.PatchFactor == nil {
@@ -18588,6 +18596,8 @@ func (ec *executionContext) fieldContext_Distro_plannerSettings(_ context.Contex
 				return ec.fieldContext_PlannerSettings_expectedRuntimeFactor(ctx, field)
 			case "generateTaskFactor":
 				return ec.fieldContext_PlannerSettings_generateTaskFactor(ctx, field)
+			case "numDependentsFactor":
+				return ec.fieldContext_PlannerSettings_numDependentsFactor(ctx, field)
 			case "groupVersions":
 				return ec.fieldContext_PlannerSettings_groupVersions(ctx, field)
 			case "mainlineTimeInQueueFactor":
@@ -40576,6 +40586,50 @@ func (ec *executionContext) _PlannerSettings_generateTaskFactor(ctx context.Cont
 }
 
 func (ec *executionContext) fieldContext_PlannerSettings_generateTaskFactor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PlannerSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PlannerSettings_numDependentsFactor(ctx context.Context, field graphql.CollectedField, obj *model.APIPlannerSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PlannerSettings_numDependentsFactor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NumDependentsFactor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PlannerSettings_numDependentsFactor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "PlannerSettings",
 		Field:      field,
@@ -75586,7 +75640,7 @@ func (ec *executionContext) unmarshalInputPlannerSettingsInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"commitQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "groupVersions", "mainlineTimeInQueueFactor", "patchFactor", "patchTimeInQueueFactor", "targetTime", "version"}
+	fieldsInOrder := [...]string{"commitQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "numDependentsFactor", "groupVersions", "mainlineTimeInQueueFactor", "patchFactor", "patchTimeInQueueFactor", "targetTime", "version"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -75614,6 +75668,13 @@ func (ec *executionContext) unmarshalInputPlannerSettingsInput(ctx context.Conte
 				return it, err
 			}
 			it.GenerateTaskFactor = data
+		case "numDependentsFactor":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("numDependentsFactor"))
+			data, err := ec.unmarshalNInt2int64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NumDependentsFactor = data
 		case "groupVersions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("groupVersions"))
 			data, err := ec.unmarshalNBoolean2bool(ctx, v)
@@ -85749,6 +85810,11 @@ func (ec *executionContext) _PlannerSettings(ctx context.Context, sel ast.Select
 			}
 		case "generateTaskFactor":
 			out.Values[i] = ec._PlannerSettings_generateTaskFactor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "numDependentsFactor":
+			out.Values[i] = ec._PlannerSettings_numDependentsFactor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -204,7 +204,7 @@ input PlannerSettingsInput {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
-  numDependentsFactor: Float!
+  numDependentsFactor: Float
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!
@@ -355,7 +355,7 @@ type PlannerSettings {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
-  numDependentsFactor: Float!
+  numDependentsFactor: Float
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -204,6 +204,7 @@ input PlannerSettingsInput {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
+  numDependentsFactor: Int!
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!
@@ -354,6 +355,7 @@ type PlannerSettings {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
+  numDependentsFactor: Int!
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -204,7 +204,7 @@ input PlannerSettingsInput {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
-  numDependentsFactor: Int!
+  numDependentsFactor: Float!
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!
@@ -355,7 +355,7 @@ type PlannerSettings {
   commitQueueFactor: Int!
   expectedRuntimeFactor: Int!
   generateTaskFactor: Int!
-  numDependentsFactor: Int!
+  numDependentsFactor: Float!
   groupVersions: Boolean!
   mainlineTimeInQueueFactor: Int!
   patchFactor: Int!

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -65,6 +65,7 @@ mutation {
           commitQueueFactor: 0
           expectedRuntimeFactor: 0
           generateTaskFactor: 0
+          numDependentsFactor: 0
           groupVersions: false
           mainlineTimeInQueueFactor: 0
           patchFactor: 0

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -65,6 +65,7 @@ mutation {
           commitQueueFactor: 0
           expectedRuntimeFactor: 0
           generateTaskFactor: 0
+          numDependentsFactor: 0
           groupVersions: false
           mainlineTimeInQueueFactor: 0
           patchFactor: 0

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -65,6 +65,7 @@ mutation {
           commitQueueFactor: 0
           expectedRuntimeFactor: 0
           generateTaskFactor: 0
+          numDependentsFactor: 0
           groupVersions: false
           mainlineTimeInQueueFactor: 0
           patchFactor: 0

--- a/graphql/tests/query/distroEvents/data.json
+++ b/graphql/tests/query/distroEvents/data.json
@@ -469,6 +469,9 @@
             "generate_task_factor": {
               "$numberLong": "0"
             },
+            "num_dependents_factor": {
+              "$numberLong": "0"
+            },
             "stepback_task_factor": {
               "$numberLong": "0"
             }

--- a/graphql/tests/query/distroEvents/data.json
+++ b/graphql/tests/query/distroEvents/data.json
@@ -87,6 +87,9 @@
             "generate_task_factor": {
               "$numberLong": "0"
             },
+            "num_dependents_factor": {
+              "$numberLong": "0"
+            },
             "stepback_task_factor": {
               "$numberLong": "0"
             }
@@ -224,6 +227,9 @@
             "generate_task_factor": {
               "$numberLong": "0"
             },
+            "num_dependents_factor": {
+              "$numberLong": "0"
+            },
             "stepback_task_factor": {
               "$numberLong": "0"
             }
@@ -345,6 +351,9 @@
               "$numberLong": "0"
             },
             "generate_task_factor": {
+              "$numberLong": "0"
+            },
+            "num_dependents_factor": {
               "$numberLong": "0"
             },
             "stepback_task_factor": {

--- a/graphql/tests/query/distroEvents/results.json
+++ b/graphql/tests/query/distroEvents/results.json
@@ -83,6 +83,7 @@
                     "mainline_time_in_queue_factor": 0,
                     "expected_runtime_factor": 0,
                     "generate_task_factor": 0,
+                    "num_dependents_factor": 0,
                     "stepback_task_factor": 0
                   },
                   "dispatcher_settings": {
@@ -191,6 +192,7 @@
                     "mainline_time_in_queue_factor": 0,
                     "expected_runtime_factor": 0,
                     "generate_task_factor": 0,
+                    "num_dependents_factor": 0,
                     "stepback_task_factor": 0
                   },
                   "dispatcher_settings": {
@@ -295,6 +297,7 @@
                     "mainline_time_in_queue_factor": 0,
                     "expected_runtime_factor": 0,
                     "generate_task_factor": 0,
+                    "num_dependents_factor": 0,
                     "stepback_task_factor": 0
                   },
                   "dispatcher_settings": {
@@ -399,6 +402,7 @@
                     "mainline_time_in_queue_factor": 0,
                     "expected_runtime_factor": 0,
                     "generate_task_factor": 0,
+                    "num_dependents_factor": 0,
                     "stepback_task_factor": 0
                   },
                   "dispatcher_settings": {

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -261,7 +261,7 @@ type PlannerSettings struct {
 	MainlineTimeInQueueFactor int64         `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64         `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 	GenerateTaskFactor        int64         `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
-	NumDependentsFactor       int64         `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
+	NumDependentsFactor       float64       `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
 	StepbackTaskFactor        int64         `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 
 	maxDurationPerHost time.Duration
@@ -347,9 +347,9 @@ func (s *PlannerSettings) GetGenerateTaskFactor() int64 {
 	return s.GenerateTaskFactor
 }
 
-func (s *PlannerSettings) GetNumDependentsFactor() int64 {
+func (s *PlannerSettings) GetNumDependentsFactor() float64 {
 	if s.NumDependentsFactor <= 0 {
-		return 10
+		return 1
 	}
 	return s.NumDependentsFactor
 }

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -261,6 +261,7 @@ type PlannerSettings struct {
 	MainlineTimeInQueueFactor int64         `bson:"mainline_time_in_queue_factor" json:"mainline_time_in_queue_factor" mapstructure:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64         `bson:"expected_runtime_factor" json:"expected_runtime_factor" mapstructure:"expected_runtime_factor"`
 	GenerateTaskFactor        int64         `bson:"generate_task_factor" json:"generate_task_factor" mapstructure:"generate_task_factor"`
+	NumDependentsFactor       int64         `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
 	StepbackTaskFactor        int64         `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 
 	maxDurationPerHost time.Duration
@@ -344,6 +345,13 @@ func (s *PlannerSettings) GetGenerateTaskFactor() int64 {
 		return 1
 	}
 	return s.GenerateTaskFactor
+}
+
+func (s *PlannerSettings) GetNumDependentsFactor() int64 {
+	if s.NumDependentsFactor <= 0 {
+		return 10
+	}
+	return s.NumDependentsFactor
 }
 
 func (s *PlannerSettings) GetMainlineTimeInQueueFactor() int64 {
@@ -691,6 +699,7 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 		MainlineTimeInQueueFactor: ps.MainlineTimeInQueueFactor,
 		ExpectedRuntimeFactor:     ps.ExpectedRuntimeFactor,
 		GenerateTaskFactor:        ps.GenerateTaskFactor,
+		NumDependentsFactor:       ps.NumDependentsFactor,
 		maxDurationPerHost:        evergreen.MaxDurationPerDistroHost,
 	}
 
@@ -733,6 +742,9 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 	}
 	if resolved.GenerateTaskFactor == 0 {
 		resolved.GenerateTaskFactor = config.GenerateTaskFactor
+	}
+	if resolved.NumDependentsFactor == 0 {
+		resolved.NumDependentsFactor = config.NumDependentsFactor
 	}
 
 	// StepbackTaskFactor isn't configurable by distro

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -384,6 +384,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 			MainlineTimeInQueueFactor: 0,
 			ExpectedRuntimeFactor:     0,
 			GenerateTaskFactor:        0,
+			NumDependentsFactor:       0,
 		},
 	}
 	config0 := evergreen.SchedulerConfig{
@@ -401,6 +402,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		MainlineTimeInQueueFactor:     10,
 		ExpectedRuntimeFactor:         7,
 		GenerateTaskFactor:            20,
+		NumDependentsFactor:           10,
 		StepbackTaskFactor:            40,
 	}
 
@@ -423,6 +425,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	// Fallback to the SchedulerConfig.ExpectedRuntimeFactor as PlannerSettings.ExpectedRunTimeFactor is equal to 0.
 	assert.EqualValues(t, 7, resolved0.ExpectedRuntimeFactor)
 	assert.EqualValues(t, 20, resolved0.GenerateTaskFactor)
+	assert.EqualValues(t, 10, resolved0.NumDependentsFactor)
 	assert.EqualValues(t, 40, resolved0.StepbackTaskFactor)
 
 	d1 := Distro{
@@ -437,6 +440,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 			MainlineTimeInQueueFactor: 0,
 			ExpectedRuntimeFactor:     0,
 			GenerateTaskFactor:        0,
+			NumDependentsFactor:       0,
 		},
 	}
 	config1 := evergreen.SchedulerConfig{
@@ -454,6 +458,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		MainlineTimeInQueueFactor:     0,
 		ExpectedRuntimeFactor:         0,
 		GenerateTaskFactor:            0,
+		NumDependentsFactor:           0,
 	}
 
 	settings1 := &evergreen.Settings{Scheduler: config1}
@@ -470,6 +475,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 	assert.EqualValues(t, 0, resolved1.MainlineTimeInQueueFactor)
 	assert.EqualValues(t, 0, resolved1.ExpectedRuntimeFactor)
 	assert.EqualValues(t, 0, resolved1.GenerateTaskFactor)
+	assert.EqualValues(t, 0, resolved1.NumDependentsFactor)
 
 	ps := &PlannerSettings{
 		Version:                   "",
@@ -481,6 +487,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		MainlineTimeInQueueFactor: 0,
 		ExpectedRuntimeFactor:     0,
 		GenerateTaskFactor:        0,
+		NumDependentsFactor:       0,
 	}
 	d2 := Distro{
 		Id:              "distro2",
@@ -501,6 +508,7 @@ func TestGetResolvedPlannerSettings(t *testing.T) {
 		MainlineTimeInQueueFactor:     0,
 		ExpectedRuntimeFactor:         0,
 		GenerateTaskFactor:            0,
+		NumDependentsFactor:           0,
 	}
 	settings2 := &evergreen.Settings{Scheduler: config2}
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2018,6 +2018,7 @@ type APISchedulerConfig struct {
 	MainlineTimeInQueueFactor     int64   `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `json:"expected_runtime_factor"`
 	GenerateTaskFactor            int64   `json:"generate_task_factor"`
+	NumDependentsFactor           int64   `json:"num_dependents_factor"`
 	StepbackTaskFactor            int64   `json:"stepback_task_factor"`
 }
 
@@ -2040,6 +2041,7 @@ func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
 		a.MainlineTimeInQueueFactor = v.MainlineTimeInQueueFactor
 		a.ExpectedRuntimeFactor = v.ExpectedRuntimeFactor
 		a.GenerateTaskFactor = v.GenerateTaskFactor
+		a.NumDependentsFactor = v.NumDependentsFactor
 		a.StepbackTaskFactor = v.StepbackTaskFactor
 	default:
 		return errors.Errorf("programmatic error: expected host scheduler config but got type %T", h)
@@ -2065,6 +2067,7 @@ func (a *APISchedulerConfig) ToService() (interface{}, error) {
 		CommitQueueFactor:             a.CommitQueueFactor,
 		MainlineTimeInQueueFactor:     a.MainlineTimeInQueueFactor,
 		GenerateTaskFactor:            a.GenerateTaskFactor,
+		NumDependentsFactor:           a.NumDependentsFactor,
 		StepbackTaskFactor:            a.StepbackTaskFactor,
 	}, nil
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2018,7 +2018,7 @@ type APISchedulerConfig struct {
 	MainlineTimeInQueueFactor     int64   `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor         int64   `json:"expected_runtime_factor"`
 	GenerateTaskFactor            int64   `json:"generate_task_factor"`
-	NumDependentsFactor           int64   `json:"num_dependents_factor"`
+	NumDependentsFactor           float64 `json:"num_dependents_factor"`
 	StepbackTaskFactor            int64   `json:"stepback_task_factor"`
 }
 

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -20,7 +20,7 @@ type APIPlannerSettings struct {
 	MainlineTimeInQueueFactor int64       `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64       `json:"expected_runtime_factor"`
 	GenerateTaskFactor        int64       `json:"generate_task_factor"`
-	NumDependentsFactor       int64       `json:"num_dependents_factor"`
+	NumDependentsFactor       float64     `json:"num_dependents_factor"`
 	CommitQueueFactor         int64       `json:"commit_queue_factor"`
 }
 

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -20,6 +20,7 @@ type APIPlannerSettings struct {
 	MainlineTimeInQueueFactor int64       `json:"mainline_time_in_queue_factor"`
 	ExpectedRuntimeFactor     int64       `json:"expected_runtime_factor"`
 	GenerateTaskFactor        int64       `json:"generate_task_factor"`
+	NumDependentsFactor       int64       `json:"num_dependents_factor"`
 	CommitQueueFactor         int64       `json:"commit_queue_factor"`
 }
 
@@ -37,6 +38,7 @@ func (s *APIPlannerSettings) BuildFromService(settings distro.PlannerSettings) {
 	s.PatchTimeInQueueFactor = settings.PatchTimeInQueueFactor
 	s.MainlineTimeInQueueFactor = settings.MainlineTimeInQueueFactor
 	s.GenerateTaskFactor = settings.GenerateTaskFactor
+	s.NumDependentsFactor = settings.NumDependentsFactor
 	s.CommitQueueFactor = settings.CommitQueueFactor
 }
 
@@ -54,6 +56,7 @@ func (s *APIPlannerSettings) ToService() distro.PlannerSettings {
 	settings.MainlineTimeInQueueFactor = s.MainlineTimeInQueueFactor
 	settings.ExpectedRuntimeFactor = s.ExpectedRuntimeFactor
 	settings.GenerateTaskFactor = s.GenerateTaskFactor
+	settings.NumDependentsFactor = s.NumDependentsFactor
 	settings.CommitQueueFactor = s.CommitQueueFactor
 
 	return settings

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -258,7 +258,7 @@ func (u *unitInfo) value() int64 {
 	// Increase the value for the number of dependents, so that
 	// tasks (and units) which block other tasks run before tasks
 	// that don't block other tasks.
-	value += priority * (u.Settings.GetNumDependentsFactor() / 10) * (u.NumDependents / length)
+	value += int64(float64(priority) * u.Settings.GetNumDependentsFactor() * float64(u.NumDependents/length))
 
 	// Increase the value for tasks with longer runtimes, given
 	// that most of our workloads have different runtimes, and we

--- a/scheduler/planner.go
+++ b/scheduler/planner.go
@@ -98,7 +98,7 @@ type Unit struct {
 	distro      *distro.Distro
 }
 
-// MakeuUnit constructs a new unit, caching a reference to the distro
+// MakeUnit constructs a new unit, caching a reference to the distro
 // in the unit. It's valid to pass a nil here.
 func MakeUnit(d *distro.Distro) *Unit {
 	return &Unit{
@@ -258,7 +258,7 @@ func (u *unitInfo) value() int64 {
 	// Increase the value for the number of dependents, so that
 	// tasks (and units) which block other tasks run before tasks
 	// that don't block other tasks.
-	value += priority * (u.NumDependents / length)
+	value += priority * (u.Settings.GetNumDependentsFactor() / 10) * (u.NumDependents / length)
 
 	// Increase the value for tasks with longer runtimes, given
 	// that most of our workloads have different runtimes, and we

--- a/scheduler/planner_test.go
+++ b/scheduler/planner_test.go
@@ -264,6 +264,18 @@ func TestPlanner(t *testing.T) {
 					unit.SetDistro(&distro.Distro{})
 					assert.EqualValues(t, 182, unit.RankValue())
 				})
+				t.Run("NumDependentsWithFactor", func(t *testing.T) {
+					unit := NewUnit(task.Task{Id: "foo", NumDependents: 2})
+					unit.SetDistro(&distro.Distro{})
+					unit.distro.PlannerSettings.NumDependentsFactor = 10
+					assert.EqualValues(t, 200, unit.RankValue())
+				})
+				t.Run("NumDependentsWithFractionFactor", func(t *testing.T) {
+					unit := NewUnit(task.Task{Id: "foo", NumDependents: 2})
+					unit.SetDistro(&distro.Distro{})
+					unit.distro.PlannerSettings.NumDependentsFactor = 0.5
+					assert.EqualValues(t, 181, unit.RankValue())
+				})
 			})
 			t.Run("RankCachesValue", func(t *testing.T) {
 				unit := NewUnit(task.Task{Id: "foo", Priority: 100})

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -806,7 +806,7 @@ Admin Settings
 												 ng-model="Settings.scheduler.stepback_task_factor">
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
-										<label>Num Dependents Factor (0 to 100 inclusive)</label>
+										<label>Num Dependents Factor (Float, 0 to 100 inclusive)</label>
 										<input type="number" step=".01" min="0" max="100"
 											   ng-model="Settings.scheduler.num_dependents_factor">
 									</md-input-container>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -805,6 +805,11 @@ Admin Settings
 										<input type="number" step="1" min="0" max="100"
 												 ng-model="Settings.scheduler.stepback_task_factor">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Num Dependents Factor (0 to 100 inclusive)</label>
+										<input type="number" step="1" min="0" max="100"
+											   ng-model="Settings.scheduler.num_dependents_factor">
+									</md-input-container>
 									<md-input-container class="control" style="width:170px;">
 										<md-checkbox ng-model="Settings.scheduler.group_versions">
 											Group Versions

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -807,7 +807,7 @@ Admin Settings
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
 										<label>Num Dependents Factor (0 to 100 inclusive)</label>
-										<input type="number" step="1" min="0" max="100"
+										<input type="number" step=".01" min="0" max="100"
 											   ng-model="Settings.scheduler.num_dependents_factor">
 									</md-input-container>
 									<md-input-container class="control" style="width:170px;">

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -469,7 +469,7 @@ func ensureHasValidPlannerSettings(ctx context.Context, d *distro.Distro, s *eve
 	}
 	if settings.NumDependentsFactor < 0 || settings.NumDependentsFactor > 100 {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("invalid planner_settings.num_dependents_factor value of %v for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.NumDependentsFactor, d.Id),
+			Message: fmt.Sprintf("invalid planner_settings.num_dependents_factor value of %f for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.NumDependentsFactor, d.Id),
 			Level:   Error,
 		})
 	}

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -467,6 +467,12 @@ func ensureHasValidPlannerSettings(ctx context.Context, d *distro.Distro, s *eve
 			Level:   Error,
 		})
 	}
+	if settings.NumDependentsFactor < 0 || settings.NumDependentsFactor > 100 {
+		errs = append(errs, ValidationError{
+			Message: fmt.Sprintf("invalid planner_settings.num_dependents_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.NumDependentsFactor, d.Id),
+			Level:   Error,
+		})
+	}
 
 	return errs
 }

--- a/validator/distro_validator.go
+++ b/validator/distro_validator.go
@@ -469,7 +469,7 @@ func ensureHasValidPlannerSettings(ctx context.Context, d *distro.Distro, s *eve
 	}
 	if settings.NumDependentsFactor < 0 || settings.NumDependentsFactor > 100 {
 		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("invalid planner_settings.num_dependents_factor value of %d for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.NumDependentsFactor, d.Id),
+			Message: fmt.Sprintf("invalid planner_settings.num_dependents_factor value of %v for distro '%s' - its value must be a non-negative integer between 0 and 100, inclusive", settings.NumDependentsFactor, d.Id),
 			Level:   Error,
 		})
 	}


### PR DESCRIPTION
DEVPROD-12086

### Description
Introduce a new queue prioritization factor that lets us tune up or tune down the influence the # of dependent tasks has on its placement in the queue. This is settable on the admin page globally, as well as overridable for specific distros.

Since it looks like we've been facing issues with a large number of tasks with unfulfilled dependencies at the front of queues causing next_task route latency issues, if we turn this factor up it might be able to alleviate the issue by fulfilling their dependencies faster.
### Testing
Tested locally
