### PR TITLE
DEVPROD-9423: initialize skeleton project vars when they do not exist

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -489,7 +489,7 @@ func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) error 
 		return errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
 	}
 	if before == nil {
-		before = &ProjectVars{}
+		before = &ProjectVars{Id: projectID}
 	}
 
 	varsToUpsert, varsToDelete := getProjectVarsDiff(before, after)
@@ -732,7 +732,7 @@ func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *Proj
 		return errors.Wrapf(err, "finding original project vars for project '%s'", vars.Id)
 	}
 	if before == nil {
-		before = &ProjectVars{}
+		before = &ProjectVars{Id: vars.Id}
 	}
 
 	grip.Debug(message.Fields{
@@ -788,7 +788,7 @@ func (projectVars *ProjectVars) Insert() error {
 
 // insertParameterStore inserts all project variables into Parameter Store.
 func insertParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
-	before := &ProjectVars{}
+	before := &ProjectVars{Id: vars.Id}
 	after := vars
 	varsToUpsert, _ := getProjectVarsDiff(before, after)
 
@@ -883,7 +883,7 @@ func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context,
 		return errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
 	}
 	if before == nil {
-		before = &ProjectVars{}
+		before = &ProjectVars{Id: projectID}
 	}
 
 	// Ignore the vars that are deleted between before and after because


### PR DESCRIPTION
DEVPROD-9423

### Description
Small fix that I caught while migrating all the projects in staging over to Parameter Store - apparently, some very old projects don't have an associated project vars doc (newer ones always appear to have corresponding project vars, even if it's empty).

* Handle nonexistent project vars for Parameter Store sync project.
* When comparing updated project vars against project vars that don't exist currently, ensure skeleton project vars are initialized with the project ID - this isn't actually necessary for correctness right now, but I have a sense that this is an easy way to prevent bugs in the future if someone assumes the before vars have a project ID set. 

### Testing
Tested in staging.

### Documentation
N/A
