### PR TITLE
DEVPROD-8478 Add context to task.FindOne queries

### DIFF
--- a/agent/command/results_gotest_test.go
+++ b/agent/command/results_gotest_test.go
@@ -60,7 +60,7 @@ func TestGotestPluginOnFailingTests(t *testing.T) {
 			}
 
 			Convey("and the tests in the task should be updated", func() {
-				updatedTask, err := task.FindOne(db.Query(task.ById(modelData.Task.Id)))
+				updatedTask, err := task.FindOne(ctx, db.Query(task.ById(modelData.Task.Id)))
 				So(err, ShouldBeNil)
 				So(updatedTask, ShouldNotBeNil)
 				So(len(updatedTask.LocalTestResults), ShouldEqual, 5)
@@ -123,7 +123,7 @@ func TestGotestPluginOnPassingTests(t *testing.T) {
 			}
 
 			Convey("and the tests in the task should be updated", func() {
-				updatedTask, err := task.FindOne(db.Query(task.ById(modelData.Task.Id)))
+				updatedTask, err := task.FindOne(ctx, db.Query(task.ById(modelData.Task.Id)))
 				So(err, ShouldBeNil)
 				So(updatedTask, ShouldNotBeNil)
 				So(len(updatedTask.LocalTestResults), ShouldEqual, 2)

--- a/agent/command/results_native_test.go
+++ b/agent/command/results_native_test.go
@@ -60,7 +60,7 @@ func TestAttachResults(t *testing.T) {
 					So(err, ShouldBeNil)
 					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
 					So(err, ShouldBeNil)
-					testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
+					testTask, err := task.FindOne(ctx, db.Query(task.ById(conf.Task.Id)))
 					require.NoError(t, err)
 					So(testTask, ShouldNotBeNil)
 
@@ -118,7 +118,7 @@ func TestAttachRawResults(t *testing.T) {
 					So(err, ShouldBeNil)
 					Convey("when retrieving task", func() {
 						// fetch the task
-						testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
+						testTask, err := task.FindOne(ctx, db.Query(task.ById(conf.Task.Id)))
 						require.NoError(t, err)
 						So(testTask, ShouldNotBeNil)
 

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -60,7 +60,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 
 					err = pluginCmds[0].Execute(ctx, comm, logger, conf)
 					So(err, ShouldBeNil)
-					testTask, err := task.FindOne(db.Query(task.ById(conf.Task.Id)))
+					testTask, err := task.FindOne(ctx, db.Query(task.ById(conf.Task.Id)))
 					require.NoError(t, err)
 					So(testTask, ShouldNotBeNil)
 				}
@@ -75,7 +75,7 @@ func runTest(t *testing.T, configPath string, customTests func(string)) {
 
 // dBTests are the database verification tests for standard one file execution
 func dBTests(taskId string) {
-	t, err := task.FindOne(db.Query(task.ById(taskId)))
+	t, err := task.FindOne(context.Background(), db.Query(task.ById(taskId)))
 	So(err, ShouldBeNil)
 	So(t, ShouldNotBeNil)
 	So(len(t.LocalTestResults), ShouldNotEqual, 0)
@@ -94,7 +94,7 @@ func dBTests(taskId string) {
 
 // dBTestsWildcard are the database verification tests for globbed file execution
 func dBTestsWildcard(taskId string) {
-	t, err := task.FindOne(db.Query(task.ById(taskId)))
+	t, err := task.FindOne(context.Background(), db.Query(task.ById(taskId)))
 	So(err, ShouldBeNil)
 	So(len(t.LocalTestResults), ShouldEqual, TotalResultCount)
 

--- a/db/query.go
+++ b/db/query.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -83,6 +84,26 @@ func (q Q) Hint(hint interface{}) Q {
 // Only reads one document from the DB.
 func FindOneQ(collection string, q Q, out interface{}) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	return db.C(collection).
+		Find(q.filter).
+		Select(q.projection).
+		Sort(q.sort...).
+		Skip(q.skip).
+		Limit(1).
+		Hint(q.hint).
+		MaxTime(q.maxTime).
+		One(out)
+}
+
+// FindOneQContext runs a Q query against the given collection, applying the results to "out."
+// Only reads one document from the DB.
+func FindOneQContext(ctx context.Context, collection string, q Q, out interface{}) error {
+	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		return err
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1305,13 +1305,13 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, ve
 		// If a task is a generated task don't schedule it until we get all of the generated tasks we want to generate
 		if t.GeneratedBy == "" {
 			// We can ignore an error while fetching tasks because this could just mean the task didn't exist on the base commit.
-			baseTask, _ := t.FindTaskOnBaseCommit()
+			baseTask, _ := t.FindTaskOnBaseCommit(ctx)
 			if baseTask != nil && baseTask.Status == evergreen.TaskUndispatched {
 				tasksToSchedule[baseTask.Id] = true
 			}
 			// If a task is generated lets find its base task if it exists otherwise we need to generate it
 		} else if t.GeneratedBy != "" {
-			baseTask, _ := t.FindTaskOnBaseCommit()
+			baseTask, _ := t.FindTaskOnBaseCommit(ctx)
 			// If the task is undispatched or doesn't exist on the base commit then we want to schedule
 			if baseTask == nil {
 				generatorTask, err := task.FindByIdExecution(t.GeneratedBy, nil)
@@ -1319,7 +1319,7 @@ func (r *mutationResolver) ScheduleUndispatchedBaseTasks(ctx context.Context, ve
 					return nil, InternalServerError.Send(ctx, fmt.Sprintf("Experienced an error trying to find the generator task: %s", err.Error()))
 				}
 				if generatorTask != nil {
-					baseGeneratorTask, _ := generatorTask.FindTaskOnBaseCommit()
+					baseGeneratorTask, _ := generatorTask.FindTaskOnBaseCommit(ctx)
 					// If baseGeneratorTask is nil then it didn't exist on the base task and we can't do anything
 					if baseGeneratorTask != nil && baseGeneratorTask.Status == evergreen.TaskUndispatched {
 						err = baseGeneratorTask.SetGeneratedTasksToActivate(t.BuildVariant, t.DisplayName)

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -100,7 +100,7 @@ func (r *patchResolver) GeneratedTaskCounts(ctx context.Context, obj *restModel.
 	for _, buildVariant := range patchProjectVariantsAndTasks.Variants {
 		for _, taskUnit := range buildVariant.Tasks {
 			if _, ok := generatorTasks[taskUnit.Name]; ok {
-				dbTask, err := task.FindOne(db.Query(bson.M{
+				dbTask, err := task.FindOne(ctx, db.Query(bson.M{
 					task.ProjectKey:      proj.DisplayName,
 					task.BuildVariantKey: buildVariant.Name,
 					task.DisplayNameKey:  taskUnit.Name,

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -118,12 +118,12 @@ func (r *taskResolver) BaseTask(ctx context.Context, obj *restModel.APITask) (*r
 		}
 	} else {
 		if evergreen.IsPatchRequester(t.Requester) {
-			baseTask, err = t.FindTaskOnBaseCommit()
+			baseTask, err = t.FindTaskOnBaseCommit(ctx)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding task '%s' on base commit: %s", utility.FromStringPtr(obj.Id), err.Error()))
 			}
 		} else {
-			baseTask, err = t.FindTaskOnPreviousCommit()
+			baseTask, err = t.FindTaskOnPreviousCommit(ctx)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding task '%s' on previous commit: %s", utility.FromStringPtr(obj.Id), err.Error()))
 			}
@@ -209,7 +209,7 @@ func (r *taskResolver) CanRestart(ctx context.Context, obj *restModel.APITask) (
 	if err != nil {
 		return false, InternalServerError.Send(ctx, fmt.Sprintf("converting task '%s' to service", *obj.Id))
 	}
-	return canRestartTask(t), nil
+	return canRestartTask(ctx, t), nil
 }
 
 // CanSchedule is the resolver for the canSchedule field.
@@ -218,7 +218,7 @@ func (r *taskResolver) CanSchedule(ctx context.Context, obj *restModel.APITask) 
 	if err != nil {
 		return false, InternalServerError.Send(ctx, fmt.Sprintf("converting task '%s' to service", *obj.Id))
 	}
-	return canScheduleTask(t), nil
+	return canScheduleTask(ctx, t), nil
 }
 
 // CanSetPriority is the resolver for the canSetPriority field.
@@ -316,7 +316,7 @@ func (r *taskResolver) DisplayTask(ctx context.Context, obj *restModel.APITask) 
 	if err != nil || t == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("Could not find task with id: %s", *obj.Id))
 	}
-	dt, err := t.GetDisplayTask()
+	dt, err := t.GetDisplayTask(ctx)
 	if dt == nil || err != nil {
 		return nil, nil
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -422,9 +422,9 @@ func mapHTTPStatusToGqlError(ctx context.Context, httpStatus int, err error) *gq
 	}
 }
 
-func canRestartTask(t *task.Task) bool {
+func canRestartTask(ctx context.Context, t *task.Task) bool {
 	// Cannot restart execution tasks.
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		return false
 	}
 	// It is possible to restart blocked display tasks. Later tasks in a display task could be blocked on
@@ -433,9 +433,9 @@ func canRestartTask(t *task.Task) bool {
 		!utility.StringSliceContains(evergreen.TaskUncompletedStatuses, t.Status)
 }
 
-func canScheduleTask(t *task.Task) bool {
+func canScheduleTask(ctx context.Context, t *task.Task) bool {
 	// Cannot schedule execution tasks or aborted tasks.
-	if t.IsPartOfDisplay() || t.Aborted {
+	if t.IsPartOfDisplay(ctx) || t.Aborted {
 		return false
 	}
 	if t.DisplayStatus != evergreen.TaskUnscheduled {
@@ -999,9 +999,9 @@ func getBaseTaskTestResultsOptions(ctx context.Context, dbTask *task.Task) ([]te
 	)
 
 	if dbTask.Requester == evergreen.RepotrackerVersionRequester {
-		baseTask, err = dbTask.FindTaskOnPreviousCommit()
+		baseTask, err = dbTask.FindTaskOnPreviousCommit(ctx)
 	} else {
-		baseTask, err = dbTask.FindTaskOnBaseCommit()
+		baseTask, err = dbTask.FindTaskOnBaseCommit(ctx)
 	}
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("Error finding base task for task '%s': %s", dbTask.Id, err))

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -61,6 +61,9 @@ func TestFilterGeneralSubscriptions(t *testing.T) {
 }
 
 func TestCanRestartTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	blockedTask := &task.Task{
 		Id: "t1",
 		DependsOn: []task.Dependency{
@@ -70,7 +73,7 @@ func TestCanRestartTask(t *testing.T) {
 		Status:        evergreen.TaskUndispatched,
 		DisplayTaskId: utility.ToStringPtr(""),
 	}
-	canRestart := canRestartTask(blockedTask)
+	canRestart := canRestartTask(ctx, blockedTask)
 	assert.False(t, canRestart)
 
 	blockedDisplayTask := &task.Task{
@@ -81,7 +84,7 @@ func TestCanRestartTask(t *testing.T) {
 		DisplayOnly:    true,
 		ExecutionTasks: []string{"exec1", "exec2"},
 	}
-	canRestart = canRestartTask(blockedDisplayTask)
+	canRestart = canRestartTask(ctx, blockedDisplayTask)
 	assert.True(t, canRestart)
 
 	executionTask := &task.Task{
@@ -89,7 +92,7 @@ func TestCanRestartTask(t *testing.T) {
 		Status:        evergreen.TaskUndispatched,
 		DisplayTaskId: utility.ToStringPtr("display task"),
 	}
-	canRestart = canRestartTask(executionTask)
+	canRestart = canRestartTask(ctx, executionTask)
 	assert.False(t, canRestart)
 
 	runningTask := &task.Task{
@@ -97,7 +100,7 @@ func TestCanRestartTask(t *testing.T) {
 		Status:        evergreen.TaskStarted,
 		DisplayTaskId: utility.ToStringPtr(""),
 	}
-	canRestart = canRestartTask(runningTask)
+	canRestart = canRestartTask(ctx, runningTask)
 	assert.False(t, canRestart)
 
 	finishedTask := &task.Task{
@@ -105,7 +108,7 @@ func TestCanRestartTask(t *testing.T) {
 		Status:        evergreen.TaskSucceeded,
 		DisplayTaskId: utility.ToStringPtr(""),
 	}
-	canRestart = canRestartTask(finishedTask)
+	canRestart = canRestartTask(ctx, finishedTask)
 	assert.True(t, canRestart)
 
 	abortedTask := &task.Task{
@@ -114,18 +117,21 @@ func TestCanRestartTask(t *testing.T) {
 		DisplayTaskId: utility.ToStringPtr(""),
 		Aborted:       true,
 	}
-	canRestart = canRestartTask(abortedTask)
+	canRestart = canRestartTask(ctx, abortedTask)
 	assert.False(t, canRestart)
 }
 
 func TestCanScheduleTask(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	abortedTask := &task.Task{
 		Id:            "t1",
 		Status:        evergreen.TaskUndispatched,
 		DisplayTaskId: utility.ToStringPtr(""),
 		Aborted:       true,
 	}
-	canSchedule := canScheduleTask(abortedTask)
+	canSchedule := canScheduleTask(ctx, abortedTask)
 	assert.False(t, canSchedule)
 
 	executionTask := &task.Task{
@@ -134,7 +140,7 @@ func TestCanScheduleTask(t *testing.T) {
 		DisplayStatus: evergreen.TaskUnscheduled,
 		DisplayTaskId: utility.ToStringPtr("display task"),
 	}
-	canSchedule = canScheduleTask(executionTask)
+	canSchedule = canScheduleTask(ctx, executionTask)
 	assert.False(t, canSchedule)
 
 	finishedTask := &task.Task{
@@ -143,7 +149,7 @@ func TestCanScheduleTask(t *testing.T) {
 		DisplayStatus: evergreen.TaskSucceeded,
 		DisplayTaskId: utility.ToStringPtr(""),
 	}
-	canSchedule = canScheduleTask(finishedTask)
+	canSchedule = canScheduleTask(ctx, finishedTask)
 	assert.False(t, canSchedule)
 
 	unscheduledTask := &task.Task{
@@ -152,7 +158,7 @@ func TestCanScheduleTask(t *testing.T) {
 		DisplayStatus: evergreen.TaskUnscheduled,
 		DisplayTaskId: utility.ToStringPtr(""),
 	}
-	canSchedule = canScheduleTask(unscheduledTask)
+	canSchedule = canScheduleTask(ctx, unscheduledTask)
 	assert.True(t, canSchedule)
 }
 

--- a/model/container_task_queue.go
+++ b/model/container_task_queue.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -20,9 +21,9 @@ type ContainerTaskQueue struct {
 
 // NewContainerTaskQueue returns a populated iterator representing an ordered
 // queue of container tasks that are ready to be allocated a container.
-func NewContainerTaskQueue() (*ContainerTaskQueue, error) {
+func NewContainerTaskQueue(ctx context.Context) (*ContainerTaskQueue, error) {
 	q := &ContainerTaskQueue{}
-	if err := q.populate(); err != nil {
+	if err := q.populate(ctx); err != nil {
 		return nil, errors.Wrap(err, "initial population of container task queue")
 	}
 	return q, nil
@@ -53,7 +54,7 @@ func (q *ContainerTaskQueue) Len() int {
 	return len(q.queue) - q.position
 }
 
-func (q *ContainerTaskQueue) populate() error {
+func (q *ContainerTaskQueue) populate(ctx context.Context) error {
 	startAt := time.Now()
 	candidates, err := task.FindNeedsContainerAllocation()
 	if err != nil {
@@ -75,7 +76,7 @@ func (q *ContainerTaskQueue) populate() error {
 
 	q.queue = readyForAllocation
 
-	q.setFirstScheduledTime(startAt)
+	q.setFirstScheduledTime(ctx, startAt)
 
 	return nil
 }
@@ -155,7 +156,7 @@ func (q *ContainerTaskQueue) getProjectRefs(tasks []task.Task) (map[string]Proje
 	return projRefsByID, nil
 }
 
-func (q *ContainerTaskQueue) setFirstScheduledTime(scheduledTime time.Time) {
+func (q *ContainerTaskQueue) setFirstScheduledTime(ctx context.Context, scheduledTime time.Time) {
 	var notScheduledBefore []task.Task
 	for i := range q.queue {
 		if utility.IsZeroTime(q.queue[i].ScheduledTime) {
@@ -167,7 +168,7 @@ func (q *ContainerTaskQueue) setFirstScheduledTime(scheduledTime time.Time) {
 		return
 	}
 
-	if err := task.SetTasksScheduledTime(notScheduledBefore, scheduledTime); err != nil {
+	if err := task.SetTasksScheduledTime(ctx, notScheduledBefore, scheduledTime); err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"message":                 "could not set first scheduled time for new container tasks",
 			"num_new_container_tasks": len(notScheduledBefore),

--- a/model/container_task_queue_test.go
+++ b/model/container_task_queue_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,8 +39,8 @@ func TestContainerTaskQueue(t *testing.T) {
 		require.False(t, ctq.HasNext())
 		require.Zero(t, ctq.Next())
 	}
-	for tName, tCase := range map[string]func(t *testing.T){
-		"ReturnsAllTasksThatNeedContainerAllocationInOrderOfActivation": func(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, ctx context.Context){
+		"ReturnsAllTasksThatNeedContainerAllocationInOrderOfActivation": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			require.NoError(t, ref.Insert())
 
@@ -56,7 +57,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation1.ActivatedTime = time.Now().Add(-time.Hour)
 			require.NoError(t, needsAllocation1.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			assert.Equal(t, 2, ctq.Len())
@@ -75,7 +76,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"SetsFirstTaskScheduledTime": func(t *testing.T) {
+		"SetsFirstTaskScheduledTime": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			require.NoError(t, ref.Insert())
 
@@ -83,7 +84,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, ctq.Len())
@@ -100,33 +101,33 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsNoTask": func(t *testing.T) {
-			ctq, err := NewContainerTaskQueue()
+		"ReturnsNoTask": func(t *testing.T, ctx context.Context) {
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, ctq)
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskMissingProject": func(t *testing.T) {
+		"DoesNotReturnTaskMissingProject": func(t *testing.T, ctx context.Context) {
 			needsAllocation := getTaskThatNeedsContainerAllocation()
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithInvalidProject": func(t *testing.T) {
+		"DoesNotReturnTaskWithInvalidProject": func(t *testing.T, ctx context.Context) {
 			needsAllocation := getTaskThatNeedsContainerAllocation()
 			needsAllocation.Project = "foo"
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(t *testing.T) {
+		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.DispatchingDisabled = utility.TruePtr()
 			require.NoError(t, ref.Insert())
@@ -135,12 +136,12 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(t *testing.T) {
+		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.PatchingDisabled = utility.FalsePtr()
 			require.NoError(t, ref.Insert())
@@ -150,7 +151,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, ctq.Len())
@@ -162,7 +163,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnPatchTaskWithProjectThatDisabledPatching": func(t *testing.T) {
+		"DoesNotReturnPatchTaskWithProjectThatDisabledPatching": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.PatchingDisabled = utility.TruePtr()
 			require.NoError(t, ref.Insert())
@@ -172,12 +173,12 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithDisabledProject": func(t *testing.T) {
+		"DoesNotReturnTaskWithDisabledProject": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			require.NoError(t, ref.Insert())
@@ -186,12 +187,12 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(t *testing.T) {
+		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			ref.Hidden = utility.TruePtr()
@@ -202,7 +203,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			assert.Equal(t, 1, ctq.Len())
@@ -214,7 +215,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnNonGitHubTaskInDisabledAndHiddenProject": func(t *testing.T) {
+		"DoesNotReturnNonGitHubTaskInDisabledAndHiddenProject": func(t *testing.T, ctx context.Context) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			ref.Hidden = utility.TruePtr()
@@ -225,15 +226,18 @@ func TestContainerTaskQueue(t *testing.T) {
 			needsAllocation.Project = ref.Id
 			require.NoError(t, needsAllocation.Insert())
 
-			ctq, err := NewContainerTaskQueue()
+			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 
 			checkEmpty(t, ctq)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			require.NoError(t, db.ClearCollections(task.Collection, ProjectRefCollection))
-			tCase(t)
+			tCase(t, ctx)
 		})
 	}
 }

--- a/model/container_task_queue_test.go
+++ b/model/container_task_queue_test.go
@@ -39,8 +39,8 @@ func TestContainerTaskQueue(t *testing.T) {
 		require.False(t, ctq.HasNext())
 		require.Zero(t, ctq.Next())
 	}
-	for tName, tCase := range map[string]func(t *testing.T, ctx context.Context){
-		"ReturnsAllTasksThatNeedContainerAllocationInOrderOfActivation": func(t *testing.T, ctx context.Context) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
+		"ReturnsAllTasksThatNeedContainerAllocationInOrderOfActivation": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			require.NoError(t, ref.Insert())
 
@@ -76,7 +76,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"SetsFirstTaskScheduledTime": func(t *testing.T, ctx context.Context) {
+		"SetsFirstTaskScheduledTime": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			require.NoError(t, ref.Insert())
 
@@ -101,14 +101,14 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsNoTask": func(t *testing.T, ctx context.Context) {
+		"ReturnsNoTask": func(ctx context.Context, t *testing.T) {
 			ctq, err := NewContainerTaskQueue(ctx)
 			require.NoError(t, err)
 			require.NotZero(t, ctq)
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskMissingProject": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnTaskMissingProject": func(ctx context.Context, t *testing.T) {
 			needsAllocation := getTaskThatNeedsContainerAllocation()
 			require.NoError(t, needsAllocation.Insert())
 
@@ -117,7 +117,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithInvalidProject": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnTaskWithInvalidProject": func(ctx context.Context, t *testing.T) {
 			needsAllocation := getTaskThatNeedsContainerAllocation()
 			needsAllocation.Project = "foo"
 			require.NoError(t, needsAllocation.Insert())
@@ -127,7 +127,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnTaskWithProjectThatDisabledTaskDispatching": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.DispatchingDisabled = utility.TruePtr()
 			require.NoError(t, ref.Insert())
@@ -141,7 +141,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(t *testing.T, ctx context.Context) {
+		"ReturnsPatchTaskWithProjectThatEnabledPatching": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.PatchingDisabled = utility.FalsePtr()
 			require.NoError(t, ref.Insert())
@@ -163,7 +163,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnPatchTaskWithProjectThatDisabledPatching": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnPatchTaskWithProjectThatDisabledPatching": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.PatchingDisabled = utility.TruePtr()
 			require.NoError(t, ref.Insert())
@@ -178,7 +178,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnTaskWithDisabledProject": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnTaskWithDisabledProject": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			require.NoError(t, ref.Insert())
@@ -192,7 +192,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(t *testing.T, ctx context.Context) {
+		"ReturnsGitHubTaskInDisabledAndHiddenProject": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			ref.Hidden = utility.TruePtr()
@@ -215,7 +215,7 @@ func TestContainerTaskQueue(t *testing.T) {
 
 			checkEmpty(t, ctq)
 		},
-		"DoesNotReturnNonGitHubTaskInDisabledAndHiddenProject": func(t *testing.T, ctx context.Context) {
+		"DoesNotReturnNonGitHubTaskInDisabledAndHiddenProject": func(ctx context.Context, t *testing.T) {
 			ref := getProjectRef()
 			ref.Enabled = false
 			ref.Hidden = utility.TruePtr()
@@ -237,7 +237,7 @@ func TestContainerTaskQueue(t *testing.T) {
 			defer cancel()
 
 			require.NoError(t, db.ClearCollections(task.Collection, ProjectRefCollection))
-			tCase(t, ctx)
+			tCase(ctx, t)
 		})
 	}
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -365,7 +365,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 			toArchive = append(toArchive, t)
 		}
 	}
-	if err := task.CheckUsersPatchTaskLimit(allFinishedTasks[0].Requester, caller, false, toArchive...); err != nil {
+	if err := task.CheckUsersPatchTaskLimit(ctx, allFinishedTasks[0].Requester, caller, false, toArchive...); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err := task.ArchiveMany(ctx, toArchive); err != nil {
@@ -382,7 +382,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	restartIds := []string{}
 	for _, t := range allFinishedTasks {
 		if t.IsPartOfSingleHostTaskGroup() {
-			if err := t.SetResetWhenFinished(caller); err != nil {
+			if err := t.SetResetWhenFinished(ctx, caller); err != nil {
 				return errors.Wrapf(err, "marking '%s' for restart when finished", t.Id)
 			}
 			taskGroupsToCheck[taskGroupAndBuild{
@@ -644,7 +644,7 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 		if taskP.IsEssentialToSucceed {
 			hasUnfinishedEssentialTask = true
 		}
-		if taskP.IsPartOfDisplay() {
+		if taskP.IsPartOfDisplay(ctx) {
 			continue // don't add execution parts of display tasks to the UI cache
 		}
 		tasks = append(tasks, *taskP)
@@ -1765,7 +1765,7 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			return nil, errors.Wrapf(err, "updating task cache for '%s'", b.Id)
 		}
 	}
-	if err = task.CheckUsersPatchTaskLimit(creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(ctx, creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
 		return nil, errors.Wrap(err, "updating patch task limit for user")
 	}
 	if len(buildIdsToActivate) > 0 {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -95,34 +95,34 @@ func TestTaskSetPriority(t *testing.T) {
 
 			So(SetTaskPriority(ctx, tasks[0], 1, "user"), ShouldBeNil)
 
-			t, err := task.FindOne(db.Query(task.ById("one")))
+			t, err := task.FindOne(ctx, db.Query(task.ById("one")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, 1)
 
-			t, err = task.FindOne(db.Query(task.ById("two")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("two")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, 5)
 
-			t, err = task.FindOne(db.Query(task.ById("three")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("three")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, 1)
 
-			t, err = task.FindOne(db.Query(task.ById("four")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("four")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "four")
 			So(t.Priority, ShouldEqual, 1)
 
-			t, err = task.FindOne(db.Query(task.ById("five")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("five")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "five")
 			So(t.Priority, ShouldEqual, 1)
 
-			t, err = task.FindOne(db.Query(task.ById("six")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("six")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "six")
@@ -135,39 +135,39 @@ func TestTaskSetPriority(t *testing.T) {
 			So(tasks[0].Activated, ShouldEqual, true)
 			So(SetTaskPriority(ctx, tasks[0], -1, "user"), ShouldBeNil)
 
-			t, err := task.FindOne(db.Query(task.ById("one")))
+			t, err := task.FindOne(ctx, db.Query(task.ById("one")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, -1)
 			So(t.Activated, ShouldEqual, false)
 
-			t, err = task.FindOne(db.Query(task.ById("two")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("two")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, 5)
 			So(t.Activated, ShouldEqual, true)
 
-			t, err = task.FindOne(db.Query(task.ById("three")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("three")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Priority, ShouldEqual, 1)
 			So(t.Activated, ShouldEqual, true)
 
-			t, err = task.FindOne(db.Query(task.ById("four")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("four")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "four")
 			So(t.Priority, ShouldEqual, 1)
 			So(t.Activated, ShouldEqual, true)
 
-			t, err = task.FindOne(db.Query(task.ById("five")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("five")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "five")
 			So(t.Priority, ShouldEqual, 1)
 			So(t.Activated, ShouldEqual, true)
 
-			t, err = task.FindOne(db.Query(task.ById("six")))
+			t, err = task.FindOne(ctx, db.Query(task.ById("six")))
 			So(err, ShouldBeNil)
 			So(t, ShouldNotBeNil)
 			So(t.Id, ShouldEqual, "six")
@@ -263,12 +263,12 @@ func TestBuildRestart(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildStarted)
 			So(b.Activated, ShouldEqual, true)
-			taskOne, err = task.FindOne(db.Query(task.ById("task1")))
+			taskOne, err = task.FindOne(ctx, db.Query(task.ById("task1")))
 			So(err, ShouldBeNil)
 			So(taskOne.Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(taskOne.Activated, ShouldEqual, true)
 			So(taskOne.DisplayStatusCache, ShouldEqual, evergreen.TaskWillRun)
-			taskTwo, err = task.FindOne(db.Query(task.ById("task2")))
+			taskTwo, err = task.FindOne(ctx, db.Query(task.ById("task2")))
 			So(err, ShouldBeNil)
 			So(taskTwo.Aborted, ShouldEqual, true)
 			So(taskTwo.DisplayStatusCache, ShouldEqual, evergreen.TaskAborted)
@@ -304,11 +304,11 @@ func TestBuildRestart(t *testing.T) {
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildStarted)
-			taskThree, err = task.FindOne(db.Query(task.ById("task3")))
+			taskThree, err = task.FindOne(ctx, db.Query(task.ById("task3")))
 			So(err, ShouldBeNil)
 			So(taskThree.Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(taskThree.DisplayStatusCache, ShouldEqual, evergreen.TaskWillRun)
-			taskFour, err = task.FindOne(db.Query(task.ById("task4")))
+			taskFour, err = task.FindOne(ctx, db.Query(task.ById("task4")))
 			So(err, ShouldBeNil)
 			So(taskFour.Aborted, ShouldEqual, false)
 			So(taskFour.Status, ShouldEqual, evergreen.TaskDispatched)
@@ -356,13 +356,13 @@ func TestBuildRestart(t *testing.T) {
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildStarted)
-			taskFive, err = task.FindOne(db.Query(task.ById("task5")))
+			taskFive, err = task.FindOne(ctx, db.Query(task.ById("task5")))
 			So(err, ShouldBeNil)
 			So(taskFive.Status, ShouldEqual, evergreen.TaskSucceeded)
 			So(taskFive.ResetWhenFinished, ShouldBeTrue)
-			taskSix, err = task.FindOne(db.Query(task.ById("task6")))
+			taskSix, err = task.FindOne(ctx, db.Query(task.ById("task6")))
 			So(err, ShouldBeNil)
-			taskSeven, err = task.FindOne(db.Query(task.ById("task7")))
+			taskSeven, err = task.FindOne(ctx, db.Query(task.ById("task7")))
 			So(err, ShouldBeNil)
 			So(taskSeven.Status, ShouldEqual, evergreen.TaskUndispatched)
 		})
@@ -399,11 +399,11 @@ func TestBuildRestart(t *testing.T) {
 			b, err = build.FindOne(build.ById(b.Id))
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildStarted)
-			taskEight, err = task.FindOne(db.Query(task.ById("task8")))
+			taskEight, err = task.FindOne(ctx, db.Query(task.ById("task8")))
 			So(err, ShouldBeNil)
 			So(taskEight.Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(taskEight.DisplayStatusCache, ShouldEqual, evergreen.TaskWillRun)
-			taskNine, err = task.FindOne(db.Query(task.ById("task9")))
+			taskNine, err = task.FindOne(ctx, db.Query(task.ById("task9")))
 			So(err, ShouldBeNil)
 			So(taskNine.Status, ShouldEqual, evergreen.TaskUndispatched)
 			So(taskNine.DisplayStatusCache, ShouldEqual, evergreen.TaskWillRun)
@@ -642,7 +642,7 @@ func TestBuildSetActivated(t *testing.T) {
 				So(deactivatedTasks[0].Id, ShouldEqual, matching.Id)
 
 				// task with the different user activating should be activated with that user
-				differentUserTask, err := task.FindOne(db.Query(task.ById(differentUser.Id)))
+				differentUserTask, err := task.FindOne(ctx, db.Query(task.ById(differentUser.Id)))
 				So(err, ShouldBeNil)
 				So(differentUserTask.Activated, ShouldBeTrue)
 				So(differentUserTask.ActivatedBy, ShouldEqual, user)
@@ -699,13 +699,13 @@ func TestBuildSetActivated(t *testing.T) {
 				So(ActivateBuildsAndTasks(ctx, []string{b.Id}, true, user), ShouldBeNil)
 
 				// task with the different user activating should be activated with that user
-				task1, err := task.FindOne(db.Query(task.ById(matching.Id)))
+				task1, err := task.FindOne(ctx, db.Query(task.ById(matching.Id)))
 				So(err, ShouldBeNil)
 				So(task1.Activated, ShouldBeTrue)
 				So(task1.ActivatedBy, ShouldEqual, user)
 
 				// task with the different user activating should be activated with that user
-				task2, err := task.FindOne(db.Query(task.ById(matching2.Id)))
+				task2, err := task.FindOne(ctx, db.Query(task.ById(matching2.Id)))
 				So(err, ShouldBeNil)
 				So(task2.Activated, ShouldBeTrue)
 				So(task2.ActivatedBy, ShouldEqual, user)
@@ -726,13 +726,13 @@ func TestBuildSetActivated(t *testing.T) {
 				So(b.ActivatedBy, ShouldEqual, user)
 
 				// task with the different user activating should be activated with that user
-				task1, err = task.FindOne(db.Query(task.ById(matching.Id)))
+				task1, err = task.FindOne(ctx, db.Query(task.ById(matching.Id)))
 				So(err, ShouldBeNil)
 				So(task1.Activated, ShouldBeTrue)
 				So(task1.ActivatedBy, ShouldEqual, user)
 
 				// task with the different user activating should be activated with that user
-				task2, err = task.FindOne(db.Query(task.ById(matching2.Id)))
+				task2, err = task.FindOne(ctx, db.Query(task.ById(matching2.Id)))
 				So(err, ShouldBeNil)
 				So(task2.Activated, ShouldBeTrue)
 				So(task2.ActivatedBy, ShouldEqual, user)
@@ -2189,7 +2189,7 @@ func TestVersionRestart(t *testing.T) {
 	assert.NoError(resetTaskData())
 	taskIds = []string{"task2"}
 	assert.NoError(RestartVersion(ctx, "version", taskIds, true, "test"))
-	dbTask, err := task.FindOne(db.Query(task.ById("task2")))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById("task2")))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.True(dbTask.Aborted)
@@ -2205,7 +2205,7 @@ func TestVersionRestart(t *testing.T) {
 	assert.NoError(resetTaskData())
 	taskIds = []string{"task2"}
 	assert.NoError(RestartVersion(ctx, "version", taskIds, false, "test"))
-	dbTask, err = task.FindOne(db.Query(task.ById("task2")))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById("task2")))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.False(dbTask.Aborted)
@@ -2274,7 +2274,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 	assert.NoError(resetTaskData())
 	dt, err := task.FindOneId("displayTask1")
 	assert.NoError(err)
-	assert.NoError(dt.SetResetFailedWhenFinished("caller"))
+	assert.NoError(dt.SetResetFailedWhenFinished(ctx, "caller"))
 
 	// Confirm that marking a display task to reset when finished increments the user's scheduling limit
 	dbUser, err := user.FindOneById("caller")
@@ -2438,6 +2438,9 @@ func TestResetTaskOrDisplayTask(t *testing.T) {
 }
 
 func resetTaskData() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	if err := db.ClearCollections(build.Collection, task.Collection, VersionCollection, task.OldCollection, user.Collection); err != nil {
 		return err
 	}
@@ -2591,7 +2594,7 @@ func resetTaskData() error {
 	if err := displayTask1.Insert(); err != nil {
 		return err
 	}
-	if err := UpdateDisplayTaskForTask(task5); err != nil {
+	if err := UpdateDisplayTaskForTask(ctx, task5); err != nil {
 		return err
 	}
 	displayTask2 := &task.Task{
@@ -2665,6 +2668,8 @@ func TestCreateTasksFromGroup(t *testing.T) {
 }
 
 func TestMarkAsHostDispatched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var (
 		taskId       string
@@ -2700,7 +2705,7 @@ func TestMarkAsHostDispatched(t *testing.T) {
 			" the task, the host it is on, and the build it is a part of"+
 			" should be set to reflect this", func() {
 
-			So(taskDoc.MarkAsHostDispatched(hostId, distroId, agentVersion, time.Now()), ShouldBeNil)
+			So(taskDoc.MarkAsHostDispatched(ctx, hostId, distroId, agentVersion, time.Now()), ShouldBeNil)
 
 			// make sure the task's fields were updated, both in ©memory and
 			// in the db
@@ -2709,7 +2714,7 @@ func TestMarkAsHostDispatched(t *testing.T) {
 			So(taskDoc.HostId, ShouldEqual, hostId)
 			So(taskDoc.AgentVersion, ShouldEqual, agentVersion)
 			So(taskDoc.LastHeartbeat, ShouldResemble, taskDoc.DispatchTime)
-			taskDoc, err := task.FindOne(db.Query(task.ById(taskId)))
+			taskDoc, err := task.FindOne(ctx, db.Query(task.ById(taskId)))
 			So(err, ShouldBeNil)
 			So(taskDoc.DispatchTime, ShouldNotResemble, time.Unix(0, 0))
 			So(taskDoc.Status, ShouldEqual, evergreen.TaskDispatched)

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -146,8 +146,8 @@ func (pd *PodDispatcher) AssignNextTask(ctx context.Context, env evergreen.Envir
 		event.LogPodAssignedTask(p.ID, t.Id, t.Execution)
 		event.LogContainerTaskDispatched(t.Id, t.Execution, p.ID)
 
-		if t.IsPartOfDisplay() {
-			if err := model.UpdateDisplayTaskForTask(t); err != nil {
+		if t.IsPartOfDisplay(ctx) {
+			if err := model.UpdateDisplayTaskForTask(ctx, t); err != nil {
 				return nil, errors.Wrap(err, "updating parent display task")
 			}
 		}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1311,9 +1311,9 @@ func FindTaskNamesByBuildVariant(projectId string, buildVariant string, repoOrde
 // DB Boilerplate
 
 // FindOne returns a single task that satisfies the query.
-func FindOne(query db.Q) (*Task, error) {
+func FindOne(ctx context.Context, query db.Q) (*Task, error) {
 	task := &Task{}
-	err := db.FindOneQ(Collection, query, task)
+	err := db.FindOneQContext(ctx, Collection, query, task)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
 	}
@@ -1745,9 +1745,9 @@ func Count(query db.Q) (int, error) {
 	return db.CountQ(Collection, query)
 }
 
-func FindProjectForTask(taskID string) (string, error) {
+func FindProjectForTask(ctx context.Context, taskID string) (string, error) {
 	query := db.Query(ById(taskID)).WithFields(ProjectKey)
-	t, err := FindOne(query)
+	t, err := FindOne(ctx, query)
 	if err != nil {
 		return "", err
 	}
@@ -1846,16 +1846,6 @@ func HasUnfinishedTaskForVersions(versionIds []string, taskName, variantName str
 	return count > 0, err
 }
 
-// FindTaskForVersion returns a task matching the given version and task info.
-func FindTaskForVersion(versionId, taskName, variantName string) (*Task, error) {
-	return FindOne(
-		db.Query(bson.M{
-			VersionKey:      versionId,
-			DisplayNameKey:  taskName,
-			BuildVariantKey: variantName,
-		}))
-}
-
 func AddHostCreateDetails(taskId, hostId string, execution int, hostCreateError error) error {
 	if hostCreateError == nil {
 		return nil
@@ -1870,8 +1860,8 @@ func AddHostCreateDetails(taskId, hostId string, execution int, hostCreateError 
 
 // FindActivatedStepbackTaskByName queries for running/scheduled stepback tasks with
 // matching build variant and task name.
-func FindActivatedStepbackTaskByName(projectId string, variantName string, taskName string) (*Task, error) {
-	t, err := FindOne(db.Query(bson.M{
+func FindActivatedStepbackTaskByName(ctx context.Context, projectId string, variantName string, taskName string) (*Task, error) {
+	t, err := FindOne(ctx, db.Query(bson.M{
 		ProjectKey:      projectId,
 		BuildVariantKey: variantName,
 		DisplayNameKey:  taskName,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -108,8 +108,8 @@ func SetActiveState(ctx context.Context, caller string, active bool, tasks ...ta
 	}
 
 	for _, t := range tasksToActivate {
-		if t.IsPartOfDisplay() {
-			catcher.Wrap(UpdateDisplayTaskForTask(&t), "updating display task")
+		if t.IsPartOfDisplay(ctx) {
+			catcher.Wrap(UpdateDisplayTaskForTask(ctx, &t), "updating display task")
 		}
 	}
 	for b, item := range buildToTaskMap {
@@ -235,7 +235,7 @@ func activatePreviousTask(ctx context.Context, taskId, caller string, originalSt
 	// find previous task limiting to just the last one
 	filter, sort := task.ByBeforeRevision(t.RevisionOrderNumber, t.BuildVariant, t.DisplayName, t.Project, t.Requester)
 	query := db.Query(filter).Sort(sort)
-	prevTask, err := task.FindOne(query)
+	prevTask, err := task.FindOne(ctx, query)
 	if err != nil {
 		return errors.Wrap(err, "finding previous task")
 	}
@@ -285,7 +285,7 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	if t == nil {
 		return errors.Errorf("cannot restart task '%s' because it could not be found", taskId)
 	}
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
 
@@ -365,7 +365,7 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 		caller = user
 	}
 	if t.IsPartOfSingleHostTaskGroup() {
-		if err = t.SetResetWhenFinished(user); err != nil {
+		if err = t.SetResetWhenFinished(ctx, user); err != nil {
 			return errors.Wrap(err, "marking task group for reset")
 		}
 		return errors.Wrap(checkResetSingleHostTaskGroup(ctx, t, caller), "resetting single host task group")
@@ -381,10 +381,10 @@ func resetTask(ctx context.Context, taskId, caller string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
 	}
-	if err = task.CheckUsersPatchTaskLimit(t.Requester, caller, false, *t); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(ctx, t.Requester, caller, false, *t); err != nil {
 		return errors.Wrap(err, "updating patch task limit for user")
 	}
 	if err = t.Archive(ctx); err != nil {
@@ -536,7 +536,7 @@ func doLinearStepback(ctx context.Context, t *task.Task) error {
 	//See if there is a prior success for this particular task.
 	//If there isn't, we should not activate the previous task because
 	//it could trigger stepping backwards ad infinitum.
-	prevTask, err := t.PreviousCompletedTask(t.Project, []string{evergreen.TaskSucceeded})
+	prevTask, err := t.PreviousCompletedTask(ctx, t.Project, []string{evergreen.TaskSucceeded})
 	if err != nil {
 		return errors.Wrap(err, "locating previous successful task")
 	}
@@ -572,7 +572,7 @@ func doBisectStepback(ctx context.Context, t *task.Task) error {
 		s = *t.StepbackInfo
 	} else {
 		// If this is the first iteration of stepback, we must get the initial condition (last successful passing task).
-		lastPassing, err := t.PreviousCompletedTask(t.Project, []string{evergreen.TaskSucceeded})
+		lastPassing, err := t.PreviousCompletedTask(ctx, t.Project, []string{evergreen.TaskSucceeded})
 		if err != nil {
 			return errors.Wrap(err, "locating previous successful task")
 		}
@@ -604,7 +604,7 @@ func doBisectStepback(ctx context.Context, t *task.Task) error {
 	}
 
 	// The midway task is our next stepback target.
-	nextTask, err := task.ByBeforeMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
+	nextTask, err := task.ByBeforeMidwayTaskFromIds(ctx, s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	if err != nil {
 		return errors.Wrap(err, "finding previous task")
 	}
@@ -662,7 +662,7 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 		// Carry over from the last task.
 		s = *lastStepbackInfo
 	} else {
-		lastPassingGenerated, err := generated.PreviousCompletedTask(generated.Project, []string{evergreen.TaskSucceeded})
+		lastPassingGenerated, err := generated.PreviousCompletedTask(ctx, generated.Project, []string{evergreen.TaskSucceeded})
 		if err != nil {
 			return errors.Wrap(err, "locating previous successful task")
 		}
@@ -704,7 +704,7 @@ func doBisectStepbackForGeneratedTask(ctx context.Context, generator *task.Task,
 	}
 
 	// The midway task is our next stepback target.
-	nextTask, err := task.ByBeforeMidwayTaskFromIds(s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
+	nextTask, err := task.ByBeforeMidwayTaskFromIds(ctx, s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	if err != nil {
 		return errors.Wrapf(err, "finding midway task between tasks '%s' and '%s'", s.LastFailingStepbackTaskId, s.LastPassingStepbackTaskId)
 	}
@@ -847,7 +847,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		"execution_platform": t.ExecutionPlatform,
 	})
 	origin := evergreen.APIServerTaskActivator
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		catcher.Add(markEndDisplayTask(ctx, settings, t, caller, origin))
 	} else if t.IsPartOfSingleHostTaskGroup() {
 		catcher.Wrap(checkResetSingleHostTaskGroup(ctx, t, caller), "resetting single host task group")
@@ -867,7 +867,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 
 	catcher.Wrap(logTaskEndStats(ctx, t), "logging task end stats")
 
-	if (t.ResetWhenFinished || t.ResetFailedWhenFinished) && !t.IsPartOfDisplay() && !t.IsPartOfSingleHostTaskGroup() {
+	if (t.ResetWhenFinished || t.ResetFailedWhenFinished) && !t.IsPartOfDisplay(ctx) && !t.IsPartOfSingleHostTaskGroup() {
 		if t.IsAutomaticRestart {
 			caller = evergreen.AutoRestartActivator
 		}
@@ -878,10 +878,10 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 }
 
 func markEndDisplayTask(ctx context.Context, settings *evergreen.Settings, t *task.Task, caller, origin string) error {
-	if err := UpdateDisplayTaskForTask(t); err != nil {
+	if err := UpdateDisplayTaskForTask(ctx, t); err != nil {
 		return errors.Wrap(err, "updating display task")
 	}
-	dt, err := t.GetDisplayTask()
+	dt, err := t.GetDisplayTask(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting display task")
 	}
@@ -891,8 +891,8 @@ func markEndDisplayTask(ctx context.Context, settings *evergreen.Settings, t *ta
 func attemptStepback(ctx context.Context, t *task.Task, status string) {
 	var err error
 	if !evergreen.IsPatchRequester(t.Requester) {
-		if t.IsPartOfDisplay() {
-			_, err = t.GetDisplayTask()
+		if t.IsPartOfDisplay(ctx) {
+			_, err = t.GetDisplayTask(ctx)
 			if err != nil {
 				err = errors.Wrap(err, "getting display task")
 			} else {
@@ -937,7 +937,7 @@ func logTaskEndStats(ctx context.Context, t *task.Task) error {
 		"version":              t.Version,
 	}
 
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		msg["display_task_id"] = t.DisplayTaskId
 	}
 
@@ -1749,7 +1749,7 @@ func UpdateVersionAndPatchStatusForBuilds(ctx context.Context, buildIds []string
 }
 
 // MarkStart updates the task, build, version and if necessary, patch documents with the task start time
-func MarkStart(t *task.Task, updates *StatusChanges) error {
+func MarkStart(ctx context.Context, t *task.Task, updates *StatusChanges) error {
 	var err error
 
 	startTime := time.Now().Round(time.Millisecond)
@@ -1780,8 +1780,8 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 		}
 	}
 
-	if t.IsPartOfDisplay() {
-		return UpdateDisplayTaskForTask(t)
+	if t.IsPartOfDisplay(ctx) {
+		return UpdateDisplayTaskForTask(ctx, t)
 	}
 
 	return nil
@@ -1789,16 +1789,16 @@ func MarkStart(t *task.Task, updates *StatusChanges) error {
 
 // MarkHostTaskDispatched marks a task as being dispatched to the host. If it's
 // part of a display task, update the display task as necessary.
-func MarkHostTaskDispatched(t *task.Task, h *host.Host) error {
-	if err := t.MarkAsHostDispatched(h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {
+func MarkHostTaskDispatched(ctx context.Context, t *task.Task, h *host.Host) error {
+	if err := t.MarkAsHostDispatched(ctx, h.Id, h.Distro.Id, h.AgentRevision, time.Now()); err != nil {
 		return errors.Wrapf(err, "marking task '%s' as dispatched "+
 			"on host '%s'", t.Id, h.Id)
 	}
 
 	event.LogHostTaskDispatched(t.Id, t.Execution, h.Id)
 
-	if t.IsPartOfDisplay() {
-		return UpdateDisplayTaskForTask(t)
+	if t.IsPartOfDisplay(ctx) {
+		return UpdateDisplayTaskForTask(ctx, t)
 	}
 
 	return nil
@@ -1896,8 +1896,8 @@ func RestartFailedTasks(ctx context.Context, opts RestartOptions) (RestartResult
 	displayTasksToCheck := map[string]task.Task{}
 	idsToRestart := []string{}
 	for _, t := range tasksToRestart {
-		if t.IsPartOfDisplay() {
-			dt, err := t.GetDisplayTask()
+		if t.IsPartOfDisplay(ctx) {
+			dt, err := t.GetDisplayTask(ctx)
 			if err != nil {
 				return results, errors.Wrap(err, "getting display task")
 			}
@@ -1918,7 +1918,7 @@ func RestartFailedTasks(ctx context.Context, opts RestartOptions) (RestartResult
 		if dt.IsFinished() {
 			idsToRestart = append(idsToRestart, id)
 		} else {
-			if err = dt.SetResetWhenFinished(opts.User); err != nil {
+			if err = dt.SetResetWhenFinished(ctx, opts.User); err != nil {
 				return results, errors.Wrapf(err, "marking display task '%s' for reset", id)
 			}
 		}
@@ -2059,12 +2059,12 @@ func FixStaleTask(ctx context.Context, settings *evergreen.Settings, t *task.Tas
 		}
 	} else {
 		if err := endAndResetSystemFailedTask(ctx, settings, t, failureDesc); err != nil {
-			if !t.IsPartOfDisplay() {
+			if !t.IsPartOfDisplay(ctx) {
 				return errors.Wrap(err, "resetting heartbeat task")
 			}
 			// It's possible for display tasks to race, since multiple execution tasks can system fail at the same time.
 			// Only error if the display task hasn't actually been reset.
-			dt, dbErr := t.GetDisplayTask()
+			dt, dbErr := t.GetDisplayTask(ctx)
 			if dbErr != nil {
 				return errors.Wrap(dbErr, "confirming display task status")
 			}
@@ -2150,8 +2150,8 @@ func endAndResetSystemFailedTask(ctx context.Context, settings *evergreen.Settin
 // Marks display tasks as reset when finished and then check if it can be reset immediately.
 func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t *task.Task, user, origin string, failedOnly bool, detail *apimodels.TaskEndDetail) error {
 	taskToReset := *t
-	if taskToReset.IsPartOfDisplay() { // if given an execution task, attempt to restart the full display task
-		dt, err := taskToReset.GetDisplayTask()
+	if taskToReset.IsPartOfDisplay(ctx) { // if given an execution task, attempt to restart the full display task
+		dt, err := taskToReset.GetDisplayTask(ctx)
 		if err != nil {
 			return errors.Wrap(err, "getting display task")
 		}
@@ -2161,11 +2161,11 @@ func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t
 	}
 	if taskToReset.DisplayOnly {
 		if failedOnly {
-			if err := taskToReset.SetResetFailedWhenFinished(user); err != nil {
+			if err := taskToReset.SetResetFailedWhenFinished(ctx, user); err != nil {
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		} else {
-			if err := taskToReset.SetResetWhenFinished(user); err != nil {
+			if err := taskToReset.SetResetWhenFinished(ctx, user); err != nil {
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		}
@@ -2176,8 +2176,8 @@ func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t
 }
 
 // UpdateDisplayTaskForTask updates the status of the given execution task's display task
-func UpdateDisplayTaskForTask(t *task.Task) error {
-	if !t.IsPartOfDisplay() {
+func UpdateDisplayTaskForTask(ctx context.Context, t *task.Task) error {
+	if !t.IsPartOfDisplay(ctx) {
 		return errors.Errorf("task '%s' is not an execution task", t.Id)
 	}
 
@@ -2201,7 +2201,7 @@ func UpdateDisplayTaskForTask(t *task.Task) error {
 		// the latest display task data.
 		t.DisplayTask = nil
 
-		originalDisplayTask, err = t.GetDisplayTask()
+		originalDisplayTask, err = t.GetDisplayTask(ctx)
 		if err != nil {
 			return errors.Wrap(err, "getting display task for task")
 		}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -503,7 +503,7 @@ func TestSetActiveState(t *testing.T) {
 		So(p.Insert(), ShouldBeNil)
 		Convey("activating the task should set the task state to active and mark the version as activated", func() {
 			So(SetActiveState(ctx, "randomUser", true, *testTask), ShouldBeNil)
-			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+			testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(testTask.Activated, ShouldBeTrue)
 			So(testTask.ScheduledTime, ShouldHappenWithin, oneMs, testTime)
@@ -513,10 +513,10 @@ func TestSetActiveState(t *testing.T) {
 			So(utility.FromBoolPtr(version.Activated), ShouldBeTrue)
 			Convey("deactivating an active task as a normal user should deactivate the task", func() {
 				So(SetActiveState(ctx, userName, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldBeFalse)
-				dependentTask, err = task.FindOne(db.Query(task.ById(dependentTask.Id)))
+				dependentTask, err = task.FindOne(ctx, db.Query(task.ById(dependentTask.Id)))
 				So(dependentTask.Activated, ShouldBeFalse)
 
 				build, err := build.FindOneId(testTask.BuildId)
@@ -530,14 +530,14 @@ func TestSetActiveState(t *testing.T) {
 		Convey("when deactivating an active task as evergreen", func() {
 			Convey("if the task is activated by evergreen, the task should deactivate", func() {
 				So(SetActiveState(ctx, "", true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, "")
 				So(SetActiveState(ctx, "", false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, false)
-				dependentTask, err = task.FindOne(db.Query(task.ById(dependentTask.Id)))
+				dependentTask, err = task.FindOne(ctx, db.Query(task.ById(dependentTask.Id)))
 				So(dependentTask.Activated, ShouldBeFalse)
 				build, err := build.FindOneId(testTask.BuildId)
 				So(err, ShouldBeNil)
@@ -548,11 +548,11 @@ func TestSetActiveState(t *testing.T) {
 			})
 			Convey("if the task is activated by stepback user, the task should not deactivate", func() {
 				So(SetActiveState(ctx, evergreen.StepbackTaskActivator, true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, evergreen.StepbackTaskActivator)
 				So(SetActiveState(ctx, evergreen.APIServerTaskActivator, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, true)
 				build, err := build.FindOneId(testTask.BuildId)
@@ -564,11 +564,11 @@ func TestSetActiveState(t *testing.T) {
 			})
 			Convey("if the task is not activated by evergreen, the task should not deactivate", func() {
 				So(SetActiveState(ctx, userName, true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, userName)
 				So(SetActiveState(ctx, evergreen.APIServerTaskActivator, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, true)
 				build, err := build.FindOneId(testTask.BuildId)
@@ -583,14 +583,14 @@ func TestSetActiveState(t *testing.T) {
 			u := "test_user"
 			Convey("if the task is activated by evergreen, the task should deactivate", func() {
 				So(SetActiveState(ctx, "", true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, "")
 				So(SetActiveState(ctx, u, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, false)
-				dependentTask, err = task.FindOne(db.Query(task.ById(dependentTask.Id)))
+				dependentTask, err = task.FindOne(ctx, db.Query(task.ById(dependentTask.Id)))
 				So(dependentTask.Activated, ShouldBeFalse)
 				build, err := build.FindOneId(testTask.BuildId)
 				So(err, ShouldBeNil)
@@ -601,14 +601,14 @@ func TestSetActiveState(t *testing.T) {
 			})
 			Convey("if the task is activated by stepback user, the task should deactivate", func() {
 				So(SetActiveState(ctx, evergreen.StepbackTaskActivator, true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, evergreen.StepbackTaskActivator)
 				So(SetActiveState(ctx, u, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, false)
-				dependentTask, err = task.FindOne(db.Query(task.ById(dependentTask.Id)))
+				dependentTask, err = task.FindOne(ctx, db.Query(task.ById(dependentTask.Id)))
 				So(dependentTask.Activated, ShouldBeFalse)
 
 				build, err := build.FindOneId(testTask.BuildId)
@@ -620,14 +620,14 @@ func TestSetActiveState(t *testing.T) {
 			})
 			Convey("if the task is not activated by evergreen, the task should deactivate", func() {
 				So(SetActiveState(ctx, userName, true, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.ActivatedBy, ShouldEqual, userName)
 				So(SetActiveState(ctx, u, false, *testTask), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Activated, ShouldEqual, false)
-				dependentTask, err = task.FindOne(db.Query(task.ById(dependentTask.Id)))
+				dependentTask, err = task.FindOne(ctx, db.Query(task.ById(dependentTask.Id)))
 				So(dependentTask.Activated, ShouldBeFalse)
 				build, err := build.FindOneId(testTask.BuildId)
 				So(err, ShouldBeNil)
@@ -696,17 +696,17 @@ func TestSetActiveState(t *testing.T) {
 
 		Convey("activating the task should activate the tasks it depends on", func() {
 			So(SetActiveState(ctx, userName, true, testTask), ShouldBeNil)
-			depTask, err := task.FindOne(db.Query(task.ById(dep1.Id)))
+			depTask, err := task.FindOne(ctx, db.Query(task.ById(dep1.Id)))
 			So(err, ShouldBeNil)
 			So(depTask.Activated, ShouldBeTrue)
 
-			depTask, err = task.FindOne(db.Query(task.ById(dep2.Id)))
+			depTask, err = task.FindOne(ctx, db.Query(task.ById(dep2.Id)))
 			So(err, ShouldBeNil)
 			So(depTask.Activated, ShouldBeTrue)
 
 			Convey("deactivating the task should not deactivate the tasks it depends on", func() {
 				So(SetActiveState(ctx, userName, false, testTask), ShouldBeNil)
-				depTask, err = task.FindOne(db.Query(task.ById(depTask.Id)))
+				depTask, err = task.FindOne(ctx, db.Query(task.ById(depTask.Id)))
 				So(err, ShouldBeNil)
 				So(depTask.Activated, ShouldBeTrue)
 			})
@@ -717,11 +717,11 @@ func TestSetActiveState(t *testing.T) {
 			So(testTask.SetOverrideDependencies(userName), ShouldBeNil)
 
 			So(SetActiveState(ctx, userName, true, testTask), ShouldBeNil)
-			depTask, err := task.FindOne(db.Query(task.ById(dep1.Id)))
+			depTask, err := task.FindOne(ctx, db.Query(task.ById(dep1.Id)))
 			So(err, ShouldBeNil)
 			So(depTask.Activated, ShouldBeFalse)
 
-			depTask, err = task.FindOne(db.Query(task.ById(dep2.Id)))
+			depTask, err = task.FindOne(ctx, db.Query(task.ById(dep2.Id)))
 			So(err, ShouldBeNil)
 			So(depTask.Activated, ShouldBeFalse)
 		})
@@ -755,28 +755,28 @@ func TestSetActiveState(t *testing.T) {
 		So(t1.Insert(), ShouldBeNil)
 		Convey("that should not restart", func() {
 			So(SetActiveState(ctx, "test", true, *dt), ShouldBeNil)
-			t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
+			t1FromDb, err := task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 			So(err, ShouldBeNil)
 			So(t1FromDb.Activated, ShouldBeTrue)
-			dtFromDb, err := task.FindOne(db.Query(task.ById(dt.Id)))
+			dtFromDb, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 			So(err, ShouldBeNil)
 			So(dtFromDb.Activated, ShouldBeTrue)
 		})
 		Convey("that should activate and deactivate", func() {
 			dt.DispatchTime = time.Now()
 			So(SetActiveState(ctx, "test", true, *dt), ShouldBeNil)
-			t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
+			t1FromDb, err := task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 			So(err, ShouldBeNil)
 			So(t1FromDb.Activated, ShouldBeTrue)
-			dtFromDb, err := task.FindOne(db.Query(task.ById(dt.Id)))
+			dtFromDb, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 			So(err, ShouldBeNil)
 			So(dtFromDb.Activated, ShouldBeTrue)
 
 			So(SetActiveState(ctx, "test", false, *t1FromDb), ShouldBeNil)
-			t1FromDb, err = task.FindOne(db.Query(task.ById(t1.Id)))
+			t1FromDb, err = task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 			So(err, ShouldBeNil)
 			So(t1FromDb.Activated, ShouldBeFalse)
-			dtFromDb, err = task.FindOne(db.Query(task.ById(dt.Id)))
+			dtFromDb, err = task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 			So(err, ShouldBeNil)
 			So(dtFromDb.Activated, ShouldBeFalse)
 		})
@@ -930,7 +930,7 @@ func TestActivatePreviousTask(t *testing.T) {
 		So(currentTask.Insert(), ShouldBeNil)
 		Convey("activating a previous task should set the previous task's active field to true", func() {
 			So(activatePreviousTask(ctx, currentTask.Id, "", nil), ShouldBeNil)
-			t, err := task.FindOne(db.Query(task.ById(previousTask.Id)))
+			t, err := task.FindOne(ctx, db.Query(task.ById(previousTask.Id)))
 			So(err, ShouldBeNil)
 			So(t.Activated, ShouldBeTrue)
 		})
@@ -1033,12 +1033,12 @@ func TestDeactivatePreviousTask(t *testing.T) {
 			So(DeactivatePreviousTasks(ctx, currentTask, userName), ShouldBeNil)
 			var err error
 			// Deactivates this task even though it has a dependent task, because it's inactive.
-			previousTask, err = task.FindOne(db.Query(task.ById(previousTask.Id)))
+			previousTask, err = task.FindOne(ctx, db.Query(task.ById(previousTask.Id)))
 			So(err, ShouldBeNil)
 			So(previousTask.Activated, ShouldBeFalse)
 
 			// Shouldn't deactivate this task because it has an active dependent task.
-			previouserTask, err = task.FindOne(db.Query(task.ById(previouserTask.Id)))
+			previouserTask, err = task.FindOne(ctx, db.Query(task.ById(previouserTask.Id)))
 			So(err, ShouldBeNil)
 			So(previouserTask.Activated, ShouldBeTrue)
 		})
@@ -1174,21 +1174,21 @@ func TestDeactivatePreviousTask(t *testing.T) {
 		So(et4.Insert(), ShouldBeNil)
 		Convey("deactivating a display task should deactivate its child tasks", func() {
 			So(DeactivatePreviousTasks(ctx, dt2, userName), ShouldBeNil)
-			dbTask, err := task.FindOne(db.Query(task.ById(dt1.Id)))
+			dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt1.Id)))
 			So(err, ShouldBeNil)
 			So(dbTask.Activated, ShouldBeFalse)
-			dbTask, err = task.FindOne(db.Query(task.ById(et1.Id)))
+			dbTask, err = task.FindOne(ctx, db.Query(task.ById(et1.Id)))
 			So(err, ShouldBeNil)
 			So(dbTask.Activated, ShouldBeFalse)
 			Convey("but should not touch any tasks that have started", func() {
-				dbTask, err = task.FindOne(db.Query(task.ById(dt3.Id)))
+				dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt3.Id)))
 				So(err, ShouldBeNil)
 				So(dbTask.Activated, ShouldBeTrue)
-				dbTask, err = task.FindOne(db.Query(task.ById(et3.Id)))
+				dbTask, err = task.FindOne(ctx, db.Query(task.ById(et3.Id)))
 				So(err, ShouldBeNil)
 				So(dbTask.Activated, ShouldBeTrue)
 				So(dbTask.Status, ShouldEqual, evergreen.TaskUndispatched)
-				dbTask, err = task.FindOne(db.Query(task.ById(et4.Id)))
+				dbTask, err = task.FindOne(ctx, db.Query(task.ById(et4.Id)))
 				So(err, ShouldBeNil)
 				So(dbTask.Activated, ShouldBeTrue)
 				So(dbTask.Status, ShouldEqual, evergreen.TaskStarted)
@@ -1998,7 +1998,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildSucceeded)
 
-			taskData, err := task.FindOne(db.Query(task.ById(testTask.Id)))
+			taskData, err := task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(taskData.Status, ShouldEqual, evergreen.TaskSucceeded)
 		})
@@ -2017,7 +2017,7 @@ func TestTaskStatusImpactedByFailedTest(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(b.Status, ShouldEqual, evergreen.BuildFailed)
 
-			taskData, err := task.FindOne(db.Query(task.ById(testTask.Id)))
+			taskData, err := task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(taskData.Status, ShouldEqual, evergreen.TaskFailed)
 			So(taskData.Details.Type, ShouldEqual, evergreen.CommandTypeTest)
@@ -2180,28 +2180,28 @@ func TestMarkEnd(t *testing.T) {
 		}
 		endTime := time.Now().Round(time.Second)
 		So(MarkEnd(ctx, settings, t1, "test", endTime, detail, false), ShouldBeNil)
-		t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
+		t1FromDb, err := task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskSucceeded)
-		dtFromDb, err := task.FindOne(db.Query(task.ById(dt.Id)))
+		dtFromDb, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 		So(err, ShouldBeNil)
 		So(dtFromDb.Status, ShouldEqual, evergreen.TaskSucceeded)
 
 		// Ensure that calling MarkEnd on a non-aborted finished task returns early
 		// by checking that its finish_time hasn't changed
 		So(MarkEnd(ctx, settings, t1, "test", time.Now().Add(time.Minute), detail, false), ShouldBeNil)
-		t1FromDb, err = task.FindOne(db.Query(task.ById(t1.Id)))
+		t1FromDb, err = task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.FinishTime, ShouldEqual, endTime)
 
 		// Ensure that calling MarkEnd on an aborted finished task does not return early.
 		endTime = time.Now().Round(time.Second)
 		So(AbortTask(ctx, t2.Id, "testUser"), ShouldBeNil)
-		t2FromDb, err := task.FindOne(db.Query(task.ById(t2.Id)))
+		t2FromDb, err := task.FindOne(ctx, db.Query(task.ById(t2.Id)))
 		So(err, ShouldBeNil)
 		So(t2FromDb.FinishTime, ShouldEqual, time.Time{})
 		So(MarkEnd(ctx, settings, t2FromDb, "test", endTime, &t2FromDb.Details, false), ShouldBeNil)
-		t2FromDb, err = task.FindOne(db.Query(task.ById(t2.Id)))
+		t2FromDb, err = task.FindOne(ctx, db.Query(task.ById(t2.Id)))
 		So(err, ShouldBeNil)
 		So(t2FromDb.FinishTime, ShouldEqual, endTime)
 	})
@@ -2254,7 +2254,7 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 			assert.Equal(t, evergreen.TaskFailed, runningTaskDB.Status)
 		},
 		"ResetWhenFinished": func(t *testing.T) {
-			assert.NoError(t, runningTask.SetResetWhenFinished("test"))
+			assert.NoError(t, runningTask.SetResetWhenFinished(ctx, "test"))
 			assert.NoError(t, MarkEnd(ctx, settings, runningTask, "test", time.Now(), detail, false))
 
 			runningTaskDB, err := task.FindOneId(runningTask.Id)
@@ -2643,7 +2643,7 @@ func TestTryResetTask(t *testing.T) {
 			So(v.Insert(), ShouldBeNil)
 			Convey("should reset and add a task to the old tasks collection", func() {
 				So(TryResetTask(ctx, settings, testTask.Id, userName, "", detail), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Details, ShouldResemble, apimodels.TaskEndDetail{})
 				So(testTask.Status, ShouldEqual, evergreen.TaskUndispatched)
@@ -2779,19 +2779,19 @@ func TestTryResetTask(t *testing.T) {
 
 			Convey("should reset if ui package tries to reset", func() {
 				So(TryResetTask(ctx, settings, testTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(testTask.Status, ShouldEqual, evergreen.TaskUndispatched)
 			})
 			Convey("should not reset if an origin other than the ui package tries to reset", func() {
 				So(TryResetTask(ctx, settings, testTask.Id, userName, "", detail), ShouldBeNil)
-				testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+				testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 				So(err, ShouldBeNil)
 				So(testTask.Details, ShouldNotResemble, *detail)
 				So(testTask.Status, ShouldNotEqual, detail.Status)
 			})
 			Convey("should reset and use detail information if the UI package passes in a detail ", func() {
 				So(TryResetTask(ctx, settings, anotherTask.Id, userName, evergreen.UIPackage, detail), ShouldBeNil)
-				a, err := task.FindOne(db.Query(task.ById(anotherTask.Id)))
+				a, err := task.FindOne(ctx, db.Query(task.ById(anotherTask.Id)))
 				So(err, ShouldBeNil)
 				So(a.Details, ShouldResemble, apimodels.TaskEndDetail{})
 				So(a.Status, ShouldEqual, evergreen.TaskUndispatched)
@@ -2807,7 +2807,7 @@ func TestTryResetTask(t *testing.T) {
 					},
 				}
 				So(TryResetTask(ctx, newSettings, systemFailedTask.Id, userName, "", detail), ShouldBeNil)
-				systemFailedTask, err = task.FindOne(db.Query(task.ById(systemFailedTask.Id)))
+				systemFailedTask, err = task.FindOne(ctx, db.Query(task.ById(systemFailedTask.Id)))
 				So(err, ShouldBeNil)
 				So(systemFailedTask.Details, ShouldNotResemble, *detail)
 				So(systemFailedTask.Status, ShouldNotEqual, detail.Status)
@@ -2816,14 +2816,14 @@ func TestTryResetTask(t *testing.T) {
 			Convey("system failed tasks should reset if they haven't reached the admin setting limit", func() {
 				detail.Type = evergreen.CommandTypeSystem
 				So(TryResetTask(ctx, settings, systemFailedTask.Id, userName, "", detail), ShouldBeNil)
-				systemFailedTask, err = task.FindOne(db.Query(task.ById(systemFailedTask.Id)))
+				systemFailedTask, err = task.FindOne(ctx, db.Query(task.ById(systemFailedTask.Id)))
 				So(err, ShouldBeNil)
 				So(systemFailedTask.Status, ShouldEqual, evergreen.TaskUndispatched)
 			})
 			Convey("system failed tasks should not reset if they've reached the admin setting limit", func() {
 				detail.Type = evergreen.CommandTypeSystem
 				So(TryResetTask(ctx, settings, anotherSystemFailedTask.Id, userName, "", detail), ShouldBeNil)
-				anotherSystemFailedTask, err = task.FindOne(db.Query(task.ById(systemFailedTask.Id)))
+				anotherSystemFailedTask, err = task.FindOne(ctx, db.Query(task.ById(systemFailedTask.Id)))
 				So(err, ShouldBeNil)
 				So(systemFailedTask.Status, ShouldNotEqual, evergreen.TaskUndispatched)
 			})
@@ -2862,10 +2862,10 @@ func TestTryResetTask(t *testing.T) {
 		So(t1.Insert(), ShouldBeNil)
 
 		So(TryResetTask(ctx, settings, dt.Id, "user", "test", nil), ShouldBeNil)
-		t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
+		t1FromDb, err := task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskUndispatched)
-		dtFromDb, err := task.FindOne(db.Query(task.ById(dt.Id)))
+		dtFromDb, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 		So(err, ShouldBeNil)
 		So(dtFromDb.Status, ShouldEqual, evergreen.TaskUndispatched)
 	})
@@ -3001,7 +3001,7 @@ func TestAbortTask(t *testing.T) {
 		var err error
 		Convey("with a task that has started, aborting a task should work", func() {
 			So(AbortTask(ctx, testTask.Id, userName), ShouldBeNil)
-			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+			testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(testTask.Activated, ShouldEqual, false)
 			So(testTask.Aborted, ShouldEqual, true)
@@ -3050,6 +3050,9 @@ func TestAbortTask(t *testing.T) {
 }
 
 func TestMarkStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	Convey("With a task, build and version", t, func() {
 		require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection))
 		displayName := "testName"
@@ -3077,11 +3080,11 @@ func TestMarkStart(t *testing.T) {
 
 		Convey("when calling MarkStart, the task, version and build should be updated", func() {
 			updates := StatusChanges{}
-			err := MarkStart(testTask, &updates)
+			err := MarkStart(ctx, testTask, &updates)
 			So(updates.BuildNewStatus, ShouldBeEmpty)
 			So(updates.PatchNewStatus, ShouldBeEmpty)
 			So(err, ShouldBeNil)
-			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+			testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(testTask.Status, ShouldEqual, evergreen.TaskStarted)
 			So(testTask.DisplayStatusCache, ShouldEqual, evergreen.TaskStarted)
@@ -3125,17 +3128,20 @@ func TestMarkStart(t *testing.T) {
 		}
 		So(t1.Insert(), ShouldBeNil)
 
-		So(MarkStart(t1, &StatusChanges{}), ShouldBeNil)
-		t1FromDb, err := task.FindOne(db.Query(task.ById(t1.Id)))
+		So(MarkStart(ctx, t1, &StatusChanges{}), ShouldBeNil)
+		t1FromDb, err := task.FindOne(ctx, db.Query(task.ById(t1.Id)))
 		So(err, ShouldBeNil)
 		So(t1FromDb.Status, ShouldEqual, evergreen.TaskStarted)
-		dtFromDb, err := task.FindOne(db.Query(task.ById(dt.Id)))
+		dtFromDb, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 		So(err, ShouldBeNil)
 		So(dtFromDb.Status, ShouldEqual, evergreen.TaskStarted)
 	})
 }
 
 func TestMarkDispatched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	Convey("With a task, build and version", t, func() {
 		require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection))
 		displayName := "testName"
@@ -3164,9 +3170,9 @@ func TestMarkDispatched(t *testing.T) {
 				},
 				AgentRevision: "testAgentVersion",
 			}
-			So(MarkHostTaskDispatched(testTask, sampleHost), ShouldBeNil)
+			So(MarkHostTaskDispatched(ctx, testTask, sampleHost), ShouldBeNil)
 			var err error
-			testTask, err = task.FindOne(db.Query(task.ById(testTask.Id)))
+			testTask, err = task.FindOne(ctx, db.Query(task.ById(testTask.Id)))
 			So(err, ShouldBeNil)
 			So(testTask.Status, ShouldEqual, evergreen.TaskDispatched)
 			So(testTask.HostId, ShouldEqual, "testHost")
@@ -3423,19 +3429,19 @@ func TestFailedTaskRestart(t *testing.T) {
 	assert.Len(results.ItemsRestarted, 4)
 	restarted = []string{systemFailTask.Id, setupFailTask.Id, ranInRangeTask.Id, startedOutOfRangeTask.Id}
 	assert.EqualValues(restarted, results.ItemsRestarted)
-	dbTask, err := task.FindOne(db.Query(task.ById(systemFailTask.Id)))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(systemFailTask.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
 	assert.Greater(dbTask.Execution, 1)
-	dbTask, err = task.FindOne(db.Query(task.ById(successfulTask.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(successfulTask.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskSucceeded, dbTask.Status)
 	assert.Equal(1, dbTask.Execution)
-	dbTask, err = task.FindOne(db.Query(task.ById(inLargerRangeTask.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(inLargerRangeTask.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 	assert.Equal(1, dbTask.Execution)
-	dbTask, err = task.FindOne(db.Query(task.ById(setupFailTask.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(setupFailTask.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
 	assert.Equal(2, dbTask.Execution)
@@ -3541,19 +3547,19 @@ func TestFailedTaskRestartWithDisplayTasksAndTaskGroup(t *testing.T) {
 	assert.Nil(results.ItemsErrored)
 	assert.Len(results.ItemsRestarted, 2) // not all are included in items restarted
 	// but all tasks are restarted
-	dbTask, err := task.FindOne(db.Query(task.ById(testTask1.Id)))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(testTask1.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	dbTask, err = task.FindOne(db.Query(task.ById(testTask2.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(testTask2.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	dbTask, err = task.FindOne(db.Query(task.ById(testTask3.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(testTask3.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	dbTask, err = task.FindOne(db.Query(task.ById(testTask4.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(testTask4.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	dbTask, err = task.FindOne(db.Query(task.ById(testTask5.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(testTask5.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
 }
@@ -3739,16 +3745,16 @@ func TestStepback(t *testing.T) {
 	assert.NoError(v3.Insert())
 	// test stepping back a regular task
 	assert.NoError(doLinearStepback(ctx, t3))
-	dbTask, err := task.FindOne(db.Query(task.ById(t2.Id)))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(t2.Id)))
 	assert.NoError(err)
 	assert.True(dbTask.Activated)
 
 	// test stepping back a display task
 	assert.NoError(doLinearStepback(ctx, dt3))
-	dbTask, err = task.FindOne(db.Query(task.ById(dt2.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt2.Id)))
 	assert.NoError(err)
 	assert.True(dbTask.Activated)
-	dbTask, err = task.FindOne(db.Query(task.ById(dt2.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt2.Id)))
 	assert.NoError(err)
 	assert.True(dbTask.Activated)
 }
@@ -3956,7 +3962,7 @@ func TestLinearStepbackWithGenerators(t *testing.T) {
 				for orderNumber := 0; orderNumber < 3; orderNumber++ {
 					// Background tasks.
 					for i := 0; i < 3; i++ {
-						dbTask, err := task.FindOne(db.Query(task.ById(fmt.Sprintf("t-success-%d-%d", orderNumber, i))))
+						dbTask, err := task.FindOne(ctx, db.Query(task.ById(fmt.Sprintf("t-success-%d-%d", orderNumber, i))))
 						require.NoError(t, err)
 						require.NotNil(t, dbTask)
 						assert.False(t, dbTask.Activated)
@@ -3964,7 +3970,7 @@ func TestLinearStepbackWithGenerators(t *testing.T) {
 
 					// 1st Generator "t-generator-1-(orderNumber)" generated tasks that passed.
 					for i := 3; i < 5; i++ {
-						dbTask, err := task.FindOne(db.Query(task.ById(fmt.Sprintf("t-generated-%d-1-%d", orderNumber, i))))
+						dbTask, err := task.FindOne(ctx, db.Query(task.ById(fmt.Sprintf("t-generated-%d-1-%d", orderNumber, i))))
 						require.NoError(t, err)
 						require.NotNil(t, dbTask)
 						assert.False(t, dbTask.Activated)
@@ -4055,7 +4061,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Version:     v.Id,
 		HostId:      taskHost.Id,
 	}
-	assert.True(exeTask0.IsPartOfDisplay())
+	assert.True(exeTask0.IsPartOfDisplay(ctx))
 	assert.NoError(exeTask0.Insert())
 	exeTask1 := &task.Task{
 		Id:          "exe1",
@@ -4068,7 +4074,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 		Version:     v.Id,
 		HostId:      taskHost.Id,
 	}
-	assert.True(exeTask1.IsPartOfDisplay())
+	assert.True(exeTask1.IsPartOfDisplay(ctx))
 	assert.NoError(exeTask1.Insert())
 
 	b := &build.Build{
@@ -4398,7 +4404,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 
-	runningTask, err := task.FindOne(db.Query(task.ById("t")))
+	runningTask, err := task.FindOne(ctx, db.Query(task.ById("t")))
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskUndispatched, runningTask.Status)
 
@@ -4413,7 +4419,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	h.RunningTask = "unschedulableTask"
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 
-	unschedulableTask, err := task.FindOne(db.Query(task.ById("unschedulableTask")))
+	unschedulableTask, err := task.FindOne(ctx, db.Query(task.ById("unschedulableTask")))
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskFailed, unschedulableTask.Status)
 
@@ -4423,7 +4429,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.True(dependencyTask.DependsOn[0].Unattainable)
 	assert.True(dependencyTask.DependsOn[0].Finished)
 
-	dt, err := task.FindOne(db.Query(task.ById("displayTask")))
+	dt, err := task.FindOne(ctx, db.Query(task.ById("displayTask")))
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskFailed, dt.Status)
 	assert.Equal(dt.Details, task.GetSystemFailureDetails(evergreen.TaskDescriptionStranded))
@@ -4439,7 +4445,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	h.RunningTask = "t2"
 	assert.NoError(resetTask(ctx, "t2", ""))
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
-	foundTask, err := task.FindOne(db.Query(task.ById("t2")))
+	foundTask, err := task.FindOne(ctx, db.Query(task.ById("t2")))
 	require.NoError(t, err)
 	// The task should not have been reset twice.
 	assert.Equal(1, foundTask.Execution)
@@ -4493,7 +4499,7 @@ func TestClearAndResetStaleStrandedHostTask(t *testing.T) {
 
 	settings := testutil.TestConfig()
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, host))
-	runningTask, err := task.FindOne(db.Query(task.ById("t")))
+	runningTask, err := task.FindOne(ctx, db.Query(task.ById("t")))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, runningTask.Status)
 	assert.Equal("system", runningTask.Details.Type)
@@ -4555,16 +4561,16 @@ func TestClearAndResetStrandedHostTaskFailedOnly(t *testing.T) {
 	assert.NoError(t, v.Insert())
 	settings := testutil.TestConfig()
 	assert.NoError(t, ClearAndResetStrandedHostTask(ctx, settings, h))
-	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
+	restartedDisplayTask, err := task.FindOne(ctx, db.Query(task.ById("dt")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)
 	assert.Equal(t, 1, restartedDisplayTask.Execution)
-	restartedExecutionTask, err := task.FindOne(db.Query(task.ById("et1")))
+	restartedExecutionTask, err := task.FindOne(ctx, db.Query(task.ById("et1")))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, restartedExecutionTask.Execution)
 	assert.Equal(t, 1, restartedExecutionTask.LatestParentExecution)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedExecutionTask.Status)
-	nonRestartedExecutionTask, err := task.FindOne(db.Query(task.ById("et2")))
+	nonRestartedExecutionTask, err := task.FindOne(ctx, db.Query(task.ById("et2")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskSucceeded, nonRestartedExecutionTask.Status)
 	assert.Equal(t, 0, nonRestartedExecutionTask.Execution)
@@ -4748,10 +4754,10 @@ func TestClearAndResetExecTask(t *testing.T) {
 
 	settings := testutil.TestConfig()
 	assert.NoError(t, ClearAndResetStrandedHostTask(ctx, settings, h))
-	restartedDisplayTask, err := task.FindOne(db.Query(task.ById("dt")))
+	restartedDisplayTask, err := task.FindOne(ctx, db.Query(task.ById("dt")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedDisplayTask.Status)
-	restartedExecutionTask, err := task.FindOne(db.Query(task.ById("et")))
+	restartedExecutionTask, err := task.FindOne(ctx, db.Query(task.ById("et")))
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.TaskUndispatched, restartedExecutionTask.Status)
 }
@@ -5295,6 +5301,9 @@ func TestMarkEndWithNoResults(t *testing.T) {
 }
 
 func TestDisplayTaskUpdates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.ClearCollections(task.Collection, event.EventCollection))
 	assert := assert.New(t)
 	dt := task.Task{
@@ -5435,8 +5444,8 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	assert.NoError(task12.Insert())
 
 	// test that updating the status + activated from execution tasks works
-	assert.NoError(UpdateDisplayTaskForTask(&task1))
-	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task1))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
@@ -5447,11 +5456,11 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	assert.Equal(task4.FinishTime, dbTask.FinishTime)
 
 	// test that you can't update a display task
-	assert.Error(UpdateDisplayTaskForTask(&dt))
+	assert.Error(UpdateDisplayTaskForTask(ctx, &dt))
 
 	// test that a display task with a finished + unfinished task is "started"
-	assert.NoError(UpdateDisplayTaskForTask(&task5))
-	dbTask, err = task.FindOne(db.Query(task.ById(dt2.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task5))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt2.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
@@ -5466,30 +5475,33 @@ func TestDisplayTaskUpdates(t *testing.T) {
 	assert.Empty(events)
 
 	// a blocked execution task + unblocked unfinshed tasks should still be "started"
-	assert.NoError(UpdateDisplayTaskForTask(&task7))
-	dbTask, err = task.FindOne(db.Query(task.ById(blockedDt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task7))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(blockedDt.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
 
 	// a blocked execution task should not contribute to the status
 	assert.NoError(task10.MarkFailed())
-	assert.NoError(UpdateDisplayTaskForTask(&task8))
-	dbTask, err = task.FindOne(db.Query(task.ById(blockedDt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task8))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(blockedDt.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 	assert.Equal(evergreen.TaskFailed, dbTask.DisplayStatusCache)
 
 	// a display task should not set its start time to any exec tasks that have zero start time
-	assert.NoError(UpdateDisplayTaskForTask(&task11))
-	dbTask, err = task.FindOne(db.Query(task.ById(dt3.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task11))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt3.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(task12.StartTime, dbTask.StartTime)
 }
 
 func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	require.NoError(t, db.ClearCollections(task.Collection, event.EventCollection))
 	assert := assert.New(t)
 	dt := task.Task{
@@ -5523,8 +5535,8 @@ func TestDisplayTaskUpdateNoUndispatched(t *testing.T) {
 	assert.NoError(task2.Insert())
 
 	// test that updating the status + activated from execution tasks shows started
-	assert.NoError(UpdateDisplayTaskForTask(&task1))
-	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &task1))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.NotNil(dbTask)
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
@@ -5580,18 +5592,18 @@ func TestDisplayTaskDelayedRestart(t *testing.T) {
 	settings := testutil.TestConfig()
 
 	// request that the task restarts when it's done
-	assert.NoError(dt.SetResetWhenFinished("caller"))
-	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
+	assert.NoError(dt.SetResetWhenFinished(ctx, "caller"))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.True(dbTask.ResetWhenFinished)
 	assert.Equal(evergreen.TaskStarted, dbTask.Status)
 
 	// end the final task so that it restarts
 	assert.NoError(checkResetDisplayTask(ctx, settings, "", "", &dt))
-	dbTask, err = task.FindOne(db.Query(task.ById(dt.Id)))
+	dbTask, err = task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask.Status)
-	dbTask2, err := task.FindOne(db.Query(task.ById(task2.Id)))
+	dbTask2, err := task.FindOne(ctx, db.Query(task.ById(task2.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskUndispatched, dbTask2.Status)
 
@@ -5605,6 +5617,8 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 	// same display task. If UpdateDisplayTaskForTask is working properly, this
 	// test should never be flaky. If it is, that's a sign that it's not
 	// concurrency safe.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	require.NoError(t, db.ClearCollections(task.Collection, event.EventCollection))
 	defer func() {
@@ -5653,7 +5667,7 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 			// The task has to be copied into the goroutine to avoid concurrent
 			// modifications of the in-memory display task.
 			et0Copy := et0
-			errs <- UpdateDisplayTaskForTask(&et0Copy)
+			errs <- UpdateDisplayTaskForTask(ctx, &et0Copy)
 		}()
 	}
 
@@ -5683,7 +5697,7 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 		// The task has to be copied into the goroutine to avoid concurrent
 		// modifications of the in-memory display task.
 		et0Copy := et0
-		errs <- UpdateDisplayTaskForTask(&et0Copy)
+		errs <- UpdateDisplayTaskForTask(ctx, &et0Copy)
 	}()
 
 	updatesDone.Wait()
@@ -5755,6 +5769,9 @@ func TestAbortedTaskDelayedRestart(t *testing.T) {
 }
 
 func TestDisplayTaskFailedExecTasks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(task.Collection))
 	dt := task.Task{
@@ -5777,8 +5794,8 @@ func TestDisplayTaskFailedExecTasks(t *testing.T) {
 	execTask1 := task.Task{Id: "exec1", Status: evergreen.TaskUndispatched}
 	assert.NoError(execTask1.Insert())
 
-	assert.NoError(UpdateDisplayTaskForTask(&execTask0))
-	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &execTask0))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 	assert.Equal(evergreen.CommandTypeSystem, dbTask.Details.Type)
@@ -5786,6 +5803,9 @@ func TestDisplayTaskFailedExecTasks(t *testing.T) {
 }
 
 func TestDisplayTaskFailedAndSucceededExecTasks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	assert := assert.New(t)
 	assert.NoError(db.ClearCollections(task.Collection))
 	dt := task.Task{
@@ -5809,8 +5829,8 @@ func TestDisplayTaskFailedAndSucceededExecTasks(t *testing.T) {
 	execTask1 := task.Task{Id: "exec1", Activated: true, Status: evergreen.TaskSucceeded}
 	assert.NoError(execTask1.Insert())
 
-	assert.NoError(UpdateDisplayTaskForTask(&execTask0))
-	dbTask, err := task.FindOne(db.Query(task.ById(dt.Id)))
+	assert.NoError(UpdateDisplayTaskForTask(ctx, &execTask0))
+	dbTask, err := task.FindOne(ctx, db.Query(task.ById(dt.Id)))
 	assert.NoError(err)
 	assert.Equal(evergreen.TaskFailed, dbTask.Status)
 	assert.Equal(evergreen.CommandTypeSetup, dbTask.Details.Type)
@@ -5928,7 +5948,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.UpdateOne(bson.M{"_id": "t1"},
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.False(midTask.Activated)
 		},
@@ -5936,7 +5956,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			// If t5 is missing, t4 should be used.
 			require.NoError(task.Remove("t5"))
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			assert.Equal("t4", midTask.Id)
@@ -5947,7 +5967,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.Remove("t4"))
 			require.NoError(task.Remove("t3"))
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			assert.Equal("t2", midTask.Id)
@@ -5961,14 +5981,14 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(task.Remove("t3"))
 			require.NoError(task.Remove("t2"))
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.False(midTask.Activated)
 			assert.Equal("t1", midTask.Id)
 		},
 		"FailedTaskInStepback": func(t *testing.T, t10 task.Task) {
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			prevTask := *midTask
 			require.NoError(err)
 			assert.True(midTask.Activated)
@@ -5998,7 +6018,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": evergreen.TaskFailed}}))
 			// Activate next stepback
 			require.NoError(evalStepback(ctx, &prevTask, evergreen.TaskFailed))
-			midTask, err = task.ByBeforeMidwayTaskFromIds(prevTask.Id, "t1")
+			midTask, err = task.ByBeforeMidwayTaskFromIds(ctx, prevTask.Id, "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6022,7 +6042,7 @@ func TestEvalBisectStepback(t *testing.T) {
 		},
 		"PassedTaskInStepback": func(t *testing.T, t10 task.Task) {
 			require.NoError(evalStepback(ctx, &t10, evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6052,7 +6072,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": evergreen.TaskSucceeded}}))
 			// Activate next stepback
 			require.NoError(evalStepback(ctx, midTask, evergreen.TaskSucceeded))
-			midTask, err = task.ByBeforeMidwayTaskFromIds("t10", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds(ctx, "t10", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			// Check mid task stepback info.
@@ -6134,7 +6154,7 @@ func TestEvalBisectStepback(t *testing.T) {
 				bson.M{"$set": bson.M{"status": generated2Tasks[9].Status}}))
 			require.NoError(evalStepback(ctx, &generated1Tasks[9], evergreen.TaskFailed))
 			require.NoError(evalStepback(ctx, &generated2Tasks[9], evergreen.TaskFailed))
-			midTask, err := task.ByBeforeMidwayTaskFromIds("t10", "t1")
+			midTask, err := task.ByBeforeMidwayTaskFromIds(ctx, "t10", "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)
@@ -6203,7 +6223,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.NoError(evalStepback(ctx, midTaskG2, evergreen.TaskFailed))
 
 			// Check mid task stepback info relating to generated task 1.
-			midTask, err = task.ByBeforeMidwayTaskFromIds("t10", prevTask.Id)
+			midTask, err = task.ByBeforeMidwayTaskFromIds(ctx, "t10", prevTask.Id)
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)
@@ -6225,7 +6245,7 @@ func TestEvalBisectStepback(t *testing.T) {
 			require.Nil(g2Info)
 
 			// Check mid task stepback info relating to generated task 2.
-			midTask, err = task.ByBeforeMidwayTaskFromIds(prevTask.Id, "t1")
+			midTask, err = task.ByBeforeMidwayTaskFromIds(ctx, prevTask.Id, "t1")
 			require.NoError(err)
 			assert.True(midTask.Activated)
 			require.NotNil(midTask.StepbackInfo)

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -184,7 +184,7 @@ func TestCLIFetchSource(t *testing.T) {
 
 		patches, err := ac.GetPatches(0)
 		So(err, ShouldBeNil)
-		testTask, err := task.FindOne(db.Query(
+		testTask, err := task.FindOne(ctx, db.Query(
 			bson.M{
 				task.VersionKey:      patches[0].Version,
 				task.BuildVariantKey: "ubuntu",

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -373,7 +373,7 @@ tasks:
 	}
 	assert.NoError(t, repoTracker.StoreRevisions(ctx, revisions))
 
-	bv1t1, err := task.FindOne(db.Query(bson.M{task.BuildVariantKey: "bv1", task.DisplayNameKey: "t1"}))
+	bv1t1, err := task.FindOne(ctx, db.Query(bson.M{task.BuildVariantKey: "bv1", task.DisplayNameKey: "t1"}))
 	require.NoError(t, err)
 	require.NotNil(t, bv1t1)
 	assert.Equal(t, 4, bv1t1.NumDependents)

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -74,7 +74,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 		if test == nil {
 			return "", http.StatusNotFound, errors.Errorf("test log '%s' not found", testLog)
 		}
-		projectID, err = task.FindProjectForTask(test.Task)
+		projectID, err = task.FindProjectForTask(ctx, test.Task)
 		if err != nil {
 			return "", http.StatusNotFound, errors.Wrapf(err, "finding project for task '%s' associated with test log '%s'", test.Task, test.Id)
 		}
@@ -82,7 +82,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 
 	taskID := paramsMap[taskIdKey]
 	if projectID == "" && taskID != "" {
-		projectID, err = task.FindProjectForTask(taskID)
+		projectID, err = task.FindProjectForTask(ctx, taskID)
 		if err != nil {
 			return "", http.StatusNotFound, errors.Wrapf(err, "finding project for task '%s'", taskID)
 		}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -259,8 +259,8 @@ func (h *markTaskForRestartHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 	taskToRestart := t
-	if t.IsPartOfDisplay() {
-		dt, err := t.GetDisplayTask()
+	if t.IsPartOfDisplay(ctx) {
+		dt, err := t.GetDisplayTask(ctx)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting display task for execution task '%s'", h.taskID))
 		}
@@ -882,7 +882,7 @@ func (h *startTaskHandler) Run(ctx context.Context) gimlet.Responder {
 	})
 
 	updates := model.StatusChanges{}
-	if err = model.MarkStart(t, &updates); err != nil {
+	if err = model.MarkStart(ctx, t, &updates); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "marking task '%s' started", t.Id))
 	}
 

--- a/rest/route/build_task.go
+++ b/rest/route/build_task.go
@@ -131,7 +131,7 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 
 		if tbh.fetchParentIds {
-			if tasks[i].IsPartOfDisplay() {
+			if tasks[i].IsPartOfDisplay(ctx) {
 				taskModel.ParentTaskId = utility.FromStringPtr(tasks[i].DisplayTaskId)
 			}
 		}

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -548,7 +548,7 @@ func (p *countEstimatedGeneratedTasksHandler) Run(ctx context.Context) gimlet.Re
 	}
 	numTasksToFinalize := 0
 	for _, vt := range p.files {
-		dbTask, err := task.FindOne(db.Query(bson.M{
+		dbTask, err := task.FindOne(ctx, db.Query(bson.M{
 			task.ProjectKey:      existingPatch.Project,
 			task.BuildVariantKey: vt.Variant,
 			task.DisplayNameKey:  vt.TaskName,

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -359,8 +359,8 @@ func (h *podAgentNextTask) checkAndRedispatchRunningTask(ctx context.Context, p 
 		return gimlet.NewJSONResponse(struct{}{})
 	}
 
-	if t.IsPartOfDisplay() {
-		if err = model.UpdateDisplayTaskForTask(t); err != nil {
+	if t.IsPartOfDisplay(ctx) {
+		if err = model.UpdateDisplayTaskForTask(ctx, t); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating parent display task for task '%s'", t.Id))
 		}
 	}
@@ -539,7 +539,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		"path":        fmt.Sprintf("/rest/v2/pods/%s/task/%s/end", p.ID, t.Id),
 	}
 
-	if t.IsPartOfDisplay() {
+	if t.IsPartOfDisplay(ctx) {
 		msg["display_task_id"] = t.DisplayTaskId
 	}
 

--- a/rest/route/task.go
+++ b/rest/route/task.go
@@ -269,7 +269,7 @@ func (rh *displayTaskGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	dt, err := t.GetDisplayTask()
+	dt, err := t.GetDisplayTask(ctx)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding display task for task '%s'", rh.taskID))
 	}

--- a/scheduler/task_queue_persister.go
+++ b/scheduler/task_queue_persister.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model"
@@ -10,7 +11,7 @@ import (
 
 // PersistTaskQueue saves the task queue to the database.
 // Returns an error if the db call returns an error.
-func PersistTaskQueue(distro string, tasks []task.Task, distroQueueInfo model.DistroQueueInfo) error {
+func PersistTaskQueue(ctx context.Context, distro string, tasks []task.Task, distroQueueInfo model.DistroQueueInfo) error {
 	startAt := time.Now()
 	taskQueue := make([]model.TaskQueueItem, 0, len(tasks))
 	for _, t := range tasks {
@@ -47,7 +48,7 @@ func PersistTaskQueue(distro string, tasks []task.Task, distroQueueInfo model.Di
 	}
 
 	// track scheduled time for prioritized tasks
-	if err := task.SetTasksScheduledTime(tasks, startAt); err != nil {
+	if err := task.SetTasksScheduledTime(ctx, tasks, startAt); err != nil {
 		return errors.Wrapf(err, "setting scheduled time for prioritized tasks for distro '%s'", distro)
 	}
 	return nil

--- a/scheduler/task_queue_persister_test.go
+++ b/scheduler/task_queue_persister_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 )
 
 func TestDBTaskQueuePersister(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var distroIds []string
 	var displayNames []string
@@ -123,8 +126,8 @@ func TestDBTaskQueuePersister(t *testing.T) {
 		Convey("saving task queues should place them in the database with the "+
 			"correct ordering of tasks along with the relevant average task "+
 			"completion times", func() {
-			So(PersistTaskQueue(distroIds[0], []task.Task{tasks[0], tasks[1], tasks[2]}, distroQueueInfo1), ShouldBeNil)
-			So(PersistTaskQueue(distroIds[1], []task.Task{tasks[3], tasks[4]}, distroQueueInfo2), ShouldBeNil)
+			So(PersistTaskQueue(ctx, distroIds[0], []task.Task{tasks[0], tasks[1], tasks[2]}, distroQueueInfo1), ShouldBeNil)
+			So(PersistTaskQueue(ctx, distroIds[1], []task.Task{tasks[3], tasks[4]}, distroQueueInfo2), ShouldBeNil)
 
 			taskQueue, err := model.LoadTaskQueue(distroIds[0])
 			So(err, ShouldBeNil)

--- a/service/task.go
+++ b/service/task.go
@@ -270,7 +270,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 		Repo:                 projCtx.ProjectRef.Repo,
 		Archived:             archived,
 		TotalExecutions:      totalExecutions,
-		PartOfDisplay:        projCtx.Task.IsPartOfDisplay(),
+		PartOfDisplay:        projCtx.Task.IsPartOfDisplay(r.Context()),
 		CanSync:              projCtx.Task.CanSync,
 		GeneratedById:        projCtx.Task.GeneratedBy,
 	}
@@ -337,7 +337,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 	if projCtx.Patch != nil {
 		var taskOnBaseCommit *task.Task
 		var testResultsOnBaseCommit []testresult.TestResult
-		taskOnBaseCommit, err = projCtx.Task.FindTaskOnBaseCommit()
+		taskOnBaseCommit, err = projCtx.Task.FindTaskOnBaseCommit(r.Context())
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -85,14 +85,14 @@ func newAlertRecord(subID string, t *task.Task, alertType string) *alertrecord.A
 	}
 }
 
-func taskFinishedTwoOrMoreDaysAgo(taskID string, sub *event.Subscription) (bool, error) {
+func taskFinishedTwoOrMoreDaysAgo(ctx context.Context, taskID string, sub *event.Subscription) (bool, error) {
 	renotify, found := sub.TriggerData[event.RenotifyIntervalKey]
 	renotifyInterval, err := strconv.Atoi(renotify)
 	if renotify == "" || err != nil || !found {
 		renotifyInterval = 48
 	}
 	query := db.Query(task.ById(taskID)).WithFields(task.FinishTimeKey)
-	t, err := task.FindOne(query)
+	t, err := task.FindOne(ctx, query)
 	if err != nil {
 		return false, errors.Wrapf(err, "finding task '%s'", taskID)
 	}
@@ -178,7 +178,7 @@ func (t *taskTriggers) Fetch(ctx context.Context, e *event.EventLogEntry) error 
 		return errors.Errorf("task '%s' execution %d not found", e.ResourceId, t.data.Execution)
 	}
 
-	_, err = t.task.GetDisplayTask()
+	_, err = t.task.GetDisplayTask(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "getting parent display task for task '%s'", t.task.Id)
 	}
@@ -414,7 +414,7 @@ func GetRecordByTriggerType(subID, triggerType string, t *task.Task) (*alertreco
 }
 
 func (t *taskTriggers) taskOutcome(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -426,7 +426,7 @@ func (t *taskTriggers) taskOutcome(ctx context.Context, sub *event.Subscription)
 }
 
 func (t *taskTriggers) taskFailure(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -451,7 +451,7 @@ func (t *taskTriggers) taskFailure(ctx context.Context, sub *event.Subscription)
 }
 
 func (t *taskTriggers) taskSuccess(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -463,7 +463,7 @@ func (t *taskTriggers) taskSuccess(ctx context.Context, sub *event.Subscription)
 }
 
 func (t *taskTriggers) taskStarted(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -475,7 +475,7 @@ func (t *taskTriggers) taskStarted(ctx context.Context, sub *event.Subscription)
 }
 
 func (t *taskTriggers) taskFailedOrBlocked(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -541,11 +541,11 @@ func (t *taskTriggers) taskFirstFailureInVersionWithName(ctx context.Context, su
 }
 
 func (t *taskTriggers) taskRegression(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
-	shouldNotify, alert, err := isTaskRegression(sub, t.task)
+	shouldNotify, alert, err := isTaskRegression(ctx, sub, t.task)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (t *taskTriggers) taskRegression(ctx context.Context, sub *event.Subscripti
 	return n, errors.Wrap(alert.Insert(), "processing regression trigger")
 }
 
-func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord.AlertRecord, error) {
+func isTaskRegression(ctx context.Context, sub *event.Subscription, t *task.Task) (bool, *alertrecord.AlertRecord, error) {
 	if t.Status != evergreen.TaskFailed || !utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, t.Requester) ||
 		t.IsUnfinishedSystemUnresponsive() {
 		return false, nil, nil
@@ -571,12 +571,12 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 
 	query := db.Query(task.ByBeforeRevisionWithStatusesAndRequesters(t.RevisionOrderNumber,
 		evergreen.TaskCompletedStatuses, t.BuildVariant, t.DisplayName, t.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
-	previousTask, err := task.FindOne(query)
+	previousTask, err := task.FindOne(ctx, query)
 	if err != nil {
 		return false, nil, errors.Wrap(err, "fetching previous task")
 	}
 
-	shouldSend, err := shouldSendTaskRegression(sub, t, previousTask)
+	shouldSend, err := shouldSendTaskRegression(ctx, sub, t, previousTask)
 	if err != nil {
 		return false, nil, errors.Wrap(err, "determining if we should send notification")
 	}
@@ -593,7 +593,7 @@ func isTaskRegression(sub *event.Subscription, t *task.Task) (bool, *alertrecord
 	return true, rec, nil
 }
 
-func shouldSendTaskRegression(sub *event.Subscription, t *task.Task, previousTask *task.Task) (bool, error) {
+func shouldSendTaskRegression(ctx context.Context, sub *event.Subscription, t *task.Task, previousTask *task.Task) (bool, error) {
 	if t.Status != evergreen.TaskFailed {
 		return false, nil
 	}
@@ -659,7 +659,7 @@ func shouldSendTaskRegression(sub *event.Subscription, t *task.Task, previousTas
 			return maybeSend, nil
 		}
 
-		return taskFinishedTwoOrMoreDaysAgo(lastAlerted.TaskId, sub)
+		return taskFinishedTwoOrMoreDaysAgo(ctx, lastAlerted.TaskId, sub)
 	}
 	return false, nil
 }
@@ -673,7 +673,7 @@ func (t *taskTriggers) taskSuccessfulExceedsDuration(ctx context.Context, sub *e
 }
 
 func (t *taskTriggers) taskExceedsDuration(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -694,7 +694,7 @@ func (t *taskTriggers) taskExceedsDuration(ctx context.Context, sub *event.Subsc
 }
 
 func (t *taskTriggers) taskRuntimeChange(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -711,7 +711,7 @@ func (t *taskTriggers) taskRuntimeChange(ctx context.Context, sub *event.Subscri
 		return nil, errors.Errorf("subscription '%s' has an invalid percentage", sub.ID)
 	}
 
-	lastGreen, err := t.task.PreviousCompletedTask(t.task.Project, []string{evergreen.TaskSucceeded})
+	lastGreen, err := t.task.PreviousCompletedTask(ctx, t.task.Project, []string{evergreen.TaskSucceeded})
 	if err != nil {
 		return nil, errors.Wrap(err, "retrieving last green task")
 	}
@@ -754,7 +754,7 @@ func testMatchesRegex(testName string, sub *event.Subscription) (bool, error) {
 	return regexp.MatchString(regex, testName)
 }
 
-func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *task.Task, currentTask *task.Task, test *testresult.TestResult) (bool, error) {
+func (t *taskTriggers) shouldIncludeTest(ctx context.Context, sub *event.Subscription, previousTask *task.Task, currentTask *task.Task, test *testresult.TestResult) (bool, error) {
 	if test.Status != evergreen.TestFailedStatus {
 		return false, nil
 	}
@@ -797,7 +797,7 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 		if mostRecentAlert == nil {
 			return true, nil
 		}
-		isOld, err := taskFinishedTwoOrMoreDaysAgo(mostRecentAlert.TaskId, sub)
+		isOld, err := taskFinishedTwoOrMoreDaysAgo(ctx, mostRecentAlert.TaskId, sub)
 		if err != nil {
 			return false, errors.Wrap(err, "getting last alert age")
 		}
@@ -811,7 +811,7 @@ func (t *taskTriggers) shouldIncludeTest(sub *event.Subscription, previousTask *
 }
 
 func (t *taskTriggers) taskRegressionByTest(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -833,7 +833,7 @@ func (t *taskTriggers) taskRegressionByTest(ctx context.Context, sub *event.Subs
 	catcher := grip.NewBasicCatcher()
 	query := db.Query(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
 		evergreen.TaskCompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
-	previousCompleteTask, err := task.FindOne(query)
+	previousCompleteTask, err := task.FindOne(ctx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding previous task")
 	}
@@ -866,7 +866,7 @@ func (t *taskTriggers) taskRegressionByTest(ctx context.Context, sub *event.Subs
 			continue
 		}
 		var shouldInclude bool
-		shouldInclude, err = t.shouldIncludeTest(sub, previousCompleteTask, t.task, &test)
+		shouldInclude, err = t.shouldIncludeTest(ctx, sub, previousCompleteTask, t.task, &test)
 		if err != nil {
 			catcher.Add(err)
 			continue
@@ -983,8 +983,8 @@ func JIRATaskPayload(ctx context.Context, params JiraIssueParameters) (*message.
 		Pod:             podDoc,
 		TaskDisplayName: params.Task.DisplayName,
 	}
-	if params.Task.IsPartOfDisplay() {
-		dt, _ := params.Task.GetDisplayTask()
+	if params.Task.IsPartOfDisplay(ctx) {
+		dt, _ := params.Task.GetDisplayTask(ctx)
 		if dt != nil {
 			data.TaskDisplayName = dt.DisplayName
 		}
@@ -1039,7 +1039,7 @@ func detailStatusToHumanSpeak(status string) string {
 
 // this is very similar to taskRegression, but different enough
 func (t *taskTriggers) buildBreak(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	if t.task.IsPartOfDisplay() {
+	if t.task.IsPartOfDisplay(ctx) {
 		return nil, nil
 	}
 
@@ -1057,7 +1057,7 @@ func (t *taskTriggers) buildBreak(ctx context.Context, sub *event.Subscription) 
 	}
 	query := db.Query(task.ByBeforeRevisionWithStatusesAndRequesters(t.task.RevisionOrderNumber,
 		evergreen.TaskCompletedStatuses, t.task.BuildVariant, t.task.DisplayName, t.task.Project, evergreen.SystemVersionRequesterTypes)).Sort([]string{"-" + task.RevisionOrderNumberKey})
-	previousTask, err := task.FindOne(query)
+	previousTask, err := task.FindOne(ctx, query)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding previous task")
 	}

--- a/trigger/version.go
+++ b/trigger/version.go
@@ -348,7 +348,7 @@ func (t *versionTriggers) versionRegression(ctx context.Context, sub *event.Subs
 	}
 	for i := range versionTasks {
 		task := &versionTasks[i]
-		isRegression, _, err := isTaskRegression(sub, task)
+		isRegression, _, err := isTaskRegression(ctx, sub, task)
 		if err != nil {
 			return nil, errors.Wrap(err, "evaluating task regression")
 		}

--- a/units/check_blocked_tasks.go
+++ b/units/check_blocked_tasks.go
@@ -162,8 +162,8 @@ func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCac
 	}
 
 	// also update the display task status in case it is out of date
-	if t.IsPartOfDisplay() {
-		catcher.Add(model.UpdateDisplayTaskForTask(t))
+	if t.IsPartOfDisplay(ctx) {
+		catcher.Add(model.UpdateDisplayTaskForTask(ctx, t))
 	}
 
 	numModified := len(finishedBlockingTasks) + len(deactivatedBlockingTasks)
@@ -172,7 +172,7 @@ func checkUnmarkedBlockingTasks(ctx context.Context, t *task.Task, dependencyCac
 		"blocking_finished_tasks_updated":    len(finishedBlockingTasks),
 		"blocking_deactivated_tasks_updated": len(deactivatedBlockingTasks),
 		"blocking_task_ids":                  blockingTaskIds,
-		"exec_task":                          t.IsPartOfDisplay(),
+		"exec_task":                          t.IsPartOfDisplay(ctx),
 		"source":                             checkBlockedTasks,
 	})
 	return catcher.Resolve()

--- a/units/crons.go
+++ b/units/crons.go
@@ -1120,7 +1120,7 @@ func podAllocatorJobs(ctx context.Context, _ evergreen.Environment, ts time.Time
 
 	remaining := settings.PodLifecycle.MaxParallelPodRequests - numInitializing
 
-	ctq, err := model.NewContainerTaskQueue()
+	ctq, err := model.NewContainerTaskQueue(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting container task queue")
 	}


### PR DESCRIPTION
DEVPROD-8478

### Description
This passes along a context to `task.FindOne` queries and all the functions that use it as well. I only did `task.FindOne` since it's a lot of small changes (adding the context everywhere) to try to reduce the PR size. 

I plan to do some more PRs for other find functions.

### Testing
Existing unit tests