### PR TITLE
DEVPROD-12217: make Parameter Store updates atomic

### DIFF
--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -19,6 +19,9 @@ type GithubAppAuth struct {
 
 	AppID      int64  `bson:"app_id" json:"app_id"`
 	PrivateKey []byte `bson:"private_key" json:"private_key"`
+	// PrivateKeyParameter is the name of the parameter that holds the
+	// GitHub app's private key.
+	PrivateKeyParameter string `bson:"private_key_parameter" json:"private_key_parameter"`
 }
 
 // CreateGitHubAppAuth returns the Evergreen-internal app id and app private key

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,6 +148,11 @@ type ProjectRef struct {
 	// project's variables have been synced to Parameter Store. If this is true,
 	// then the project variables can all be found in Parameter Store.
 	ParameterStoreVarsSynced bool `bson:"parameter_store_vars_synced,omitempty" json:"parameter_store_vars_synced,omitempty" yaml:"parameter_store_vars_synced,omitempty"`
+	// ParameterStoreGitHubAppSynced is a temporary flag that indicates whether
+	// the project's GitHub app's private key have been synced to Parameter
+	// Store. If this is true, then the project's GitHub app private key can be
+	// found in Parameter Store.
+	ParameterStoreGitHubAppSynced bool `bson:"parameter_store_github_app_synced,omitempty" json:"parameter_store_github_app_synced,omitempty" yaml:"parameter_store_github_app_synced,omitempty"`
 	// LastAutoRestartedTaskAt is the last timestamp that a task in this project was restarted automatically.
 	LastAutoRestartedTaskAt time.Time `bson:"last_auto_restarted_task_at"`
 	// NumAutoRestartedTasks is the number of tasks this project has restarted automatically in the past 24-hour period.

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -473,17 +473,13 @@ func (projectVars *ProjectVars) Upsert() (*adb.ChangeInfo, error) {
 		privateVarsMapKey:   projectVars.PrivateVars,
 		adminOnlyVarsMapKey: projectVars.AdminOnlyVars,
 	}
-	unsetUpdate := bson.M{}
 	update := bson.M{}
 	if len(projectVars.Parameters) > 0 {
 		setUpdate[projectVarsParametersKey] = projectVars.Parameters
 	} else {
-		unsetUpdate[projectVarsParametersKey] = 1
+		update["$unset"] = bson.M{projectVarsParametersKey: 1}
 	}
 	update["$set"] = setUpdate
-	if len(unsetUpdate) > 0 {
-		update["$unset"] = unsetUpdate
-	}
 
 	return db.Upsert(
 		ProjectVarsCollection,
@@ -798,14 +794,10 @@ func (projectVars *ProjectVars) Insert() error {
 		}
 	}, "Insert")
 
-	if err := db.Insert(
+	return db.Insert(
 		ProjectVarsCollection,
 		projectVars,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 // insertParameterStore inserts all project variables into Parameter Store.

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -536,37 +536,33 @@ func (projectVars *ProjectVars) syncParameterDiff(ctx context.Context, pm Parame
 	}
 
 	updatedParamMappings := getUpdatedParamMappings(pm, paramMappingsToUpsert, paramMappingsToDelete)
-	//
-	// // kim: TODO: return param mappings rather than upsert.
-	// if err := projectVars.setParamMappings(updatedParamMappings); err != nil {
-	//     return nil, errors.Wrap(err, "updating parameter mappings for project vars")
-	// }
 
 	return &updatedParamMappings, nil
 }
 
-// kim: TODO: remove once absorbed into atomic DB ops
-// func (projectVars *ProjectVars) setParamMappings(pm ParameterMappings) error {
-//     update := bson.M{}
-//     if len(pm) == 0 {
-//         update["$unset"] = bson.M{projectVarsParametersKey: 1}
-//     } else {
-//         update["$set"] = bson.M{projectVarsParametersKey: pm}
-//     }
-//     if _, err := db.Upsert(
-//         ProjectVarsCollection,
-//         bson.M{
-//             projectVarIdKey: projectVars.Id,
-//         },
-//         update,
-//     ); err != nil {
-//         return errors.Wrap(err, "updating parameter mappings for project vars")
-//     }
-//
-//     projectVars.Parameters = pm
-//
-//     return nil
-// }
+// SetParamMappings sets the parameter mappings for project variables.
+// TODO (DEVPROD-11882): remove this function once the rollout is stable.
+func (projectVars *ProjectVars) SetParamMappings(pm ParameterMappings) error {
+	update := bson.M{}
+	if len(pm) == 0 {
+		update["$unset"] = bson.M{projectVarsParametersKey: 1}
+	} else {
+		update["$set"] = bson.M{projectVarsParametersKey: pm}
+	}
+	if _, err := db.Upsert(
+		ProjectVarsCollection,
+		bson.M{
+			projectVarIdKey: projectVars.Id,
+		},
+		update,
+	); err != nil {
+		return errors.Wrap(err, "updating parameter mappings for project vars")
+	}
+
+	projectVars.Parameters = pm
+
+	return nil
+}
 
 // upsertParameters upserts the parameter mappings for project variables into
 // Parameter Store. It returns the parameter mappings for the upserted

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -444,34 +444,53 @@ func (projectVars *ProjectVars) Upsert() (*adb.ChangeInfo, error) {
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
 		if !ref.ParameterStoreVarsSynced {
-			grip.Error(message.WrapError(FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
+			pm, err := FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef)
+			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not fully sync project vars into Parameter Store; falling back to using the DB",
 				"op":         "Upsert",
 				"project_id": projectVars.Id,
 				"epic":       "DEVPROD-5552",
 			}))
+			if pm != nil {
+				projectVars.Parameters = *pm
+			}
 		} else {
-			grip.Error(message.WrapError(projectVars.upsertParameterStore(ctx), message.Fields{
+			pm, err := projectVars.upsertParameterStore(ctx)
+			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not upsert project vars into Parameter Store; falling back to using the DB",
 				"op":         "Upsert",
 				"project_id": projectVars.Id,
 				"epic":       "DEVPROD-5552",
 			}))
+			if pm != nil {
+				projectVars.Parameters = *pm
+			}
 		}
 	}, "Upsert")
