### PR TITLE
DEVPROD-9423: create job to sync project vars to Parameter Store

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3697,6 +3697,7 @@ var psEnabledButNotSyncedQuery = bson.M{
 
 // FindProjectRefsToSync finds all project refs that have Parameter Sore enabled
 // but don't have their project variables synced to Parameter Store yet.
+// TODO (DEVPROD-11882): remove this function once the rollout is stable.
 func FindProjectRefsToSync(ctx context.Context) ([]ProjectRef, error) {
 	cur, err := evergreen.GetEnvironment().DB().Collection(ProjectRefCollection).Find(ctx, psEnabledButNotSyncedQuery)
 	if err != nil {

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -164,15 +164,7 @@ func FindOneProjectVars(projectId string) (*ProjectVars, error) {
 	defer cancel()
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
-		if !ref.ParameterStoreVarsSynced {
-			grip.Debug(message.Fields{
-				"message":     "project has Parameter Store enabled for project vars, but they're not synced; falling back to using the DB",
-				"op":          "FindOneProjectVars",
-				"project_id":  ref.Id,
-				"is_repo_ref": isRepoRef,
-				"epic":        "DEVPROD-5552",
-			})
-		} else {
+		if ref.ParameterStoreVarsSynced {
 			projectVarsFromPS, err := projectVars.findParameterStore(ctx)
 			if err != nil {
 				grip.Error(message.WrapError(err, message.Fields{

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -452,7 +452,7 @@ func (projectVars *ProjectVars) Upsert() (*adb.ChangeInfo, error) {
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
 		if !ref.ParameterStoreVarsSynced {
-			grip.Error(message.WrapError(fullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
+			grip.Error(message.WrapError(FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
 				"message":    "could not fully sync project vars into Parameter Store; falling back to using the DB",
 				"op":         "Upsert",
 				"project_id": projectVars.Id,
@@ -734,7 +734,7 @@ func (projectVars *ProjectVars) findProjectRef() (ref *ProjectRef, isRepoRef boo
 // TODO (DEVPROD-11882): remove full sync logic once the Parameter Store
 // rollout is complete. This functionality only exists to aid the migration
 // process.
-func fullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
+func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
 	before, err := FindOneProjectVars(vars.Id)
 	if err != nil {
 		return errors.Wrapf(err, "finding original project vars for project '%s'", vars.Id)
@@ -821,7 +821,7 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
 		if !ref.ParameterStoreVarsSynced {
-			grip.Error(message.WrapError(fullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
+			grip.Error(message.WrapError(FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
 				"message":    "could not fully sync project vars into Parameter Store; falling back to using the DB",
 				"op":         "FindANdModify",
 				"project_id": projectVars.Id,

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -1166,7 +1166,7 @@ func TestFullSyncToParameterStore(t *testing.T) {
 			}
 			require.NoError(t, db.Insert(ProjectVarsCollection, projVars))
 
-			require.NoError(t, fullSyncToParameterStore(ctx, &projVars, &projRef, false))
+			require.NoError(t, FullSyncToParameterStore(ctx, &projVars, &projRef, false))
 
 			checkAndSetProjectVarsSynced(t, &projRef, false)
 
@@ -1195,7 +1195,7 @@ func TestFullSyncToParameterStore(t *testing.T) {
 			}
 			require.NoError(t, db.Insert(ProjectVarsCollection, repoVars))
 
-			require.NoError(t, fullSyncToParameterStore(ctx, &repoVars, &repoRef.ProjectRef, true))
+			require.NoError(t, FullSyncToParameterStore(ctx, &repoVars, &repoRef.ProjectRef, true))
 
 			checkAndSetProjectVarsSynced(t, &repoRef.ProjectRef, true)
 
@@ -1243,7 +1243,7 @@ func TestFullSyncToParameterStore(t *testing.T) {
 				Vars: newVars,
 			}
 
-			require.NoError(t, fullSyncToParameterStore(ctx, &newProjVars, &projRef, false))
+			require.NoError(t, FullSyncToParameterStore(ctx, &newProjVars, &projRef, false))
 
 			newDBProjVars, err := FindOneProjectVars(projVars.Id)
 			require.NoError(t, err)

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -91,6 +91,7 @@ func FindRepoRefByOwnerAndRepo(owner, repoName string) (*RepoRef, error) {
 
 // FindRepoRefsToSync finds all repo refs that have Parameter Sore enabled but
 // don't have their project variables synced to Parameter Store yet.
+// TODO (DEVPROD-11882): remove this function once the rollout is stable.
 func FindRepoRefsToSync(ctx context.Context) ([]RepoRef, error) {
 	cur, err := evergreen.GetEnvironment().DB().Collection(RepoRefCollection).Find(ctx, psEnabledButNotSyncedQuery)
 	if err != nil {

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
@@ -86,6 +87,20 @@ func FindRepoRefByOwnerAndRepo(owner, repoName string) (*RepoRef, error) {
 		RepoRefOwnerKey: owner,
 		RepoRefRepoKey:  repoName,
 	}))
+}
+
+// FindRepoRefsToSync finds all repo refs that have Parameter Sore enabled but
+// don't have their project variables synced to Parameter Store yet.
+func FindRepoRefsToSync(ctx context.Context) ([]RepoRef, error) {
+	cur, err := evergreen.GetEnvironment().DB().Collection(RepoRefCollection).Find(ctx, psEnabledButNotSyncedQuery)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding repo refs to sync")
+	}
+	repoRefs := []RepoRef{}
+	if err := cur.All(ctx, &repoRefs); err != nil {
+		return nil, errors.Wrap(err, "decoding repo refs to sync")
+	}
+	return repoRefs, nil
 }
 
 // addPermissions adds the repo ref to the general scope and gives the inputted creator admin permissions

--- a/units/crons.go
+++ b/units/crons.go
@@ -1234,6 +1234,16 @@ func PopulateUnexpirableSpawnHostStatsJob() amboy.QueueOperation {
 	}
 }
 
+func sleepSchedulerJobs(ctx context.Context, env evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
+	return []amboy.Job{NewSleepSchedulerJob(env, ts.Format(TSFormat))}, nil
+}
+
+func populateParameterStoreSyncJobs() amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		return amboy.EnqueueUniqueJob(ctx, queue, NewParameterStoreSyncJob(utility.RoundPartOfMinute(0).Format(TSFormat)))
+	}
+}
+
 func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGroupName string, factory cronJobFactory, ts time.Time) error {
 	appCtx, _ := env.Context()
 	queueGroup, err := env.RemoteQueueGroup().Get(appCtx, queueGroupName)
@@ -1246,8 +1256,4 @@ func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGro
 	}
 
 	return errors.Wrapf(amboy.EnqueueManyUniqueJobs(ctx, queueGroup, jobs), "populating '%s' queue", queueGroupName)
-}
-
-func sleepSchedulerJobs(ctx context.Context, env evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
-	return []amboy.Job{NewSleepSchedulerJob(env, ts.Format(TSFormat))}, nil
 }

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -51,6 +51,7 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 		PopulateActivationJobs(10),
 		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateHostRestartJasperJobs(j.env),
+		populateParameterStoreSyncJobs(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -40,6 +40,7 @@ func makeParameterStoreSyncJob() *parameterStoreSyncJob {
 // NewParameterStoreSyncJob creates a job that syncs project variables to SSM
 // Parameter Store for any branch project or repo ref that has Parameter Store
 // enabled but whose vars are not already in sync.
+// TODO (DEVPROD-11882): remove this job once the rollout is stable.
 func NewParameterStoreSyncJob(ts string) amboy.Job {
 	j := makeParameterStoreSyncJob()
 	j.SetID(fmt.Sprintf("%s.%s", parameterStoreSyncJobName, ts))

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -1,0 +1,96 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+const (
+	parameterStoreSyncJobName = "parameter-store-sync"
+)
+
+func init() {
+	registry.AddJobType(parameterStoreSyncJobName, func() amboy.Job { return makeParameterStoreSyncJob() })
+}
+
+type parameterStoreSyncJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+}
+
+func makeParameterStoreSyncJob() *parameterStoreSyncJob {
+	j := &parameterStoreSyncJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    parameterStoreSyncJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewParameterStoreSyncJob creates a job that syncs project variables to SSM
+// Parameter Store for any branch project or repo ref that has Parameter Store
+// enabled but whose vars are not already in sync.
+func NewParameterStoreSyncJob(ts string) amboy.Job {
+	j := makeParameterStoreSyncJob()
+	j.SetID(fmt.Sprintf("%s.%s", parameterStoreSyncJobName, ts))
+	j.SetScopes([]string{parameterStoreSyncJobName})
+	j.SetEnqueueAllScopes(true)
+	return j
+}
+
+func (j *parameterStoreSyncJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "getting service flags to check if Parameter Store is enabled"))
+		return
+	}
+	if flags.ParameterStoreDisabled {
+		return
+	}
+
+	pRefs, err := model.FindProjectRefsToSync(ctx)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "finding project refs to sync"))
+		return
+	}
+	j.AddError(errors.Wrap(j.sync(ctx, pRefs, false), "syncing project variables for branch project refs"))
+
+	repoRefs, err := model.FindRepoRefsToSync(ctx)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "finding repo refs to sync"))
+		return
+	}
+
+	repoProjRefs := make([]model.ProjectRef, 0, len(repoRefs))
+	for _, repoRef := range repoRefs {
+		repoProjRefs = append(repoProjRefs, repoRef.ProjectRef)
+	}
+	j.AddError(errors.Wrap(j.sync(ctx, repoProjRefs, true), "syncing project variables for repo refs"))
+}
+
+func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectRef, areRepoRefs bool) error {
+	catcher := grip.NewBasicCatcher()
+	for _, pRef := range pRefs {
+		pVars, err := model.FindOneProjectVars(pRef.Id)
+		if err != nil {
+			catcher.Wrapf(err, "finding project vars for project '%s'", pRef.Id)
+			continue
+		}
+		if err := model.FullSyncToParameterStore(ctx, pVars, &pRef, areRepoRefs); err != nil {
+			catcher.Wrapf(err, "syncing project vars for project '%s'", pRef.Id)
+		}
+	}
+	return catcher.Resolve()
+}


### PR DESCRIPTION
DEVPROD-11187

### Description
Project vars can use Parameter Store now, but they need to be migrated into Parameter Store first. This temporary job aids the migration by automatically syncing the project vars into Parameter Store whenever it detects that a project has Parameter Store enabled but its vars are not in sync.

### Testing
Tested it on a branch project and repo project in staging, and it synced their vars as expected.

### Documentation
N/A
