### PR TITLE
DEVPROD-9405: rename method

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -894,7 +894,7 @@ func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varN
 		varValue = paramValue
 	}
 
-	m, ok := pm.ParamNameMap()[paramName]
+	m, ok := pm.ParameterNameMap()[paramName]
 	if !ok {
 		return "", "", errors.Errorf("cannot find project variable name corresponding to parameter '%s'", paramName)
 	}


### PR DESCRIPTION
DEVPROD-9405

Tiny addition to #8398 because I didn't rebase it and one of the methods was renamed, which causes compile to fail.
