### PR TITLE
DEVPROD-7742 Fix lint warnings and errors

### DIFF
--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -229,7 +229,7 @@ func (h *annotationByTaskGetHandler) Run(ctx context.Context) gimlet.Responder {
 // PUT /rest/v2/tasks/{task_id}/annotation
 
 // Parsing logic for task annotation put and patch routes.
-func annotationByTaskPutOrPatchParser(ctx context.Context, r *http.Request) (string, *restModel.APITaskAnnotation, error) {
+func annotationByTaskPutOrPatchParser(_ context.Context, r *http.Request) (string, *restModel.APITaskAnnotation, error) {
 	var taskId string
 	var annotation *restModel.APITaskAnnotation
 	var err error

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -414,7 +414,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		},
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=1", buffer)
@@ -435,6 +435,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution1,
 	}
 	jsonBody, err = json.Marshal(a)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=1", buffer)
@@ -451,6 +452,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution1,
 	}
 	jsonBody, err = json.Marshal(a)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=2", buffer)
@@ -466,6 +468,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskId: utility.ToStringPtr("TaskFailedId"),
 	}
 	jsonBody, err = json.Marshal(a)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations", buffer)
@@ -482,7 +485,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution1,
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskSystemFailedId/annotations", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskFailedId"})
@@ -498,7 +501,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskId: utility.ToStringPtr("TaskFailedId"),
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=1", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskFailedId"})
@@ -515,6 +518,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution1,
 	}
 	jsonBody, err = json.Marshal(a)
+	assert.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=abc", buffer)
@@ -527,11 +531,12 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 	h = &annotationByTaskPutHandler{}
 	a = &restModel.APITaskAnnotation{}
 	jsonBody, err = json.Marshal(a)
+	assert.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskFailedId/annotations?execution=1", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskFailedId"})
 	assert.NoError(t, err)
-	err = h.Parse(ctx, r)
+	require.NoError(t, h.Parse(ctx, r))
 	assert.Equal(t, "TaskFailedId", h.taskId)
 
 	//test with id not equal to annotation id
@@ -542,6 +547,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution0,
 	}
 	jsonBody, err = json.Marshal(a)
+	assert.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskSystemUnresponseId/annotations?execution=0", buffer)
@@ -554,7 +560,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 	h = &annotationByTaskPutHandler{}
 	a = &restModel.APITaskAnnotation{}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskSystemFailedId/annotations?execution=0", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskSystemFailedId"})
@@ -565,7 +571,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 
 	a = &restModel.APITaskAnnotation{}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskTimedOutId/annotations?execution=0", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskTimedOutId"})
@@ -576,7 +582,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 
 	a = &restModel.APITaskAnnotation{}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskSetupFailedId/annotations?execution=0", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "TaskSetupFailedId"})
@@ -593,7 +599,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution0,
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskSucceededId/annotations?execution=0", buffer)
@@ -608,7 +614,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution0,
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskWillRunId/annotations?execution=0", buffer)
@@ -623,7 +629,7 @@ func TestAnnotationByTaskPutHandlerParse(t *testing.T) {
 		TaskExecution: &execution0,
 	}
 	jsonBody, err = json.Marshal(a)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/TaskDispatchedId/annotations?execution=0", buffer)
