### PR TITLE
DEVPROD-11577 include all system statuses in host quarantine

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -146,7 +146,7 @@ const (
 	// because it was manually aborted.
 	TaskDescriptionAborted = "aborted"
 
-	// Task Statuses that are currently used only by the UI and event logs, and in tests
+	// Task Statuses that are only used by the UI, event log  and tests
 	// (these may be used in old tasks as actual task statuses rather than just
 	// task display statuses).
 	TaskSystemUnresponse = "system-unresponsive"

--- a/globals.go
+++ b/globals.go
@@ -146,7 +146,7 @@ const (
 	// because it was manually aborted.
 	TaskDescriptionAborted = "aborted"
 
-	// Task Statuses that are currently used only by the UI, and in tests
+	// Task Statuses that are currently used only by the UI and event logs, and in tests
 	// (these may be used in old tasks as actual task statuses rather than just
 	// task display statuses).
 	TaskSystemUnresponse = "system-unresponsive"
@@ -402,6 +402,13 @@ var TaskStatuses = []string{
 	TaskUnscheduled,
 	TaskUndispatched,
 	TaskDispatched,
+}
+
+// TaskSystemFailureStatuses contains only system failure statuses used by the UI and event logs.
+var TaskSystemFailureStatuses = []string{
+	TaskSystemFailed,
+	TaskSystemUnresponse,
+	TaskSystemTimedOut,
 }
 
 var InternalAliases = []string{

--- a/model/event/host_event_finder.go
+++ b/model/event/host_event_finder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -62,7 +63,8 @@ func getRecentStatusesForHost(ctx context.Context, hostId string, n int) (int, [
 	return hostStatusDistros[0].Count, hostStatusDistros[0].Status
 }
 
-func AllRecentHostEventsMatchStatus(ctx context.Context, hostId string, n int, status string) bool {
+// AllRecentHostEventsAreSystemFailed returns true if all recent host events are system failures, and false if any are not.
+func AllRecentHostEventsAreSystemFailed(ctx context.Context, hostId string, n int) bool {
 	if n == 0 {
 		return false
 	}
@@ -77,7 +79,7 @@ func AllRecentHostEventsMatchStatus(ctx context.Context, hostId string, n int, s
 	}
 
 	for _, stat := range statuses {
-		if stat != status {
+		if !utility.StringSliceContains(evergreen.TaskSystemFailureStatuses, stat) {
 			return false
 		}
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1916,7 +1916,7 @@ func addStatusColorSort(key string) bson.M {
 						},
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, []string{evergreen.TaskSystemFailed, evergreen.TaskSystemUnresponse, evergreen.TaskSystemTimedOut}},
+								"$in": []interface{}{"$" + key, evergreen.TaskSystemFailureStatuses},
 							},
 							"then": 4, // purple
 						},

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1240,7 +1240,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 
 	// Disable hosts and prevent them from performing more work if they have
 	// system failed many tasks in a row.
-	if event.AllRecentHostEventsMatchStatus(ctx, currentHost.Id, consecutiveSystemFailureThreshold, evergreen.TaskSystemFailed) {
+	if event.AllRecentHostEventsAreSystemFailed(ctx, currentHost.Id, consecutiveSystemFailureThreshold) {
 		msg := fmt.Sprintf("host encountered %d consecutive system failures", consecutiveSystemFailureThreshold)
 		grip.Error(message.WrapError(units.HandlePoisonedHost(ctx, h.env, currentHost, msg), message.Fields{
 			"message": "unable to disable poisoned host",


### PR DESCRIPTION
DEVPROD-11577

### Description
A host that was repeatedly timing out wasn't being caught by the quarantine logic; we should use all statuses here , because this is what the event logs use.

### Testing
Added unit tests.
<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
