### PR TITLE
DEVPROD-13470: encode compressed project variable bytes as base64

### DIFF
--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -100,6 +100,15 @@ func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Param
 	}
 
 	fullName := pm.getPrefixedName(name)
+	if len(value) > 4000 {
+		grip.Info(message.Fields{
+			"message":            "kim: inserting long parameter value",
+			"partial_param_name": name,
+			"param_name":         fullName,
+			"param_value_len":    len(value),
+			"param_value_prefix": value[:100],
+		})
+	}
 	if _, err := pm.ssmClient.PutParameter(ctx, &ssm.PutParameterInput{
 		Name:      aws.String(fullName),
 		Value:     aws.String(value),

--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -100,15 +100,6 @@ func (pm *ParameterManager) Put(ctx context.Context, name, value string) (*Param
 	}
 
 	fullName := pm.getPrefixedName(name)
-	if len(value) > 4000 {
-		grip.Info(message.Fields{
-			"message":            "kim: inserting long parameter value",
-			"partial_param_name": name,
-			"param_name":         fullName,
-			"param_value_len":    len(value),
-			"param_value_prefix": value[:100],
-		})
-	}
 	if _, err := pm.ssmClient.PutParameter(ctx, &ssm.PutParameterInput{
 		Name:      aws.String(fullName),
 		Value:     aws.String(value),

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -1173,14 +1173,6 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 	// gzip-compressed value in Parameter Store.
 	compressedBase64Value := base64.StdEncoding.EncodeToString(compressedValue.Bytes())
 
-	grip.Info(message.Fields{
-		"message":                             "kim: created compressed base64-encoded parameter",
-		"var_name":                            varName,
-		"uncompressed_value_len":              len(varValue),
-		"compressed_value_len":                compressedValue.Len(),
-		"compressed_base64_encoded_value_len": len(compressedBase64Value),
-	})
-
 	if len(compressedBase64Value) >= parameterstore.ParamValueMaxLength {
 		return "", "", errors.Errorf("project variable value exceeds maximum length, even after attempted compression (value is %d bytes, compressed value is %d bytes, maximum is %d bytes)", len(varValue), len(compressedBase64Value), parameterstore.ParamValueMaxLength)
 	}
@@ -1192,22 +1184,10 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 // name and value. This is the inverse operation of convertVarToParam.
 func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varName, varValue string, err error) {
 	if strings.HasSuffix(paramName, gzipCompressedParamExtension) {
-		grip.Info(message.Fields{
-			"message":                             "kim: found compressed base64-encoded parameter",
-			"param_name":                          paramName,
-			"compressed_base64_encoded_param_len": len(paramValue),
-			"compressed_base64_encoded_param_value_prefix": paramValue[:100],
-		})
 		compressedValue, err := base64.StdEncoding.DecodeString(paramValue)
 		if err != nil {
 			return "", "", errors.Wrap(err, "decoding base64-encoded compressed parameter value")
 		}
-		grip.Info(message.Fields{
-			"message":                       "kim: found compressed parameter (with base64 encoding removed)",
-			"param_name":                    paramName,
-			"compressed_param_len":          len(compressedValue),
-			"compressed_param_value_prefix": compressedValue[:100],
-		})
 		gzr, err := gzip.NewReader(bytes.NewReader(compressedValue))
 		if err != nil {
 			return "", "", errors.Wrap(err, "creating gzip reader for compressed project variable")

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"regexp"
@@ -1158,8 +1159,8 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 		return varName, varValue, nil
 	}
 
-	compressedValue := bytes.NewBuffer(make([]byte, 0, len(varValue)))
-	gzw := gzip.NewWriter(compressedValue)
+	var compressedValue bytes.Buffer
+	gzw := gzip.NewWriter(&compressedValue)
 	if _, err := gzw.Write([]byte(varValue)); err != nil {
 		return "", "", errors.Wrap(err, "compressing long project variable value")
 	}
@@ -1167,18 +1168,47 @@ func getCompressedParamForVar(varName, varValue string) (paramName string, param
 		return "", "", errors.Wrap(err, "closing gzip writer after compressing long project variable value")
 	}
 
-	if compressedValue.Len() >= parameterstore.ParamValueMaxLength {
-		return "", "", errors.Errorf("project variable value exceeds maximum length, even after attempted compression (value is %d bytes, compressed value is %d bytes, maximum is %d bytes)", len(varValue), compressedValue.Len(), parameterstore.ParamValueMaxLength)
+	// gzip produces raw binary data, whereas Parameter Store can only handle
+	// strings. Encoding it as a base64 string makes it possible to store the
+	// gzip-compressed value in Parameter Store.
+	compressedBase64Value := base64.StdEncoding.EncodeToString(compressedValue.Bytes())
+
+	grip.Info(message.Fields{
+		"message":                             "kim: created compressed base64-encoded parameter",
+		"var_name":                            varName,
+		"uncompressed_value_len":              len(varValue),
+		"compressed_value_len":                compressedValue.Len(),
+		"compressed_base64_encoded_value_len": len(compressedBase64Value),
+	})
+
+	if len(compressedBase64Value) >= parameterstore.ParamValueMaxLength {
+		return "", "", errors.Errorf("project variable value exceeds maximum length, even after attempted compression (value is %d bytes, compressed value is %d bytes, maximum is %d bytes)", len(varValue), len(compressedBase64Value), parameterstore.ParamValueMaxLength)
 	}
 
-	return fmt.Sprintf("%s%s", varName, gzipCompressedParamExtension), compressedValue.String(), nil
+	return fmt.Sprintf("%s%s", varName, gzipCompressedParamExtension), compressedBase64Value, nil
 }
 
 // convertParamToVar converts a parameter back to its original project variable
 // name and value. This is the inverse operation of convertVarToParam.
 func convertParamToVar(pm ParameterMappings, paramName, paramValue string) (varName, varValue string, err error) {
 	if strings.HasSuffix(paramName, gzipCompressedParamExtension) {
-		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
+		grip.Info(message.Fields{
+			"message":                             "kim: found compressed base64-encoded parameter",
+			"param_name":                          paramName,
+			"compressed_base64_encoded_param_len": len(paramValue),
+			"compressed_base64_encoded_param_value_prefix": paramValue[:100],
+		})
+		compressedValue, err := base64.StdEncoding.DecodeString(paramValue)
+		if err != nil {
+			return "", "", errors.Wrap(err, "decoding base64-encoded compressed parameter value")
+		}
+		grip.Info(message.Fields{
+			"message":                       "kim: found compressed parameter (with base64 encoding removed)",
+			"param_name":                    paramName,
+			"compressed_param_len":          len(compressedValue),
+			"compressed_param_value_prefix": compressedValue[:100],
+		})
+		gzr, err := gzip.NewReader(bytes.NewReader(compressedValue))
 		if err != nil {
 			return "", "", errors.Wrap(err, "creating gzip reader for compressed project variable")
 		}

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -1,8 +1,10 @@
 package model
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"sort"
@@ -758,7 +760,10 @@ func TestConvertVarToParam(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%s/%s.gz", GetVarsParameterPath(projectID), varName), paramName, "should include project ID prefix and gzip extension to indicate the value was compressed")
 		assert.NotEqual(t, longVarValue, paramValue, "compressed value should not match original variable value")
 
-		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
+		compressedValue, err := base64.StdEncoding.DecodeString(paramValue)
+		require.NoError(t, err)
+
+		gzr, err := gzip.NewReader(bytes.NewReader(compressedValue))
 		require.NoError(t, err)
 		decompressed, err := io.ReadAll(gzr)
 		require.NoError(t, err)

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -791,11 +791,14 @@ func TestConvertVarToParam(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%s.gz", existingParamName), paramName, "project variable that was previously short but now is long enough to require compression should have its parameter name changed")
 		assert.NotEqual(t, longVarValue, paramValue)
 
-		gzr, err := gzip.NewReader(strings.NewReader(paramValue))
+		compressedValue, err := base64.StdEncoding.DecodeString(paramValue)
+		require.NoError(t, err)
+
+		gzr, err := gzip.NewReader(bytes.NewReader(compressedValue))
 		require.NoError(t, err)
 		decompressed, err := io.ReadAll(gzr)
 		require.NoError(t, err)
-		assert.Equal(t, longVarValue, string(decompressed))
+		assert.Equal(t, longVarValue, string(decompressed), "decompressed value should match original value")
 	})
 	t.Run("ReturnsErrorForEmptyVariableName", func(t *testing.T) {
 		const (


### PR DESCRIPTION
DEVPROD-13470

### Description
In DEVPROD-9472, I added a workaround to allow some project vars that are longer than 8 KB to be compressed so that they can be migrated to Parameter Store. I didn't realize when I was testing at the time that Parameter Store actually will store the gzipped binary data with no error, but it can't return that binary data properly when reading it back out because it only supports text strings, not binary data (it just returns a garbled parameter value rather than the original value because it was binary data instead of text).

To further work around this limitation of Parameter Store, I encoded the gzipped binary data to a base64 text string.

### Testing
* Existing tests pass.
* Tested in staging that Parameter Store could both store and also successfully return back a long project variable (> 8 KB long) with gzip + encoding as base64.

### Documentation
N/A