### PR TITLE
DEVPROD-6589 Impose auto restart limit on projects

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -48,6 +48,9 @@ type TaskLimitsConfig struct {
 
 	// MaxTaskExecution is the maximum task (zero based) execution number.
 	MaxTaskExecution int `bson:"max_task_execution" json:"max_task_execution" yaml:"max_task_execution"`
+
+	// MaxDailyAutomaticRestarts is the maximum number of times a project can automatically restart a task within a 24-hour period.
+	MaxDailyAutomaticRestarts int `bson:"max_daily_automatic_restarts" json:"max_daily_automatic_restarts" yaml:"max_daily_automatic_restarts"`
 }
 
 var (
@@ -62,6 +65,7 @@ var (
 	MaxExecTimeoutSecs                               = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxExecTimeoutSecs")
 	maxDegradedModeConcurrentLargeParserProjectTasks = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDegradedModeConcurrentLargeParserProjectTasks")
 	maxTaskExecutionKey                              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTaskExecution")
+	maxDailyAutomaticRestartsKey                     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDailyAutomaticRestarts")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -84,6 +88,7 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			MaxExecTimeoutSecs:                               c.MaxExecTimeoutSecs,
 			maxDegradedModeConcurrentLargeParserProjectTasks: c.MaxDegradedModeConcurrentLargeParserProjectTasks,
 			maxTaskExecutionKey:                              c.MaxTaskExecution,
+			maxDailyAutomaticRestartsKey:                     c.MaxDailyAutomaticRestarts,
 		},
 	}), "updating config section '%s'", c.SectionId())
 }

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -1667,7 +1667,8 @@ when it completes, regardless of the failure type.
 
 This is only recommended for commands that are known to be flaky, or fail intermittently.
 **In order to prevent overuse of this feature, the number of times a single
-task can be automatically restarted on failure is limited to 1 time.**
+task can be automatically restarted on failure is limited to 1 time, and a given project may only
+automatically restart a maximum of 200 tasks in a given 24-hour period.**
 
 In the example below, both `task1` and `task2` will retry automatically:
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,9 +148,10 @@ type ProjectRef struct {
 	// project's variables have been synced to Parameter Store. If this is true,
 	// then the project variables can all be found in Parameter Store.
 	ParameterStoreVarsSynced bool `bson:"parameter_store_vars_synced,omitempty" json:"parameter_store_vars_synced,omitempty" yaml:"parameter_store_vars_synced,omitempty"`
-	// LastAutoRestartedTaskAt is the TODO
+	// LastAutoRestartedTaskAt is the last timestamp that a task in this project was restarted automatically.
 	LastAutoRestartedTaskAt time.Time `bson:"last_auto_restarted_task_at"`
-	NumAutoRestartedTasks   int       `bson:"num_auto_restarted_tasks"`
+	// NumAutoRestartedTasks is the number of tasks this project has restarted automatically in the past 24-hour period.
+	NumAutoRestartedTasks int `bson:"num_auto_restarted_tasks"`
 }
 
 // GitHubDynamicTokenPermissionGroup is a permission group for GitHub dynamic access tokens.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,6 +148,9 @@ type ProjectRef struct {
 	// project's variables have been synced to Parameter Store. If this is true,
 	// then the project variables can all be found in Parameter Store.
 	ParameterStoreVarsSynced bool `bson:"parameter_store_vars_synced,omitempty" json:"parameter_store_vars_synced,omitempty" yaml:"parameter_store_vars_synced,omitempty"`
+	// LastAutoRestartedTaskAt is the TODO
+	LastAutoRestartedTaskAt time.Time `bson:"last_auto_restarted_task_at"`
+	NumAutoRestartedTasks   int       `bson:"num_auto_restarted_tasks"`
 }
 
 // GitHubDynamicTokenPermissionGroup is a permission group for GitHub dynamic access tokens.
