### PR TITLE
DEVPROD-9426: support writing GitHub app private key to Parameter Store

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -480,7 +480,7 @@ func (r *mutationResolver) DeleteGithubAppCredentials(ctx context.Context, opts 
 	if app == nil {
 		return nil, InputValidationError.Send(ctx, fmt.Sprintf("project '%s' does not have a GitHub app defined", opts.ProjectID))
 	}
-	if err = githubapp.RemoveGithubAppAuth(opts.ProjectID); err != nil {
+	if err = model.GitHubAppAuthRemove(app); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("removing GitHub app auth for project '%s': %s", opts.ProjectID, err.Error()))
 	}
 	before := model.ProjectSettings{

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -42,9 +42,9 @@ func githubAppCheckAndRunParameterStoreOp(ctx context.Context, appAuth *githubap
 	op(ref, isRepoRef)
 }
 
-// GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
+// githubAppAuthUpsert upserts the GitHub app auth into the database and to
 // Parameter Store if enabled.
-func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
+func githubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -42,8 +42,6 @@ func githubAppCheckAndRunParameterStoreOp(ctx context.Context, appAuth *githubap
 	op(ref, isRepoRef)
 }
 
-// kim: TODO: migrate usages of auth.Upsert to use this function temporarily.
-// kim: TODO: write test similar to one for vars.Upsert.
 // GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
 // Parameter Store if enabled.
 func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
@@ -95,19 +93,13 @@ func githubAppAuthUpsertParameterStore(ctx context.Context, appAuth *githubapp.G
 	return paramName, nil
 }
 
-// kim: TODO: migrate usages of auth.Remove to use this function temporarily.
-// GitHubAppAuthRemove deletes the GitHub app auth from the database and
+// GitHubAppAuthRemove removes the GitHub app auth from the database and from
 // Parameter Store if enabled.
-// kim: TODO: write test similar to one for vars.Clear.
 func GitHubAppAuthRemove(appAuth *githubapp.GithubAppAuth) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 
 	githubAppCheckAndRunParameterStoreOp(ctx, appAuth, func(ref *ProjectRef, isRepoRef bool) {
-		// kim: NOTE: no need to check if app is synced here because it uploads
-		// the one field rather than doing a smarter diff like project vars have
-		// to. Only the sync job needs that info to determine which GitHub apps
-		// to sync.
 		if err := githubAppAuthRemoveParameterStore(ctx, appAuth); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":    "could not delete GitHub app auth from Parameter Store",

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO (DEVPROD-11883): move all of this logic into githubapp package once all
-// project GitHub apps are using Parameter Store and the rollout is stable. The
-// functions are only here temporarily to avoid a dependency cycle between
-// githubapp and model packages due to the project ref feature flag.
+// TODO (DEVPROD-11883): move all of this logic into the githubapp package once
+// all project GitHub apps are using Parameter Store and the rollout is stable.
+// The functions are only here temporarily to avoid a dependency cycle between
+// the githubapp and model packages due to the project ref feature flag.
 
 // githubAppCheckAndRunParameterStoreOp checks if the project corresponding to
 // the GitHub app auth has Parameter Store enabled, and if so, runs the given

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -1,0 +1,145 @@
+package model
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/githubapp"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+// TODO (DEVPROD-11883): move all of this logic into githubapp package once all
+// project GitHub apps are using Parameter Store and the rollout is stable. The
+// functions are only here temporarily to avoid a dependency cycle between
+// githubapp and model packages due to the project ref feature flag.
+
+// githubAppCheckAndRunParameterStoreOp checks if the project corresponding to
+// the GitHub app auth has Parameter Store enabled, and if so, runs the given
+// Parameter Store operation.
+func githubAppCheckAndRunParameterStoreOp(ctx context.Context, appAuth *githubapp.GithubAppAuth, op func(ref *ProjectRef, isRepoRef bool), opName string) {
+	ref, isRepoRef, err := findProjectRef(appAuth.Id)
+	grip.Error(message.WrapError(err, message.Fields{
+		"message":    "could not check if Parameter Store is enabled for project; assuming it's disabled and will not use Parameter Store",
+		"op":         opName,
+		"project_id": appAuth.Id,
+		"epic":       "DEVPROD-5552",
+	}))
+	isPSEnabled, err := isParameterStoreEnabledForProject(ctx, ref)
+	grip.Error(message.WrapError(err, message.Fields{
+		"message":    "could not check if Parameter Store is enabled for project; assuming it's disabled and will not use Parameter Store",
+		"op":         opName,
+		"project_id": appAuth.Id,
+		"epic":       "DEVPROD-5552",
+	}))
+	if !isPSEnabled {
+		return
+	}
+
+	op(ref, isRepoRef)
+}
+
+// kim: TODO: write test similar to one for vars.Upsert.
+// kim: TODO: migrate usages of auth.Upsert to use this function temporarily.
+// GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
+// Parameter Store if enabled.
+func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+	defer cancel()
+
+	githubAppCheckAndRunParameterStoreOp(ctx, appAuth, func(ref *ProjectRef, isRepoRef bool) {
+		// kim: NOTE: no need to check if app is synced here because it uploads
+		// the one field rather than doing a smarter diff like project vars have
+		// to. Only the sync job needs that info to determine which GitHub apps
+		// to sync.
+		paramName, err := githubAppAuthUpsertParameterStore(ctx, appAuth, ref, isRepoRef)
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":    "could not upsert GitHub app auth into Parameter Store",
+			"op":         "Upsert",
+			"project_id": appAuth.Id,
+			"epic":       "DEVPROD-5552",
+		}))
+		if paramName != "" {
+			appAuth.PrivateKeyParameter = paramName
+		}
+	}, "Upsert")
+
+	return githubapp.UpsertGithubAppAuth(appAuth)
+}
+
+// githubAppAuthUpsertParameterStore upserts the GitHub app auth into Parameter
+// Store.
+func githubAppAuthUpsertParameterStore(ctx context.Context, appAuth *githubapp.GithubAppAuth, pRef *ProjectRef, isRepoRef bool) (string, error) {
+	projectID := appAuth.Id
+	partialParamName := getPrivateKeyParamName(projectID)
+
+	paramMgr := evergreen.GetEnvironment().ParameterManager()
+	paramValue := string(appAuth.PrivateKey)
+
+	param, err := paramMgr.Put(ctx, partialParamName, paramValue)
+	if err != nil {
+		return "", errors.Wrap(err, "upserting GitHub app private key into Parameter Store")
+	}
+	paramName := param.Name
+
+	existingParamName := appAuth.PrivateKeyParameter
+	if existingParamName != "" && existingParamName != paramName {
+		if err := paramMgr.Delete(ctx, existingParamName); err != nil {
+			return "", errors.Wrapf(err, "deleting old GitHub app private key parameter '%s' from Parameter Store after it was renamed to '%s'", existingParamName, paramName)
+		}
+	}
+
+	if err := pRef.setParameterStoreGitHubAppAuthSynced(true, isRepoRef); err != nil {
+		return "", errors.Wrapf(err, "marking project/repo ref '%s' as having its GitHub app auth synced to Parameter Store", pRef.Id)
+	}
+
+	return paramName, nil
+}
+
+// kim: TODO: write test similar to one for vars.Clear.
+// kim: TODO: migrate usages of auth.Remove to use this function temporarily.
+// GitHubAppAuthRemove deletes the GitHub app auth from the database and
+// Parameter Store if enabled.
+func GitHubAppAuthRemove(appAuth *githubapp.GithubAppAuth) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+	defer cancel()
+
+	githubAppCheckAndRunParameterStoreOp(ctx, appAuth, func(ref *ProjectRef, isRepoRef bool) {
+		// kim: NOTE: no need to check if app is synced here because it uploads
+		// the one field rather than doing a smarter diff like project vars have
+		// to. Only the sync job needs that info to determine which GitHub apps
+		// to sync.
+		if err := githubAppAuthRemoveParameterStore(ctx, appAuth); err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message":    "could not delete GitHub app auth from Parameter Store",
+				"op":         "Remove",
+				"project_id": appAuth.Id,
+				"epic":       "DEVPROD-5552",
+			}))
+		}
+	}, "Remove")
+	return githubapp.RemoveGithubAppAuth(appAuth.Id)
+}
+
+// githubAppAuthRemoveParameterStore removes the GitHub app auth from Parameter
+// Store.
+func githubAppAuthRemoveParameterStore(ctx context.Context, appAuth *githubapp.GithubAppAuth) error {
+	if appAuth.PrivateKeyParameter == "" {
+		return nil
+	}
+	paramMgr := evergreen.GetEnvironment().ParameterManager()
+	if err := paramMgr.Delete(ctx, appAuth.PrivateKeyParameter); err != nil {
+		return errors.Wrapf(err, "deleting GitHub app private key parameter '%s' from Parameter Store", appAuth.PrivateKeyParameter)
+	}
+	return nil
+}
+
+// getPrivateKeyParamName returns the parameter name for the GitHub app's
+// private key in Parameter Store for the given project.
+func getPrivateKeyParamName(projectID string) string {
+	hashedProjectID := util.GetSHA256Hash(projectID)
+	return fmt.Sprintf("github_apps/%s/private_key", hashedProjectID)
+}

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -42,8 +42,8 @@ func githubAppCheckAndRunParameterStoreOp(ctx context.Context, appAuth *githubap
 	op(ref, isRepoRef)
 }
 
