### PR TITLE
DEVPROD-11692 Re-apply adding auth for CLI downloads

### DIFF
--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -436,7 +436,7 @@ func (m *dockerManager) GetContainerImage(ctx context.Context, parent *host.Host
 	}
 
 	// Build image containing Evergreen executable.
-	_, err = m.client.BuildImageWithAgent(ctx, m.env, parent, image)
+	_, err = m.client.BuildImageWithAgent(ctx, m.env.ClientConfig().S3URLPrefix, parent, image)
 	if err != nil {
 		return errors.Wrapf(err, "building image '%s' with agent on host '%s'", options.Image, parent.Id)
 	}

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -436,7 +436,7 @@ func (m *dockerManager) GetContainerImage(ctx context.Context, parent *host.Host
 	}
 
 	// Build image containing Evergreen executable.
-	_, err = m.client.BuildImageWithAgent(ctx, parent, image)
+	_, err = m.client.BuildImageWithAgent(ctx, m.env, parent, image)
 	if err != nil {
 		return errors.Wrapf(err, "building image '%s' with agent on host '%s'", options.Image, parent.Id)
 	}

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -31,7 +31,7 @@ import (
 type DockerClient interface {
 	Init(string) error
 	EnsureImageDownloaded(context.Context, *host.Host, host.DockerOptions) (string, error)
-	BuildImageWithAgent(context.Context, evergreen.Environment, *host.Host, string) (string, error)
+	BuildImageWithAgent(context.Context, string, *host.Host, string) (string, error)
 	CreateContainer(context.Context, *host.Host, *host.Host) error
 	GetContainer(context.Context, *host.Host, string) (*types.ContainerJSON, error)
 	GetDockerLogs(context.Context, string, *host.Host, types.ContainerLogsOptions) (io.Reader, error)
@@ -255,7 +255,7 @@ func (c *dockerClientImpl) pullImage(ctx context.Context, h *host.Host, url, use
 
 // BuildImageWithAgent takes a base image and builds a new image on the specified
 // host from a Dockfile in the root directory, which adds the Evergreen binary
-func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, env evergreen.Environment, h *host.Host, baseImage string) (string, error) {
+func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, s3URLPrefix string, h *host.Host, baseImage string) (string, error) {
 	const dockerfileRoute = "dockerfile"
 	start := time.Now()
 
@@ -289,7 +289,7 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, env evergree
 			"BASE_IMAGE":          &baseImage,
 			"EXECUTABLE_SUB_PATH": &executableSubPath,
 			"BINARY_NAME":         &binaryName,
-			"URL":                 utility.ToStringPtr(env.ClientConfig().S3URLPrefix),
+			"URL":                 utility.ToStringPtr(s3URLPrefix),
 		},
 		Remove:        true,
 		RemoteContext: dockerfileUrl,

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -31,7 +31,7 @@ import (
 type DockerClient interface {
 	Init(string) error
 	EnsureImageDownloaded(context.Context, *host.Host, host.DockerOptions) (string, error)
-	BuildImageWithAgent(context.Context, *host.Host, string) (string, error)
+	BuildImageWithAgent(context.Context, evergreen.Environment, *host.Host, string) (string, error)
 	CreateContainer(context.Context, *host.Host, *host.Host) error
 	GetContainer(context.Context, *host.Host, string) (*types.ContainerJSON, error)
 	GetDockerLogs(context.Context, string, *host.Host, types.ContainerLogsOptions) (io.Reader, error)
@@ -255,7 +255,7 @@ func (c *dockerClientImpl) pullImage(ctx context.Context, h *host.Host, url, use
 
 // BuildImageWithAgent takes a base image and builds a new image on the specified
 // host from a Dockfile in the root directory, which adds the Evergreen binary
-func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host, baseImage string) (string, error) {
+func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, env evergreen.Environment, h *host.Host, baseImage string) (string, error) {
 	const dockerfileRoute = "dockerfile"
 	start := time.Now()
 
@@ -289,7 +289,7 @@ func (c *dockerClientImpl) BuildImageWithAgent(ctx context.Context, h *host.Host
 			"BASE_IMAGE":          &baseImage,
 			"EXECUTABLE_SUB_PATH": &executableSubPath,
 			"BINARY_NAME":         &binaryName,
-			"URL":                 &c.evergreenSettings.Ui.Url,
+			"URL":                 utility.ToStringPtr(env.ClientConfig().S3URLPrefix),
 		},
 		Remove:        true,
 		RemoteContext: dockerfileUrl,

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/pkg/errors"
 )
@@ -56,7 +55,7 @@ func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, ho
 	return c.baseImage, nil
 }
 
-func (c *dockerClientMock) BuildImageWithAgent(context.Context, evergreen.Environment, *host.Host, string) (string, error) {
+func (c *dockerClientMock) BuildImageWithAgent(context.Context, string, *host.Host, string) (string, error) {
 	if c.failBuild {
 		return "", errors.New("failed to build image with agent")
 	}

--- a/cloud/docker_mock.go
+++ b/cloud/docker_mock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/pkg/errors"
 )
@@ -55,7 +56,7 @@ func (c *dockerClientMock) EnsureImageDownloaded(context.Context, *host.Host, ho
 	return c.baseImage, nil
 }
 
-func (c *dockerClientMock) BuildImageWithAgent(context.Context, *host.Host, string) (string, error) {
+func (c *dockerClientMock) BuildImageWithAgent(context.Context, evergreen.Environment, *host.Host, string) (string, error) {
 	if c.failBuild {
 		return "", errors.New("failed to build image with agent")
 	}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -73,6 +73,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/commit_queue/{patch_id}/additional").Version(2).Get().Wrap(requireTask).RouteHandler(makeCommitQueueAdditionalPatches())
 	app.AddRoute("/commit_queue/{patch_id}/conclude_merge").Version(2).Post().Wrap(requireTask).RouteHandler(makeCommitQueueConcludeMerge())
 	app.AddRoute("/distros/{distro_id}/ami").Version(2).Get().Wrap(requireTask).RouteHandler(makeGetDistroAMI())
+	app.AddRoute("/distros/{distro_id}/client_urls").Version(2).Get().Wrap(requireHost).RouteHandler(makeGetDistroClientURLs(env))
 	app.AddRoute("/hosts/{host_id}/agent/next_task").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostAgentNextTask(env, opts.TaskDispatcher, opts.TaskAliasDispatcher))
 	app.AddRoute("/hosts/{host_id}/task/{task_id}/end").Version(2).Post().Wrap(requireHost, requireTask).RouteHandler(makeHostAgentEndTask(env))
 	app.AddRoute("/hosts/{host_id}/disable").Version(2).Post().Wrap(requireHost).RouteHandler(makeDisableHostHandler(env))
@@ -153,8 +154,6 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}").Version(2).Put().Wrap(requireUser, createDistro).RouteHandler(makePutDistro())
 	app.AddRoute("/distros/{distro_id}/setup").Version(2).Get().Wrap(requireUser, editDistroSettings).RouteHandler(makeGetDistroSetup())
 	app.AddRoute("/distros/{distro_id}/setup").Version(2).Patch().Wrap(requireUser, editDistroSettings).RouteHandler(makeChangeDistroSetup())
-	// client_urls is used by the agent monitor deploy job which does not pass in user info
-	app.AddRoute("/distros/{distro_id}/client_urls").Version(2).Get().RouteHandler(makeGetDistroClientURLs(env))
 
 	app.AddRoute("/hooks/github").Version(2).Post().Wrap(requireValidGithubPayload).RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
 	app.AddRoute("/hooks/aws").Version(2).Post().Wrap(requireValidSNSPayload).RouteHandler(makeEC2SNS(env, opts.APIQueue))

--- a/service/host.go
+++ b/service/host.go
@@ -319,7 +319,7 @@ func getDockerfile(w http.ResponseWriter, r *http.Request) {
 		"ARG URL",
 		"ARG EXECUTABLE_SUB_PATH",
 		"ARG BINARY_NAME",
-		"ADD ${URL}/clients/${EXECUTABLE_SUB_PATH} /",
+		"ADD ${URL}/${EXECUTABLE_SUB_PATH} /",
 		"RUN chmod 0777 /${BINARY_NAME}",
 	}
 

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -162,7 +162,7 @@ func TestGetDockerfile(t *testing.T) {
 		"ARG URL",
 		"ARG EXECUTABLE_SUB_PATH",
 		"ARG BINARY_NAME",
-		"ADD ${URL}/clients/${EXECUTABLE_SUB_PATH} /",
+		"ADD ${URL}/${EXECUTABLE_SUB_PATH} /",
 		"RUN chmod 0777 /${BINARY_NAME}",
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -51,7 +51,7 @@ func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler,
 	clients := gimlet.NewApp()
 	if uis.env.ClientConfig().S3URLPrefix != "" {
 		clients.NoVersions = true
-		clients.AddPrefixRoute("/clients").Get().Head().Handler(func(w http.ResponseWriter, r *http.Request) {
+		clients.AddPrefixRoute("/clients").Get().Head().Wrap(gimlet.NewRequireAuthHandler()).Handler(func(w http.ResponseWriter, r *http.Request) {
 			path := strings.TrimPrefix(r.URL.Path, "/clients")
 			path = uis.env.ClientConfig().S3URLPrefix + path
 			http.Redirect(w, r, path, http.StatusTemporaryRedirect)


### PR DESCRIPTION
DEVPROD-11692

### Description
This re-applies #8381, which was reverted due to breaking an external build Dockerfile. That Dockerfile has since been updated so this can be re-deployed.