### PR TITLE
DEVPROD-2577 Abort all tasks when a merge queue version task fails

### DIFF
--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -17,9 +17,11 @@ merge, like you would have to without the queue.
 
 Evergreen will fail the entire version if any task in a merge queue version
 fails, so only include tasks that must pass for a merge queue version to pass.
-You can run more tasks than are required to fulfill branch protections in a PR,
-but only trigger the required tasks for a PR. You can configure this according
-to the instructions below, "Turn on Evergreen's merge queue integration."
+That is, in the GitHub section of your project settings in Evergreen, you can
+set Patch Definitions for GitHub Pull Request Testing that select tasks beyond
+those required by your GitHub branch protection rules. But in the Patch
+Definitions for the Merge Queue, the selected tasks must be exactly those
+required by your GitHub branch protection rules.
 
 ## Enable the merge queue
 

--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -15,6 +15,12 @@ turn on the GitHub merge queue in GitHub.
 GitHub's merge queue requires that you have write access to the repository to
 merge, like you would have to without the queue.
 
+Evergreen will fail the entire version if any task in a merge queue version
+fails, so only include tasks that must pass for a merge queue version to pass.
+You can run more tasks than are required to fulfill branch protections in a PR,
+but only trigger the required tasks for a PR. You can configure this according
+to the instructions below, "Turn on Evergreen's merge queue integration."
+
 ## Enable the merge queue
 
 ### Turn on Evergreen's merge queue integration

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7528,3 +7528,75 @@ func (s *TaskConnectorAbortTaskSuite) TestAbortFail() {
 	err := AbortTask(ctx, "task1", "user1")
 	s.Error(err)
 }
+
+func TestHandleEndTaskForGithubMergeQueueTask(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, VersionCollection))
+	defer func() {
+		require.NoError(t, db.ClearCollections(task.Collection, VersionCollection))
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v1 := Version{
+		Id:        "version1",
+		Requester: evergreen.GithubMergeRequester,
+	}
+	v1.Insert()
+	t1 := &task.Task{
+		Id:        "task1",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t1.Insert()
+	t2 := &task.Task{
+		Id:        "task2",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+		Aborted:   true,
+	}
+	t2.Insert()
+	t3 := &task.Task{
+		Id:        "task2",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+	}
+	t3.Insert()
+	t4 := &task.Task{
+		Id:        "task2",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+	}
+	t4.Insert()
+
+	// Neither of these should abort any tasks.
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t1, evergreen.TaskSucceeded))
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t2, evergreen.TaskFailed))
+	tasks, err := task.Find(task.ByVersion("version1"))
+	assert.NoError(t, err)
+	for _, task := range tasks {
+		// only t2 should be aborted, since it already was
+		if task.Id == "task2" {
+			assert.True(t, task.Aborted, task.Id)
+		} else {
+			assert.False(t, task.Aborted, task.Id)
+		}
+	}
+
+	// This should abort all tasks.
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t3, evergreen.TaskFailed))
+	tasks, err = task.Find(task.ByVersion("version1"))
+	assert.NoError(t, err)
+	for _, task := range tasks {
+		// all but t1, which already succeeded, should be aborted
+		if task.Id == "task1" {
+			assert.False(t, task.Aborted, task.Id)
+		} else {
+			assert.True(t, task.Aborted, task.Id)
+		}
+	}
+}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1234,6 +1234,12 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
+	if evergreen.IsGithubMergeQueueRequester(t.Requester) {
+		if err = model.HandleEndTaskForGithubMergeQueueTask(ctx, t, h.details.Status); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
+	}
+
 	// the task was aborted if it is still in undispatched.
 	// the active state should be inactive.
 	if h.details.Status == evergreen.TaskUndispatched {

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -504,6 +504,12 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
+	if evergreen.IsGithubMergeQueueRequester(t.Requester) {
+		if err = model.HandleEndTaskForGithubMergeQueueTask(ctx, t, h.details.Status); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
+	}
+
 	// the task was aborted if it is still in undispatched.
 	// the active state should be inactive.
 	if h.details.Status == evergreen.TaskUndispatched {


### PR DESCRIPTION
DEVPROD-2577

### Description

When a task in a GitHub merge queue version fails, fail the entire version. There's a subtle point that we cannot do this in a PR, since users might have triggered more tasks in a PR than are required for status checks, since they can use variant-level status checks. However, for a merge queue version, we can fail the entire version, since users can opt into only those tasks that must pass for a merge queue version to pass.

### Testing

Added a unit test for the new function

### Documentation

Edited docs.