### PR TITLE
DEVPROD-6029 Return unexpanded string in expansion error message

### DIFF
--- a/util/expand_params.go
+++ b/util/expand_params.go
@@ -65,16 +65,16 @@ func expandMap(inputMap reflect.Value, expansions *Expansions) error {
 		case reflect.String:
 			expandedValString, err := expansions.ExpandString(val.String())
 			if err != nil {
-				return errors.Wrapf(err, "expanding value '%s'", val.String())
+				return errors.Wrapf(err, "expanding value for key '%s'", key.String())
 			}
 			expandedVal = reflect.ValueOf(expandedValString)
 		case reflect.Map:
 			if err := expandMap(val, expansions); err != nil {
-				return errors.Wrapf(err, "expanding value '%s'", val.String())
+				return errors.Wrapf(err, "expanding value for key '%s'", key.String())
 			}
 			expandedVal = val
 		default:
-			return errors.Errorf("could not expand value '%s' because it is not a string, map, or struct", val.String())
+			return errors.Errorf("could not expand value for key '%s' because it is not a string, map, or struct", key.String())
 		}
 
 		// unset unexpanded key then set expanded key

--- a/util/expand_params.go
+++ b/util/expand_params.go
@@ -65,7 +65,7 @@ func expandMap(inputMap reflect.Value, expansions *Expansions) error {
 		case reflect.String:
 			expandedValString, err := expansions.ExpandString(val.String())
 			if err != nil {
-				return errors.Wrapf(err, "expanding value '%v'", val.String())
+				return errors.Wrapf(err, "expanding value '%s'", val.String())
 			}
 			expandedVal = reflect.ValueOf(expandedValString)
 		case reflect.Map:

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -74,7 +74,7 @@ func (exp *Expansions) Remove(expansion string) {
 	delete(*exp, expansion)
 }
 
-// Apply the expansions to a single string.
+// ExpandString applies the expansions to a single string.
 // Return the expanded string, or an error if the input string is malformed.
 func (exp *Expansions) ExpandString(toExpand string) (string, error) {
 	// replace all expandable parts of the string
@@ -116,7 +116,7 @@ func (exp *Expansions) ExpandString(toExpand string) (string, error) {
 		}))
 
 	if malformedFound || strings.Contains(expanded, "${") {
-		return expanded, errors.Errorf("'%s' contains an unclosed expansion", expanded)
+		return expanded, errors.Errorf("'%s' contains an unclosed expansion", toExpand)
 	}
 
 	return expanded, nil


### PR DESCRIPTION
DEVPROD-6029

### Description
When expanding a string fails, the error message may include a partially expanded string, which may leak a secret in logs. Return the unexpanded string in the error message instead.
### Testing
Existing tests
