### PR TITLE
 DEVPROD-9432: sync GitHub app private key to Parameter Store 

### DIFF
--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -112,8 +112,6 @@ func githubAppAuthFindParameterStore(ctx context.Context, appAuth *githubapp.Git
 
 // GitHubAppAuthUpsert upserts the GitHub app auth into the database and upserts
 // the private key to Parameter Store if enabled.
-// GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
-// Parameter Store if enabled.
 func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -110,9 +110,11 @@ func githubAppAuthFindParameterStore(ctx context.Context, appAuth *githubapp.Git
 	return nil
 }
 
-// githubAppAuthUpsert upserts the GitHub app auth into the database and upserts
+// GitHubAppAuthUpsert upserts the GitHub app auth into the database and upserts
 // the private key to Parameter Store if enabled.
-func githubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
+// GitHubAppAuthUpsert upserts the GitHub app auth into the database and to
+// Parameter Store if enabled.
+func GitHubAppAuthUpsert(appAuth *githubapp.GithubAppAuth) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
 	defer cancel()
 

--- a/model/github_app_auth_test.go
+++ b/model/github_app_auth_test.go
@@ -34,7 +34,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, githubAppAuthUpsert(appAuth))
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err := GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 	paramName := appAuth.PrivateKeyParameter
 
 	appAuth.PrivateKey = []byte("new_private_key")
-	require.NoError(t, githubAppAuthUpsert(appAuth))
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err = GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func TestRemoveGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, githubAppAuthUpsert(appAuth))
+	require.NoError(t, GitHubAppAuthUpsert(appAuth))
 
 	dbAppAuth, err := GitHubAppAuthFindOne(projectID)
 	require.NoError(t, err)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -816,7 +816,7 @@ func (p *ProjectRef) SetGithubAppCredentials(appID int64, privateKey []byte) err
 		AppID:      appID,
 		PrivateKey: privateKey,
 	}
-	return githubAppAuthUpsert(&auth)
+	return GitHubAppAuthUpsert(&auth)
 }
 
 // DefaultGithubAppCredentialsToRepo defaults the app credentials to the repo by

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3760,6 +3760,8 @@ var psEnabledButNotSyncedQuery = bson.M{
 	"$or": []bson.M{
 		{projectRefParameterStoreVarsSyncedKey: false},
 		{projectRefParameterStoreVarsSyncedKey: bson.M{"$exists": false}},
+		{projectRefParameterStoreGitHubAppSyncedKey: false},
+		{projectRefParameterStoreGitHubAppSyncedKey: bson.M{"$exists": false}},
 	},
 }
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1461,7 +1461,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				AppID:      9999,
 				PrivateKey: []byte("repo-secret"),
 			}
