### PR TITLE
DEVPROD-969 Deprecate s3Copy.copy command

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -121,9 +121,6 @@ var (
 
 	// GithubCheckRun keys
 	checkRunLimitKey = bsonutil.MustHaveTag(GitHubCheckRunConfig{}, "CheckRunLimit")
-
-	// Single Task Distro keys
-	singleTaskDistroSettings = bsonutil.MustHaveTag(SingleTaskDistroConfig{}, "Settings")
 )
 
 func byId(id string) bson.M {

--- a/config_db.go
+++ b/config_db.go
@@ -121,6 +121,9 @@ var (
 
 	// GithubCheckRun keys
 	checkRunLimitKey = bsonutil.MustHaveTag(GitHubCheckRunConfig{}, "CheckRunLimit")
+
+	// Single Task Distro keys
+	singleTaskDistroSettings = bsonutil.MustHaveTag(SingleTaskDistroConfig{}, "Settings")
 )
 
 func byId(id string) bson.M {

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1511,9 +1511,9 @@ Parameters:
 -   `max_retries`: Optional. The maximum number of times it will attempt
     to pull a file from S3.
 
-## s3Copy.copy
+## s3Copy.copy (Deprecated)
 
-`s3Copy.copy` copies files from one s3 location to another
+`s3Copy.copy` is deprecated. Please use `s3.put` instead.
 
 ``` yaml
 - command: s3Copy.copy


### PR DESCRIPTION
DEVPROD-969

just update docs to say it's deprecated 