### PR TITLE
DEVPROD-7896 create stub version if alias not found

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -621,11 +621,32 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 	v.Ignored = ignore
 
+	// Compute aliases first, so we can include this in the version errors if  there's a problem.
+	var aliases model.ProjectAliases
+	var aliasErr string
+	if metadata.Alias == evergreen.GitTagAlias {
+		aliases, err = model.FindMatchingGitTagAliasesInProject(projectInfo.Ref.Id, metadata.GitTag.Tag)
+		if err != nil {
+			return v, errors.Wrapf(err, "error finding project alias for tag '%s'", metadata.GitTag.Tag)
+		}
+	} else if metadata.Alias != "" {
+		aliases, err = model.FindAliasInProjectRepoOrConfig(projectInfo.Ref.Id, metadata.Alias)
+		if err != nil {
+			return v, errors.Wrap(err, "error finding project alias")
+		}
+		if metadata.Alias != "" && len(aliases) == 0 {
+			aliasErr = fmt.Sprintf("requested alias '%s' is undefined", metadata.Alias)
+		}
+	}
+
 	verrs := validator.CheckProject(ctx, projectInfo.Project, projectInfo.Config, projectInfo.Ref, true, projectInfo.Ref.Id, nil)
-	if len(verrs) > 0 || versionErrs != nil {
+	if len(verrs) > 0 || versionErrs != nil || aliasErr != "" {
 		// We have errors in the project.
 		// Format them, as we need to store + display them to the user
 		var projectErrors, projectWarnings []string
+		if aliasErr != "" {
+			projectErrors = append(projectErrors, aliasErr)
+		}
 		for _, e := range verrs {
 			if e.Level == validator.Error {
 				projectErrors = append(projectErrors, e.Error())
@@ -652,26 +673,6 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 			}
 			return v, nil
 
-		}
-	}
-
-	var aliases model.ProjectAliases
-	if metadata.Alias == evergreen.GitTagAlias {
-		aliases, err = model.FindMatchingGitTagAliasesInProject(projectInfo.Ref.Id, metadata.GitTag.Tag)
-		if err != nil {
-			return v, errors.Wrapf(err, "error finding project alias for tag '%s'", metadata.GitTag.Tag)
-		}
-		grip.Debug(message.Fields{
-			"message":            "aliases for creating version",
-			"tag":                metadata.GitTag.Tag,
-			"project":            projectInfo.Ref.Id,
-			"project_identifier": projectInfo.Ref.Identifier,
-			"aliases":            aliases,
-		})
-	} else if metadata.Alias != "" {
-		aliases, err = model.FindAliasInProjectRepoOrConfig(projectInfo.Ref.Id, metadata.Alias)
-		if err != nil {
-			return v, errors.Wrap(err, "error finding project alias")
 		}
 	}
 


### PR DESCRIPTION
DEVPROD-7896
### Description
This change creates a stub version with an error if an alias is requested but not found.

The git tag version of the error isn't super human readable but I also think it's worth keeping it to this level of simplicity, since that case shouldn't happen with validation anyway. 

### Testing
Added a unit test.
