### PR TITLE
DEVPROD-13165 Add more s3.get/s3.put otel attributes

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -43,6 +43,9 @@ type s3get struct {
 	// RemoteFile is the file path of the file to get, within its bucket.
 	RemoteFile string `mapstructure:"remote_file" plugin:"expand"`
 
+	// remoteFile is the file path without any expansions applied.
+	remoteFile string
+
 	// Region is the S3 region where the bucket is located. It defaults to
 	// "us-east-1".
 	Region string `mapstructure:"region" plugin:"region"`
@@ -144,6 +147,8 @@ func (c *s3get) shouldRunForVariant(buildVariantName string) bool {
 // Apply the expansions from the relevant task config
 // to all appropriate fields of the s3get.
 func (c *s3get) expandParams(conf *internal.TaskConfig) error {
+	c.remoteFile = c.RemoteFile
+
 	var err error
 	if err = util.ExpandValues(c, &conf.Expansions); err != nil {
 		return errors.Wrap(err, "applying expansions")
@@ -175,7 +180,7 @@ func (c *s3get) Execute(ctx context.Context,
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String(s3GetBucketAttribute, c.Bucket),
 		attribute.Bool(s3GetTemporaryCredentialsAttribute, c.AwsSessionToken != ""),
-		attribute.String(s3GetRemoteFileAttribute, c.RemoteFile),
+		attribute.String(s3GetRemoteFileAttribute, c.remoteFile),
 	)
 
 	// create pail bucket

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -28,6 +28,7 @@ const (
 var (
 	s3GetBucketAttribute               = fmt.Sprintf("%s.bucket", s3GetAttribute)
 	s3GetTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3GetAttribute)
+	s3GetRemoteFileAttribute           = fmt.Sprintf("%s.remote_file", s3GetAttribute)
 )
 
 // s3get is a command to fetch a resource from an S3 bucket and download it to
@@ -174,6 +175,7 @@ func (c *s3get) Execute(ctx context.Context,
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String(s3GetBucketAttribute, c.Bucket),
 		attribute.Bool(s3GetTemporaryCredentialsAttribute, c.AwsSessionToken != ""),
+		attribute.String(s3GetRemoteFileAttribute, c.RemoteFile),
 	)
 
 	// create pail bucket

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -35,6 +35,7 @@ var (
 	s3PutTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3PutAttribute)
 	s3PutVisibilityAttribute           = fmt.Sprintf("%s.visibility", s3PutAttribute)
 	s3PutPermissionsAttribute          = fmt.Sprintf("%s.permissions", s3PutAttribute)
+	s3PutRemotePathAttribute           = fmt.Sprintf("%s.remote_path", s3PutAttribute)
 )
 
 // s3pc is a command to put a resource to an S3 bucket and download it to
@@ -303,6 +304,7 @@ func (s3pc *s3put) Execute(ctx context.Context,
 		attribute.Bool(s3PutTemporaryCredentialsAttribute, s3pc.AwsSessionToken != ""),
 		attribute.String(s3PutVisibilityAttribute, s3pc.Visibility),
 		attribute.String(s3PutPermissionsAttribute, s3pc.Permissions),
+		attribute.String(s3PutRemotePathAttribute, s3pc.RemoteFile),
 	)
 
 	// create pail bucket

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -62,6 +62,9 @@ type s3put struct {
 	// within an S3 bucket. Is a prefix when multiple files are uploaded via LocalFilesIncludeFilter.
 	RemoteFile string `mapstructure:"remote_file" plugin:"expand"`
 
+	// remoteFile is the file path without any expansions applied.
+	remoteFile string
+
 	// PreservePath, when set to true, causes multi part uploads uploaded with LocalFilesIncludeFilter to
 	// preserve the original folder structure instead of putting all the files into the same folder
 	PreservePath string ` mapstructure:"preserve_path" plugin:"expand"`
@@ -208,6 +211,8 @@ func (s3pc *s3put) validate() error {
 // Apply the expansions from the relevant task config
 // to all appropriate fields of the s3put.
 func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
+	s3pc.remoteFile = s3pc.RemoteFile
+
 	var err error
 	if err = util.ExpandValues(s3pc, &conf.Expansions); err != nil {
 		return errors.Wrap(err, "applying expansions")
@@ -304,7 +309,7 @@ func (s3pc *s3put) Execute(ctx context.Context,
 		attribute.Bool(s3PutTemporaryCredentialsAttribute, s3pc.AwsSessionToken != ""),
 		attribute.String(s3PutVisibilityAttribute, s3pc.Visibility),
 		attribute.String(s3PutPermissionsAttribute, s3pc.Permissions),
-		attribute.String(s3PutRemotePathAttribute, s3pc.RemoteFile),
+		attribute.String(s3PutRemotePathAttribute, s3pc.remoteFile),
 	)
 
 	// create pail bucket

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -33,6 +33,8 @@ const (
 var (
 	s3PutBucketAttribute               = fmt.Sprintf("%s.bucket", s3PutAttribute)
 	s3PutTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3PutAttribute)
+	s3PutVisibilityAttribute           = fmt.Sprintf("%s.visibility", s3PutAttribute)
+	s3PutPermissionsAttribute          = fmt.Sprintf("%s.permissions", s3PutAttribute)
 )
 
 // s3pc is a command to put a resource to an S3 bucket and download it to
@@ -299,6 +301,8 @@ func (s3pc *s3put) Execute(ctx context.Context,
 	trace.SpanFromContext(ctx).SetAttributes(
 		attribute.String(s3PutBucketAttribute, s3pc.Bucket),
 		attribute.Bool(s3PutTemporaryCredentialsAttribute, s3pc.AwsSessionToken != ""),
+		attribute.String(s3PutVisibilityAttribute, s3pc.Visibility),
+		attribute.String(s3PutPermissionsAttribute, s3pc.Permissions),
 	)
 
 	// create pail bucket

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-12-03-a"
+	AgentVersion = "2024-12-10"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13165

### Description
This adds otel attributes for 'visibility' and 'permissions' to understand how often which one is used and the combination of them.

It also adds the remote file name, this is more for individual debugging more than aggregate results. It won't be that useful as an aggregate since projects don't use consistent paths.