@@ -773,7 +779,7 @@ func TestCreatedTicketByTaskPutHandlerParse(t *testing.T) {
 	h = &createdTicketByTaskPutHandler{}
 	ticket.URL = utility.ToStringPtr("issuelink.com")
 	jsonBody, err = json.Marshal(ticket)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	buffer = bytes.NewBuffer(jsonBody)
 
 	r, err = http.NewRequest(http.MethodPut, "/task/t1/annotations?execution=1", buffer)

--- a/rest/route/commit_queue_test.go
+++ b/rest/route/commit_queue_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/commitqueue"
@@ -225,7 +224,7 @@ func TestCqMessageForPatch(t *testing.T) {
 
 func TestAdditionalPatches(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(commitqueue.Collection, patch.Collection))
-	patchId := bson.NewObjectId()
+	patchId := mgobson.NewObjectId()
 	p := patch.Patch{
 		Id:      patchId,
 		Project: "proj",

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -473,7 +473,7 @@ func (h *distroAMIHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding distro '%s'", h.distroID))
 	}
-	if err != nil || d == nil {
+	if d == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("distro '%s' not found", h.distroID),

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -131,7 +131,7 @@ func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo stri
 	return (fromApp && !hasApp) || (!fromApp && hasApp)
 }
 
-func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
+func (gh *githubHookApi) Run(_ context.Context) gimlet.Responder {
 	// GitHub occasionally aborts requests early before we are able to complete the full operation
 	// (for example enqueueing a PR to the commit queue). We therefore want to use a custom context
 	// instead of using the request context.

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -484,7 +484,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		}
 
 		lockErr := dispatchHostTaskAtomically(ctx, env, currentHost, nextTask)
-		if err != nil && !db.IsDuplicateKey(lockErr) {
+		if lockErr != nil && !db.IsDuplicateKey(lockErr) {
 			return nil, false, errors.Wrapf(err, "dispatching task '%s' to host '%s'", nextTask.Id, currentHost.Id)
 		}
 		dispatchedTask := lockErr == nil

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -554,7 +554,7 @@ func TestGetDockerLogs(t *testing.T) {
 
 	// valid Run
 	cloudClient := cloud.GetMockClient()
-	logs, err := cloudClient.GetDockerLogs(nil, "containerId", handler.host, types.ContainerLogsOptions{})
+	logs, err := cloudClient.GetDockerLogs(ctx, "containerId", handler.host, types.ContainerLogsOptions{})
 	assert.NoError(err)
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, logs)
@@ -636,7 +636,7 @@ func TestGetDockerStatus(t *testing.T) {
 
 	// valid Run
 	cloudClient := cloud.GetMockClient()
-	status, err := cloudClient.GetDockerStatus(nil, "containerId", handler.host)
+	status, err := cloudClient.GetDockerStatus(ctx, "containerId", handler.host)
 	assert.NoError(err)
 	require.NotNil(status)
 	require.True(status.HasStarted)

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -254,11 +254,11 @@ func TestHostModifyHandlers(t *testing.T) {
 	}()
 
 	checkSubscriptions := func(t *testing.T, userID string, numSubs int) {
-		subscriptions, err := data.GetSubscriptions("user", event.OwnerTypePerson)
+		subscriptions, err := data.GetSubscriptions(userID, event.OwnerTypePerson)
 		assert.NoError(t, err)
 		assert.Len(t, subscriptions, numSubs)
 	}
-	checkSpawnHostModifyQueueGroup := func(ctx context.Context, t *testing.T, env *mock.Environment, numQueues int) {
+	checkSpawnHostModifyQueueGroup := func(t *testing.T, env *mock.Environment, numQueues int) {
 		qg := env.RemoteQueueGroup()
 		assert.Equal(t, numQueues, qg.Len())
 	}
@@ -277,7 +277,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"StopHandlerEnqueuesStopJobForStoppingHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStopHandler{
@@ -292,7 +292,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"StopHandlerEnqueuesStopJobForAlreadyStoppedHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStopHandler{
@@ -307,7 +307,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"StopHandlerErrorsForNonstoppableHostStatus": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStopHandler{
@@ -322,7 +322,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.Status())
 
 			checkSubscriptions(t, "user", 0)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 0)
+			checkSpawnHostModifyQueueGroup(t, env, 0)
 		},
 		"StartHandlerEnqueuesStartJobForStoppedHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStartHandler{
@@ -337,7 +337,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"StartHandlerEnqueuesStartJobForStoppingHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStartHandler{
@@ -352,7 +352,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"StartHandlerErrorsForNonstartableHostStatus": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStartHandler{
@@ -367,7 +367,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, resp.Status())
 
 			checkSubscriptions(t, "user", 0)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 0)
+			checkSpawnHostModifyQueueGroup(t, env, 0)
 		},
 		"StartHandlerEnqueuesJobForAlreadyRunningHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostStartHandler{
@@ -382,7 +382,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			assert.Equal(t, http.StatusOK, resp.Status())
 
 			checkSubscriptions(t, "user", 1)
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"ModifyHandlerModifiesHost": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostModifyHandler{
@@ -398,7 +398,7 @@ func TestHostModifyHandlers(t *testing.T) {
 			require.NotZero(t, resp)
 			assert.Equal(t, http.StatusOK, resp.Status())
 
-			checkSpawnHostModifyQueueGroup(ctx, t, env, 1)
+			checkSpawnHostModifyQueueGroup(t, env, 1)
 		},
 		"ModifyHandlerFailsWithVeryLongTemporaryExemption": func(ctx context.Context, t *testing.T, env *mock.Environment, hosts []host.Host) {
 			rh := &hostModifyHandler{

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -295,6 +295,7 @@ func (m *TaskHostAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Reque
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("task '%s' not found", h.StartedBy),
 		}))
+		return
 	}
 	if _, code, err := model.ValidateHost(t.HostId, r); err != nil {
 		gimlet.WriteResponse(rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
-	_ "github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
@@ -78,8 +77,6 @@ func TestPrefetchProject(t *testing.T) {
 				So(err, ShouldResemble, errToResemble)
 			})
 			Convey("should error if patch exists and no user is set", func() {
-				opCtx := model.Context{}
-				opCtx.Patch = &patch.Patch{}
 				ctx, err = PrefetchProjectContext(ctx, req, map[string]string{"patch_id": "aabbccddeeff112233445566"})
 				So(ctx.Value(RequestContext), ShouldBeNil)
 

--- a/rest/route/notification_test.go
+++ b/rest/route/notification_test.go
@@ -152,5 +152,5 @@ func (s *EmailNotificationSuite) TestParseValidJSON() {
 	s.Equal(utility.ToStringPtr("This is the email's subject"), apiEmail.Subject)
 	s.Equal(utility.ToStringPtr("This is the email's body"), apiEmail.Body)
 	s.Equal(true, apiEmail.PlainTextContents)
-	s.Equal(map[string][]string{"h1": []string{"v11", "v12"}, "h2": []string{"v21", "v22"}}, apiEmail.Headers)
+	s.Equal(map[string][]string{"h1": {"v11", "v12"}, "h2": {"v21", "v22"}}, apiEmail.Headers)
 }

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	restmodel "github.com/evergreen-ci/evergreen/rest/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/units"
 	"github.com/evergreen-ci/evergreen/util"
@@ -70,7 +70,7 @@ func (s *PatchByIdSuite) TestFindById() {
 	s.NotNil(res)
 	s.Equal(http.StatusOK, res.Status(), "%+v", res.Data())
 
-	p, ok := res.Data().(*restmodel.APIPatch)
+	p, ok := res.Data().(*restModel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[0]), p.Id)
 }
@@ -179,15 +179,15 @@ func (s *PatchesByProjectSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	s.NotNil(payload)
 
 	s.Len(payload, 2)
-	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restmodel.APIPatch).CreateTime)
-	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restmodel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restModel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restModel.APIPatch).CreateTime)
 
 	pages := resp.Pages()
 	s.NotNil(pages)
 	s.Nil(pages.Prev)
 	s.NotNil(pages.Next)
 
-	nextTime := s.now.Format(restmodel.APITimeFormat)
+	nextTime := s.now.Format(restModel.APITimeFormat)
 	s.Equal(nextTime, pages.Next.Key)
 }
 
