### PR TITLE
DEVPROD-7742 Fix current spanend lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,5 @@ linters:
     - gosimple
     - govet
     - misspell
-    - spancheck
     - unconvert
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,5 +9,6 @@ linters:
     - gosimple
     - govet
     - misspell
+    - spancheck
     - unconvert
     - unused

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-01-06"
+	ClientVersion = "2025-01-09"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -65,6 +65,8 @@ func startWebService() cli.Command {
 
 			tracer := tp.Tracer("github.com/evergreen-ci/evergreen/operations")
 			ctx, startServiceSpan := tracer.Start(ctx, "StartService")
+			// This is only in case of an error.
+			defer startServiceSpan.End()
 
 			confPath := c.String(confFlagName)
 			versionID := c.String(versionIDFlagName)
@@ -153,6 +155,7 @@ func startWebService() cli.Command {
 				close(adminWait)
 			}()
 
+			// This end span is the correct time to end the span for the service startup.
 			startServiceSpan.End()
 			if sdkTracerProvider != nil {
 				catcher.Add(sdkTracerProvider.Shutdown(ctx))


### PR DESCRIPTION
DEVPROD-7742

### Description
Before merging in the fix for our linter and adding stricter rules, I'm doing smaller PRs to fix the current mistakes that our linter should be catching.

This PR fixes the spanend lint issues. There was only one. This lint will call usually if the span isn't deferred and there's error branches that would prevent the later call to `span.End()` not to be ran.

This PR does not add the spanend to our linters yet, this is blocked on upgrading our go version. The corresponding ticket is [DEVPROD-13940](https://jira.mongodb.org/browse/DEVPROD-13940).

### Testing
Running golangci-lint run in my terminal results in no more lint errors. This pulls from the .golangci.yml file's configuration (which our linter task should be doing.