### PR TITLE
DEVPROD-11829 Document git.get_project token parameter only clones source

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -604,7 +604,7 @@ Parameters:
     expansion. For example, you could provide an expansion called
     "github_token" and then set this field to \${github_token}.
     Evergreen will populate the expansion when it parses the project
-    yaml.
+    yaml. This token is *only* used for the source repository, not modules.
 -   `is_oauth`: If a project token is provided and that token is an OAuth token and not a
     GitHub app token, `is_oauth` must be set to true so that the clone command is formatted properly.
 -   `clone_depth`: Clone with `git clone --depth <clone_depth>`. For


### PR DESCRIPTION
DEVPROD-11829

### Description
This documents git.get_project `token` parameter to specify that it only clones the source repository and not modules
