### PR TITLE
DEVPROD-12217: add fields for GitHub app private key parameter

### DIFF
--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -19,6 +19,9 @@ type GithubAppAuth struct {
 
 	AppID      int64  `bson:"app_id" json:"app_id"`
 	PrivateKey []byte `bson:"private_key" json:"private_key"`
+	// PrivateKeyParameter is the name of the parameter that holds the
+	// GitHub app's private key.
+	PrivateKeyParameter string `bson:"private_key_parameter" json:"private_key_parameter"`
 }
 
 // CreateGitHubAppAuth returns the Evergreen-internal app id and app private key

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -148,6 +148,11 @@ type ProjectRef struct {
 	// project's variables have been synced to Parameter Store. If this is true,
 	// then the project variables can all be found in Parameter Store.
 	ParameterStoreVarsSynced bool `bson:"parameter_store_vars_synced,omitempty" json:"parameter_store_vars_synced,omitempty" yaml:"parameter_store_vars_synced,omitempty"`
+	// ParameterStoreGitHubAppSynced is a temporary flag that indicates whether
+	// the project's GitHub app's private key have been synced to Parameter
+	// Store. If this is true, then the project's GitHub app private key can be
+	// found in Parameter Store.
+	ParameterStoreGitHubAppSynced bool `bson:"parameter_store_github_app_synced,omitempty" json:"parameter_store_github_app_synced,omitempty" yaml:"parameter_store_github_app_synced,omitempty"`
 	// LastAutoRestartedTaskAt is the last timestamp that a task in this project was restarted automatically.
 	LastAutoRestartedTaskAt time.Time `bson:"last_auto_restarted_task_at"`
 	// NumAutoRestartedTasks is the number of tasks this project has restarted automatically in the past 24-hour period.


### PR DESCRIPTION
DEVPROD-12217

### Description
* Add a field that tracks where a project's GitHub app private key is located in Parameter Store.
* Add a temporary field indicating if the GitHub app private key is synced to Parameter Store. This is analogous to the one made for project vars in DEVPROD-9393.

### Testing
N/A

### Documentation
N/A
