### PR TITLE
DEVPROD-12860: split project events model from project vars

### DIFF
--- a/model/project_event.go
+++ b/model/project_event.go
@@ -71,7 +71,7 @@ type ProjectSettingsEvent struct {
 	// project variables are not stored in the database for security reasons.
 	// However, the project event model needs to keep track of which project
 	// variables changed, hence the need for a separate model in that situation.
-	ProjectRef         ProjectRef              `bson:"project_ref" json:"project_ref"`
+	ProjectRef         ProjectRef              `bson:"proj_ref" json:"proj_ref"`
 	GithubHooksEnabled bool                    `bson:"github_hooks_enabled" json:"github_hooks_enabled"`
 	Aliases            []ProjectAlias          `bson:"aliases" json:"aliases"`
 	Subscriptions      []event.Subscription    `bson:"subscriptions" json:"subscriptions"`

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -46,8 +46,6 @@ func NewProjectSettingsFromEvent(e ProjectSettingsEvent) ProjectSettings {
 // ProjectEventVars contains the project variable data relevant to project
 // modification events.
 type ProjectEventVars struct {
-	// kim: TODO: verify if ID is needed. It's present in the project event
-	// model, but I don't think it visually displays at all nor is it relevant.
 	// Vars contain the names of project variables and redacted placeholders for
 	// their values.
 	Vars          map[string]string `bson:"vars" json:"vars"`
@@ -58,15 +56,9 @@ type ProjectEventVars struct {
 // ProjectSettingsEvent contains the event data about a single revision of a
 // project's settings.
 type ProjectSettingsEvent struct {
-	// kim: TODO: remove in favor of copy-pasted fields
-	// ProjectSettings `bson:",inline"`
-
-	// kim: NOTE: easier to just copy-paste the struct rather than make a new
-	// field because don't need to fix all the tests, update the GQL models,
-	// etc. It's also consistent with existing model.
 	// These fields are mostly copied from ProjectSettings, except for a few
 	// where the data available to project events differs from the original data
-	// model due to security concerns.
+	// model.
 	// For example, the ProjectVars model cannot be used as-is because the
 	// project variables are not stored in the database for security reasons.
 	// However, the project event model needs to keep track of which project
@@ -93,8 +85,6 @@ type ProjectSettingsEvent struct {
 // settings.
 func NewProjectSettingsEvent(p ProjectSettings) ProjectSettingsEvent {
 	return ProjectSettingsEvent{
-		// kim: TODO: remove
-		// ProjectSettings:    *p,
 		ProjectRef:         p.ProjectRef,
 		GithubHooksEnabled: p.GithubHooksEnabled,
 		Aliases:            p.Aliases,

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -91,7 +91,9 @@ func (s *ProjectEventSuite) TestModifyProjectEvent() {
 	s.Equal(before.ProjectRef.Admins, eventData.Before.ProjectRef.Admins)
 	s.True(eventData.Before.PeriodicBuildsDefault)
 	s.Equal(before.GithubHooksEnabled, eventData.Before.GithubHooksEnabled)
-	s.Equal(before.Vars, eventData.Before.Vars)
+	s.Equal(before.Vars.Vars, eventData.Before.Vars.Vars)
+	s.Equal(before.Vars.PrivateVars, eventData.Before.Vars.PrivateVars)
+	s.Equal(before.Vars.AdminOnlyVars, eventData.Before.Vars.AdminOnlyVars)
 	s.Equal(before.Aliases, eventData.Before.Aliases)
 	s.Equal(before.Subscriptions, eventData.Before.Subscriptions)
 
@@ -103,7 +105,9 @@ func (s *ProjectEventSuite) TestModifyProjectEvent() {
 	s.Equal(after.ProjectRef.Id, eventData.After.ProjectRef.Id)
 	s.Equal(after.ProjectRef.Admins, eventData.After.ProjectRef.Admins)
 	s.Equal(after.GithubHooksEnabled, eventData.After.GithubHooksEnabled)
-	s.Equal(after.Vars, eventData.After.Vars)
+	s.Equal(after.Vars.Vars, eventData.After.Vars.Vars)
+	s.Equal(after.Vars.PrivateVars, eventData.After.Vars.PrivateVars)
+	s.Equal(after.Vars.AdminOnlyVars, eventData.After.Vars.AdminOnlyVars)
 	s.Equal(after.Aliases, eventData.After.Aliases)
 	s.Equal(after.Subscriptions, eventData.After.Subscriptions)
 }

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1731,13 +1731,9 @@ func TestFindProjectsSuite(t *testing.T) {
 				EventType:    event.EventTypeProjectModified,
 				ResourceId:   projectId,
 				Data: &ProjectChangeEvent{
-					User: username,
-					Before: ProjectSettingsEvent{
-						ProjectSettings: before,
-					},
-					After: ProjectSettingsEvent{
-						ProjectSettings: after,
-					},
+					User:   username,
+					Before: *before.resolveDefaults(),
+					After:  *after.resolveDefaults(),
 				},
 			}
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1732,8 +1732,8 @@ func TestFindProjectsSuite(t *testing.T) {
 				ResourceId:   projectId,
 				Data: &ProjectChangeEvent{
 					User:   username,
-					Before: *before.resolveDefaults(),
-					After:  *after.resolveDefaults(),
+					Before: NewProjectSettingsEvent(before),
+					After:  NewProjectSettingsEvent(after),
 				},
 			}
 

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -712,8 +712,8 @@ func TestGetLegacyProjectEvents(t *testing.T) {
 		ResourceId:   projectId,
 		Data: map[string]interface{}{
 			"user":   username,
-			"before": before,
-			"after":  after,
+			"before": model.NewProjectSettingsEvent(before),
+			"after":  model.NewProjectSettingsEvent(after),
 		},
 	}
 
@@ -721,7 +721,7 @@ func TestGetLegacyProjectEvents(t *testing.T) {
 
 	events, err := GetProjectEventLog(projectId, time.Now(), 0)
 	require.NoError(t, err)
-	require.Equal(t, len(events), 1)
+	require.Len(t, events, 1)
 	eventLog := events[0]
 	require.NotNil(t, eventLog)
 

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -93,11 +93,11 @@ func (e *APIProjectEvent) BuildFromService(entry model.ProjectChangeEventEntry) 
 	}
 
 	user := utility.ToStringPtr(data.User)
-	before, err := DbProjectSettingsToRestModel(data.Before.ProjectSettings)
+	before, err := DbProjectSettingsToRestModel(model.NewProjectSettingsFromEvent(data.Before))
 	if err != nil {
 		return errors.Wrap(err, "converting 'before' project settings to API model")
 	}
-	after, err := DbProjectSettingsToRestModel(data.After.ProjectSettings)
+	after, err := DbProjectSettingsToRestModel(model.NewProjectSettingsFromEvent(data.After))
 	if err != nil {
 		return errors.Wrap(err, "converting 'after' project settings to API model")
 	}

--- a/rest/model/project_event_test.go
+++ b/rest/model/project_event_test.go
@@ -75,13 +75,9 @@ func (s *ProjectEventSuite) SetupTest() {
 			EventType:    event.EventTypeProjectModified,
 			ResourceId:   projectId,
 			Data: &model.ProjectChangeEvent{
-				User: username,
-				Before: model.ProjectSettingsEvent{
-					ProjectSettings: before,
-				},
-				After: model.ProjectSettingsEvent{
-					ProjectSettings: after,
-				},
+				User:   username,
+				Before: model.NewProjectSettingsEvent(before),
+				After:  model.NewProjectSettingsEvent(after),
 			},
 		},
 	}
@@ -150,7 +146,7 @@ func checkProjRef(suite *ProjectEventSuite, in model.ProjectRef, out APIProjectR
 	suite.Equal(in.NotifyOnBuildFailure, out.NotifyOnBuildFailure)
 }
 
-func checkVars(suite *ProjectEventSuite, in model.ProjectVars, out APIProjectVars) {
+func checkVars(suite *ProjectEventSuite, in model.ProjectEventVars, out APIProjectVars) {
 	suite.Require().Equal(len(in.Vars), len(out.Vars))
 	for k, v := range in.Vars {
 		suite.Equal(v, out.Vars[k])

--- a/rest/route/project_events_test.go
+++ b/rest/route/project_events_test.go
@@ -63,13 +63,9 @@ func (s *ProjectEventsTestSuite) SetupSuite() {
 	afterSettings.ProjectRef.Enabled = false
 
 	s.event = model.ProjectChangeEvent{
-		User: "me",
-		Before: model.ProjectSettingsEvent{
-			ProjectSettings: beforeSettings,
-		},
-		After: model.ProjectSettingsEvent{
-			ProjectSettings: afterSettings,
-		},
+		User:   "me",
+		Before: model.NewProjectSettingsEvent(beforeSettings),
+		After:  model.NewProjectSettingsEvent(afterSettings),
 	}
 
 	s.NoError(db.ClearCollections(event.EventCollection, model.ProjectRefCollection))


### PR DESCRIPTION
DEVPROD-12860

### Description
The plan to stop storing project var values in the DB includes [removing the BSON tag from the `ProjectVars` model](https://github.com/evergreen-ci/evergreen/blob/3e97e565fadb2db8e2bba635b132a4eb99ef4e4d/model/project_vars.go#L54-L57) - this is a security measure to avoid putting vars in the DB and future-proofing so that nobody can insert them into the DB by accident. Unfortunately, the [project change events](https://github.com/evergreen-ci/evergreen/blob/3e97e565fadb2db8e2bba635b132a4eb99ef4e4d/model/project_event.go#L24-L30) still needs a map of vars stored in the DB to keep track of which vars changed, so currently, removing the `ProjectVars.Vars` BSON tag will _also_ remove the vars from the event log. The easiest way to keep track of modified vars in the project event log  to just split the data models so that project events can keep track of the changed vars.

### Testing
* Updated existing tests.
* Tested in staging by adding/creating/deleting vars to verify that the project event log looked reasonable in the UI/the DB.

### Documentation
N/A
