### PR TITLE
DEVPROD-10189: Fix pagination bugs in Waterfall resolver

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1706,6 +1706,7 @@ type ComplexityRoot struct {
 		Builds      func(childComplexity int) int
 		DisplayName func(childComplexity int) int
 		Id          func(childComplexity int) int
+		Version     func(childComplexity int) int
 	}
 
 	WaterfallTask struct {
@@ -10278,6 +10279,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.WaterfallBuildVariant.Id(childComplexity), true
+
+	case "WaterfallBuildVariant.version":
+		if e.complexity.WaterfallBuildVariant.Version == nil {
+			break
+		}
+
+		return e.complexity.WaterfallBuildVariant.Version(childComplexity), true
 
 	case "WaterfallTask.displayName":
 		if e.complexity.WaterfallTask.DisplayName == nil {
@@ -69811,6 +69819,8 @@ func (ec *executionContext) fieldContext_Waterfall_buildVariants(_ context.Conte
 				return ec.fieldContext_WaterfallBuildVariant_displayName(ctx, field)
 			case "builds":
 				return ec.fieldContext_WaterfallBuildVariant_builds(ctx, field)
+			case "version":
+				return ec.fieldContext_WaterfallBuildVariant_version(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallBuildVariant", field.Name)
 		},
@@ -70322,6 +70332,50 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_builds(_ context.
 				return ec.fieldContext_WaterfallBuild_tasks(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallBuild", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallBuildVariant_version(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuildVariant) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallBuildVariant_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Version, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallBuildVariant_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallBuildVariant",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -94244,6 +94298,11 @@ func (ec *executionContext) _WaterfallBuildVariant(ctx context.Context, sel ast.
 			}
 		case "builds":
 			out.Values[i] = ec._WaterfallBuildVariant_builds(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "version":
+			out.Values[i] = ec._WaterfallBuildVariant_version(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -968,7 +968,6 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		if limitOpt > model.MaxWaterfallVersionLimit {
 			return nil, InputValidationError.Send(ctx, fmt.Sprintf("limit exceeds max limit of %d", model.MaxWaterfallVersionLimit))
 		}
-
 		limit = limitOpt
 	}
 
@@ -1033,9 +1032,24 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		// If no order options were specified, we're on the first page and should not put a limit on the first version returned so that we don't omit inactive versions
 		maxVersionOrder = 0
 	} else if maxOrderOpt == 0 {
-		// If we're paginating backwards, use the newest active version as the upper bound
-		maxVersionOrder = activeVersions[0].RevisionOrderNumber
+		// Find the next active version. If it doesn't exist, we're on the first page. If it does,
+		// set the max order to one less than its order so that we fetch all of the inactive versions
+		// in between.
+		nextActiveVersion, err := model.GetNextActiveWaterfallVersion(ctx, projectId, activeVersions[0].RevisionOrderNumber)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching next active waterfall version: %s", err.Error()))
+		}
+		if nextActiveVersion != nil {
+			maxVersionOrder = nextActiveVersion.RevisionOrderNumber - 1
+		} else {
+			maxVersionOrder = 0
+		}
 	}
+
+	grip.Debug(message.Fields{
+		"minVersionOrder": minVersionOrder,
+		"maxVersionOrder": maxVersionOrder,
+	})
 
 	allVersions, err := model.GetAllWaterfallVersions(ctx, projectId, minVersionOrder, maxVersionOrder)
 	if err != nil {
@@ -1069,8 +1083,12 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		prevPageOrder = allVersions[0].RevisionOrderNumber
 		nextPageOrder = allVersions[len(allVersions)-1].RevisionOrderNumber
 
-		// If loading base page, there's no prev page to navigate to regardless of max order
-		if maxOrderOpt == 0 && minOrderOpt == 0 {
+		mostRecentWaterfallVersion, err := model.GetMostRecentWaterfallVersion(ctx, projectId)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching most recent waterfall version: %s", err.Error()))
+		}
+		// There's no prev page to navigate to if we've reached the most recent commit.
+		if mostRecentWaterfallVersion.RevisionOrderNumber <= prevPageOrder {
 			prevPageOrder = 0
 		}
 	}

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -5,7 +5,8 @@ input WaterfallOptions {
   minOrder: Int
   "Return versions with an order lower than maxOrder. Used for paginating forward."
   maxOrder: Int
-  projectIdentifier: String! @requireProjectAccess(permission: TASKS, access: VIEW)
+  projectIdentifier: String!
+    @requireProjectAccess(permission: TASKS, access: VIEW)
   requesters: [String!]
   revision: String
 }
@@ -29,6 +30,7 @@ type WaterfallBuildVariant {
   id: String!
   displayName: String!
   builds: [WaterfallBuild!]!
+  version: String!
 }
 
 type WaterfallVersion {

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -222,7 +222,7 @@
         "data": {
           "waterfall": {
             "nextPageOrder": 43,
-            "prevPageOrder": 45,
+            "prevPageOrder": 0,
             "versions": [
               {
                 "inactiveVersions": null,
@@ -419,9 +419,7 @@
         "errors": [
           {
             "message": "version with revision 'foobarbaz' not found",
-            "path": [
-              "waterfall"
-            ],
+            "path": ["waterfall"],
             "extensions": {
               "code": "PARTIAL_ERROR"
             }
@@ -550,9 +548,7 @@
         "errors": [
           {
             "message": "version on or before date '2019-11-07' not found",
-            "path": [
-              "waterfall"
-            ],
+            "path": ["waterfall"],
             "extensions": {
               "code": "PARTIAL_ERROR"
             }

--- a/model/version.go
+++ b/model/version.go
@@ -434,16 +434,21 @@ func VersionGetHistory(versionId string, N int) ([]Version, error) {
 	return versions, nil
 }
 
-func getMostRecentMainlineCommit(ctx context.Context, projectId string) (*Version, error) {
+// GetMostRecentWaterfallVersion returns the most recent version, activated or unactivated, on the waterfall.
+func GetMostRecentWaterfallVersion(ctx context.Context, projectId string) (*Version, error) {
 	match := bson.M{
 		VersionIdentifierKey: projectId,
 		VersionRequesterKey: bson.M{
 			"$in": evergreen.SystemVersionRequesterTypes,
 		},
 	}
-	pipeline := []bson.M{{"$match": match}, {"$sort": bson.M{VersionRevisionOrderNumberKey: -1}}, {"$limit": 1}}
-	res := []Version{}
+	pipeline := []bson.M{
+		{"$match": match},
+		{"$sort": bson.M{VersionRevisionOrderNumberKey: -1}},
+		{"$limit": 1},
+	}
 
+	res := []Version{}
 	env := evergreen.GetEnvironment()
 	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
@@ -453,7 +458,6 @@ func getMostRecentMainlineCommit(ctx context.Context, projectId string) (*Versio
 	if err != nil {
 		return nil, err
 	}
-
 	if len(res) == 0 {
 		return nil, errors.Errorf("could not find mainline commit for project '%s'", projectId)
 	}
@@ -467,7 +471,7 @@ func GetPreviousPageCommitOrderNumber(ctx context.Context, projectId string, ord
 		return nil, errors.Errorf("invalid requesters %s", invalidRequesters)
 	}
 	// First check if we are already looking at the most recent commit.
-	mostRecentCommit, err := getMostRecentMainlineCommit(ctx, projectId)
+	mostRecentCommit, err := GetMostRecentWaterfallVersion(ctx, projectId)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -741,27 +741,32 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	assert.Len(t, buildVariants, 3)
 
 	// Assert build variants are sorted alphabetically
-	assert.Equal(t, buildVariants[0].DisplayName, "01 Build A")
-	assert.Equal(t, buildVariants[1].DisplayName, "02 Build C")
-	assert.Equal(t, buildVariants[2].DisplayName, "03 Build B")
+	assert.Equal(t, "01 Build A", buildVariants[0].DisplayName)
+	assert.Equal(t, "02 Build C", buildVariants[1].DisplayName)
+	assert.Equal(t, "03 Build B", buildVariants[2].DisplayName)
+
+	// Check that build variants have an associated version field.
+	assert.Equal(t, "v_1", buildVariants[0].Version)
+	assert.Equal(t, "v_1", buildVariants[1].Version)
+	assert.Equal(t, "v_1", buildVariants[2].Version)
 
 	// Each variant has 4 builds, corresponding to `limit`
 	assert.Len(t, buildVariants[0].Builds, 4)
 	assert.Len(t, buildVariants[1].Builds, 4)
 	assert.Len(t, buildVariants[2].Builds, 4)
 
-	assert.Equal(t, buildVariants[0].Builds[0].Id, "b_c")
+	assert.Equal(t, "b_c", buildVariants[0].Builds[0].Id)
 	assert.Len(t, buildVariants[0].Builds[0].Tasks, 3)
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[0].Id, "t_32")
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[1].Id, "t_66")
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[2].Id, "t_89")
-	assert.Equal(t, buildVariants[0].Builds[1].Id, "b_e")
+	assert.Equal(t, "t_32", buildVariants[0].Builds[0].Tasks[0].Id)
+	assert.Equal(t, "t_66", buildVariants[0].Builds[0].Tasks[1].Id)
+	assert.Equal(t, "t_89", buildVariants[0].Builds[0].Tasks[2].Id)
+	assert.Equal(t, "b_e", buildVariants[0].Builds[1].Id)
 	assert.Len(t, buildVariants[0].Builds[1].Tasks, 2)
-	assert.Equal(t, buildVariants[0].Builds[1].Tasks[0].Id, "t_473")
-	assert.Equal(t, buildVariants[0].Builds[1].Tasks[1].Id, "t_995")
+	assert.Equal(t, "t_473", buildVariants[0].Builds[1].Tasks[0].Id)
+	assert.Equal(t, "t_995", buildVariants[0].Builds[1].Tasks[1].Id)
 
-	assert.Equal(t, buildVariants[0].Builds[2].Id, "b_g")
+	assert.Equal(t, "b_g", buildVariants[0].Builds[2].Id)
 	assert.Len(t, buildVariants[0].Builds[2].Tasks, 4)
-	assert.Equal(t, buildVariants[0].Builds[3].Id, "b_k")
+	assert.Equal(t, "b_k", buildVariants[0].Builds[3].Id)
 	assert.Len(t, buildVariants[0].Builds[3].Tasks, 2)
 }


### PR DESCRIPTION
DEVPROD-10189

### Description
* `WaterfallBuildVariant`s need `Version` field because `ID` field is not unique and will not cache properly
* Bug where returning to the first page will fail to fetch leading inactive versions
* Bug where previous page order would be populated even though there's no previous page

### Testing
add a description of how you tested it

### Documentation
remember to add or edit docs in the docs/ directory if relevant

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
