### PR TITLE
DEVPROD-13406: silence patch info logs for JSON output

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -103,6 +103,10 @@ func buildApp() *cli.App {
 }
 
 func loggingSetup(name, l string) error {
+	// Warning: this logging setup means all grip-logged output goes to stderr
+	// instead of stdout. This is unintuitive in a lot of scenarios (e.g. a
+	// grip.Info will log to stderr), but it's difficult to change at this point
+	// due to user reliance on CLI logs for scripting.
 	if err := grip.SetSender(send.MakeErrorLogger()); err != nil {
 		return err
 	}

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-01-09"
+	ClientVersion = "2025-01-09b"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -120,6 +121,14 @@ func Patch() cli.Command {
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
 			outputJSON := c.Bool(jsonFlagName)
+			if outputJSON {
+				// If outputting the patch data as JSON, suppress any non-error
+				// logs since the logs won't be in JSON format. Errors should
+				// still appear so users can diagnose issues.
+				l := grip.GetSender().Level()
+				l.Threshold = level.Error
+				grip.Error(errors.Wrap(grip.SetLevel(l), "increasing log level to suppress non-errors for JSON output"))
+			}
 			args := c.Args()
 			params := &patchParams{
 				Project:           c.String(projectFlagName),
@@ -257,7 +266,7 @@ func Patch() cli.Command {
 						continue
 					}
 					if err = addModuleToPatch(params, args, conf, newPatch, &module, modulePath); err != nil {
-						grip.ErrorWhen(!outputJSON, fmt.Sprintf("Error adding module '%s' to patch: %s", module.Name, err))
+						grip.Errorf("Error adding module '%s' to patch: %s", module.Name, err)
 					}
 				}
 			}

--- a/operations/patch_module.go
+++ b/operations/patch_module.go
@@ -141,7 +141,7 @@ func addModuleToPatch(params *patchParams, args cli.Args, conf *ClientSettings,
 	if !params.SkipConfirm {
 		grip.Infof("Using branch '%s' for module '%s'.", module.Branch, module.Name)
 		if diffData.patchSummary != "" {
-			fmt.Println(diffData.patchSummary)
+			grip.Info(diffData.patchSummary)
 		}
 		if len(diffData.fullPatch) > 0 {
 			if !confirm("This is a summary of the module patch to be submitted. Include this module's changes?", true) {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -191,11 +191,16 @@ func (p *patchParams) displayPatch(ac *legacyClient, params outputPatchParams) e
 	}
 
 	grip.Info("Patch successfully created.")
-	// This is intentionally using fmt.Println instead of grip because if the
-	// output is JSON, informational grip logs are suppressed. Using fmt.Println
-	// ensures the patch output is displayed regardless of logging
-	// configuration.
-	fmt.Println(patchDisp)
+	// Logging to stderr using fmt.Fprintf is a hack to work around two
+	// problems:
+	// 1. The patch display log has historically been written to stderr instead
+	//    of stdout.
+	// 2. Only grip.Error or higher priority messages are logged if running a
+	//    patch with JSON output.
+	// To maintain both behaviors, fmt.Fprintf ensures the patch output is
+	// displayed regardless of grip logging configuration and ensures it
+	// continues going to stderr.
+	fmt.Fprintln(os.Stderr, patchDisp)
 
 	if len(params.patches) == 1 && p.Browse {
 		browserCmd, err := findBrowserCommand()

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -190,8 +190,12 @@ func (p *patchParams) displayPatch(ac *legacyClient, params outputPatchParams) e
 		return err
 	}
 
-	grip.InfoWhen(!params.outputJSON, "Patch successfully created.")
-	grip.Info(patchDisp)
+	grip.Info("Patch successfully created.")
+	// This is intentionally using fmt.Println instead of grip because if the
+	// output is JSON, informational grip logs are suppressed. Using fmt.Println
+	// ensures the patch output is displayed regardless of logging
+	// configuration.
+	fmt.Println(patchDisp)
 
 	if len(params.patches) == 1 && p.Browse {
 		browserCmd, err := findBrowserCommand()
@@ -236,7 +240,7 @@ func findBrowserCommand() ([]string, error) {
 // Performs validation for patch or patch-file
 func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSettings, ac *legacyClient, comm client.Communicator) (*model.ProjectRef, error) {
 	if err := p.loadProject(conf); err != nil {
-		grip.Warningf("warning - failed to set default project: %v\n", err)
+		grip.Errorf("failed to resolve project: %s\n", err)
 	}
 
 	// If reusing a previous definition, ignore defaults.
@@ -245,7 +249,7 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 	}
 
 	if err := p.loadParameters(conf); err != nil {
-		grip.Warningf("warning - failed to set default parameters: %v\n", err)
+		grip.Warningf("warning - failed to set default parameters: %s\n", err)
 	}
 
 	if p.Uncommitted || conf.UncommittedChanges {


### PR DESCRIPTION
DEVPROD-13406

### Description
This is the exact same as #8599 except for [this one fix](https://github.com/evergreen-ci/evergreen/blob/57802d0dfd3d04634b56cc71bb4d953d6c6bf7d5/operations/patch_util.go#L194-L204) - it came up in [a user thread](https://mongodb.slack.com/archives/C0V896UV8/p1736448187823239?thread_ts=1736446708.114339&cid=C0V896UV8) that `evergreen patch-file` apparently writes grip logs to stderr, whereas `evergreen patch` writes grip logs to stdout. That means when a script scans for the patch info (like the patch URL), you have to check stdout for `evergreen patch` and stderr for `evergreen patch-file`. The change in #8599 made `evergreen patch-file` write to stdout, which broke their script that was looking at stderr for the patch info.

Writing to stderr in `evergreen patch-file` seems like a bug, but I'm not looking to fix that discrepancy here. Instead, I changed #8599 to log at a high enough level so that the grip log will appear when running `evergreen patch --json`, and will also maintain the grip logging split between `evergreen patch` and `evergreen patch-file`.

DEVPROD-13964 will consider whether to fix `evergreen patch-file` so that it writes to stdout.

### Testing
Ran `evergreen patch` and confirmed it writes the patch info to stdout. `evergreen patch-file` writes the patch info to stderr.

### Documentation
N/A
