### PR TITLE
DEVPROD-13221 Add extra nil-check

### DIFF
--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -484,6 +484,9 @@ func (d *basicCachedDAGDispatcherImpl) tryMarkNextTaskGroupTaskDispatched(taskGr
 		// next is a *TaskQueueItem, sourced for d.taskGroups (map[string]schedulableUnit) tasks' field, which in turn is a []TaskQueueItem.
 		// taskGroupTask is a *TaskQueueItem sourced from d.nodeItemMap, which is a map[node.ID()]*TaskQueueItem.
 		node := d.getNodeByItemID(next.Id)
+		if node == nil {
+			return nil
+		}
 		taskGroupTask := d.getItemByNodeID(node.ID())
 		if taskGroupTask == nil {
 			return nil


### PR DESCRIPTION
DEVPROD-13221

### Description
I didn't realize that the `graph.Node` structs can also be nil, they need to be nil-checked as well. This should address the other panic we saw.