-// kim: TODO: write test similar to one for vars.Upsert.
 // kim: TODO: migrate usages of auth.Upsert to use this function temporarily.
+// kim: TODO: write test similar to one for vars.Upsert.
 // GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
 // Parameter Store if enabled.
 func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
@@ -51,10 +51,6 @@ func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
 	defer cancel()
 
 	githubAppCheckAndRunParameterStoreOp(ctx, appAuth, func(ref *ProjectRef, isRepoRef bool) {
-		// kim: NOTE: no need to check if app is synced here because it uploads
-		// the one field rather than doing a smarter diff like project vars have
-		// to. Only the sync job needs that info to determine which GitHub apps
-		// to sync.
 		paramName, err := githubAppAuthUpsertParameterStore(ctx, appAuth, ref, isRepoRef)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":    "could not upsert GitHub app auth into Parameter Store",
@@ -99,10 +95,10 @@ func githubAppAuthUpsertParameterStore(ctx context.Context, appAuth *githubapp.G
 	return paramName, nil
 }
 
-// kim: TODO: write test similar to one for vars.Clear.
 // kim: TODO: migrate usages of auth.Remove to use this function temporarily.
 // GitHubAppAuthRemove deletes the GitHub app auth from the database and
 // Parameter Store if enabled.
+// kim: TODO: write test similar to one for vars.Clear.
 func GitHubAppAuthRemove(appAuth *githubapp.GithubAppAuth) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -52,7 +52,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 	assert.Equal(t, paramName, dbAppAuth.PrivateKeyParameter, "private key parameter name should remain the same on following upsert")
 }
 
-func TestRemoveGithubAppAuth(t *testing.T) {
+func TestRemoveGitHubAppAuth(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	require.NoError(t, db.ClearCollections(ProjectRefCollection, githubapp.GitHubAppAuthCollection, fakeparameter.Collection))

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -1,0 +1,97 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/githubapp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO (DEVPROD-11883): move all these tests into the githubapp package once
+// all project GitHub apps are using Parameter Store and the rollout is stable.
+// The tests are only here temporarily to avoid a dependency cycle between the
+// githubapp and model packages due to the project ref feature flag.
+
+func TestUpsertGitHubAppAuth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, db.ClearCollections(githubapp.GitHubAppAuthCollection, ProjectRefCollection))
+
+	const projectID = "mongodb"
+	pRef := ProjectRef{
+		Id:                    projectID,
+		ParameterStoreEnabled: true,
+	}
+	require.NoError(t, pRef.Insert())
+
+	key := []byte("private_key")
+	appAuth := &githubapp.GithubAppAuth{
+		Id:         projectID,
+		AppID:      1234,
+		PrivateKey: key,
+	}
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+
+	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
+	require.NoError(t, err)
+	require.NotZero(t, dbAppAuth)
+	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
+	paramName := appAuth.PrivateKeyParameter
+
+	appAuth.PrivateKey = []byte("new_private_key")
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+
+	dbAppAuth, err = githubapp.FindOneGithubAppAuth(projectID)
+	require.NoError(t, err)
+	require.NotZero(t, dbAppAuth)
+	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
+	assert.Equal(t, paramName, dbAppAuth.PrivateKeyParameter, "private key parameter name should remain the same on following upsert")
+}
+
+func TestRemoveGithubAppAuth(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, githubapp.GitHubAppAuthCollection, fakeparameter.Collection))
+
+	const projectID = "mongodb"
+	pRef := ProjectRef{
+		Id:                    projectID,
+		ParameterStoreEnabled: true,
+	}
+	require.NoError(t, pRef.Insert())
+
+	key := []byte("private_key")
+	appAuth := &githubapp.GithubAppAuth{
+		Id:         projectID,
+		AppID:      1234,
+		PrivateKey: key,
+	}
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+
+	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
+	require.NoError(t, err)
+	require.NotZero(t, dbAppAuth)
+	checkParameterMatchesPrivateKey(ctx, t, appAuth)
+	paramName := appAuth.PrivateKeyParameter
+
+	require.NoError(t, GitHubAppAuthRemove(dbAppAuth))
+
+	dbAppAuth, err = githubapp.FindOneGithubAppAuth(projectID)
+	assert.NoError(t, err)
+	assert.Zero(t, dbAppAuth)
+
+	fakeParams, err := fakeparameter.FindByIDs(ctx, paramName)
+	assert.NoError(t, err)
+	assert.Empty(t, fakeParams, "private key parameter should be deleted")
+}
+
+func checkParameterMatchesPrivateKey(ctx context.Context, t *testing.T, appAuth *githubapp.GithubAppAuth) {
+	fakeParams, err := fakeparameter.FindByIDs(ctx, appAuth.PrivateKeyParameter)
+	assert.NoError(t, err)
+	require.Len(t, fakeParams, 1)
+	assert.Equal(t, string(appAuth.PrivateKey), fakeParams[0].Value)
+}

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -34,7 +34,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+	require.NoError(t, githubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 	paramName := appAuth.PrivateKeyParameter
 
 	appAuth.PrivateKey = []byte("new_private_key")
-	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+	require.NoError(t, githubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err = githubapp.FindOneGithubAppAuth(projectID)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestRemoveGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, GitHubAppAuthUpsert(appAuth))
+	require.NoError(t, githubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
 	require.NoError(t, err)

--- a/model/githubapp/github_app_auth_db.go
+++ b/model/githubapp/github_app_auth_db.go
@@ -14,9 +14,10 @@ const (
 )
 
 var (
-	GhAuthIdKey         = bsonutil.MustHaveTag(GithubAppAuth{}, "Id")
-	GhAuthAppIdKey      = bsonutil.MustHaveTag(GithubAppAuth{}, "AppID")
-	GhAuthPrivateKeyKey = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKey")
+	GhAuthIdKey                  = bsonutil.MustHaveTag(GithubAppAuth{}, "Id")
+	GhAuthAppIdKey               = bsonutil.MustHaveTag(GithubAppAuth{}, "AppID")
+	GhAuthPrivateKeyKey          = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKey")
+	GhAuthPrivateKeyParameterKey = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKeyParameter")
 )
 
 // FindOneGithubAppAuth finds the github app auth for the given project or repo id
@@ -57,22 +58,10 @@ func UpsertGithubAppAuth(githubAppAuth *GithubAppAuth) error {
 		},
 		bson.M{
 			"$set": bson.M{
-				GhAuthAppIdKey:      githubAppAuth.AppID,
-				GhAuthPrivateKeyKey: githubAppAuth.PrivateKey,
+				GhAuthAppIdKey:               githubAppAuth.AppID,
+				GhAuthPrivateKeyKey:          githubAppAuth.PrivateKey,
+				GhAuthPrivateKeyParameterKey: githubAppAuth.PrivateKeyParameter,
 			},
-		},
-	)
-	return err
-}
-
-// InsertGithubAppAuth inserts the app auth for the given project id in the database
-func InsertGithubAppAuth(githubAppAuth *GithubAppAuth) error {
-	err := db.Insert(
-		GitHubAppAuthCollection,
-		bson.M{
-			GhAuthIdKey:         githubAppAuth.Id,
-			GhAuthAppIdKey:      githubAppAuth.AppID,
-			GhAuthPrivateKeyKey: githubAppAuth.PrivateKey,
 		},
 	)
 	return err

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -538,6 +538,7 @@ var (
 	projectRefGithubPermissionGroupByRequesterKey   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubPermissionGroupByRequester")
 	projectRefParameterStoreEnabledKey              = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreEnabled")
 	projectRefParameterStoreVarsSyncedKey           = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreVarsSynced")
+	projectRefParameterStoreGitHubAppSyncedKey      = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreGitHubAppSynced")
 	projectRefLastAutoRestartedTaskAtKey            = bsonutil.MustHaveTag(ProjectRef{}, "LastAutoRestartedTaskAt")
 	projectRefNumAutoRestartedTasksKey              = bsonutil.MustHaveTag(ProjectRef{}, "NumAutoRestartedTasks")
 
@@ -3747,6 +3748,29 @@ var psEnabledButNotSyncedQuery = bson.M{
 		{projectRefParameterStoreVarsSyncedKey: false},
 		{projectRefParameterStoreVarsSyncedKey: bson.M{"$exists": false}},
 	},
+}
+
+// setParameterStoreGitHubAppAuthSynced marks the project or repo ref to indicate whether
+// its GitHub app auth is synced to Parameter Store.
+func (p *ProjectRef) setParameterStoreGitHubAppAuthSynced(isSynced bool, isRepoRef bool) error {
+	if p.ParameterStoreGitHubAppSynced == isSynced {
+		return nil
+	}
+
+	coll := ProjectRefCollection
+	if isRepoRef {
+		coll = RepoRefCollection
+	}
+
+	if err := db.UpdateId(coll, p.Id, bson.M{
+		"$set": bson.M{
+			projectRefParameterStoreGitHubAppSyncedKey: isSynced,
+		},
+	}); err != nil {
+		return errors.Wrapf(err, "updating project/repo ref GitHub app auth sync state to %t", isSynced)
+	}
+
+	return nil
 }
 
 // FindProjectRefsToSync finds all project refs that have Parameter Sore enabled

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -816,7 +816,7 @@ func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) err
 		AppID:      appID,
 		PrivateKey: privateKey,
 	}
