### PR TITLE
DEVPROD-11321 Do not activate disabled dependencies in repotracker

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -147,8 +147,11 @@ func setTaskActivationForBuilds(ctx context.Context, buildIds []string, active, 
 			if err != nil {
 				return errors.Wrap(err, "getting recursive dependencies")
 			}
-			tasksToActivate = append(tasksToActivate, dependOn...)
-
+			for _, depTask := range dependOn {
+				if depTask.Priority != evergreen.DisabledTaskPriority {
+					tasksToActivate = append(tasksToActivate, depTask)
+				}
+			}
 		}
 		if err = task.ActivateTasks(tasksToActivate, time.Now(), withDependencies, caller); err != nil {
 			return errors.Wrap(err, "updating tasks for activation")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2585,7 +2585,7 @@ func GetRecursiveDependenciesUp(tasks []Task, depCache map[string]Task) ([]Task,
 		return nil, nil
 	}
 
-	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey, DisplayNameKey)
+	deps, err := FindWithFields(ByIds(tasksToFind), IdKey, DependsOnKey, ExecutionKey, BuildIdKey, StatusKey, TaskGroupKey, ActivatedKey, DisplayNameKey, PriorityKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dependencies")
 	}

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -298,14 +298,23 @@ buildvariants:
   run_on: d2
   tasks:
   - name: t1
+- name: bv3
+  display_name: bv3_display
+  run_on: d2
+  tasks:
+  - name: t4
 tasks:
 - name: t1
   priority: 3
 - name: t2
   priority: -1
 - name: t3
+  depends_on:
+  - name: t4
+    variant: bv3
+- name: t4
+  priority: -1
 `
-
 	previouslyActivatedVersion := &model.Version{
 		Id:         "previously activated",
 		Identifier: "testproject",
@@ -367,7 +376,7 @@ tasks:
 	v, err := model.VersionFindOne(model.VersionByMostRecentSystemRequester("testproject"))
 	require.NoError(t, err)
 	require.NotNil(t, v)
-	assert.Len(t, v.BuildVariants, 2)
+	assert.Len(t, v.BuildVariants, 3)
 	assert.False(t, v.BuildVariants[0].Activated)
 	assert.False(t, v.BuildVariants[1].Activated)
 	bv, _ := findStatus(v, "bv1")
@@ -378,9 +387,10 @@ tasks:
 	ok, err := model.ActivateElapsedBuildsAndTasks(ctx, v)
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	assert.Len(t, v.BuildVariants, 2)
+	assert.Len(t, v.BuildVariants, 3)
 	assert.True(t, v.BuildVariants[0].Activated)
 	assert.True(t, v.BuildVariants[1].Activated)
+	assert.True(t, v.BuildVariants[2].Activated)
 	bv, _ = findStatus(v, "bv1")
 	assert.Len(t, bv.BatchTimeTasks, 1)
 	assert.False(t, bv.BatchTimeTasks[0].Activated)
@@ -405,6 +415,18 @@ tasks:
 			assert.True(t, tsk.Activated)
 		}
 	}
+
+	bv, _ = findStatus(v, "bv3")
+
+	build3, err := build.FindOneId(bv.BuildId)
+	assert.NoError(t, err)
+	require.NotZero(t, build3)
+
+	tasks, err = task.Find(task.ByBuildId(build3.Id))
+	assert.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, tasks[0].Priority, evergreen.DisabledTaskPriority)
+	assert.False(t, tasks[0].Activated)
 
 	// now we should update just the task even though the build is activated already
 	for i, bv := range v.BuildVariants {


### PR DESCRIPTION
DEVPROD-11321

### Description
Currently, if a task is disabled in YAML and gets activated through being pulled in as a dependency, its disabled status will be ignored and it will be activated anyway. Patched a change to fix this.
### Testing
Added test case + confirmed in staging