### PR TITLE
DEVPROD-8298 redact longer expansions first

### DIFF
--- a/agent/internal/redactor/redacting_sender_test.go
+++ b/agent/internal/redactor/redacting_sender_test.go
@@ -53,6 +53,15 @@ func TestRedactingSender(t *testing.T) {
 			inputString:        "secret_val",
 			expected:           fmt.Sprintf(redactedVariableTemplate, "secret_key1"),
 		},
+		"LargerExpansionRedactedFirst": {
+			expansions: map[string]string{
+				"secret_key1": "value",
+				"secret_key2": "longer_value",
+			},
+			expansionsToRedact: []string{"secret_key1", "secret_key2"},
+			inputString:        "longer_value",
+			expected:           fmt.Sprintf(redactedVariableTemplate, "secret_key2"),
+		},
 		"NonexistantExpansion": {
 			expansions: map[string]string{
 				"secret_key": "secret_val",

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-12-10"
+	AgentVersion = "2024-12-18"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-8298 
### Description
Introduce sort to redact longer expansions first.
### Testing
Added a unit test.

