### PR TITLE
DEVPROD-8938 allow empty commits with patch-file

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-01-02"
+	ClientVersion = "2025-01-06"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -357,6 +357,7 @@ func PatchFile() cli.Command {
 		baseFlagName        = "base"
 		diffPathFlagName    = "diff-file"
 		diffPatchIdFlagName = "diff-patchId"
+		allowEmptyFlagName  = "allow-empty"
 	)
 
 	return cli.Command{
@@ -375,6 +376,10 @@ func PatchFile() cli.Command {
 				Name:  diffPatchIdFlagName,
 				Usage: "patch id to fetch the full diff (including modules) from",
 			},
+			cli.BoolFlag{
+				Name:  allowEmptyFlagName,
+				Usage: "create an empty patch with no diff",
+			},
 			cli.StringFlag{
 				Name: patchAuthorFlag,
 				Usage: "optionally define the patch author by providing an Evergreen username; " +
@@ -385,11 +390,14 @@ func PatchFile() cli.Command {
 			autoUpdateCLI,
 			mutuallyExclusiveArgs(false, patchDescriptionFlagName, autoDescriptionFlag),
 			mutuallyExclusiveArgs(false, diffPathFlagName, diffPatchIdFlagName),
+			mutuallyExclusiveArgs(false, allowEmptyFlagName, diffPatchIdFlagName),
+			mutuallyExclusiveArgs(false, allowEmptyFlagName, diffPathFlagName),
 			mutuallyExclusiveArgs(false, baseFlagName, diffPatchIdFlagName),
 		),
 		Action: func(c *cli.Context) error {
 			diffPatchId := c.String(diffPatchIdFlagName)
 			diffFilePath := c.String(diffPathFlagName)
+			allowEmpty := c.Bool(allowEmptyFlagName)
 			if diffPatchId == "" && diffFilePath != "" {
 				if _, err := os.Stat(diffFilePath); os.IsNotExist(err) {
 					return errors.Errorf("file '%s' does not exist", diffFilePath)
@@ -448,7 +456,9 @@ func PatchFile() cli.Command {
 			params.Description = params.getDescription()
 			var diffData localDiff
 			var rp *restmodel.APIRawPatch
-			if diffPatchId == "" {
+			if allowEmpty {
+				diffData.base = base
+			} else if diffPatchId == "" {
 				fullPatch, err := os.ReadFile(diffPath)
 				if err != nil {
 					return errors.Wrapf(err, "reading diff file '%s'", diffPath)


### PR DESCRIPTION
[DEVPROD-8938](https://jira.mongodb.org/browse/DEVPROD-8938)

### Description
For UI deploys to the new stagings there will be a new task in spruce to trigger. It would be nice to not need to use the local spruce clone (maybe you won't have the commit you're trying to deploy in your local repo, maybe your local repo is in a funny state, etc).
This PR adds an option to `patch-file` to allow empty patches. We could add it to the regular patch command, but patch-file seemed appropriate because it's already giving users more control over their patch.

### Testing
Used it to create an empty patch.
