### PR TITLE
DEVPROD-13250 ensure helpful github error returned for yaml unmarshal

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -298,25 +298,26 @@ func GetPatchedProject(ctx context.Context, settings *evergreen.Settings, p *pat
 		return nil, nil, errors.Wrap(err, "getting patched project file as YAML")
 	}
 
-	var pc string
-	if projectRef.IsVersionControlEnabled() {
-		pc, err = getProjectConfigYAML(p, projectFileBytes)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "getting patched project config")
-		}
-	}
-
 	project := &Project{}
 	pp, err := LoadProjectInto(ctx, projectFileBytes, opts, p.Project, project)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
+
 	// LoadProjectInto does not set the parser project's identifier, so set it
 	// here.
 	pp.Identifier = utility.ToStringPtr(p.Project)
 	ppOut, err := yaml.Marshal(pp)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "marshalling parser project into YAML")
+	}
+
+	var pc string
+	if projectRef.IsVersionControlEnabled() {
+		pc, err = getProjectConfigYAML(p, projectFileBytes)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "getting patched project config")
+		}
 	}
 
 	patchConfig := &PatchConfig{

--- a/model/project_config.go
+++ b/model/project_config.go
@@ -90,7 +90,7 @@ func CreateProjectConfig(yml []byte, identifier string) (*ProjectConfig, error) 
 	p := &ProjectConfig{}
 	if err := util.UnmarshalYAMLWithFallback(yml, p); err != nil {
 		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
-		return nil, errors.Wrap(yamlErr, "unmarshalling project config from YAML")
+		return nil, errors.Wrap(yamlErr, TranslateProjectConfigError)
 	}
 	if p.isEmpty() {
 		return nil, nil

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -26,6 +26,7 @@ import (
 
 const LoadProjectError = "load project error(s)"
 const TranslateProjectError = "error translating project"
+const TranslateProjectConfigError = "unmarshalling project config from YAML"
 const EmptyConfigurationError = "received empty configuration file"
 
 // DefaultParserProjectAccessTimeout is the default timeout for accessing a

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -105,7 +105,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 
 	versionParserProject := &model.ParserProject{}
 	if err = util.UnmarshalYAMLWithFallback(projectConfig, &versionParserProject); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling project config from YAML")
+		return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 	}
 	versionParserProject.Id = "sample_version"
 	if err = versionParserProject.Insert(); err != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -408,8 +408,8 @@ func (repoTracker *RepoTracker) GetProjectConfig(ctx context.Context, revision s
 		_, ymlFmtErr := errors.Cause(err).(thirdparty.YAMLFormatError)
 		_, noFileErr := errors.Cause(err).(thirdparty.FileNotFoundError)
 		parsingErr := strings.Contains(err.Error(), model.TranslateProjectError)
-		mergingErr := strings.Contains(err.Error(), model.MergeProjectConfigError)
-		if apiReqErr || noFileErr || ymlFmtErr || parsingErr || mergingErr {
+		configErr := strings.Contains(err.Error(), model.TranslateProjectConfigError) || strings.Contains(err.Error(), model.MergeProjectConfigError)
+		if apiReqErr || noFileErr || ymlFmtErr || parsingErr || configErr {
 			// If there's an error getting the remote config, e.g. because it
 			// does not exist, we treat this the same as when the remote config
 			// is invalid - but add a different error message

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -510,7 +510,9 @@ func (j *patchIntentProcessor) setGitHubPatchingError(err error) error {
 	if strings.Contains(err.Error(), thirdparty.Github502Error) {
 		j.gitHubError = GitHubInternalError
 	}
-	if strings.Contains(err.Error(), model.LoadProjectError) {
+	if strings.Contains(err.Error(), model.LoadProjectError) ||
+		strings.Contains(err.Error(), model.TranslateProjectConfigError) {
+		// We use the same GitHub error in these cases, because the remedy is the same.
 		j.gitHubError = InvalidConfig
 	}
 	return err


### PR DESCRIPTION
DEVPROD-NNNNN

### Description
This was actually fixed just by rearranging the order of checking parser project before project config in GetPatchedProject, but I think it was worth going through and also checking the unmarshal error for project config. 

### Testing
Tested in https://github.com/evergreen-ci/commit-queue-sandbox/pull/731 
