### PR TITLE
DEVPROD-9824 Repeat patch command should work with local modules

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-10-15"
+	ClientVersion = "2024-11-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -192,8 +192,7 @@ type Patch struct {
 	// the merged patch is based off of, if applicable.
 	MergedFrom string `bson:"merged_from,omitempty"`
 	// LocalModuleIncludes is only used for CLI patches to store local module changes.
-	// Not stored in the database since the DB patch should already include changes from this module.
-	LocalModuleIncludes []LocalModuleInclude `bson:"-"`
+	LocalModuleIncludes []LocalModuleInclude `bson:"local_module_includes,omitempty"`
 	// ReferenceManifestID stores the ID of the manifest that this patch is based on.
 	// It is used to determine the module revisions for this patch during creation.
 	// This could potentially reference an invalid manifest, and should not error

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -887,6 +887,7 @@ func getLoadProjectOptsForPatch(p *patch.Patch) (*ProjectRef, *GetProjectOpts, e
 		ReadFileFrom:        ReadFromPatch,
 		Revision:            hash,
 		LocalModuleIncludes: p.LocalModuleIncludes,
+		ReferencePatchID:    p.ReferenceManifestID,
 		ReferenceManifestID: manifestID,
 		PatchOpts: &PatchOpts{
 			patch: p,

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -644,6 +644,7 @@ func processIntermediateProjectIncludes(ctx context.Context, identifier string, 
 		Identifier:          identifier,
 		UnmarshalStrict:     projectOpts.UnmarshalStrict,
 		LocalModuleIncludes: projectOpts.LocalModuleIncludes,
+		ReferencePatchID:    projectOpts.ReferencePatchID,
 		ReferenceManifestID: projectOpts.ReferenceManifestID,
 	}
 	localOpts.UpdateReadFileFrom(include.FileName)
@@ -851,7 +852,17 @@ func retrieveFile(ctx context.Context, opts GetProjectOpts) ([]byte, error) {
 }
 
 func retrieveFileForModule(ctx context.Context, opts GetProjectOpts, modules ModuleList, include parserInclude) ([]byte, error) {
-	// Check if the module has a local change passed in through the CLI
+	// Check if the module has a local change passed in through the CLI or previous patch.
+	if opts.ReferencePatchID != "" {
+		p, err := patch.FindOneId(opts.ReferencePatchID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding patch to repeat '%s'", opts.ReferencePatchID)
+		}
+		if p == nil {
+			return nil, errors.Errorf("patch to repeat '%s' not found", opts.ReferencePatchID)
+		}
+		opts.LocalModuleIncludes = p.LocalModuleIncludes
+	}
 	for _, patchedInclude := range opts.LocalModuleIncludes {
 		if patchedInclude.Module == include.Module && patchedInclude.FileName == include.FileName {
 			return patchedInclude.FileContent, nil

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -99,6 +99,7 @@ func Patch() cli.Command {
 			mutuallyExclusiveArgs(false, patchDescriptionFlagName, autoDescriptionFlag),
 			mutuallyExclusiveArgs(false, preserveCommitsFlag, uncommittedChangesFlag),
 			mutuallyExclusiveArgs(false, repeatDefinitionFlag, repeatPatchIdFlag),
+			mutuallyExclusiveArgs(false, repeatPatchIdFlag, includeModulesFlag),
 			func(c *cli.Context) error {
 				catcher := grip.NewBasicCatcher()
 				for _, status := range utility.SplitCommas(c.StringSlice(syncStatusesFlagName)) {

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -1,13 +1,3 @@
-modules:
-  - name: sandbox
-    repo: git@github.com:evergreen-ci/commit-queue-sandbox.git
-    prefix: ${workdir}/src
-    branch: bynntest
-
-include:
-  - filename: include1.yml
-    module: sandbox  
-
 command_type: test
 stepback: true
 ignore:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -1,3 +1,13 @@
+modules:
+  - name: sandbox
+    repo: git@github.com:evergreen-ci/commit-queue-sandbox.git
+    prefix: ${workdir}/src
+    branch: bynntest
+
+include:
+  - filename: include1.yml
+    module: sandbox  
+
 command_type: test
 stepback: true
 ignore:


### PR DESCRIPTION
DEVPROD-9824

### Description
we save local modules in the db so that a repeat patch call will correctly use the same changes 

### Testing
tested on staging 
made a local change on a module and created a [patch](https://spruce-staging.corp.mongodb.com/version/6723de5cd2421f0007fb96e3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) 
ran `evgs patch-file --diff-patchId 6723de5cd2421f0007fb96e3 --repeat-patch 6723de5cd2421f0007fb96e3 -f`
which created a successful [patch](https://evergreen-staging.corp.mongodb.com/version/6723e569f3450a000747d8a9?redirect_spruce_users=true) with the correct task selected 