-	return GitHubAppAuthUpsert(&auth)
+	return githubAppAuthUpsert(&auth)
 }
 
 // DefaultGithubAppCredentialsToRepo defaults the app credentials to the repo by

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1461,7 +1461,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				AppID:      9999,
 				PrivateKey: []byte("repo-secret"),
 			}
-			err = githubapp.UpsertGithubAppAuth(&auth)
+			err = GitHubAppAuthUpsert(&auth)
 			assert.NoError(t, err)
 			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAppSettingsSection, "me"))
 			pRefFromDb, err = FindBranchProjectRef(id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1461,7 +1461,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				AppID:      9999,
 				PrivateKey: []byte("repo-secret"),
 			}
-			err = GitHubAppAuthUpsert(&auth)
+			err = githubAppAuthUpsert(&auth)
 			assert.NoError(t, err)
 			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAppSettingsSection, "me"))
 			pRefFromDb, err = FindBranchProjectRef(id)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -707,10 +707,9 @@ func isParameterStoreEnabledForProject(ctx context.Context, ref *ProjectRef) (bo
 	return ref.ParameterStoreEnabled, nil
 }
 
-// findProjectRef finds the project ref associated with the project variables.
+// findProjectRef finds the project ref associated with the ID.
 // Returns a bool indicating if it's a branch project ref or a repo ref.
