### PR TITLE
DEVPROD-13165 Add expanded remote path to otel for s3 commands

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -29,6 +29,7 @@ var (
 	s3GetBucketAttribute               = fmt.Sprintf("%s.bucket", s3GetAttribute)
 	s3GetTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3GetAttribute)
 	s3GetRemoteFileAttribute           = fmt.Sprintf("%s.remote_file", s3GetAttribute)
+	s3GetExpandedRemoteFileAttribute   = fmt.Sprintf("%s.expanded_remote_file", s3GetAttribute)
 )
 
 // s3get is a command to fetch a resource from an S3 bucket and download it to
@@ -181,6 +182,7 @@ func (c *s3get) Execute(ctx context.Context,
 		attribute.String(s3GetBucketAttribute, c.Bucket),
 		attribute.Bool(s3GetTemporaryCredentialsAttribute, c.AwsSessionToken != ""),
 		attribute.String(s3GetRemoteFileAttribute, c.remoteFile),
+		attribute.String(s3GetExpandedRemoteFileAttribute, c.RemoteFile),
 	)
 
 	// create pail bucket

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -36,6 +36,7 @@ var (
 	s3PutVisibilityAttribute           = fmt.Sprintf("%s.visibility", s3PutAttribute)
 	s3PutPermissionsAttribute          = fmt.Sprintf("%s.permissions", s3PutAttribute)
 	s3PutRemotePathAttribute           = fmt.Sprintf("%s.remote_path", s3PutAttribute)
+	s3PutExpandedRemotePathAttribute   = fmt.Sprintf("%s.expanded_remote_path", s3PutAttribute)
 )
 
 // s3pc is a command to put a resource to an S3 bucket and download it to
@@ -311,6 +312,7 @@ func (s3pc *s3put) Execute(ctx context.Context,
 		attribute.String(s3PutVisibilityAttribute, s3pc.Visibility),
 		attribute.String(s3PutPermissionsAttribute, s3pc.Permissions),
 		attribute.String(s3PutRemotePathAttribute, s3pc.remoteFile),
+		attribute.String(s3PutExpandedRemotePathAttribute, s3pc.RemoteFile),
 	)
 
 	s3pc.internalBuckets = conf.InternalBuckets

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -35,8 +35,8 @@ var (
 	s3PutTemporaryCredentialsAttribute = fmt.Sprintf("%s.temporary_credentials", s3PutAttribute)
 	s3PutVisibilityAttribute           = fmt.Sprintf("%s.visibility", s3PutAttribute)
 	s3PutPermissionsAttribute          = fmt.Sprintf("%s.permissions", s3PutAttribute)
-	s3PutRemotePathAttribute           = fmt.Sprintf("%s.remote_path", s3PutAttribute)
-	s3PutExpandedRemotePathAttribute   = fmt.Sprintf("%s.expanded_remote_path", s3PutAttribute)
+	s3PutRemoteFileAttribute           = fmt.Sprintf("%s.remote_file", s3PutAttribute)
+	s3PutExpandedRemoteFileAttribute   = fmt.Sprintf("%s.expanded_remote_file", s3PutAttribute)
 )
 
 // s3pc is a command to put a resource to an S3 bucket and download it to
@@ -311,8 +311,8 @@ func (s3pc *s3put) Execute(ctx context.Context,
 		attribute.Bool(s3PutTemporaryCredentialsAttribute, s3pc.AwsSessionToken != ""),
 		attribute.String(s3PutVisibilityAttribute, s3pc.Visibility),
 		attribute.String(s3PutPermissionsAttribute, s3pc.Permissions),
-		attribute.String(s3PutRemotePathAttribute, s3pc.remoteFile),
-		attribute.String(s3PutExpandedRemotePathAttribute, s3pc.RemoteFile),
+		attribute.String(s3PutRemoteFileAttribute, s3pc.remoteFile),
+		attribute.String(s3PutExpandedRemoteFileAttribute, s3pc.RemoteFile),
 	)
 
 	s3pc.internalBuckets = conf.InternalBuckets

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-02"
+	AgentVersion = "2025-01-07"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13165

### Description
This adds the expanded remote path/file to the otel attributes for s3 proejct commands.

This will allow for more insight for s3 commands that use a user-made expansion.

It also renames the s3.put otel attribute to match the field it is tracking (path -> file) and be more consistent with the s3.get field which is already named file appropriately.