### PR TITLE
DEVPROD-11466 Copy module manifest from base version if it exists

### DIFF
--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -194,10 +194,10 @@ type Patch struct {
 	// LocalModuleIncludes is only used for CLI patches to store local module changes.
 	// Not stored in the database since the DB patch should already include changes from this module.
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
-	// ReferencePatchID is used to store the ID of the patch that this patch references.
-	// This patch will use the referenced patch's module revisions.
+	// ReferenceManifestID stores the ID of the manifest that this patch is based on.
+	// It is used to determine the module revisions for this patch during creation.
 	// Not stored in the database since it is only needed during patch creation.
-	ReferencePatchID string `bson:"-"`
+	ReferenceManifestID string `bson:"-"`
 }
 
 func (p *Patch) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(p) }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -195,6 +195,7 @@ type Patch struct {
 	// Not stored in the database since the DB patch should already include changes from this module.
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
 	// ReferencePatchID is used to store the ID of the patch that this patch references.
+	// This patch will use the referenced patch's module revisions.
 	// Not stored in the database since it is only needed during patch creation.
 	ReferencePatchID string `bson:"-"`
 }

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -196,6 +196,8 @@ type Patch struct {
 	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
 	// ReferenceManifestID stores the ID of the manifest that this patch is based on.
 	// It is used to determine the module revisions for this patch during creation.
+	// This could potentially reference an invalid manifest, and should not error
+	// when the manifest is not found.
 	// Not stored in the database since it is only needed during patch creation.
 	ReferenceManifestID string `bson:"-"`
 }

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -875,14 +875,13 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		hash = p.GithubMergeData.HeadSHA
 	}
 
-	referencePatchID := ""
-	baseVersion, err := FindBaseVersionForVersion(p.Version)
+	manifestID := ""
+	baseVersion, err := VersionFindOne(BaseVersionByProjectIdAndRevision(p.Project, p.Githash))
 	if err == nil && baseVersion != nil {
-		referencePatchID = baseVersion.Id
+		manifestID = baseVersion.Id
 	}
-
-	if p.ReferencePatchID != "" {
-		referencePatchID = p.ReferencePatchID
+	if p.ReferenceManifestID != "" {
+		manifestID = p.ReferenceManifestID
 	}
 
 	opts := GetProjectOpts{
@@ -891,7 +890,7 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		ReadFileFrom:        ReadFromPatch,
 		Revision:            hash,
 		LocalModuleIncludes: p.LocalModuleIncludes,
-		ReferencePatchID:    referencePatchID,
+		ReferenceManifestID: manifestID,
 		PatchOpts: &PatchOpts{
 			patch: p,
 		},

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -875,13 +875,23 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		hash = p.GithubMergeData.HeadSHA
 	}
 
+	referencePatchID := ""
+	baseVersion, err := FindBaseVersionForVersion(p.Version)
+	if err == nil && baseVersion != nil {
+		referencePatchID = baseVersion.Id
+	}
+
+	if p.ReferencePatchID != "" {
+		referencePatchID = p.ReferencePatchID
+	}
+
 	opts := GetProjectOpts{
 		Ref:                 projectRef,
 		Token:               githubOauthToken,
 		ReadFileFrom:        ReadFromPatch,
 		Revision:            hash,
 		LocalModuleIncludes: p.LocalModuleIncludes,
-		ReferencePatchID:    p.ReferencePatchID,
+		ReferencePatchID:    referencePatchID,
 		PatchOpts: &PatchOpts{
 			patch: p,
 		},

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -875,13 +875,17 @@ func getLoadProjectOptsForPatch(p *patch.Patch, githubOauthToken string) (*Proje
 		hash = p.GithubMergeData.HeadSHA
 	}
 
-	manifestID := ""
-	baseVersion, err := VersionFindOne(BaseVersionByProjectIdAndRevision(p.Project, p.Githash))
-	if err == nil && baseVersion != nil {
-		manifestID = baseVersion.Id
-	}
+	var manifestID string
 	if p.ReferenceManifestID != "" {
 		manifestID = p.ReferenceManifestID
+	} else {
+		baseVersion, err := VersionFindOne(BaseVersionByProjectIdAndRevision(p.Project, p.Githash))
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "finding base version for project '%s' and revision '%s'", p.Project, p.Githash)
+		}
+		if baseVersion != nil {
+			manifestID = baseVersion.Id
+		}
 	}
 
 	opts := GetProjectOpts{

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -903,20 +903,19 @@ func retrieveFileForModule(ctx context.Context, opts GetProjectOpts, modules Mod
 		Identifier:   include.Module,
 	}
 
-	// If provided a patch to repeat, use the same githash as the original patch did for the module.
+	// If a reference manifest is provided, use the module revision from the manifest.
 	if opts.ReferenceManifestID != "" {
 		m, err := manifest.FindOne(manifest.ById(opts.ReferenceManifestID))
 		if err != nil {
 			return nil, errors.Wrapf(err, "finding manifest to reference '%s'", opts.ReferenceManifestID)
 		}
-		if m == nil {
-			return nil, errors.Errorf("manifest '%s' not found", opts.ReferenceManifestID)
-		}
-
-		for name, mod := range m.Modules {
-			if name == include.Module {
-				moduleOpts.Revision = mod.Revision
-				break
+		// Sometimes the manifest might be nil, in which case we don't want to set the revision.
+		if m != nil {
+			for name, mod := range m.Modules {
+				if name == include.Module {
+					moduleOpts.Revision = mod.Revision
+					break
+				}
 			}
 		}
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -308,7 +308,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		var patchConfig *model.PatchConfig
 		repeatPatchID, shouldRepeat := j.intent.RepeatPreviousPatchDefinition()
 		if shouldRepeat {
-			patchDoc.ReferencePatchID = repeatPatchID
+			patchDoc.ReferenceManifestID = repeatPatchID
 		}
 		patchedProject, patchConfig, err = model.GetPatchedProject(ctx, j.env.Settings(), patchDoc, token)
 		if err != nil {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -308,6 +308,8 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		var patchConfig *model.PatchConfig
 		repeatPatchID, shouldRepeat := j.intent.RepeatPreviousPatchDefinition()
 		if shouldRepeat {
+			// When we create Manifests, their ID is set to the patch/version
+			// they are created from.
 			patchDoc.ReferenceManifestID = repeatPatchID
 		}
 		patchedProject, patchConfig, err = model.GetPatchedProject(ctx, j.env.Settings(), patchDoc, token)


### PR DESCRIPTION
DEVPROD-11466

### Description
This copies the module manifest from the base version to a patch

### Testing
#### Before change
I made [this](https://spruce-staging.corp.mongodb.com/version/zackary_bisect_d254bbfb89f0e1c5ffaab6eed68c377d653aa1d3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) mainline version where `task 2` comes from an included module config file. `task 2` echo's "v1". I made a new commit on the module config file to echo "v2". I reran the mainline version, it echo's "v1" still (as it should). I made [this](https://spruce-staging.corp.mongodb.com/version/6716973661272a000743d984/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) patch based off of that commit. It echo's "v2" when it should do "v1" (like the mainline commit did).

#### After change
I made [this](https://spruce-staging.corp.mongodb.com/version/6716c1fab9205f0007b61553/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) new patch based off of that commit and it echo's "v1" like the mainline commit did.
