### PR TITLE
DEVPROD-1429 Remove GITHUB_TOKEN from smoke test

### DIFF
--- a/agent/command/git_patch_test.go
+++ b/agent/command/git_patch_test.go
@@ -47,7 +47,7 @@ func TestPatchPluginAPI(t *testing.T) {
 		require.NoError(t, err)
 		taskConfig, err := agentutil.MakeTaskConfigFromModelData(ctx, settings, modelData)
 		require.NoError(t, err)
-		taskConfig.Expansions = *util.NewExpansions(settings.Credentials)
+		taskConfig.Expansions = *util.NewExpansions(map[string]string{})
 
 		err = setupTestPatchData(modelData, patchFile, t)
 		require.NoError(t, err)

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,10 +2,13 @@ package fakeparameter
 
 import (
 	"context"
+	"flag"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -16,13 +19,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	// if ExecutionEnvironmentType != "test" {
-	// 	grip.EmergencyFatal(message.Fields{
-	// 		"message":     "fake Parameter Store testing code called in a non-testing environment",
-	// 		"environment": ExecutionEnvironmentType,
-	// 		"args":        flag.Args(),
-	// 	})
-	// }
+	if ExecutionEnvironmentType != "test" {
+		grip.EmergencyFatal(message.Fields{
+			"message":     "fake Parameter Store testing code called in a non-testing environment",
+			"environment": ExecutionEnvironmentType,
+			"args":        flag.Args(),
+		})
+	}
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,13 +2,10 @@ package fakeparameter
 
 import (
 	"context"
-	"flag"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -19,13 +16,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	if ExecutionEnvironmentType != "test" {
-		grip.EmergencyFatal(message.Fields{
-			"message":     "fake Parameter Store testing code called in a non-testing environment",
-			"environment": ExecutionEnvironmentType,
-			"args":        flag.Args(),
-		})
-	}
+	// if ExecutionEnvironmentType != "test" {
+	// 	grip.EmergencyFatal(message.Fields{
+	// 		"message":     "fake Parameter Store testing code called in a non-testing environment",
+	// 		"environment": ExecutionEnvironmentType,
+	// 		"args":        flag.Args(),
+	// 	})
+	// }
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/config.go
+++ b/config.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/util"
@@ -556,34 +555,9 @@ func (s *Settings) makeSplunkSender(ctx context.Context, client *http.Client, le
 	return sender, nil
 }
 
-func (s *Settings) GetGithubOauthString() (string, error) {
-
-	token, ok := s.Credentials["github"]
-	if ok && token != "" {
-		return token, nil
-	}
-
-	return "", errors.New("no github token in settings")
-}
-
-// TODO DEVPROD-1429: Delete this function
+// TODO DEVPROD-2923: Delete this function
 func (s *Settings) GetGithubOauthToken() (string, error) {
-	if s == nil {
-		return "", errors.New("not defined")
-	}
-	if s.ServiceFlags.GlobalGitHubTokenDisabled {
-		return "", nil
-	}
-
-	oauthString, err := s.GetGithubOauthString()
-	if err != nil {
-		return "", nil
-	}
-	splitToken := strings.Split(oauthString, " ")
-	if len(splitToken) != 2 || splitToken[0] != "token" {
-		return "", errors.New("token format was invalid, expected 'token [token]'")
-	}
-	return splitToken[1], nil
+	return "", nil
 }
 
 // PluginConfig holds plugin-specific settings, which are handled.

--- a/config.go
+++ b/config.go
@@ -74,8 +74,6 @@ type Settings struct {
 	CommitQueue         CommitQueueConfig         `yaml:"commit_queue" bson:"commit_queue" json:"commit_queue" id:"commit_queue"`
 	ConfigDir           string                    `yaml:"configdir" bson:"configdir" json:"configdir"`
 	ContainerPools      ContainerPoolsConfig      `yaml:"container_pools" bson:"container_pools" json:"container_pools" id:"container_pools"`
-	Credentials         map[string]string         `yaml:"credentials" bson:"credentials" json:"credentials"`
-	CredentialsNew      util.KeyValuePairSlice    `yaml:"credentials_new" bson:"credentials_new" json:"credentials_new"`
 	Database            DBSettings                `yaml:"database" json:"database" bson:"database"`
 	DomainName          string                    `yaml:"domain_name" bson:"domain_name" json:"domain_name"`
 	Expansions          map[string]string         `yaml:"expansions" bson:"expansions" json:"expansions"`
@@ -133,8 +131,6 @@ func (c *Settings) Set(ctx context.Context) error {
 			bannerThemeKey:        c.BannerTheme,
 			commitQueueKey:        c.CommitQueue,
 			configDirKey:          c.ConfigDir,
-			credentialsKey:        c.Credentials,
-			credentialsNewKey:     c.CredentialsNew,
 			domainNameKey:         c.DomainName,
 			expansionsKey:         c.Expansions,
 			expansionsNewKey:      c.ExpansionsNew,
@@ -165,11 +161,6 @@ func (c *Settings) ValidateAndDefault() error {
 		catcher.Add(errors.New("config directory must not be empty"))
 	}
 
-	if len(c.CredentialsNew) > 0 {
-		if c.Credentials, err = c.CredentialsNew.Map(); err != nil {
-			catcher.Add(errors.Wrap(err, "parsing credentials"))
-		}
-	}
 	if len(c.ExpansionsNew) > 0 {
 		if c.Expansions, err = c.ExpansionsNew.Map(); err != nil {
 			catcher.Add(errors.Wrap(err, "parsing expansions"))

--- a/config_db.go
+++ b/config_db.go
@@ -34,8 +34,6 @@ var (
 	slackKey              = bsonutil.MustHaveTag(Settings{}, "Slack")
 	providersKey          = bsonutil.MustHaveTag(Settings{}, "Providers")
 	kanopySSHKeyPathKey   = bsonutil.MustHaveTag(Settings{}, "KanopySSHKeyPath")
-	credentialsKey        = bsonutil.MustHaveTag(Settings{}, "Credentials")
-	credentialsNewKey     = bsonutil.MustHaveTag(Settings{}, "CredentialsNew")
 	authConfigKey         = bsonutil.MustHaveTag(Settings{}, "AuthConfig")
 	repoTrackerConfigKey  = bsonutil.MustHaveTag(Settings{}, "RepoTracker")
 	apiKey                = bsonutil.MustHaveTag(Settings{}, "Api")

--- a/config_test.go
+++ b/config_test.go
@@ -139,7 +139,6 @@ func (s *AdminSuite) TestBaseConfig() {
 		Banner:              "banner",
 		BannerTheme:         Important,
 		ConfigDir:           "cfg_dir",
-		Credentials:         map[string]string{"k1": "v1"},
 		DomainName:          "example.com",
 		Expansions:          map[string]string{"k2": "v2"},
 		GithubPRCreatorOrg:  "org",
@@ -162,7 +161,6 @@ func (s *AdminSuite) TestBaseConfig() {
 	s.Equal(config.Banner, settings.Banner)
 	s.Equal(config.BannerTheme, settings.BannerTheme)
 	s.Equal(config.ConfigDir, settings.ConfigDir)
-	s.Equal(config.Credentials, settings.Credentials)
 	s.Equal(config.DomainName, settings.DomainName)
 	s.Equal(config.Expansions, settings.Expansions)
 	s.Equal(config.GithubPRCreatorOrg, settings.GithubPRCreatorOrg)
@@ -528,9 +526,6 @@ func (s *AdminSuite) TestKeyValPairsToMap() {
 	config := Settings{
 		ApiUrl:    "foo",
 		ConfigDir: "foo",
-		CredentialsNew: util.KeyValuePairSlice{
-			{Key: "cred1key", Value: "cred1val"},
-		},
 		ExpansionsNew: util.KeyValuePairSlice{
 			{Key: "exp1key", Value: "exp1val"},
 		},
@@ -544,10 +539,8 @@ func (s *AdminSuite) TestKeyValPairsToMap() {
 	s.NoError(config.Set(ctx))
 	dbConfig := Settings{}
 	s.NoError(dbConfig.Get(ctx))
-	s.Len(dbConfig.CredentialsNew, 1)
 	s.Len(dbConfig.ExpansionsNew, 1)
 	s.Len(dbConfig.PluginsNew, 1)
-	s.Equal(config.CredentialsNew[0].Value, dbConfig.Credentials[config.CredentialsNew[0].Key])
 	s.Equal(config.ExpansionsNew[0].Value, dbConfig.Expansions[config.ExpansionsNew[0].Key])
 	pluginMap := dbConfig.Plugins[config.PluginsNew[0].Key]
 	s.NotNil(pluginMap)

--- a/config_test/evg_settings.yml
+++ b/config_test/evg_settings.yml
@@ -14,7 +14,6 @@ buckets:
 domain_name: "evergreen.localhost"
 
 configdir: "config_test"
-credentials: { github: "token xxx" }
 
 amboy:
   name: test_queue

--- a/config_test/evg_settings_with_3rd_party_defaults.yml
+++ b/config_test/evg_settings_with_3rd_party_defaults.yml
@@ -5,7 +5,6 @@ database:
     wmode: "majority"
 
 configdir: "config_test"
-credentials: { github: "token xxx" }
 
 amboy:
   name: test_queue
@@ -147,4 +146,3 @@ github_pr_creator_org: "10gen"
 
 task_limits:
   max_hourly_patch_tasks: 100
-

--- a/model/event/admin_event_test.go
+++ b/model/event/admin_event_test.go
@@ -54,8 +54,7 @@ func (s *AdminEventSuite) TestEventLogging() {
 
 func (s *AdminEventSuite) TestEventLogging2() {
 	before := evergreen.Settings{
-		ApiUrl:      "api",
-		Credentials: map[string]string{"k1": "v1"},
+		ApiUrl: "api",
 	}
 	after := evergreen.Settings{}
 	s.NoError(LogAdminEvent(before.SectionId(), &before, &after, s.username))
@@ -67,9 +66,7 @@ func (s *AdminEventSuite) TestEventLogging2() {
 	beforeVal := eventData.Changes.Before.(*evergreen.Settings)
 	afterVal := eventData.Changes.After.(*evergreen.Settings)
 	s.Equal(before.ApiUrl, beforeVal.ApiUrl)
-	s.Equal(before.Credentials, beforeVal.Credentials)
 	s.Equal("", afterVal.ApiUrl)
-	s.Equal(map[string]string{}, afterVal.Credentials)
 }
 
 func (s *AdminEventSuite) TestEventLogging3() {
@@ -169,15 +166,13 @@ func (s *AdminEventSuite) TestRevertingRoot() {
 
 	// this verifies that reverting the root document does not revert other sections
 	before := evergreen.Settings{
-		Banner:      "before_banner",
-		Credentials: map[string]string{"k1": "v1"},
+		Banner: "before_banner",
 		Ui: evergreen.UIConfig{
 			Url: "before_url",
 		},
 	}
 	after := evergreen.Settings{
-		Banner:      "after_banner",
-		Credentials: map[string]string{"k2": "v2"},
+		Banner: "after_banner",
 		Ui: evergreen.UIConfig{
 			Url:            "after_url",
 			CacheTemplates: true,
@@ -196,13 +191,11 @@ func (s *AdminEventSuite) TestRevertingRoot() {
 	settings, err := evergreen.GetConfig(ctx)
 	s.NoError(err)
 	s.Equal(after.Banner, settings.Banner)
-	s.Equal(after.Credentials, settings.Credentials)
 	s.Equal(after.Ui, settings.Ui)
 	s.NoError(RevertConfig(ctx, guid, "me"))
 	settings, err = evergreen.GetConfig(ctx)
 	s.NoError(err)
 	s.Equal(before.Banner, settings.Banner)
-	s.Equal(before.Credentials, settings.Credentials)
 	s.Equal(after.Ui, settings.Ui)
 }
 

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -25,7 +25,10 @@ type GithubAppAuth struct {
 // if they exist. If the either are not set, it will return nil.
 func CreateGitHubAppAuth(settings *evergreen.Settings) *GithubAppAuth {
 	if settings.AuthConfig.Github == nil || settings.AuthConfig.Github.AppId == 0 {
-		return nil
+		settings = evergreen.GetEnvironment().Settings()
+		if settings.AuthConfig.Github == nil || settings.AuthConfig.Github.AppId == 0 {
+			return nil
+		}
 	}
 
 	key := settings.Expansions[evergreen.GithubAppPrivateKey]

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -138,7 +138,7 @@ func TestCreateGitHubAppAuth(t *testing.T) {
 	delete(settings.Expansions, evergreen.GithubAppPrivateKey)
 
 	authFields := CreateGitHubAppAuth(settings)
-	assert.Nil(t, authFields)
+	assert.Equal(t, "", authFields.Id)
 
 	settings.AuthConfig.Github = &evergreen.GithubAuthConfig{
 		AppId: 1234,

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -134,7 +134,6 @@ func TestCLIFetchSource(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, testConfig)
 	testutil.DisablePermissionsForTests()
 	defer testutil.EnablePermissionsForTests()
-	evergreen.GetEnvironment().Settings().Credentials = testConfig.Credentials
 	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": build.Collection})
 	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": task.Collection})
 	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": model.VersionCollection})
@@ -214,7 +213,6 @@ func TestCLIFetchArtifacts(t *testing.T) {
 	defer cancel()
 
 	testutil.ConfigureIntegrationTest(t, testConfig)
-	evergreen.GetEnvironment().Settings().Credentials = testConfig.Credentials
 
 	Convey("with API test server running", t, func() {
 		testSetup := setupCLITestHarness(ctx)
@@ -366,7 +364,6 @@ func TestCLIFunctions(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, testConfig)
 	testutil.DisablePermissionsForTests()
 	defer testutil.EnablePermissionsForTests()
-	evergreen.GetEnvironment().Settings().Credentials = testConfig.Credentials
 	require.NoError(t, evergreen.UpdateConfig(ctx, testConfig), ShouldBeNil)
 
 	var patches []patch.Patch

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -657,22 +657,6 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
 
     return user;
   }
-  $scope.addCredential = function (chip) {
-    var obj = {};
-    pieces = chip.split(":");
-    if (pieces.length !== 2) {
-      alert("Input must be in the format of key:value");
-      return null;
-    }
-    var key = pieces[0];
-    if ($scope.tempCredentials[key]) {
-      alert("Duplicate credential: " + key);
-      return null;
-    }
-    obj[key] = pieces[1];
-    $scope.tempCredentials[key] = pieces[1];
-    return obj;
-  }
 
   $scope.addSSHKeyPair = function () {
     if ($scope.tempSSHKeyPairs.length === 0) {

--- a/public/static/js/tests/admin.test.js
+++ b/public/static/js/tests/admin.test.js
@@ -15,28 +15,6 @@ describe('AdminSettingsController', function() {
     });
   }));
 
-  describe('addCredential', function () {
-    var validChip = "foo:bar";
-    var invalidChip = "foobar";
-
-    it('returns a chip object for valid input', function() {
-      scope.tempCredentials = {};
-      expect(scope.addCredential(validChip)).toEqual(
-        {"foo": "bar"}
-      );
-      // adding the same thing twice is an error
-      expect(scope.addCredential(validChip)).toBe(
-        null
-      );
-    });
-
-    it('returns null for invalid chips', function() {
-      expect(scope.addCredential(invalidChip)).toBe(
-        null
-      );
-    });
-  });
-
   describe('chipToUserJSON', function () {
     it('returns a chip object for valid json', function() {
       var input = '{"username": "u", "password": "p"}';

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -181,7 +181,6 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	foundNotifyEvent := false
 	foundFlagsEvent := false
 	foundProvidersEvent := false
-	foundRootEvent := false
 	foundUiEvent := false
 	for _, evt := range events {
 		s.Equal(event.EventTypeValueChanged, evt.EventType)
@@ -198,9 +197,6 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 			foundProvidersEvent = true
 			s.Require().True(len(v.AWS.EC2Keys) > 0)
 			s.Equal(testSettings.Providers.AWS.EC2Keys[0].Key, v.AWS.EC2Keys[0].Key)
-		case *evergreen.Settings:
-			foundRootEvent = true
-			s.Equal(testSettings.Credentials, v.Credentials)
 		case *evergreen.UIConfig:
 			foundUiEvent = true
 			s.Equal(testSettings.Ui.Url, v.Url)
@@ -210,7 +206,6 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.True(foundNotifyEvent)
 	s.True(foundFlagsEvent)
 	s.True(foundProvidersEvent)
-	s.True(foundRootEvent)
 	s.True(foundUiEvent)
 
 	// test that updating the model with nil values does not change them

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -323,9 +323,7 @@ buildvariants:
 		pp.Id = "v3"
 		assert.NoError(t, pp.Insert())
 
-		settings := &evergreen.Settings{
-			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
-		}
+		settings := &evergreen.Settings{}
 		assert.NoError(t, evergreen.UpdateConfig(ctx, settings))
 
 		assert.NoError(t, CreateHostsFromTask(ctx, env, &t3, user.DBUser{Id: "me"}, ""))
@@ -391,9 +389,7 @@ buildvariants:
 		pp.Id = "v4"
 		assert.NoError(t, pp.Insert())
 
-		settings := &evergreen.Settings{
-			Credentials: map[string]string{"github": "token globalGitHubOauthToken"},
-		}
+		settings := &evergreen.Settings{}
 		assert.NoError(t, evergreen.UpdateConfig(ctx, settings))
 
 		assert.NoError(t, CreateHostsFromTask(ctx, env, &t4, user.DBUser{Id: "me"}, ""))

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -19,7 +19,6 @@ func NewConfigModel() *APIAdminSettings {
 		Cedar:               &APICedarConfig{},
 		CommitQueue:         &APICommitQueueConfig{},
 		ContainerPools:      &APIContainerPoolsConfig{},
-		Credentials:         map[string]string{},
 		Expansions:          map[string]string{},
 		HostInit:            &APIHostInitConfig{},
 		HostJasper:          &APIHostJasperConfig{},
@@ -62,7 +61,6 @@ type APIAdminSettings struct {
 	CommitQueue         *APICommitQueueConfig             `json:"commit_queue,omitempty"`
 	ConfigDir           *string                           `json:"configdir,omitempty"`
 	ContainerPools      *APIContainerPoolsConfig          `json:"container_pools,omitempty"`
-	Credentials         map[string]string                 `json:"credentials,omitempty"`
 	DomainName          *string                           `json:"domain_name,omitempty"`
 	Expansions          map[string]string                 `json:"expansions,omitempty"`
 	GithubPRCreatorOrg  *string                           `json:"github_pr_creator_org,omitempty"`
@@ -140,7 +138,6 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 		as.LogPath = &v.LogPath
 		as.Plugins = v.Plugins
 		as.PprofPort = &v.PprofPort
-		as.Credentials = v.Credentials
 		as.Expansions = v.Expansions
 		as.KanopySSHKeyPath = utility.ToStringPtr(v.KanopySSHKeyPath)
 		as.GithubOrgs = v.GithubOrgs
@@ -205,7 +202,6 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 // ToService returns a service model from an API model
 func (as *APIAdminSettings) ToService() (interface{}, error) {
 	settings := evergreen.Settings{
-		Credentials:        map[string]string{},
 		Expansions:         map[string]string{},
 		Plugins:            evergreen.PluginConfig{},
 		GithubOrgs:         as.GithubOrgs,
@@ -260,9 +256,6 @@ func (as *APIAdminSettings) ToService() (interface{}, error) {
 		}
 		valToSet := reflect.ValueOf(i)
 		dbModelReflect.FieldByName(propName).Set(valToSet)
-	}
-	for k, v := range as.Credentials {
-		settings.Credentials[k] = v
 	}
 	for k, v := range as.Expansions {
 		settings.Expansions[k] = v

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -61,10 +61,7 @@ func TestModelConversion(t *testing.T) {
 	assert.Equal(testSettings.GithubPRCreatorOrg, *apiSettings.GithubPRCreatorOrg)
 	assert.Equal(testSettings.LogPath, *apiSettings.LogPath)
 	assert.Equal(testSettings.PprofPort, *apiSettings.PprofPort)
-	for k, v := range testSettings.Credentials {
-		assert.Contains(apiSettings.Credentials, k)
-		assert.Equal(v, apiSettings.Credentials[k])
-	}
+
 	for k, v := range testSettings.Expansions {
 		assert.Contains(apiSettings.Expansions, k)
 		assert.Equal(v, apiSettings.Expansions[k])

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -465,7 +465,6 @@ func TestAgentCheckGetPullRequestHandler(t *testing.T) {
 
 			env := &mock.Environment{}
 			assert.NoError(t, env.Configure(ctx))
-			env.EvergreenSettings.Credentials = map[string]string{"github": "token globalGitHubOauthToken"}
 
 			tsk := &task.Task{
 				Id:      "t1",

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -17,9 +17,6 @@ database:
 domain_name: "evergreen.local"
 
 configdir: "config_test"
-credentials: {
-  github: "token $GITHUB_TOKEN",
-}
 
 api_url: http://localhost:9090
 api:

--- a/scripts/setup-smoke-config.sh
+++ b/scripts/setup-smoke-config.sh
@@ -5,9 +5,6 @@ set -o errexit
 
 mkdir -p clients
 cat >> smoke/internal/testdata/admin_settings.yml <<EOF
-credentials:
-  github: "token $GITHUB_TOKEN"
-
 auth:
   naive:
     users:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -108,7 +108,6 @@ variables:
           env:
             GITHUB_APP_ID: ${staging_github_app_id}
             GITHUB_APP_KEY: ${staging_github_app_key}
-            GITHUB_TOKEN: ${github_token}
           command: bash scripts/setup-smoke-config.sh
       - func: run-make
         vars: { target: "set-smoke-vars" }
@@ -277,7 +276,6 @@ functions:
         silent: true
         working_dir: evergreen
         env:
-          GITHUB_TOKEN: ${github_token}
           GITHUB_APP_ID: ${staging_github_app_id}
           GITHUB_APP_KEY: ${staging_github_app_key}
           JIRA_SERVER: ${jiraserver}

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -92,7 +92,6 @@ Admin Settings
 						<li class="link" ng-click="scrollTo('docker')">Docker</li>
 						<div>Other</div>
 						<li class="link" ng-click="scrollTo('misc')">Misc Settings</li>
-						<li class="link" ng-click="scrollTo('credentials')">Credentials</li>
 						<li class="link" ng-click="scrollTo('buckets')">Bucket Config</li>
 						<li class="link" ng-click="scrollTo('expansions')">Expansions</li>
 						<li class="link" ng-click="scrollTo('host_jasper')">Host Jasper</li>
@@ -2219,17 +2218,7 @@ Admin Settings
 
 						<section layout="row" flex>
 
-							<md-card flex=50 id="credentials">
-								<md-card-title>
-									<md-card-title-text>
-										<span>Credentials</span>
-									</md-card-title-text>
-								</md-card-title>
-								<md-card-content>
-									<md-chips md-transform-chip="addCredential($chip)" ng-model="tempCredentials"
-										placeholder="Enter each line as a key:value">
-									</md-chips>
-								</md-card-content>
+							<md-card flex=50 id="credentials">	
 								<md-card-content>
 									<label>SSH Keys</label>
 									<md-list>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -212,7 +212,6 @@ func MockConfig() *evergreen.Settings {
 				},
 			},
 		},
-		Credentials:        map[string]string{"k1": "v1"},
 		DomainName:         "example.com",
 		Expansions:         map[string]string{"k2": "v2"},
 		GithubPRCreatorOrg: "org",

--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -80,7 +80,6 @@ func ConfigureIntegrationTest(t *testing.T, testSettings *evergreen.Settings) {
 		testSettings.Providers.AWS.Pod.ECS.AllowedImages = allowedImages
 	}
 
-	testSettings.Credentials = integrationSettings.Credentials
 	testSettings.Plugins = integrationSettings.Plugins
 	testSettings.Jira = integrationSettings.Jira
 	testSettings.RuntimeEnvironments = integrationSettings.RuntimeEnvironments

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -415,6 +415,12 @@ func getInstallationTokenWithDefaultOwnerRepo(ctx context.Context, opts *github.
 	if err != nil {
 		return "", errors.Wrap(err, "getting evergreen settings")
 	}
+
+	if settings.AuthConfig.Github == nil {
+		settings = evergreen.GetEnvironment().Settings()
+		grip.Info("no Github settings in auth config, using cached settings")
+	}
+
 	token, err := githubapp.CreateCachedInstallationTokenWithDefaultOwnerRepo(ctx, settings, defaultGitHubAPIRequestLifetime, opts)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -254,7 +254,6 @@ func (s *githubStatusUpdateSuite) TestWithGithub() {
 	settings := testutil.TestConfig()
 
 	testutil.ConfigureIntegrationTest(s.T(), settings)
-	env.Settings().Credentials = settings.Credentials
 	env.Settings().Ui.Url = "http://example.com"
 
 	s.patchDoc.GithubPatchData.BaseRepo = "sample"


### PR DESCRIPTION
DEVPROD-1429 

### Description
These changes were approved in https://github.com/evergreen-ci/evergreen/pull/8420 but were reverted because js tests were failing. This adds a commit removing the js test that's no longer needed. 

### Testing
[The js test now passes. ](https://spruce.mongodb.com/version/671fc16a8cf2830007ee29fa/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

