### PR TITLE
DEVPROD-2731 Update task.status field to reflect a tasks original status

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -460,8 +460,6 @@ models:
         resolver: true
       spawnHostLink:
         resolver: true
-      status:
-        resolver: true
       isPerfPluginEnabled:
         resolver: true
       project:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2041,8 +2041,6 @@ type TaskResolver interface {
 
 	SpawnHostLink(ctx context.Context, obj *model.APITask) (*string, error)
 
-	Status(ctx context.Context, obj *model.APITask) (string, error)
-
 	TaskLogs(ctx context.Context, obj *model.APITask) (*TaskLogs, error)
 	Tests(ctx context.Context, obj *model.APITask, opts *TestFilterOptions) (*TaskTestResult, error)
 
@@ -58377,7 +58375,7 @@ func (ec *executionContext) _Task_status(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Task().Status(rctx, obj)
+		return obj.Status, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -58389,17 +58387,17 @@ func (ec *executionContext) _Task_status(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Task_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Task",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -90743,41 +90741,10 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 		case "startTime":
 			out.Values[i] = ec._Task_startTime(ctx, field, obj)
 		case "status":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Task_status(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Task_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "tags":
 			out.Values[i] = ec._Task_tags(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -73,6 +73,9 @@ type Task {
   details: TaskEndDetail
   dispatchTime: Time
   displayName: String!
+  """
+  This is a task's display status and is what is commonly used on the UI.
+  """
   displayStatus: String!
   displayOnly: Boolean
   displayTask: Task
@@ -111,10 +114,9 @@ type Task {
   spawnHostLink: String
   startTime: Time
   """
-  This is a task's display status and is what is commonly used on the UI.
-  In future releases this will be migrated to represent the original status of the task
+  This is a tasks original status before the displayStatus was added
   """
-  status: String! @deprecated(reason: "use displayStatus instead. Status will be migrated to reflect the original status")
+  status: String! 
   tags: [String!]!
   taskGroup: String
   taskGroupMaxHosts: Int

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -557,11 +557,6 @@ func (r *taskResolver) SpawnHostLink(ctx context.Context, obj *restModel.APITask
 	return nil, nil
 }
 
-// Status is the resolver for the status field.
-func (r *taskResolver) Status(ctx context.Context, obj *restModel.APITask) (string, error) {
-	return *obj.DisplayStatus, nil
-}
-
 // TaskLogs is the resolver for the taskLogs field.
 func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*TaskLogs, error) {
 	canView := hasLogViewPermission(ctx, obj)

--- a/graphql/tests/task/displayStatus/results.json
+++ b/graphql/tests/task/displayStatus/results.json
@@ -5,7 +5,7 @@
             "result": {
                 "data": {
                     "task": {
-                        "status": "known-issue",
+                        "status": "failed",
                         "displayStatus": "known-issue"
                     }
                 }


### PR DESCRIPTION
DEVPROD-2731

### Description
the task.status field will now start returning a tasks original status. The UI has been updated to use `displayStatus` in https://github.com/evergreen-ci/ui/pull/534. 

