### PR TITLE
DEVPROD-9474: use Parameter Store for project variable tests

### DIFF
--- a/graphql/tests/mutation/attachProjectToNewRepo/data.json
+++ b/graphql/tests/mutation/attachProjectToNewRepo/data.json
@@ -9,6 +9,7 @@
       "repo_name" : "commit-queue-sandbox",
       "branch_name" : "main",
       "repo_ref_id": "repo_id",
+      "parameter_store_enabled": true,
       "admins": ["me"]
     }
   ],
@@ -16,11 +17,13 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     },
     {
       "_id": "different",
       "owner_name": "newOwner",
+      "parameter_store_enabled": true,
       "repo_name": "box"
     }
   ],

--- a/graphql/tests/mutation/attachProjectToRepo/data.json
+++ b/graphql/tests/mutation/attachProjectToRepo/data.json
@@ -8,6 +8,7 @@
       "owner_name" : "evergreen-ci",
       "repo_name" : "commit-queue-sandbox",
       "branch_name" : "main",
+      "parameter_store_enabled": true,
       "admins": ["me"]
     }
   ],
@@ -15,6 +16,7 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/mutation/copyProject/data.json
+++ b/graphql/tests/mutation/copyProject/data.json
@@ -6,10 +6,12 @@
       "owner_name": "evergreen-ci",
       "repo_name": "evergreen",
       "enabled": true,
+      "parameter_store_enabled": true,
       "repoRefId": "something"
     },
     {
       "_id": "logkeeper",
+      "parameter_store_enabled": true,
       "identifier": "keeperOfLogs"
     }
   ]

--- a/graphql/tests/mutation/defaultSectionToRepo/data.json
+++ b/graphql/tests/mutation/defaultSectionToRepo/data.json
@@ -9,11 +9,13 @@
       "repo_name" : "commit-queue-sandbox",
       "branch_name" : "main",
       "admins": ["me"],
+      "parameter_store_enabled": true,
       "repo_ref_id": "repo_id"
     },
     {
       "_id" : "evergreen_id",
       "identifier" : "evergreen",
+      "parameter_store_enabled": true,
       "display_name" : "Sandbox"
     }
   ],
@@ -21,6 +23,7 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/mutation/deleteProject/data.json
+++ b/graphql/tests/mutation/deleteProject/data.json
@@ -3,6 +3,7 @@
     {
       "_id": "animals",
       "identifier": "animals",
+      "parameter_store_enabled": true,
       "display_name": "animals_display"
     }
   ],
@@ -10,6 +11,7 @@
     {
       "_id" : "already_hidden",
       "enabled" : false,
+      "parameter_store_enabled": true,
       "hidden": true
     },
     {
@@ -19,6 +21,7 @@
       "enabled" : true,
       "owner_name" : "evergreen-ci",
       "repo_name" : "evergreen",
+      "parameter_store_enabled": true,
       "branch_name" : "main"
     },
     {
@@ -39,6 +42,7 @@
         "merge_method": ""
       },
       "admins": null,
+      "parameter_store_enabled": true,
       "repo_ref_id": "animals"
     }
   ]

--- a/graphql/tests/mutation/detachProjectFromRepo/data.json
+++ b/graphql/tests/mutation/detachProjectFromRepo/data.json
@@ -9,6 +9,7 @@
       "repo_name" : "commit-queue-sandbox",
       "branch_name" : "main",
       "admins": ["me"],
+      "parameter_store_enabled": true,
       "repo_ref_id": "repo_id"
     }
   ],
@@ -16,6 +17,7 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/mutation/promoteVarsToRepo/data.json
+++ b/graphql/tests/mutation/promoteVarsToRepo/data.json
@@ -9,6 +9,7 @@
       "repo_name" : "commit-queue-sandbox",
       "branch_name" : "main",
       "repo_ref_id": "repo_id",
+      "parameter_store_enabled": true,
       "admins": ["me"]
     }
   ],
@@ -16,6 +17,7 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/mutation/saveProjectSettingsForSection/data.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/data.json
@@ -14,6 +14,7 @@
         "enabled": true,
         "require_signed": false
       },
+      "parameter_store_enabled": true,
       "github_dynamic_token_permission_groups": [
         {
           "name": "permission-group-1",
@@ -31,6 +32,7 @@
     },
     {
       "_id": "second_project_id",
+      "parameter_store_enabled": true,
       "identifier": "new_identifier"
     }
   ],
@@ -38,6 +40,7 @@
     {
       "_id": "myRepo",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/mutation/saveRepoSettingsForSection/data.json
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/data.json
@@ -10,6 +10,7 @@
       "branch_name" : "main",
       "admins": ["me"],
       "spawn_host_script_path": "spawn_script",
+      "parameter_store_enabled": true,
       "commit_queue" : {
         "enabled" : false,
         "require_signed": true
@@ -20,6 +21,7 @@
     {
       "_id": "repo_id",
       "owner_name": "evergreen-ci",
+      "parameter_store_enabled": true,
       "repo_name": "commit-queue-sandbox"
     }
   ],

--- a/graphql/tests/projectSettings/vars/data.json
+++ b/graphql/tests/projectSettings/vars/data.json
@@ -94,6 +94,7 @@
         "git_clone": false
       },
       "hidden": false,
