### PR TITLE
DEVPROD-12405: Update Waterfall resolver to help with pagination investigation

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1688,10 +1688,10 @@ type ComplexityRoot struct {
 	}
 
 	Waterfall struct {
-		BuildVariants func(childComplexity int) int
-		NextPageOrder func(childComplexity int) int
-		PrevPageOrder func(childComplexity int) int
-		Versions      func(childComplexity int) int
+		BuildVariants     func(childComplexity int) int
+		FlattenedVersions func(childComplexity int) int
+		Pagination        func(childComplexity int) int
+		Versions          func(childComplexity int) int
 	}
 
 	WaterfallBuild struct {
@@ -1706,6 +1706,14 @@ type ComplexityRoot struct {
 		Builds      func(childComplexity int) int
 		DisplayName func(childComplexity int) int
 		Id          func(childComplexity int) int
+		Version     func(childComplexity int) int
+	}
+
+	WaterfallPagination struct {
+		HasNextPage   func(childComplexity int) int
+		HasPrevPage   func(childComplexity int) int
+		NextPageOrder func(childComplexity int) int
+		PrevPageOrder func(childComplexity int) int
 	}
 
 	WaterfallTask struct {
@@ -10202,19 +10210,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Waterfall.BuildVariants(childComplexity), true
 
-	case "Waterfall.nextPageOrder":
-		if e.complexity.Waterfall.NextPageOrder == nil {
+	case "Waterfall.flattenedVersions":
+		if e.complexity.Waterfall.FlattenedVersions == nil {
 			break
 		}
 
-		return e.complexity.Waterfall.NextPageOrder(childComplexity), true
+		return e.complexity.Waterfall.FlattenedVersions(childComplexity), true
 
-	case "Waterfall.prevPageOrder":
-		if e.complexity.Waterfall.PrevPageOrder == nil {
+	case "Waterfall.pagination":
+		if e.complexity.Waterfall.Pagination == nil {
 			break
 		}
 
-		return e.complexity.Waterfall.PrevPageOrder(childComplexity), true
+		return e.complexity.Waterfall.Pagination(childComplexity), true
 
 	case "Waterfall.versions":
 		if e.complexity.Waterfall.Versions == nil {
@@ -10278,6 +10286,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.WaterfallBuildVariant.Id(childComplexity), true
+
+	case "WaterfallBuildVariant.version":
+		if e.complexity.WaterfallBuildVariant.Version == nil {
+			break
+		}
+
+		return e.complexity.WaterfallBuildVariant.Version(childComplexity), true
+
+	case "WaterfallPagination.hasNextPage":
+		if e.complexity.WaterfallPagination.HasNextPage == nil {
+			break
+		}
+
+		return e.complexity.WaterfallPagination.HasNextPage(childComplexity), true
+
+	case "WaterfallPagination.hasPrevPage":
+		if e.complexity.WaterfallPagination.HasPrevPage == nil {
+			break
+		}
+
+		return e.complexity.WaterfallPagination.HasPrevPage(childComplexity), true
+
+	case "WaterfallPagination.nextPageOrder":
+		if e.complexity.WaterfallPagination.NextPageOrder == nil {
+			break
+		}
+
+		return e.complexity.WaterfallPagination.NextPageOrder(childComplexity), true
+
+	case "WaterfallPagination.prevPageOrder":
+		if e.complexity.WaterfallPagination.PrevPageOrder == nil {
+			break
+		}
+
+		return e.complexity.WaterfallPagination.PrevPageOrder(childComplexity), true
 
 	case "WaterfallTask.displayName":
 		if e.complexity.WaterfallTask.DisplayName == nil {
@@ -49749,12 +49792,12 @@ func (ec *executionContext) fieldContext_Query_waterfall(ctx context.Context, fi
 			switch field.Name {
 			case "buildVariants":
 				return ec.fieldContext_Waterfall_buildVariants(ctx, field)
-			case "nextPageOrder":
-				return ec.fieldContext_Waterfall_nextPageOrder(ctx, field)
-			case "prevPageOrder":
-				return ec.fieldContext_Waterfall_prevPageOrder(ctx, field)
 			case "versions":
 				return ec.fieldContext_Waterfall_versions(ctx, field)
+			case "flattenedVersions":
+				return ec.fieldContext_Waterfall_flattenedVersions(ctx, field)
+			case "pagination":
+				return ec.fieldContext_Waterfall_pagination(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Waterfall", field.Name)
 		},
@@ -69807,100 +69850,14 @@ func (ec *executionContext) fieldContext_Waterfall_buildVariants(_ context.Conte
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_WaterfallBuildVariant_id(ctx, field)
-			case "displayName":
-				return ec.fieldContext_WaterfallBuildVariant_displayName(ctx, field)
 			case "builds":
 				return ec.fieldContext_WaterfallBuildVariant_builds(ctx, field)
+			case "displayName":
+				return ec.fieldContext_WaterfallBuildVariant_displayName(ctx, field)
+			case "version":
+				return ec.fieldContext_WaterfallBuildVariant_version(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallBuildVariant", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Waterfall_nextPageOrder(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Waterfall_nextPageOrder(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.NextPageOrder, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Waterfall_nextPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Waterfall",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Waterfall_prevPageOrder(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Waterfall_prevPageOrder(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PrevPageOrder, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Waterfall_prevPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Waterfall",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -69951,6 +69908,184 @@ func (ec *executionContext) fieldContext_Waterfall_versions(_ context.Context, f
 				return ec.fieldContext_WaterfallVersion_version(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallVersion", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Waterfall_flattenedVersions(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Waterfall_flattenedVersions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FlattenedVersions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.APIVersion)
+	fc.Result = res
+	return ec.marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Waterfall",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Version_id(ctx, field)
+			case "activated":
+				return ec.fieldContext_Version_activated(ctx, field)
+			case "author":
+				return ec.fieldContext_Version_author(ctx, field)
+			case "authorEmail":
+				return ec.fieldContext_Version_authorEmail(ctx, field)
+			case "baseTaskStatuses":
+				return ec.fieldContext_Version_baseTaskStatuses(ctx, field)
+			case "baseVersion":
+				return ec.fieldContext_Version_baseVersion(ctx, field)
+			case "branch":
+				return ec.fieldContext_Version_branch(ctx, field)
+			case "buildVariants":
+				return ec.fieldContext_Version_buildVariants(ctx, field)
+			case "buildVariantStats":
+				return ec.fieldContext_Version_buildVariantStats(ctx, field)
+			case "childVersions":
+				return ec.fieldContext_Version_childVersions(ctx, field)
+			case "createTime":
+				return ec.fieldContext_Version_createTime(ctx, field)
+			case "errors":
+				return ec.fieldContext_Version_errors(ctx, field)
+			case "externalLinksForMetadata":
+				return ec.fieldContext_Version_externalLinksForMetadata(ctx, field)
+			case "finishTime":
+				return ec.fieldContext_Version_finishTime(ctx, field)
+			case "generatedTaskCounts":
+				return ec.fieldContext_Version_generatedTaskCounts(ctx, field)
+			case "gitTags":
+				return ec.fieldContext_Version_gitTags(ctx, field)
+			case "ignored":
+				return ec.fieldContext_Version_ignored(ctx, field)
+			case "isPatch":
+				return ec.fieldContext_Version_isPatch(ctx, field)
+			case "manifest":
+				return ec.fieldContext_Version_manifest(ctx, field)
+			case "message":
+				return ec.fieldContext_Version_message(ctx, field)
+			case "order":
+				return ec.fieldContext_Version_order(ctx, field)
+			case "parameters":
+				return ec.fieldContext_Version_parameters(ctx, field)
+			case "patch":
+				return ec.fieldContext_Version_patch(ctx, field)
+			case "previousVersion":
+				return ec.fieldContext_Version_previousVersion(ctx, field)
+			case "project":
+				return ec.fieldContext_Version_project(ctx, field)
+			case "projectIdentifier":
+				return ec.fieldContext_Version_projectIdentifier(ctx, field)
+			case "projectMetadata":
+				return ec.fieldContext_Version_projectMetadata(ctx, field)
+			case "repo":
+				return ec.fieldContext_Version_repo(ctx, field)
+			case "requester":
+				return ec.fieldContext_Version_requester(ctx, field)
+			case "revision":
+				return ec.fieldContext_Version_revision(ctx, field)
+			case "startTime":
+				return ec.fieldContext_Version_startTime(ctx, field)
+			case "status":
+				return ec.fieldContext_Version_status(ctx, field)
+			case "taskCount":
+				return ec.fieldContext_Version_taskCount(ctx, field)
+			case "tasks":
+				return ec.fieldContext_Version_tasks(ctx, field)
+			case "taskStatuses":
+				return ec.fieldContext_Version_taskStatuses(ctx, field)
+			case "taskStatusStats":
+				return ec.fieldContext_Version_taskStatusStats(ctx, field)
+			case "upstreamProject":
+				return ec.fieldContext_Version_upstreamProject(ctx, field)
+			case "versionTiming":
+				return ec.fieldContext_Version_versionTiming(ctx, field)
+			case "warnings":
+				return ec.fieldContext_Version_warnings(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Waterfall_pagination(ctx context.Context, field graphql.CollectedField, obj *Waterfall) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Waterfall_pagination(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pagination, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*WaterfallPagination)
+	fc.Result = res
+	return ec.marshalNWaterfallPagination2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallPagination(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Waterfall_pagination(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Waterfall",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "prevPageOrder":
+				return ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
+			case "nextPageOrder":
+				return ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_WaterfallPagination_hasNextPage(ctx, field)
+			case "hasPrevPage":
+				return ec.fieldContext_WaterfallPagination_hasPrevPage(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type WaterfallPagination", field.Name)
 		},
 	}
 	return fc, nil
@@ -70227,50 +70362,6 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_id(_ context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _WaterfallBuildVariant_displayName(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuildVariant) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_WaterfallBuildVariant_displayName(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.DisplayName, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_WaterfallBuildVariant_displayName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "WaterfallBuildVariant",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _WaterfallBuildVariant_builds(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuildVariant) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_WaterfallBuildVariant_builds(ctx, field)
 	if err != nil {
@@ -70322,6 +70413,270 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_builds(_ context.
 				return ec.fieldContext_WaterfallBuild_tasks(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallBuild", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallBuildVariant_displayName(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuildVariant) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallBuildVariant_displayName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallBuildVariant_displayName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallBuildVariant",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallBuildVariant_version(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuildVariant) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallBuildVariant_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Version, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallBuildVariant_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallBuildVariant",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_prevPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrevPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_prevPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_nextPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_nextPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_hasNextPage(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_hasNextPage(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HasNextPage, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_hasNextPage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_hasPrevPage(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_hasPrevPage(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HasPrevPage, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_hasPrevPage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -94127,18 +94482,18 @@ func (ec *executionContext) _Waterfall(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "nextPageOrder":
-			out.Values[i] = ec._Waterfall_nextPageOrder(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "prevPageOrder":
-			out.Values[i] = ec._Waterfall_prevPageOrder(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "versions":
 			out.Values[i] = ec._Waterfall_versions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "flattenedVersions":
+			out.Values[i] = ec._Waterfall_flattenedVersions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pagination":
+			out.Values[i] = ec._Waterfall_pagination(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -94237,13 +94592,72 @@ func (ec *executionContext) _WaterfallBuildVariant(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "builds":
+			out.Values[i] = ec._WaterfallBuildVariant_builds(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "displayName":
 			out.Values[i] = ec._WaterfallBuildVariant_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "builds":
-			out.Values[i] = ec._WaterfallBuildVariant_builds(ctx, field, obj)
+		case "version":
+			out.Values[i] = ec._WaterfallBuildVariant_version(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var waterfallPaginationImplementors = []string{"WaterfallPagination"}
+
+func (ec *executionContext) _WaterfallPagination(ctx context.Context, sel ast.SelectionSet, obj *WaterfallPagination) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, waterfallPaginationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("WaterfallPagination")
+		case "prevPageOrder":
+			out.Values[i] = ec._WaterfallPagination_prevPageOrder(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "nextPageOrder":
+			out.Values[i] = ec._WaterfallPagination_nextPageOrder(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "hasNextPage":
+			out.Values[i] = ec._WaterfallPagination_hasNextPage(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "hasPrevPage":
+			out.Values[i] = ec._WaterfallPagination_hasPrevPage(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -99447,6 +99861,50 @@ func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋever
 	return ec._Version(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIVersion) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v *model.APIVersion) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -99671,6 +100129,16 @@ func (ec *executionContext) marshalNWaterfallBuildVariant2ᚖgithubᚗcomᚋever
 func (ec *executionContext) unmarshalNWaterfallOptions2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallOptions(ctx context.Context, v interface{}) (WaterfallOptions, error) {
 	res, err := ec.unmarshalInputWaterfallOptions(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNWaterfallPagination2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐWaterfallPagination(ctx context.Context, sel ast.SelectionSet, v *WaterfallPagination) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._WaterfallPagination(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNWaterfallTask2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallTask(ctx context.Context, sel ast.SelectionSet, v model1.WaterfallTask) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -70076,14 +70076,14 @@ func (ec *executionContext) fieldContext_Waterfall_pagination(_ context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "prevPageOrder":
-				return ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
-			case "nextPageOrder":
-				return ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
 			case "hasNextPage":
 				return ec.fieldContext_WaterfallPagination_hasNextPage(ctx, field)
 			case "hasPrevPage":
 				return ec.fieldContext_WaterfallPagination_hasPrevPage(ctx, field)
+			case "nextPageOrder":
+				return ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
+			case "prevPageOrder":
+				return ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type WaterfallPagination", field.Name)
 		},
@@ -70506,94 +70506,6 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_version(_ context
 	return fc, nil
 }
 
-func (ec *executionContext) _WaterfallPagination_prevPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PrevPageOrder, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_WaterfallPagination_prevPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "WaterfallPagination",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _WaterfallPagination_nextPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.NextPageOrder, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_WaterfallPagination_nextPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "WaterfallPagination",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _WaterfallPagination_hasNextPage(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_WaterfallPagination_hasNextPage(ctx, field)
 	if err != nil {
@@ -70677,6 +70589,94 @@ func (ec *executionContext) fieldContext_WaterfallPagination_hasPrevPage(_ conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_nextPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_nextPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NextPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_nextPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WaterfallPagination_prevPageOrder(ctx context.Context, field graphql.CollectedField, obj *WaterfallPagination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallPagination_prevPageOrder(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PrevPageOrder, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallPagination_prevPageOrder(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallPagination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -94641,8 +94641,13 @@ func (ec *executionContext) _WaterfallPagination(ctx context.Context, sel ast.Se
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("WaterfallPagination")
-		case "prevPageOrder":
-			out.Values[i] = ec._WaterfallPagination_prevPageOrder(ctx, field, obj)
+		case "hasNextPage":
+			out.Values[i] = ec._WaterfallPagination_hasNextPage(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "hasPrevPage":
+			out.Values[i] = ec._WaterfallPagination_hasPrevPage(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -94651,13 +94656,8 @@ func (ec *executionContext) _WaterfallPagination(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "hasNextPage":
-			out.Values[i] = ec._WaterfallPagination_hasNextPage(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "hasPrevPage":
-			out.Values[i] = ec._WaterfallPagination_hasPrevPage(ctx, field, obj)
+		case "prevPageOrder":
+			out.Values[i] = ec._WaterfallPagination_prevPageOrder(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -609,10 +609,10 @@ type VolumeHost struct {
 }
 
 type Waterfall struct {
-	BuildVariants []*model1.WaterfallBuildVariant `json:"buildVariants"`
-	NextPageOrder int                             `json:"nextPageOrder"`
-	PrevPageOrder int                             `json:"prevPageOrder"`
-	Versions      []*WaterfallVersion             `json:"versions"`
+	BuildVariants     []*model1.WaterfallBuildVariant `json:"buildVariants"`
+	Versions          []*WaterfallVersion             `json:"versions"`
+	FlattenedVersions []*model.APIVersion             `json:"flattenedVersions"`
+	Pagination        *WaterfallPagination            `json:"pagination"`
 }
 
 type WaterfallOptions struct {
@@ -625,6 +625,13 @@ type WaterfallOptions struct {
 	ProjectIdentifier string   `json:"projectIdentifier"`
 	Requesters        []string `json:"requesters,omitempty"`
 	Revision          *string  `json:"revision,omitempty"`
+}
+
+type WaterfallPagination struct {
+	PrevPageOrder int  `json:"prevPageOrder"`
+	NextPageOrder int  `json:"nextPageOrder"`
+	HasNextPage   bool `json:"hasNextPage"`
+	HasPrevPage   bool `json:"hasPrevPage"`
 }
 
 type WaterfallVersion struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -628,10 +628,10 @@ type WaterfallOptions struct {
 }
 
 type WaterfallPagination struct {
-	PrevPageOrder int  `json:"prevPageOrder"`
-	NextPageOrder int  `json:"nextPageOrder"`
 	HasNextPage   bool `json:"hasNextPage"`
 	HasPrevPage   bool `json:"hasPrevPage"`
+	NextPageOrder int  `json:"nextPageOrder"`
+	PrevPageOrder int  `json:"prevPageOrder"`
 }
 
 type WaterfallVersion struct {

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1035,8 +1035,8 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	} else if maxOrderOpt == 0 {
 		// Find the next recent active version. If it doesn't exist, that means there are leading inactive versions
 		// on the waterfall and we should just reset to the first page.
-		// If it does exist, we should set the max order to one less than its order. This is guaranteed to be an
-		// inactive version, and will allow us to fetch all of the inactive versions in between.
+		// If it does exist, we should set the max order to one less than its order. This is guaranteed to either be
+		// the 0th version in activeVersions or the most recent inactive version within its collapsed group.
 		nextActiveVersion, err := model.GetNextRecentActiveWaterfallVersion(ctx, projectId, activeVersions[0].RevisionOrderNumber)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching next active waterfall version: %s", err.Error()))

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1034,7 +1034,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		maxVersionOrder = 0
 	} else if maxOrderOpt == 0 {
 		// Find the next recent active version. If it doesn't exist, that means there are leading inactive versions
-		// on the waterfall and we should just reset to the first page.
+		// on the waterfall and we should reset to the first page.
 		// If it does exist, we should set the max order to one less than its order. This is guaranteed to either be
 		// the 0th version in activeVersions or the most recent inactive version within its collapsed group.
 		nextActiveVersion, err := model.GetNextRecentActiveWaterfallVersion(ctx, projectId, activeVersions[0].RevisionOrderNumber)

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -5,7 +5,8 @@ input WaterfallOptions {
   minOrder: Int
   "Return versions with an order lower than maxOrder. Used for paginating forward."
   maxOrder: Int
-  projectIdentifier: String! @requireProjectAccess(permission: TASKS, access: VIEW)
+  projectIdentifier: String!
+    @requireProjectAccess(permission: TASKS, access: VIEW)
   requesters: [String!]
   revision: String
 }
@@ -27,8 +28,9 @@ type WaterfallBuild {
 
 type WaterfallBuildVariant {
   id: String!
-  displayName: String!
   builds: [WaterfallBuild!]!
+  displayName: String!
+  version: String!
 }
 
 type WaterfallVersion {
@@ -36,9 +38,16 @@ type WaterfallVersion {
   version: Version
 }
 
+type WaterfallPagination {
+  prevPageOrder: Int!
+  nextPageOrder: Int!
+  hasNextPage: Boolean!
+  hasPrevPage: Boolean!
+}
+
 type Waterfall {
   buildVariants: [WaterfallBuildVariant!]!
-  nextPageOrder: Int!
-  prevPageOrder: Int!
   versions: [WaterfallVersion!]!
+  flattenedVersions: [Version!]!
+  pagination: WaterfallPagination!
 }

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -39,10 +39,10 @@ type WaterfallVersion {
 }
 
 type WaterfallPagination {
-  prevPageOrder: Int!
-  nextPageOrder: Int!
   hasNextPage: Boolean!
   hasPrevPage: Boolean!
+  nextPageOrder: Int!
+  prevPageOrder: Int!
 }
 
 type Waterfall {

--- a/graphql/tests/query/waterfall/queries/all_inactive_versions.graphql
+++ b/graphql/tests/query/waterfall/queries/all_inactive_versions.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "mci" }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         activated
@@ -15,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/date.graphql
+++ b/graphql/tests/query/waterfall/queries/date.graphql
@@ -1,7 +1,7 @@
 {
-  waterfall(options: { projectIdentifier: "spruce", date: "2019-12-31T00:00:00Z" }) {
-    nextPageOrder
-    prevPageOrder
+  waterfall(
+    options: { projectIdentifier: "spruce", date: "2019-12-31T00:00:00Z" }
+  ) {
     versions {
       version {
         createTime
@@ -13,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/date_unmatching.graphql
+++ b/graphql/tests/query/waterfall/queries/date_unmatching.graphql
@@ -1,7 +1,7 @@
 {
-  waterfall(options: { projectIdentifier: "spruce", date: "2019-11-07T00:00:00Z" }) {
-    nextPageOrder
-    prevPageOrder
+  waterfall(
+    options: { projectIdentifier: "spruce", date: "2019-11-07T00:00:00Z" }
+  ) {
     versions {
       version {
         createTime
@@ -13,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/flattened_versions.graphql
+++ b/graphql/tests/query/waterfall/queries/flattened_versions.graphql
@@ -1,0 +1,10 @@
+{
+  waterfall(options: { projectIdentifier: "spruce-identifier" }) {
+    flattenedVersions {
+      id
+      activated
+      order
+      author
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/queries/no_filters.graphql
+++ b/graphql/tests/query/waterfall/queries/no_filters.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "spruce-identifier" }) {
-    nextPageOrder
-    prevPageOrder
     buildVariants {
       builds {
         activated
@@ -30,6 +28,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/no_versions.graphql
+++ b/graphql/tests/query/waterfall/queries/no_versions.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "project_sandbox" }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         activated
@@ -15,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/pagination_backward.graphql
+++ b/graphql/tests/query/waterfall/queries/pagination_backward.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "spruce-identifier", minOrder: 42 }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         activated
@@ -15,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/pagination_forward.graphql
+++ b/graphql/tests/query/waterfall/queries/pagination_forward.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "spruce-identifier", maxOrder: 45 }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         activated
@@ -15,6 +13,10 @@
         id
         order
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/revision.graphql
+++ b/graphql/tests/query/waterfall/queries/revision.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "spruce", revision: "da39a3e" }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         id
@@ -13,6 +11,10 @@
         order
         revision
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/queries/revision_nonexistent.graphql
+++ b/graphql/tests/query/waterfall/queries/revision_nonexistent.graphql
@@ -1,7 +1,5 @@
 {
   waterfall(options: { projectIdentifier: "spruce", revision: "foobarbaz" }) {
-    nextPageOrder
-    prevPageOrder
     versions {
       version {
         id
@@ -13,6 +11,10 @@
         order
         revision
       }
+    }
+    pagination {
+      nextPageOrder
+      prevPageOrder
     }
   }
 }

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -5,8 +5,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 0,
             "buildVariants": [
               {
                 "id": "enterprise-ubuntu1604-64",
@@ -140,7 +138,11 @@
                   "order": 39
                 }
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 0
+            }
           }
         }
       }
@@ -150,8 +152,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 44,
             "versions": [
               {
                 "inactiveVersions": [
@@ -211,7 +211,11 @@
                   "order": 39
                 }
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 44
+            }
           }
         }
       }
@@ -221,8 +225,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 43,
-            "prevPageOrder": 45,
             "versions": [
               {
                 "inactiveVersions": null,
@@ -253,7 +255,11 @@
                   "order": 43
                 }
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 43,
+              "prevPageOrder": 0
+            }
           }
         }
       }
@@ -263,8 +269,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 1,
-            "prevPageOrder": 0,
             "versions": [
               {
                 "version": null,
@@ -289,7 +293,11 @@
                   }
                 ]
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 1,
+              "prevPageOrder": 0
+            }
           }
         }
       }
@@ -299,9 +307,11 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 0,
-            "prevPageOrder": 0,
-            "versions": []
+            "versions": [],
+            "pagination": {
+              "nextPageOrder": 0,
+              "prevPageOrder": 0
+            }
           }
         }
       }
@@ -311,8 +321,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 41,
             "versions": [
               {
                 "version": {
@@ -340,7 +348,11 @@
                 },
                 "inactiveVersions": null
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 41
+            }
           }
         }
       }
@@ -350,8 +362,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 0,
             "versions": [
               {
                 "version": {
@@ -413,15 +423,17 @@
                 },
                 "inactiveVersions": null
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 0
+            }
           }
         },
         "errors": [
           {
             "message": "version with revision 'foobarbaz' not found",
-            "path": [
-              "waterfall"
-            ],
+            "path": ["waterfall"],
             "extensions": {
               "code": "PARTIAL_ERROR"
             }
@@ -434,8 +446,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 42,
             "versions": [
               {
                 "version": {
@@ -471,7 +481,11 @@
                 },
                 "inactiveVersions": null
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 42
+            }
           }
         }
       }
@@ -481,8 +495,6 @@
       "result": {
         "data": {
           "waterfall": {
-            "nextPageOrder": 39,
-            "prevPageOrder": 0,
             "versions": [
               {
                 "version": {
@@ -544,20 +556,75 @@
                 },
                 "inactiveVersions": null
               }
-            ]
+            ],
+            "pagination": {
+              "nextPageOrder": 39,
+              "prevPageOrder": 0
+            }
           }
         },
         "errors": [
           {
             "message": "version on or before date '2019-11-07' not found",
-            "path": [
-              "waterfall"
-            ],
+            "path": ["waterfall"],
             "extensions": {
               "code": "PARTIAL_ERROR"
             }
           }
         ]
+      }
+    },
+    {
+      "query_file": "flattened_versions.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "flattenedVersions": [
+              {
+                "activated": true,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version5",
+                "order": 45
+              },
+              {
+                "activated": false,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version4",
+                "order": 44
+              },
+              {
+                "activated": true,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version3",
+                "order": 43
+              },
+              {
+                "activated": true,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version2",
+                "order": 42
+              },
+              {
+                "activated": true,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version1",
+                "order": 41
+              },
+              {
+                "activated": false,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version0",
+                "order": 40
+              },
+              {
+                "activated": true,
+                "author": "mohamed.khelif",
+                "id": "evergreen_version39",
+                "order": 39
+              }
+            ]
+          }
+        }
       }
     }
   ]

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -229,16 +229,16 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	return res, nil
 }
 
-// GetNextRecentActiveWaterfallVersion returns the next recent active version on the waterfall, i.e., a newer
-// version that is activated.
-func GetNextRecentActiveWaterfallVersion(ctx context.Context, projectId string, maxOrder int) (*Version, error) {
+// GetNextRecentActiveWaterfallVersion returns the next recent active version on the waterfall, i.e. a newer
+// activated version than the version with the given minOrder.
+func GetNextRecentActiveWaterfallVersion(ctx context.Context, projectId string, minOrder int) (*Version, error) {
 	match := bson.M{
 		VersionIdentifierKey: projectId,
 		VersionRequesterKey: bson.M{
 			"$in": evergreen.SystemVersionRequesterTypes,
 		},
 		VersionRevisionOrderNumberKey: bson.M{
-			"$gt": maxOrder,
+			"$gt": minOrder,
 		},
 		VersionActivatedKey: true,
 	}

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -37,6 +37,7 @@ type WaterfallBuildVariant struct {
 	Id          string           `bson:"_id" json:"_id"`
 	DisplayName string           `bson:"display_name" json:"display_name"`
 	Builds      []WaterfallBuild `bson:"builds" json:"builds"`
+	Version     string           `bson:"version" json:"version"`
 }
 
 type WaterfallOptions struct {
@@ -204,6 +205,9 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	})
 	pipeline = append(pipeline, bson.M{
 		"$project": bson.M{
+			build.VersionKey: bson.M{
+				"$first": "$" + bsonutil.GetDottedKeyName(buildsKey, build.VersionKey),
+			},
 			build.DisplayNameKey: bson.M{
 				"$first": "$" + bsonutil.GetDottedKeyName(buildsKey, build.DisplayNameKey),
 			},
@@ -223,4 +227,38 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	}
 
 	return res, nil
+}
+
+// GetNextActiveWaterfallVersion returns the next active version on the waterfall.
+func GetNextActiveWaterfallVersion(ctx context.Context, projectId string, maxOrder int) (*Version, error) {
+	match := bson.M{
+		VersionIdentifierKey: projectId,
+		VersionRequesterKey: bson.M{
+			"$in": evergreen.SystemVersionRequesterTypes,
+		},
+		VersionRevisionOrderNumberKey: bson.M{
+			"$gt": maxOrder,
+		},
+		VersionActivatedKey: true,
+	}
+	pipeline := []bson.M{
+		{"$match": match},
+		{"$sort": bson.M{VersionRevisionOrderNumberKey: 1}},
+		{"$limit": 1},
+	}
+
+	res := []Version{}
+	env := evergreen.GetEnvironment()
+	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "aggregating versions")
+	}
+	err = cursor.All(ctx, &res)
+	if err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, nil
+	}
+	return &res[0], nil
 }

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -229,8 +229,9 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	return res, nil
 }
 
-// GetNextActiveWaterfallVersion returns the next active version on the waterfall.
-func GetNextActiveWaterfallVersion(ctx context.Context, projectId string, maxOrder int) (*Version, error) {
+// GetNextRecentActiveWaterfallVersion returns the next recent active version on the waterfall, i.e., a newer
+// version that is activated.
+func GetNextRecentActiveWaterfallVersion(ctx context.Context, projectId string, maxOrder int) (*Version, error) {
 	match := bson.M{
 		VersionIdentifierKey: projectId,
 		VersionRequesterKey: bson.M{

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -771,7 +771,7 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	assert.Len(t, buildVariants[0].Builds[3].Tasks, 2)
 }
 
-func TestGetNextActiveWaterfallVersion(t *testing.T) {
+func TestGetNextRecentActiveWaterfallVersion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -820,7 +820,7 @@ func TestGetNextActiveWaterfallVersion(t *testing.T) {
 	}
 	assert.NoError(t, v.Insert())
 
-	version, err := GetNextActiveWaterfallVersion(ctx, p.Id, 7)
+	version, err := GetNextRecentActiveWaterfallVersion(ctx, p.Id, 7)
 	assert.NoError(t, err)
 	require.NotNil(t, version)
 	assert.Equal(t, "v_1", version.Id)

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -775,7 +775,7 @@ func TestGetNextRecentActiveWaterfallVersion(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
+	assert.NoError(t, db.ClearCollections(VersionCollection, ProjectRefCollection))
 	start := time.Now()
 	p := ProjectRef{
 		Id:         "a_project",

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -217,21 +217,21 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		CreateTime:          start,
 		Activated:           utility.TruePtr(),
 		BuildVariants: []VersionBuildStatus{
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_3",
 				BuildId:      "b_a",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_2",
 				BuildId:      "b_b",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
@@ -250,21 +250,21 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 		Activated:           utility.FalsePtr(),
 		BuildVariants: []VersionBuildStatus{
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: false,
 				},
 				BuildVariant: "bv_2",
 				BuildId:      "b_d",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: false,
 				},
 				BuildVariant: "bv_1",
 				BuildId:      "b_e",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: false,
 				},
@@ -283,21 +283,21 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 		Activated:           utility.TruePtr(),
 		BuildVariants: []VersionBuildStatus{
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_1",
 				BuildId:      "b_g",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_2",
 				BuildId:      "b_h",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
@@ -316,21 +316,21 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 		Activated:           utility.TruePtr(),
 		BuildVariants: []VersionBuildStatus{
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_3",
 				BuildId:      "b_j",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_1",
 				BuildId:      "b_k",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
@@ -349,21 +349,21 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		CreateTime:          start.Add(-2 * time.Minute),
 		Activated:           utility.TruePtr(),
 		BuildVariants: []VersionBuildStatus{
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_2",
 				BuildId:      "b_m",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
 				BuildVariant: "bv_1",
 				BuildId:      "b_n",
 			},
-			VersionBuildStatus{
+			{
 				ActivationStatus: ActivationStatus{
 					Activated: true,
 				},
@@ -380,16 +380,16 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "02 Build C",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_80",
 			},
-			build.TaskCache{
+			{
 				Id: "t_79",
 			},
-			build.TaskCache{
+			{
 				Id: "t_86",
 			},
-			build.TaskCache{
+			{
 				Id: "t_200",
 			},
 		},
@@ -401,10 +401,10 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "03 Build B",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_45",
 			},
-			build.TaskCache{
+			{
 				Id: "t_12",
 			},
 		},
@@ -416,13 +416,13 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "01 Build A",
 		Version:     "v_1",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_66",
 			},
-			build.TaskCache{
+			{
 				Id: "t_89",
 			},
-			build.TaskCache{
+			{
 				Id: "t_32",
 			},
 		},
@@ -434,16 +434,16 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "03 Build B",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_54",
 			},
-			build.TaskCache{
+			{
 				Id: "t_432",
 			},
-			build.TaskCache{
+			{
 				Id: "t_98",
 			},
-			build.TaskCache{
+			{
 				Id: "t_235",
 			},
 		},
@@ -455,10 +455,10 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "01 Build A",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_995",
 			},
-			build.TaskCache{
+			{
 				Id: "t_473",
 			},
 		},
@@ -470,13 +470,13 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "02 Build C",
 		Version:     "v_2",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_347",
 			},
-			build.TaskCache{
+			{
 				Id: "t_36",
 			},
-			build.TaskCache{
+			{
 				Id: "t_3632",
 			},
 		},
@@ -488,16 +488,16 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "01 Build A",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_537",
 			},
-			build.TaskCache{
+			{
 				Id: "t_737",
 			},
-			build.TaskCache{
+			{
 				Id: "t_135",
 			},
-			build.TaskCache{
+			{
 				Id: "t_1",
 			},
 		},
@@ -509,10 +509,10 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "03 Build B",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_92",
 			},
-			build.TaskCache{
+			{
 				Id: "t_91",
 			},
 		},
@@ -524,13 +524,13 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "02 Build C",
 		Version:     "v_3",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_9166",
 			},
-			build.TaskCache{
+			{
 				Id: "t_46",
 			},
-			build.TaskCache{
+			{
 				Id: "t_236",
 			},
 		},
@@ -542,16 +542,16 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "02 Build C",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_23",
 			},
-			build.TaskCache{
+			{
 				Id: "t_3333",
 			},
-			build.TaskCache{
+			{
 				Id: "t_8458",
 			},
-			build.TaskCache{
+			{
 				Id: "t_8423",
 			},
 		},
@@ -563,10 +563,10 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "01 Build A",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_8648",
 			},
-			build.TaskCache{
+			{
 				Id: "t_845",
 			},
 		},
@@ -578,13 +578,13 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "03 Build B",
 		Version:     "v_4",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_4834",
 			},
-			build.TaskCache{
+			{
 				Id: "t_233",
 			},
-			build.TaskCache{
+			{
 				Id: "t_37",
 			},
 		},
@@ -596,16 +596,16 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "03 Build B",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_377",
 			},
-			build.TaskCache{
+			{
 				Id: "t_1366",
 			},
-			build.TaskCache{
+			{
 				Id: "t_2372",
 			},
-			build.TaskCache{
+			{
 				Id: "t_8548",
 			},
 		},
@@ -617,10 +617,10 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "01 Build A",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_695",
 			},
-			build.TaskCache{
+			{
 				Id: "t_854",
 			},
 		},
@@ -632,13 +632,13 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 		DisplayName: "02 Build C",
 		Version:     "v_5",
 		Tasks: []build.TaskCache{
-			build.TaskCache{
+			{
 				Id: "t_5888",
 			},
-			build.TaskCache{
+			{
 				Id: "t_894",
 			},
-			build.TaskCache{
+			{
 				Id: "t_394",
 			},
 		},
@@ -741,27 +741,87 @@ func TestGetWaterfallBuildVariants(t *testing.T) {
 	assert.Len(t, buildVariants, 3)
 
 	// Assert build variants are sorted alphabetically
-	assert.Equal(t, buildVariants[0].DisplayName, "01 Build A")
-	assert.Equal(t, buildVariants[1].DisplayName, "02 Build C")
-	assert.Equal(t, buildVariants[2].DisplayName, "03 Build B")
+	assert.Equal(t, "01 Build A", buildVariants[0].DisplayName)
+	assert.Equal(t, "02 Build C", buildVariants[1].DisplayName)
+	assert.Equal(t, "03 Build B", buildVariants[2].DisplayName)
+
+	// Check that build variants have an associated version field.
+	assert.Equal(t, "v_1", buildVariants[0].Version)
+	assert.Equal(t, "v_1", buildVariants[1].Version)
+	assert.Equal(t, "v_1", buildVariants[2].Version)
 
 	// Each variant has 4 builds, corresponding to `limit`
 	assert.Len(t, buildVariants[0].Builds, 4)
 	assert.Len(t, buildVariants[1].Builds, 4)
 	assert.Len(t, buildVariants[2].Builds, 4)
 
-	assert.Equal(t, buildVariants[0].Builds[0].Id, "b_c")
+	assert.Equal(t, "b_c", buildVariants[0].Builds[0].Id)
 	assert.Len(t, buildVariants[0].Builds[0].Tasks, 3)
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[0].Id, "t_32")
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[1].Id, "t_66")
-	assert.Equal(t, buildVariants[0].Builds[0].Tasks[2].Id, "t_89")
-	assert.Equal(t, buildVariants[0].Builds[1].Id, "b_e")
+	assert.Equal(t, "t_32", buildVariants[0].Builds[0].Tasks[0].Id)
+	assert.Equal(t, "t_66", buildVariants[0].Builds[0].Tasks[1].Id)
+	assert.Equal(t, "t_89", buildVariants[0].Builds[0].Tasks[2].Id)
+	assert.Equal(t, "b_e", buildVariants[0].Builds[1].Id)
 	assert.Len(t, buildVariants[0].Builds[1].Tasks, 2)
-	assert.Equal(t, buildVariants[0].Builds[1].Tasks[0].Id, "t_473")
-	assert.Equal(t, buildVariants[0].Builds[1].Tasks[1].Id, "t_995")
+	assert.Equal(t, "t_473", buildVariants[0].Builds[1].Tasks[0].Id)
+	assert.Equal(t, "t_995", buildVariants[0].Builds[1].Tasks[1].Id)
 
-	assert.Equal(t, buildVariants[0].Builds[2].Id, "b_g")
+	assert.Equal(t, "b_g", buildVariants[0].Builds[2].Id)
 	assert.Len(t, buildVariants[0].Builds[2].Tasks, 4)
-	assert.Equal(t, buildVariants[0].Builds[3].Id, "b_k")
+	assert.Equal(t, "b_k", buildVariants[0].Builds[3].Id)
 	assert.Len(t, buildVariants[0].Builds[3].Tasks, 2)
+}
+
+func TestGetNextActiveWaterfallVersion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, ProjectRefCollection))
+	start := time.Now()
+	p := ProjectRef{
+		Id:         "a_project",
+		Identifier: "a_project_identifier",
+	}
+	assert.NoError(t, p.Insert())
+
+	v := Version{
+		Id:                  "v_1",
+		Identifier:          "a_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 10,
+		CreateTime:          start,
+		Activated:           utility.TruePtr(),
+	}
+	assert.NoError(t, v.Insert())
+	v = Version{
+		Id:                  "v_2",
+		Identifier:          "a_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 9,
+		CreateTime:          start.Add(-2 * time.Minute),
+		Activated:           utility.FalsePtr(),
+	}
+	assert.NoError(t, v.Insert())
+	v = Version{
+		Id:                  "v_3",
+		Identifier:          "a_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 8,
+		CreateTime:          start.Add(-2 * time.Minute),
+		Activated:           utility.FalsePtr(),
+	}
+	assert.NoError(t, v.Insert())
+	v = Version{
+		Id:                  "v_4",
+		Identifier:          "a_project",
+		Requester:           evergreen.RepotrackerVersionRequester,
+		RevisionOrderNumber: 7,
+		CreateTime:          start.Add(-2 * time.Minute),
+		Activated:           utility.TruePtr(),
+	}
+	assert.NoError(t, v.Insert())
+
+	version, err := GetNextActiveWaterfallVersion(ctx, p.Id, 7)
+	assert.NoError(t, err)
+	require.NotNil(t, version)
+	assert.Equal(t, "v_1", version.Id)
 }


### PR DESCRIPTION
DEVPROD-12405

### Description
(600 lines were autogenerated) 

We are having some issues with reconciling the mainline commits page and cursor based pagination. This PR is a precursor to doing some investigative work here. This PR adds new fields for the investigation, and fixes 2 small bugs in the resolver.

Changes:
* Return `flattenedVersions` array from Waterfall resolver. We will evaluate if this field makes it easier to cache.
* Return `Pagination` object from Waterfall resolver. Cursor based pagination method recommends returning an object containing pagination information.
* Add `Version` field to `WaterfallBuildVariant`. This will be used for caching.
* Fix bug where returning to the first page will fail to fetch leading inactive versions.
* Fix bug where previous page order would be populated even though there's no previous page.

### Testing
- Updated existing tests
- Added GraphQL & unit tests for new fields
