### PR TITLE
DEVPROD-13614 Remove EC2 Keys for ec2.assume_role from agent config

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -49,7 +49,6 @@ type TaskConfig struct {
 	Timeout            Timeout
 	TaskOutput         evergreen.S3Credentials
 	TaskSync           evergreen.S3Credentials
-	EC2Keys            []evergreen.EC2Key
 	ModulePaths        map[string]string
 	CedarTestResultsID string
 	TaskGroup          *model.TaskGroup

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -370,7 +370,6 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	}
 	taskConfig.TaskOutput = a.opts.SetupData.TaskOutput
 	taskConfig.TaskSync = a.opts.SetupData.TaskSync
-	taskConfig.EC2Keys = a.opts.SetupData.EC2Keys
 	taskConfig.MaxExecTimeoutSecs = a.opts.SetupData.MaxExecTimeoutSecs
 
 	// Set AWS credentials for task output buckets.

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -119,7 +119,6 @@ type AgentSetupData struct {
 	SplunkChannel          string                  `json:"splunk_channel"`
 	TaskSync               evergreen.S3Credentials `json:"task_sync"`
 	TaskOutput             evergreen.S3Credentials `json:"task_output"`
-	EC2Keys                []evergreen.EC2Key      `json:"ec2_keys"`
 	TraceCollectorEndpoint string                  `json:"trace_collector_endpoint"`
 	MaxExecTimeoutSecs     int                     `json:"max_exec_timeout_secs"`
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-12-10"
+	AgentVersion = "2024-12-19"
 )
 
 const (

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -92,7 +92,6 @@ func (h *agentSetup) Run(ctx context.Context) gimlet.Responder {
 		SplunkChannel:      h.settings.Splunk.SplunkConnectionInfo.Channel,
 		TaskOutput:         h.settings.Buckets.Credentials,
 		TaskSync:           h.settings.Providers.AWS.TaskSync,
-		EC2Keys:            h.settings.Providers.AWS.EC2Keys,
 		MaxExecTimeoutSecs: h.settings.TaskLimits.MaxExecTimeoutSecs,
 	}
 	if h.settings.Tracer.Enabled {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -442,7 +442,6 @@ func TestAgentSetup(t *testing.T) {
 			assert.Equal(t, data.SplunkClientToken, s.Splunk.SplunkConnectionInfo.Token)
 			assert.Equal(t, data.SplunkChannel, s.Splunk.SplunkConnectionInfo.Channel)
 			assert.Equal(t, data.TaskSync, s.Providers.AWS.TaskSync)
-			assert.Equal(t, data.EC2Keys, s.Providers.AWS.EC2Keys)
 			assert.Equal(t, data.MaxExecTimeoutSecs, s.TaskLimits.MaxExecTimeoutSecs)
 		},
 		"ReturnsEmpty": func(ctx context.Context, t *testing.T, rh *agentSetup, s *evergreen.Settings) {


### PR DESCRIPTION
DEVPROD-13614

### Description
This removes the EC2 keys from the agent config. We don't use these anywhere anymore, I discovered we were still passing it through in #8566. 

Waiting for an approval before updating agent version.

### Testing
Existing tests.