### PR TITLE
DEVPROD-9430: support reading GitHub app private key from Parameter Store

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -473,7 +473,7 @@ func (r *mutationResolver) DefaultSectionToRepo(ctx context.Context, opts Defaul
 // DeleteGithubAppCredentials is the resolver for the deleteGithubAppCredentials field.
 func (r *mutationResolver) DeleteGithubAppCredentials(ctx context.Context, opts DeleteGithubAppCredentialsInput) (*DeleteGithubAppCredentialsPayload, error) {
 	usr := mustHaveUser(ctx)
-	app, err := githubapp.FindOneGithubAppAuth(opts.ProjectID)
+	app, err := model.GitHubAppAuthFindOne(opts.ProjectID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", opts.ProjectID, err.Error()))
 	}

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/githubapp"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
@@ -20,7 +21,7 @@ func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.AP
 
 // GithubAppAuth is the resolver for the githubAppAuth field.
 func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIGithubAppAuth, error) {
-	app, err := githubapp.FindOneGithubAppAuth(utility.FromStringPtr(obj.ProjectRef.Id))
+	app, err := model.GitHubAppAuthFindOne(utility.FromStringPtr(obj.ProjectRef.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
 	}

--- a/graphql/repo_settings_resolver.go
+++ b/graphql/repo_settings_resolver.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/githubapp"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
@@ -20,7 +21,7 @@ func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIPr
 
 // GithubAppAuth is the resolver for the githubAppAuth field.
 func (r *repoSettingsResolver) GithubAppAuth(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIGithubAppAuth, error) {
-	app, err := githubapp.FindOneGithubAppAuth(utility.FromStringPtr(obj.ProjectRef.Id))
+	app, err := model.GitHubAppAuthFindOne(utility.FromStringPtr(obj.ProjectRef.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
 	}

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -80,6 +80,9 @@ func githubAppAuthFindParameterStore(ctx context.Context, appAuth *githubapp.Git
 	if err != nil {
 		return errors.Wrapf(err, "getting GitHub app private key from Parameter Store")
 	}
+	if len(params) != 1 {
+		return errors.Errorf("expected to get exactly one parameter '%s', but actually got %d", appAuth.PrivateKeyParameter, len(params))
+	}
 
 	privKey := []byte(params[0].Value)
 

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -36,7 +36,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 	}
 	require.NoError(t, githubAppAuthUpsert(appAuth))
 
-	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
+	dbAppAuth, err := GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
 	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
@@ -45,7 +45,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 	appAuth.PrivateKey = []byte("new_private_key")
 	require.NoError(t, githubAppAuthUpsert(appAuth))
 
-	dbAppAuth, err = githubapp.FindOneGithubAppAuth(projectID)
+	dbAppAuth, err = GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
 	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
@@ -72,7 +72,7 @@ func TestRemoveGitHubAppAuth(t *testing.T) {
 	}
 	require.NoError(t, githubAppAuthUpsert(appAuth))
 
-	dbAppAuth, err := githubapp.FindOneGithubAppAuth(projectID)
+	dbAppAuth, err := GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
 	checkParameterMatchesPrivateKey(ctx, t, appAuth)
@@ -80,7 +80,7 @@ func TestRemoveGitHubAppAuth(t *testing.T) {
 
 	require.NoError(t, GitHubAppAuthRemove(dbAppAuth))
 
-	dbAppAuth, err = githubapp.FindOneGithubAppAuth(projectID)
+	dbAppAuth, err = GitHubAppAuthFindOne(projectID)
 	assert.NoError(t, err)
 	assert.Zero(t, dbAppAuth)
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -208,7 +208,7 @@ func (p *ProjectRef) GetGitHubPermissionGroup(requester string) (GitHubDynamicTo
 // GetGitHubAppAuth returns the App auth for the given project.
 // If the project defaults to the repo and the app is not defined on the project, it will return the app from the repo.
 func (p *ProjectRef) GetGitHubAppAuth() (*githubapp.GithubAppAuth, error) {
-	appAuth, err := githubapp.FindOneGithubAppAuth(p.Id)
+	appAuth, err := GitHubAppAuthFindOne(p.Id)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding GitHub app auth")
 	}
@@ -218,7 +218,7 @@ func (p *ProjectRef) GetGitHubAppAuth() (*githubapp.GithubAppAuth, error) {
 	if !p.UseRepoSettings() {
 		return nil, nil
 	}
-	appAuth, err = githubapp.FindOneGithubAppAuth(p.RepoRefId)
+	appAuth, err = GitHubAppAuthFindOne(p.RepoRefId)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding GitHub app auth")
 	}
@@ -799,7 +799,7 @@ func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
 // are empty, the entry is deleted.
 func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) error {
 	if appID == 0 && len(privateKey) == 0 {
-		ghApp, err := githubapp.FindOneGithubAppAuth(p.Id)
+		ghApp, err := GitHubAppAuthFindOne(p.Id)
 		if err != nil {
 			return errors.Wrap(err, "finding GitHub app auth")
 		}
@@ -827,7 +827,7 @@ func DefaultGithubAppCredentialsToRepo(projectId string) error {
 		return errors.Wrap(err, "finding project ref")
 	}
 
-	ghApp, err := githubapp.FindOneGithubAppAuth(p.Id)
+	ghApp, err := GitHubAppAuthFindOne(p.Id)
 	if err != nil {
 		return errors.Wrap(err, "finding GitHub app auth")
 	}
@@ -2122,7 +2122,7 @@ func GetProjectSettings(p *ProjectRef) (*ProjectSettings, error) {
 		return nil, errors.Wrapf(err, "finding subscription for project '%s'", p.Id)
 	}
 
-	githubApp, err := githubapp.FindOneGithubAppAuth(p.Id)
+	githubApp, err := GitHubAppAuthFindOne(p.Id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding GitHub app for project '%s'", p.Id)
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1536,6 +1536,14 @@ func TestDefaultRepoBySection(t *testing.T) {
 			}
 			assert.NoError(t, pRef.Insert())
 
+			repoRef := RepoRef{
+				ProjectRef: ProjectRef{
+					Id:                    pRef.RepoRefId,
+					ParameterStoreEnabled: true,
+				},
+			}
+			assert.NoError(t, repoRef.Upsert())
+
 			pVars := ProjectVars{
 				Id:          pRef.Id,
 				Vars:        map[string]string{"hello": "world"},
@@ -1860,7 +1868,8 @@ func TestSetGithubAppCredentials(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(ProjectRefCollection, githubapp.GitHubAppAuthCollection))
 			p := &ProjectRef{
-				Id: "id1",
+				Id:                    "id1",
+				ParameterStoreEnabled: true,
 			}
 			require.NoError(t, p.Insert())
 			test(t, p)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1787,13 +1787,13 @@ func TestSetGithubAppCredentials(t *testing.T) {
 	samplePrivateKey := []byte("private_key")
 	for name, test := range map[string]func(t *testing.T, p *ProjectRef){
 		"NoCredentialsWhenNoneExist": func(t *testing.T, p *ProjectRef) {
-			app, err := githubapp.FindOneGithubAppAuth(p.Id)
+			app, err := GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},
 		"CredentialsCanBeSet": func(t *testing.T, p *ProjectRef) {
 			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGithubAppAuth(p.Id)
+			app, err := GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
@@ -1801,28 +1801,28 @@ func TestSetGithubAppCredentials(t *testing.T) {
 		"CredentialsCanBeRemovedByEmptyAppIDAndEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
 			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGithubAppAuth(p.Id)
+			app, err := GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
 
 			// Remove credentials.
 			require.NoError(t, p.SetGithubAppCredentials(0, []byte("")))
-			app, err = githubapp.FindOneGithubAppAuth(p.Id)
+			app, err = GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},
 		"CredentialsCanBeRemovedByEmptyAppIDAndNilPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
 			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGithubAppAuth(p.Id)
+			app, err := GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
 
 			// Remove credentials.
 			require.NoError(t, p.SetGithubAppCredentials(0, nil))
-			app, err = githubapp.FindOneGithubAppAuth(p.Id)
+			app, err = GitHubAppAuthFindOne(p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
 	"github.com/evergreen-ci/evergreen/model/event"
-	"github.com/evergreen-ci/evergreen/model/githubapp"
 	"github.com/evergreen-ci/evergreen/model/user"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
@@ -487,7 +486,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err := githubapp.FindOneGithubAppAuth(ref.Id)
+			githubAppFromDB, err := model.GitHubAppAuthFindOne(ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
@@ -504,7 +503,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGithubAppAuth(ref.Id)
+			githubAppFromDB, err = model.GitHubAppAuthFindOne(ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
@@ -521,7 +520,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGithubAppAuth(ref.Id)
+			githubAppFromDB, err = model.GitHubAppAuthFindOne(ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, githubAppFromDB.AppID, int64(12345))
@@ -538,7 +537,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGithubAppAuth(ref.Id)
+			githubAppFromDB, err = model.GitHubAppAuthFindOne(ref.Id)
 			assert.NoError(t, err)
 			assert.Nil(t, githubAppFromDB)
 


### PR DESCRIPTION
DEVPROD-9430

### Description
Support FindOne for GitHub app auth, using Parameter Store to fetch the private key if Parameter Store is enabled for the project.

### Testing
* Updated existing tests to ensure they have Parameter Store enabled for GitHub app auth and still pass.
* Tested in staging by enabling Parameter Store, setting a private key, and running a task to see that it read the private key from Parameter Store. I also tested that a project with Parameter Store disabled works as it did before.