+      "parameter_store_enabled": true,
       "external_links": [
         {
           "display_name": "A link to somewhere",
@@ -105,6 +106,7 @@
     {
       "_id": "vars_test",
       "identifier": "varsTest",
+      "parameter_store_enabled": true,
       "display_name": "Vars test"
     }
   ],

--- a/graphql/tests/repoSettings/vars/data.json
+++ b/graphql/tests/repoSettings/vars/data.json
@@ -72,6 +72,7 @@
         "setup_commands": null,
         "git_clone": false
       },
+      "parameter_store_enabled": true,
       "hidden": false
     }
   ],
@@ -79,6 +80,7 @@
     {
       "_id": "vars_test",
       "identifier": "varsTest",
+      "parameter_store_enabled": true,
       "display_name": "Vars test"
     }
   ],

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1254,6 +1254,7 @@ func (p *ProjectRef) createNewRepoRef(u *user.DBUser) (repoRef *RepoRef, err err
 	if len(allEnabledProjects) == 0 {
 		repoRef.ParameterStoreEnabled = p.ParameterStoreEnabled
 	}
+	repoRef.ParameterStoreVarsSynced = false
 	_, err = SetTracksPushEvents(context.Background(), &repoRef.ProjectRef)
 	if err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3633,9 +3633,6 @@ func ProjectCanDispatchTask(pRef *ProjectRef, t *task.Task) (canDispatch bool, r
 
 // setParameterStoreVarsSynced marks the project or repo ref to indicate whether
 // its project variables are fully synced to Parameter Store.
-// kim: TODO: verify that no functionality that sets this (in the DB only)
-// accidentally unsets it via an Upsert later on. Since we don't pass the
-// project ref into project var DB ops, it has to be manually checked.
 func (p *ProjectRef) setParameterStoreVarsSynced(isSynced bool, isRepoRef bool) error {
 	if p.ParameterStoreVarsSynced == isSynced {
 		return nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3632,6 +3632,9 @@ func ProjectCanDispatchTask(pRef *ProjectRef, t *task.Task) (canDispatch bool, r
 
 // setParameterStoreVarsSynced marks the project or repo ref to indicate whether
 // its project variables are fully synced to Parameter Store.
+// kim: TODO: verify that no functionality that sets this (in the DB only)
+// accidentally unsets it via an Upsert later on. Since we don't pass the
+// project ref into project var DB ops, it has to be manually checked.
 func (p *ProjectRef) setParameterStoreVarsSynced(isSynced bool, isRepoRef bool) error {
 	if p.ParameterStoreVarsSynced == isSynced {
 		return nil

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2267,8 +2267,6 @@ func TestGithubPermissionGroups(t *testing.T) {
 }
 
 func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
-	// kim: TODO: remove skip once done testing
-	t.Skip("kim: NOTE: skipping this test for now locally because cannot safely create a new skeleton project with PS enabled")
 	assert := assert.New(t)
 	require := require.New(t)
 

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -31,7 +32,7 @@ func CleanupAPITestData() error {
 	testCollections := []string{
 		task.Collection, build.Collection, host.Collection,
 		distro.Collection, model.VersionCollection, patch.Collection,
-		model.PushlogCollection, model.ProjectVarsCollection, model.TaskQueuesCollection,
+		model.PushlogCollection, model.ProjectVarsCollection, fakeparameter.Collection, model.TaskQueuesCollection,
 		manifest.Collection, model.ProjectRefCollection, model.ParserProjectCollection}
 
 	if err := db.ClearCollections(testCollections...); err != nil {

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -82,11 +82,12 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{
-		Id:      project.DisplayName,
-		Owner:   "evergreen-ci",
-		Repo:    "sample",
-		Branch:  "main",
-		Enabled: true,
+		Id:                    project.Identifier,
+		Owner:                 "evergreen-ci",
+		Repo:                  "sample",
+		Branch:                "main",
+		Enabled:               true,
+		ParameterStoreEnabled: true,
 	}
 	if err = projectRef.Insert(); err != nil {
 		return nil, errors.Wrap(err, "inserting project ref")
@@ -95,7 +96,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	version := &model.Version{
 		Id:         "sample_version",
-		Identifier: project.DisplayName,
+		Identifier: project.Identifier,
 		Requester:  evergreen.RepotrackerVersionRequester,
 	}
 	if err = version.Insert(); err != nil {
@@ -116,7 +117,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 		return nil, errors.New("no EC2 Keys in test config")
 	}
 	projectVars := &model.ProjectVars{
-		Id: project.DisplayName,
+		Id: project.Identifier,
 		Vars: map[string]string{
 			"aws_key":    testConfig.Providers.AWS.EC2Keys[0].Key,
 			"aws_secret": testConfig.Providers.AWS.EC2Keys[0].Secret,
@@ -158,7 +159,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 		BuildId:        "testBuildId",
 		DistroId:       "test-distro-one",
 		BuildVariant:   variant,
-		Project:        project.DisplayName,
+		Project:        project.Identifier,
 		DisplayName:    taskDisplayName,
 		HostId:         "",
 		Secret:         "testTaskSecret",

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -82,7 +82,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	// Create the ref for the project
 	projectRef := &model.ProjectRef{
-		Id:                    project.Identifier,
+		Id:                    project.DisplayName,
 		Owner:                 "evergreen-ci",
 		Repo:                  "sample",
 		Branch:                "main",
@@ -96,7 +96,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	version := &model.Version{
 		Id:         "sample_version",
-		Identifier: project.Identifier,
+		Identifier: project.DisplayName,
 		Requester:  evergreen.RepotrackerVersionRequester,
 	}
 	if err = version.Insert(); err != nil {
@@ -117,7 +117,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 		return nil, errors.New("no EC2 Keys in test config")
 	}
 	projectVars := &model.ProjectVars{
-		Id: project.Identifier,
+		Id: project.DisplayName,
 		Vars: map[string]string{
 			"aws_key":    testConfig.Providers.AWS.EC2Keys[0].Key,
 			"aws_secret": testConfig.Providers.AWS.EC2Keys[0].Secret,
@@ -159,7 +159,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 		BuildId:        "testBuildId",
 		DistroId:       "test-distro-one",
 		BuildVariant:   variant,
-		Project:        project.Identifier,
+		Project:        project.DisplayName,
 		DisplayName:    taskDisplayName,
 		HostId:         "",
 		Secret:         "testTaskSecret",

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
@@ -1458,7 +1459,7 @@ func TestCreateManifest(t *testing.T) {
 	assert := assert.New(t)
 	settings := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, settings)
-	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection, model.ProjectVarsCollection))
+	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection, model.ProjectVarsCollection), fakeparameter.Collection)
 	// with a revision from 5/31/15
 	v := model.Version{
 		Id:         "aaaaaaaaaaff001122334455",
@@ -1487,10 +1488,11 @@ func TestCreateManifest(t *testing.T) {
 		},
 	}
 	projRef := &model.ProjectRef{
-		Owner:  "evergreen-ci",
-		Repo:   "evergreen",
-		Branch: "main",
-		Id:     "project1",
+		Owner:                 "evergreen-ci",
+		Repo:                  "evergreen",
+		Branch:                "main",
+		Id:                    "project1",
+		ParameterStoreEnabled: true,
 	}
 	require.NoError(t, projRef.Insert())
 
@@ -1501,6 +1503,7 @@ func TestCreateManifest(t *testing.T) {
 		},
 	}
 	require.NoError(t, projVars.Insert())
+	projRef.ParameterStoreVarsSynced = true
 
 	manifest, err := model.CreateManifest(&v, proj.Modules, projRef, settings)
 	assert.NoError(err)

--- a/rest/data/commit_queue_test.go
+++ b/rest/data/commit_queue_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
@@ -411,6 +412,7 @@ func TestCheckCanRemoveCommitQueueItem(t *testing.T) {
 		user.Collection,
 		model.ProjectRefCollection,
 		model.ProjectVarsCollection,
+		fakeparameter.Collection,
 		evergreen.ScopeCollection,
 		evergreen.RoleCollection,
 		patch.Collection,
@@ -438,6 +440,7 @@ func TestCheckCanRemoveCommitQueueItem(t *testing.T) {
 		CommitQueue: model.CommitQueueParams{
 			Enabled: utility.TruePtr(),
 		},
+		ParameterStoreEnabled: true,
 	}
 	require.NoError(t, project.Add(projectAdmin))
 

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
@@ -104,7 +105,7 @@ func TestCreateHostsFromTask(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	require.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
+	require.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection, host.Collection, model.ParserProjectCollection))
 
 	env := &mock.Environment{}
 	require.NoError(t, env.Configure(ctx))
@@ -133,15 +134,17 @@ func TestCreateHostsFromTask(t *testing.T) {
 	}
 	assert.NoError(t, d.Insert(ctx))
 	p := model.ProjectRef{
-		Id:    "p",
-		Owner: "evergreen-ci",
-		Repo:  "sample",
+		Id:                    "p",
+		Owner:                 "evergreen-ci",
+		Repo:                  "sample",
+		ParameterStoreEnabled: true,
 	}
 	assert.NoError(t, p.Insert())
 	pvars := model.ProjectVars{
 		Id: "p",
 	}
 	assert.NoError(t, pvars.Insert())
+	checkAndSetProjectVarsSynced(t, &p, false)
 
 	// Run tests
 	t.Run("Classic", func(t *testing.T) {
@@ -420,7 +423,7 @@ func TestCreateContainerFromTask(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(db.ClearCollections(task.Collection, model.VersionCollection, distro.Collection, model.ProjectRefCollection,
-		model.ProjectVarsCollection, host.Collection, model.ParserProjectCollection))
+		model.ProjectVarsCollection, fakeparameter.Collection, host.Collection, model.ParserProjectCollection))
 
 	env := &mock.Environment{}
 	require.NoError(env.Configure(ctx))
@@ -510,15 +513,17 @@ buildvariants:
 	require.NoError(d.Insert(ctx))
 
 	p := model.ProjectRef{
-		Id:    "p",
-		Owner: "evergreen-ci",
-		Repo:  "sample",
+		Id:                    "p",
+		Owner:                 "evergreen-ci",
+		Repo:                  "sample",
+		ParameterStoreEnabled: true,
 	}
 	assert.NoError(p.Insert())
 	pvars := model.ProjectVars{
 		Id: "p",
 	}
 	assert.NoError(pvars.Insert())
+	checkAndSetProjectVarsSynced(t, &p, false)
 
 	assert.NoError(CreateHostsFromTask(ctx, env, &t1, user.DBUser{Id: "me"}, ""))
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -437,13 +437,14 @@ func HideBranch(projectID string) error {
 	}
 
 	skeletonProj := model.ProjectRef{
-		Id:        pRef.Id,
-		Owner:     pRef.Owner,
-		Repo:      pRef.Repo,
-		Branch:    pRef.Branch,
-		RepoRefId: pRef.RepoRefId,
-		Enabled:   false,
-		Hidden:    utility.TruePtr(),
+		Id:                    pRef.Id,
+		Owner:                 pRef.Owner,
+		Repo:                  pRef.Repo,
+		Branch:                pRef.Branch,
+		RepoRefId:             pRef.RepoRefId,
+		Enabled:               false,
+		Hidden:                utility.TruePtr(),
+		ParameterStoreEnabled: pRef.ParameterStoreEnabled,
 	}
 	if err := skeletonProj.Upsert(); err != nil {
 		return errors.Wrapf(err, "updating project '%s'", pRef.Id)

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -176,7 +176,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			assert.True(t, varsFromDb.PrivateVars["banana"])
 		},
 	} {
-		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection,
 			event.SubscriptionsCollection, event.EventCollection, evergreen.ScopeCollection, user.Collection))
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
@@ -201,9 +201,10 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 		assert.NoError(t, pRefThatDefaults.Upsert())
 
 		pRefThatDoesNotDefault := model.ProjectRef{
-			Id:    "myId2",
-			Owner: "evergreen-ci",
-			Repo:  "evergreen",
+			Id:                    "myId2",
+			Owner:                 "evergreen-ci",
+			Repo:                  "evergreen",
+			ParameterStoreEnabled: true,
 		}
 		assert.NoError(t, pRefThatDoesNotDefault.Upsert())
 
@@ -213,6 +214,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			PrivateVars: map[string]bool{"hello": true},
 		}
 		assert.NoError(t, pVars.Insert())
+		checkAndSetProjectVarsSynced(t, &repoRef.ProjectRef, true)
 
 		// add scopes
 		allProjectsScope := gimlet.Scope{
@@ -1015,7 +1017,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Len(t, projectFromDB.ParsleyFilters, 2)
 		},
 	} {
-		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection,
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection,
 			event.SubscriptionsCollection, event.EventCollection, evergreen.ScopeCollection, user.Collection,
 			model.RepositoriesCollection, evergreen.ConfigCollection))
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -180,20 +180,22 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
 
 		repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
-			Id:         "myRepoId",
-			Owner:      "evergreen-ci",
-			Repo:       "evergreen",
-			Restricted: utility.FalsePtr(),
-			Admins:     []string{"oldAdmin"},
+			Id:                    "myRepoId",
+			Owner:                 "evergreen-ci",
+			Repo:                  "evergreen",
+			Restricted:            utility.FalsePtr(),
+			Admins:                []string{"oldAdmin"},
+			ParameterStoreEnabled: true,
 		}}
 		assert.NoError(t, repoRef.Upsert())
 
 		pRefThatDefaults := model.ProjectRef{
-			Id:        "myId",
-			Owner:     "evergreen-ci",
-			Repo:      "evergreen",
-			RepoRefId: "myRepoId",
-			Admins:    []string{"oldAdmin"},
+			Id:                    "myId",
+			Owner:                 "evergreen-ci",
+			Repo:                  "evergreen",
+			RepoRefId:             "myRepoId",
+			Admins:                []string{"oldAdmin"},
+			ParameterStoreEnabled: true,
 		}
 		assert.NoError(t, pRefThatDefaults.Upsert())
 
@@ -210,6 +212,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			PrivateVars: map[string]bool{"hello": true},
 		}
 		assert.NoError(t, pVars.Insert())
+
 		// add scopes
 		allProjectsScope := gimlet.Scope{
 			ID:        evergreen.AllProjectsScope,

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
@@ -103,7 +104,7 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 
 			testutil.ConfigureIntegrationTest(t, env.Settings())
 
-			require.NoError(t, db.ClearCollections(host.Collection, task.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, model.VersionCollection, model.ParserProjectCollection))
+			require.NoError(t, db.ClearCollections(host.Collection, task.Collection, model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection, model.VersionCollection, model.ParserProjectCollection))
 
 			const hostID = "host_id"
 			t1 := task.Task{
@@ -118,9 +119,10 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 				Version: "aaaaaaaaaaff001122334456",
 			}
 			pRef := model.ProjectRef{
-				Id:    "p1",
-				Owner: "evergreen-ci",
-				Repo:  "sample",
+				Id:                    "p1",
+				Owner:                 "evergreen-ci",
+				Repo:                  "sample",
+				ParameterStoreEnabled: true,
 			}
 			vars := &model.ProjectVars{
 				Id:          "p1",

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -338,6 +338,8 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 		return errors.Wrap(err, "converting new project to service model")
 	}
 	newProjectRef.RepoRefId = oldProject.RepoRefId // this can't be modified by users
+	newProjectRef.ParameterStoreEnabled = oldProject.ParameterStoreEnabled
+	newProjectRef.ParameterStoreVarsSynced = oldProject.ParameterStoreVarsSynced
 
 	h.newProjectRef = newProjectRef
 	h.originalProject = oldProject

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -30,25 +31,27 @@ func TestProjectCopySuite(t *testing.T) {
 }
 
 func (s *ProjectCopySuite) SetupSuite() {
-	s.NoError(db.ClearCollections(model.ProjectRefCollection, user.Collection, model.ProjectVarsCollection))
+	s.NoError(db.ClearCollections(model.ProjectRefCollection, user.Collection, model.ProjectVarsCollection, fakeparameter.Collection))
 	pRefs := []model.ProjectRef{
 		{
-			Id:         "12345",
-			Identifier: "projectA",
-			Branch:     "abcd",
-			Owner:      "evergreen-ci",
-			Repo:       "evergreen",
-			Enabled:    true,
-			Admins:     []string{"my-user"},
+			Id:                    "12345",
+			Identifier:            "projectA",
+			Branch:                "abcd",
+			Owner:                 "evergreen-ci",
+			Repo:                  "evergreen",
+			Enabled:               true,
+			Admins:                []string{"my-user"},
+			ParameterStoreEnabled: true,
 		},
 		{
-			Id:         "23456",
-			Identifier: "projectB",
-			Branch:     "bcde",
-			Owner:      "evergreen-ci",
-			Repo:       "evergreen",
-			Enabled:    true,
-			Admins:     []string{"my-user"},
+			Id:                    "23456",
+			Identifier:            "projectB",
+			Branch:                "bcde",
+			Owner:                 "evergreen-ci",
+			Repo:                  "evergreen",
+			Enabled:               true,
+			Admins:                []string{"my-user"},
+			ParameterStoreEnabled: true,
 		},
 	}
 	for _, pRef := range pRefs {
@@ -140,26 +143,29 @@ func TestCopyVariablesSuite(t *testing.T) {
 
 func (s *copyVariablesSuite) SetupTest() {
 	s.route = &copyVariablesHandler{}
-	s.NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, model.RepoRefCollection))
+	s.NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection, model.RepoRefCollection))
 	pRefs := []model.ProjectRef{
 		{
-			Id:      "projectA",
-			Branch:  "abcd",
-			Enabled: true,
-			Admins:  []string{"my-user"},
+			Id:                    "projectA",
+			Branch:                "abcd",
+			Enabled:               true,
+			Admins:                []string{"my-user"},
+			ParameterStoreEnabled: true,
 		},
 		{
-			Id:      "projectB",
-			Branch:  "bcde",
-			Enabled: true,
-			Admins:  []string{"my-user"},
+			Id:                    "projectB",
+			Branch:                "bcde",
+			Enabled:               true,
+			Admins:                []string{"my-user"},
+			ParameterStoreEnabled: true,
 		},
 	}
 	for _, pRef := range pRefs {
 		s.NoError(pRef.Insert())
 	}
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
-		Id: "repoRef",
+		Id:                    "repoRef",
+		ParameterStoreEnabled: true,
 	}}
 	s.NoError(repoRef.Upsert())
 	projectVar1 := &model.ProjectVars{

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -600,8 +600,6 @@ func (s *ProjectPutSuite) TestParse() {
 }
 
 func (s *ProjectPutSuite) TestRunNewWithValidEntity() {
-	// kim: TODO: remove skip once tests are all passing
-	s.T().Skip("kim: NOTE: cannot pass because it'll create a project with PS disabled and we can't change default")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -12,6 +12,7 @@ import (
 	cocoaMock "github.com/evergreen-ci/cocoa/mock"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
@@ -50,7 +51,7 @@ func TestProjectPatchSuite(t *testing.T) {
 }
 
 func (s *ProjectPatchByIDSuite) SetupTest() {
-	s.NoError(db.ClearCollections(serviceModel.RepoRefCollection, user.Collection, serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, serviceModel.RepositoriesCollection, serviceModel.ProjectAliasCollection,
+	s.NoError(db.ClearCollections(serviceModel.RepoRefCollection, user.Collection, serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection, serviceModel.RepositoriesCollection, serviceModel.ProjectAliasCollection,
 		evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection))
 	user := user.DBUser{
 		Id:          "langdon.alger",
@@ -228,7 +229,7 @@ func (s *ProjectPatchByIDSuite) TestRunWithValidBbConfig() {
 	resp := s.rm.Run(ctx)
 	s.NotNil(resp)
 	s.NotNil(resp.Data())
-	s.Require().Equal(http.StatusOK, resp.Status())
+	s.Require().Equal(http.StatusOK, resp.Status(), resp.Data())
 	pRef, err := data.FindProjectById("dimoxinil", false, false)
 	s.NoError(err)
 	s.Require().Equal("EVG", pRef.BuildBaronSettings.TicketCreateProject)
@@ -360,7 +361,7 @@ func (s *ProjectPatchByIDSuite) TestUpdateParsleyFilters() {
 	resp = s.rm.Run(ctx)
 	s.NotNil(resp)
 	s.NotNil(resp.Data())
-	s.Equal(resp.Status(), http.StatusOK)
+	s.Equal(resp.Status(), http.StatusOK, resp.Data())
 
 	p, err := data.FindProjectById("dimoxinil", true, false)
 	s.NoError(err)
@@ -558,7 +559,7 @@ func (s *ProjectPutSuite) SetupTest() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, user.Collection))
+	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection, user.Collection))
 	s.NoError(getTestProjectRef().Insert())
 
 	settings := s.env.Settings()
@@ -599,6 +600,8 @@ func (s *ProjectPutSuite) TestParse() {
 }
 
 func (s *ProjectPutSuite) TestRunNewWithValidEntity() {
+	// kim: TODO: remove skip once tests are all passing
+	s.T().Skip("kim: NOTE: cannot pass because it'll create a project with PS disabled and we can't change default")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
@@ -680,7 +683,7 @@ func TestProjectGetByIDSuite(t *testing.T) {
 }
 
 func (s *ProjectGetByIDSuite) SetupTest() {
-	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, serviceModel.ProjectConfigCollection))
+	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection, serviceModel.ProjectConfigCollection))
 	s.NoError(getTestProjectRef().Insert())
 	s.NoError(getTestVar().Insert())
 	s.NoError(getTestProjectConfig().Insert())
@@ -909,11 +912,12 @@ func getTestProjectRef() *serviceModel.ProjectRef {
 		CommitQueue: serviceModel.CommitQueueParams{
 			Enabled: utility.FalsePtr(),
 		},
-		Hidden:               utility.FalsePtr(),
-		PatchingDisabled:     utility.FalsePtr(),
-		Admins:               []string{"langdon.alger"},
-		NotifyOnBuildFailure: utility.FalsePtr(),
-		DisabledStatsCache:   utility.TruePtr(),
+		Hidden:                utility.FalsePtr(),
+		PatchingDisabled:      utility.FalsePtr(),
+		Admins:                []string{"langdon.alger"},
+		NotifyOnBuildFailure:  utility.FalsePtr(),
+		DisabledStatsCache:    utility.TruePtr(),
+		ParameterStoreEnabled: true,
 	}
 }
 
@@ -1028,6 +1032,7 @@ func TestDeleteProject(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(
 		serviceModel.ProjectRefCollection,
 		serviceModel.RepoRefCollection,
+		fakeparameter.Collection,
 		serviceModel.ProjectAliasCollection,
 		serviceModel.ProjectVarsCollection,
 		evergreen.ScopeCollection,
@@ -1040,9 +1045,10 @@ func TestDeleteProject(t *testing.T) {
 
 	repo := serviceModel.RepoRef{
 		ProjectRef: serviceModel.ProjectRef{
-			Id:    "repo_ref",
-			Owner: "mongodb",
-			Repo:  "test_repo",
+			Id:                    "repo_ref",
+			Owner:                 "mongodb",
+			Repo:                  "test_repo",
+			ParameterStoreEnabled: true,
 		},
 	}
 	assert.NoError(t, repo.Upsert())
@@ -1052,21 +1058,23 @@ func TestDeleteProject(t *testing.T) {
 	var projects []serviceModel.ProjectRef
 	for i := 0; i < numGoodProjects; i++ {
 		project := serviceModel.ProjectRef{
-			Id:                   fmt.Sprintf("id_%d", i),
-			Owner:                "mongodb",
-			Repo:                 "test_repo",
-			Branch:               fmt.Sprintf("branch_%d", i),
-			Enabled:              true,
-			DisplayName:          fmt.Sprintf("display_%d", i),
-			RepoRefId:            "repo_ref",
-			TracksPushEvents:     utility.TruePtr(),
-			PRTestingEnabled:     utility.TruePtr(),
-			Admins:               []string{"admin0", "admin1"},
-			NotifyOnBuildFailure: utility.TruePtr(),
+			Id:                    fmt.Sprintf("id_%d", i),
+			Owner:                 "mongodb",
+			Repo:                  "test_repo",
+			Branch:                fmt.Sprintf("branch_%d", i),
+			Enabled:               true,
+			DisplayName:           fmt.Sprintf("display_%d", i),
+			RepoRefId:             "repo_ref",
+			TracksPushEvents:      utility.TruePtr(),
+			PRTestingEnabled:      utility.TruePtr(),
+			Admins:                []string{"admin0", "admin1"},
+			NotifyOnBuildFailure:  utility.TruePtr(),
+			ParameterStoreEnabled: true,
 		}
 
 		projects = append(projects, project)
 		require.NoError(t, project.Add(&u))
+		project.ParameterStoreVarsSynced = true
 	}
 
 	numAliases := 2
@@ -1103,13 +1111,15 @@ func TestDeleteProject(t *testing.T) {
 		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, "", true)
 		assert.NoError(t, err)
 		skeletonProj := serviceModel.ProjectRef{
-			Id:        projects[i].Id,
-			Owner:     repo.Owner,
-			Repo:      repo.Repo,
-			Branch:    projects[i].Branch,
-			RepoRefId: repo.Id,
-			Enabled:   false,
-			Hidden:    utility.TruePtr(),
+			Id:                       projects[i].Id,
+			Owner:                    repo.Owner,
+			Repo:                     repo.Repo,
+			Branch:                   projects[i].Branch,
+			RepoRefId:                repo.Id,
+			Enabled:                  false,
+			Hidden:                   utility.TruePtr(),
+			ParameterStoreEnabled:    true,
+			ParameterStoreVarsSynced: true,
 		}
 		assert.Equal(t, skeletonProj, *hiddenProj)
 
@@ -1118,7 +1128,8 @@ func TestDeleteProject(t *testing.T) {
 		assert.Equal(t, 0, len(projAliases))
 
 		skeletonProjVars := serviceModel.ProjectVars{
-			Id: projects[i].Id,
+			Id:   projects[i].Id,
+			Vars: map[string]string{},
 		}
 		projVars, err := serviceModel.FindOneProjectVars(projects[i].Id)
 		assert.NoError(t, err)
@@ -1138,8 +1149,9 @@ func TestDeleteProject(t *testing.T) {
 
 	// Project with UseRepoSettings == false
 	nonTrackingProject := serviceModel.ProjectRef{
-		Id:        "non_tracking_project",
-		RepoRefId: "",
+		Id:                    "non_tracking_project",
+		RepoRefId:             "",
+		ParameterStoreEnabled: true,
 	}
 	require.NoError(t, nonTrackingProject.Insert())
 	pdh.projectName = nonTrackingProject.Id
@@ -1151,21 +1163,22 @@ func TestAttachProjectToRepo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	assert.NoError(t, db.ClearCollections(serviceModel.ProjectRefCollection,
-		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, user.Collection,
+		serviceModel.RepoRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection, user.Collection,
 		evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection))
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
 	u := &user.DBUser{Id: "me"}
 	assert.NoError(t, u.Insert())
 
 	pRef := serviceModel.ProjectRef{
-		Id:         "project1",
-		Identifier: "projectIdent",
-		Owner:      "evergreen-ci",
-		Repo:       "evergreen",
-		Branch:     "main",
-		RepoRefId:  "hello",
-		Enabled:    true,
-		Admins:     []string{"me"},
+		Id:                    "project1",
+		Identifier:            "projectIdent",
+		Owner:                 "evergreen-ci",
+		Repo:                  "evergreen",
+		Branch:                "main",
+		RepoRefId:             "hello",
+		Enabled:               true,
+		Admins:                []string{"me"},
+		ParameterStoreEnabled: true,
 	}
 	assert.NoError(t, pRef.Insert())
 	projVars := serviceModel.ProjectVars{
@@ -1225,13 +1238,14 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	assert.NoError(t, u.Insert())
 
 	pRef := serviceModel.ProjectRef{
-		Id:         "project1",
-		Identifier: "projectIdent",
-		Owner:      "evergreen-ci",
-		Repo:       "evergreen",
-		Branch:     "main",
-		Enabled:    true,
-		Admins:     []string{"me"},
+		Id:                    "project1",
+		Identifier:            "projectIdent",
+		Owner:                 "evergreen-ci",
+		Repo:                  "evergreen",
+		Branch:                "main",
+		Enabled:               true,
+		Admins:                []string{"me"},
+		ParameterStoreEnabled: true,
 	}
 	assert.NoError(t, pRef.Insert())
 	projVars := serviceModel.ProjectVars{
@@ -1296,9 +1310,9 @@ func TestProjectPutRotateSuite(t *testing.T) {
 }
 
 func (s *ProjectPutRotateSuite) SetupTest() {
-	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection))
-	s.NoError(getTestVar().Insert())
+	s.NoError(db.ClearCollections(serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection))
 	s.NoError(getTestProjectRef().Insert())
+	s.NoError(getTestVar().Insert())
 	s.rm = makeProjectVarsPut().(*projectVarsPutHandler)
 }
 

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -1061,7 +1061,7 @@ func TestOffboardUserHandlerHosts(t *testing.T) {
 	assert.True(t, hostFromDB.NoExpiration)
 }
 
-func TestOffboardUserHandlerAdminis(t *testing.T) {
+func TestOffboardUserHandlerAdmins(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection, model.ProjectRefCollection))
 	projectRef0 := &model.ProjectRef{
 		Owner:     "mongodb",

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
@@ -104,7 +105,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 	evergreen.SetEnvironment(s.env)
 	s.NoError(evergreen.UpdateConfig(s.ctx, s.env.Settings()))
 
-	s.NoError(db.ClearCollections(evergreen.ConfigCollection, task.Collection, model.ProjectVarsCollection,
+	s.NoError(db.ClearCollections(evergreen.ConfigCollection, task.Collection, model.ProjectVarsCollection, fakeparameter.Collection,
 		model.ParserProjectCollection, model.VersionCollection, user.Collection, model.ProjectRefCollection,
 		model.ProjectAliasCollection, patch.Collection, patch.IntentCollection, event.SubscriptionsCollection, distro.Collection))
 	s.NoError(db.ClearGridCollections(patch.GridFSPrefix))
@@ -146,13 +147,14 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 	}).Insert())
 
 	s.NoError((&model.ProjectRef{
-		Id:         "childProj",
-		Identifier: "childProj",
-		Owner:      "evergreen-ci",
-		Repo:       "evergreen",
-		Branch:     "main",
-		Enabled:    true,
-		RemotePath: "self-tests.yml",
+		Id:                    "childProj",
+		Identifier:            "childProj",
+		Owner:                 "evergreen-ci",
+		Repo:                  "evergreen",
+		Branch:                "main",
+		Enabled:               true,
+		RemotePath:            "self-tests.yml",
+		ParameterStoreEnabled: true,
 	}).Insert())
 
 	s.NoError((&user.DBUser{

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -129,6 +129,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 				TaskSpecifiers: []patch.TaskSpecifier{{PatchAlias: "childProj-patch-alias"}},
 			},
 		},
+		ParameterStoreEnabled: true,
 	}).Insert())
 
 	s.NoError((&model.ProjectRef{
@@ -144,6 +145,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 			Enabled: utility.TruePtr(),
 		},
 		OldestAllowedMergeBase: "536cde7f7b29f7e117371a48a3e59540a44af1ac",
+		ParameterStoreEnabled:  true,
 	}).Insert())
 
 	s.NoError((&model.ProjectRef{

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
@@ -4856,7 +4857,7 @@ func TestValidateContainers(t *testing.T) {
 	}
 	assert.NoError(t, evergreen.UpdateConfig(ctx, testutil.TestConfig()))
 	defer func() {
-		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection))
 	}()
 	for tName, tCase := range map[string]func(t *testing.T, p *model.Project, ref *model.ProjectRef){
 		"SucceedsWithValidProjectAndRef": func(t *testing.T, p *model.Project, ref *model.ProjectRef) {
@@ -4943,7 +4944,7 @@ func TestValidateContainers(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection))
+			require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection))
 
 			p := &model.Project{
 				Identifier: "proj",
@@ -4985,6 +4986,7 @@ func TestValidateContainers(t *testing.T) {
 						Type:       model.ContainerSecretRepoCreds,
 					},
 				},
+				ParameterStoreEnabled: true,
 			}
 
 			require.NoError(t, ref.Upsert())


### PR DESCRIPTION
DEVPROD-9474

### Description
Use Parameter Store in as many tests as reasonably possible that involve project variables to ensure that we have as much coverage of the project variable behavior in advance of the migration to Parameter Store.

* Enable Parameter Store in all Go/GQL tests involving project vars. The only exceptions are those that are testing project creation and the smoke test.
* Fix a few subtle bugs found through testing that are related to moving variables between projects to ensure that projects don't share parameters. For example, if copying variables from project A to project B, the underlying parameters storing project A and project B's variables should still be separate, even if they have the same variable values.
* Fix a bug related to the project PATCH route to ensure that the modified projects preserves its original Parameter Store fields. This is because they're internal flags for the rollout, and users shouldn't be able to manually change them.

### Testing
* Updated existing unit tests and GQL tests to use Parameter Store and check that the project vars still work.
* Tested manually in staging to double-check that the project vars page could use project vars from Parameter Store instead of the DB.

### Documentation
N/A