### PR TITLE
DEVPROD-6798 make display task restarts more resilient

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3084,8 +3084,8 @@ func archiveAll(ctx context.Context, taskIds, execTaskIds, toRestartExecTaskIds 
 
 	_, err = session.WithTransaction(ctx, txFunc)
 
-	// Return nil if the task has already been archived. Because we use a transaction here,
-	// we can trust that either the whole task has already been archived, or none of it.
+	// Return nil if the tasks have already been archived. Because we use a transaction here,
+	// we can trust that either all tasks have already been archived, or none of them.
 	if err == nil || db.IsDuplicateKey(err) || adb.ResultsNotFound(err) {
 		return nil
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2949,7 +2949,7 @@ func (t *Task) Archive(ctx context.Context) error {
 			},
 			updateDisplayTasksAndTasksExpression,
 		)
-		// return nil if the task has already been archived
+		// Return nil if the task has already been archived
 		if adb.ResultsNotFound(err) {
 			return nil
 		}
@@ -3084,6 +3084,11 @@ func archiveAll(ctx context.Context, taskIds, execTaskIds, toRestartExecTaskIds 
 
 	_, err = session.WithTransaction(ctx, txFunc)
 
+	// Return nil if the task has already been archived. Because we use a transaction here,
+	// we can trust that either the whole task has already been archived, or none of it.
+	if err == nil || db.IsDuplicateKey(err) || adb.ResultsNotFound(err) {
+		return nil
+	}
 	return errors.Wrap(err, "archiving execution tasks and updating execution tasks")
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3509,7 +3509,7 @@ func TestArchiveMany(t *testing.T) {
 	tasks := []Task{t1, t2, dt}
 	err := ArchiveMany(ctx, tasks)
 	assert.NoError(t, err)
-	verifyTasksFunc := func() {
+	verifyTasksState := func() {
 		currentTasks, err := FindAll(db.Query(ByVersion("v")))
 		assert.NoError(t, err)
 		assert.Len(t, currentTasks, 4)
@@ -3525,13 +3525,13 @@ func TestArchiveMany(t *testing.T) {
 			assert.Equal(t, 0, task.Execution)
 		}
 	}
-	verifyTasksFunc()
+	verifyTasksState()
 
 	// We shouldn't error if we try archiving again, in case we got stuck part way.
 	err = ArchiveMany(ctx, tasks)
 	assert.NoError(t, err)
 	// Verify that nothing actually changed when re-archiving.
-	verifyTasksFunc()
+	verifyTasksState()
 }
 
 func TestArchiveManyAfterFailedOnly(t *testing.T) {
@@ -3661,7 +3661,7 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 	// t2 (execution 4)
 	// t3: t1 (execution 2), t2 (execution 2), t3 (execution 2)
 	// t4 (execution 2)
-	verifyTasksFunc := func() {
+	verifyTasksState := func() {
 		currentTasks, err = FindAll(db.Query(ByVersion("v")))
 		assert.NoError(t, err)
 		assert.Len(t, currentTasks, 9)
@@ -3693,12 +3693,12 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 			}
 		}
 	}
-	verifyTasksFunc()
+	verifyTasksState()
 
 	// We shouldn't error if we try archiving again, in case we got stuck part way.
 	assert.NoError(t, ArchiveMany(ctx, []Task{t1, t2, *t3Pointer, t4}))
 	// Verify that nothing actually changed when re-archiving.
-	verifyTasksFunc()
+	verifyTasksState()
 }
 
 func TestAddParentDisplayTasks(t *testing.T) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3509,24 +3509,29 @@ func TestArchiveMany(t *testing.T) {
 	tasks := []Task{t1, t2, dt}
 	err := ArchiveMany(ctx, tasks)
 	assert.NoError(t, err)
-	currentTasks, err := FindAll(db.Query(ByVersion("v")))
-	assert.NoError(t, err)
-	assert.Len(t, currentTasks, 4)
-	for _, task := range currentTasks {
-		assert.False(t, task.Aborted)
-		assert.Equal(t, 1, task.Execution)
+	verifyTasksFunc := func() {
+		currentTasks, err := FindAll(db.Query(ByVersion("v")))
+		assert.NoError(t, err)
+		assert.Len(t, currentTasks, 4)
+		for _, task := range currentTasks {
+			assert.False(t, task.Aborted)
+			assert.Equal(t, 1, task.Execution)
+		}
+		oldTasks, err := FindAllOld(db.Query(ByVersion("v")))
+		assert.NoError(t, err)
+		assert.Len(t, oldTasks, 4)
+		for _, task := range oldTasks {
+			assert.True(t, task.Archived)
+			assert.Equal(t, 0, task.Execution)
+		}
 	}
-	oldTasks, err := FindAllOld(db.Query(ByVersion("v")))
-	assert.NoError(t, err)
-	assert.Len(t, oldTasks, 4)
-	for _, task := range oldTasks {
-		assert.True(t, task.Archived)
-		assert.Equal(t, 0, task.Execution)
-	}
+	verifyTasksFunc()
 
 	// We shouldn't error if we try archiving again, in case we got stuck part way.
 	err = ArchiveMany(ctx, tasks)
 	assert.NoError(t, err)
+	// Verify that nothing actually changed when re-archiving.
+	verifyTasksFunc()
 }
 
 func TestArchiveManyAfterFailedOnly(t *testing.T) {
@@ -3656,40 +3661,44 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 	// t2 (execution 4)
 	// t3: t1 (execution 2), t2 (execution 2), t3 (execution 2)
 	// t4 (execution 2)
+	verifyTasksFunc := func() {
+		currentTasks, err = FindAll(db.Query(ByVersion("v")))
+		assert.NoError(t, err)
+		assert.Len(t, currentTasks, 9)
 
-	currentTasks, err = FindAll(db.Query(ByVersion("v")))
-	assert.NoError(t, err)
-	assert.Len(t, currentTasks, 9)
-
-	// Every display task or task should have a '0' LatestParentExecution (it is an execution task only field)
-	// For execution tasks, the execution should be their latestparentexecution after archiving all
-	for _, task := range currentTasks {
-		switch task.Id {
-		case t1.Id:
-			assert.Equal(t, 3, task.Execution)
-			assert.Equal(t, 0, task.LatestParentExecution)
-		case et1.Id, et2.Id:
-			assert.Equal(t, 3, task.Execution)
-			assert.Equal(t, task.LatestParentExecution, task.Execution)
-		case t2.Id:
-			assert.Equal(t, 4, task.Execution)
-			assert.Equal(t, 0, task.LatestParentExecution)
-		case t3.Id:
-			assert.Equal(t, 2, task.Execution)
-			assert.Equal(t, 0, task.LatestParentExecution)
-		case et3.Id, et4.Id, et5.Id:
-			assert.Equal(t, 2, task.Execution)
-			assert.Equal(t, task.LatestParentExecution, task.Execution)
-		case t4.Id:
-			assert.Equal(t, 2, task.Execution)
-			assert.Equal(t, 0, task.LatestParentExecution)
-		default:
-			assert.Error(t, nil, "A task was not accounted for")
+		// Every display task or task should have a '0' LatestParentExecution (it is an execution task only field)
+		// For execution tasks, the execution should be their latestparentexecution after archiving all
+		for _, task := range currentTasks {
+			switch task.Id {
+			case t1.Id:
+				assert.Equal(t, 3, task.Execution)
+				assert.Equal(t, 0, task.LatestParentExecution)
+			case et1.Id, et2.Id:
+				assert.Equal(t, 3, task.Execution)
+				assert.Equal(t, task.LatestParentExecution, task.Execution)
+			case t2.Id:
+				assert.Equal(t, 4, task.Execution)
+				assert.Equal(t, 0, task.LatestParentExecution)
+			case t3.Id:
+				assert.Equal(t, 2, task.Execution)
+				assert.Equal(t, 0, task.LatestParentExecution)
+			case et3.Id, et4.Id, et5.Id:
+				assert.Equal(t, 2, task.Execution)
+				assert.Equal(t, task.LatestParentExecution, task.Execution)
+			case t4.Id:
+				assert.Equal(t, 2, task.Execution)
+				assert.Equal(t, 0, task.LatestParentExecution)
+			default:
+				assert.Error(t, nil, "A task was not accounted for")
+			}
 		}
 	}
+	verifyTasksFunc()
 
 	// We shouldn't error if we try archiving again, in case we got stuck part way.
 	assert.NoError(t, ArchiveMany(ctx, []Task{t1, t2, *t3Pointer, t4}))
+	// Verify that nothing actually changed when re-archiving.
+	verifyTasksFunc()
 }
 
 func TestAddParentDisplayTasks(t *testing.T) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3523,6 +3523,10 @@ func TestArchiveMany(t *testing.T) {
 		assert.True(t, task.Archived)
 		assert.Equal(t, 0, task.Execution)
 	}
+
+	// We shouldn't error if we try archiving again, in case we got stuck part way.
+	err = ArchiveMany(ctx, tasks)
+	assert.NoError(t, err)
 }
 
 func TestArchiveManyAfterFailedOnly(t *testing.T) {
@@ -3683,6 +3687,9 @@ func TestArchiveManyAfterFailedOnly(t *testing.T) {
 			assert.Error(t, nil, "A task was not accounted for")
 		}
 	}
+
+	// We shouldn't error if we try archiving again, in case we got stuck part way.
+	assert.NoError(t, ArchiveMany(ctx, []Task{t1, t2, *t3Pointer, t4}))
 }
 
 func TestAddParentDisplayTasks(t *testing.T) {


### PR DESCRIPTION
DEVPROD-6798
### Description
In Archive, we don't error if the task has already been archived (because it's already been inserted into the old task collection, or because the task collection doc has been updated already). This logic isn't extended to the display task restarts however. 

### Testing
Updated unit test (this failed without the changes). 