### PR TITLE
DEVPROD-5498 Do not consider elapased communication time during group teardown

### DIFF
--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,13 +2,10 @@ package fakeparameter
 
 import (
 	"context"
-	"flag"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -19,13 +16,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	if ExecutionEnvironmentType != "test" {
-		grip.EmergencyFatal(message.Fields{
-			"message":     "fake Parameter Store testing code called in a non-testing environment",
-			"environment": ExecutionEnvironmentType,
-			"args":        flag.Args(),
-		})
-	}
+	//if ExecutionEnvironmentType != "test" {
+	//	grip.EmergencyFatal(message.Fields{
+	//		"message":     "fake Parameter Store testing code called in a non-testing environment",
+	//		"environment": ExecutionEnvironmentType,
+	//		"args":        flag.Args(),
+	//	})
+	//}
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/cloud/parameterstore/fakeparameter/fake_parameter.go
+++ b/cloud/parameterstore/fakeparameter/fake_parameter.go
@@ -2,10 +2,13 @@ package fakeparameter
 
 import (
 	"context"
+	"flag"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -16,13 +19,13 @@ import (
 var ExecutionEnvironmentType = "production"
 
 func init() {
-	//if ExecutionEnvironmentType != "test" {
-	//	grip.EmergencyFatal(message.Fields{
-	//		"message":     "fake Parameter Store testing code called in a non-testing environment",
-	//		"environment": ExecutionEnvironmentType,
-	//		"args":        flag.Args(),
-	//	})
-	//}
+	if ExecutionEnvironmentType != "test" {
+		grip.EmergencyFatal(message.Fields{
+			"message":     "fake Parameter Store testing code called in a non-testing environment",
+			"environment": ExecutionEnvironmentType,
+			"args":        flag.Args(),
+		})
+	}
 }
 
 // FakeParameter is the data model for a fake parameter stored in the DB. This

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2169,6 +2169,12 @@ func (h *Host) Replace(ctx context.Context) error {
 
 // GetElapsedCommunicationTime returns how long since this host has communicated with evergreen or vice versa
 func (h *Host) GetElapsedCommunicationTime() time.Duration {
+	// If the host is currently tearing down a task group, it is not considered idle, and
+	// can acceptably not communicate with evergreen because the task has completed and will
+	// no longer be sending heartbeat requests.
+	if h.IsTearingDown() {
+		return 0
+	}
 	if h.LastCommunicationTime.After(h.CreationTime) {
 		return time.Since(h.LastCommunicationTime)
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2170,8 +2170,8 @@ func (h *Host) Replace(ctx context.Context) error {
 // GetElapsedCommunicationTime returns how long since this host has communicated with evergreen or vice versa
 func (h *Host) GetElapsedCommunicationTime() time.Duration {
 	// If the host is currently tearing down a task group, it is not considered idle, and
-	// can acceptably not communicate with evergreen because the task has completed and will
-	// no longer be sending heartbeat requests.
+	// it is expected that it will not communicate with evergreen because the task has completed
+	// and will no longer be sending heartbeat requests.
 	if h.IsTearingDown() {
 		return 0
 	}

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1791,11 +1791,17 @@ func TestHostElapsedCommTime(t *testing.T) {
 		Id:           "hostWithOnlyCreateTime",
 		CreationTime: now.Add(-7 * time.Minute),
 	}
+	hostThatsRunningTeardown := Host{
+		Id:                         "hostThatsRunningTeardown",
+		CreationTime:               now.Add(-7 * time.Minute),
+		TaskGroupTeardownStartTime: now.Add(-1 * time.Minute),
+	}
 
 	assert.InDelta(int64(10*time.Minute), int64(hostThatRanTask.GetElapsedCommunicationTime()), float64(1*time.Millisecond))
 	assert.InDelta(int64(1*time.Minute), int64(hostThatJustStarted.GetElapsedCommunicationTime()), float64(1*time.Millisecond))
 	assert.InDelta(int64(15*time.Minute), int64(hostWithNoCreateTime.GetElapsedCommunicationTime()), float64(1*time.Millisecond))
 	assert.InDelta(int64(7*time.Minute), int64(hostWithOnlyCreateTime.GetElapsedCommunicationTime()), float64(1*time.Millisecond))
+	assert.Zero(hostThatsRunningTeardown.GetElapsedCommunicationTime())
 }
 
 func TestHostUpsert(t *testing.T) {


### PR DESCRIPTION
DEVPROD-5498

### Description
Currently, hosts can get hit with an idle timeout due to lack of communication with the Evergreen app server if their teardown group is sufficiently long, because the teardown group happens after task completion, so no heartbeat signals are sent during that period. 

Since the change introduced in #7635 adds protections against long-running teardown groups, it should be sufficient to skip the last communicated time in the idle host check _if_ a host is actively tearing down a task group.
### Testing
[Tested in staging](https://spruce-staging.corp.mongodb.com/version/6740dfc0f354c60008e9cf6a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) (executions 3 vs 4 for reference) and confirmed that without the change, a host that just ran a task group with a long teardown group is unable to pick up more tasks afterwards because it immediately gets marked by the idle termination job, whereas after the change, said host is able to continue picking up tasks.
