### PR TITLE
DEVPROD-12086 Remove noisy log

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -507,14 +507,6 @@ func (d *basicCachedDAGDispatcherImpl) getTaskGroup(taskGroupID string) (schedul
 			hasDispatchableTask = true
 		}
 	}
-	grip.DebugWhen(!hasDispatchableTask, message.Fields{
-		"investigation": "DEVPROD-12086",
-		"message":       "group has no ready tasks, skipping",
-		"group":         taskGroupUnit.group,
-		"variant":       taskGroupUnit.variant,
-		"project":       taskGroupUnit.project,
-		"version":       taskGroupUnit.version,
-	})
 	return taskGroupUnit, true, hasDispatchableTask
 }
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -388,6 +388,12 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// validate that the task can be run, if not fetch the next one in the queue.
 		if !nextTask.IsHostDispatchable() {
+			grip.Warning(message.Fields{
+				"message": "task was not dispatchable",
+				"task":    nextTask.Id,
+				"variant": nextTask.BuildVariant,
+				"project": nextTask.Project,
+			})
 			// Dequeue the task so we don't get it on another iteration of the loop.
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":   "nextTask.IsHostDispatchable() is false, but there was an issue dequeuing the task",
@@ -532,6 +538,12 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		}))
 
 		if !dispatchedTask {
+			grip.Warning(message.Fields{
+				"message": "task was not dispatched",
+				"task":    nextTask.Id,
+				"variant": nextTask.BuildVariant,
+				"project": nextTask.Project,
+			})
 			continue
 		}
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -388,13 +388,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 		// validate that the task can be run, if not fetch the next one in the queue.
 		if !nextTask.IsHostDispatchable() {
-			grip.Debug(message.Fields{
-				"investigation": "DEVPROD-12086",
-				"message":       "task was not dispatchable",
-				"task":          nextTask.Id,
-				"variant":       nextTask.BuildVariant,
-				"project":       nextTask.Project,
-			})
 			// Dequeue the task so we don't get it on another iteration of the loop.
 			grip.Warning(message.WrapError(taskQueue.DequeueTask(nextTask.Id), message.Fields{
 				"message":   "nextTask.IsHostDispatchable() is false, but there was an issue dequeuing the task",
@@ -539,13 +532,6 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		}))
 
 		if !dispatchedTask {
-			grip.Debug(message.Fields{
-				"investigation": "DEVPROD-12086",
-				"message":       "task was not dispatched",
-				"task":          nextTask.Id,
-				"variant":       nextTask.BuildVariant,
-				"project":       nextTask.Project,
-			})
 			continue
 		}
 


### PR DESCRIPTION
DEVPROD-12086

### Description
The change from #8479 appears to be stable, but one of the logs appears to be both noisy and not providing too much insight, so removing it. The other two logs hit much less frequently and I believe to offer some insight so opting to keep those and change them from debug -> warning logs.