### PR TITLE
DEVPROD-13221 Add more nil checks to dispatcher

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -485,6 +485,9 @@ func (d *basicCachedDAGDispatcherImpl) tryMarkNextTaskGroupTaskDispatched(taskGr
 		// taskGroupTask is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 		node := d.getNodeByItemID(next.Id)
 		taskGroupTask := d.getItemByNodeID(node.ID())
+		if taskGroupTask == nil {
+			return nil
+		}
 		taskGroupTask.IsDispatched = true
 		return next
 	}
@@ -587,6 +590,9 @@ func getMaxConcurrentLargeParserProjTasks(settings *evergreen.Settings) int {
 }
 
 func (d *basicCachedDAGDispatcherImpl) nextTaskGroupTask(unit schedulableUnit) *TaskQueueItem {
+	if len(d.taskGroups[unit.id].tasks) != len(unit.tasks) {
+		return nil
+	}
 	for i, nextTaskQueueItem := range unit.tasks {
 		// Dispatch this task if all of the following are true:
 		// (a) it's not marked as dispatched in the in-memory queue.


### PR DESCRIPTION
DEVPROD-13221

### Description
Now that mutex locking has is used by various helper functions inside `FindNextTask` rather than across the entire function, there's a small chance the queue will be [refreshed](https://github.com/evergreen-ci/evergreen/blob/26704b62db54d3fcaee2654f40d6999af39e4605/model/task_queue_service_dependency.go#L73)  in-between those helper functions, leaving subsequent helper functions with stale data. 

Added some checks to return nil if this happens. This should fix the occasional nil dereference / index OOB we've been seeing.
### Testing
Existing tests
