### PR TITLE
DEVPROD-11187: document best practices for variables

### DIFF
--- a/docs/Project-Configuration/Best-Practices.md
+++ b/docs/Project-Configuration/Best-Practices.md
@@ -50,3 +50,17 @@ echo $foo
 ## Distro Choice
 
 Tasks on more popular distros are often run quicker than tasks on less popular ones. Prefer more popular distros where possible. For more information about available distro choices see [Guidelines around Evergreen distros](https://wiki.corp.mongodb.com/x/CZ7yBg)
+
+## Secrets in Project Variables
+
+If possible, prefer to use private variables instead of public variables to store secrets. Using private variables
+ensures that the plaintext secret is not visible in user-facing endpoints and the UI, which reduces the possibility of
+someone accidentally being able to view the plaintext value that shouldn't have access. Also, private variables are
+always redacted from task logs, making it less likely that the secret will be leaked accidentally (e.g. by echoing the
+secret in a script). If you use a public variable for a secret, Evergreen may still attempt to redact it if it contains
+a suspicious pattern (e.g. if it looks like a GitHub API key), but that automatic redaction logic is more of a last
+resort, best effort mechanism and by nature will never be perfectly reliable.
+
+If you wish to securely provide access to the plaintext secret value to other people, it's recommended to use an
+external secrets management service such as 1Password rather than relying on setting an Evergreen public variable with a
+secret.

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -123,9 +123,10 @@ file via an expansion.
 
 Options:
 
--   Checking **private** makes the variable redacted so the value won't
-    be visible on the projects page or by API routes. Per  
-    [Evergreen policy](https://mongodb.stackenterprise.co/questions/1232), private variables cannot be retrieved. 
+-   Checking **private** makes the variable redacted so the value won't be
+    visible on the projects page or by API routes. Additionally, private
+    variables will be redacted from task logs. After saving them, private
+    variables cannot be retrieved.
 -   Checking **admin only** ensures that the variable can only be used
     by admins and mainline commits.
 


### PR DESCRIPTION
DEVPROD-11187

* As part of comms to warn users that are storing secrets in public vars, I'm gonna link to this best practices doc recommending to use private vars instead of public vars to store secrets.
* Also updated docs on private vars to mention they are redacted from task logs.