### PR TITLE
DEVPROD-11973: support fully syncing project vars to Parameter Store

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -144,6 +144,10 @@ type ProjectRef struct {
 	// ParameterStoreEnabled is a temporary feature flag to enable/disable
 	// Parameter Store for storing project secrets.
 	ParameterStoreEnabled bool `bson:"parameter_store_enabled,omitempty" json:"parameter_store_enabled,omitempty" yaml:"parameter_store_enabled,omitempty"`
+	// ParameterStoreVarsSynced is a temporary flag that indicates whether the
+	// project's variables have been synced to Parameter Store. If this is true,
+	// then the project variables can all be found in Parameter Store.
+	ParameterStoreVarsSynced bool `bson:"parameter_store_vars_synced,omitempty" json:"parameter_store_vars_synced,omitempty" yaml:"parameter_store_vars_synced,omitempty"`
 }
 
 // GitHubDynamicTokenPermissionGroup is a permission group for GitHub dynamic access tokens.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -497,6 +497,7 @@ var (
 	projectRefProjectHealthViewKey                  = bsonutil.MustHaveTag(ProjectRef{}, "ProjectHealthView")
 	projectRefGitHubDynamicTokenPermissionGroupsKey = bsonutil.MustHaveTag(ProjectRef{}, "GitHubDynamicTokenPermissionGroups")
 	projectRefGithubPermissionGroupByRequesterKey   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubPermissionGroupByRequester")
+	projectRefParameterStoreVarsSyncedKey           = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreVarsSynced")
 
 	commitQueueEnabledKey          = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")
 	commitQueueMergeQueueKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "MergeQueue")

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1220,7 +1220,7 @@ func TestDetachFromRepo(t *testing.T) {
 				PRTestingEnabled:      utility.FalsePtr(),          // neither of these should be changed when overwriting
 				GitTagVersionsEnabled: utility.TruePtr(),
 				GithubChecksEnabled:   nil, // for now this is defaulting to repo
-				//GithubTriggerAliases:  nil,
+				ParameterStoreEnabled: true,
 			}
 			assert.NoError(t, pRef.Insert())
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1253,6 +1253,11 @@ func TestDetachFromRepo(t *testing.T) {
 			_, err := pVars.Upsert()
 			assert.NoError(t, err)
 
+			dbProjRef, err := FindBranchProjectRef(pRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjRef)
+			assert.True(t, dbProjRef.ParameterStoreVarsSynced, "branch project vars should be synced to Parameter Store after Upsert")
+
 			repoVars := &ProjectVars{
 				Id: repoRef.Id,
 				Vars: map[string]string{
@@ -1265,6 +1270,11 @@ func TestDetachFromRepo(t *testing.T) {
 			}
 			_, err = repoVars.Upsert()
 			assert.NoError(t, err)
+
+			dbRepoRef, err := FindOneRepoRef(repoRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbRepoRef)
+			assert.True(t, dbRepoRef.ParameterStoreVarsSynced, "repo vars should be synced to Parameter Store after Upsert")
 
 			u := &user.DBUser{
 				Id:          "me",

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -653,6 +653,8 @@ func fullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *Proj
 		return errors.Wrapf(err, "marking project/repo '%s' as having its project vars fully synced", pRef.Id)
 	}
 
+	pRef.ParameterStoreVarsSynced = true
+
 	return nil
 }
 

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -894,7 +894,7 @@ func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varN
 		varValue = paramValue
 	}
 
-	m, ok := pm.ParamNameMap()[paramName]
+	m, ok := pm.ParameterNameMap()[paramName]
 	if !ok {
 		return "", "", errors.Errorf("cannot find project variable name corresponding to parameter '%s'", paramName)
 	}
@@ -904,4 +904,18 @@ func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varN
 	}
 
 	return varName, varValue, nil
+}
+
+// areParameterStoreVarsSynced returns whether or not the project's variables
+// are fully synced to Parameter Store.
+func areParameterStoreVarsSynced(projectID string) (bool, error) {
+	// kim: TODO: merge this logic with isParameterStoreEnabled (DEVPROD-9405).
+	pRef, err := FindBranchProjectRef(projectID)
+	if err != nil {
+		return false, err
+	}
+	if pRef == nil {
+		return false, errors.Errorf("project '%s' not found", projectID)
+	}
+	return pRef.ParameterStoreVarsSynced, nil
 }

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 
 	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
@@ -699,5 +700,154 @@ func TestShouldGetAdminOnlyVars(t *testing.T) {
 			}
 		}
 		assert.True(t, tested, fmt.Sprintf("requester '%s' not tested with non-admin", requester))
