### PR TITLE
DEVPROD-10185: Query waterfall by date

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -78368,13 +78368,20 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 		asMap["limit"] = 5
 	}
 
-	fieldsInOrder := [...]string{"limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision"}
+	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "date":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Date = data
 		case "limit":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
 			data, err := ec.unmarshalOInt2ᚖint(ctx, v)

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -616,7 +616,8 @@ type Waterfall struct {
 }
 
 type WaterfallOptions struct {
-	Limit *int `json:"limit,omitempty"`
+	Date  *time.Time `json:"date,omitempty"`
+	Limit *int       `json:"limit,omitempty"`
 	// Return versions with an order greater than minOrder. Used for paginating backward.
 	MinOrder *int `json:"minOrder,omitempty"`
 	// Return versions with an order lower than maxOrder. Used for paginating forward.

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -990,11 +990,13 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		}
 	} else if options.Date != nil {
 		date := utility.FromTimePtr(options.Date)
-		found, err := model.VersionFindOne(model.VersionByProjectIdAndCreateTime(projectId, date))
+		// Use the end of the provided date to find the most recent version created on or before it
+		eod := time.Date(date.Year(), date.Month(), date.Day(), 23, 59, 59, date.Nanosecond(), date.Location())
+		found, err := model.VersionFindOne(model.VersionByProjectIdAndCreateTime(projectId, eod))
 		if err != nil {
-			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("getting version on or after date '%s': %s", date.Format(time.DateOnly), err)))
+			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("getting version on or before date '%s': %s", eod.Format(time.DateOnly), err)))
 		} else if found == nil {
-			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("version on or after date '%s' not found", date.Format(time.DateOnly))))
+			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("version on or before date '%s' not found", eod.Format(time.DateOnly))))
 		} else {
 			// Offset the order number so the specified version lands nearer to the center of the page.
 			maxOrderOpt = found.RevisionOrderNumber + limit/2 + 1

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -991,7 +991,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	} else if options.Date != nil {
 		date := utility.FromTimePtr(options.Date)
 		// Use the end of the provided date to find the most recent version created on or before it
-		eod := time.Date(date.Year(), date.Month(), date.Day(), 23, 59, 59, date.Nanosecond(), date.Location())
+		eod := time.Date(date.Year(), date.Month(), date.Day(), 23, 59, 59, 0, date.Location())
 		found, err := model.VersionFindOne(model.VersionByProjectIdAndCreateTime(projectId, eod))
 		if err != nil {
 			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("getting version on or before date '%s': %s", eod.Format(time.DateOnly), err)))

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -1,4 +1,5 @@
 input WaterfallOptions {
+  date: Time
   limit: Int = 5
   "Return versions with an order greater than minOrder. Used for paginating backward."
   minOrder: Int

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -8,7 +8,10 @@
       "activated": true,
       "author": "mohamed.khelif",
       "status": "failed",
-      "order": 39
+      "order": 39,
+      "create_time": {
+        "$date": "2019-12-30T00:00:03Z"
+      }
     },
     {
       "_id": "evergreen_version0",
@@ -19,6 +22,9 @@
       "author": "mohamed.khelif",
       "status": "failed",
       "order": 40,
+      "create_time": {
+        "$date": "2019-12-31T00:00:03Z"
+      },
       "build_variants_status": {
         "activated": false,
         "build_id": "evergreen_version1_build",
@@ -34,6 +40,9 @@
       "author": "mohamed.khelif",
       "status": "success",
       "order": 41,
+      "create_time": {
+        "$date": "2020-01-01T00:00:00Z"
+      },
       "build_variants_status": {
         "activated": true,
         "build_id": "evergreen_version1_build",
@@ -49,6 +58,9 @@
       "author": "mohamed.khelif",
       "status": "success",
       "order": 42,
+      "create_time": {
+        "$date": "2020-01-02T06:43:00Z"
+      },
       "build_variants_status": {
         "activated": true,
         "build_id": "evergreen_version2_build",
@@ -64,6 +76,9 @@
       "author": "mohamed.khelif",
       "status": "created",
       "order": 43,
+      "create_time": {
+        "$date": "2020-01-03T13:30:00Z"
+      },
       "build_variants_status": {
         "activated": true,
         "build_id": "evergreen_version3_build",
@@ -78,7 +93,10 @@
       "activated": false,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 44
+      "order": 44,
+      "create_time": {
+        "$date": "2020-01-04T08:15:00Z"
+      }
     },
     {
       "_id": "evergreen_version5",
@@ -88,7 +106,10 @@
       "activated": true,
       "author": "mohamed.khelif",
       "status": "created",
-      "order": 45
+      "order": 45,
+      "create_time": {
+        "$date": "2020-01-05T12:00:00Z"
+      }
     },
     {
       "_id": "inactive1",

--- a/graphql/tests/query/waterfall/queries/date.graphql
+++ b/graphql/tests/query/waterfall/queries/date.graphql
@@ -1,0 +1,18 @@
+{
+  waterfall(options: { projectIdentifier: "spruce", date: "2019-12-31T00:00:00Z" }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        createTime
+        id
+        order
+      }
+      inactiveVersions {
+        createTime
+        id
+        order
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/queries/date_unmatching.graphql
+++ b/graphql/tests/query/waterfall/queries/date_unmatching.graphql
@@ -1,0 +1,18 @@
+{
+  waterfall(options: { projectIdentifier: "spruce", date: "2019-11-07T00:00:00Z" }) {
+    nextPageOrder
+    prevPageOrder
+    versions {
+      version {
+        createTime
+        id
+        order
+      }
+      inactiveVersions {
+        createTime
+        id
+        order
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -423,6 +423,137 @@
           }
         ]
       }
+    },
+    {
+      "query_file": "date.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 42,
+            "versions": [
+              {
+                "version": {
+                  "createTime": "2020-01-02T01:43:00-05:00",
+                  "id": "evergreen_version2",
+                  "order": 42
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": {
+                  "createTime": "2019-12-31T19:00:00-05:00",
+                  "id": "evergreen_version1",
+                  "order": 41
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "createTime": "2019-12-30T19:00:03-05:00",
+                    "id": "evergreen_version0",
+                    "order": 40
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "createTime": "2019-12-29T19:00:03-05:00",
+                  "id": "evergreen_version39",
+                  "order": 39
+                },
+                "inactiveVersions": null
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "query_file": "date_unmatching.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "nextPageOrder": 39,
+            "prevPageOrder": 0,
+            "versions": [
+              {
+                "version": {
+                  "createTime": "2020-01-05T07:00:00-05:00",
+                  "id": "evergreen_version5",
+                  "order": 45
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "createTime": "2020-01-04T03:15:00-05:00",
+                    "id": "evergreen_version4",
+                    "order": 44
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "createTime": "2020-01-03T08:30:00-05:00",
+                  "id": "evergreen_version3",
+                  "order": 43
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": {
+                  "createTime": "2020-01-02T01:43:00-05:00",
+                  "id": "evergreen_version2",
+                  "order": 42
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": {
+                  "createTime": "2019-12-31T19:00:00-05:00",
+                  "id": "evergreen_version1",
+                  "order": 41
+                },
+                "inactiveVersions": null
+              },
+              {
+                "version": null,
+                "inactiveVersions": [
+                  {
+                    "createTime": "2019-12-30T19:00:03-05:00",
+                    "id": "evergreen_version0",
+                    "order": 40
+                  }
+                ]
+              },
+              {
+                "version": {
+                  "createTime": "2019-12-29T19:00:03-05:00",
+                  "id": "evergreen_version39",
+                  "order": 39
+                },
+                "inactiveVersions": null
+              }
+            ]
+          }
+        },
+        "errors": [
+          {
+            "message": "version on or before date '2019-11-07' not found",
+            "path": [
+              "waterfall"
+            ],
+            "extensions": {
+              "code": "PARTIAL_ERROR"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -140,17 +140,18 @@ func VersionByProjectIdAndRevisionPrefix(projectId, revisionPrefix string) db.Q 
 		})
 }
 
+// VersionByProjectIdAndCreateTime finds the most recent system-requested version created on or before a specified createTime.
 func VersionByProjectIdAndCreateTime(projectId string, createTime time.Time) db.Q {
 	return db.Query(
 		bson.M{
 			VersionIdentifierKey: projectId,
 			VersionCreateTimeKey: bson.M{
-				"$gte": createTime,
+				"$lte": createTime,
 			},
 			VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
-		})
+		}).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
 // ByProjectIdAndOrder finds non-patch versions for the given project with revision

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -140,6 +140,19 @@ func VersionByProjectIdAndRevisionPrefix(projectId, revisionPrefix string) db.Q 
 		})
 }
 
+func VersionByProjectIdAndCreateTime(projectId string, createTime time.Time) db.Q {
+	return db.Query(
+		bson.M{
+			VersionIdentifierKey: projectId,
+			VersionCreateTimeKey: bson.M{
+				"$gte": createTime,
+			},
+			VersionRequesterKey: bson.M{
+				"$in": evergreen.SystemVersionRequesterTypes,
+			},
+		})
+}
+
 // ByProjectIdAndOrder finds non-patch versions for the given project with revision
 // order numbers less than or equal to revisionOrderNumber.
 func VersionByProjectIdAndOrder(projectId string, revisionOrderNumber int) db.Q {

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -327,41 +327,40 @@ func TestFindBaseVersionForVersion(t *testing.T) {
 
 func TestVersionByProjectIdAndRevisionPrefix(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(VersionCollection))
-	day := 24 * time.Hour
 	ts := time.Now()
 	v1 := Version{
 		Id:                  "v1",
 		Identifier:          "proj",
 		Requester:           evergreen.RepotrackerVersionRequester,
-		CreateTime:          ts.Add(-1 * day),
+		CreateTime:          ts.Add(-1 * utility.Day),
 		RevisionOrderNumber: 5,
 	}
 	v2 := Version{
 		Id:                  "v2",
-		Identifier:          "proj",
+		Identifier:          "proj_2",
 		Requester:           evergreen.RepotrackerVersionRequester,
-		CreateTime:          ts.Add(-2 * day),
+		CreateTime:          ts.Add(-2 * utility.Day),
 		RevisionOrderNumber: 4,
 	}
 	v3 := Version{
 		Id:                  "v3",
 		Identifier:          "proj",
 		Requester:           evergreen.RepotrackerVersionRequester,
-		CreateTime:          ts.Add(-3 * day).Add(30 * time.Minute),
+		CreateTime:          ts.Add(-3 * utility.Day).Add(30 * time.Minute),
 		RevisionOrderNumber: 3,
 	}
 	v4 := Version{
 		Id:                  "v4",
 		Identifier:          "proj",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		CreateTime:          ts.Add(-3 * day),
+		Requester:           evergreen.GitTagRequester,
+		CreateTime:          ts.Add(-3 * utility.Day),
 		RevisionOrderNumber: 2,
 	}
 	v5 := Version{
 		Id:                  "v5",
 		Identifier:          "proj",
-		Requester:           evergreen.RepotrackerVersionRequester,
-		CreateTime:          ts.Add(-5 * day),
+		Requester:           evergreen.PatchVersionRequester,
+		CreateTime:          ts.Add(-5 * utility.Day),
 		RevisionOrderNumber: 1,
 	}
 
@@ -371,15 +370,24 @@ func TestVersionByProjectIdAndRevisionPrefix(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, v.Id, "v1")
 
-	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-3*day)))
+	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-3*utility.Day)))
 	assert.NoError(t, err)
 	assert.Equal(t, v.Id, "v4")
 
-	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-2*day).Add(-30*time.Minute)))
+	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-2*utility.Day).Add(-30*time.Minute)))
 	assert.NoError(t, err)
 	assert.Equal(t, v.Id, "v3")
 
-	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-2*day)))
+	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-2*utility.Day)))
+	assert.NoError(t, err)
+	assert.Equal(t, v.Id, "v3")
+
+	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj_2", ts.Add(-2*utility.Day)))
 	assert.NoError(t, err)
 	assert.Equal(t, v.Id, "v2")
+
+	// Does not match on patch requester
+	v, err = VersionFindOne(VersionByProjectIdAndCreateTime("proj", ts.Add(-5*utility.Day)))
+	assert.NoError(t, err)
+	assert.Nil(t, v)
 }


### PR DESCRIPTION
DEVPROD-10185

### Description
Update GraphQL resolver to accept a date input. This value is used to fetch the most recent query created on or before the specified date. The resolver then utilizes the revision order number returned version to find `limit` versions around that version, very similarly to how the git hash selector works in the `getRevisionOrder` utility.

The versions collection already contains the index `{ identifier: 1, r: 1, create_time: 1 }` which can be used to fulfill this query.

### Testing
Add GraphQL and unit tests
