### PR TITLE
DEVPROD-13824 Do not validate symlinks when extracting tarballs

### DIFF
--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -25,7 +25,7 @@ func validateRelativePath(filePath, rootPath string) error {
 	// Generally, paths are resolved before they are passed
 	// to filepath.Rel to prevent tarballs from containing
 	// symlinks to files outside the data directory.
-	// However, on our Window's hosts, the data directory
+	// However, on our Windows hosts, the data directory
 	// is symlinked to another drive so we can't resolve
 	// the symlinks or it will falsely report that the
 	// path is outside the data directory.

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -22,15 +22,13 @@ func validateRelativePath(filePath, rootPath string) error {
 		return errors.New("filepath is absolute")
 	}
 	realPath := filepath.Join(rootPath, filePath)
-	resolvedPath, err := filepath.EvalSymlinks(realPath)
-	// If the error is a non-existence error, we can ignore it.
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return errors.Wrap(err, "evaluating symlinks")
-	}
-	// If the path was resolved, use the resolved path.
-	if err == nil {
-		realPath = resolvedPath
-	}
+	// Generally, paths are resolved before they are passed
+	// to filepath.Rel to prevent tarballs from containing
+	// symlinks to files outside the data directory.
+	// However, on our Window's hosts, the data directory
+	// is symlinked to another drive so we can't resolve
+	// the symlinks or it will falsely report that the
+	// path is outside the data directory.
 	relpath, err := filepath.Rel(rootPath, realPath)
 	if err != nil {
 		return errors.Wrap(err, "getting relative path")

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-08"
+	AgentVersion = "2025-01-13"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13824

### Description
In a recent change I made to the tarball extraction utilities, I added the `validateRelativePath` from a github action check recommendation. This caused an unintended consequence on windows, because the data directory is symlinked to another drive. I removed the symlink and the test is passing.

We didn't do this validation before, so it's added security. Removing it does allow for tarballs to override symlinked files outside the target directory, but this isn't as much of an issue since we generally should trust users to only extract files they know they can extract.

### Testing
Unit tests.