### PR TITLE
DEVPROD-11373: ensure parameters are separated by project

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1072,11 +1072,8 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *ProjectRef, isRepoRef b
 	projRef.ParameterStoreVarsSynced = true
 }
 
-// kim: TODO: manually test in staging that it creates parameter copies when:
-// - Copying project.
-// - Copying vars to another project.
-// - Promoting branch vars to repo.
-// - Detaching branch project vars from repo.
+// checkParametersNamespacedByProject checks that the parameter names for the
+// project vars all include the project ID as a prefix.
 func checkParametersNamespacedByProject(t *testing.T, vars ProjectVars) {
 	projectID := vars.Id
 	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), projectID)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1669,6 +1669,7 @@ func TestFindProjectsSuite(t *testing.T) {
 		}
 		s.NoError(vars.Insert())
 		checkAndSetProjectVarsSynced(s.T(), projectWithVars, false)
+		checkParametersNamespacedByProject(s.T(), *vars)
 
 		repoWithVars := &RepoRef{ProjectRef{
 			Id:                    repoProjectId,
@@ -1683,6 +1684,7 @@ func TestFindProjectsSuite(t *testing.T) {
 		}
 		s.NoError(repoVars.Insert())
 		checkAndSetProjectVarsSynced(s.T(), &repoWithVars.ProjectRef, true)
+		checkParametersNamespacedByProject(s.T(), *repoVars)
 
 		before := getMockProjectSettings()
 		after := getMockProjectSettings()

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -1082,6 +1082,7 @@ func (projectVars *ProjectVars) MergeWithRepoVars(repoVars *ProjectVars) {
 		return
 	}
 
+	nameToParamMapping := repoVars.Parameters.NameMap()
 	// Branch-level vars have priority, so we only need to add a repo vars if it doesn't already exist in the branch
 	for key, val := range repoVars.Vars {
 		if _, ok := projectVars.Vars[key]; !ok {
@@ -1092,8 +1093,12 @@ func (projectVars *ProjectVars) MergeWithRepoVars(repoVars *ProjectVars) {
 			if v, ok := repoVars.AdminOnlyVars[key]; ok {
 				projectVars.AdminOnlyVars[key] = v
 			}
+			if pm, ok := nameToParamMapping[key]; ok {
+				projectVars.Parameters = append(projectVars.Parameters, pm)
+			}
 		}
 	}
+	sort.Sort(projectVars.Parameters)
 }
 
 // convertVarToParam converts a project variable to its equivalent parameter


### PR DESCRIPTION
DEVPROD-11373

### Description
Some operations allow copying variables between projects. However, even if the project variable key/value is copied to a different project, Evergreen also needs to make a duplicate copy of the parameter itself. Otherwise, if the parameters weren't duplicated, two projects could end up sharing the same underlying parameter.

For example, if there's `projectA` that has one variable `my_var` stored in `/projectA/my_var` and it's copied to a new `projectB`, the variable `my_var` should be duplicated and stored in a parameter called `/projectB/my_var`. It would be a bug if copying the project resulted in `projectB` sharing the original parameter `/projectA/my_var`.

* When copying project vars between projects or when duplicating a project, ensure that the parameter is duplicated as well.
* When merging branch and repo project vars, ensure the parameter mappings include those for the branch project vars and the inherited repo project vars.

### Testing
* Tested manually in staging that using the UI to duplicate projects and the copy vars route to copy vars to a different project resulted in each project having its own separate parameters.
* Updated existing tests for project copying and added more coverage to low-level operations (`Insert`/`Upsert`/`FindAndModify`) to ensure they made copies of parameters.

### Documentation
N/A