### PR TITLE
DEVPROD-12086 Persist whether task's dependencies are met to queue items

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-11-04-ab"
+	AgentVersion = "2024-11-11"
 )
 
 const (

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -770,7 +770,7 @@ func (t *Task) RemoveDependency(dependencyId string) error {
 // used to check rather than fetching from the database. All queries
 // are cached back into the map for later use.
 func (t *Task) DependenciesMet(depCaches map[string]Task) (bool, error) {
-	if len(t.DependsOn) == 0 || t.OverrideDependencies || !utility.IsZeroTime(t.DependenciesMetTime) {
+	if t.HasDependenciesMet() {
 		return true, nil
 	}
 
@@ -3418,6 +3418,11 @@ func FindHostSchedulableForAlias(ctx context.Context, id string) ([]Task, error)
 
 func (t *Task) IsPartOfSingleHostTaskGroup() bool {
 	return t.TaskGroup != "" && t.TaskGroupMaxHosts == 1
+}
+
+// HasDependenciesMet indicates whether the task has had its dependencies met.
+func (t *Task) HasDependenciesMet() bool {
+	return len(t.DependsOn) == 0 || t.OverrideDependencies || !utility.IsZeroTime(t.DependenciesMetTime)
 }
 
 // HasCheckRun retruns true if the task specifies a check run path.

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -115,6 +115,7 @@ type TaskQueueItem struct {
 	Priority            int64         `bson:"priority" json:"priority"`
 	PriorityRankValue   int64         `bson:"priority_rank_value" json:"priority_rank_value"`
 	Dependencies        []string      `bson:"dependencies" json:"dependencies"`
+	DependenciesMet     bool          `bson:"dependencies_met" json:"dependencies_met"`
 	ActivatedBy         string        `bson:"activated_by" json:"activated_by"`
 }
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -388,6 +388,13 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// validate that the task can be run, if not fetch the next one in the queue.
 		if !nextTask.IsHostDispatchable() {
+			grip.Debug(message.WrapError(err, message.Fields{
+				"investigation": "DEVPROD-12086",
+				"message":       "task was not dispatchable",
+				"task":          nextTask.Id,
+				"variant":       nextTask.BuildVariant,
+				"project":       nextTask.Project,
+			}))
 			// Dequeue the task so we don't get it on another iteration of the loop.
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":   "nextTask.IsHostDispatchable() is false, but there was an issue dequeuing the task",
@@ -532,6 +539,13 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		}))
 
 		if !dispatchedTask {
+			grip.Debug(message.WrapError(err, message.Fields{
+				"investigation": "DEVPROD-12086",
+				"message":       "task was not dispatched",
+				"task":          nextTask.Id,
+				"variant":       nextTask.BuildVariant,
+				"project":       nextTask.Project,
+			}))
 			continue
 		}
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -388,13 +388,13 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// validate that the task can be run, if not fetch the next one in the queue.
 		if !nextTask.IsHostDispatchable() {
-			grip.Debug(message.WrapError(err, message.Fields{
+			grip.Debug(message.Fields{
 				"investigation": "DEVPROD-12086",
 				"message":       "task was not dispatchable",
 				"task":          nextTask.Id,
 				"variant":       nextTask.BuildVariant,
 				"project":       nextTask.Project,
-			}))
+			})
 			// Dequeue the task so we don't get it on another iteration of the loop.
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":   "nextTask.IsHostDispatchable() is false, but there was an issue dequeuing the task",

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -578,9 +578,9 @@ func TestHostNextTask(t *testing.T) {
 			tq := &model.TaskQueue{
 				Distro: distroID,
 				Queue: []model.TaskQueueItem{
-					{Id: "task1"},
-					{Id: "task2"},
-					{Id: "task3"},
+					{Id: "task1", DependenciesMet: true},
+					{Id: "task2", DependenciesMet: true},
+					{Id: "task3", DependenciesMet: true},
 				},
 			}
 
@@ -1133,7 +1133,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Equal(t, "", h.RunningTask)
 		},
 		"an invalid task in a task queue should skip it and noop": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
-			d.Tq3.Queue = append([]model.TaskQueueItem{{Id: "invalid"}}, d.Tq3.Queue...)
+			d.Tq3.Queue = append([]model.TaskQueueItem{{Id: "invalid", DependenciesMet: true}}, d.Tq3.Queue...)
 			require.NoError(t, d.Tq3.Save())
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)
@@ -1411,7 +1411,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 				Status: evergreen.HostRunning,
 			}
 			require.NoError(t, extraHost.Insert(ctx))
-			d.Tq1.Queue = append(d.Tq1.Queue, model.TaskQueueItem{Id: "tg1-task3"})
+			d.Tq1.Queue = append(d.Tq1.Queue, model.TaskQueueItem{Id: "tg1-task3", DependenciesMet: true})
 			d.Tq1.DistroQueueInfo = model.DistroQueueInfo{
 				Length:         3,
 				TaskGroupInfos: []model.TaskGroupInfo{{Name: "task-group-1", Count: 3}},
@@ -1642,8 +1642,8 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			data.Tq1 = &model.TaskQueue{
 				Distro: data.Distro1.Id,
 				Queue: []model.TaskQueueItem{
-					{Id: data.Tg1Task1.Id},
-					{Id: data.Tg1Task2.Id},
+					{Id: data.Tg1Task1.Id, DependenciesMet: true},
+					{Id: data.Tg1Task2.Id, DependenciesMet: true},
 				},
 				DistroQueueInfo: model.DistroQueueInfo{
 					Length:         2,
@@ -1706,10 +1706,10 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			data.Tq2 = &model.TaskQueue{
 				Distro: data.Distro2.Id,
 				Queue: []model.TaskQueueItem{
-					{Id: data.Tg2Task1.Id},
-					{Id: data.Task1.Id},
-					{Id: data.Task2.Id},
-					{Id: data.Tg2Task2.Id},
+					{Id: data.Tg2Task1.Id, DependenciesMet: true},
+					{Id: data.Task1.Id, DependenciesMet: true},
+					{Id: data.Task2.Id, DependenciesMet: true},
+					{Id: data.Tg2Task2.Id, DependenciesMet: false},
 				},
 				DistroQueueInfo: model.DistroQueueInfo{
 					Length:         4,
@@ -1742,8 +1742,8 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			data.Tq3 = &model.TaskQueue{
 				Distro: data.Distro3.Id,
 				Queue: []model.TaskQueueItem{
-					{Id: data.Task3.Id},
-					{Id: data.Task4.Id},
+					{Id: data.Task3.Id, DependenciesMet: true},
+					{Id: data.Task4.Id, DependenciesMet: true},
 				},
 				DistroQueueInfo: model.DistroQueueInfo{
 					Length:         2,

--- a/scheduler/task_queue_persister.go
+++ b/scheduler/task_queue_persister.go
@@ -36,6 +36,7 @@ func PersistTaskQueue(distro string, tasks []task.Task, distroQueueInfo model.Di
 			Version:             t.Version,
 			ActivatedBy:         t.ActivatedBy,
 			Dependencies:        dependencies,
+			DependenciesMet:     t.HasDependenciesMet(),
 		})
 	}
 


### PR DESCRIPTION
DEVPROD-12086

### Description
This PR is a re-staging of the changes from #8428 with the following additional fixes:

- Change `getTaskGroup` to return **both** `ok` and `hasDispatchableTask`. There was an issue in the previous PR where SHTG tasks were incorrectly skipped for dispatch because their cached  `DependenciesMet` field was still false, b                       the `DependenciesMet` field refreshes every 15 seconds, which means for SHTGs, the field may not have accurately been updated by the time a host requests a subsequent group task to run.
 We need both parameters because if a host just ran a SHTG task, we can assume that it's likely the case that the next task in the group can be run, since the host just ran its parent dependency. 
- Move the marking of a TG task as dispatched [here](https://github.com/evergreen-ci/evergreen/pull/8474/commits/f749d3db482913d35c7296efa953d023608eeaa2#diff-b843eb16a854431304da1fbc4589faa91d2464dcc0911a02993da858307b6242R664), because there is a failure mode for SHTG tasks that are last in their group: they get marked dispatched, but if [this code](https://github.com/evergreen-ci/evergreen/blob/main/model/task_queue_service_dependency.go#L611-L639) hits, the group will not be deleted from memory. This makes the task inaccessible for all subsequent requests on that app server (because it will be [skipped](https://github.com/evergreen-ci/evergreen/blob/main/model/task_queue_service_dependency.go#L583)) until the cache refreshes.

### Testing
I re-performed the testing section from #8428 to confirm that I can reproduce slow latency from a large dummy MMS version on HEAD, and that the latency was gone with these changes.

Additionally, I configured a [patch](https://spruce-staging.corp.mongodb.com/version/673281189e918d000defd9e6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) to run ~350 SHTG tasks on the same distro, and added logging to determine if the setup group was incorrectly run by tasks that were not the first in their group. Interestingly, even on our current HEAD, [several tasks](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%22ran%20setup%20group%22%7C%20spath%20order%20%7C%20search%20order!%3D1&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1731382680&latest=1731383040&sid=1731442938.4055254) incorrectly ran their setup group out of order, signifying that TG dispatching is vulnerable to races currently.

I re-deployed the changes from #8428 and confirmed it significantly [exacerbated](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20%22ran%20setup%20group%22%7C%20spath%20order%20%7C%20search%20order!%3D1&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1731383340&latest=1731383940&sid=1731443036.4055463) the issue of tasks running their setup group out of order which would explain why it had to be reverted.

Finally, with the changes in this PR, I confirmed that there were no results in Splunk for tasks running setup group out of order, so (hopefully) this PR will not just fix the issue that required #8428 to revert, but will also generally make TG dispatching more resilient to races.
