### PR TITLE
DEVPROD-12203: ignore google.golang.org/protobuf due to go version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,6 @@ updates:
       - dependency-name: "github.com/aws/smithy-go" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "golang.org/x/oauth2" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "github.com/vektah/gqlparser/v2" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
+      - dependency-name: "google.golang.org/protobuf" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.21
       - dependency-name: "github.com/99designs/gqlgen" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.22. If it is not possible to upgrade to 1.22 in DEVPROD-3611, create a separate ticket from DEVPROD-6962 for this dependency.
       - dependency-name: "github.com/gorilla/sessions" # TODO: (DEVPROD-6962) Remove this ignore once we upgrade to minimum golang version 1.23. If it is not possible to upgrade to 1.23 in DEVPROD-3611, create a separate ticket from DEVPROD-6962 for this dependency.


### PR DESCRIPTION
DEVPROD-12203

### Description
[This Dependabot upgrade](https://github.com/evergreen-ci/evergreen/pull/8404) can't be merged because the latest tag requires go 1.21 or higher. Adding to the dependency ignore list until the go version is upgraded.