### PR TITLE
DEVPROD-11734: Include task execution in waterfall query

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1710,6 +1710,7 @@ type ComplexityRoot struct {
 
 	WaterfallTask struct {
 		DisplayName func(childComplexity int) int
+		Execution   func(childComplexity int) int
 		Id          func(childComplexity int) int
 		Status      func(childComplexity int) int
 	}
@@ -10284,6 +10285,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.WaterfallTask.DisplayName(childComplexity), true
+
+	case "WaterfallTask.execution":
+		if e.complexity.WaterfallTask.Execution == nil {
+			break
+		}
+
+		return e.complexity.WaterfallTask.Execution(childComplexity), true
 
 	case "WaterfallTask.id":
 		if e.complexity.WaterfallTask.Id == nil {
@@ -70162,10 +70170,12 @@ func (ec *executionContext) fieldContext_WaterfallBuild_tasks(_ context.Context,
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_WaterfallTask_id(ctx, field)
-			case "status":
-				return ec.fieldContext_WaterfallTask_status(ctx, field)
 			case "displayName":
 				return ec.fieldContext_WaterfallTask_displayName(ctx, field)
+			case "execution":
+				return ec.fieldContext_WaterfallTask_execution(ctx, field)
+			case "status":
+				return ec.fieldContext_WaterfallTask_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallTask", field.Name)
 		},
@@ -70361,50 +70371,6 @@ func (ec *executionContext) fieldContext_WaterfallTask_id(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _WaterfallTask_status(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallTask) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_WaterfallTask_status(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Status, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_WaterfallTask_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "WaterfallTask",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _WaterfallTask_displayName(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallTask) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_WaterfallTask_displayName(ctx, field)
 	if err != nil {
@@ -70437,6 +70403,94 @@ func (ec *executionContext) _WaterfallTask_displayName(ctx context.Context, fiel
 }
 
 func (ec *executionContext) fieldContext_WaterfallTask_displayName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallTask",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallTask_execution(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallTask) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallTask_execution(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Execution, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallTask_execution(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallTask",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallTask_status(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallTask) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallTask_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallTask_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "WaterfallTask",
 		Field:      field,
@@ -94225,13 +94279,18 @@ func (ec *executionContext) _WaterfallTask(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "status":
-			out.Values[i] = ec._WaterfallTask_status(ctx, field, obj)
+		case "displayName":
+			out.Values[i] = ec._WaterfallTask_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "displayName":
-			out.Values[i] = ec._WaterfallTask_displayName(ctx, field, obj)
+		case "execution":
+			out.Values[i] = ec._WaterfallTask_execution(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "status":
+			out.Values[i] = ec._WaterfallTask_status(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -11,8 +11,9 @@ input WaterfallOptions {
 
 type WaterfallTask {
   id: String!
-  status: String!
   displayName: String!
+  execution: Int!
+  status: String!
 }
 
 type WaterfallBuild {

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -134,6 +134,7 @@
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
+      "execution": 0,
       "display_task_id": ""
     },
     {
@@ -148,6 +149,7 @@
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
+      "execution": 1,
       "display_task_id": ""
     },
     {
@@ -162,6 +164,7 @@
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
+      "execution": 0,
       "display_task_id": ""
     },
     {
@@ -176,6 +179,7 @@
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
+      "execution": 0,
       "display_task_id": ""
     },
     {
@@ -190,6 +194,7 @@
       "create_time": {
         "$date": "2020-01-01T00:00:05Z"
       },
+      "execution": 0,
       "display_task_id": ""
     }
   ],

--- a/graphql/tests/query/waterfall/queries/no_filters.graphql
+++ b/graphql/tests/query/waterfall/queries/no_filters.graphql
@@ -10,6 +10,7 @@
           status
           id
           displayName
+          execution
         }
         version
       }

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -18,11 +18,13 @@
                     "tasks": [
                       {
                         "displayName": "Some Task",
+                        "execution": 0,
                         "id": "task_1",
                         "status": "success"
                       },
                       {
                         "displayName": "Some Other Task",
+                        "execution": 1,
                         "id": "task_2",
                         "status": "success"
                       }
@@ -35,11 +37,13 @@
                     "tasks": [
                       {
                         "displayName": "Some Task",
+                        "execution": 0,
                         "id": "task_3",
                         "status": "failed"
                       },
                       {
                         "displayName": "Some Other Task",
+                        "execution": 0,
                         "id": "task_4",
                         "status": "success"
                       }
@@ -56,6 +60,7 @@
                     "tasks": [
                       {
                         "displayName": "Task Number 5",
+                        "execution": 0,
                         "id": "task_5",
                         "status": "success"
                       }

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -21,6 +21,7 @@ const (
 type WaterfallTask struct {
 	Id          string `bson:"_id" json:"_id"`
 	DisplayName string `bson:"display_name" json:"display_name"`
+	Execution   int    `bson:"execution" json:"execution"`
 	Status      string `bson:"status" json:"status"`
 }
 
@@ -161,7 +162,6 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 		},
 	})
 	pipeline = append(pipeline, bson.M{
-		// TODO DEVPROD-10178: Should be able to filter on build variant ID/name here.
 		"$lookup": bson.M{
 			"from":         build.Collection,
 			"localField":   buildsKey,
@@ -180,12 +180,12 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 			{
 				"$sort": bson.M{task.IdKey: 1},
 			},
-			// TODO DEVPROD-10179, DEVPROD-10180: Should be able to filter on the returned task names and statuses here.
 			{
 				"$project": bson.M{
 					task.IdKey:          1,
 					task.StatusKey:      1,
 					task.DisplayNameKey: 1,
+					task.ExecutionKey:   1,
 				},
 			},
 		},


### PR DESCRIPTION
DEVPROD-11734

### Description
Add task's execution number to the waterfall query by including it in the `$lookup` stage where tasks are fetched

Also removed TODOs for tickets that were closed as won't do.

### Testing
Update GraphQL unit tests