@@ -301,7 +301,7 @@ func (s *PatchAbortSuite) TestAbort() {
 	task2, err := task.FindOneId("task2")
 	s.NoError(err)
 	s.False(task2.Aborted)
-	p, ok := (res.Data()).(*restmodel.APIPatch)
+	p, ok := (res.Data()).(*restModel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[0]), p.Id)
 
@@ -316,7 +316,7 @@ func (s *PatchAbortSuite) TestAbort() {
 	task2, err = task.FindOneId("task2")
 	s.NoError(err)
 	s.True(task2.Aborted)
-	p, ok = (res.Data()).(*restmodel.APIPatch)
+	p, ok = (res.Data()).(*restModel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[1]), p.Id)
 
@@ -544,15 +544,15 @@ func (s *PatchesByUserSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	payload := resp.Data().([]interface{})
 
 	s.Len(payload, 2)
-	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restmodel.APIPatch).CreateTime)
-	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restmodel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restModel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restModel.APIPatch).CreateTime)
 
 	pageData := resp.Pages()
 
 	s.Nil(pageData.Prev)
 	s.NotNil(pageData.Next)
 
-	nextTime := s.now.Format(restmodel.APITimeFormat)
+	nextTime := s.now.Format(restModel.APITimeFormat)
 	s.Equal(nextTime, pageData.Next.Key)
 }
 