+
+	setUpdate := bson.M{
+		projectVarsMapKey:   projectVars.Vars,
+		privateVarsMapKey:   projectVars.PrivateVars,
+		adminOnlyVarsMapKey: projectVars.AdminOnlyVars,
+	}
+	unsetUpdate := bson.M{}
+	update := bson.M{}
+	if len(projectVars.Parameters) > 0 {
+		setUpdate[projectVarsParametersKey] = projectVars.Parameters
+	} else {
+		unsetUpdate[projectVarsParametersKey] = 1
+	}
+	update["$set"] = setUpdate
+	if len(unsetUpdate) > 0 {
+		update["$unset"] = unsetUpdate
+	}
 
 	return db.Upsert(
 		ProjectVarsCollection,
 		bson.M{
 			projectVarIdKey: projectVars.Id,
 		},
-		bson.M{
-			"$set": bson.M{
-				projectVarsMapKey:   projectVars.Vars,
-				privateVarsMapKey:   projectVars.PrivateVars,
-				adminOnlyVarsMapKey: projectVars.AdminOnlyVars,
-			},
-		},
+		update,
 	)
 }
 
@@ -480,13 +499,13 @@ func (projectVars *ProjectVars) Upsert() (*adb.ChangeInfo, error) {
 // TODO (DEVPROD-11882): remove temporary logic that currently continues on
 // error once all project vars are using Parameter Store and the rollout is
 // stable.
-func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) error {
+func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) (*ParameterMappings, error) {
 	projectID := projectVars.Id
 	after := projectVars
 
 	before, err := FindOneProjectVars(projectID)
 	if err != nil {
-		return errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
 	}
 	if before == nil {
 		before = &ProjectVars{Id: projectID}
@@ -494,57 +513,60 @@ func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) error 
 
 	varsToUpsert, varsToDelete := getProjectVarsDiff(before, after)
 
-	if err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varsToDelete); err != nil {
-		return errors.Wrap(err, "syncing project vars diff to Parameter Store")
+	pm, err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varsToDelete)
+	if err != nil {
+		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
 	}
 
-	return nil
+	return pm, nil
 }
 
 // syncParameterDiff syncs the diff of project variables to Parameter Store. It
 // adds/updates varsToUpsert to Parameter Store, deletes varsToDelete from
 // Parameter Store, and updates the project variable parameter mappings.
