### PR TITLE
DEVPROD-10200: Remove offset from date filter in Waterfall query

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -944,7 +944,6 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		if limitOpt > model.MaxWaterfallVersionLimit {
 			return nil, InputValidationError.Send(ctx, fmt.Sprintf("limit exceeds max limit of %d", model.MaxWaterfallVersionLimit))
 		}
-
 		limit = limitOpt
 	}
 
@@ -974,8 +973,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		} else if found == nil {
 			graphql.AddError(ctx, PartialError.Send(ctx, fmt.Sprintf("version on or before date '%s' not found", eod.Format(time.DateOnly))))
 		} else {
-			// Offset the order number so the specified version lands nearer to the center of the page.
-			maxOrderOpt = found.RevisionOrderNumber + limit/2 + 1
+			maxOrderOpt = found.RevisionOrderNumber + 1
 		}
 	}
 

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -453,22 +453,6 @@
           "waterfall": {
             "versions": [
               {
-                "version": {
-                  "createTime": "2020-01-02T01:43:00-05:00",
-                  "id": "evergreen_version2",
-                  "order": 42
-                },
-                "inactiveVersions": null
-              },
-              {
-                "version": {
-                  "createTime": "2019-12-31T19:00:00-05:00",
-                  "id": "evergreen_version1",
-                  "order": 41
-                },
-                "inactiveVersions": null
-              },
-              {
                 "version": null,
                 "inactiveVersions": [
                   {
@@ -489,7 +473,7 @@
             ],
             "pagination": {
               "nextPageOrder": 39,
-              "prevPageOrder": 42
+              "prevPageOrder": 40
             }
           }
         }


### PR DESCRIPTION
DEVPROD-10200

### Description
In design sync, we decided we can remove the offset in the date filter. The most recent matching commit will show up as the leftmost version.

### Testing
- Updated GraphQL tests
