### PR TITLE
DEVPROD-8000: fix duplicate notification for generate.tasks

### DIFF
--- a/model/build/db.go
+++ b/model/build/db.go
@@ -277,7 +277,6 @@ func SetBuildStartedForTasks(tasks []task.Task, caller string) error {
 
 // FindByVersionAndVariants finds all builds that are in the given version and
 // match one of the build variant names.
-// kim: TODO: add small unit test
 func FindByVersionAndVariants(ctx context.Context, version string, variants []string) ([]Build, error) {
 	if len(variants) == 0 {
 		return nil, nil

--- a/model/generate.go
+++ b/model/generate.go
@@ -374,12 +374,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 // that have added generated tasks to run. For example, if a build was already
 // finished and just had new tasks generated, the status should be updated to
 // running.
-// kim: TODO: add Save tests for build status updates.
 func updateBuildStatusesForGeneratedTasks(ctx context.Context, versionID string, newTVPairsForExistingVariants TaskVariantPairs) error {
-	// kim: NOTE: first need to get build IDs of existing builds that had tasks
-	// added to determine which builds may need their status updated. The
-	// task/build creation functions don't return the created tasks/builds, so
-	// we have to query them.
 	bvs := getBuildVariantsFromPairs(newTVPairsForExistingVariants)
 
 	builds, err := build.FindByVersionAndVariants(ctx, versionID, bvs)
@@ -392,10 +387,6 @@ func updateBuildStatusesForGeneratedTasks(ctx context.Context, versionID string,
 		buildIDs = append(buildIDs, b.Id)
 	}
 
-	// kim: NOTE: I didn't verify, but it may be sufficient to call
-	// UpdateVersionAndPatchStatusForBuilds here to ensure the build statuses
-	// are updated for new tasks. Should write unit test and verify that it
-	// fails before change and succeeds after change.
 	return UpdateVersionAndPatchStatusForBuilds(ctx, buildIDs)
 }
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -352,6 +352,10 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		return errors.Wrap(err, "adding new builds")
 	}
 
+	// kim: NOTE: I didn't verify, but it may be sufficient to call
+	// UpdateVersionAndPatchStatusForBuilds here to ensure the build statuses
+	// are updated for new tasks.
+
 	numActivatedGenerateTasks := len(activatedTasksInExistingBuilds) + len(activatedTasksInNewBuilds)
 	span.SetAttributes(attribute.Int(numActivatedGenerateTasksAttribute, numActivatedGenerateTasks))
 	if err = g.Task.SetNumActivatedGeneratedTasks(numActivatedGenerateTasks); err != nil {

--- a/model/generate.go
+++ b/model/generate.go
@@ -374,7 +374,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 // that have added generated tasks to run. For example, if a build was already
 // finished and just had new tasks generated, the status should be updated to
 // running.
-// kim: TODO: add tests for build status updates.
+// kim: TODO: add Save tests for build status updates.
 func updateBuildStatusesForGeneratedTasks(ctx context.Context, versionID string, newTVPairsForExistingVariants TaskVariantPairs) error {
 	// kim: NOTE: first need to get build IDs of existing builds that had tasks
 	// added to determine which builds may need their status updated. The

--- a/model/generate.go
+++ b/model/generate.go
@@ -352,9 +352,9 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		return errors.Wrap(err, "adding new builds")
 	}
 
-	// kim: NOTE: I didn't verify, but it may be sufficient to call
-	// UpdateVersionAndPatchStatusForBuilds here to ensure the build statuses
-	// are updated for new tasks.
+	if err := updateBuildStatusesForGeneratedTasks(ctx, v.Id, newTVPairsForExistingVariants); err != nil {
+		return errors.Wrap(err, "updating statuses for builds that have added generated tasks")
+	}
 
 	numActivatedGenerateTasks := len(activatedTasksInExistingBuilds) + len(activatedTasksInNewBuilds)
 	span.SetAttributes(attribute.Int(numActivatedGenerateTasksAttribute, numActivatedGenerateTasks))
@@ -368,6 +368,54 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 	}
 
 	return nil
+}
+
+// updateBuildStatusesForGeneratedTasks updates the statuses of existing builds
+// that have added generated tasks to run. For example, if a build was already
+// finished and just had new tasks generated, the status should be updated to
+// running.
+// kim: TODO: add tests for build status updates.
+func updateBuildStatusesForGeneratedTasks(ctx context.Context, versionID string, newTVPairsForExistingVariants TaskVariantPairs) error {
+	// kim: NOTE: first need to get build IDs of existing builds that had tasks
+	// added to determine which builds may need their status updated. The
+	// task/build creation functions don't return the created tasks/builds, so
+	// we have to query them.
+	bvs := getBuildVariantsFromPairs(newTVPairsForExistingVariants)
+
+	builds, err := build.FindByVersionAndVariants(ctx, versionID, bvs)
+	if err != nil {
+		return errors.Wrap(err, "finding builds that need their status updated")
+	}
+
+	buildIDs := make([]string, 0, len(builds))
+	for _, b := range builds {
+		buildIDs = append(buildIDs, b.Id)
+	}
+
+	// kim: NOTE: I didn't verify, but it may be sufficient to call
+	// UpdateVersionAndPatchStatusForBuilds here to ensure the build statuses
+	// are updated for new tasks. Should write unit test and verify that it
+	// fails before change and succeeds after change.
+	return UpdateVersionAndPatchStatusForBuilds(ctx, buildIDs)
+}
+
+// getBuildVariantsFromPair returns a slice of all unique build variant names
+// from build variant task pairs.
+func getBuildVariantsFromPairs(pairs TaskVariantPairs) []string {
+	bvSet := make(map[string]any)
+	for _, pair := range pairs.ExecTasks {
+		bvSet[pair.Variant] = struct{}{}
+	}
+	for _, pair := range pairs.DisplayTasks {
+		bvSet[pair.Variant] = struct{}{}
+	}
+
+	var uniqueBVs []string
+	for bv := range bvSet {
+		uniqueBVs = append(uniqueBVs, bv)
+	}
+
+	return uniqueBVs
 }
 
 func validateGeneratedProjectMaxTasks(ctx context.Context, v *Version, tasksToBeCreated int) error {

--- a/model/generate.go
+++ b/model/generate.go
@@ -390,7 +390,7 @@ func updateBuildStatusesForGeneratedTasks(ctx context.Context, versionID string,
 	return UpdateVersionAndPatchStatusForBuilds(ctx, buildIDs)
 }
 
-// getBuildVariantsFromPair returns a slice of all unique build variant names
+// getBuildVariantsFromPairs returns a slice of all unique build variant names
 // from build variant task pairs.
 func getBuildVariantsFromPairs(pairs TaskVariantPairs) []string {
 	bvSet := make(map[string]any)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1293,6 +1293,108 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependenciesInNewBuilds() {
 		s.Equal(true, t.Activated)
 	}
 }
+
+func (s *GenerateSuite) TestSaveNewTasksInExistingVariantUpdatesBuildStatus() {
+	genTask := &task.Task{
+		Id:          "t1",
+		DisplayName: "generator_task",
+		BuildId:     "b1",
+		Version:     "v1",
+	}
+	s.NoError(genTask.Insert())
+
+	finishedTask := task.Task{
+		Id:           "t2",
+		DisplayName:  "finished_task",
+		BuildId:      "b2",
+		BuildVariant: "other_bv",
+		Version:      "v1",
+	}
+	s.NoError(finishedTask.Insert())
+
+	existingGenBuild := build.Build{
+		Id:           "b1",
+		BuildVariant: "generator_bv",
+		Version:      "v1",
+		Activated:    true,
+		Status:       evergreen.BuildStarted,
+	}
+	s.NoError(existingGenBuild.Insert())
+
+	existingFinishedBuild := build.Build{
+		Id:           "b2",
+		BuildVariant: "other_bv",
+		Version:      "v1",
+		Activated:    true,
+		Status:       evergreen.BuildSucceeded,
+	}
+	s.NoError(existingFinishedBuild.Insert())
+
+	v := &Version{
+		Id:       "v1",
+		BuildIds: []string{"b1", "b2"},
+	}
+	s.NoError(v.Insert())
+
+	parserProj := ParserProject{}
+	initialConfig := `
+tasks:
+- name: generator_task
+- name: finished_task
+
+buildvariants:
+- name: generator_bv
+  run_on:
+  - arch
+  tasks:
+  - name: generator_task
+- name: other_bv
+  run_on:
+  - arch
+  tasks:
+  - name: finished_task
+`
+	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	parserProj.Id = "v1"
+	s.NoError(parserProj.Insert())
+
+	generateTasksJSON := `
+{
+	"tasks": [
+		{
+			"name": "new_task"
+		}
+	],
+	"buildvariants": [
+		{
+			"name": "other_bv",
+			"tasks": ["new_task"]
+		}
+	]
+}
+`
+
+	g, err := ParseProjectFromJSONString(generateTasksJSON)
+	s.Require().NoError(err)
+	g.Task = genTask
+
+	p, pp, err := FindAndTranslateProjectForVersion(s.ctx, s.env.Settings(), v, false)
+	s.Require().NoError(err)
+	p, pp, v, err = g.NewVersion(context.Background(), p, pp, v)
+	s.NoError(err)
+	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
+
+	dbExistingGenBuild, err := build.FindOneId(existingGenBuild.Id)
+	s.Require().NoError(err)
+	s.NotZero(dbExistingGenBuild)
+	s.Equal(evergreen.BuildStarted, dbExistingGenBuild.Status, "status for build generating tasks should not change")
+
+	dbExistingOtherBuild, err := build.FindOneId(existingFinishedBuild.Id)
+	s.Require().NoError(err)
+	s.NotZero(dbExistingOtherBuild)
+	s.Equal(evergreen.BuildStarted, dbExistingOtherBuild.Status, "status for build that previously had only finished tasks and now has new generated tasks to run should be running")
+}
+
 func (s *GenerateSuite) TestSaveNewTasksInNewVariantWithCrossVariantDependencyOnExistingUnscheduledTaskInExistingVariant() {
 	// This tests generating a task that depends on a task in a different BV
 	// that has already been defined but is not scheduled. It should scheduled

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1386,12 +1386,12 @@ buildvariants:
 
 	dbExistingGenBuild, err := build.FindOneId(existingGenBuild.Id)
 	s.Require().NoError(err)
-	s.NotZero(dbExistingGenBuild)
+	s.Require().NotZero(dbExistingGenBuild)
 	s.Equal(evergreen.BuildStarted, dbExistingGenBuild.Status, "status for build generating tasks should not change")
 
 	dbExistingOtherBuild, err := build.FindOneId(existingFinishedBuild.Id)
 	s.Require().NoError(err)
-	s.NotZero(dbExistingOtherBuild)
+	s.Require().NotZero(dbExistingOtherBuild)
 	s.Equal(evergreen.BuildStarted, dbExistingOtherBuild.Status, "status for build that previously had only finished tasks and now has new generated tasks to run should be running")
 }
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1600,19 +1600,6 @@ func UpdatePatchStatus(ctx context.Context, p *patch.Patch, status string) error
 // UpdateBuildAndVersionStatusForTask updates the status of the task's build based on all the tasks in the build
 // and the task's version based on all the builds in the version.
 // Also update build and version Github statuses based on the subset of tasks and builds included in github checks
-// kim: NOTE: this runs at the end of a task to update its build, then update
-// the version assuming just this task's build changed.
-// kim: NOTE: it uses the cached build statuses to compute the overall version
-// status. It does not re-evaluate every single build. If generate.tasks creates
-// new tasks in a build, I'm pretty sure it doesn't update the build/version
-// status to reflect that. That means this could happen:
-// * generate_resmoke_build_variants runs and creates new builds/tasks, build is
-// "created"
-// * all the tasks in the new build finish, build is "success"
-// * another generator runs and adds new tasks to existing builds, build is
-// "success" (because it wasn't updated by the generator)
-// * generate.tasks finishes and reports the version status as success because
-// all the version's builds are finished.
 func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error {
 	ctx, span := tracer.Start(ctx, "save-builds-and-tasks")
 	defer span.End()

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1600,6 +1600,19 @@ func UpdatePatchStatus(ctx context.Context, p *patch.Patch, status string) error
 // UpdateBuildAndVersionStatusForTask updates the status of the task's build based on all the tasks in the build
 // and the task's version based on all the builds in the version.
 // Also update build and version Github statuses based on the subset of tasks and builds included in github checks
+// kim: NOTE: this runs at the end of a task to update its build, then update
+// the version assuming just this task's build changed.
+// kim: NOTE: it uses the cached build statuses to compute the overall version
+// status. It does not re-evaluate every single build. If generate.tasks creates
+// new tasks in a build, I'm pretty sure it doesn't update the build/version
+// status to reflect that. That means this could happen:
+// * generate_resmoke_build_variants runs and creates new builds/tasks, build is
+// "created"
+// * all the tasks in the new build finish, build is "success"
+// * another generator runs and adds new tasks to existing builds, build is
+// "success" (because it wasn't updated by the generator)
+// * generate.tasks finishes and reports the version status as success because
+// all the version's builds are finished.
 func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error {
 	ctx, span := tracer.Start(ctx, "save-builds-and-tasks")
 	defer span.End()


### PR DESCRIPTION
DEVPROD-8000

### Description
This fixes a bug where a user could get multiple notifications for a version finishing when there are multiple tasks running generate.tasks. The core of the bug is that when generate.tasks adds new tasks to an existing build, that could change the build's state, but generate.tasks didn't update the build state to reflect that, which left the build in a stale state. I fixed it so that when adding new tasks to an existing build, it updates the build's status to take the new tasks into account.

The sequence of events that cause the bug is:

1. Patch schedules generator task 1 and 2 in build variant B1.
2. Generator task 1 runs and creates a new build variant B2 with a new task T1. B1 hasn't run anything yet, so it starts out as "created".
3. T1 succeeds, so B2 finishes with "success".
4. Generator task 2 runs and adds new task T2 to B2. The generator does not update the build status, so the build is still marked "success".
5. Generator task 2 finishes, so B1 is marked finished. Both B1 and B2 are marked finished, so Evergreen sends a notification that the version is finished. However, B2 is actually not finished since it has to run T2.
6. T2 runs and finishes, causing B2 to be marked "success" again, which results in a second version completion notification.

### Testing
* Added unit test that fails before this change and passes afterwards.
* Confirmed in manual test that a [version](https://spruce-staging.corp.mongodb.com/version/67802cd15d75d600073bdaac/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with two generators sent only one version completion notification. That same patch created two notifications if I didn't deploy my fix.