### PR TITLE
DEVPROD-3925 Pass in context for task.PopulateTestResults calls

### DIFF
--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -44,7 +44,7 @@ func (err GqlError) Send(ctx context.Context, message string) *gqlerror.Error {
 	}
 }
 
-func formError(ctx context.Context, msg string, code GqlError) *gqlerror.Error {
+func formError(_ context.Context, msg string, code GqlError) *gqlerror.Error {
 	return &gqlerror.Error{
 		Message: msg,
 		Extensions: map[string]interface{}{

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -191,7 +191,7 @@ func setup(ctx context.Context, t *testing.T, state *AtomicGraphQLState) {
 
 	require.NoError(t, setupDBIndexes())
 	require.NoError(t, setupDBData(ctx, env, state.DBData))
-	require.NoError(t, setupTaskOutputData(ctx, env, state))
+	require.NoError(t, setupTaskOutputData(ctx, state))
 	roleManager := env.RoleManager()
 
 	roles, err := roleManager.GetAllRoles()
@@ -410,7 +410,7 @@ func setupDBData(ctx context.Context, env evergreen.Environment, data map[string
 	return catcher.Resolve()
 }
 
-func setupTaskOutputData(ctx context.Context, env evergreen.Environment, state *AtomicGraphQLState) error {
+func setupTaskOutputData(ctx context.Context, state *AtomicGraphQLState) error {
 	for taskOutputType, data := range state.TaskOutputData {
 		switch taskOutputType {
 		case taskoutput.TaskLogOutput{}.ID():

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -408,7 +408,7 @@ func (r *mutationResolver) CreateProject(ctx context.Context, project restModel.
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("looking in project collection: %s", err.Error()))
 	}
 	if projectRef == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("finding project: %s", err.Error()))
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("finding project: %s", utility.FromStringPtr(project.Id)))
 	}
 	apiProjectRef := restModel.APIProjectRef{}
 	if err = apiProjectRef.BuildFromService(*projectRef); err != nil {

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -43,7 +43,7 @@ func (r *queryResolver) BbGetCreatedTickets(ctx context.Context, taskID string) 
 func (r *queryResolver) BuildBaron(ctx context.Context, taskID string, execution int) (*BuildBaron, error) {
 	execString := strconv.Itoa(execution)
 
-	searchReturnInfo, bbConfig, err := model.GetSearchReturnInfo(taskID, execString)
+	searchReturnInfo, bbConfig, err := model.GetSearchReturnInfo(ctx, taskID, execString)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/model/build_baron.go
+++ b/model/build_baron.go
@@ -125,9 +125,9 @@ type buildBaronConfig struct {
 	TicketCreationDefined bool
 }
 
-func GetSearchReturnInfo(taskId string, exec string) (*thirdparty.SearchReturnInfo, buildBaronConfig, error) {
+func GetSearchReturnInfo(ctx context.Context, taskId string, exec string) (*thirdparty.SearchReturnInfo, buildBaronConfig, error) {
 	bbConfig := buildBaronConfig{}
-	t, err := BbGetTask(taskId, exec)
+	t, err := BbGetTask(ctx, taskId, exec)
 	if err != nil {
 		return nil, bbConfig, err
 	}
@@ -177,7 +177,7 @@ func GetSearchReturnInfo(taskId string, exec string) (*thirdparty.SearchReturnIn
 	return &thirdparty.SearchReturnInfo{Issues: tickets, Search: jql, Source: source, FeaturesURL: featuresURL}, bbConfig, nil
 }
 
-func BbGetTask(taskId string, executionString string) (*task.Task, error) {
+func BbGetTask(ctx context.Context, taskId string, executionString string) (*task.Task, error) {
 	execution, err := strconv.Atoi(executionString)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid execution number")
@@ -191,7 +191,7 @@ func BbGetTask(taskId string, executionString string) (*task.Task, error) {
 		return nil, errors.Errorf("no task found for task '%s' and execution %d", taskId, execution)
 	}
 
-	if err = t.PopulateTestResults(); err != nil {
+	if err = t.PopulateTestResults(ctx); err != nil {
 		return nil, errors.Wrap(err, "populating test results")
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3108,16 +3108,15 @@ func (t *Task) makeArchivedTask() *Task {
 // PopulateTestResults populates the task's LocalTestResults field with any
 // test results the task may have. If the results are already populated, this
 // function no-ops.
-func (t *Task) PopulateTestResults() error {
+func (t *Task) PopulateTestResults(ctx context.Context) error {
 	if len(t.LocalTestResults) > 0 {
 		return nil
 	}
 
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	taskTestResults, err := t.GetTestResults(ctx, env, nil)
+	taskTestResults, err := t.GetTestResults(ctx, evergreen.GetEnvironment(), nil)
 	if err != nil {
 		return errors.Wrap(err, "populating test results")
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3113,9 +3113,6 @@ func (t *Task) PopulateTestResults(ctx context.Context) error {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	taskTestResults, err := t.GetTestResults(ctx, evergreen.GetEnvironment(), nil)
 	if err != nil {
 		return errors.Wrap(err, "populating test results")

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3880,7 +3880,7 @@ func TestArchive(t *testing.T) {
 		assert.Zero(t, dbTask.AbortInfo)
 	}
 
-	checkEventLogHostTaskExecutions := func(t *testing.T, hostID, oldTaskID string, execution int) {
+	checkEventLogHostTaskExecutions := func(t *testing.T, hostID, oldTaskID string, _ int) {
 		dbTask, err := FindOneOldId(oldTaskID)
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
@@ -4013,7 +4013,7 @@ func TestArchiveFailedOnly(t *testing.T) {
 		assert.Nil(t, nextExecution)
 	}
 
-	checkEventLogHostTaskExecutions := func(t *testing.T, hostID, oldTaskID string, execution int) {
+	checkEventLogHostTaskExecutions := func(t *testing.T, hostID, oldTaskID string, _ int) {
 		dbTask, err := FindOneOldId(oldTaskID)
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)

--- a/rest/data/build_baron.go
+++ b/rest/data/build_baron.go
@@ -136,7 +136,7 @@ func makeJiraNotification(ctx context.Context, settings *evergreen.Settings, t *
 	if err := mappings.Get(ctx); err != nil {
 		return nil, errors.Wrap(err, "getting Jira mappings")
 	}
-	payload, err := trigger.JIRATaskPayload(trigger.JiraIssueParameters{
+	payload, err := trigger.JIRATaskPayload(ctx, trigger.JiraIssueParameters{
 		Project:  jiraOpts.project,
 		UiURL:    settings.Ui.Url,
 		Mappings: mappings,

--- a/rest/data/version.go
+++ b/rest/data/version.go
@@ -38,7 +38,7 @@ func GetProjectVersionsWithOptions(projectName string, opts model.GetVersionsOpt
 // The skip value indicates how many versions back in time should be skipped
 // before starting to fetch versions, the project indicates which project the
 // returned versions should be a part of.
-func GetVersionsAndVariants(skip, numVersionElements int, project *model.Project) (*restModel.VersionVariantData, error) {
+func GetVersionsAndVariants(ctx context.Context, skip, numVersionElements int, project *model.Project) (*restModel.VersionVariantData, error) {
 	// the final array of versions to return
 	finalVersions := []restModel.APIVersions{}
 
@@ -174,7 +174,7 @@ func GetVersionsAndVariants(skip, numVersionElements int, project *model.Project
 
 		}
 
-		if err = addFailedAndStartedTests(buildList, failedAndStartedTasks); err != nil {
+		if err = addFailedAndStartedTests(ctx, buildList, failedAndStartedTasks); err != nil {
 			return nil, err
 		}
 	}
@@ -193,9 +193,9 @@ func GetVersionsAndVariants(skip, numVersionElements int, project *model.Project
 }
 
 // addFailedAndStartedTests adds all of the failed tests associated with a task
-func addFailedAndStartedTests(rows map[string]restModel.BuildList, failedAndStartedTasks []task.Task) error {
+func addFailedAndStartedTests(ctx context.Context, rows map[string]restModel.BuildList, failedAndStartedTasks []task.Task) error {
 	for i := range failedAndStartedTasks {
-		if err := failedAndStartedTasks[i].PopulateTestResults(); err != nil {
+		if err := failedAndStartedTasks[i].PopulateTestResults(ctx); err != nil {
 			return errors.Wrap(err, "populating test results")
 		}
 	}

--- a/rest/data/version_test.go
+++ b/rest/data/version_test.go
@@ -230,7 +230,9 @@ func (s *VersionConnectorSuite) TestGetVersionsAndVariants() {
 	for _, t := range tasks {
 		s.NoError(t.Insert())
 	}
-	results, err := GetVersionsAndVariants(0, 10, &proj)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results, err := GetVersionsAndVariants(ctx, 0, 10, &proj)
 	s.NoError(err)
 
 	bv1 := results.Rows["bv1"]

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -170,7 +170,7 @@ func (h *legacyVersionsGetHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding latest version for project '%s'", projRefId))
 	}
 
-	versions, err := data.GetVersionsAndVariants(h.offset, h.limit, proj)
+	versions, err := data.GetVersionsAndVariants(ctx, h.offset, h.limit, proj)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting versions and variants"))
 	}

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -146,7 +146,7 @@ func TestGetHostDNS(t *testing.T) {
 	require.NoError(t, err)
 	r = gimlet.SetURLVars(r, map[string]string{"host_id": "i-1234"})
 
-	uis := UIServer{hostCache: map[string]hostCacheItem{"i-1234": hostCacheItem{dnsName: "www.example.com", inserted: time.Now()}}}
+	uis := UIServer{hostCache: map[string]hostCacheItem{"i-1234": {dnsName: "www.example.com", inserted: time.Now()}}}
 	path, err := uis.getHostDNS((r))
 	assert.NoError(t, err)
 	assert.Len(t, path, 1)

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -144,7 +144,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	destTask.StatusDetails.TimeoutStage = srcTask.Details.Description
 
 	// Copy over the test results.
-	if err := srcTask.PopulateTestResults(); err != nil {
+	if err := srcTask.PopulateTestResults(r.Context()); err != nil {
 		err = errors.Wrapf(err, "Error finding test results for task '%s'", srcTask.Id)
 		grip.Error(err)
 		gimlet.WriteJSONInternalError(w, responseError{Message: err.Error()})
@@ -207,7 +207,7 @@ func (restapi restAPI) getTaskStatus(w http.ResponseWriter, r *http.Request) {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "error finding task"})
 		return
 	}
-	if err := task.PopulateTestResults(); err != nil {
+	if err := task.PopulateTestResults(r.Context()); err != nil {
 		gimlet.WriteJSONResponse(w, http.StatusNotFound, responseError{Message: "error populating test results"})
 		return
 	}

--- a/service/task.go
+++ b/service/task.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -332,7 +333,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	testResults := uis.getTestResults(projCtx, &uiTask)
+	testResults := uis.getTestResults(r.Context(), projCtx, &uiTask)
 	if projCtx.Patch != nil {
 		var taskOnBaseCommit *task.Task
 		var testResultsOnBaseCommit []testresult.TestResult
@@ -343,7 +344,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		}
 		taskPatch := &uiPatch{Patch: *projCtx.Patch}
 		if taskOnBaseCommit != nil {
-			if err = taskOnBaseCommit.PopulateTestResults(); err != nil {
+			if err = taskOnBaseCommit.PopulateTestResults(r.Context()); err != nil {
 				uis.LoggedError(w, r, http.StatusInternalServerError, err)
 				return
 			}
@@ -893,8 +894,8 @@ func (uis *UIServer) testLog(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (uis *UIServer) getTestResults(projCtx projectContext, uiTask *uiTaskData) []testresult.TestResult {
-	if err := projCtx.Task.PopulateTestResults(); err != nil {
+func (uis *UIServer) getTestResults(ctx context.Context, projCtx projectContext, uiTask *uiTaskData) []testresult.TestResult {
+	if err := projCtx.Task.PopulateTestResults(ctx); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"task_id": projCtx.Task.Id,
 			"message": "fetching test results for task",

--- a/service/task_test.go
+++ b/service/task_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestGetTestResults(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	testutil.Setup()
 
@@ -32,6 +35,6 @@ func TestGetTestResults(t *testing.T) {
 		},
 	}
 	uiTask := uiTaskData{}
-	results := uis.getTestResults(projectContext, &uiTask)
+	results := uis.getTestResults(ctx, projectContext, &uiTask)
 	assert.Nil(t, results)
 }

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -132,7 +132,7 @@ func (uis *UIServer) bbJiraSearch(rw http.ResponseWriter, r *http.Request) {
 	taskId := vars["task_id"]
 	exec := vars["execution"]
 
-	searchReturnInfo, bbConfig, err := model.GetSearchReturnInfo(taskId, exec)
+	searchReturnInfo, bbConfig, err := model.GetSearchReturnInfo(r.Context(), taskId, exec)
 	if err != nil {
 		gimlet.WriteJSONInternalError(rw, err.Error())
 		return

--- a/trigger/build.go
+++ b/trigger/build.go
@@ -111,14 +111,14 @@ func (t *buildTriggers) Attributes() event.Attributes {
 	return attributes
 }
 
-func (t *buildTriggers) buildGithubCheckOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildGithubCheckOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.GithubCheckStatus != evergreen.BuildSucceeded && t.data.GithubCheckStatus != evergreen.BuildFailed {
 		return nil, nil
 	}
 	return t.generate(sub, "")
 }
 
-func (t *buildTriggers) buildOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.BuildSucceeded && t.data.Status != evergreen.BuildFailed {
 		return nil, nil
 	}
@@ -126,7 +126,7 @@ func (t *buildTriggers) buildOutcome(sub *event.Subscription) (*notification.Not
 	return t.generate(sub, "")
 }
 
-func (t *buildTriggers) buildFailure(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.BuildFailed {
 		return nil, nil
 	}
@@ -134,7 +134,7 @@ func (t *buildTriggers) buildFailure(sub *event.Subscription) (*notification.Not
 	return t.generate(sub, "")
 }
 
-func (t *buildTriggers) buildSuccess(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildSuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.BuildSucceeded {
 		return nil, nil
 	}
@@ -142,7 +142,7 @@ func (t *buildTriggers) buildSuccess(sub *event.Subscription) (*notification.Not
 	return t.generate(sub, "")
 }
 
-func (t *buildTriggers) buildExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildExceedsDuration(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.BuildSucceeded && t.data.Status != evergreen.BuildFailed {
 		return nil, nil
 	}
@@ -162,7 +162,7 @@ func (t *buildTriggers) buildExceedsDuration(sub *event.Subscription) (*notifica
 	return t.generate(sub, fmt.Sprintf("exceeded %d seconds", threshold))
 }
 
-func (t *buildTriggers) buildRuntimeChange(sub *event.Subscription) (*notification.Notification, error) {
+func (t *buildTriggers) buildRuntimeChange(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.BuildSucceeded && t.data.Status != evergreen.BuildFailed {
 		return nil, nil
 	}

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -172,110 +172,128 @@ func (s *buildSuite) TestAllTriggers() {
 }
 
 func (s *buildSuite) TestSuccess() {
-	n, err := s.t.buildSuccess(&s.subs[1])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.buildSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildSuccess(&s.subs[1])
+	n, err = s.t.buildSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildSuccess(&s.subs[1])
+	n, err = s.t.buildSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestFailure() {
-	n, err := s.t.buildFailure(&s.subs[2])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.buildFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildFailure(&s.subs[2])
+	n, err = s.t.buildFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildFailure(&s.subs[2])
+	n, err = s.t.buildFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestOutcome() {
-	n, err := s.t.buildOutcome(&s.subs[1])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.buildOutcome(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
-	n, err = s.t.buildOutcome(&s.subs[0])
+	n, err = s.t.buildOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildOutcome(&s.subs[0])
+	n, err = s.t.buildOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildOutcome(&s.subs[0])
+	n, err = s.t.buildOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestGithubCheckOutcome() {
-	n, err := s.t.buildGithubCheckOutcome(&s.subs[1])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.buildGithubCheckOutcome(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
-	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.GithubCheckStatus = evergreen.BuildSucceeded
-	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.GithubCheckStatus = evergreen.BuildFailed
-	n, err = s.t.buildGithubCheckOutcome(&s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestBuildExceedsTime() {
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
 	// build that exceeds time should generate
 	s.t.event = &event.EventLogEntry{
 		ResourceType: event.BuildStateChange,
 	}
 	s.t.data.Status = evergreen.BuildSucceeded
 	s.t.build.TimeTaken = 20 * time.Minute
-	n, err := s.t.buildExceedsDuration(&s.subs[3])
+	n, err := s.t.buildExceedsDuration(ctx, &s.subs[3])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// build that does not exceed should not generate
 	s.t.build.TimeTaken = 4 * time.Minute
-	n, err = s.t.buildExceedsDuration(&s.subs[3])
+	n, err = s.t.buildExceedsDuration(ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 
 	// unfinished build should not generate
 	s.t.data.Status = evergreen.BuildStarted
 	s.t.build.TimeTaken = 20 * time.Minute
-	n, err = s.t.buildExceedsDuration(&s.subs[3])
+	n, err = s.t.buildExceedsDuration(ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 }
 
 func (s *buildSuite) TestBuildRuntimeChange() {
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
 	// no previous task should not generate
 	s.build.TimeTaken = 20 * time.Minute
 	s.t.event = &event.EventLogEntry{
 		ResourceType: event.BuildStateChange,
 	}
 	s.t.data.Status = evergreen.BuildSucceeded
-	n, err := s.t.buildRuntimeChange(&s.subs[4])
+	n, err := s.t.buildRuntimeChange(ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 
@@ -289,19 +307,19 @@ func (s *buildSuite) TestBuildRuntimeChange() {
 		Requester:           evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(lastGreen.Insert())
-	n, err = s.t.buildRuntimeChange(&s.subs[4])
+	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// build that does not exceed threshold should not generate
 	s.build.TimeTaken = 11 * time.Minute
-	n, err = s.t.buildRuntimeChange(&s.subs[4])
+	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 
 	// build that finished too quickly should generate
 	s.build.TimeTaken = 4 * time.Minute
-	n, err = s.t.buildRuntimeChange(&s.subs[4])
+	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
 	s.NoError(err)
 	s.NotNil(n)
 }

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -172,128 +172,110 @@ func (s *buildSuite) TestAllTriggers() {
 }
 
 func (s *buildSuite) TestSuccess() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.buildSuccess(ctx, &s.subs[1])
+	n, err := s.t.buildSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildSuccess(ctx, &s.subs[1])
+	n, err = s.t.buildSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildSuccess(ctx, &s.subs[1])
+	n, err = s.t.buildSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestFailure() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.buildFailure(ctx, &s.subs[2])
+	n, err := s.t.buildFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildFailure(ctx, &s.subs[2])
+	n, err = s.t.buildFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildFailure(ctx, &s.subs[2])
+	n, err = s.t.buildFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestOutcome() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.buildOutcome(ctx, &s.subs[1])
+	n, err := s.t.buildOutcome(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
-	n, err = s.t.buildOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.BuildSucceeded
-	n, err = s.t.buildOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.Status = evergreen.BuildFailed
-	n, err = s.t.buildOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestGithubCheckOutcome() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.buildGithubCheckOutcome(ctx, &s.subs[1])
+	n, err := s.t.buildGithubCheckOutcome(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
-	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.GithubCheckStatus = evergreen.BuildSucceeded
-	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.GithubCheckStatus = evergreen.BuildFailed
-	n, err = s.t.buildGithubCheckOutcome(ctx, &s.subs[0])
+	n, err = s.t.buildGithubCheckOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *buildSuite) TestBuildExceedsTime() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	// build that exceeds time should generate
 	s.t.event = &event.EventLogEntry{
 		ResourceType: event.BuildStateChange,
 	}
 	s.t.data.Status = evergreen.BuildSucceeded
 	s.t.build.TimeTaken = 20 * time.Minute
-	n, err := s.t.buildExceedsDuration(ctx, &s.subs[3])
+	n, err := s.t.buildExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// build that does not exceed should not generate
 	s.t.build.TimeTaken = 4 * time.Minute
-	n, err = s.t.buildExceedsDuration(ctx, &s.subs[3])
+	n, err = s.t.buildExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 
 	// unfinished build should not generate
 	s.t.data.Status = evergreen.BuildStarted
 	s.t.build.TimeTaken = 20 * time.Minute
-	n, err = s.t.buildExceedsDuration(ctx, &s.subs[3])
+	n, err = s.t.buildExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 }
 
 func (s *buildSuite) TestBuildRuntimeChange() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	// no previous task should not generate
 	s.build.TimeTaken = 20 * time.Minute
 	s.t.event = &event.EventLogEntry{
 		ResourceType: event.BuildStateChange,
 	}
 	s.t.data.Status = evergreen.BuildSucceeded
-	n, err := s.t.buildRuntimeChange(ctx, &s.subs[4])
+	n, err := s.t.buildRuntimeChange(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 
@@ -307,19 +289,19 @@ func (s *buildSuite) TestBuildRuntimeChange() {
 		Requester:           evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(lastGreen.Insert())
-	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
+	n, err = s.t.buildRuntimeChange(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// build that does not exceed threshold should not generate
 	s.build.TimeTaken = 11 * time.Minute
-	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
+	n, err = s.t.buildRuntimeChange(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 
 	// build that finished too quickly should generate
 	s.build.TimeTaken = 4 * time.Minute
-	n, err = s.t.buildRuntimeChange(ctx, &s.subs[4])
+	n, err = s.t.buildRuntimeChange(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.NotNil(n)
 }

--- a/trigger/commit_queue.go
+++ b/trigger/commit_queue.go
@@ -68,7 +68,7 @@ func (t *commitQueueTriggers) Attributes() event.Attributes {
 	}
 }
 
-func (t *commitQueueTriggers) commitQueueOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *commitQueueTriggers) commitQueueOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	data, err := t.makeData(sub)
 	if err != nil {
 		return nil, errors.Wrap(err, "collecting patch data")

--- a/trigger/commit_queue_test.go
+++ b/trigger/commit_queue_test.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -80,7 +81,10 @@ func (s *commitQueueSuite) SetupTest() {
 }
 
 func (s *commitQueueSuite) TestEmailUnescapesDescription() {
-	n, err := s.t.commitQueueOutcome(&s.subs[0])
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	n, err := s.t.commitQueueOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 	payload, ok := n.Payload.(*message.Email)

--- a/trigger/commit_queue_test.go
+++ b/trigger/commit_queue_test.go
@@ -23,9 +23,11 @@ func TestCommitQueueTriggers(t *testing.T) {
 }
 
 type commitQueueSuite struct {
-	event event.EventLogEntry
-	data  *event.CommitQueueEventData
-	subs  []event.Subscription
+	event  event.EventLogEntry
+	data   *event.CommitQueueEventData
+	subs   []event.Subscription
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	t *commitQueueTriggers
 
@@ -37,6 +39,8 @@ func (s *commitQueueSuite) SetupSuite() {
 }
 
 func (s *commitQueueSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+
 	s.NoError(db.ClearCollections(event.EventCollection, patch.Collection, event.SubscriptionsCollection, event.SubscriptionsCollection, model.ProjectRefCollection))
 
 	s.data = &event.CommitQueueEventData{
@@ -80,11 +84,12 @@ func (s *commitQueueSuite) SetupTest() {
 	s.t.patch = &p
 }
 
-func (s *commitQueueSuite) TestEmailUnescapesDescription() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+func (s *commitQueueSuite) TearDownTest() {
+	s.cancel()
+}
 
-	n, err := s.t.commitQueueOutcome(ctx, &s.subs[0])
+func (s *commitQueueSuite) TestEmailUnescapesDescription() {
+	n, err := s.t.commitQueueOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 	payload, ok := n.Payload.(*message.Email)

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -217,7 +217,7 @@ func (t *hostTemplateData) hostSlackPayload(messageString string, linkTitle stri
 	}, nil
 }
 
-func (t *hostTriggers) hostExpiration(sub *event.Subscription) (*notification.Notification, error) {
+func (t *hostTriggers) hostExpiration(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	switch t.event.EventType {
 	case event.EventHostExpirationWarningSent:
 		return t.makeHostExpirationNotification(sub)
@@ -263,7 +263,7 @@ func (t *hostTriggers) getTimeZone(sub *event.Subscription, trigger string) *tim
 	return time.Local
 }
 
-func (t *hostTriggers) spawnHostIdle(sub *event.Subscription) (*notification.Notification, error) {
+func (t *hostTriggers) spawnHostIdle(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	shouldNotify, err := t.host.ShouldNotifyStoppedSpawnHostIdle()
 	if err != nil {
 		return nil, err

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -34,7 +35,7 @@ func makeSpawnHostProvisioningTriggers() eventHandler {
 	return t
 }
 
-func (t *spawnHostProvisioningTriggers) hostSpawnProvisionOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *spawnHostProvisioningTriggers) hostSpawnProvisionOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !t.host.UserHost {
 		return nil, nil
 	}
@@ -173,7 +174,7 @@ func makeSpawnHostStateChangeTriggers() eventHandler {
 	return t
 }
 
-func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !t.host.UserHost {
 		return nil, nil
 	}

--- a/trigger/host_spawn_test.go
+++ b/trigger/host_spawn_test.go
@@ -67,35 +67,38 @@ func (s *spawnHostTriggersSuite) TestSuccessfulSpawn() {
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
-	n, err := s.tProvisioning.Process(&sub)
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.tProvisioning.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber.Type = event.JIRAIssueSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.JIRACommentSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.GithubPullRequestSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.EvergreenWebhookSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
@@ -112,35 +115,38 @@ func (s *spawnHostTriggersSuite) TestFailedSpawn() {
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
-	n, err := s.tProvisioning.Process(&sub)
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.tProvisioning.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber.Type = event.JIRAIssueSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.JIRACommentSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.GithubPullRequestSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
 
 	sub.Subscriber.Type = event.EvergreenWebhookSubscriberType
-	n, err = s.tProvisioning.Process(&sub)
+	n, err = s.tProvisioning.Process(ctx, &sub)
 	s.Nil(n)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "unsupported subscriber type")
@@ -156,32 +162,35 @@ func (s *spawnHostTriggersSuite) TestSpawnHostStateChange() {
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
-	n, err := s.tStateChange.Process(&sub)
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.tStateChange.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.NotNil(n)
 	s.NoError(err)
 
 	sub.Subscriber.Type = event.JIRAIssueSubscriberType
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.Nil(n)
 	s.Error(err)
 
 	sub.Subscriber.Type = event.JIRACommentSubscriberType
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.Nil(n)
 	s.Error(err)
 
 	sub.Subscriber.Type = event.GithubPullRequestSubscriberType
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.Nil(n)
 	s.Error(err)
 
 	sub.Subscriber.Type = event.EvergreenWebhookSubscriberType
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.Nil(n)
 	s.Error(err)
 }
@@ -200,12 +209,15 @@ func (s *spawnHostTriggersSuite) TestSpawnHostSuccessfulStopForSleepScheduleDoes
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
-	n, err := s.tStateChange.Process(&sub)
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.tStateChange.Process(ctx, &sub)
 	s.Nil(n)
 	s.NoError(err, "should suppress notification for successfully stopping spawn host")
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.Nil(n, "should suppress notification for successfully stopping spawn host")
 	s.NoError(err)
 }
@@ -224,12 +236,15 @@ func (s *spawnHostTriggersSuite) TestSpawnHostUnsuccessfulStopForSleepScheduleCr
 		Subscriber: event.NewSlackSubscriber("@test.user"),
 	}
 
-	n, err := s.tStateChange.Process(&sub)
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.tStateChange.Process(ctx, &sub)
 	s.NotNil(n, "should create notification for error trying to stop spawn host")
 	s.NoError(err)
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
-	n, err = s.tStateChange.Process(&sub)
+	n, err = s.tStateChange.Process(ctx, &sub)
 	s.NotNil(n, "should create notification for error trying to stop spawn host")
 	s.NoError(err)
 }

--- a/trigger/host_test.go
+++ b/trigger/host_test.go
@@ -204,7 +204,7 @@ func (s *hostSuite) TestAllTriggers() {
 }
 
 func (s *hostSuite) TestHostExpiration() {
-	n, err := s.t.hostExpiration(&s.subs[0])
+	n, err := s.t.hostExpiration(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -220,7 +220,7 @@ func (s *hostSuite) TestHostTemporaryExemptionExpiration() {
 	s.t.host.ExpirationTime = time.Now().Add(evergreen.SpawnHostExpireDays * evergreen.SpawnHostNoExpirationDuration)
 	s.t.host.SleepSchedule.TemporarilyExemptUntil = time.Now().Add(time.Hour)
 
-	n, err := s.t.hostExpiration(&s.subs[0])
+	n, err := s.t.hostExpiration(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -228,7 +228,7 @@ func (s *hostSuite) TestHostTemporaryExemptionExpiration() {
 func (s *hostSuite) TestSpawnHostIdle() {
 	s.t.host.NoExpiration = true
 	s.t.host.Status = evergreen.HostStopped
-	n, err := s.t.spawnHostIdle(&s.subs[1])
+	n, err := s.t.spawnHostIdle(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }

--- a/trigger/interface.go
+++ b/trigger/interface.go
@@ -23,25 +23,25 @@ type eventHandler interface {
 
 	// Process creates a notification for an event from a single
 	// Subscription
-	Process(*event.Subscription) (*notification.Notification, error)
+	Process(context.Context, *event.Subscription) (*notification.Notification, error)
 
 	// Validate returns true if the string refers to a valid trigger
 	ValidateTrigger(string) bool
 }
 
-type trigger func(*event.Subscription) (*notification.Notification, error)
+type trigger func(context.Context, *event.Subscription) (*notification.Notification, error)
 
 type base struct {
 	triggers map[string]trigger
 }
 
-func (b *base) Process(sub *event.Subscription) (*notification.Notification, error) {
+func (b *base) Process(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	f, found := b.triggers[sub.Trigger]
 	if !found {
 		return nil, nil
 	}
 
-	return f(sub)
+	return f(ctx, sub)
 }
 
 func (b *base) ValidateTrigger(t string) bool {

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -85,7 +85,7 @@ func (t *patchTriggers) Attributes() event.Attributes {
 	}
 }
 
-func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) || t.event.EventType == event.PatchChildrenCompletion {
 		return nil, nil
 	}
@@ -124,7 +124,7 @@ func (t *patchTriggers) patchOutcome(sub *event.Subscription) (*notification.Not
 	return t.generate(sub)
 }
 
-func (t *patchTriggers) patchFailure(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionFailed || t.event.EventType == event.PatchChildrenCompletion {
 		return nil, nil
 	}
@@ -167,7 +167,7 @@ func finalizeChildPatch(sub *event.Subscription) error {
 	return nil
 }
 
-func (t *patchTriggers) patchSuccess(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchSuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionSucceeded || t.event.EventType == event.PatchChildrenCompletion {
 		return nil, nil
 	}
@@ -175,7 +175,7 @@ func (t *patchTriggers) patchSuccess(sub *event.Subscription) (*notification.Not
 	return t.generate(sub)
 }
 
-func (t *patchTriggers) patchStarted(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchStarted(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionStarted {
 		return nil, nil
 	}
@@ -327,7 +327,7 @@ func (t *patchTriggers) getGithubContext(projectIdentifier string) (string, erro
 	return patch.GetGithubContextForChildPatch(projectIdentifier, parentPatch, t.patch)
 }
 
-func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchFamilyOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) {
 		return nil, nil
 	}
@@ -347,7 +347,7 @@ func (t *patchTriggers) patchFamilyOutcome(sub *event.Subscription) (*notificati
 	return t.generate(sub)
 }
 
-func (t *patchTriggers) patchFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchFamilySuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) || t.event.EventType != event.PatchChildrenCompletion {
 		return nil, nil
 	}
@@ -355,7 +355,7 @@ func (t *patchTriggers) patchFamilySuccess(sub *event.Subscription) (*notificati
 	return t.generate(sub)
 }
 
-func (t *patchTriggers) patchFamilyFailure(sub *event.Subscription) (*notification.Notification, error) {
+func (t *patchTriggers) patchFamilyFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionFailed || t.event.EventType != event.PatchChildrenCompletion {
 		return nil, nil
 	}

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -179,60 +179,51 @@ func (s *patchSuite) TestAllTriggers() {
 }
 
 func (s *patchSuite) TestPatchSuccess() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.patchSuccess(ctx, &s.subs[1])
+	n, err := s.t.patchSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchSuccess(ctx, &s.subs[1])
+	n, err = s.t.patchSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchSuccess(ctx, &s.subs[1])
+	n, err = s.t.patchSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *patchSuite) TestPatchFailure() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.patchFailure(ctx, &s.subs[2])
+	n, err := s.t.patchFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchFailure(ctx, &s.subs[2])
+	n, err = s.t.patchFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchFailure(ctx, &s.subs[2])
+	n, err = s.t.patchFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *patchSuite) TestPatchOutcome() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.patchOutcome(ctx, &s.subs[0])
+	n, err := s.t.patchOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchOutcome(ctx, &s.subs[0])
+	n, err = s.t.patchOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(ctx, &s.subs[0])
+	n, err = s.t.patchOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -273,11 +264,8 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	for i := range s.subs {
 		s.NoError(s.subs[i].Upsert())
 	}
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	s.data.Status = evergreen.VersionSucceeded
-	n, err := s.t.patchOutcome(ctx, &s.subs[0])
+	n, err := s.t.patchOutcome(s.ctx, &s.subs[0])
 	// there is no token set up in settings, but hitting this error
 	// means it's trying to finalize the patch
 	s.Require().Error(err)
@@ -285,19 +273,19 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(ctx, &s.subs[1])
+	n, err = s.t.patchOutcome(s.ctx, &s.subs[1])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchOutcome(ctx, &s.subs[2])
+	n, err = s.t.patchOutcome(s.ctx, &s.subs[2])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(ctx, &s.subs[2])
+	n, err = s.t.patchOutcome(s.ctx, &s.subs[2])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
@@ -305,15 +293,12 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 }
 
 func (s *patchSuite) TestPatchStarted() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	n, err := s.t.patchStarted(ctx, &s.subs[0])
+	n, err := s.t.patchStarted(s.ctx, &s.subs[0])
 	s.Nil(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionStarted
-	n, err = s.t.patchStarted(ctx, &s.subs[0])
+	n, err = s.t.patchStarted(s.ctx, &s.subs[0])
 	s.Nil(err)
 	s.NotNil(n)
 }

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model"
-	dbModel "github.com/evergreen-ci/evergreen/model"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -42,14 +41,14 @@ func (s *patchSuite) SetupSuite() {
 func (s *patchSuite) SetupTest() {
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
-	s.NoError(db.ClearCollections(event.EventCollection, patch.Collection, event.SubscriptionsCollection, dbModel.ProjectRefCollection, model.VersionCollection))
+	s.NoError(db.ClearCollections(event.EventCollection, patch.Collection, event.SubscriptionsCollection, model.ProjectRefCollection, model.VersionCollection))
 	startTime := time.Now().Truncate(time.Millisecond)
 
 	patchID := mgobson.ObjectIdHex("5aeb4514f27e4f9984646d97")
 
 	childPatchId := "5aab4514f27e4f9984646d97"
 
-	pRef := dbModel.ProjectRef{
+	pRef := model.ProjectRef{
 		Id:         "test",
 		Identifier: "testing",
 	}
@@ -180,51 +179,60 @@ func (s *patchSuite) TestAllTriggers() {
 }
 
 func (s *patchSuite) TestPatchSuccess() {
-	n, err := s.t.patchSuccess(&s.subs[1])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.patchSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchSuccess(&s.subs[1])
+	n, err = s.t.patchSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchSuccess(&s.subs[1])
+	n, err = s.t.patchSuccess(ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *patchSuite) TestPatchFailure() {
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.patchFailure(&s.subs[2])
+	n, err := s.t.patchFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchFailure(&s.subs[2])
+	n, err = s.t.patchFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchFailure(&s.subs[2])
+	n, err = s.t.patchFailure(ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *patchSuite) TestPatchOutcome() {
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.patchOutcome(&s.subs[0])
+	n, err := s.t.patchOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchOutcome(&s.subs[0])
+	n, err = s.t.patchOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(&s.subs[0])
+	n, err = s.t.patchOutcome(ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -265,9 +273,11 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	for i := range s.subs {
 		s.NoError(s.subs[i].Upsert())
 	}
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err := s.t.patchOutcome(&s.subs[0])
+	n, err := s.t.patchOutcome(ctx, &s.subs[0])
 	// there is no token set up in settings, but hitting this error
 	// means it's trying to finalize the patch
 	s.Require().Error(err)
@@ -275,19 +285,19 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(&s.subs[1])
+	n, err = s.t.patchOutcome(ctx, &s.subs[1])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.patchOutcome(&s.subs[2])
+	n, err = s.t.patchOutcome(ctx, &s.subs[2])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.patchOutcome(&s.subs[2])
+	n, err = s.t.patchOutcome(ctx, &s.subs[2])
 	s.Require().Error(err)
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
@@ -295,12 +305,15 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 }
 
 func (s *patchSuite) TestPatchStarted() {
-	n, err := s.t.patchStarted(&s.subs[0])
+	ctx, cancel := context.WithCancel(s.ctx)
+	defer cancel()
+
+	n, err := s.t.patchStarted(ctx, &s.subs[0])
 	s.Nil(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionStarted
-	n, err = s.t.patchStarted(&s.subs[0])
+	n, err = s.t.patchStarted(ctx, &s.subs[0])
 	s.Nil(err)
 	s.NotNil(n)
 }

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -64,7 +64,7 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 
 	catcher := grip.NewSimpleCatcher()
 	for i := range subscriptions {
-		n, err := h.Process(&subscriptions[i])
+		n, err := h.Process(ctx, &subscriptions[i])
 		msg := message.Fields{
 			"source":              "events-processing",
 			"message":             "processed subscription and created notifications",

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -270,7 +270,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection, evergreen.ConfigCollection,
 		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection, model.ParserProjectCollection, manifest.Collection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": model.ParserProjectCollection})
 
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config)
@@ -400,7 +400,7 @@ func TestProjectTriggerIntegrationForBuild(t *testing.T) {
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection, evergreen.ConfigCollection,
 		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection, model.ParserProjectCollection, manifest.Collection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": model.ParserProjectCollection})
 
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config)
@@ -533,7 +533,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection, evergreen.ConfigCollection,
 		model.ProjectRefCollection, model.RepositoriesCollection, model.ProjectAliasCollection, model.ParserProjectCollection, manifest.Collection))
-	_ = evergreen.GetEnvironment().DB().RunCommand(nil, map[string]string{"create": model.ParserProjectCollection})
+	_ = evergreen.GetEnvironment().DB().RunCommand(ctx, map[string]string{"create": model.ParserProjectCollection})
 
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config)

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -143,5 +143,5 @@ func makeDownstreamProjectFromFile(ctx context.Context, ref model.ProjectRef, fi
 		RemotePath: file,
 		Revision:   ref.Branch,
 	}
-	return model.GetProjectFromFile(context.Background(), opts)
+	return model.GetProjectFromFile(ctx, opts)
 }

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -221,8 +222,8 @@ func makeSummaryPrefix(t *task.Task, failed int) string {
 	}
 }
 
-func (j *jiraBuilder) build() (*message.JiraIssue, error) {
-	if err := j.data.Task.PopulateTestResults(); err != nil {
+func (j *jiraBuilder) build(ctx context.Context) (*message.JiraIssue, error) {
+	if err := j.data.Task.PopulateTestResults(ctx); err != nil {
 		return nil, errors.Wrap(err, "populating test results")
 	}
 

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -1,6 +1,7 @@
 package trigger
 
 import (
+	"context"
 	"regexp"
 	"strings"
 	"testing"
@@ -491,7 +492,9 @@ func TestCustomFields(t *testing.T) {
 			TaskDisplayName: taskName,
 		},
 	}
-	issue, err := j.build()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	issue, err := j.build(ctx)
 	assert.NoError(err)
 	assert.NotNil(issue)
 
@@ -617,7 +620,10 @@ func TestJiraBuilderBuild(t *testing.T) {
 	var err error
 	assert.NoError(t, err)
 
-	message, err := builder.build()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	message, err := builder.build(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "EVG", message.Project)
 	assert.Len(t, message.Fields, 1)

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -200,7 +200,7 @@ func (t *versionTriggers) generate(sub *event.Subscription, pastTenseOverride st
 
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
-func (t *versionTriggers) versionOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) || t.event.EventType == event.VersionChildrenCompletion {
 		return nil, nil
 	}
@@ -208,7 +208,7 @@ func (t *versionTriggers) versionOutcome(sub *event.Subscription) (*notification
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionGithubCheckOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionGithubCheckOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) {
 		return nil, nil
 	}
@@ -216,7 +216,7 @@ func (t *versionTriggers) versionGithubCheckOutcome(sub *event.Subscription) (*n
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionFailure(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionFailed || t.event.EventType == event.VersionChildrenCompletion {
 		return nil, nil
 	}
@@ -239,7 +239,7 @@ func (t *versionTriggers) versionFailure(sub *event.Subscription) (*notification
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionSuccess(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionSuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionSucceeded || t.event.EventType == event.VersionChildrenCompletion {
 		return nil, nil
 	}
@@ -247,7 +247,7 @@ func (t *versionTriggers) versionSuccess(sub *event.Subscription) (*notification
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionExceedsDuration(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionExceedsDuration(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) {
 		return nil, nil
 	}
@@ -266,7 +266,7 @@ func (t *versionTriggers) versionExceedsDuration(sub *event.Subscription) (*noti
 	}
 	return t.generate(sub, fmt.Sprintf("exceeded %d seconds", threshold))
 }
-func (t *versionTriggers) versionFamilyOutcome(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionFamilyOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) {
 		return nil, nil
 	}
@@ -276,7 +276,7 @@ func (t *versionTriggers) versionFamilyOutcome(sub *event.Subscription) (*notifi
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionFamilyFailure(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionFamilyFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionFailed || t.event.EventType != event.VersionChildrenCompletion {
 		return nil, nil
 	}
@@ -300,7 +300,7 @@ func (t *versionTriggers) versionFamilyFailure(sub *event.Subscription) (*notifi
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionFamilySuccess(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionFamilySuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionSucceeded || t.event.EventType != event.VersionChildrenCompletion {
 		return nil, nil
 	}
@@ -308,7 +308,7 @@ func (t *versionTriggers) versionFamilySuccess(sub *event.Subscription) (*notifi
 	return t.generate(sub, "")
 }
 
-func (t *versionTriggers) versionRuntimeChange(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionRuntimeChange(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if !evergreen.IsFinishedVersionStatus(t.data.Status) {
 		return nil, nil
 	}
@@ -337,7 +337,7 @@ func (t *versionTriggers) versionRuntimeChange(sub *event.Subscription) (*notifi
 	return t.generate(sub, fmt.Sprintf("changed in runtime by %.1f%% (over threshold of %s%%)", percentChange, percentString))
 }
 
-func (t *versionTriggers) versionRegression(sub *event.Subscription) (*notification.Notification, error) {
+func (t *versionTriggers) versionRegression(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	if t.data.Status != evergreen.VersionFailed || !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.version.Requester) {
 		return nil, nil
 	}

--- a/trigger/version_test.go
+++ b/trigger/version_test.go
@@ -175,51 +175,51 @@ func (s *VersionSuite) TestAllTriggers() {
 }
 
 func (s *VersionSuite) TestVersionSuccess() {
-	n, err := s.t.versionSuccess(&s.subs[1])
+	n, err := s.t.versionSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.versionSuccess(&s.subs[1])
+	n, err = s.t.versionSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.versionSuccess(&s.subs[1])
+	n, err = s.t.versionSuccess(s.ctx, &s.subs[1])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *VersionSuite) TestVersionFailure() {
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.versionOutcome(&s.subs[0])
+	n, err := s.t.versionOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.versionFailure(&s.subs[2])
+	n, err = s.t.versionFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.versionFailure(&s.subs[2])
+	n, err = s.t.versionFailure(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 }
 
 func (s *VersionSuite) TestVersionOutcome() {
 	s.data.Status = evergreen.VersionCreated
-	n, err := s.t.versionOutcome(&s.subs[0])
+	n, err := s.t.versionOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.Nil(n)
 
 	s.data.Status = evergreen.VersionSucceeded
-	n, err = s.t.versionOutcome(&s.subs[0])
+	n, err = s.t.versionOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.versionOutcome(&s.subs[0])
+	n, err = s.t.versionOutcome(s.ctx, &s.subs[0])
 	s.NoError(err)
 	s.NotNil(n)
 }
@@ -239,7 +239,7 @@ func (s *VersionSuite) TestVersionRegression() {
 
 	// a successful version should not generate
 	s.data.Status = evergreen.VersionSucceeded
-	n, err := s.t.versionRegression(&s.subs[3])
+	n, err := s.t.versionRegression(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 
@@ -256,7 +256,7 @@ func (s *VersionSuite) TestVersionRegression() {
 	}
 	s.NoError(t2.Insert())
 	s.data.Status = evergreen.VersionFailed
-	n, err = s.t.versionRegression(&s.subs[3])
+	n, err = s.t.versionRegression(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.NotNil(n)
 
@@ -274,7 +274,7 @@ func (s *VersionSuite) TestVersionRegression() {
 	}
 	s.NoError(t3.Insert())
 	s.NoError(newAlertRecord(s.subs[3].ID, &t3, alertrecord.TaskFailTransitionId).Insert())
-	n, err = s.t.versionRegression(&s.subs[3])
+	n, err = s.t.versionRegression(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
 }
@@ -287,20 +287,20 @@ func (s *VersionSuite) TestVersionExceedsTime() {
 	s.t.data.Status = evergreen.VersionSucceeded
 	s.t.version.FinishTime = time.Now()
 	s.t.version.StartTime = s.t.version.FinishTime.Add(-20 * time.Minute)
-	n, err := s.t.versionExceedsDuration(&s.subs[4])
+	n, err := s.t.versionExceedsDuration(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// build that does not exceed should not generate
 	s.t.version.StartTime = s.t.version.FinishTime.Add(-4 * time.Minute)
-	n, err = s.t.versionExceedsDuration(&s.subs[4])
+	n, err = s.t.versionExceedsDuration(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 
 	// unfinished build should not generate
 	s.t.data.Status = evergreen.VersionStarted
 	s.t.version.StartTime = s.t.version.FinishTime.Add(-20 * time.Minute)
-	n, err = s.t.versionExceedsDuration(&s.subs[4])
+	n, err = s.t.versionExceedsDuration(s.ctx, &s.subs[4])
 	s.NoError(err)
 	s.Nil(n)
 }
@@ -313,7 +313,7 @@ func (s *VersionSuite) TestVersionRuntimeChange() {
 		EventType: event.VersionStateChange,
 	}
 	s.t.data.Status = evergreen.VersionSucceeded
-	n, err := s.t.versionRuntimeChange(&s.subs[5])
+	n, err := s.t.versionRuntimeChange(s.ctx, &s.subs[5])
 	s.NoError(err)
 	s.Nil(n)
 
@@ -327,19 +327,19 @@ func (s *VersionSuite) TestVersionRuntimeChange() {
 		Requester:           evergreen.RepotrackerVersionRequester,
 	}
 	s.NoError(lastGreen.Insert())
-	n, err = s.t.versionRuntimeChange(&s.subs[5])
+	n, err = s.t.versionRuntimeChange(s.ctx, &s.subs[5])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// version that does not exceed threshold should not generate
 	s.t.version.StartTime = s.t.version.FinishTime.Add(-11 * time.Minute)
-	n, err = s.t.versionRuntimeChange(&s.subs[5])
+	n, err = s.t.versionRuntimeChange(s.ctx, &s.subs[5])
 	s.NoError(err)
 	s.Nil(n)
 
 	// build that finished too quickly should generate
 	s.t.version.StartTime = s.t.version.FinishTime.Add(-4 * time.Minute)
-	n, err = s.t.versionRuntimeChange(&s.subs[5])
+	n, err = s.t.versionRuntimeChange(s.ctx, &s.subs[5])
 	s.NoError(err)
 	s.NotNil(n)
 }

--- a/trigger/volume.go
+++ b/trigger/volume.go
@@ -94,7 +94,7 @@ func (t *volumeTriggers) generate(sub *event.Subscription) (*notification.Notifi
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
 
-func (t *volumeTriggers) volumeExpiration(sub *event.Subscription) (*notification.Notification, error) {
+func (t *volumeTriggers) volumeExpiration(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
 	timeZone := time.Local
 	if sub.OwnerType == event.OwnerTypePerson {
 		userTimeZone, err := getUserTimeZone(sub.Owner)

--- a/trigger/volume_test.go
+++ b/trigger/volume_test.go
@@ -88,7 +88,7 @@ func TestVolumeExpiration(t *testing.T) {
 			sub.Subscriber = event.Subscriber{Type: event.EmailSubscriberType}
 			sub.Selectors = []event.Selector{{Type: event.SelectorID, Data: v.ID}}
 			sub.Trigger = "t"
-			n, err := triggers.volumeExpiration(sub)
+			n, err := triggers.volumeExpiration(ctx, sub)
 			assert.NoError(t, err)
 			assert.NotNil(t, n)
 		},


### PR DESCRIPTION
DEVPROD-3925

### Description
This is a cascade of changes in our notification system essentially. I also cleaned up _some_ of the lint warnings that were along the way 

### Testing
Existing unit tests
