### PR TITLE
DEVPROD-12560 Remove RetryMarshalBSON on project parser struct

### DIFF
--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -2990,7 +2990,7 @@ func TestMarshalBSON(t *testing.T) {
 		Identifier: utility.ToStringPtr("small"),
 	}
 
-	encoded, err := pp.RetryMarshalBSON(5)
+	encoded, err := pp.MarshalBSON()
 	require.NoError(t, err)
 	require.NotEmpty(t, encoded)
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -587,7 +587,7 @@ func (h *getParserProjectHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("parser project '%s' not found", v.Id),
 		})
 	}
-	projBytes, err := pp.RetryMarshalBSON(5)
+	projBytes, err := pp.MarshalBSON()
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "marshalling project bytes to bson"))
 	}


### PR DESCRIPTION
DEVPROD-12560

### Description
This removes the retry marshal bson which was an attempt to fix tasks that were failing on specific distros with a route that returns this marshal'ed data. The log line was never hit, so we can confirm that it's not the problem (my concern was this is still using the legacy evergreen custom go driver/marshal program).
