### PR TITLE
DEVPROD-7885 Retry on invalid body for parser project route

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -279,7 +279,7 @@ func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*
 	defer resp.Body.Close()
 
 	respBytes, err := io.ReadAll(resp.Body)
-	if err == nil {
+	if err != nil {
 		return nil, errors.Wrap(err, "reading parser project from response")
 	}
 

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -267,8 +267,9 @@ func (c *baseCommunicator) GetDistroAMI(ctx context.Context, distro, region stri
 
 func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*model.Project, error) {
 	info := requestInfo{
-		method:   http.MethodGet,
-		taskData: &taskData,
+		method:             http.MethodGet,
+		taskData:           &taskData,
+		retryOnInvalidBody: true, // This route has returned an invalid body for older distros. See DEVPROD-7885.
 	}
 	info.setTaskPathSuffix("parser_project")
 	resp, err := c.retryRequest(ctx, info, nil)
@@ -277,15 +278,12 @@ func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*
 	}
 	defer resp.Body.Close()
 
-	// Retry reading body since it may error on certain distros for certain go versions.
-	for i := 0; i < c.retry.MaxAttempts; i++ {
-		var respBytes []byte
-		respBytes, err = io.ReadAll(resp.Body)
-		if err == nil {
-			return model.GetProjectFromBSON(respBytes)
-		}
+	respBytes, err := io.ReadAll(resp.Body)
+	if err == nil {
+		return nil, errors.Wrap(err, "reading parser project from response")
 	}
-	return nil, errors.Wrap(err, "reading parser project from response")
+
+	return model.GetProjectFromBSON(respBytes)
 }
 
 func (c *baseCommunicator) GetExpansions(ctx context.Context, taskData TaskData) (util.Expansions, error) {

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -35,10 +35,12 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 		minDelay    = time.Second
 		maxDelay    = 10 * time.Second
 	)
-	resp, err := utility.RetryRequest(ctx, req, utility.RetryOptions{
-		MaxAttempts: maxAttempts,
-		MinDelay:    minDelay,
-		MaxDelay:    maxDelay,
+	resp, err := utility.RetryRequest(ctx, req, utility.RetryRequestOptions{
+		RetryOptions: utility.RetryOptions{
+			MaxAttempts: maxAttempts,
+			MinDelay:    minDelay,
+			MaxDelay:    maxDelay,
+		},
 	})
 	if resp != nil {
 		defer resp.Body.Close()

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-10-30"
+	AgentVersion = "2024-11-01"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20241014191612-891426af27cb
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20240509150854-9d66df03b40e
-	github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604
+	github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20241014191612-891426af27cb
 	github.com/evergreen-ci/shrub v0.0.0-20231121224157-600e066f9de6
 	github.com/evergreen-ci/timber v0.0.0-20240509150854-9d66df03b40e
-	github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155
+	github.com/evergreen-ci/utility v0.0.0-20241104181620-267066777913
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-github/v52 v52.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,6 @@ github.com/evergreen-ci/timber v0.0.0-20240509150854-9d66df03b40e/go.mod h1:dOoy
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155 h1:bGICGjItyBcjJ/L0HG6V6z2Y9vWn45/bLwFNFmuvtiM=
-github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/evergreen-ci/utility v0.0.0-20241104181620-267066777913 h1:3rQZj320TrlMKANWd69q80EJzKA5cChbnF+jiYYBUA4=
 github.com/evergreen-ci/utility v0.0.0-20241104181620-267066777913/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,6 @@ github.com/evergreen-ci/timber v0.0.0-20240509150854-9d66df03b40e/go.mod h1:dOoy
 github.com/evergreen-ci/utility v0.0.0-20211026201827-97b21fa2660a/go.mod h1:fuEDytmDhOv+UCUwRPG/qD7mjVkUgx37KEv+thUgHVk=
 github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSui4nRyDZzm2db7Ju7ZzBAelLyVLmcTPJEIh1IdSrc=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604 h1:QIMOonyxTVB6Za1mxzqNIoCEZWyxQ4SEbbiOEBEujyI=
-github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155 h1:bGICGjItyBcjJ/L0HG6V6z2Y9vWn45/bLwFNFmuvtiM=
 github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSu
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155 h1:bGICGjItyBcjJ/L0HG6V6z2Y9vWn45/bLwFNFmuvtiM=
 github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
+github.com/evergreen-ci/utility v0.0.0-20241104181620-267066777913 h1:3rQZj320TrlMKANWd69q80EJzKA5cChbnF+jiYYBUA4=
+github.com/evergreen-ci/utility v0.0.0-20241104181620-267066777913/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,8 @@ github.com/evergreen-ci/utility v0.0.0-20220404192535-d16eb64796e6/go.mod h1:wSu
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604 h1:QIMOonyxTVB6Za1mxzqNIoCEZWyxQ4SEbbiOEBEujyI=
 github.com/evergreen-ci/utility v0.0.0-20240812204255-c58f66487604/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
+github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155 h1:bGICGjItyBcjJ/L0HG6V6z2Y9vWn45/bLwFNFmuvtiM=
+github.com/evergreen-ci/utility v0.0.0-20241030204140-017aebded155/go.mod h1:SHfOAE51SKTA4NLJFvm046A4CNLDr0gfRTQoTM5l1Zc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/thirdparty"
@@ -158,7 +159,7 @@ func (pp *ParserProject) Insert() error {
 }
 
 func (pp *ParserProject) MarshalBSON() ([]byte, error) {
-	return bson.Marshal(pp)
+	return mgobson.Marshal(pp)
 }
 
 // MarshalBSON marshals the BSON and attempts to unmarshal it back to make sure

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -165,6 +165,10 @@ func (pp *ParserProject) MarshalBSON() ([]byte, error) {
 // it is valid. It only retries when it fails at reading the BSON, not if it encountered
 // an error while marshalling.
 func (pp *ParserProject) RetryMarshalBSON(retries int) ([]byte, error) {
+	return pp.retryMarshalBSON(retries, retries)
+}
+
+func (pp *ParserProject) retryMarshalBSON(maxRetries, retries int) ([]byte, error) {
 	projBytes, err := bson.Marshal(pp)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling project")
@@ -172,9 +176,17 @@ func (pp *ParserProject) RetryMarshalBSON(retries int) ([]byte, error) {
 	_, err = GetProjectFromBSON(projBytes)
 	if err != nil {
 		if retries > 0 {
-			return pp.RetryMarshalBSON(retries - 1)
+			return pp.retryMarshalBSON(maxRetries, retries-1)
 		}
 		return nil, errors.Wrap(err, "unmarshalling project to verify it's integrity")
+	}
+	// TODO (TBA-IN-REVIEW): Remove this log line, potentially the whole retry if it's
+	// never been logged since that means the retries are never actually happening.
+	if retries < maxRetries {
+		grip.Debug(message.Fields{
+			"message": "parser project marshalling succeeded after retries",
+			"retries": maxRetries - retries,
+		})
 	}
 	return projBytes, nil
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -181,7 +181,7 @@ func (pp *ParserProject) retryMarshalBSON(maxRetries, retries int) ([]byte, erro
 		}
 		return nil, errors.Wrap(err, "unmarshalling project to verify it's integrity")
 	}
-	// TODO (TBA-IN-REVIEW): Remove this log line, potentially the whole retry if it's
+	// TODO (DEVPROD-12560): Remove this log line, potentially the whole retry if it's
 	// never been logged since that means the retries are never actually happening.
 	if retries < maxRetries {
 		grip.Debug(message.Fields{

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -162,7 +162,7 @@ func (pp *ParserProject) MarshalBSON() ([]byte, error) {
 	return mgobson.Marshal(pp)
 }
 
-// MarshalBSON marshals the BSON and attempts to unmarshal it back to make sure
+// RetryMarshalBSON marshals the BSON and attempts to unmarshal it back to make sure
 // it is valid. It only retries when it fails at reading the BSON, not if it encountered
 // an error while marshalling.
 func (pp *ParserProject) RetryMarshalBSON(retries int) ([]byte, error) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2984,3 +2984,18 @@ func TestFindAndTranslateProjectForPatch(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalBSON(t *testing.T) {
+	pp := ParserProject{
+		Identifier: utility.ToStringPtr("small"),
+	}
+
+	encoded, err := pp.RetryMarshalBSON(5)
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+
+	decoded, err := GetProjectFromBSON(encoded)
+	require.NoError(t, err)
+	require.NotEmpty(t, decoded)
+	assert.Equal(t, utility.FromStringPtr(pp.Identifier), decoded.Identifier)
+}

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1513,10 +1513,12 @@ func (c *communicatorImpl) PostHostIsUp(ctx context.Context, ec2InstanceID strin
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
 	}
-	resp, err := utility.RetryRequest(ctx, r, utility.RetryOptions{
-		MaxAttempts: c.maxAttempts,
-		MinDelay:    c.timeoutStart,
-		MaxDelay:    c.timeoutMax,
+	resp, err := utility.RetryRequest(ctx, r, utility.RetryRequestOptions{
+		RetryOptions: utility.RetryOptions{
+			MaxAttempts: c.maxAttempts,
+			MinDelay:    c.timeoutStart,
+			MaxDelay:    c.timeoutMax,
+		},
 	})
 	if err != nil {
 		return nil, util.RespErrorf(resp, errors.Wrapf(err, "sending request to indicate host '%s' is up", c.hostID).Error())
@@ -1541,10 +1543,12 @@ func (c *communicatorImpl) GetHostProvisioningOptions(ctx context.Context) (*res
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
 	}
-	resp, err := utility.RetryRequest(ctx, r, utility.RetryOptions{
-		MaxAttempts: c.maxAttempts,
-		MinDelay:    c.timeoutStart,
-		MaxDelay:    c.timeoutMax,
+	resp, err := utility.RetryRequest(ctx, r, utility.RetryRequestOptions{
+		RetryOptions: utility.RetryOptions{
+			MaxAttempts: c.maxAttempts,
+			MinDelay:    c.timeoutStart,
+			MaxDelay:    c.timeoutMax,
+		},
 	})
 	if err != nil {
 		return nil, util.RespErrorf(resp, errors.Wrapf(err, "sending request to get provisioning options for host '%s'", c.hostID).Error())

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -125,10 +125,12 @@ func (c *communicatorImpl) retryRequest(ctx context.Context, info requestInfo, d
 
 	r.Header.Add(evergreen.ContentLengthHeader, strconv.Itoa(len(out)))
 
-	resp, err := utility.RetryRequest(ctx, r, utility.RetryOptions{
-		MaxAttempts: c.maxAttempts,
-		MinDelay:    c.timeoutStart,
-		MaxDelay:    c.timeoutMax,
+	resp, err := utility.RetryRequest(ctx, r, utility.RetryRequestOptions{
+		RetryOptions: utility.RetryOptions{
+			MaxAttempts: c.maxAttempts,
+			MinDelay:    c.timeoutStart,
+			MaxDelay:    c.timeoutMax,
+		},
 	})
 	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
 		return resp, util.RespErrorf(resp, AuthError)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -30,7 +30,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"go.mongodb.org/mongo-driver/bson"
 )
 
 // GET /rest/v2/agent/cedar_config
@@ -570,7 +569,7 @@ func (h *getParserProjectHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("parser project '%s' not found", v.Id),
 		})
 	}
-	projBytes, err := bson.Marshal(pp)
+	projBytes, err := pp.RetryMarshalBSON(5)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "marshalling project bytes to bson"))
 	}


### PR DESCRIPTION
DEVPROD-7885

### Description
See ticket description for occurrences, but when the agent reads this route sometimes it gets an unexpected EOF. We only call this get project [once](https://github.com/ZackarySantana/evergreen/blob/d2f59c4c012b4fe7d4cf1baf8f7deb3920c20dd5/agent/agent.go#L558) and the unexpected EOF doesn't happen for the other functions right below it (GetTask and GetExpansionsAndVars), I think it has to do with that we send it over as binary which we don't do with any other route. It could also be that parser projects tend to be on the larger side.

This PR adds retries for invalid bodies and add retries on the server side to verify the integrity of marshaling. I suspect it won't be called, but I'll create a ticket and attach it to be removed once we verify that the retries on the server side aren't helping.