### PR TITLE
DEVPROD-13165 Add Otel attributes for s3 commands

### DIFF
--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -29,7 +29,8 @@ const (
 )
 
 var (
-	s3CopyBucketAttribute               = fmt.Sprintf("%s.bucket", s3CopyAttribute)
+	s3CopySourceBucketAttribute         = fmt.Sprintf("%s.source_bucket", s3CopyAttribute)
+	s3CopyDestinationBucketAttribute    = fmt.Sprintf("%s.destination_bucket", s3CopyAttribute)
 	s3CopyTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3CopyAttribute)
 )
 
@@ -171,13 +172,15 @@ func (c *s3copy) Execute(ctx context.Context,
 		return errors.Wrap(err, "validating params")
 	}
 
-	buckets := []string{}
+	sourceBuckets, destinationBuckets := []string{}, []string{}
 	for _, s3CopyFile := range c.S3CopyFiles {
-		buckets = append(buckets, s3CopyFile.Source.Bucket, s3CopyFile.Destination.Bucket)
+		sourceBuckets = append(sourceBuckets, s3CopyFile.Source.Bucket)
+		destinationBuckets = append(sourceBuckets, s3CopyFile.Destination.Bucket)
 	}
 
 	trace.SpanFromContext(ctx).SetAttributes(
-		attribute.StringSlice(s3CopyBucketAttribute, buckets),
+		attribute.StringSlice(s3CopySourceBucketAttribute, sourceBuckets),
+		attribute.StringSlice(s3CopyDestinationBucketAttribute, destinationBuckets),
 		attribute.Bool(s3CopyTemporaryCredentialsAttribute, c.AwsSessionToken != ""),
 	)
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-11-27"
+	AgentVersion = "2024-12-03"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13165

### Description
This adds `bucket` and `temporary_credentials` otel attributes for our s3 commands (s3.get, s3.put, s3copy.copy)

s3 buckets shouldn't (and cannot be) protected through obscurity. Buckets are more prone to this since they're on a [global unique naming constriction](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) and it's pretty easy to see if one exists (`curl -sI https://<bucket_name>.s3.amazonaws.com/ | grep bucket-region` can tell you if one exists and the regions it exists in.)