### PR TITLE
DEVPROD-11437 Reset git remote configuration after fetch

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2024-12-17"
+	ClientVersion = "2024-12-27"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -320,7 +320,10 @@ func clone(opts cloneOptions) error {
 	// Reset Git remote URL to SSH after source has been fetched
 	// because the token in the https URL will be revoked.
 	if opts.isAppToken {
-		resetGitRemoteToSSH(opts.owner, opts.repository, opts.rootDir)
+		err = resetGitRemoteToSSH(opts.owner, opts.repository, opts.rootDir)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
DEVPROD-11437

### Description
This change updates the Git remote configuration on spawned hosts. After fetching data with a temporary token, the remote is reset to an SSH URL to enable the use of -o ForwardAgent=yes for subsequent Git operations. 

### Testing
Added a unit test 


