### PR TITLE
DEVPROD-11156 Increase default fetch depth to 1000

### DIFF
--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -29,7 +29,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-const defaultCloneDepth = 500
+const defaultCloneDepth = 1000
 const fileNameMaxLength = 250
 
 func Fetch() cli.Command {


### PR DESCRIPTION
DEVPROD-11156

### Description
sever sometimes needs hosts to have more history when git cloning so updating the default to 1000 from 500