@@ -662,7 +662,7 @@ func (s *CountEstimatedGeneratedTasksSuite) TestFindById() {
 	res := s.route.Run(context.TODO())
 	s.Require().NotNil(res)
 	s.Require().Equal(http.StatusOK, res.Status())
-	result := (res.Data()).(*restmodel.APINumTasksToFinalize)
+	result := (res.Data()).(*restModel.APINumTasksToFinalize)
 	s.Equal(utility.ToIntPtr(120), result.NumTasksToFinalize)
 }
 
@@ -712,7 +712,7 @@ func TestPatchRawModulesHandler(t *testing.T) {
 	defer cancel()
 	response := route.Run(ctx)
 
-	rawModulesResponse, ok := response.Data().(*restmodel.APIRawPatch)
+	rawModulesResponse, ok := response.Data().(*restModel.APIRawPatch)
 	require.True(t, ok)
 
 	rp := rawModulesResponse.Patch
@@ -978,7 +978,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp := handler.Run(ctx)
-	respVersion := resp.Data().(restmodel.APIVersion)
+	respVersion := resp.Data().(restModel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err := task.Find(task.ByVersion(*respVersion.Id))
@@ -1014,7 +1014,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(restmodel.APIVersion)
+	respVersion = resp.Data().(restModel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1071,7 +1071,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(restmodel.APIVersion)
+	respVersion = resp.Data().(restModel.APIVersion)
 	assert.Equal(t, patch2.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, "", *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1104,7 +1104,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(restmodel.APIVersion)
+	respVersion = resp.Data().(restModel.APIVersion)
 	assert.Equal(t, patch3.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, "", *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1391,7 +1391,7 @@ tasks:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp := handler.Run(ctx)
-	respVersion := resp.Data().(restmodel.APIVersion)
+	respVersion := resp.Data().(restModel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err := task.Find(task.ByVersion(*respVersion.Id))
@@ -1423,7 +1423,7 @@ tasks:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(restmodel.APIVersion)
+	respVersion = resp.Data().(restModel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1450,7 +1450,7 @@ tasks:
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
 
-	respVersion = resp.Data().(restmodel.APIVersion)
+	respVersion = resp.Data().(restModel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
-	"github.com/evergreen-ci/evergreen/rest/model"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/units"
@@ -71,7 +70,7 @@ func (s *PatchByIdSuite) TestFindById() {
 	s.NotNil(res)
 	s.Equal(http.StatusOK, res.Status(), "%+v", res.Data())
 
-	p, ok := res.Data().(*model.APIPatch)
+	p, ok := res.Data().(*restmodel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[0]), p.Id)
 }
@@ -180,15 +179,15 @@ func (s *PatchesByProjectSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	s.NotNil(payload)
 
 	s.Len(payload, 2)
-	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(model.APIPatch).CreateTime)
-	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(model.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restmodel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restmodel.APIPatch).CreateTime)
 
 	pages := resp.Pages()
 	s.NotNil(pages)
 	s.Nil(pages.Prev)
 	s.NotNil(pages.Next)
 
-	nextTime := s.now.Format(model.APITimeFormat)
+	nextTime := s.now.Format(restmodel.APITimeFormat)
 	s.Equal(nextTime, pages.Next.Key)
 }
 
@@ -302,7 +301,7 @@ func (s *PatchAbortSuite) TestAbort() {
 	task2, err := task.FindOneId("task2")
 	s.NoError(err)
 	s.False(task2.Aborted)
-	p, ok := (res.Data()).(*model.APIPatch)
+	p, ok := (res.Data()).(*restmodel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[0]), p.Id)
 
@@ -317,7 +316,7 @@ func (s *PatchAbortSuite) TestAbort() {
 	task2, err = task.FindOneId("task2")
 	s.NoError(err)
 	s.True(task2.Aborted)
-	p, ok = (res.Data()).(*model.APIPatch)
+	p, ok = (res.Data()).(*restmodel.APIPatch)
 	s.True(ok)
 	s.Equal(utility.ToStringPtr(s.objIds[1]), p.Id)
 
@@ -545,15 +544,15 @@ func (s *PatchesByUserSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	payload := resp.Data().([]interface{})
 
 	s.Len(payload, 2)
-	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(model.APIPatch).CreateTime)
-	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(model.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restmodel.APIPatch).CreateTime)
+	s.Equal(s.now.Add(time.Second*4), *(payload[1]).(restmodel.APIPatch).CreateTime)
 
 	pageData := resp.Pages()
 
 	s.Nil(pageData.Prev)
 	s.NotNil(pageData.Next)
 
-	nextTime := s.now.Format(model.APITimeFormat)
+	nextTime := s.now.Format(restmodel.APITimeFormat)
 	s.Equal(nextTime, pageData.Next.Key)
 }
 
@@ -979,7 +978,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp := handler.Run(ctx)
-	respVersion := resp.Data().(model.APIVersion)
+	respVersion := resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err := task.Find(task.ByVersion(*respVersion.Id))
@@ -1015,7 +1014,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(model.APIVersion)
+	respVersion = resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1072,7 +1071,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(model.APIVersion)
+	respVersion = resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, patch2.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, "", *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1105,7 +1104,7 @@ buildvariants:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(model.APIVersion)
+	respVersion = resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, patch3.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, "", *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1392,7 +1391,7 @@ tasks:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp := handler.Run(ctx)
-	respVersion := resp.Data().(model.APIVersion)
+	respVersion := resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err := task.Find(task.ByVersion(*respVersion.Id))
@@ -1424,7 +1423,7 @@ tasks:
 	assert.NoError(t, err)
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
-	respVersion = resp.Data().(model.APIVersion)
+	respVersion = resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))
@@ -1451,7 +1450,7 @@ tasks:
 	assert.NoError(t, handler.Parse(ctx, req))
 	resp = handler.Run(ctx)
 
-	respVersion = resp.Data().(model.APIVersion)
+	respVersion = resp.Data().(restmodel.APIVersion)
 	assert.Equal(t, unfinalized.Id.Hex(), *respVersion.Id)
 	assert.Equal(t, description, *respVersion.Message)
 	tasks, err = task.Find(task.ByVersion(*respVersion.Id))

--- a/rest/route/project_events_test.go
+++ b/rest/route/project_events_test.go
@@ -36,13 +36,12 @@ func getTestProjectSettings(projectId string) model.ProjectSettings {
 			Vars:        map[string]string{},
 			PrivateVars: map[string]bool{},
 		},
-		Aliases: []model.ProjectAlias{model.ProjectAlias{
+		Aliases: []model.ProjectAlias{{
 			Alias:   "alias1",
 			Variant: "ubuntu",
 			Task:    "subcommand",
-		},
-		},
-		Subscriptions: []event.Subscription{event.Subscription{
+		}},
+		Subscriptions: []event.Subscription{{
 			ID:           "subscription1",
 			ResourceType: "project",
 			Owner:        "admin",
@@ -50,8 +49,7 @@ func getTestProjectSettings(projectId string) model.ProjectSettings {
 				Type:   event.GithubPullRequestSubscriberType,
 				Target: restModel.APIGithubPRSubscriber{},
 			},
-		},
-		},
+		}},
 	}
 }
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1076,7 +1076,6 @@ func TestDeleteProject(t *testing.T) {
 	}
 
 	numAliases := 2
