### PR TITLE
DEVPROD-3983 Spawn host setup script notifications

### DIFF
--- a/docs/Project-Configuration/Notifications.md
+++ b/docs/Project-Configuration/Notifications.md
@@ -20,7 +20,7 @@ For all new patches you create in the future (including GitHub Pull Requests), y
 For new tasks that fit the desired requester and finish type, you'll receive a notification. Note that for system unresponsive tasks, we only send a notification on the last execution, since we auto-retry these.
 
 ### Spawn Host Outcome
-For your spawn hosts, you will receive notifications when a host is started, stopped, modified, or terminated.
+For your spawn hosts, you will receive notifications when a host is started, stopped, modified, or terminated. You will also receive notifications when your project-specific host setup script succeeds or fails to run on the spawn host.
 
 ### Spawn Host Expiration
 Receive notifications that your spawn host is going to expire soon, so you can update expiration accordingly if you don't want to lose the host.

--- a/globals.go
+++ b/globals.go
@@ -359,10 +359,11 @@ const (
 	// to tear down a task group. This is set one minute longer than the agent's maxTeardownGroupTimeout.
 	MaxTeardownGroupThreshold = 4 * time.Minute
 
-	SaveGenerateTasksError     = "error saving config in `generate.tasks`"
-	TasksAlreadyGeneratedError = "generator already ran and generated tasks"
-	KeyTooLargeToIndexError    = "key too large to index"
-	InvalidDivideInputError    = "$divide only supports numeric types"
+	SaveGenerateTasksError          = "error saving config in `generate.tasks`"
+	TasksAlreadyGeneratedError      = "generator already ran and generated tasks"
+	KeyTooLargeToIndexError         = "key too large to index"
+	InvalidDivideInputError         = "$divide only supports numeric types"
+	FetchingTaskDataUnfinishedError = "fetching task data not finished"
 
 	// ContainerHealthDashboard is the name of the Splunk dashboard that displays
 	// charts relating to the health of container tasks.

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -297,11 +297,11 @@ func LogSpawnHostIdleNotification(hostID string) {
 }
 
 func LogHostScriptExecuted(hostID string, logs string) {
-	LogHostEvent(hostID, EventHostScriptExecuted, HostEventData{Logs: logs, Successful: true})
+	LogHostEvent(hostID, EventHostScriptExecuted, HostEventData{Logs: logs})
 }
 
 func LogHostScriptExecuteFailed(hostID string, err error) {
-	LogHostEvent(hostID, EventHostScriptExecuteFailed, HostEventData{Logs: err.Error(), Successful: false})
+	LogHostEvent(hostID, EventHostScriptExecuteFailed, HostEventData{Logs: err.Error()})
 }
 
 // LogVolumeMigrationFailed is used when a volume is unable to migrate to a new host.

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -22,6 +22,8 @@ func init() {
 	registry.AllowSubscription(ResourceTypeHost, EventHostStarted)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStopped)
 	registry.AllowSubscription(ResourceTypeHost, EventHostModified)
+	registry.AllowSubscription(ResourceTypeHost, EventHostScriptExecuted)
+	registry.AllowSubscription(ResourceTypeHost, EventHostScriptExecuteFailed)
 }
 
 const (
@@ -295,11 +297,11 @@ func LogSpawnHostIdleNotification(hostID string) {
 }
 
 func LogHostScriptExecuted(hostID string, logs string) {
-	LogHostEvent(hostID, EventHostScriptExecuted, HostEventData{Logs: logs})
+	LogHostEvent(hostID, EventHostScriptExecuted, HostEventData{Logs: logs, Successful: true})
 }
 
 func LogHostScriptExecuteFailed(hostID string, err error) {
-	LogHostEvent(hostID, EventHostScriptExecuteFailed, HostEventData{Logs: err.Error()})
+	LogHostEvent(hostID, EventHostScriptExecuteFailed, HostEventData{Logs: err.Error(), Successful: false})
 }
 
 // LogVolumeMigrationFailed is used when a volume is unable to migrate to a new host.

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -936,8 +936,8 @@ func (h *Host) CheckTaskDataFetched(ctx context.Context, env evergreen.Environme
 
 	const (
 		checkAttempts      = 10
-		checkRetryMinDelay = time.Second
-		checkRetryMaxDelay = 45 * time.Second
+		checkRetryMinDelay = 3 * time.Second
+		checkRetryMaxDelay = time.Minute
 	)
 
 	return h.withTaggedProcs(ctx, env, evergreen.HostFetchTag, func(procs []jasper.Process) error {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -955,7 +955,7 @@ func (h *Host) CheckTaskDataFetched(ctx context.Context, env evergreen.Environme
 					if proc.Complete(ctx) {
 						return false, nil
 					}
-					return true, errors.New("fetching task data not finished")
+					return true, errors.New(evergreen.FetchingTaskDataUnfinishedError)
 				}, utility.RetryOptions{
 					MaxAttempts: checkAttempts,
 					MinDelay:    checkRetryMinDelay,

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -305,7 +305,7 @@ func (t *spawnHostSetupScriptTriggers) makePayload(sub *event.Subscription) (int
 	}
 
 	var result string
-	if t.data.Successful {
+	if t.event.EventType == event.EventHostScriptExecuted {
 		result = "succeeded"
 	} else {
 		result = "failed"

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -300,18 +300,17 @@ func (t *spawnHostSetupScriptTriggers) spawnHostSetupScriptOutcome(sub *event.Su
 }
 
 func (t *spawnHostSetupScriptTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
-	if t.event.EventType != event.EventHostScriptExecuteFailed && t.event.EventType != event.EventHostScriptExecuted {
-		return nil, errors.Errorf("unexpected event type '%s'", t.event.EventType)
-	}
-
 	var result string
-	if t.event.EventType == event.EventHostScriptExecuted {
+	switch t.event.EventType {
+	case event.EventHostScriptExecuted:
 		result = "succeeded"
-	} else {
+	case event.EventHostScriptExecuteFailed:
 		result = "failed"
 		if strings.Contains(t.data.Logs, evergreen.FetchingTaskDataUnfinishedError) {
 			result = "failed to start"
 		}
+	default:
+		return nil, errors.Errorf("unexpected event type '%s'", t.event.EventType)
 	}
 	var spawnHostScriptPath string
 	if t.host.ProvisionOptions != nil && t.host.ProvisionOptions.TaskId != "" {
@@ -360,7 +359,7 @@ func (t *spawnHostSetupScriptTriggers) slackPayload(spawnHostScriptPath, result,
 			})
 		attachment.Fields = append(attachment.Fields,
 			&message.SlackAttachmentField{
-				Title: "Setup Script Command",
+				Title: "Setup Script Path",
 				Value: spawnHostScriptPath,
 			})
 	}

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/notification"
@@ -20,6 +21,8 @@ func init() {
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStarted, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStopped, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostModified, makeSpawnHostStateChangeTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostScriptExecuted, makeSpawnHostSetupScriptTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostScriptExecuteFailed, makeSpawnHostSetupScriptTriggers)
 }
 
 type spawnHostProvisioningTriggers struct {
@@ -265,6 +268,123 @@ func (t *spawnHostStateChangeTriggers) emailPayload(action, result, hostID, url,
 	</body>
 	</html>
 	`, action, hostURL, hostID, result, url)
+
+	return &message.Email{
+		Subject:           subject,
+		Body:              body,
+		PlainTextContents: false,
+	}
+}
+
+type spawnHostSetupScriptTriggers struct {
+	hostBase
+}
+
+func makeSpawnHostSetupScriptTriggers() eventHandler {
+	t := &spawnHostSetupScriptTriggers{}
+	t.triggers = map[string]trigger{
+		event.TriggerOutcome: t.spawnHostSetupScriptOutcome,
+	}
+	return t
+}
+
+func (t *spawnHostSetupScriptTriggers) spawnHostSetupScriptOutcome(sub *event.Subscription) (*notification.Notification, error) {
+	if !t.host.UserHost {
+		return nil, nil
+	}
+	payload, err := t.makePayload(sub)
+	if err != nil {
+		return nil, errors.Wrap(err, "making payload")
+	}
+	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
+}
+
+func (t *spawnHostSetupScriptTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
+	if t.event.EventType != event.EventHostScriptExecuteFailed && t.event.EventType != event.EventHostScriptExecuted {
+		return nil, errors.Errorf("unexpected event type '%s'", t.event.EventType)
+	}
+
+	var result string
+	if t.data.Successful {
+		result = "succeeded"
+	} else {
+		result = "failed"
+		if strings.Contains(t.data.Logs, evergreen.FetchingTaskDataUnfinishedError) {
+			result = "failed to start"
+		}
+	}
+	var spawnHostScriptPath string
+	if t.host.ProvisionOptions != nil && t.host.ProvisionOptions.TaskId != "" {
+		pRef, err := model.GetProjectRefForTask(t.host.ProvisionOptions.TaskId)
+		if err != nil {
+			return "", errors.Wrap(err, "getting project")
+		}
+		if pRef != nil {
+			spawnHostScriptPath = pRef.SpawnHostScriptPath
+		}
+	}
+
+	switch sub.Subscriber.Type {
+	case event.SlackSubscriberType:
+		return t.slackPayload(spawnHostScriptPath, result, t.host.Id, spawnHostURL(t.uiConfig.Url), hostURL(t.uiConfig.Url, t.host.Id)), nil
+	case event.EmailSubscriberType:
+		return t.emailPayload(spawnHostScriptPath, result, t.host.Id, spawnHostURL(t.uiConfig.Url), hostURL(t.uiConfig.Url, t.host.Id)), nil
+	default:
+		return nil, errors.Errorf("unexpected subscriber type '%s'", sub.Subscriber.Type)
+	}
+}
+
+func (t *spawnHostSetupScriptTriggers) slackPayload(spawnHostScriptPath, result, hostID, url, hostURL string) *notification.SlackPayload {
+	color := evergreenSuccessColor
+	if !t.data.Successful {
+		color = evergreenFailColor
+	}
+
+	attachment := message.SlackAttachment{
+		Title:     "Spawn hosts page",
+		TitleLink: url,
+		Color:     color,
+		Fields: []*message.SlackAttachmentField{
+			{
+				Title: "SSH Command",
+				Value: fmt.Sprintf("`%s`", sshCommand(t.host)),
+			},
+		},
+	}
+	if spawnHostScriptPath != "" {
+		attachment.Fields = append(attachment.Fields,
+			&message.SlackAttachmentField{
+				Title: "With data from task",
+				Value: fmt.Sprintf("<%s|%s>", taskLink(t.uiConfig.Url, t.host.ProvisionOptions.TaskId, -1), t.host.ProvisionOptions.TaskId),
+				Short: true,
+			})
+		attachment.Fields = append(attachment.Fields,
+			&message.SlackAttachmentField{
+				Title: "Setup Script Command",
+				Value: spawnHostScriptPath,
+			})
+	}
+	payload := &notification.SlackPayload{
+		Body:        fmt.Sprintf("The setup script for spawn host <%s|%s> has %s", hostURL, hostID, result),
+		Attachments: []message.SlackAttachment{attachment},
+	}
+	return payload
+}
+
+func (t *spawnHostSetupScriptTriggers) emailPayload(spawnHostScriptPath, result, hostID, url, hostURL string) *message.Email {
+	subject := fmt.Sprintf("The setup script for spawn host has %s", result)
+	body := fmt.Sprintf(`<html>
+	<head>
+	</head>
+	<body>
+	<p>Hi,</p>
+	<p>The setup script '%s' for spawn host <a href="%s">%s</a> has %s.</p>
+	<p>Manage spawn hosts from <a href="%s">your hosts page</a> or the Evergreen CLI</p>
+
+
+	</body>
+	</html>
+	`, spawnHostScriptPath, hostURL, hostID, result, url)
 
 	return &message.Email{
 		Subject:           subject,

--- a/trigger/host_spawn_test.go
+++ b/trigger/host_spawn_test.go
@@ -2,7 +2,6 @@ package trigger
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -258,7 +257,8 @@ func (s *spawnHostTriggersSuite) TestSpawnHostSetupScriptCompletion() {
 	slackResponse, ok := n.Payload.(*notification.SlackPayload)
 	s.Require().True(ok)
 	s.Require().NotNil(slackResponse)
-	s.Equal(slackResponse.Body, fmt.Sprintf("The setup script for spawn host <%s|%s> has succeeded", hostURL("", s.h.Id), s.h.Id))
+	s.Contains(slackResponse.Body, "The setup script for spawn host")
+	s.Contains(slackResponse.Body, "has succeeded")
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
 	n, err = s.tSetupScript.Process(&sub)
@@ -286,7 +286,8 @@ func (s *spawnHostTriggersSuite) TestSpawnHostSetupScriptCompletion() {
 	slackResponse, ok = n.Payload.(*notification.SlackPayload)
 	s.Require().True(ok)
 	s.Require().NotNil(slackResponse)
-	s.Equal(slackResponse.Body, fmt.Sprintf("The setup script for spawn host <%s|%s> has failed", hostURL("", s.h.Id), s.h.Id))
+	s.Contains(slackResponse.Body, "The setup script for spawn host")
+	s.Contains(slackResponse.Body, "has failed")
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
 	n, err = s.tSetupScript.Process(&sub)
@@ -316,7 +317,8 @@ func (s *spawnHostTriggersSuite) TestSpawnHostSetupScriptCompletion() {
 	slackResponse, ok = n.Payload.(*notification.SlackPayload)
 	s.Require().True(ok)
 	s.Require().NotNil(slackResponse)
-	s.Equal(slackResponse.Body, fmt.Sprintf("The setup script for spawn host <%s|%s> has failed to start", hostURL("", s.h.Id), s.h.Id))
+	s.Contains(slackResponse.Body, "The setup script for spawn host")
+	s.Contains(slackResponse.Body, "has failed to start")
 
 	sub.Subscriber = event.NewEmailSubscriber("example@domain.invalid")
 	n, err = s.tSetupScript.Process(&sub)

--- a/units/host_setup_script.go
+++ b/units/host_setup_script.go
@@ -23,7 +23,7 @@ const (
 
 	// maxSpawnHostSetupScriptCheckDuration is the total amount of time that the
 	// spawn host setup script job can poll to see if the task data is loaded.
-	maxSpawnHostSetupScriptCheckDuration = 10 * time.Minute
+	maxSpawnHostSetupScriptCheckDuration = 25 * time.Minute
 	// maxSpawnHostSetupScriptDuration is the total amount of time that the
 	// spawn host setup script can run after task data is loaded.
 	maxSpawnHostSetupScriptDuration = 30 * time.Minute

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -127,7 +127,7 @@ clientsLoop:
 					}))
 					statuses[hostID] = cloud.StatusNonExistent
 				}
-				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, hosts[i], status), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
+				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, hosts[i], status), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
 			}
 
 			continue
@@ -141,7 +141,7 @@ clientsLoop:
 				j.AddError(errors.Wrapf(err, "checking instance status of host '%s'", h.Id))
 				continue clientsLoop
 			}
-			j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, m, h, cloudInfo.Status), "setting status for host '%s' based on its cloud instance's status", h.Id))
+			j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, h, cloudInfo.Status), "setting status for host '%s' based on its cloud instance's status", h.Id))
 		}
 	}
 }
@@ -184,7 +184,7 @@ func (j *cloudHostReadyJob) terminateUnknownHosts(ctx context.Context, awsErr st
 // determine the next step in the host lifecycle. Hosts that are running
 // in the cloud can successfully transition to the next step in the lifecycle.
 // Hosts found in an unrecoverable state are terminated.
-func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, m cloud.Manager, h host.Host, cloudStatus cloud.CloudStatus) error {
+func (j *cloudHostReadyJob) setCloudHostStatus(ctx context.Context, h host.Host, cloudStatus cloud.CloudStatus) error {
 	switch cloudStatus {
 	case cloud.StatusFailed, cloud.StatusTerminated, cloud.StatusStopped, cloud.StatusStopping, cloud.StatusNonExistent:
 		j.logHostStatusMessage(&h, cloudStatus)

--- a/units/host_status_test.go
+++ b/units/host_status_test.go
@@ -160,7 +160,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			h.Distro.BootstrapSettings.Method = distro.BootstrapMethodLegacySSH
 			require.NoError(t, h.Insert(ctx))
 
-			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, mockInstance.Status))
+			require.NoError(t, j.setCloudHostStatus(ctx, *h, mockInstance.Status))
 
 			dbHost, err := host.FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			h.Distro.BootstrapSettings.Method = distro.BootstrapMethodUserData
 			require.NoError(t, h.Insert(ctx))
 
-			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, mockInstance.Status))
+			require.NoError(t, j.setCloudHostStatus(ctx, *h, mockInstance.Status))
 
 			dbHost, err := host.FindOneId(ctx, h.Id)
 			require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 		},
 		"NonExistentStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			require.NoError(t, h.Insert(ctx))
-			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusNonExistent))
+			require.NoError(t, j.setCloudHostStatus(ctx, *h, cloud.StatusNonExistent))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
 			require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 		},
 		"FailedStatusInitiatesTermination": func(ctx context.Context, t *testing.T, env *mock.Environment, h *host.Host, j *cloudHostReadyJob, mockMgr cloud.Manager) {
 			require.NoError(t, h.Insert(ctx))
-			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusFailed))
+			require.NoError(t, j.setCloudHostStatus(ctx, *h, cloud.StatusFailed))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
 			require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestSetCloudHostStatus(t *testing.T) {
 			require.NoError(t, tsk.Insert())
 			h.RunningTask = tsk.Id
 			require.NoError(t, h.Insert(ctx))
-			require.NoError(t, j.setCloudHostStatus(ctx, mockMgr, *h, cloud.StatusStopped))
+			require.NoError(t, j.setCloudHostStatus(ctx, *h, cloud.StatusStopped))
 
 			queue, err := env.RemoteQueueGroup().Get(ctx, terminateHostQueueGroup)
 			require.NoError(t, err)

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -592,7 +592,7 @@ func (j *setupHostJob) fetchRemoteTaskData(ctx context.Context) error {
 	}
 	var output string
 	var err error
-	fetchTimeout := 15 * time.Minute
+	fetchTimeout := 20 * time.Minute
 	getTaskDataCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 	if j.host.Distro.LegacyBootstrap() {


### PR DESCRIPTION
DEVPROD-3983

### Description
Sends notifications on the success/failure of host setup scripts to users who are opted into "Spawn host outcome" notifications, as well as increases the timeout period in which we poll for the setup script to complete to make the issue described in the ticket less likely.

Deleted an unused parameter I noticed along the way.
### Testing
Forced the timeout situation in staging and confirmed the notification received was as expected.
### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
