### PR TITLE
DEVPROD-9092: Check project exists before creating merge queue intent

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -462,7 +462,7 @@ func (gh *githubHookApi) handleMergeGroupChecksRequested(event *github.MergeGrou
 		"head_sha": event.GetMergeGroup().GetHeadSHA(),
 		"message":  "merge group received",
 	})
-	// Ensure that a project exists before creating an intent. Otherwise, intent creation will fail.
+	// Ensure that a project exists before creating an intent. Otherwise, intent creation will fail which will always yield an unactionable 'Evergreen error' posted to GitHub.
 	projectRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(org, repo, branch)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "finding project ref"))

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -462,6 +462,14 @@ func (gh *githubHookApi) handleMergeGroupChecksRequested(event *github.MergeGrou
 		"head_sha": event.GetMergeGroup().GetHeadSHA(),
 		"message":  "merge group received",
 	})
+	// Ensure that a project exists before creating an intent. Otherwise, intent creation will fail.
+	projectRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(org, repo, branch)
+	if err != nil {
+		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "finding project ref"))
+	}
+	if len(projectRefs) == 0 {
+		return gimlet.NewJSONInternalErrorResponse(errors.New("no matching project ref"))
+	}
 	if err := gh.AddIntentForGithubMerge(event); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"source":   "GitHub hook",

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -592,6 +592,13 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 			assert.Contains(t, str, "message ID cannot be empty")
 			assert.NotContains(t, str, "200")
 		},
+		"nonexistentProject": func(t *testing.T) {
+			response := gh.handleMergeGroupChecksRequested(event)
+			// check for error returned by GitHub merge queue handler
+			str := fmt.Sprintf("%#v", response)
+			assert.Contains(t, str, "no matching project ref")
+			assert.NotContains(t, str, "200")
+		},
 	} {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
 		t.Run(testCase, test)


### PR DESCRIPTION
DEVPROD-9092 - third time's the charm!

### Description
For GitHub merge queue requests, don't create an intent if there is no associated project. This will avoid the "Evergreen error" response occurring on non-LeafyGreen repos: https://github.com/mongodb/leafygreen-ui/commit/1da29495dff3ca98e82148ae94ef87b537677a69

### Testing
Ensure that intent is not created for GitHub requests with no project