@@ -498,6 +501,8 @@ var (
 	projectRefGitHubDynamicTokenPermissionGroupsKey = bsonutil.MustHaveTag(ProjectRef{}, "GitHubDynamicTokenPermissionGroups")
 	projectRefGithubPermissionGroupByRequesterKey   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubPermissionGroupByRequester")
 	projectRefParameterStoreVarsSyncedKey           = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreVarsSynced")
+	projectRefLastAutoRestartedTaskAtKey            = bsonutil.MustHaveTag(ProjectRef{}, "LastAutoRestartedTaskAt")
+	projectRefNumAutoRestartedTasksKey              = bsonutil.MustHaveTag(ProjectRef{}, "NumAutoRestartedTasks")
 
 	commitQueueEnabledKey          = bsonutil.MustHaveTag(CommitQueueParams{}, "Enabled")
 	commitQueueMergeQueueKey       = bsonutil.MustHaveTag(CommitQueueParams{}, "MergeQueue")
@@ -2540,6 +2545,39 @@ func (p *ProjectRef) GetActivationTimeForVariant(variant *BuildVariant, versionC
 	}
 
 	return versionCreateTime, nil
+}
+
+// CheckAndUpdateAutoRestartLimit checks if auto restarting a task for a project is allowed given
+// the global per-project daily auto restarting limit, and updates relevant timestamp and counter used
+// to track the project's usage.
+func (p *ProjectRef) CheckAndUpdateAutoRestartLimit(maxDailyAutoRestarts int) error {
+	if maxDailyAutoRestarts == 0 {
+		return nil
+	}
+	var update bson.M
+	now := time.Now()
+	oneDayAgo := now.Add(-1 * 24 * time.Hour)
+	// If the last time the project auto restarted a task was within the day, increment the number
+	// of auto restarted tasks counter, erroring if the global limit is breached.
+	if p.LastAutoRestartedTaskAt.After(oneDayAgo) {
+		update = bson.M{
+			"$set": bson.M{projectRefLastAutoRestartedTaskAtKey: p.NumAutoRestartedTasks + 1},
+		}
+		if 1+p.NumAutoRestartedTasks >= maxDailyAutoRestarts {
+			minutesRemaining := 24 - int(now.Sub(p.LastAutoRestartedTaskAt).Hours())
+			return errors.Errorf("project '%s' has auto-restarted %d out of %d allowed tasks in the past day, limit refreshes in %d hour(s)", p.Id, p.NumAutoRestartedTasks, maxDailyAutoRestarts, minutesRemaining)
+		}
+	} else {
+		// Otherwise, if the project has not automatically restarted any tasks within the past day, reset the timestamp to now,
+		// and reset the number of auto restarted tasks to 1.
+		update = bson.M{
+			"$set": bson.M{
+				projectRefNumAutoRestartedTasksKey:   1,
+				projectRefLastAutoRestartedTaskAtKey: time.Now(),
+			},
+		}
+	}
+	return db.Update(ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, update)
 }
 
 // isActiveCronTimeRange checks that the proposed cron should activate now or

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2775,6 +2775,8 @@ type APITaskLimitsConfig struct {
 	MaxExecTimeoutSecs *int `json:"max_exec_timeout_secs"`
 	// MaxTaskExecution is the maximum task (zero based) execution number.
 	MaxTaskExecution *int `json:"max_task_execution"`
+	// MaxDailyAutomaticRestarts is the maximum number of times a project can automatically restart a task within a 24-hour period.
+	MaxDailyAutomaticRestarts *int `json:"max_daily_automatic_restarts"`
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
@@ -2791,6 +2793,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 		c.MaxParserProjectSize = utility.ToIntPtr(v.MaxParserProjectSize)
 		c.MaxExecTimeoutSecs = utility.ToIntPtr(v.MaxExecTimeoutSecs)
 		c.MaxTaskExecution = utility.ToIntPtr(v.MaxTaskExecution)
+		c.MaxDailyAutomaticRestarts = utility.ToIntPtr(v.MaxDailyAutomaticRestarts)
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -2810,6 +2813,7 @@ func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
 		MaxExecTimeoutSecs:                               utility.FromIntPtr(c.MaxExecTimeoutSecs),
 		MaxDegradedModeConcurrentLargeParserProjectTasks: utility.FromIntPtr(c.MaxDegradedModeConcurrentLargeParserProjectTasks),
 		MaxTaskExecution:                                 utility.FromIntPtr(c.MaxTaskExecution),
+		MaxDailyAutomaticRestarts:                        utility.FromIntPtr(c.MaxDailyAutomaticRestarts),
 	}, nil
 }
 

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -259,15 +259,59 @@ func TestMarkTaskForReset(t *testing.T) {
 			assert.True(t, foundTask.IsAutomaticRestart)
 			assert.Equal(t, 1, foundTask.NumAutomaticRestarts)
 		},