+	}
+}
+
+func TestFullSyncToParameterStore(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(ProjectVarsCollection, fakeparameter.Collection))
+	}()
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
+		"InitiallySyncsAllParametersWithNewProjectVars": func(ctx context.Context, t *testing.T) {
+			projRef := ProjectRef{
+				Id:                    "project_id",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, projRef.Insert())
+			vars := map[string]string{
+				"var1": "value1",
+				"var2": "value2",
+			}
+			projVars := ProjectVars{
+				Id:   "project_id",
+				Vars: vars,
+			}
+
+			require.NoError(t, fullSyncToParameterStore(ctx, &projVars, &projRef, false))
+
+			dbProjVars, err := FindOneProjectVars(projVars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjVars)
+
+			// kim: TODO: needs DEVPROD-9405
+			checkParametersMatchVars(ctx, t, dbProjVars.Parameters, vars)
+
+			dbProjRef, err := FindBranchProjectRef(projRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjRef)
+			assert.True(t, dbProjRef.ParameterStoreVarsSynced)
+		},
+		"InitiallySyncsAllParametersWithPreexistingProjectVars": func(ctx context.Context, t *testing.T) {
+			projRef := ProjectRef{
+				Id:                    "project_id",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, projRef.Insert())
+			vars := map[string]string{
+				"var1": "value1",
+				"var2": "value2",
+			}
+			projVars := ProjectVars{
+				Id:   "project_id",
+				Vars: vars,
+			}
+			require.NoError(t, projVars.Insert())
+
+			require.NoError(t, fullSyncToParameterStore(ctx, &projVars, &projRef, false))
+
+			dbProjVars, err := FindOneProjectVars(projVars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjVars)
+
+			// kim: TODO: needs DEVPROD-9405
+			checkParametersMatchVars(ctx, t, dbProjVars.Parameters, vars)
+
+			dbProjRef, err := FindBranchProjectRef(projRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjRef)
+			assert.True(t, dbProjRef.ParameterStoreVarsSynced)
+		},
+		"InitiallySyncsAllParametersForRepoVars": func(ctx context.Context, t *testing.T) {
+			vars := map[string]string{
+				"var1": "value1",
+				"var2": "value2",
+			}
+			repoVars := ProjectVars{
+				Id:   "repo_id",
+				Vars: vars,
+			}
+			repoRef := ProjectRef{
+				Id:                    "repo_id",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, fullSyncToParameterStore(ctx, &repoVars, &repoRef, false))
+
+			dbRepoVars, err := FindOneProjectVars(repoVars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbRepoVars)
+
+			// kim: TODO: needs DEVPROD-9405
+			checkParametersMatchVars(ctx, t, dbRepoVars.Parameters, vars)
+
+			dbRepoRef, err := FindOneRepoRef(repoRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbRepoRef)
+			assert.True(t, dbRepoRef.ParameterStoreVarsSynced)
+		},
+		"DeletesExistingDesyncedParametersAndResyncs": func(ctx context.Context, t *testing.T) {
+			vars := map[string]string{
+				"var1": "value1",
+				"var2": "value2",
+				"var3": "value3",
+			}
+			projVars := ProjectVars{
+				Id:   "project_id",
+				Vars: vars,
+			}
+			projRef := ProjectRef{
+				Id:                    "project_id",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, fullSyncToParameterStore(ctx, &projVars, &projRef, false))
+
+			dbProjVars, err := FindOneProjectVars(projVars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjVars)
+
+			// kim: TODO: needs DEVPROD-9405
+			checkParametersMatchVars(ctx, t, dbProjVars.Parameters, vars)
+
+			dbProjRef, err := FindBranchProjectRef(projRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbProjRef)
+			assert.True(t, dbProjRef.ParameterStoreVarsSynced)
+
+			newProjRef := *dbProjRef
+			newProjRef.ParameterStoreVarsSynced = false
+			newVars := map[string]string{
+				"var1": "value1",
+				"var3": "new_value3",
+				"var4": "value4",
+			}
+			newProjVars := ProjectVars{
+				Id:   projVars.Id,
+				Vars: newVars,
+			}
+
+			require.NoError(t, fullSyncToParameterStore(ctx, &newProjVars, &newProjRef, false))
+
+			newDBProjVars, err := FindOneProjectVars(projVars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, newDBProjVars)
+
+			checkParametersMatchVars(ctx, t, newDBProjVars.Parameters, newVars)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(ProjectVarsCollection, fakeparameter.Collection))
+			tCase(ctx, t)
+		})
 	}
 }


### PR DESCRIPTION
DEVPROD-11973

### Description
While the migration is ongoing, we need a way to initially sync the existing project vars into Parameter Store, and a way to re-sync if we have to toggle Parameter Store while the rollout is ongoing. This temporary logic will take all the existing project vars for a project and put them all in Parameter Store, at which point the two will be in sync.

I also added a project ref flag to indicate if a full sync is needed to get Parameter Store. If it's set, the logic will do a one-time sync. This flag has to be manually unset if I disable Parameter Store, but I think that's okay since I'm going to be setting it as needed while projects are being migrated to Parameter Store.

### Testing
* Added unit tests.
* Tested in staging with the sandbox project to ensure its project vars could be fully synced to Parameter Store.

### Documentation
N/A