### PR TITLE
DEVPROD-7676 Filter set tasks scheduled time in memory

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1397,11 +1397,14 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 		}
 	}
 	// Remove duplicates to prevent large updates
-	ids = utility.UniqueStrings(ids)
+	uniqueIDs := utility.UniqueStrings(ids)
+	if len(uniqueIDs) == 0 {
+		return nil
+	}
 	_, err := UpdateAll(
 		bson.M{
 			IdKey: bson.M{
-				"$in": ids,
+				"$in": uniqueIDs,
 			},
 			ScheduledTimeKey: bson.M{
 				"$lte": utility.ZeroTime,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1385,8 +1385,11 @@ func (t *Task) SetGeneratedTasksToActivate(buildVariantName, taskName string) er
 func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 	ids := []string{}
 	for i := range tasks {
-		tasks[i].ScheduledTime = scheduledTime
-		ids = append(ids, tasks[i].Id)
+		// Skip tasks with scheduled time to prevent large updates
+		if utility.IsZeroTime(tasks[i].ScheduledTime) {
+			tasks[i].ScheduledTime = scheduledTime
+			ids = append(ids, tasks[i].Id)
+		}
 
 		// Display tasks are considered scheduled when their first exec task is scheduled
 		if tasks[i].IsPartOfDisplay() {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1393,6 +1393,8 @@ func SetTasksScheduledTime(tasks []Task, scheduledTime time.Time) error {
 			ids = append(ids, utility.FromStringPtr(tasks[i].DisplayTaskId))
 		}
 	}
+	// Remove duplicates to prevent large updates
+	ids = utility.UniqueStrings(ids)
 	_, err := UpdateAll(
 		bson.M{
 			IdKey: bson.M{

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -829,6 +829,27 @@ func TestSetTasksScheduledTime(t *testing.T) {
 					})
 				})
 
+				Convey("if we update a third time", func() {
+					newTime := time.Unix(99999999, 0)
+					So(newTime, ShouldHappenAfter, testTime)
+					So(SetTasksScheduledTime(tasks, newTime), ShouldBeNil)
+
+					Convey("nothing should have updated", func() {
+						t0, err := FindOne(db.Query(ById("t0")))
+						So(err, ShouldBeNil)
+						So(t0.ScheduledTime.Round(oneMs), ShouldResemble, testTime)
+						t1, err := FindOne(db.Query(ById("t1")))
+						So(err, ShouldBeNil)
+						So(t1.ScheduledTime.Round(oneMs), ShouldResemble, newTime)
+						t2, err := FindOne(db.Query(ById("t2")))
+						So(err, ShouldBeNil)
+						So(t2.ScheduledTime.Round(oneMs), ShouldResemble, testTime)
+						t3, err := FindOne(db.Query(ById("t3")))
+						So(err, ShouldBeNil)
+						So(t3.ScheduledTime.Round(oneMs), ShouldResemble, testTime)
+					})
+				})
+
 			})
 
 		})


### PR DESCRIPTION
DEVPROD-7676

### Description
this query was failing sometimes due to large document so we filter the tasks in memory before making the query
I also thought that the cause of the large document error could be us putting in a massive amount of the same display task id for each execution task so I added a filter for that in memory as well

golang wasn't happy with $in getting a function returning a string array so this pr updates that

### Testing
existing tests pass