### PR TITLE
DEVPROD-6301 Allow patch route to return 400

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-10-15"
+	ClientVersion = "2024-10-30"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/http.go
+++ b/operations/http.go
@@ -595,6 +595,9 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 	if resp.StatusCode != http.StatusCreated {
 		return nil, NewAPIError(resp)
 	}
+	if resp.StatusCode == http.StatusBadRequest {
+		return nil, NewAPIError(resp)
+	}
 
 	reply := struct {
 		Patch *patch.Patch `json:"patch"`

--- a/operations/http.go
+++ b/operations/http.go
@@ -595,9 +595,6 @@ func (ac *legacyClient) PutPatch(incomingPatch patchSubmission) (*patch.Patch, e
 	if resp.StatusCode != http.StatusCreated {
 		return nil, NewAPIError(resp)
 	}
-	if resp.StatusCode == http.StatusBadRequest {
-		return nil, NewAPIError(resp)
-	}
 
 	reply := struct {
 		Patch *patch.Patch `json:"patch"`

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -238,7 +238,7 @@ func Patch() cli.Command {
 
 			newPatch, err := params.createPatch(ac, diffData)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "creating cli patch")
 			}
 			patchId := newPatch.Id.Hex()
 			if params.IncludeModules {

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -247,7 +247,12 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	job.Run(r.Context())
 
 	if err = job.Error(); err != nil {
-		as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error processing patch"))
+		// Return a 400 error if the error is due to the user's input
+		if strings.Contains(err.Error(), units.BuildTasksAndVariantsError) {
+			as.LoggedError(w, r, http.StatusBadRequest, err)
+		} else {
+			as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "error processing patch"))
+		}
 		return
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -29,9 +29,10 @@ import (
 )
 
 const (
-	patchIntentJobName    = "patch-intent-processor"
-	githubDependabotUser  = "dependabot[bot]"
-	maxPatchIntentJobTime = 10 * time.Minute
+	patchIntentJobName         = "patch-intent-processor"
+	githubDependabotUser       = "dependabot[bot]"
+	BuildTasksAndVariantsError = "building tasks and variants"
+	maxPatchIntentJobTime      = 10 * time.Minute
 )
 
 func init() {
@@ -357,7 +358,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	if err = j.buildTasksAndVariants(patchDoc, patchedProject); err != nil {
-		return err
+		return errors.Wrap(err, BuildTasksAndVariantsError)
 	}
 
 	if (j.intent.ShouldFinalizePatch() || patchDoc.IsCommitQueuePatch()) &&


### PR DESCRIPTION
DEVPROD-6301

### Description
We were returning mixed status codes when creating patches 
ex) `creating patch: Unexpected reply from server (500 Internal Server Error): 400 (Bad Request): no such buildvariant matching 'b'`

The proposed solution is a bit hacky because it is not 100% accurate but it doesn't seem worth it to special case on every single case that this could hit. I am going to assume that if we failed to build tasks and variants for the cli patch, it is because of a user error. I am arguing for this change because it is slightly more accurate than our current behavior which is more inaccurate more frequently 

### Testing
now) `creating patch: Unexpected reply from server (400 Bad Request): 400 (Bad Request): building tasks and variants: no such buildvariant matching 'b'`