### PR TITLE
DEVPROD-13638 Add message about patches permission in MANA

### DIFF
--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -158,7 +158,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		RequiredLevel: evergreen.PatchSubmit.Value,
 	})
 	if !hasPermission {
-		as.LoggedError(w, r, http.StatusUnauthorized, errors.Errorf("not authorized to patch for project '%s', please ensure you have Patches: Submit and Edit permission in MANA", data.Project))
+		as.LoggedError(w, r, http.StatusUnauthorized, errors.Errorf("not authorized to patch for project '%s', please ensure you have 'Patches: Submit and Edit' permission in MANA", data.Project))
 		return
 	}
 

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -158,7 +158,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		RequiredLevel: evergreen.PatchSubmit.Value,
 	})
 	if !hasPermission {
-		as.LoggedError(w, r, http.StatusUnauthorized, errors.Errorf("not authorized to patch for project '%s'", data.Project))
+		as.LoggedError(w, r, http.StatusUnauthorized, errors.Errorf("not authorized to patch for project '%s', please ensure you have Patches: Submit and Edit permission in MANA", data.Project))
 		return
 	}
 


### PR DESCRIPTION
DEVPROD-13638

### Description

Ths has come up a few times in Slack. Currently the error message suggests logging in again through the web UI, only. This adds a more specific hint about patch permissions.

### Testing

Changes a string, so should be covered by existing tests.

### Documentation

N/A
