### PR TITLE
DEVPROD-12635 remove mac build for staging

### DIFF
--- a/makefile
+++ b/makefile
@@ -81,7 +81,7 @@ goarch := $(shell $(gobin) env GOARCH 2> /dev/null)
 endif
 
 clientBuildDir := clients
-macOSPlatforms := darwin_amd64 $(if $(STAGING_ONLY),,darwin_arm64)
+macOSPlatforms := $(if $(STAGING_ONLY),,darwin_amd64 darwin_arm64)
 linuxPlatforms := linux_amd64 $(if $(STAGING_ONLY),,linux_s390x linux_arm64 linux_ppc64le)
 windowsPlatforms := windows_amd64
 unixBinaryBasename := evergreen
@@ -130,7 +130,6 @@ build-darwin_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename) $(clientBuildDi
 
 build-linux-staging_%: $(clientBuildDir)/linux_%/$(unixBinaryBasename);
 build-windows-staging_%: $(clientBuildDir)/windows_%/$(windowsBinaryBasename);
-build-darwin-staging_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename) $(clientBuildDir)/darwin_%/.signed;
 
 build-darwin-unsigned_%: $(clientBuildDir)/darwin_%/$(unixBinaryBasename);
 

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -770,9 +770,6 @@ tasks:
   - <<: *build-and-push-client
     name: build-windows-staging_amd64
     tags: ["build-staging"]
-  - <<: *build-and-push-client
-    name: build-darwin-staging_amd64
-    tags: ["build-staging"]
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets-staging
     tags: ["build-staging"]


### PR DESCRIPTION
[DEVPROD-12635](https://jira.mongodb.org/browse/DEVPROD-12635)

### Description
There is no longer a mac host in staging. We should remove the macOS build for staging. This will help the most for when you build in Evergreen with the build-and-push-staging task (because signing could take a while), but should make the local build 33% faster too.

### Testing
The local build (`STAGING_ONLY=1 make local`) didn't include a macOS build and neither did [the build-and-push-staging task](https://spruce.mongodb.com/version/672bd7f9cab18c00071f8e85/tasks).