-func (projectVars *ProjectVars) findProjectRef() (ref *ProjectRef, isRepoRef bool, err error) {
-	projectID := projectVars.Id
+func findProjectRef(projectID string) (ref *ProjectRef, isRepoRef bool, err error) {
 	// This intentionally looks for a branch project ref without merging with
 	// its repo ref because project vars for a branch project are stored
 	// separately from project vars for a repo. Therefore, a branch project and
@@ -974,16 +973,16 @@ func (projectVars *ProjectVars) Clear() error {
 // has Parameter Store enabled and if so, runs the provided Parameter Store
 // operation.
 func (projectVars *ProjectVars) checkAndRunParameterStoreOp(ctx context.Context, op func(ref *ProjectRef, isRepoRef bool), opName string) {
-	ref, isRepoRef, err := projectVars.findProjectRef()
+	ref, isRepoRef, err := findProjectRef(projectVars.Id)
 	grip.Error(message.WrapError(err, message.Fields{
-		"message":    "could not get project ref to check if Parameter Store is enabled for project; assuming it's disabled and refusing to clear any project variables from Parameter Store",
+		"message":    "could not get project ref to check if Parameter Store is enabled for project; assuming it's disabled and will not use Parameter Store",
 		"op":         opName,
 		"project_id": projectVars.Id,
 		"epic":       "DEVPROD-5552",
 	}))
 	isPSEnabled, err := isParameterStoreEnabledForProject(ctx, ref)
 	grip.Error(message.WrapError(err, message.Fields{
-		"message":    "could not check if Parameter Store is enabled for project; assuming it's disabled and refusing to clear any project variables from Parameter Store",
+		"message":    "could not check if Parameter Store is enabled for project; assuming it's disabled and will not use Parameter Store",
 		"op":         opName,
 		"project_id": projectVars.Id,
 		"epic":       "DEVPROD-5552",


### PR DESCRIPTION
DEVPROD-9426

### Description
When writing GitHub app private keys and Parameter Store is enabled for the project, store it in Parameter Store. Unfortunately, because the temporary feature flag is on the project ref, I can't put these functions directly in the `githubapp` package yet or else it'll cause a package dependency cycle. They'll be moved over in DEVPROD-11883 once the project ref feature flag is no longer used.

* Add functions to upsert/remove GitHub app private keys using Parameter Store as the backing storage.
* Switch GitHub app DB calls to use temporary functions for now, until DEVPROD-11883 can move them into the correct package.
* Delete `InsertGitHubAppAuth` because it's unused and didn't seem worth implementing for Parameter Store.

### Testing
* Add unit tests for upsert/remove.
* Tested that the parameter was created/deleted in staging by adding GitHub app auth and then deleting it.

### Documentation
N/A
