### PR TITLE
DEVPROD-12557 add AllowRemoteAccess tag

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -161,6 +161,7 @@ func makeTags(intentHost *host.Host) []host.Tag {
 		{Key: evergreen.TagMode, Value: "production", CanBeModified: false},
 		{Key: evergreen.TagStartTime, Value: intentHost.CreationTime.Format(evergreen.NameTimeFormat), CanBeModified: false},
 		{Key: evergreen.TagExpireOn, Value: expireOn, CanBeModified: false},
+		{Key: evergreen.TagAllowRemoteAccess, Value: "true", CanBeModified: false},
 	}
 
 	if intentHost.UserHost {

--- a/globals.go
+++ b/globals.go
@@ -294,14 +294,15 @@ const (
 	DefaultSleepScheduleTimeZone     = "America/New_York"
 
 	// host resource tag names
-	TagName             = "name"
-	TagDistro           = "distro"
-	TagEvergreenService = "evergreen-service"
-	TagUsername         = "username"
-	TagOwner            = "owner"
-	TagMode             = "mode"
-	TagStartTime        = "start-time"
-	TagExpireOn         = "expire-on"
+	TagName              = "name"
+	TagDistro            = "distro"
+	TagEvergreenService  = "evergreen-service"
+	TagUsername          = "username"
+	TagOwner             = "owner"
+	TagMode              = "mode"
+	TagStartTime         = "start-time"
+	TagExpireOn          = "expire-on"
+	TagAllowRemoteAccess = "AllowRemoteAccess"
 
 	FinderVersionLegacy    = "legacy"
 	FinderVersionParallel  = "parallel"


### PR DESCRIPTION
[DEVPROD-12557](https://jira.mongodb.org/browse/DEVPROD-12557)

### Description
The IAM policy that controls SSM access only allows SSM connections to hosts tagged with `AllowRemoteAccess: true`. This PR adds this tag for all hosts evergreen starts.

### Testing
The tag was added to a host that started in staging.
