### PR TITLE
DEVPROD-7289 Use absolute path for syslink files when extracting tar.gz files

### DIFF
--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -157,7 +157,7 @@ func extractTarArchive(ctx context.Context, tarReader *tar.Reader, rootPath stri
 				return errors.WithStack(err)
 			}
 		} else if hdr.Typeflag == tar.TypeSymlink {
-			if err = os.Symlink(hdr.Name, hdr.Linkname); err != nil {
+			if err = os.Symlink(hdr.Name, filepath.Join(rootPath, hdr.Linkname)); err != nil {
 				return errors.WithStack(err)
 			}
 		} else if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2024-12-18"
+	AgentVersion = "2024-12-19-a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-7289

### Description
This switches over to using the absolute path when extracting files

### Testing
[Old task](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_s3_misc_s3_symlink_file_patch_64d76a6b8a60a98d94ba2890a51b791cc16d1539_67644fd64842d90007d1665b_24_12_19_16_54_51/logs?execution=0) and [new task](#tba). The new one extracts correctly while the old one fails.
