### PR TITLE
DEVPROD-13845: check most recent alertrecord for spawn host expiration

### DIFF
--- a/model/alertrecord/alert_bookkeeping.go
+++ b/model/alertrecord/alert_bookkeeping.go
@@ -176,12 +176,14 @@ func FindByTaskRegressionTestAndOrderNumber(subscriptionID, testName, taskDispla
 	return FindOne(db.Query(q))
 }
 
-func FindBySpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
+// FindByMostRecentSpawnHostExpirationWithHours finds the most recent alert
+// record for a spawn host that is about to expire.
+func FindByMostRecentSpawnHostExpirationWithHours(hostID string, hours int) (*AlertRecord, error) {
 	alertType := fmt.Sprintf(spawnHostWarningTemplate, hours)
 	q := subscriptionIDQuery(legacyAlertsSubscription)
 	q[TypeKey] = alertType
 	q[HostIdKey] = hostID
-	return FindOne(db.Query(q).Limit(1))
+	return FindOne(db.Query(q).Sort([]string{"-" + AlertTimeKey}).Limit(1))
 }
 
 // FindByMostRecentTemporaryExemptionExpirationWithHours finds the most recent

--- a/units/spawnhost_expiration_warning.go
+++ b/units/spawnhost_expiration_warning.go
@@ -117,7 +117,7 @@ func shouldNotifyForSpawnhostExpiration(h *host.Host, numHours int) (bool, error
 	if h == nil || h.ExpirationTime.IsZero() || time.Until(h.ExpirationTime) > (time.Duration(numHours)*time.Hour) {
 		return false, nil
 	}
-	rec, err := alertrecord.FindBySpawnHostExpirationWithHours(h.Id, numHours)
+	rec, err := alertrecord.FindByMostRecentSpawnHostExpirationWithHours(h.Id, numHours)
 	if err != nil {
 		return false, err
 	}

--- a/units/spawnhost_expiration_warning_test.go
+++ b/units/spawnhost_expiration_warning_test.go
@@ -177,6 +177,11 @@ func (s *spawnHostExpirationSuite) TestDuplicateEventsAreLoggedAfterRenotificati
 	eventsAfterRerun, err := event.FindUnprocessedEvents(-1)
 	s.NoError(err)
 	s.Len(eventsAfterRerun, len(events)+numHostsToRenotify, "should log new expiration warnings when renotification interval has passed")
+
+	s.j.Run(s.ctx)
+	eventsAfterSecondRerun, err := event.FindUnprocessedEvents(-1)
+	s.NoError(err)
+	s.Len(eventsAfterSecondRerun, len(events)+numHostsToRenotify, "should not log any more expiration warnings when the host was recently renotified")
 }
 
 func (s *spawnHostExpirationSuite) TestCanceledJob() {


### PR DESCRIPTION
DEVPROD-13845

### Description
Fix a bug where a user would get repeated notifications for a spawn host about to expire. The issue was that Evergreen checked a random record instead of the most recent alertrecord to find out the last time it notified a user about their spawn host expiring. Now, it checks the most recent record.

### Testing
Updated unit test.
