### PR TITLE
DEVPROD-12947: use hash of project ID in parameter name

### DIFF
--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v52/github"
@@ -1077,9 +1076,8 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *ProjectRef, isRepoRef b
 // project vars all include the project ID as a prefix.
 func checkParametersNamespacedByProject(t *testing.T, vars ProjectVars) {
 	projectID := vars.Id
-	hashedProjectID := util.GetSHA256Hash(projectID)
 
-	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
+	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), GetVarsParameterPath(projectID))
 	for _, pm := range vars.Parameters {
 		assert.True(t, strings.HasPrefix(pm.ParameterName, commonAndProjectIDPrefix), "parameter name '%s' should have standard prefix '%s'", pm.ParameterName, commonAndProjectIDPrefix)
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1076,7 +1076,11 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *ProjectRef, isRepoRef b
 // project vars all include the project ID as a prefix.
 func checkParametersNamespacedByProject(t *testing.T, vars ProjectVars) {
 	projectID := vars.Id
-	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), projectID)
+	hasher := utility.NewSHA256Hash()
+	hasher.Add(projectID)
+	hashedProjectID := hasher.Sum()
+
+	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
 	for _, pm := range vars.Parameters {
 		assert.True(t, strings.HasPrefix(pm.ParameterName, commonAndProjectIDPrefix), "parameter name '%s' should have standard prefix '%s'", pm.ParameterName, commonAndProjectIDPrefix)
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v52/github"
@@ -1076,9 +1077,7 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *ProjectRef, isRepoRef b
 // project vars all include the project ID as a prefix.
 func checkParametersNamespacedByProject(t *testing.T, vars ProjectVars) {
 	projectID := vars.Id
-	hasher := utility.NewSHA256Hash()
-	hasher.Add(projectID)
-	hashedProjectID := hasher.Sum()
+	hashedProjectID := util.GetSHA256Hash(projectID)
 
 	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
 	for _, pm := range vars.Parameters {

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -1126,6 +1126,17 @@ func (projectVars *ProjectVars) MergeWithRepoVars(repoVars *ProjectVars) {
 	sort.Sort(projectVars.Parameters)
 }
 
+// GetVarsParameterPath returns the parameter path for project variables in the
+// given project.
+func GetVarsParameterPath(projectID string) string {
+	// Include a hash of the project ID in the parameter name for uniqueness.
+	// The hashing is necessary because project IDs are unique but some
+	// existing projects contain characters (e.g. spaces) that are invalid for
+	// parameter names.
+	hashedProjectID := util.GetSHA256Hash(projectID)
+	return fmt.Sprintf("vars/%s", hashedProjectID)
+}
+
 // convertVarToParam converts a project variable to its equivalent parameter
 // name and value. In particular, it validates that the variable name and value
 // fits within parameter constraints and if the name or value doesn't fit in the
@@ -1140,12 +1151,7 @@ func convertVarToParam(projectID string, pm ParameterMappings, varName, varValue
 		return "", "", errors.Errorf("project variable '%s' cannot have an empty value", varName)
 	}
 
-	// Include a hash of the project ID in the parameter name for uniqueness.
-	// The hashing is necessary because project IDs are unique but some
-	// existing projects contain characters (e.g. spaces) that are invalid for
-	// parameter names.
-	hashedProjectID := util.GetSHA256Hash(projectID)
-	prefix := fmt.Sprintf("%s/", hashedProjectID)
+	prefix := GetVarsParameterPath(projectID) + "/"
 
 	varsToParams := pm.NameMap()
 	m, ok := varsToParams[varName]

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -1156,7 +1156,15 @@ func convertVarToParam(projectID string, pm ParameterMappings, varName, varValue
 		return "", "", errors.Wrapf(err, "getting compressed parameter name and value for project variable '%s'", varName)
 	}
 
-	prefix := fmt.Sprintf("%s/", projectID)
+	// Include a hash of the project ID in the parameter name for uniqueness.
+	// The hashing is necessary because project IDs are unique but some
+	// existing projects contain characters (e.g. spaces) that are invalid for
+	// parameter names.
+	hasher := utility.NewSHA256Hash()
+	hasher.Add(projectID)
+	hashedProjectID := hasher.Sum()
+
+	prefix := fmt.Sprintf("%s/", hashedProjectID)
 	if !strings.Contains(paramName, prefix) {
 		paramName = fmt.Sprintf("%s%s", prefix, paramName)
 	}

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/gimlet"
 
 	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
@@ -756,60 +757,67 @@ func TestAWSVars(t *testing.T) {
 func TestConvertVarToParam(t *testing.T) {
 	t.Run("ReturnsNewParamNameForValidVarNameAndValue", func(t *testing.T) {
 		const (
-			varName  = "var_name"
-			varValue = "var_value"
+			varName   = "var_name"
+			varValue  = "var_value"
+			projectID = "project_id"
 		)
-		paramName, paramValue, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		paramName, paramValue, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		require.NoError(t, err)
-		assert.Equal(t, "project_id/var_name", paramName, "new parameter name should include project ID prefix")
+		assert.Equal(t, fmt.Sprintf("%s/%s", util.GetSHA256Hash(projectID), varName), paramName, "new parameter name should include project ID prefix")
 		assert.Equal(t, varValue, paramValue, "variable value is valid and should be unchanged")
 	})
 	t.Run("ReturnsValidParamNameForVarContainingDisallowedAWSPrefix", func(t *testing.T) {
 		const (
-			varName  = "aws_secret"
-			varValue = "super_secret"
+			varName   = "aws_secret"
+			varValue  = "super_secret"
+			projectID = "project_id"
 		)
-		paramName, paramValue, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		paramName, paramValue, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		require.NoError(t, err)
-		assert.Equal(t, "project_id/_aws_secret", paramName, "new parameter name should prevent invalid 'aws' prefix from appearing in basename")
+		assert.Equal(t, fmt.Sprintf("%s/_%s", util.GetSHA256Hash(projectID), varName), paramName, "new parameter name should prevent invalid 'aws' prefix from appearing in basename")
 		assert.Equal(t, varValue, paramValue, "parameter value should match variable value because variable value is valid")
 	})
 	t.Run("ReturnsValidParamNameForVarContainingDisallowedSSMPrefix", func(t *testing.T) {
 		const (
-			varName  = "ssm_secret"
-			varValue = "super_secret"
+			varName   = "ssm_secret"
+			varValue  = "super_secret"
+			projectID = "project_id"
 		)
-		paramName, paramValue, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		paramName, paramValue, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		require.NoError(t, err)
-		assert.Equal(t, "project_id/_ssm_secret", paramName, "new parameter name should prevent invalid 'ssm' prefix from appearing in basename")
+		assert.Equal(t, fmt.Sprintf("%s/_%s", util.GetSHA256Hash(projectID), varName), paramName, "new parameter name should prevent invalid 'ssm' prefix from appearing in basename")
 		assert.Equal(t, varValue, paramValue, "parameter value should match variable value because variable value is valid")
 	})
 	t.Run("ReturnsExistingParameterNameAndNewVarValueForVarWithExistingParameter", func(t *testing.T) {
 		const (
-			varName           = "var_name"
-			varValue          = "var_value"
-			existingParamName = "/prefix/project_id/var_name"
+			varName   = "var_name"
+			varValue  = "var_value"
+			projectID = "project_id"
 		)
+		existingParamName := fmt.Sprintf("/prefix/%s/%s", util.GetSHA256Hash(projectID), varName)
 		pm := ParameterMappings{
 			{
 				Name:          varName,
 				ParameterName: existingParamName,
 			},
 		}
-		paramName, paramValue, err := convertVarToParam("project_id", pm, varName, varValue)
+		paramName, paramValue, err := convertVarToParam(projectID, pm, varName, varValue)
 		require.NoError(t, err)
 		assert.Equal(t, existingParamName, paramName, "should return already-existing parameter name")
 		assert.Equal(t, varValue, paramValue, "parameter value should match variable value")
 	})
 	t.Run("ReturnsNewParameterNameAndCompressedParameterValueWhenVarValueExceedsLimit", func(t *testing.T) {
-		const varName = "var_name"
+		const (
+			varName   = "var_name"
+			projectID = "project_id"
+		)
 
 		longVarValue := strings.Repeat("abc", parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(longVarValue), parameterstore.ParamValueMaxLength)
 
-		paramName, paramValue, err := convertVarToParam("project_id", ParameterMappings{}, varName, longVarValue)
+		paramName, paramValue, err := convertVarToParam(projectID, ParameterMappings{}, varName, longVarValue)
 		require.NoError(t, err)
-		assert.Equal(t, "project_id/var_name.gz", paramName, "should include project ID prefix and gzip extension to indicate the value was compressed")
+		assert.Equal(t, fmt.Sprintf("%s/%s.gz", util.GetSHA256Hash(projectID), varName), paramName, "should include project ID prefix and gzip extension to indicate the value was compressed")
 		assert.NotEqual(t, longVarValue, paramValue, "compressed value should not match original variable value")
 
 		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
@@ -820,9 +828,10 @@ func TestConvertVarToParam(t *testing.T) {
 	})
 	t.Run("ReturnsNewParameterNameAndCompressedParameterValueWhenLengthOfExistingVarIncreasesBeyondLimit", func(t *testing.T) {
 		const (
-			varName           = "var_name"
-			existingParamName = "/prefix/project_id/var_name"
+			varName   = "var_name"
+			projectID = "project_id"
 		)
+		existingParamName := fmt.Sprintf("/prefix/%s/%s", util.GetSHA256Hash(projectID), varName)
 		pm := ParameterMappings{
 			{
 				Name:          varName,
@@ -833,10 +842,10 @@ func TestConvertVarToParam(t *testing.T) {
 		longVarValue := strings.Repeat("abc", parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(longVarValue), parameterstore.ParamValueMaxLength)
 
-		paramName, paramValue, err := convertVarToParam("project_id", pm, varName, longVarValue)
+		paramName, paramValue, err := convertVarToParam(projectID, pm, varName, longVarValue)
 		require.NoError(t, err)
 		assert.NotEqual(t, existingParamName, paramName)
-		assert.Equal(t, existingParamName+gzipCompressedParamExtension, paramName, "project variable that was previously short but now is long enoguh to require compression should have its parameter name changed")
+		assert.Equal(t, fmt.Sprintf("%s.gz", existingParamName), paramName, "project variable that was previously short but now is long enough to require compression should have its parameter name changed")
 		assert.NotEqual(t, longVarValue, paramValue)
 
 		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
@@ -847,51 +856,58 @@ func TestConvertVarToParam(t *testing.T) {
 	})
 	t.Run("ReturnsErrorForEmptyVariableName", func(t *testing.T) {
 		const (
-			varName  = ""
-			varValue = "var_value"
+			varName   = ""
+			varValue  = "var_value"
+			projectID = "project_id"
 		)
-		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		_, _, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		assert.Error(t, err, "should not allow variable with empty name")
 	})
 	t.Run("ReturnsErrorForEmptyVariableValue", func(t *testing.T) {
 		const (
-			varName  = "var_name"
-			varValue = ""
+			varName   = "var_name"
+			varValue  = ""
+			projectID = "project_id"
 		)
-		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		_, _, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		assert.Error(t, err, "should not allow variable with empty value")
 	})
 	t.Run("ReturnsErrorForVariableNameEndingInGzipExtension", func(t *testing.T) {
 		const (
-			varName  = "var_name.gz"
-			varValue = "var_value"
+			varName   = "var_name.gz"
+			varValue  = "var_value"
+			projectID = "project_id"
 		)
-		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, varValue)
+		_, _, err := convertVarToParam(projectID, ParameterMappings{}, varName, varValue)
 		assert.Error(t, err, "should not allow variable with gzip extension")
 	})
 	t.Run("ReturnsErrorForVarValueThatExceedsMaxLengthAfterCompression", func(t *testing.T) {
-		const varName = "var_name"
+		const (
+			varName   = "var_name"
+			projectID = "project_id"
+		)
 		// Since this is a purely random string, there's no realistic way to
 		// compress it to fit within the max length limit.
 		longVarValue := utility.MakeRandomString(10 * parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(longVarValue), parameterstore.ParamValueMaxLength)
 
-		_, _, err := convertVarToParam("project_id", ParameterMappings{}, varName, longVarValue)
+		_, _, err := convertVarToParam(projectID, ParameterMappings{}, varName, longVarValue)
 		assert.Error(t, err)
 	})
 	t.Run("ReturnsErrorForNewParameterThatWouldConflictWithExistingParameter", func(t *testing.T) {
 		const (
-			varName  = "aws_secret"
-			varValue = "super_secret"
+			varName   = "aws_secret"
+			varValue  = "super_secret"
+			projectID = "project_id"
 		)
 		pm := ParameterMappings{
 			{
 				Name:          "_aws_secret",
-				ParameterName: "/prefix/project_id/_aws_secret",
+				ParameterName: fmt.Sprintf("/prefix/%s/_%s", util.GetSHA256Hash(projectID), varName),
 			},
 		}
 
-		_, _, err := convertVarToParam("project_id", pm, varName, varValue)
+		_, _, err := convertVarToParam(projectID, pm, varName, varValue)
 		assert.Error(t, err, "should not allow creation of new parameter whose name conflicts with an already-existing parameter")
 	})
 }
@@ -901,8 +917,9 @@ func TestConvertParamToVar(t *testing.T) {
 		const (
 			varName   = "var_name"
 			varValue  = "var_value"
-			paramName = "/prefix/project_id/var_name"
+			projectID = "project_id"
 		)
+		paramName := fmt.Sprintf("/prefix/%s/%s", util.GetSHA256Hash(projectID), varName)
 		pm := ParameterMappings{
 			{
 				Name:          varName,
@@ -918,8 +935,9 @@ func TestConvertParamToVar(t *testing.T) {
 		const (
 			varName   = "aws_secret"
 			varValue  = "super_secret"
-			paramName = "/prefix/project_id/_aws_secret"
+			projectID = "project_Id"
 		)
+		paramName := fmt.Sprintf("/prefix/%s/_%s", util.GetSHA256Hash(projectID), varName)
 		pm := ParameterMappings{
 			{
 				Name:          varName,
@@ -932,10 +950,14 @@ func TestConvertParamToVar(t *testing.T) {
 		assert.Equal(t, varValue, varValueFromParam, "should return original variable value")
 	})
 	t.Run("ReturnsErrorForVariableMissingParameterMapping", func(t *testing.T) {
+		const (
+			varName   = "var_name"
+			projectID = "project_id"
+		)
 		pm := ParameterMappings{
 			{
-				Name:          "var_name",
-				ParameterName: "/prefix/project_id/var_name",
+				Name:          varName,
+				ParameterName: fmt.Sprintf("/prefix/%s/%s", util.GetSHA256Hash(projectID), varName),
 			},
 		}
 		varNameFromParam, varValueFromParam, err := convertParamToVar(pm, "some_other_var_name", "some_other_var_value")
@@ -945,8 +967,10 @@ func TestConvertParamToVar(t *testing.T) {
 	})
 	t.Run("ReturnsErrorForParameterThatMapsToEmptyVariable", func(t *testing.T) {
 		const (
-			paramName = "/prefix/project_id/var_name"
+			projectID = "project_id"
+			varName   = "var_name"
 		)
+		paramName := fmt.Sprintf("/prefix/%s/%s", util.GetSHA256Hash(projectID), varName)
 		pm := ParameterMappings{
 			{
 				ParameterName: paramName,
@@ -960,8 +984,9 @@ func TestConvertParamToVar(t *testing.T) {
 	t.Run("DecompressesParameterValueToOriginalVariableValue", func(t *testing.T) {
 		const (
 			varName   = "var_name"
-			paramName = "/prefix/project_id/var_name.gz"
+			projectID = "project_id"
 		)
+		paramName := fmt.Sprintf("/prefix/%s/%s.gz", util.GetSHA256Hash(projectID), varName)
 
 		longVarValue := strings.Repeat("abc", parameterstore.ParamValueMaxLength)
 		assert.Greater(t, len(longVarValue), parameterstore.ParamValueMaxLength)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/user"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
@@ -313,9 +314,7 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *model.ProjectRef, isRep
 
 func checkParametersNamespacedByProject(t *testing.T, vars model.ProjectVars) {
 	projectID := vars.Id
-	hasher := utility.NewSHA256Hash()
-	hasher.Add(projectID)
-	hashedProjectID := hasher.Sum()
+	hashedProjectID := util.GetSHA256Hash(projectID)
 
 	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
 	for _, pm := range vars.Parameters {

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -313,7 +313,11 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *model.ProjectRef, isRep
 
 func checkParametersNamespacedByProject(t *testing.T, vars model.ProjectVars) {
 	projectID := vars.Id
-	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), projectID)
+	hasher := utility.NewSHA256Hash()
+	hasher.Add(projectID)
+	hashedProjectID := hasher.Sum()
+
+	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
 	for _, pm := range vars.Parameters {
 		assert.True(t, strings.HasPrefix(pm.ParameterName, commonAndProjectIDPrefix), "parameter name '%s' should have standard prefix '%s'", pm.ParameterName, commonAndProjectIDPrefix)
 	}

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/notification"
 	"github.com/evergreen-ci/evergreen/model/user"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip/message"
 	"github.com/stretchr/testify/assert"
@@ -314,9 +313,7 @@ func checkAndSetProjectVarsSynced(t *testing.T, projRef *model.ProjectRef, isRep
 
 func checkParametersNamespacedByProject(t *testing.T, vars model.ProjectVars) {
 	projectID := vars.Id
-	hashedProjectID := util.GetSHA256Hash(projectID)
-
-	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), hashedProjectID)
+	commonAndProjectIDPrefix := fmt.Sprintf("/%s/%s/", strings.TrimSuffix(strings.TrimPrefix(evergreen.GetEnvironment().Settings().Providers.AWS.ParameterStore.Prefix, "/"), "/"), model.GetVarsParameterPath(projectID))
 	for _, pm := range vars.Parameters {
 		assert.True(t, strings.HasPrefix(pm.ParameterName, commonAndProjectIDPrefix), "parameter name '%s' should have standard prefix '%s'", pm.ParameterName, commonAndProjectIDPrefix)
 	}

--- a/util/hash.go
+++ b/util/hash.go
@@ -1,0 +1,10 @@
+package util
+
+import "github.com/evergreen-ci/utility"
+
+// GetSHA256Hash returns the SHA256 hash of the given string.
+func GetSHA256Hash(s string) string {
+	hasher := utility.NewSHA256Hash()
+	hasher.Write([]byte(s))
+	return hasher.Sum()
+}


### PR DESCRIPTION
DEVPROD-12947

### Description
I made an assumption that nobody would choose project IDs that have special characters (e.g. `my cool project (v1.2)`) when they could do that in the display name or identifier. Unfortunately this isn't true - a couple projects in production chose project IDs that have special characters in them. This means we can't use the project ID as-is in paramater paths to give projects their own unique namespaces since special characters can't be used in parameter paths (e.g. `/evergreen/my cool project (v1.2)/myVariable` is an invalid parameter path).

To work around this, I changed the parameter path to use the SHA256 hash of the project ID, which transforms all projec IDs into 64-character hexadecimal strings. So far, nobody's found a collision in SHA256 hashes, so each project ID maps to a unique hash.

* Use hash of the project ID in the parameter path.
* Include `/vars/` in the parameter path. This isn't necessary but it does more neatly group the project vars parameters in the hierarchy and makes it easier to identify what secrets are stored where when we use Parameter Store for more secrets.

### Testing
Updated existing unit tests.

### Documentation
N/A