### PR TITLE
DEVPROD-11827: remove project secrets redaction when reading logs

### DIFF
--- a/graphql/tests/query/projectEvents/data.json
+++ b/graphql/tests/query/projectEvents/data.json
@@ -40,13 +40,13 @@
           },
           "github_app_auth": {
             "app_id": 12345,
-            "private_key": "secret_before"
+            "private_key": "{REDACTED_BEFORE}"
           },
           "github_hooks_enabled": false,
           "vars": {
             "_id": "sandbox_project_id",
             "vars": {
-              "hello": "world"
+              "hello": "{REDACTED_BEFORE}"
             }
           }
         },
@@ -60,13 +60,13 @@
           },
           "github_app_auth": {
             "app_id": 67890,
-            "private_key": "secret_after"
+            "private_key": "{REDACTED_AFTER}"
           },
           "github_hooks_enabled": true,
           "vars": {
             "_id": "sandbox_project_id",
             "vars": {
-              "hello": "universe"
+              "hello": "{REDACTED_AFTER}"
             }
           }
         }
@@ -95,7 +95,7 @@
           },
           "github_app_auth": {
             "app_id": 11111,
-            "private_key": "secret"
+            "private_key": ""
           },
           "github_hooks_enabled": false
         },
@@ -109,7 +109,7 @@
           },
           "github_app_auth": {
             "app_id": 11111,
-            "private_key": "secret"
+            "private_key": ""
           },
           "github_hooks_enabled": false
         }

--- a/graphql/tests/query/repoEvents/data.json
+++ b/graphql/tests/query/repoEvents/data.json
@@ -101,7 +101,7 @@
           "vars": {
             "_id": "repo_id",
             "vars": {
-              "hello": "world"
+              "hello": "{REDACTED_BEFORE}"
             }
           }
         },
@@ -117,7 +117,7 @@
           "vars": {
             "_id": "repo_id",
             "vars": {
-              "hello": "universe"
+              "hello": "{REDACTED_AFTER}"
             }
           }
         }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -355,8 +355,6 @@ func GetEventsById(id string, before time.Time, n int) ([]restModel.APIProjectEv
 	if err != nil {
 		return nil, err
 	}
-	events.RedactGitHubPrivateKey()
-	events.RedactSecrets()
 	events.ApplyDefaults()
 
 	out := []restModel.APIProjectEvent{}

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -81,8 +81,6 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 		}
 		var loggedProjectEvents model.ProjectChangeEvents
 		loggedProjectEvents, err = model.MostRecentProjectEvents(resourceID, 200)
-		loggedProjectEvents.RedactSecrets()
-		loggedProjectEvents.RedactGitHubPrivateKey()
 		for _, event := range loggedProjectEvents {
 			loggedEvents = append(loggedEvents, event.EventLogEntry)
 		}


### PR DESCRIPTION
DEVPROD-11827

### Description
I migrated all the project change event logs across all projects so that the DB only stores redacted placeholder values (`{REDACTED_BEFORE}` and `{REDACTED_AFTER}`) instead of their actual plaintext value for project vars and GitHub app private key. Because the DB docs store only redacted values now and not the plaintext value, it's no longer necessary to redact the plaintext value when reading project change events out of the DB.

### Testing
* Existing tests pass.
* I checked a bunch of events in the prod DB to verify that the project var values and GitHub app private key are replaced with redacted placeholders.