### PR TITLE
DEVPROD-13287 FIx documentation on alias paramters

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -675,7 +675,9 @@ patch_aliases:
     task: "^test.*$"
     parameters:
         - key: "myParam"
-        - value: "defaultValue"
+          value: "defaultValue"
+        - key: "myOtherParam"
+          value: "anotherOne"
 ```
 
 ### Merge Queue Aliases


### PR DESCRIPTION
DEVPROD-13287

### Documentation
Fix documentation on alias parameters to not have a keyless parameters
