### PR TITLE
DEVPROD-9405: support Insert and FindAndModify for Parameter Store

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3635,3 +3635,26 @@ func ProjectCanDispatchTask(pRef *ProjectRef, t *task.Task) (canDispatch bool, r
 
 	return true, reason
 }
+
+func (p *ProjectRef) setParameterStoreVarsSynced(isSynced bool, isRepoRef bool) error {
+	if p.ParameterStoreVarsSynced == isSynced {
+		return nil
+	}
+
+	coll := ProjectRefCollection
+	if isRepoRef {
+		coll = RepoRefCollection
+	}
+
+	if err := db.UpdateId(coll, p.Id, bson.M{
+		"$set": bson.M{
+			projectRefParameterStoreVarsSyncedKey: isSynced,
+		},
+	}); err != nil {
+		return errors.Wrapf(err, "updating project/repo ref vars sync state to %t", isSynced)
+	}
+
+	p.ParameterStoreVarsSynced = true
+
+	return nil
+}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3636,6 +3636,8 @@ func ProjectCanDispatchTask(pRef *ProjectRef, t *task.Task) (canDispatch bool, r
 	return true, reason
 }
 
+// setParameterStoreVarsSynced marks the project or repo ref to indicate whether
+// its project variables are fully synced to Parameter Store.
 func (p *ProjectRef) setParameterStoreVarsSynced(isSynced bool, isRepoRef bool) error {
 	if p.ParameterStoreVarsSynced == isSynced {
 		return nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1032,7 +1032,7 @@ func checkParametersMatchVars(ctx context.Context, t *testing.T, pm ParameterMap
 	assert.Len(t, pm, len(vars), "each project var should have exactly one corresponding parameter")
 	fakeParams, err := fakeparameter.FindByIDs(ctx, pm.ParameterNames()...)
 	assert.NoError(t, err)
-	assert.Len(t, fakeParams, len(vars))
+	assert.Len(t, fakeParams, len(vars), "number of parameters for project vars should match number of project vars defined")
 
 	paramNamesMap := pm.ParameterNameMap()
 	for _, fakeParam := range fakeParams {

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -333,6 +333,7 @@ func GetAWSKeyForProject(projectId string) (*AWSSSHKey, error) {
 const defaultParameterStoreAccessTimeout = 30 * time.Second
 
 func (projectVars *ProjectVars) Upsert() (*adb.ChangeInfo, error) {
+	// kim: TODO: needs updated logic from DEVPROD-11973 to check if PS is enabled.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 
@@ -690,7 +691,6 @@ func fullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *Proj
 	return nil
 }
 
-// kim: TODO: consider testing explicitly since it now uses PS
 func (projectVars *ProjectVars) Insert() error {
 	if err := db.Insert(
 		ProjectVarsCollection,
@@ -702,6 +702,7 @@ func (projectVars *ProjectVars) Insert() error {
 	// This has to be done after inserting the initial document because it
 	// upserts the project vars doc. If this ran first, it would cause the DB
 	// insert to fail due to the ID already existing.
+	// kim: TODO: needs updated logic from DEVPROD-11973 to check if PS is enabled.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 	isPSEnabled, err := isParameterStoreEnabledForProject(ctx, projectVars.Id)
@@ -737,6 +738,7 @@ func (projectVars *ProjectVars) insertParameterStore(ctx context.Context) error 
 }
 
 func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.ChangeInfo, error) {
+	// kim: TODO: needs updated logic from DEVPROD-11973 to check if PS is enabled.
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 	isPSEnabled, err := isParameterStoreEnabledForProject(ctx, projectVars.Id)
@@ -796,13 +798,10 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	)
 }
 
-// kim: TODO: update FindAndModify tests as well as UpdateProjectVars tests.
 // findAndModifyParameterStore is almost the same functionally as Upsert, except
 // that it only deletes project vars that are explicitly provided in
 // varsToDelete.
 func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context, varsToDelete []string) error {
-	// kim: TODO: reuse logic from DEVPROD-11973 to check if PS is
-	// enabled/synced.
 	projectID := projectVars.Id
 
 	after := projectVars

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -413,8 +413,8 @@ func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) error 
 }
 
 // syncParameterDiff syncs the diff of project variables to Parameter Store. It
-// adds/updates varsToUpsert, deletes varsToDelete from Parameter Store, and
-// updates the project variable parameter mappings.
+// adds/updates varsToUpsert to Parameter Store, deletes varsToDelete from
+// Parameter Store, and updates the project variable parameter mappings.
 func (projectVars *ProjectVars) syncParameterDiff(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string, varsToDelete map[string]struct{}) error {
 	paramMappingsToUpsert, err := projectVars.upsertParameters(ctx, pm, varsToUpsert)
 	if err != nil {
@@ -693,6 +693,7 @@ func (projectVars *ProjectVars) Insert() error {
 	return nil
 }
 
+// insertParameterStore inserts all project variables into Parameter Store.
 func insertParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
 	before := &ProjectVars{}
 	after := vars
@@ -791,6 +792,8 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 
 // findAndModifyParameterStore is almost the same functionally as Upsert, except
 // that it only deletes project vars that are explicitly provided in
+// varsToDelete. In other words, even if a project variable is omitted from
+// projectVars, it won't be deleted unless that variable is explicitly listed in
 // varsToDelete.
 func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context, varsToDelete []string) error {
 	projectID := projectVars.Id
@@ -845,7 +848,6 @@ func shouldGetAdminOnlyVars(t *task.Task) bool {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": fmt.Sprintf("problem with fetching user '%s'", t.ActivatedBy),
 			"task_id": t.Id,
-			"epic":    "DEVPROD-5552",
 		}))
 		return false
 	}

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -161,45 +161,108 @@ func TestProjectVarsInsert(t *testing.T) {
 }
 
 func TestProjectVarsFindAndModify(t *testing.T) {
-	assert := assert.New(t)
+	defer func() {
+		assert.NoError(t, db.ClearCollections(ProjectVarsCollection, ProjectRefCollection))
+	}()
 
-	require.NoError(t, db.Clear(ProjectVarsCollection),
-		"Error clearing collection")
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
+		"ShouldModifyExistingVars": func(ctx context.Context, t *testing.T) {
+			pRef := ProjectRef{
+				Id:                    "123",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, pRef.Insert())
 
-	vars := &ProjectVars{
-		Id:          "123",
-		Vars:        map[string]string{"a": "1", "b": "3", "d": "4"},
-		PrivateVars: map[string]bool{"b": true, "d": true},
+			vars := &ProjectVars{
+				Id:          pRef.Id,
+				Vars:        map[string]string{"a": "1", "b": "3", "d": "4"},
+				PrivateVars: map[string]bool{"b": true, "d": true},
+			}
+			assert.NoError(t, vars.Insert())
+
+			dbVars, err := FindOneProjectVars(pRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Len(t, dbVars.Vars, 3)
+			assert.Equal(t, "1", dbVars.Vars["a"])
+			assert.Equal(t, "3", dbVars.Vars["b"])
+			assert.Equal(t, "4", dbVars.Vars["d"])
+
+			assert.True(t, dbVars.PrivateVars["b"])
+			assert.True(t, dbVars.PrivateVars["d"])
+
+			checkParametersMatchVars(ctx, t, dbVars.Parameters, dbVars.Vars)
+
+			// want to "fix" b, add c, delete d
+			newVars := *vars
+			newVars.Vars = map[string]string{"b": "2", "c": "3"}
+			newVars.PrivateVars = map[string]bool{"a": true, "b": false}
+			varsToDelete := []string{"d"}
+
+			info, err := newVars.FindAndModify(varsToDelete)
+			assert.NoError(t, err)
+			require.NotNil(t, info)
+			assert.Equal(t, info.Updated, 1)
+
+			dbVars, err = FindOneProjectVars(pRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Len(t, dbVars.Vars, 3)
+			assert.Equal(t, "1", dbVars.Vars["a"])
+			assert.Equal(t, "2", dbVars.Vars["b"])
+			assert.Equal(t, "3", dbVars.Vars["c"])
+			_, ok := dbVars.Vars["d"]
+			assert.False(t, ok)
+
+			assert.True(t, dbVars.PrivateVars["a"])
+			assert.False(t, dbVars.PrivateVars["b"])
+
+			checkParametersMatchVars(ctx, t, dbVars.Parameters, dbVars.Vars)
+		},
+		"ShouldUpsertNewVars": func(ctx context.Context, t *testing.T) {
+			pRef := ProjectRef{
+				Id:                    "234",
+				ParameterStoreEnabled: true,
+			}
+			require.NoError(t, pRef.Insert())
+
+			vars := &ProjectVars{
+				Id:          pRef.Id,
+				Vars:        map[string]string{"b": "2", "c": "3"},
+				PrivateVars: map[string]bool{"b": false, "a": true},
+			}
+			varsToDelete := []string{"d"}
+			vars.Id = pRef.Id
+			_, err := vars.FindAndModify(varsToDelete)
+			assert.NoError(t, err)
+
+			dbVars, err := FindOneProjectVars(pRef.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Len(t, dbVars.Vars, 2)
+			assert.Equal(t, "2", dbVars.Vars["b"])
+			assert.Equal(t, "3", dbVars.Vars["c"])
+			_, ok := dbVars.Vars["d"]
+			assert.False(t, ok)
+
+			assert.True(t, dbVars.PrivateVars["a"])
+			assert.False(t, dbVars.PrivateVars["b"])
+
+			checkParametersMatchVars(ctx, t, dbVars.Parameters, dbVars.Vars)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(ProjectVarsCollection, ProjectRefCollection))
+
+			tCase(ctx, t)
+		})
 	}
-	assert.NoError(vars.Insert())
 
-	// want to "fix" b, add c, delete d
-	newVars := &ProjectVars{
-		Id:          "123",
-		Vars:        map[string]string{"b": "2", "c": "3"},
-		PrivateVars: map[string]bool{"b": false, "a": true},
-	}
-	varsToDelete := []string{"d"}
-
-	info, err := newVars.FindAndModify(varsToDelete)
-	assert.NoError(err)
-	assert.NotNil(info)
-	assert.Equal(info.Updated, 1)
-
-	assert.Equal(newVars.Vars["a"], "1")
-	assert.Equal(newVars.Vars["b"], "2")
-	assert.Equal(newVars.Vars["c"], "3")
-	_, ok := newVars.Vars["d"]
-	assert.False(ok)
-
-	assert.Equal(newVars.PrivateVars["b"], false)
-	assert.Equal(newVars.PrivateVars["a"], true)
-	_, ok = newVars.Vars["d"]
-	assert.False(ok)
-
-	newVars.Id = "234"
-	info, err = newVars.FindAndModify(varsToDelete)
-	assert.NoError(err) // should upsert
 }
 
 func TestRedactPrivateVars(t *testing.T) {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -301,8 +301,6 @@ func FindProjectVarsById(id string, repoId string, redact bool) (*restModel.APIP
 // will be fully replaced by those in varsModel. Otherwise, it will only set the
 // value for variables that are explicitly present in varsModel and will not
 // delete variables that are omitted.
-// TODO (DEVPROD-9405): add more test coverage for Parameter Store functionality
-// once FindAndModify is implemented.
 func UpdateProjectVars(projectId string, varsModel *restModel.APIProjectVars, overwrite bool) error {
 	if varsModel == nil {
 		return nil

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -88,7 +88,7 @@ func getMockProjectSettings() model.ProjectSettings {
 func TestProjectConnectorGetSuite(t *testing.T) {
 	s := new(ProjectConnectorGetSuite)
 	s.setup = func() error {
-		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
+		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameters.Collection))
 
 		projects := []*model.ProjectRef{
 			{
@@ -202,7 +202,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 	}
 
 	s.teardown = func() error {
-		return db.Clear(model.ProjectRefCollection)
+		return db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameters.Collection)
 	}
 
 	suite.Run(t, s)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
@@ -91,33 +92,48 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 
 		projects := []*model.ProjectRef{
 			{
-				Id:          "projectA",
-				Enabled:     true,
-				CommitQueue: model.CommitQueueParams{Enabled: utility.TruePtr()},
-				Owner:       "evergreen-ci",
-				Repo:        "gimlet",
-				Branch:      "main",
+				Id:                    "projectA",
+				Enabled:               true,
+				CommitQueue:           model.CommitQueueParams{Enabled: utility.TruePtr()},
+				Owner:                 "evergreen-ci",
+				Repo:                  "gimlet",
+				Branch:                "main",
+				ParameterStoreEnabled: true,
 			},
 			{
-				Id:          "projectB",
-				Enabled:     true,
-				CommitQueue: model.CommitQueueParams{Enabled: utility.TruePtr()},
-				Owner:       "evergreen-ci",
-				Repo:        "evergreen",
-				Branch:      "main",
+				Id:                    "projectB",
+				Enabled:               true,
+				CommitQueue:           model.CommitQueueParams{Enabled: utility.TruePtr()},
+				Owner:                 "evergreen-ci",
+				Repo:                  "evergreen",
+				Branch:                "main",
+				ParameterStoreEnabled: true,
 			},
 			{
-				Id:          "projectC",
-				Enabled:     true,
-				CommitQueue: model.CommitQueueParams{Enabled: utility.TruePtr()},
-				Owner:       "mongodb",
-				Repo:        "mongo",
-				Branch:      "main",
+				Id:                    "projectC",
+				Enabled:               true,
+				CommitQueue:           model.CommitQueueParams{Enabled: utility.TruePtr()},
+				Owner:                 "mongodb",
+				Repo:                  "mongo",
+				Branch:                "main",
+				ParameterStoreEnabled: true,
 			},
-			{Id: "projectD"},
-			{Id: "projectE"},
-			{Id: "projectF"},
-			{Id: projectId},
+			{
+				Id:                    "projectD",
+				ParameterStoreEnabled: true,
+			},
+			{
+				Id:                    "projectE",
+				ParameterStoreEnabled: true,
+			},
+			{
+				Id:                    "projectF",
+				ParameterStoreEnabled: true,
+			},
+			{
+				Id:                    projectId,
+				ParameterStoreEnabled: true,
+			},
 		}
 
 		for _, p := range projects {
@@ -269,7 +285,24 @@ func (s *ProjectConnectorGetSuite) TestFindProjectVarsById() {
 	s.Error(err)
 }
 
+func checkParametersMatchVars(ctx context.Context, t *testing.T, pm model.ParameterMappings, vars map[string]string) {
+	assert.Len(t, pm, len(vars), "each project var should have exactly one corresponding parameter")
+	fakeParams, err := fakeparameter.FindByIDs(ctx, pm.ParameterNames()...)
+	assert.NoError(t, err)
+	assert.Len(t, fakeParams, len(vars), "number of parameters for project vars should match number of project vars defined")
+
+	paramNamesMap := pm.ParameterNameMap()
+	for _, fakeParam := range fakeParams {
+		varName := paramNamesMap[fakeParam.Name].Name
+		assert.NotEmpty(t, varName, "parameter should have corresponding project variable")
+		assert.Equal(t, vars[varName], fakeParam.Value, "project variable value should match the parameter value")
+	}
+}
+
 func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	//successful update
 	varsToDelete := []string{"a"}
 	newVars := restModel.APIProjectVars{
@@ -278,9 +311,10 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 		VarsToDelete: varsToDelete,
 	}
 	s.NoError(UpdateProjectVars(projectId, &newVars, false))
-	s.Equal(newVars.Vars["b"], "") // can't unredact previously redacted  variables
-	s.Equal(newVars.Vars["c"], "")
-	s.Equal(newVars.Vars["d"], "4") // can't overwrite a value with the empty string
+
+	s.Empty(newVars.Vars["b"]) // can't unredact previously redacted variables
+	s.Empty(newVars.Vars["c"])
+	s.Equal("4", newVars.Vars["d"]) // can't overwrite a value with the empty string
 	_, ok := newVars.Vars["a"]
 	s.False(ok)
 
@@ -289,8 +323,39 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	_, ok = newVars.PrivateVars["a"]
 	s.False(ok)
 
+	dbNewVars, err := model.FindOneProjectVars(projectId)
+	s.NoError(err)
+	s.Require().NotZero(dbNewVars)
+
+	s.Len(dbNewVars.Vars, 3)
+	s.Equal("2", dbNewVars.Vars["b"])
+	s.Equal("3", dbNewVars.Vars["c"])
+	s.Equal("4", dbNewVars.Vars["d"])
+	_, ok = dbNewVars.Vars["a"]
+	s.False(ok)
+
+	s.True(newVars.PrivateVars["b"])
+	s.True(newVars.PrivateVars["c"])
+	s.False(newVars.PrivateVars["a"])
+
+	checkParametersMatchVars(ctx, s.T(), dbNewVars.Parameters, dbNewVars.Vars)
+
+	newProjRef := model.ProjectRef{
+		Id:                    "new_project",
+		ParameterStoreEnabled: true,
+	}
+	s.Require().NoError(newProjRef.Insert())
 	// successful upsert
-	s.NoError(UpdateProjectVars("not-an-id", &newVars, false))
+	s.NoError(UpdateProjectVars(newProjRef.Id, &newVars, false))
+
+	dbUpsertedVars, err := model.FindOneProjectVars(newProjRef.Id)
+	s.NoError(err)
+	s.Require().NotZero(dbUpsertedVars)
+
+	s.Len(dbUpsertedVars.Vars, 1)
+	s.Equal("4", dbUpsertedVars.Vars["d"])
+
+	checkParametersMatchVars(ctx, s.T(), dbUpsertedVars.Parameters, dbUpsertedVars.Vars)
 }
 
 func TestUpdateProjectVarsByValue(t *testing.T) {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -88,7 +88,7 @@ func getMockProjectSettings() model.ProjectSettings {
 func TestProjectConnectorGetSuite(t *testing.T) {
 	s := new(ProjectConnectorGetSuite)
 	s.setup = func() error {
-		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameters.Collection))
+		s.Require().NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection))
 
 		projects := []*model.ProjectRef{
 			{
@@ -202,7 +202,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 	}
 
 	s.teardown = func() error {
-		return db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameters.Collection)
+		return db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection)
 	}
 
 	suite.Run(t, s)


### PR DESCRIPTION
DEVPROD-9405

### Description
Follow-up to #8398, which added support for `Upsert` to put project variables in Parameter Store. This PR supports `FindAndModify` and `Insert` for project variables so they'll be written to Parameter Store if it's enabled for the project.

* Support `FindAndModify` and `Insert` for storing project variables in Parameter Store.
* Refactor common Parameter Store operations into more helper functions.

### Testing
* Switched some existing tests to write to Parameter Store.
* Existing tests still pass.

### Documentation
N/A