### PR TITLE
DEVPROD-9947 Remove ec2.assume_role temporary feature flag

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -2,14 +2,7 @@ package command
 
 import (
 	"context"
-	"fmt"
-	"strconv"
-	"time"
 
-	"github.com/aws/aws-sdk-go-v2/credentials"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/globals"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -32,10 +25,6 @@ type ec2AssumeRole struct {
 	// The duration, in seconds, of the role session.
 	// Defaults to 900s (15 minutes).
 	DurationSeconds int32 `mapstructure:"duration_seconds"`
-
-	// TemporaryFeatureFlag is a flag to flip between the new and old implementation.
-	// TODO (DEVPROD-9947): Remove this.
-	TemporaryFeatureFlag bool `mapstructure:"temporary_feature_flag"`
 
 	base
 }
@@ -68,15 +57,6 @@ func (r *ec2AssumeRole) Execute(ctx context.Context, comm client.Communicator, l
 		return errors.WithStack(err)
 	}
 
-	// TODO (DEVPROD-9947): Remove feature flag check and just use the new implementation.
-	if r.TemporaryFeatureFlag {
-		return r.execute(ctx, comm, logger, conf)
-	}
-
-	return r.legacyExecute(ctx, comm, logger, conf)
-}
-
-func (r *ec2AssumeRole) execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 	request := apimodels.AssumeRoleRequest{
 		RoleARN: r.RoleARN,
 	}
@@ -99,49 +79,5 @@ func (r *ec2AssumeRole) execute(ctx context.Context, comm client.Communicator, l
 	conf.NewExpansions.PutAndRedact(globals.AWSSessionToken, creds.SessionToken)
 	conf.NewExpansions.Put(globals.AWSRoleExpiration, creds.Expiration)
 
-	return nil
-}
-
-func (r *ec2AssumeRole) legacyExecute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
-	// TODO (DEVPROD-9947): Remove this.
-	if len(conf.EC2Keys) == 0 {
-		return errors.New("no EC2 keys in config")
-	}
-
-	key := conf.EC2Keys[0].Key
-	secret := conf.EC2Keys[0].Secret
-
-	if key == "" || secret == "" {
-		return errors.New("AWS key and secret must not be empty")
-	}
-
-	assumeRoleCreds := credentials.NewStaticCredentialsProvider(key, secret, "")
-	assumeRoleClient := sts.New(sts.Options{
-		Region:      evergreen.DefaultEC2Region,
-		Credentials: assumeRoleCreds,
-	})
-	stsCreds := stscreds.NewAssumeRoleProvider(assumeRoleClient, r.RoleARN, func(opts *stscreds.AssumeRoleOptions) {
-		opts.RoleSessionName = strconv.Itoa(int(time.Now().Unix()))
-		// External ID is a combination of project ID and requester to avoid the
-		// confused deputy problem. Mainline commits might have higher trust
-		// than patches.
-		opts.ExternalID = utility.ToStringPtr(fmt.Sprintf("%s-%s", conf.ProjectRef.Id, conf.Task.Requester))
-		if r.Policy != "" {
-			opts.Policy = utility.ToStringPtr(r.Policy)
-		}
-		if r.DurationSeconds != 0 {
-			opts.Duration = time.Duration(r.DurationSeconds) * time.Second
-		}
-	})
-
-	creds, err := stsCreds.Retrieve(ctx)
-	if err != nil {
-		return errors.Wrap(err, "retrieving sts credentials")
-	}
-
-	conf.NewExpansions.Put(globals.AWSAccessKeyId, creds.AccessKeyID)
-	conf.NewExpansions.Put(globals.AWSSecretAccessKey, creds.SecretAccessKey)
-	conf.NewExpansions.Put(globals.AWSSessionToken, creds.SessionToken)
-	conf.NewExpansions.Put(globals.AWSRoleExpiration, creds.Expires.String())
 	return nil
 }

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -44,21 +44,12 @@ func TestEC2AssumeRoleParse(t *testing.T) {
 
 func TestEC2AssumeRoleExecute(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig){
-		"OldMigration": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
-			// TODO (DEVPROD-9947): Remove this.
-			c := &ec2AssumeRole{
-				RoleARN:         "randomRoleArn1234567890",
-				DurationSeconds: 10,
-			}
-			assert.EqualError(t, c.Execute(ctx, comm, logger, conf), "no EC2 keys in config")
-		},
 		"BadAWSResponse": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
 			comm.AssumeRoleResponse = nil
 
 			c := &ec2AssumeRole{
-				RoleARN:              "randomRoleArn1234567890",
-				DurationSeconds:      10,
-				TemporaryFeatureFlag: true,
+				RoleARN:         "randomRoleArn1234567890",
+				DurationSeconds: 10,
 			}
 			assert.EqualError(t, c.Execute(ctx, comm, logger, conf), "nil credentials returned")
 		},
@@ -71,9 +62,8 @@ func TestEC2AssumeRoleExecute(t *testing.T) {
 			}
 
 			c := &ec2AssumeRole{
-				RoleARN:              "randomRoleArn1234567890",
-				DurationSeconds:      10,
-				TemporaryFeatureFlag: true,
+				RoleARN:         "randomRoleArn1234567890",
+				DurationSeconds: 10,
 			}
 			require.NoError(t, c.Execute(ctx, comm, logger, conf))
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-10-14"
+	AgentVersion = "2024-10-21"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.30.3
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
-	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
+	github.com/aws/aws-sdk-go-v2/credentials v1.17.27 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.168.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.23.1


### PR DESCRIPTION
DEVPROD-9947

### Description
This removes the temporary feature flag and the old way of doing ec2.assume_role.

### Testing
Removed legacy testing. Existing testing covers new implementation.