### PR TITLE
DEVPROD-11883: remove temporary GitHub app sync flag

### DIFF
--- a/graphql/tests/mutation/deleteGithubAppCredentials/data.json
+++ b/graphql/tests/mutation/deleteGithubAppCredentials/data.json
@@ -13,7 +13,24 @@
     {
       "_id": "sandbox_project_id",
       "app_id": 12345,
-      "private_key": "secret"
+      "private_key_parameter": "/evg-test/github_apps/sandbox_project_id/private_key"
     }
+  ],
+  "fake_parameters": [
+      {
+        "_id": "/evg-test/github_apps/sandbox_project_id/private_key",
+        "value": "secret",
+        "last_updated": {
+            "$date": "2025-01-13T00:00:00.000Z"
+        }
+      }
+  ],
+  "parameter_records": [
+      {
+          "_id": "/evg-test/github_apps/sandbox_project_id/private_key",
+          "last_updated": {
+              "$date": "2025-01-13T00:00:00.000Z"
+          }
+      }
   ]
 }

--- a/model/github_app_auth.go
+++ b/model/github_app_auth.go
@@ -52,9 +52,7 @@ func GitHubAppAuthFindOne(id string) (*githubapp.GithubAppAuth, error) {
 	}
 
 	if err := githubAppCheckAndRunParameterStoreOp(ctx, appAuth, func(ref *ProjectRef, isRepoRef bool) error {
-		if ref.ParameterStoreGitHubAppSynced {
-			return githubAppAuthFindParameterStore(ctx, appAuth)
-		}
+		return githubAppAuthFindParameterStore(ctx, appAuth)
 		return nil
 	}); err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
@@ -150,10 +148,6 @@ func githubAppAuthUpsertParameterStore(ctx context.Context, appAuth *githubapp.G
 		if err := paramMgr.Delete(ctx, existingParamName); err != nil {
 			return "", errors.Wrapf(err, "deleting old GitHub app private key parameter '%s' from Parameter Store after it was renamed to '%s'", existingParamName, paramName)
 		}
-	}
-
-	if err := pRef.setParameterStoreGitHubAppAuthSynced(true, isRepoRef); err != nil {
-		return "", errors.Wrapf(err, "marking project/repo ref '%s' as having its GitHub app private key synced to Parameter Store", pRef.Id)
 	}
 
 	return paramName, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -536,7 +536,6 @@ var (
 	projectRefGithubPermissionGroupByRequesterKey   = bsonutil.MustHaveTag(ProjectRef{}, "GitHubPermissionGroupByRequester")
 	projectRefParameterStoreEnabledKey              = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreEnabled")
 	projectRefParameterStoreVarsSyncedKey           = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreVarsSynced")
-	projectRefParameterStoreGitHubAppSyncedKey      = bsonutil.MustHaveTag(ProjectRef{}, "ParameterStoreGitHubAppSynced")
 	projectRefLastAutoRestartedTaskAtKey            = bsonutil.MustHaveTag(ProjectRef{}, "LastAutoRestartedTaskAt")
 	projectRefNumAutoRestartedTasksKey              = bsonutil.MustHaveTag(ProjectRef{}, "NumAutoRestartedTasks")
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3681,32 +3681,7 @@ var psEnabledButNotSyncedQuery = bson.M{
 	"$or": []bson.M{
 		{projectRefParameterStoreVarsSyncedKey: false},
 		{projectRefParameterStoreVarsSyncedKey: bson.M{"$exists": false}},
-		{projectRefParameterStoreGitHubAppSyncedKey: false},
-		{projectRefParameterStoreGitHubAppSyncedKey: bson.M{"$exists": false}},
 	},
-}
-
-// setParameterStoreGitHubAppAuthSynced marks the project or repo ref to indicate whether
-// its GitHub app auth is synced to Parameter Store.
-func (p *ProjectRef) setParameterStoreGitHubAppAuthSynced(isSynced bool, isRepoRef bool) error {
-	if p.ParameterStoreGitHubAppSynced == isSynced {
-		return nil
-	}
-
-	coll := ProjectRefCollection
-	if isRepoRef {
-		coll = RepoRefCollection
-	}
-
-	if err := db.UpdateId(coll, p.Id, bson.M{
-		"$set": bson.M{
-			projectRefParameterStoreGitHubAppSyncedKey: isSynced,
-		},
-	}); err != nil {
-		return errors.Wrapf(err, "updating project/repo ref GitHub app auth sync state to %t", isSynced)
-	}
-
-	return nil
 }
 
 // FindProjectRefsToSync finds all project refs that have Parameter Sore enabled

--- a/testdata/local/fake_parameters.json
+++ b/testdata/local/fake_parameters.json
@@ -1,0 +1,1 @@
+{ "_id": "/evg-test/github_apps/spruce/private_key", "value": "secret", "last_updated": { "$date": "2025-01-13T00:00:00.000Z" } }

--- a/testdata/local/github_app_auth.json
+++ b/testdata/local/github_app_auth.json
@@ -1,1 +1,1 @@
-{ "_id": "spruce", "app_id": 12345, "private_key": { "$binary": { "base64": "c2VjcmV0", "subType": "00" } } }
+{ "_id": "spruce", "app_id": 12345, "private_key_parameter": "/evg-test/github_apps/spruce/private_key" }

--- a/testdata/local/parameter_records.json
+++ b/testdata/local/parameter_records.json
@@ -1,0 +1,1 @@
+{ "_id": "/evg-test/github_apps/spruce/private_key", "last_updated": { "$date": "2025-01-13T00:00:00.000Z" } }


### PR DESCRIPTION
DEVPROD-11883

### Description
As the last step of deleting the temporary feature flag logic, delete the flag that checks if the GitHub app is synced to Parameter Store before using it for GitHub app keys. Deleting this logic should not affect any project - all projects in staging/prod are already using Parameter Store for their GitHub app keys and new projects automatically use Parameter Store for GitHub app keys.

* Stop using temporary project feature flag to indicate if GitHub app keys are synced to Parameter Store.
* Remove temporary safety check for data consistency between Parameter Store and the DB.
* Update GQL/Spruce e2e test data that were still relying on the DB to instead use the test implementation of Parameter Store for GitHub app keys.

### Testing
* Existing tests pass.
* Manually checked that all GitHub app keys are currently synced to Parameter Store.

### Documentation
N/A