### PR TITLE
DEVPROD-13471: check data consistency after syncing to Parameter Store

### DIFF
--- a/units/parameter_store_sync.go
+++ b/units/parameter_store_sync.go
@@ -109,6 +109,15 @@ func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectR
 				catcher.Wrapf(err, "updating parameter mappings for project '%s'", pRef.Id)
 				continue
 			}
+
+			// Double check that the project vars that were just synced agree
+			// with the project vars in the DB when read out of Parameter Store.
+			// This is mostly to cover inactive projects that may not have users
+			// actively using them (and therefore the project vars never get
+			// read out of Parameter Store to trigger a consistency check).
+			// The consistency check happens internally within FindOne, so
+			// the actual return value doesn't matter.
+			_, _ = model.FindOneProjectVars(pRef.Id)
 		}
 
 		if !pRef.ParameterStoreGitHubAppSynced {
@@ -130,6 +139,16 @@ func (j *parameterStoreSyncJob) sync(ctx context.Context, pRefs []model.ProjectR
 					catcher.Wrapf(err, "syncing GitHub app private key for project '%s' to Parameter Store", pRef.Id)
 					continue
 				}
+
+				// Double check that the GitHub app private key that was just
+				// synced agrees with the private key in the DB when read out of
+				// Parameter Store. This is to cover inactive projects that may
+				// not have users actively using them (and therefore the GitHub
+				// app private key may never get read out of Parameter Store to
+				// trigger a consistency check).
+				// The consistency check happens internally within FindOne, so
+				// the actual return value doesn't matter.
+				_, _ = model.GitHubAppAuthFindOne(pRef.Id)
 			}
 		}
 	}


### PR DESCRIPTION
DEVPROD-13471

### Description
Within `FindOne` for project vars and GitHub app auth, I added a consistency check to each one to verify that when we read the values out of Parameter Store, they exactly match the project vars/GitHub app auth in the DB. However, I realized during the rollout that there's so many disabled projects in Evergreen that many of them likely would never hit that consistency check because nobody's using them at all right now.

To address this and ensure that the Parameter Store parameters are checked for consistency, I added `FindOne` as part of the sync job. Now, on top of just syncing to Parameter Store to write the secrets into Parameter Store, it'll also check that the data read out of Parameter Store agrees between Parameter Store and the DB. This improves our confidence that the migration is working correctly for inactive projects.

### Testing
Tested in staging to verify that it did check the consistency of project vars/GitHub app auth.

### Documentation
N/A
