### PR TITLE
DEVPROD-9617 add pre-commit hook alternative to include

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -338,7 +338,15 @@ include:
      module: module_name
 ```
 
-Warning: YAML anchors currently not supported
+Warning: YAML anchors currently not supported.
+
+#### Limitations and Alternatives
+
+We do limit the [number of included files](../Reference#Include-Limits) that can be given in order to ensure safe GitHub API usage. 
+An alternative to relying on Evergreen for including the files would be to use `evergreen evaluate` as a pre-commit hook. 
+[This command](..#Validating-changes-to-config-files) generates the effective project yaml from all the include files and remove the includes list, 
+so you could have one "generated" yaml that's committed to your repo to use for Evergreen testing that doesn't need to pull files from GitHub.
+**Note that files included from modules aren't supported right now.** If you have questions about this please reach out.
 
 #### Merging Rules
 


### PR DESCRIPTION
DEVPROD-9617
### Description
Added a section about how to use `evergreen evaluate` instead of include. @gmishkin i don't think mms is actually doing this yet but curious if there's anything else you think I should add while keeping this lightweight. 

### Documentation
![image](https://github.com/user-attachments/assets/d33a3a1f-5159-4a62-821d-dce3b5c2d909)

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
