### PR TITLE
DEVPROD-2577 Abort all tasks when a merge queue version task fails

### DIFF
--- a/docs/Project-Configuration/Merge-Queue.md
+++ b/docs/Project-Configuration/Merge-Queue.md
@@ -15,6 +15,14 @@ turn on the GitHub merge queue in GitHub.
 GitHub's merge queue requires that you have write access to the repository to
 merge, like you would have to without the queue.
 
+Evergreen will fail the entire version if any task in a merge queue version
+fails, so only include tasks that must pass for a merge queue version to pass.
+That is, in the GitHub section of your project settings in Evergreen, you can
+set Patch Definitions for GitHub Pull Request Testing that select tasks beyond
+those required by your GitHub branch protection rules. But in the Patch
+Definitions for the Merge Queue, the selected tasks must be exactly those
+required by your GitHub branch protection rules.
+
 ## Enable the merge queue
 
 ### Turn on Evergreen's merge queue integration

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2476,6 +2476,8 @@ func MarkUnallocatableContainerTasksSystemFailed(ctx context.Context, settings *
 	return catcher.Resolve()
 }
 
+// HandleEndTaskForGithubMergeQueueTask stops running GitHub merge queue tasks as soon as one task is finished.
+// This is done to save resources and speed up the CI processing by preventing unnecessary tasks from running.
 func HandleEndTaskForGithubMergeQueueTask(ctx context.Context, t *task.Task, status string) error {
 	// If the task has succeeded, we don't need to do anything.
 	// If the task is already aborted, we shouldn't do anything, because the version has already been aborted.
@@ -2483,7 +2485,7 @@ func HandleEndTaskForGithubMergeQueueTask(ctx context.Context, t *task.Task, sta
 		return nil
 	}
 
-	reason := fmt.Sprintf("task '%s' failed", t.DisplayName)
+	reason := fmt.Sprintf("task '%s' on variant '%s' failed", t.DisplayName, t.BuildVariantDisplayName)
 	if err := SetVersionActivation(ctx, t.Version, false, reason); err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7061,14 +7061,14 @@ func TestHandleEndTaskForGithubMergeQueueTask(t *testing.T) {
 		Id:        "version1",
 		Requester: evergreen.GithubMergeRequester,
 	}
-	v1.Insert()
+	require.NoError(t, v1.Insert())
 	t1 := &task.Task{
 		Id:        "task1",
 		Version:   "version1",
 		Requester: evergreen.GithubMergeRequester,
 		Status:    evergreen.TaskSucceeded,
 	}
-	t1.Insert()
+	require.NoError(t, t1.Insert())
 	t2 := &task.Task{
 		Id:        "task2",
 		Version:   "version1",
@@ -7076,28 +7076,28 @@ func TestHandleEndTaskForGithubMergeQueueTask(t *testing.T) {
 		Status:    evergreen.TaskStarted,
 		Aborted:   true,
 	}
-	t2.Insert()
+	require.NoError(t, t2.Insert())
 	t3 := &task.Task{
 		Id:        "task3",
 		Version:   "version1",
 		Requester: evergreen.GithubMergeRequester,
 		Status:    evergreen.TaskStarted,
 	}
-	t3.Insert()
+	require.NoError(t, t3.Insert())
 	t4 := &task.Task{
 		Id:        "task4",
 		Version:   "version1",
 		Requester: evergreen.GithubMergeRequester,
 		Status:    evergreen.TaskStarted,
 	}
-	t4.Insert()
+	require.NoError(t, t4.Insert())
 	t5 := &task.Task{
 		Id:        "task5",
 		Version:   "version1",
 		Requester: evergreen.GithubMergeRequester,
 		Status:    evergreen.TaskStarted,
 	}
-	t5.Insert()
+	require.NoError(t, t5.Insert())
 
 	// Neither of these should abort any tasks.
 	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t1, evergreen.TaskSucceeded))

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -7047,3 +7047,82 @@ func (s *TaskConnectorAbortTaskSuite) TestAbortFail() {
 	err := AbortTask(ctx, "task1", "user1")
 	s.Error(err)
 }
+
+func TestHandleEndTaskForGithubMergeQueueTask(t *testing.T) {
+	require.NoError(t, db.ClearCollections(task.Collection, VersionCollection))
+	defer func() {
+		require.NoError(t, db.ClearCollections(task.Collection, VersionCollection))
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	v1 := Version{
+		Id:        "version1",
+		Requester: evergreen.GithubMergeRequester,
+	}
+	v1.Insert()
+	t1 := &task.Task{
+		Id:        "task1",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskSucceeded,
+	}
+	t1.Insert()
+	t2 := &task.Task{
+		Id:        "task2",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+		Aborted:   true,
+	}
+	t2.Insert()
+	t3 := &task.Task{
+		Id:        "task3",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+	}
+	t3.Insert()
+	t4 := &task.Task{
+		Id:        "task4",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+	}
+	t4.Insert()
+	t5 := &task.Task{
+		Id:        "task5",
+		Version:   "version1",
+		Requester: evergreen.GithubMergeRequester,
+		Status:    evergreen.TaskStarted,
+	}
+	t5.Insert()
+
+	// Neither of these should abort any tasks.
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t1, evergreen.TaskSucceeded))
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t2, evergreen.TaskFailed))
+	tasks, err := task.Find(task.ByVersion("version1"))
+	assert.NoError(t, err)
+	for _, task := range tasks {
+		// only t2 should be aborted, since it already was
+		if task.Id == "task2" {
+			assert.True(t, task.Aborted, task.Id)
+		} else {
+			assert.False(t, task.Aborted, task.Id)
+		}
+	}
+
+	// This should abort all tasks.
+	assert.NoError(t, HandleEndTaskForGithubMergeQueueTask(ctx, t3, evergreen.TaskFailed))
+	tasks, err = task.Find(task.ByVersion("version1"))
+	assert.NoError(t, err)
+	for _, task := range tasks {
+		// all but t1, which already succeeded, and t3, the caller, should be aborted
+		if task.Id == "task1" || task.Id == "task3" {
+			assert.False(t, task.Aborted, task.Id)
+		} else {
+			assert.True(t, task.Aborted, task.Id)
+		}
+	}
+}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1228,6 +1228,12 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
 
+	if evergreen.IsGithubMergeQueueRequester(t.Requester) {
+		if err = model.HandleEndTaskForGithubMergeQueueTask(ctx, t, h.details.Status); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
+	}
+
 	// the task was aborted if it is still in undispatched.
 	// the active state should be inactive.
 	if h.details.Status == evergreen.TaskUndispatched {

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -498,6 +498,12 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
 	}
 
+	if evergreen.IsGithubMergeQueueRequester(t.Requester) {
+		if err = model.HandleEndTaskForGithubMergeQueueTask(ctx, t, h.details.Status); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(err)
+		}
+	}
+
 	// the task was aborted if it is still in undispatched.
 	// the active state should be inactive.
 	if h.details.Status == evergreen.TaskUndispatched {


### PR DESCRIPTION
DEVPROD-2577

# Description

When a task in a GitHub merge queue version fails, fail the entire version. There's a subtle point that we cannot do this in a PR, since users might have triggered more tasks in a PR than are required for status checks, since they can use variant-level status checks. However, for a merge queue version, we can fail the entire version, since users can opt into only those tasks that must pass for a merge queue version to pass.

# Testing

Added a unit test for the new function

# Documentation

Edited docs.