### PR TITLE
DEVPROD-12451 Update last communication time during host reprovisioning

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1663,6 +1663,7 @@ func (h *Host) MarkAsReprovisioning(ctx context.Context) error {
 		needsAgentMonitor = h.StartedBy == evergreen.User
 	}
 
+	now := time.Now()
 	err := UpdateOne(ctx, bson.M{
 		IdKey:               h.Id,
 		NeedsReprovisionKey: h.NeedsReprovision,
@@ -1670,11 +1671,12 @@ func (h *Host) MarkAsReprovisioning(ctx context.Context) error {
 	},
 		bson.M{
 			"$set": bson.M{
-				AgentStartTimeKey:       utility.ZeroTime,
-				ProvisionedKey:          false,
-				StatusKey:               evergreen.HostProvisioning,
-				NeedsNewAgentKey:        needsAgent,
-				NeedsNewAgentMonitorKey: needsAgentMonitor,
+				AgentStartTimeKey:        utility.ZeroTime,
+				ProvisionedKey:           false,
+				StatusKey:                evergreen.HostProvisioning,
+				NeedsNewAgentKey:         needsAgent,
+				NeedsNewAgentMonitorKey:  needsAgentMonitor,
+				LastCommunicationTimeKey: now,
 			},
 		},
 	)
@@ -1687,6 +1689,7 @@ func (h *Host) MarkAsReprovisioning(ctx context.Context) error {
 	h.Status = evergreen.HostProvisioning
 	h.NeedsNewAgent = needsAgent
 	h.NeedsNewAgentMonitor = needsAgentMonitor
+	h.LastCommunicationTime = now
 
 	return nil
 }

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/evergreen/units"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -61,8 +62,9 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 	t.Run("SuccessfullyUnquarantinesHostAndMarksAsReprovisioning", func(t *testing.T) {
 		user := user.DBUser{Id: "user"}
 		h := host.Host{
-			Id:     "h2",
-			Status: evergreen.HostQuarantined,
+			Id:       "h2",
+			Provider: evergreen.ProviderNameStatic,
+			Status:   evergreen.HostQuarantined,
 			Distro: distro.Distro{
 				BootstrapSettings: distro.BootstrapSettings{
 					Method:        distro.BootstrapMethodSSH,
@@ -70,6 +72,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 				},
 			},
 			NumAgentCleanupFailures: 10,
+			LastCommunicationTime:   time.Now().Add(-24 * time.Hour),
 		}
 		require.NoError(h.Insert(ctx))
 
@@ -79,10 +82,16 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 		assert.Equal(h.Status, evergreen.HostProvisioning)
 		assert.Equal(host.ReprovisionToNew, h.NeedsReprovision)
 
+		// Verify that host monitoring job does not immediately re-quarantine host
+		// due to long time since last communication
+		j := units.NewHostMonitoringCheckJob(env, &h, "job_id")
+		j.Run(ctx)
+
 		dbHost, err := host.FindOneId(ctx, h.Id)
 		require.NoError(err)
 		require.NotNil(t, dbHost)
 		assert.Equal(0, dbHost.NumAgentCleanupFailures)
+		assert.Equal(evergreen.HostProvisioning, dbHost.Status)
 	})
 	t.Run("FailsToDecommissionStaticHosts", func(t *testing.T) {
 		user := user.DBUser{Id: "user"}

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/evergreen/units"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
DEVPROD-12451

### Description
When un-quaranting a static host that has been quarantined for a while, sometimes it can get immediately re-quarantined because of a race:

 - [this host monitoring job](https://github.com/evergreen-ci/evergreen/blob/bd1bfa286f54049a9bc31c34b938bb64118d3fa1/units/host_monitoring_check.go#L52) auto-quarantines the host for having a `LastCommunicatedTime` from too long ago, before the [re-provisioning job](https://github.com/evergreen-ci/evergreen/blob/ccc124bd866f1cb74b4a3fd513771d524eac1802/units/util.go#L73) (which gets queued immediately when the host is un-quarantined) can update `LastCommunicatedTime`.

This change updates a host's `LastCommunicatedTime` right at the time it gets marked as reprovisioning to fix this.

### Testing
Added a check to an existing unit test