-			err = githubAppAuthUpsert(&auth)
+			err = GitHubAppAuthUpsert(&auth)
 			assert.NoError(t, err)
 			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAppSettingsSection, "me"))
 			pRefFromDb, err = FindBranchProjectRef(id)

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -112,7 +112,7 @@ func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectR
 		}
 
 		if !pRef.ParameterStoreGitHubAppSynced {
-			ghAppAuth, err := model.GitHubAppAuthFindOne(pRef.Owner)
+			ghAppAuth, err := model.GitHubAppAuthFindOne(pRef.Id)
 			if err != nil {
 				catcher.Wrapf(err, "finding GitHub App auth for project '%s'", pRef.Id)
 				continue

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -85,45 +85,45 @@ func (j *parameterStoreSyncJob) Run(ctx context.Context) {
 func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectRef, areRepoRefs bool) error {
 	catcher := grip.NewBasicCatcher()
 	for _, pRef := range pRefs {
-		pVars, err := model.FindOneProjectVars(pRef.Id)
-		if err != nil {
-			catcher.Wrapf(err, "finding project vars for project '%s'", pRef.Id)
-			continue
-		}
-		if pVars == nil {
-			grip.Notice(message.Fields{
-				"message":     "found project that has no project vars, initializing with empty project vars",
-				"project":     pRef.Id,
-				"is_repo_ref": areRepoRefs,
-				"job":         j.ID(),
-			})
-			pVars = &model.ProjectVars{Id: pRef.Id}
-		}
-		pm, err := model.FullSyncToParameterStore(ctx, pVars, &pRef, areRepoRefs)
-		if err != nil {
-			catcher.Wrapf(err, "syncing project vars for project '%s'", pRef.Id)
-			continue
-		}
-		if err := pVars.SetParamMappings(*pm); err != nil {
-			catcher.Wrapf(err, "updating parameter mappings for project '%s'", pRef.Id)
-			continue
-		}
-
-		// kim: TODO: test in staging that GH app private key syncs to PS.
-
-		// kim: TODO: needs DEVPROD-9430.
-		ghAppAuth, err := model.GitHubAppAuthFindOne(pRef.Owner)
-		if err != nil {
-			catcher.Wrapf(err, "finding GitHub App auth for project '%s'", pRef.Id)
-			continue
-		}
-		if ghAppAuth != nil {
-			if err := model.GitHubAppAuthUpsert(ghAppAuth); err != nil {
-				catcher.Wrapf(err, "syncing GitHub app private key for project '%s' to Parameter Store", pRef.Id)
+		if !pRef.ParameterStoreVarsSynced {
+			pVars, err := model.FindOneProjectVars(pRef.Id)
+			if err != nil {
+				catcher.Wrapf(err, "finding project vars for project '%s'", pRef.Id)
+				continue
+			}
+			if pVars == nil {
+				grip.Notice(message.Fields{
+					"message":     "found project that has no project vars, initializing with empty project vars",
+					"project":     pRef.Id,
+					"is_repo_ref": areRepoRefs,
+					"job":         j.ID(),
+				})
+				pVars = &model.ProjectVars{Id: pRef.Id}
+			}
+			pm, err := model.FullSyncToParameterStore(ctx, pVars, &pRef, areRepoRefs)
+			if err != nil {
+				catcher.Wrapf(err, "syncing project vars for project '%s'", pRef.Id)
+				continue
+			}
+			if err := pVars.SetParamMappings(*pm); err != nil {
+				catcher.Wrapf(err, "updating parameter mappings for project '%s'", pRef.Id)
 				continue
 			}
 		}
 
+		if !pRef.ParameterStoreGitHubAppSynced {
+			ghAppAuth, err := model.GitHubAppAuthFindOne(pRef.Owner)
+			if err != nil {
+				catcher.Wrapf(err, "finding GitHub App auth for project '%s'", pRef.Id)
+				continue
+			}
+			if ghAppAuth != nil {
+				if err := model.GitHubAppAuthUpsert(ghAppAuth); err != nil {
+					catcher.Wrapf(err, "syncing GitHub app private key for project '%s' to Parameter Store", pRef.Id)
+					continue
+				}
+			}
+		}
 	}
 	return catcher.Resolve()
 }

--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -118,6 +118,14 @@ func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectR
 				continue
 			}
 			if ghAppAuth != nil {
+				grip.Info(message.Fields{
+					"message":                 "syncing project GitHub app private key to Parameter Store",
+					"existing_parameter_name": ghAppAuth.PrivateKeyParameter,
+					"project_id":              pRef.Id,
+					"is_repo_ref":             areRepoRefs,
+					"epic":                    "DEVPROD-5552",
+					"job":                     j.ID(),
+				})
 				if err := model.GitHubAppAuthUpsert(ghAppAuth); err != nil {
 					catcher.Wrapf(err, "syncing GitHub app private key for project '%s' to Parameter Store", pRef.Id)
 					continue


### PR DESCRIPTION
DEVPROD-9432

### Description
Similar to project variables, when a project has Parameter Store enabled but the GitHub app private key isn't in Parameter Store yet, sync the private key to Parameter Store.

### Testing
Tested in staging to verify that the job synced the GitHub app private keys for staging projects to Parameter Store.