-	var aliases []serviceModel.ProjectAlias
 	for i := 0; i < numAliases; i++ {
 		projAlias := serviceModel.ProjectAlias{
 			ProjectID: projects[0].Id,
@@ -1085,7 +1084,6 @@ func TestDeleteProject(t *testing.T) {
 			Task:      fmt.Sprintf("task_%d", i),
 		}
 
-		aliases = append(aliases, projAlias)
 		require.NoError(t, projAlias.Upsert())
 	}
 

--- a/rest/route/reliability_test.go
+++ b/rest/route/reliability_test.go
@@ -51,7 +51,7 @@ func enableTaskReliability() error {
 	return configureTaskReliability(false)
 }
 
-func setupTest(t *testing.T) error {
+func setupTest(_ *testing.T) error {
 	return enableTaskReliability()
 }
 

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -576,7 +576,6 @@ func TestTaskByBuildPaginator(t *testing.T) {
 	Convey("When paginating with a Connector", t, func() {
 		assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection))
 		Convey("and there are tasks to be found", func() {
-			cachedTasks := []task.Task{}
 			cachedOldTasks := []task.Task{}
 			for i := 0; i < numTasks; i++ {
 				prefix := int(math.Log10(float64(i)))
@@ -587,7 +586,6 @@ func TestTaskByBuildPaginator(t *testing.T) {
 					Id: fmt.Sprintf("%dbuild%d", prefix, i),
 				}
 				So(db.Insert(task.Collection, nextTask), ShouldBeNil)
-				cachedTasks = append(cachedTasks, nextTask)
 			}
 			for i := 0; i < 5; i++ {
 				prefix := int(math.Log10(float64(i)))

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -260,18 +260,19 @@ func (h *testCountGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 	t := projCtx.Task
+	originalTask := t
 	if t.Execution != h.execution {
 		t, err := task.FindOneIdOldOrNew(t.Id, h.execution)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
-				Message:    errors.Wrapf(err, "finding task '%s' with execution %d", t.Id, h.execution).Error(),
+				Message:    errors.Wrapf(err, "finding task '%s' with execution %d", originalTask.Id, h.execution).Error(),
 			})
 		}
 		if t == nil {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusNotFound,
-				Message:    fmt.Sprintf("task '%s' with execution %d not found", t.Id, h.execution),
+				Message:    fmt.Sprintf("task '%s' with execution %d not found", originalTask.Id, h.execution),
 			})
 		}
 	}

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -348,8 +348,7 @@ type UsersPermissionsInput struct {
 // UserPermissionsResult is a map from userId to their highest permission for the resource
 type UsersPermissionsResult map[string]gimlet.Permissions
 
-// Swagger-only type, included because this API route returns an external type
-// nolint:all
+//lint:ignore U1000 Swagger-only type, included because this API route returns an external type
 type swaggerUsersPermissionsResult map[string]swaggerPermissions
 
 type allUsersPermissionsGetHandler struct {
@@ -476,8 +475,7 @@ func (h *userPermissionsGetHandler) Factory() gimlet.RouteHandler {
 	}
 }
 
-// Swagger-only type, included because this API route returns an external type
-// nolint:all
+//lint:ignore U1000 Swagger-only type, included because this API route returns an external type
 type swaggerPermissionSummary struct {
 	//   type - the type of resources for which the listed permissions apply.
 	//   Will be "project", "distro", or "superuser"
@@ -491,12 +489,10 @@ type swaggerPermissionSummary struct {
 	Permissions swaggerPermissionsForResources `json:"permissions"`
 }
 
-// Swagger-only type, included because this API route returns an external type
-// nolint:all
+//lint:ignore U1000 Swagger-only type, included because this API route returns an external type
 type swaggerPermissionsForResources map[string]swaggerPermissions
 
-// Swagger-only type, included because this API route returns an external type
-// nolint:all
+//lint:ignore U1000 Swagger-only type, included because this API route returns an external type
 type swaggerPermissions map[string]int
 
 func (h *userPermissionsGetHandler) Parse(ctx context.Context, r *http.Request) error {

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -545,7 +545,7 @@ func TestServiceUserOperations(t *testing.T) {
 	assert.NoError(t, handler.Parse(ctx, request))
 	_ = handler.Run(ctx)
 
-	request, err = http.NewRequest(http.MethodGet, "", nil)
+	_, err = http.NewRequest(http.MethodGet, "", nil)
 	require.NoError(t, err)
 	handler = makeGetServiceUsers()
 	resp = handler.Run(ctx)


### PR DESCRIPTION
DEVPROD-7742

### Description
This fixes the various lint warnings and errors we have throughout our project. I'm going to open a 2nd PR to try to fix up a task to fail PR's on this lint warnings and errors, this is to keep the work separated.

### Testing
Existing unit tests. Nothing stood out to me to manually test, it's mostly in test files. The ones outside of test files is just removing an unused variable, preventing a nil dereference, and other things that manual checks aren't needed for.