### PR TITLE
DEVPROD-11922: Prevent task page from erroring due to missing distro

### DIFF
--- a/graphql/tests/task/imageId/data.json
+++ b/graphql/tests/task/imageId/data.json
@@ -14,6 +14,11 @@
       "_id": "container-task",
       "branch": "spruce",
       "container": "ubuntu1604-container"
+    },
+    {
+      "_id": "nonexistent-distro-task",
+      "branch": "spruce",
+      "distro": "i-was-deleted"
     }
   ],
   "distro": [

--- a/graphql/tests/task/imageId/queries/nonexistent_distro_task.graphql
+++ b/graphql/tests/task/imageId/queries/nonexistent_distro_task.graphql
@@ -1,0 +1,5 @@
+{
+  task(taskId: "nonexistent-distro-task") {
+    imageId
+  }
+}

--- a/graphql/tests/task/imageId/results.json
+++ b/graphql/tests/task/imageId/results.json
@@ -29,6 +29,16 @@
           }
         }
       }
+    },
+    {
+      "query_file": "nonexistent_distro_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "imageId": ""
+          }
+        }
+      }
     }
   ]
 }

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -927,8 +927,9 @@ func GetImageIDFromDistro(ctx context.Context, distro string) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "finding distro '%s'", distro)
 	}
+	// Do not return an error, as the distro may have been deleted.
 	if d == nil {
-		return "", errors.Errorf("distro '%s' not found", distro)
+		return "", nil
 	}
 	return d.ImageID, nil
 }


### PR DESCRIPTION
DEVPROD-11922

### Description
Runtime Environments team wants to delete distros, but they found a bug where deleting the distro makes the task page unviewable due to a 404 error. 

This PR fixes the bug by not throwing an error in the case of a missing distro.

### Testing
- I made a new distro on staging called `ubuntu1604-large-mina` and then ran a [task](https://spruce-staging.corp.mongodb.com/task/sandbox_ubuntu2004_batchtime_task_patch_35af2286511f3b738ce514b25c45b21f6b35af28_673ff91a1a77c40007e2d0fa_24_11_22_03_23_38/logs?execution=0) on that distro. Then I deleted the distro, which caused the task page to error with a 404. After applying the changes in this PR, I could view the task page properly again.