-func (projectVars *ProjectVars) syncParameterDiff(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string, varsToDelete map[string]struct{}) error {
+func (projectVars *ProjectVars) syncParameterDiff(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string, varsToDelete map[string]struct{}) (*ParameterMappings, error) {
 	paramMappingsToUpsert, err := projectVars.upsertParameters(ctx, pm, varsToUpsert)
 	if err != nil {
-		return errors.Wrap(err, "upserting project variables into Parameter Store")
+		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
 	}
 
 	paramMappingsToDelete, err := projectVars.deleteParameters(ctx, pm, varsToDelete)
 	if err != nil {
-		return errors.Wrap(err, "deleting project variables from Parameter Store")
+		return nil, errors.Wrap(err, "deleting project variables from Parameter Store")
 	}
 
 	updatedParamMappings := getUpdatedParamMappings(pm, paramMappingsToUpsert, paramMappingsToDelete)
+	//
+	// // kim: TODO: return param mappings rather than upsert.
+	// if err := projectVars.setParamMappings(updatedParamMappings); err != nil {
+	//     return nil, errors.Wrap(err, "updating parameter mappings for project vars")
+	// }
 
-	if err := projectVars.setParamMappings(updatedParamMappings); err != nil {
-		return errors.Wrap(err, "updating parameter mappings for project vars")
-	}
-
-	return nil
+	return &updatedParamMappings, nil
 }
 
-func (projectVars *ProjectVars) setParamMappings(pm ParameterMappings) error {
-	update := bson.M{}
-	if len(pm) == 0 {
-		update["$unset"] = bson.M{projectVarsParametersKey: 1}
-	} else {
-		update["$set"] = bson.M{projectVarsParametersKey: pm}
-	}
-	if _, err := db.Upsert(
-		ProjectVarsCollection,
-		bson.M{
-			projectVarIdKey: projectVars.Id,
-		},
-		update,
-	); err != nil {
-		return errors.Wrap(err, "updating parameter mappings for project vars")
-	}
-
-	projectVars.Parameters = pm
-
-	return nil
-}
+// kim: TODO: remove once absorbed into atomic DB ops
+// func (projectVars *ProjectVars) setParamMappings(pm ParameterMappings) error {
+//     update := bson.M{}
+//     if len(pm) == 0 {
+//         update["$unset"] = bson.M{projectVarsParametersKey: 1}
+//     } else {
+//         update["$set"] = bson.M{projectVarsParametersKey: pm}
+//     }
+//     if _, err := db.Upsert(
+//         ProjectVarsCollection,
+//         bson.M{
+//             projectVarIdKey: projectVars.Id,
+//         },
+//         update,
+//     ); err != nil {
+//         return errors.Wrap(err, "updating parameter mappings for project vars")
+//     }
+//
+//     projectVars.Parameters = pm
+//
+//     return nil
+// }
 
 // upsertParameters upserts the parameter mappings for project variables into
 // Parameter Store. It returns the parameter mappings for the upserted
@@ -726,10 +748,10 @@ func (projectVars *ProjectVars) findProjectRef() (ref *ProjectRef, isRepoRef boo
 // TODO (DEVPROD-11882): remove full sync logic once the Parameter Store
 // rollout is complete. This functionality only exists to aid the migration
 // process.
-func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
+func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) (*ParameterMappings, error) {
 	before, err := FindOneProjectVars(vars.Id)
 	if err != nil {
-		return errors.Wrapf(err, "finding original project vars for project '%s'", vars.Id)
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", vars.Id)
 	}
 	if before == nil {
 		before = &ProjectVars{Id: vars.Id}
@@ -750,7 +772,7 @@ func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *Proj
 	paramMgr := evergreen.GetEnvironment().ParameterManager()
 	if len(paramNames) > 0 {
 		if err := paramMgr.Delete(ctx, paramNames...); err != nil {
-			return errors.Wrap(err, "deleting existing parameters for project vars")
+			return nil, errors.Wrap(err, "deleting existing parameters for project vars")
 		}
 	}
 
@@ -761,13 +783,6 @@ func FullSyncToParameterStore(ctx context.Context, vars *ProjectVars, pRef *Proj
 // variables in the DB. If Parameter Store is enabled for the project, it also
 // stores the variables in Parameter Store.
 func (projectVars *ProjectVars) Insert() error {
-	if err := db.Insert(
-		ProjectVarsCollection,
-		projectVars,
-	); err != nil {
-		return err
-	}
-
 	// This has to be done after inserting the initial document because it
 	// upserts the project vars doc. If this ran first, it would cause the DB
 	// insert to fail due to the ID already existing.
@@ -775,32 +790,44 @@ func (projectVars *ProjectVars) Insert() error {
 	defer cancel()
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
-		grip.Error(message.WrapError(insertParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
+		pm, err := insertParameterStore(ctx, projectVars, ref, isRepoRef)
+		grip.Error(message.WrapError(err, message.Fields{
 			"message":    "could not insert project vars into Parameter Store; falling back to using the DB",
 			"op":         "Insert",
 			"project_id": projectVars.Id,
 			"epic":       "DEVPROD-5552",
 		}))
+		if pm != nil {
+			projectVars.Parameters = *pm
+		}
 	}, "Insert")
+
+	if err := db.Insert(
+		ProjectVarsCollection,
+		projectVars,
+	); err != nil {
+		return err
+	}
 
 	return nil
 }
 
 // insertParameterStore inserts all project variables into Parameter Store.
-func insertParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) error {
+func insertParameterStore(ctx context.Context, vars *ProjectVars, pRef *ProjectRef, isRepoRef bool) (*ParameterMappings, error) {
 	before := &ProjectVars{Id: vars.Id}
 	after := vars
 	varsToUpsert, _ := getProjectVarsDiff(before, after)
 
-	if err := vars.syncParameterDiff(ctx, ParameterMappings{}, varsToUpsert, nil); err != nil {
-		return errors.Wrap(err, "syncing project vars diff to Parameter Store")
+	pm, err := vars.syncParameterDiff(ctx, ParameterMappings{}, varsToUpsert, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
 	}
 
 	if err := pRef.setParameterStoreVarsSynced(true, isRepoRef); err != nil {
-		return errors.Wrapf(err, "marking project/repo ref '%s' as having its project vars fully synced to Parameter Store", pRef.Id)
+		return nil, errors.Wrapf(err, "marking project/repo ref '%s' as having its project vars fully synced to Parameter Store", pRef.Id)
 	}
 
-	return nil
+	return pm, nil
 }
 
 // FindAndModify is almost the same functionally as Upsert, except that it only
@@ -813,19 +840,27 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
 		if !ref.ParameterStoreVarsSynced {
-			grip.Error(message.WrapError(FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef), message.Fields{
+			pm, err := FullSyncToParameterStore(ctx, projectVars, ref, isRepoRef)
+			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not fully sync project vars into Parameter Store; falling back to using the DB",
 				"op":         "FindANdModify",
 				"project_id": projectVars.Id,
 				"epic":       "DEVPROD-5552",
 			}))
+			if pm != nil {
+				projectVars.Parameters = *pm
+			}
 		} else {
-			grip.Error(message.WrapError(projectVars.findAndModifyParameterStore(ctx, varsToDelete), message.Fields{
+			pm, err := projectVars.findAndModifyParameterStore(ctx, varsToDelete)
+			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not find and modify project vars in Parameter Store; falling back to using the DB",
 				"op":         "FindAndModify",
 				"project_id": projectVars.Id,
 				"epic":       "DEVPROD-5552",
 			}))
+			if pm != nil {
+				projectVars.Parameters = *pm
+			}
 		}
 	}, "FindAndModify")
 
@@ -833,7 +868,7 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	unsetUpdate := bson.M{}
 	update := bson.M{}
 	if len(projectVars.Vars) == 0 && len(projectVars.PrivateVars) == 0 &&
-		len(projectVars.AdminOnlyVars) == 0 && len(varsToDelete) == 0 {
+		len(projectVars.AdminOnlyVars) == 0 && len(projectVars.Parameters) == 0 && len(varsToDelete) == 0 {
 		return nil, nil
 	}
 	for key, val := range projectVars.Vars {
@@ -844,6 +879,11 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	}
 	for key, val := range projectVars.AdminOnlyVars {
 		setUpdate[bsonutil.GetDottedKeyName(adminOnlyVarsMapKey, key)] = val
+	}
+	if len(projectVars.Parameters) > 0 {
+		setUpdate[projectVarsParametersKey] = projectVars.Parameters
+	} else {
+		unsetUpdate[projectVarsParametersKey] = 1
 	}
 	if len(setUpdate) > 0 {
 		update["$set"] = setUpdate
@@ -875,12 +915,12 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 // varsToDelete. In other words, even if a project variable is omitted from
 // projectVars, it won't be deleted unless that variable is explicitly listed in
 // varsToDelete.
-func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context, varsToDelete []string) error {
+func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context, varsToDelete []string) (*ParameterMappings, error) {
 	projectID := projectVars.Id
 
 	before, err := FindOneProjectVars(projectID)
 	if err != nil {
-		return errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
 	}
 	if before == nil {
 		before = &ProjectVars{Id: projectID}
@@ -897,11 +937,12 @@ func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context,
 		varSetToDelete[varName] = struct{}{}
 	}
 
-	if err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varSetToDelete); err != nil {
-		return errors.Wrap(err, "syncing project vars diff to Parameter Store")
+	pm, err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varSetToDelete)
+	if err != nil {
+		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
 	}
 
-	return nil
+	return pm, nil
 }
 
 // Clears clears all variables for a project.
@@ -914,7 +955,8 @@ func (projectVars *ProjectVars) Clear() error {
 	defer cancel()
 	projectVars.checkAndRunParameterStoreOp(ctx, func(ref *ProjectRef, isRepoRef bool) {
 		if ref.ParameterStoreVarsSynced {
-			grip.Error(message.WrapError(projectVars.upsertParameterStore(ctx), message.Fields{
+			_, err := projectVars.upsertParameterStore(ctx)
+			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not clear project vars from Parameter Store",
 				"op":         "Clear",
 				"project_id": projectVars.Id,
@@ -927,9 +969,10 @@ func (projectVars *ProjectVars) Clear() error {
 		bson.M{ProjectRefIdKey: projectVars.Id},
 		bson.M{
 			"$unset": bson.M{
-				projectVarsMapKey:   1,
-				privateVarsMapKey:   1,
-				adminOnlyVarsMapKey: 1,
+				projectVarsMapKey:        1,
+				privateVarsMapKey:        1,
+				adminOnlyVarsMapKey:      1,
+				projectVarsParametersKey: 1,
 			},
 		})
 	if err != nil {

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -1164,13 +1164,15 @@ func TestFullSyncToParameterStore(t *testing.T) {
 			}
 			require.NoError(t, db.Insert(ProjectVarsCollection, projVars))
 
-			require.NoError(t, FullSyncToParameterStore(ctx, &projVars, &projRef, false))
+			pm, err := FullSyncToParameterStore(ctx, &projVars, &projRef, false)
+			require.NoError(t, err)
 
 			checkAndSetProjectVarsSynced(t, &projRef, false)
 
 			dbProjVars, err := FindOneProjectVars(projVars.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjVars)
+			dbProjVars.Parameters = *pm
 
 			checkParametersMatchVars(ctx, t, dbProjVars.Parameters, vars)
 			checkParametersNamespacedByProject(t, *dbProjVars)
@@ -1193,13 +1195,15 @@ func TestFullSyncToParameterStore(t *testing.T) {
 			}
 			require.NoError(t, db.Insert(ProjectVarsCollection, repoVars))
 
-			require.NoError(t, FullSyncToParameterStore(ctx, &repoVars, &repoRef.ProjectRef, true))
+			pm, err := FullSyncToParameterStore(ctx, &repoVars, &repoRef.ProjectRef, true)
+			require.NoError(t, err)
 
 			checkAndSetProjectVarsSynced(t, &repoRef.ProjectRef, true)
 
 			dbRepoVars, err := FindOneProjectVars(repoVars.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbRepoVars)
+			dbRepoVars.Parameters = *pm
 
 			checkParametersMatchVars(ctx, t, dbRepoVars.Parameters, vars)
 			checkParametersNamespacedByProject(t, *dbRepoVars)
@@ -1241,11 +1245,13 @@ func TestFullSyncToParameterStore(t *testing.T) {
 				Vars: newVars,
 			}
 
-			require.NoError(t, FullSyncToParameterStore(ctx, &newProjVars, &projRef, false))
+			pm, err := FullSyncToParameterStore(ctx, &newProjVars, &projRef, false)
+			require.NoError(t, err)
 
 			newDBProjVars, err := FindOneProjectVars(projVars.Id)
 			require.NoError(t, err)
 			require.NotZero(t, newDBProjVars)
+			newDBProjVars.Parameters = *pm
 
 			checkParametersMatchVars(ctx, t, newDBProjVars.Parameters, newVars)
 			checkParametersNamespacedByProject(t, *newDBProjVars)

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -99,8 +99,13 @@ func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectR
 			})
 			pVars = &model.ProjectVars{Id: pRef.Id}
 		}
-		if err := model.FullSyncToParameterStore(ctx, pVars, &pRef, areRepoRefs); err != nil {
+		pm, err := model.FullSyncToParameterStore(ctx, pVars, &pRef, areRepoRefs)
+		if err != nil {
 			catcher.Wrapf(err, "syncing project vars for project '%s'", pRef.Id)
+			continue
+		}
+		if err := pVars.SetParamMappings(*pm); err != nil {
+			catcher.Wrapf(err, "updating parameter mappings for project '%s'", pRef.Id)
 		}
 	}
 	return catcher.Resolve()


### PR DESCRIPTION
DEVPROD-12217

### Description
Before, the Parameter Store parameters would be upserted into the project vars document separately from the main DB query. This wasn't ideal since it means the project variables could be partially updated (e.g. the project variable could be created but not marked as private). Now, these operations should all happen within a single atomic DB write.

### Testing
Updated existing tests.

### Documentation
N/A