### PR TITLE
DEVPROD-11826: redact GitHub app auth from project event log

### DIFF
--- a/graphql/tests/query/projectEvents/results.json
+++ b/graphql/tests/query/projectEvents/results.json
@@ -61,7 +61,7 @@
                   },
                   "githubAppAuth": {
                     "appId": 11111,
-                    "privateKey": "{REDACTED}"
+                    "privateKey": ""
                   },
                   "githubWebhooksEnabled": false
                 },
@@ -71,7 +71,7 @@
                   },
                   "githubAppAuth": {
                     "appId": 11111,
-                    "privateKey": "{REDACTED}"
+                    "privateKey": ""
                   },
                   "githubWebhooksEnabled": false
                 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -52,10 +52,6 @@ func (e *ProjectChangeEvent) RedactSecrets() {
 	modifiedVarKeys := e.getModifiedProjectVars()
 	e.Before.Vars.Vars = getRedactedVarsCopy(e.Before.Vars.Vars, modifiedVarKeys, evergreen.RedactedBeforeValue)
 	e.After.Vars.Vars = getRedactedVarsCopy(e.After.Vars.Vars, modifiedVarKeys, evergreen.RedactedAfterValue)
-	// kim: TODO: add test
-	// kim: TODO: test in staging
-	// kim: TODO: make sure that deleting and then re-adding the app with
-	// different credentials produces an event log change.
 	e.Before.GitHubAppAuth = getRedactedGitHubAppCopy(e.Before.GitHubAppAuth, evergreen.RedactedValue)
 	e.After.GitHubAppAuth = getRedactedGitHubAppCopy(e.After.GitHubAppAuth, evergreen.RedactedValue)
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -215,20 +215,11 @@ func (p *ProjectChangeEvents) RedactGitHubPrivateKey() {
 // are migrated to not store any project var values or GitHub app credentials.
 // Project change events should already redact those secret values when the log
 // is inserted into the DB (see (ProjectChangeEvent).RedactSecrets).
-func (p *ProjectChangeEvents) RedactSecrets(read bool) {
+func (p *ProjectChangeEvents) RedactSecrets() {
 	for _, event := range *p {
 		changeEvent, isChangeEvent := event.Data.(*ProjectChangeEvent)
 		if !isChangeEvent {
 			continue
-		}
-		if read {
-			grip.Debug(message.Fields{
-				"message":            "kim: read GH app creds from DB",
-				"before_private_key": string(changeEvent.Before.GitHubAppAuth.PrivateKey),
-				"before_app_id":      changeEvent.Before.GitHubAppAuth.AppID,
-				"after_private_key":  string(changeEvent.After.GitHubAppAuth.PrivateKey),
-				"after_app_id":       changeEvent.After.GitHubAppAuth.AppID,
-			})
 		}
 		changeEvent.RedactSecrets()
 		event.EventLogEntry.Data = changeEvent

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -117,6 +117,8 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 	after.Vars.Vars["added"] = "added_value"
 	after.Vars.Vars["modified"] = "new_value"
 	after.Vars.Vars["unmodified"] = "same_value"
+	after.GitHubAppAuth.AppID = 12345
+	after.GitHubAppAuth.PrivateKey = []byte("secret")
 
 	s.NoError(LogProjectModified(projectId, username, &before, &after))
 
@@ -144,6 +146,8 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 	s.Equal(evergreen.RedactedBeforeValue, eventData.Before.Vars.Vars["modified"], "modified var should be redacted")
 	s.Empty(eventData.Before.Vars.Vars["unmodified"], "unmodified var should be present but empty to indicate it wasn't changed")
 	s.Equal(before.Aliases, eventData.Before.Aliases)
+	s.Equal(after.GitHubAppAuth.AppID, eventData.After.GitHubAppAuth.AppID)
+	s.Equal(evergreen.RedactedValue, string(eventData.After.GitHubAppAuth.PrivateKey))
 	s.Equal(before.Subscriptions, eventData.Before.Subscriptions)
 
 	s.Equal(after.ProjectRef.Owner, eventData.After.ProjectRef.Owner)

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -145,9 +145,9 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 	s.Equal(evergreen.RedactedBeforeValue, eventData.Before.Vars.Vars["deleted"], "deleted var should be redacted")
 	s.Equal(evergreen.RedactedBeforeValue, eventData.Before.Vars.Vars["modified"], "modified var should be redacted")
 	s.Empty(eventData.Before.Vars.Vars["unmodified"], "unmodified var should be present but empty to indicate it wasn't changed")
+	s.Empty(eventData.Before.GitHubAppAuth.AppID)
+	s.Empty(eventData.Before.GitHubAppAuth.PrivateKey)
 	s.Equal(before.Aliases, eventData.Before.Aliases)
-	s.Equal(after.GitHubAppAuth.AppID, eventData.After.GitHubAppAuth.AppID)
-	s.Equal(evergreen.RedactedValue, string(eventData.After.GitHubAppAuth.PrivateKey))
 	s.Equal(before.Subscriptions, eventData.Before.Subscriptions)
 
 	s.Equal(after.ProjectRef.Owner, eventData.After.ProjectRef.Owner)
@@ -162,6 +162,8 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 	s.Equal(evergreen.RedactedAfterValue, eventData.After.Vars.Vars["added"], "newly-added var should be redacted")
 	s.Equal(evergreen.RedactedAfterValue, eventData.After.Vars.Vars["modified"], "modified var should be redacted")
 	s.Empty(eventData.After.Vars.Vars["unmodified"], "unmodified var should be present but empty to indicate it wasn't changed")
+	s.Equal(after.GitHubAppAuth.AppID, eventData.After.GitHubAppAuth.AppID)
+	s.Equal(evergreen.RedactedAfterValue, string(eventData.After.GitHubAppAuth.PrivateKey))
 	s.Equal(after.Aliases, eventData.After.Aliases)
 	s.Equal(after.Subscriptions, eventData.After.Subscriptions)
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -356,7 +356,7 @@ func GetEventsById(id string, before time.Time, n int) ([]restModel.APIProjectEv
 		return nil, err
 	}
 	events.RedactGitHubPrivateKey()
-	events.RedactVars()
+	events.RedactSecrets(true)
 	events.ApplyDefaults()
 
 	out := []restModel.APIProjectEvent{}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -356,7 +356,7 @@ func GetEventsById(id string, before time.Time, n int) ([]restModel.APIProjectEv
 		return nil, err
 	}
 	events.RedactGitHubPrivateKey()
-	events.RedactSecrets(true)
+	events.RedactSecrets()
 	events.ApplyDefaults()
 
 	out := []restModel.APIProjectEvent{}

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -225,8 +225,8 @@ func (s *ProjectConnectorGetSuite) TestGetProjectEvents() {
 		s.Equal(evergreen.RedactedAfterValue, eventLog.After.Vars.Vars["hello"])
 		s.Equal(evergreen.RedactedBeforeValue, eventLog.Before.Vars.Vars["world"])
 		s.Equal(evergreen.RedactedAfterValue, eventLog.After.Vars.Vars["world"])
-		s.Equal(utility.FromStringPtr(eventLog.Before.GithubAppAuth.PrivateKey), "")
-		s.Equal(utility.FromStringPtr(eventLog.After.GithubAppAuth.PrivateKey), evergreen.RedactedValue)
+		s.Empty(utility.FromStringPtr(eventLog.Before.GithubAppAuth.PrivateKey))
+		s.Equal(evergreen.RedactedAfterValue, utility.FromStringPtr(eventLog.After.GithubAppAuth.PrivateKey))
 	}
 
 	// No error for empty events

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -187,29 +187,9 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 		s.NotEmpty(before.Aliases[0].ID)
 		s.NotEmpty(after.Aliases[0].ID)
 
-		data := model.ProjectChangeEvent{
-			User: username,
-			Before: model.ProjectSettingsEvent{
-				PeriodicBuildsDefault:      true,
-				WorkstationCommandsDefault: true,
-				ProjectSettings:            before,
-			},
-			After: model.ProjectSettingsEvent{
-				ProjectSettings: after,
-			},
-		}
-		h := event.EventLogEntry{
-			Timestamp:    time.Now(),
-			ResourceType: event.EventResourceTypeProject,
-			EventType:    event.EventTypeProjectModified,
-			ResourceId:   projectId,
-			Data:         data,
-		}
-
 		s.Require().NoError(db.ClearCollections(event.EventCollection))
 		for i := 0; i < projEventCount; i++ {
-			eventShallowCpy := h
-			s.NoError(eventShallowCpy.Log())
+			s.NoError(model.LogProjectModified(projectId, username, &before, &after))
 		}
 
 		return nil

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -81,7 +81,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		var loggedProjectEvents model.ProjectChangeEvents
 		loggedProjectEvents, err = model.MostRecentProjectEvents(resourceID, 200)
-		loggedProjectEvents.RedactSecrets(false)
+		loggedProjectEvents.RedactSecrets()
 		loggedProjectEvents.RedactGitHubPrivateKey()
 		for _, event := range loggedProjectEvents {
 			loggedEvents = append(loggedEvents, event.EventLogEntry)

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -81,7 +81,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		var loggedProjectEvents model.ProjectChangeEvents
 		loggedProjectEvents, err = model.MostRecentProjectEvents(resourceID, 200)
-		loggedProjectEvents.RedactVars()
+		loggedProjectEvents.RedactSecrets(false)
 		loggedProjectEvents.RedactGitHubPrivateKey()
 		for _, event := range loggedProjectEvents {
 			loggedEvents = append(loggedEvents, event.EventLogEntry)


### PR DESCRIPTION
DEVPROD-11826

### Description
When storing a project event in the DB, replace the project's GitHub app private key with a `{REDACTED_BEFORE}`/`{REDACTED_AFTER}` placeholder to prevent it from appearing in plaintext in the DB.

### Testing
* Tested adding/deleting GitHub app credentials in staging.
* Updated unit tests.

### Documentation
N/A