+		"SuccessfullyChecksMaxRestartLimit": func(ctx context.Context, t *testing.T, rh *markTaskForRestartHandler) {
+			// Should succeed normally for first task
+			rh.taskID = "t2"
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status())
+
+			foundTask, err := task.FindOneId("t2")
+			require.NoError(t, err)
+			require.NotNil(t, foundTask)
+			assert.True(t, foundTask.ResetWhenFinished)
+			assert.True(t, foundTask.IsAutomaticRestart)
+			assert.Equal(t, 1, foundTask.NumAutomaticRestarts)
+
+			// Should fail on second task since a limit is in place of 1
+			rh.taskID = "t3"
+			resp = rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusInternalServerError, resp.Status())
+			require.NotNil(t, resp.Data())
+			assert.Contains(t, resp.Data().(gimlet.ErrorResponse).Message, "project 'p1' has auto-restarted 1 out of 1 allowed tasks in the past day")
+
+			// Should succeed again if simulating >1 day passing
+			pRef := model.ProjectRef{
+				Id:                      "p1",
+				NumAutoRestartedTasks:   1,
+				LastAutoRestartedTaskAt: time.Now().Add(-25 * time.Hour),
+			}
+			require.NoError(t, pRef.Upsert())
+			rh.taskID = "t4"
+			resp = rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status())
+
+			foundTask, err = task.FindOneId("t4")
+			require.NoError(t, err)
+			require.NotNil(t, foundTask)
+			assert.True(t, foundTask.ResetWhenFinished)
+			assert.True(t, foundTask.IsAutomaticRestart)
+			assert.Equal(t, 1, foundTask.NumAutomaticRestarts)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
-
-			require.NoError(t, db.ClearCollections(task.Collection))
+			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
+			settings := &evergreen.Settings{
+				TaskLimits: evergreen.TaskLimitsConfig{
+					MaxDailyAutomaticRestarts: 1,
+				},
+			}
+			require.NoError(t, evergreen.UpdateConfig(ctx, settings))
 
 			et1 := task.Task{
 				Id:      "et1",
@@ -291,10 +335,26 @@ func TestMarkTaskForReset(t *testing.T) {
 				Project: "p1",
 				Version: "aaaaaaaaaaff001122334456",
 			}
+			t3 := task.Task{
+				Id:      "t3",
+				Project: "p1",
+				Version: "aaaaaaaaaaff001122334456",
+			}
+			t4 := task.Task{
+				Id:      "t4",
+				Project: "p1",
+				Version: "aaaaaaaaaaff001122334456",
+			}
+			pRef := model.ProjectRef{
+				Id: "p1",
+			}
+			require.NoError(t, pRef.Insert())
 			require.NoError(t, et1.Insert())
 			require.NoError(t, et2.Insert())
 			require.NoError(t, dt.Insert())
 			require.NoError(t, t2.Insert())
+			require.NoError(t, t3.Insert())
+			require.NoError(t, t4.Insert())
 			r, ok := makeMarkTaskForRestart().(*markTaskForRestartHandler)
 			require.True(t, ok)
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -643,6 +643,10 @@ Admin Settings
 										<label>Max Task Execution Number (zero based)</label>
 										<input type="number" ng-model="Settings.task_limits.max_task_execution">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>Max Daily Automatic Restarts Per Project</label>
+										<input type="number" ng-model="Settings.task_limits.max_daily_automatic_restarts">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/util/time.go
+++ b/util/time.go
@@ -1,0 +1,10 @@
+package util
+
+import "time"
+
+// TimeIsWithinLastDay indicates if the timestamp occurred within the last day.
+func TimeIsWithinLastDay(timestamp time.Time) bool {
+	now := time.Now()
+	oneDayAgo := now.Add(-1 * 24 * time.Hour)
+	return timestamp.After(oneDayAgo)
+}


### PR DESCRIPTION
DEVPROD-6589

### Description
In order to prevent overuse of the feature, this PR imposes a limit that a single project cannot restart more than X number of tasks using the `retry_on_failure` flag in a given 24 hour period. 

I verified using historical data that this limit should not get in the way of the current usage of this feature while still keeping usage conservative. Will set this to 200 as stated in the docs once this change deploys.
### Testing
Added unit tests and tested in staging