### PR TITLE
DEVPROD-12713: do not allow empty project variable values

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -1105,6 +1105,9 @@ func convertVarToParam(projectID string, pm ParameterMappings, varName, varValue
 	if err := validateVarNameCharset(varName); err != nil {
 		return "", "", errors.Wrapf(err, "validating project variable name '%s'", varName)
 	}
+	if len(varValue) == 0 {
+		return "", "", errors.Errorf("project variable '%s' cannot have an empty value", varName)
+	}
 
 	varsToParams := pm.NameMap()
 	m, ok := varsToParams[varName]

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -764,16 +764,6 @@ func TestConvertVarToParam(t *testing.T) {
 		assert.Equal(t, "project_id/var_name", paramName, "new parameter name should include project ID prefix")
 		assert.Equal(t, varValue, paramValue, "variable value is valid and should be unchanged")
 	})
-	t.Run("ReturnsNewParamNameAndEmptyValueForValidVarNameAndValue", func(t *testing.T) {
-		const (
-			varName  = "var_name"
-			varValue = ""
-		)
-		paramName, paramValue, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
-		require.NoError(t, err)
-		assert.Equal(t, "project_id/var_name", paramName, "new parameter name should include project ID prefix")
-		assert.Equal(t, varValue, paramValue, "variable value is empty, which is valid, so parameter value should also be empty")
-	})
 	t.Run("ReturnsValidParamNameForVarContainingDisallowedAWSPrefix", func(t *testing.T) {
 		const (
 			varName  = "aws_secret"
@@ -862,6 +852,14 @@ func TestConvertVarToParam(t *testing.T) {
 		)
 		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
 		assert.Error(t, err, "should not allow variable with empty name")
+	})
+	t.Run("ReturnsErrorForEmptyVariableValue", func(t *testing.T) {
+		const (
+			varName  = "var_name"
+			varValue = ""
+		)
+		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		assert.Error(t, err, "should not allow variable with empty value")
 	})
 	t.Run("ReturnsErrorForVariableNameEndingInGzipExtension", func(t *testing.T) {
 		const (


### PR DESCRIPTION
DEVPROD-12713

### Description
Error out early if trying to set a project variable to an empty string value. Parameter Store requires parameter values to be non-empty, and the Evergreen UI/REST API currently do not let users set empty project variables either.

### Testing
Updated unit tests.

### Documentation
N/A
