### PR TITLE
DEVPROD-8030 use shared db for distros

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -126,7 +126,7 @@ func Find(ctx context.Context, query bson.M, options ...*options.FindOptions) ([
 
 // Insert writes the distro to the database.
 func (d *Distro) Insert(ctx context.Context) error {
-	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertOne(ctx, d)
+	_, err := distroDB().Collection(Collection).InsertOne(ctx, d)
 	return errors.Wrap(err, "inserting distro")
 }
 


### PR DESCRIPTION
[DEVPROD-8030](https://jira.mongodb.org/browse/DEVPROD-8030)

### Description
When we all have our own staging it'll be good to have one place to configure distros (since they're likely to change often)

### Testing
We won't know for sure if it works until the other pieces are in place. DIdn't break staging, fwiw.
