### PR TITLE
DEVPROD-9870 Support repeat patch with same module versions

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -195,6 +195,7 @@ type Patch struct {
 	// Not stored in the database since the DB patch should already include changes from this module.
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
 	// ReferencePatchID is used to store the ID of the patch that this patch references.
+	// Not stored in the database since it is only needed during patch creation.
 	ReferencePatchID string `bson:"-"`
 }
 

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -194,6 +194,8 @@ type Patch struct {
 	// LocalModuleIncludes is only used for CLI patches to store local module changes.
 	// Not stored in the database since the DB patch should already include changes from this module.
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
+	// RepeatPatchID is used to store the ID of the patch that this patch is a repeating from the CLI.
+	RepeatPatchID string `bson:"-"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -194,8 +194,8 @@ type Patch struct {
 	// LocalModuleIncludes is only used for CLI patches to store local module changes.
 	// Not stored in the database since the DB patch should already include changes from this module.
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
-	// RepeatPatchID is used to store the ID of the patch that this patch is a repeating from the CLI.
-	RepeatPatchID string `bson:"-"`
+	// ReferencePatchID is used to store the ID of the patch that this patch references.
+	ReferencePatchID string `bson:"-"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -881,7 +881,7 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		ReadFileFrom:        ReadFromPatch,
 		Revision:            hash,
 		LocalModuleIncludes: p.LocalModuleIncludes,
-		RepeatPatchID:       p.RepeatPatchID,
+		ReferencePatchID:    p.ReferencePatchID,
 		PatchOpts: &PatchOpts{
 			patch: p,
 		},

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -881,6 +881,7 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		ReadFileFrom:        ReadFromPatch,
 		Revision:            hash,
 		LocalModuleIncludes: p.LocalModuleIncludes,
+		RepeatPatchID:       p.RepeatPatchID,
 		PatchOpts: &PatchOpts{
 			patch: p,
 		},

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -644,7 +644,7 @@ func processIntermediateProjectIncludes(ctx context.Context, identifier string, 
 		Identifier:          identifier,
 		UnmarshalStrict:     projectOpts.UnmarshalStrict,
 		LocalModuleIncludes: projectOpts.LocalModuleIncludes,
-		RepeatPatchID:       projectOpts.RepeatPatchID,
+		ReferencePatchID:    projectOpts.ReferencePatchID,
 	}
 	localOpts.UpdateReadFileFrom(include.FileName)
 
@@ -790,7 +790,7 @@ type GetProjectOpts struct {
 	Identifier          string
 	UnmarshalStrict     bool
 	LocalModuleIncludes []patch.LocalModuleInclude
-	RepeatPatchID       string
+	ReferencePatchID    string
 }
 
 type PatchOpts struct {
@@ -902,13 +902,13 @@ func retrieveFileForModule(ctx context.Context, opts GetProjectOpts, modules Mod
 	}
 
 	// If provided a patch to repeat, use the same githash as the original patch did for the module.
-	if opts.RepeatPatchID != "" {
-		p, err := patch.FindOneId(opts.RepeatPatchID)
+	if opts.ReferencePatchID != "" {
+		p, err := patch.FindOneId(opts.ReferencePatchID)
 		if err != nil {
-			return nil, errors.Wrapf(err, "finding patch to repeat '%s'", opts.RepeatPatchID)
+			return nil, errors.Wrapf(err, "finding patch to repeat '%s'", opts.ReferencePatchID)
 		}
 		if p == nil {
-			return nil, errors.Errorf("patch to repeat '%s' not found", opts.RepeatPatchID)
+			return nil, errors.Errorf("patch to repeat '%s' not found", opts.ReferencePatchID)
 		}
 
 		for _, mod := range p.Patches {

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -1,13 +1,3 @@
-modules:
-  - name: sandbox
-    repo: git@github.com:evergreen-ci/commit-queue-sandbox.git
-    prefix: ${workdir}src
-    branch: bynntest
-
-# include:
-#   - filename: include1.yml
-#     module: sandbox
-
 command_type: test
 stepback: true
 ignore:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -1,3 +1,13 @@
+modules:
+  - name: sandbox
+    repo: git@github.com:evergreen-ci/commit-queue-sandbox.git
+    prefix: ${workdir}src
+    branch: bynntest
+
+include:
+  - filename: bynntest.yml
+    module: sandbox
+
 command_type: test
 stepback: true
 ignore:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -5,7 +5,7 @@ modules:
     branch: bynntest
 
 include:
-  - filename: bynntest.yml
+  - filename: include1.yml
     module: sandbox
 
 command_type: test

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -4,9 +4,9 @@ modules:
     prefix: ${workdir}src
     branch: bynntest
 
-include:
-  - filename: include1.yml
-    module: sandbox
+# include:
+#   - filename: include1.yml
+#     module: sandbox
 
 command_type: test
 stepback: true

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -308,7 +308,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		var patchConfig *model.PatchConfig
 		repeatPatchID, shouldRepeat := j.intent.RepeatPreviousPatchDefinition()
 		if shouldRepeat {
-			patchDoc.RepeatPatchID = repeatPatchID
+			patchDoc.ReferencePatchID = repeatPatchID
 		}
 		patchedProject, patchConfig, err = model.GetPatchedProject(ctx, j.env.Settings(), patchDoc, token)
 		if err != nil {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -306,6 +306,10 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 	} else {
 		var patchConfig *model.PatchConfig
+		repeatPatchID, shouldRepeat := j.intent.RepeatPreviousPatchDefinition()
+		if shouldRepeat {
+			patchDoc.RepeatPatchID = repeatPatchID
+		}
 		patchedProject, patchConfig, err = model.GetPatchedProject(ctx, j.env.Settings(), patchDoc, token)
 		if err != nil {
 			return errors.Wrap(j.setGitHubPatchingError(err), "getting patched project")


### PR DESCRIPTION
DEVPROD-9870

### Description
The repeat patch option was not working for modules because it would always use the latest version of the branch that the module was on. We now pull the correct module

### Testing
Created a patch with a task from a module
Updated the module to not have the task 

Trying to repeat that patch will output `Unexpected reply from server (500 Internal Server Error): 400 (Bad Request): getting patched project: load project error(s): error translating project: task selectors for build variant 'included-variant' did not match any tasks`

Confirmed that the change now creates the patch correctly with the version of the module that the initial patch was created with 
`evgs patch-file --diff-patchId 67123c6e386b5e0007b8f8cb --repeat-patch 67123c6e386b5e0007b8f8cb`
https://spruce-staging.corp.mongodb.com/patch/67123d93c2e7680007d2e446/configure/tasks