### PR TITLE
DEVPROD-8819: make more specific host creation failure event for spawn host outcome

### DIFF
--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -18,7 +18,7 @@ func init() {
 	registry.AllowSubscription(ResourceTypeHost, EventSpawnHostIdleNotification)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisioned)
 	registry.AllowSubscription(ResourceTypeHost, EventHostProvisionFailed)
-	registry.AllowSubscription(ResourceTypeHost, EventHostCreatedError)
+	registry.AllowSubscription(ResourceTypeHost, EventSpawnHostCreatedError)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStarted)
 	registry.AllowSubscription(ResourceTypeHost, EventHostStopped)
 	registry.AllowSubscription(ResourceTypeHost, EventHostModified)
@@ -33,6 +33,7 @@ const (
 	// event types
 	EventHostCreated                                 = "HOST_CREATED"
 	EventHostCreatedError                            = "HOST_CREATED_ERROR"
+	EventSpawnHostCreatedError                       = "SPAWN_HOST_CREATED_ERROR"
 	EventHostStarted                                 = "HOST_STARTED"
 	EventHostStopped                                 = "HOST_STOPPED"
 	EventHostModified                                = "HOST_MODIFIED"
@@ -141,6 +142,14 @@ func LogManyHostsCreated(hostIDs []string) {
 // was being created.
 func LogHostCreatedError(hostID, logs string) {
 	LogHostEvent(hostID, EventHostCreatedError, HostEventData{Successful: false, Logs: logs})
+}
+
+// LogSpawnHostCreatedError is the same as LogHostCreatedError but specifically
+// for spawn hosts. The spawn host event is separate from the more general host
+// creation errors to make notifications on spawn host creation errors more
+// efficient.
+func LogSpawnHostCreatedError(hostID, logs string) {
+	LogHostEvent(hostID, EventSpawnHostCreatedError, HostEventData{Successful: false, Logs: logs})
 }
 
 // LogHostStartSucceeded logs an event indicating that the host was successfully

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisioned, makeSpawnHostProvisioningTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostProvisionFailed, makeSpawnHostProvisioningTriggers)
-	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostCreatedError, makeSpawnHostStateChangeTriggers)
+	registry.registerEventHandler(event.ResourceTypeHost, event.EventSpawnHostCreatedError, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStarted, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostStopped, makeSpawnHostStateChangeTriggers)
 	registry.registerEventHandler(event.ResourceTypeHost, event.EventHostModified, makeSpawnHostStateChangeTriggers)
@@ -190,7 +190,7 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(ctx context.C
 		return nil, nil
 	}
 	if t.data.Successful && t.data.Source == string(evergreen.ModifySpawnHostSleepSchedule) {
-		// Skip notifying for host modifications due to the sleep schedule they
+		// Skip notifying for host modifications due to the sleep schedule. They
 		// can be noisy if users regularly receive them.
 		return nil, nil
 	}
@@ -206,7 +206,7 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(ctx context.C
 func (t *spawnHostStateChangeTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
 	var action string
 	switch t.event.EventType {
-	case event.EventHostCreatedError:
+	case event.EventSpawnHostCreatedError, event.EventHostCreatedError:
 		action = "Creating"
 	case event.EventHostStarted:
 		action = "Starting"

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -340,6 +340,14 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 
 	hostReplaced, err := j.spawnAndReplaceHost(ctx, cloudManager)
 	if err != nil {
+		if j.host.UserHost {
+			// Log a more specific event than the generic host created error
+			// when the host is a spawn host. This makes subscriptions on spawn
+			// host errors more efficient because the notification system can
+			// process just spawn host errors rather than every single host
+			// creation error.
+			event.LogSpawnHostCreatedError(j.host.Id, err.Error())
+		}
 		event.LogHostCreatedError(j.host.Id, err.Error())
 		return errors.Wrapf(err, "spawning and updating host '%s'", j.host.Id)
 	}


### PR DESCRIPTION
DEVPROD-8819

### Description
The user subscription for previously listened for host creation errors in general, which would notify them when their spawn host fails to start up (e.g. due to insufficient capacity). However, the way the notification infrastructure works that means _all_ host creation errors have to be processed for notifications, even for non-spawn-hosts. This can put strain on the notification system when lots of hosts are failing to start (e.g. because many task hosts are hitting insufficient capacity).

Since we only want to process notifications for spawn hosts failing to be created, I made a more specific error message.

### Testing
* Added unit tests for triggers.
* Tested in staging that starting a spawn host (and manually hard-coding an error during host creation) sent me a Slack notification about it failing to start up.

### Documentation
N/A
