### PR TITLE
DEVPROD-13370 Validate single task distros during project validation

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -794,7 +794,6 @@ buildvariants:
     run_on:
       - ubuntu2204-small
       - ubuntu2204-large
-      - aerudhoeuiedoi
     expansions:
       goos: linux
       goarch: amd64

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -794,6 +794,7 @@ buildvariants:
     run_on:
       - ubuntu2204-small
       - ubuntu2204-large
+      - aerudhoeuiedoi
     expansions:
       goos: linux
       goarch: amd64

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1016,7 +1016,7 @@ func ensureReferentialIntegrity(project *model.Project, containerNameMap map[str
 			} else if utility.StringSliceContains(singleTaskDistroIDs, name) {
 				errs = append(errs,
 					ValidationError{
-						Message: fmt.Sprintf("buildvariant '%s' references a single task distro '%s' which is not allowed for buildvariants"),
+						Message: fmt.Sprintf("buildvariant '%s' references a single task distro '%s' which is not allowed for buildvariants", buildVariant.Name, name),
 						Level:   Error,
 					},
 				)

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3147,8 +3147,10 @@ func TestCheckTaskCommands(t *testing.T) {
 
 func TestEnsureReferentialIntegrity(t *testing.T) {
 	Convey("When validating a project", t, func() {
-		distroIds := []string{"rhel55"}
+		distroIds := []string{"rhel55", "singleTaskDistro"}
 		distroAliases := []string{"rhel55-alias"}
+		singleTaskDistroIDs := []string{"singleTaskDistro"}
+		allowedSingleTaskDistroTasks := []string{"allowedSingleTask"}
 		distroWarnings := map[string]string{
 			"rhel55":       "55 is not the best number",
 			"rhel55-alias": "and this is not the best alias",
@@ -3170,7 +3172,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, nil)
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs), ShouldEqual, 1)
 		})
@@ -3189,7 +3191,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, nil), ShouldResemble,
+			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil), ShouldResemble,
 				ValidationErrors{})
 		})
 		Convey("an error should be thrown if a task references a distro has a warning", func() {
@@ -3206,7 +3208,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, distroWarnings)
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, distroWarnings)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs.AtLevel(Notice)), ShouldEqual, 1)
 			So(errs[0].Message, ShouldContainSubstring, "distro 'rhel55' with the following admin-defined warning(s): 55 is not the best number")
@@ -3226,7 +3228,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, distroWarnings)
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, distroWarnings)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs.AtLevel(Notice)), ShouldEqual, 1)
 			So(errs[0].Message, ShouldContainSubstring, "distro 'rhel55-alias' with the following admin-defined warning: and this is not the best alias")
@@ -3241,11 +3243,43 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, nil)
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs), ShouldEqual, 1)
 		})
-
+		Convey("an error should be thrown if a referenced distro for a "+
+			"task is a single task only distro and the task is not allowed", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{
+					{Name: "compile", RunOn: []string{"singleTaskDistro"}},
+				},
+				BuildVariants: []model.BuildVariant{
+					{
+						Name: "linux",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "compile", Variant: "linux", RunOn: []string{"rhel55"}},
+						},
+					},
+				},
+			}
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
+		})
+		Convey("an error should be thrown if a refrerenced distro for a "+
+			"buildvariant is a single task only distro", func() {
+			project := &model.Project{
+				BuildVariants: []model.BuildVariant{
+					{
+						Name:  "enterprise",
+						RunOn: []string{"singleTaskDistro"},
+					},
+				},
+			}
+			errs := ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
+			So(errs, ShouldNotResemble, ValidationErrors{})
+			So(len(errs), ShouldEqual, 1)
+		})
 		Convey("an error should be thrown if a referenced distro for a "+
 			"buildvariant has the same name as an existing container", func() {
 			project := &model.Project{
@@ -3259,7 +3293,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 			containerNameMap := map[string]bool{
 				"rhel55": true,
 			}
-			errs := ensureReferentialIntegrity(project, containerNameMap, distroIds, distroAliases, nil)
+			errs := ensureReferentialIntegrity(project, containerNameMap, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs), ShouldEqual, 2)
 			So(errs[0].Message, ShouldContainSubstring, "buildvariant 'enterprise' references a container name overlapping with an existing distro 'rhel55'")
@@ -3278,7 +3312,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 			containerNameMap := map[string]bool{
 				"c1": true,
 			}
-			errs := ensureReferentialIntegrity(project, containerNameMap, distroIds, distroAliases, nil)
+			errs := ensureReferentialIntegrity(project, containerNameMap, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil)
 			So(errs, ShouldNotResemble, ValidationErrors{})
 			So(len(errs), ShouldEqual, 1)
 			So(errs[0].Message, ShouldContainSubstring, "run_on cannot contain a mixture of containers and distros")
@@ -3294,7 +3328,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, nil), ShouldResemble, ValidationErrors{})
+			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil), ShouldResemble, ValidationErrors{})
 		})
 
 		Convey("no error should be thrown if a referenced distro alias for a"+
@@ -3307,7 +3341,25 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 					},
 				},
 			}
-			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, nil), ShouldResemble, ValidationErrors{})
+			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil), ShouldResemble, ValidationErrors{})
+		})
+
+		Convey("no error should be thrown if a referenced single task distro ID for a "+
+			"task is allowed to use single task distros", func() {
+			project := &model.Project{
+				Tasks: []model.ProjectTask{
+					{Name: "allowedSingleTask", RunOn: []string{"singleTaskDistro"}},
+				},
+				BuildVariants: []model.BuildVariant{
+					{
+						Name: "linux",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "compile", Variant: "linux", RunOn: []string{"rhel55"}},
+						},
+					},
+				},
+			}
+			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil), ShouldResemble, ValidationErrors{})
 		})
 	})
 }
@@ -4727,8 +4779,9 @@ func TestGetDistrosForProject(t *testing.T) {
 	}
 	require.NoError(d2.Insert(ctx))
 	d3 := distro.Distro{
-		Id:            "distro3",
-		ValidProjects: []string{"project5"},
+		Id:               "distro3",
+		ValidProjects:    []string{"project5"},
+		SingleTaskDistro: true,
 	}
 	require.NoError(d3.Insert(ctx))
 
@@ -4747,25 +4800,28 @@ func TestGetDistrosForProject(t *testing.T) {
 	assert.Contains(warnings["distro1and2-alias"], d1.WarningNote)
 	assert.Contains(warnings["distro1and2-alias"], d2.WarningNote)
 
-	ids, aliases, warnings, err = getDistrosForProject(ctx, "project1")
+	ids, aliases, singleTaskDistroIDs, warnings, err := getDistrosForProject(ctx, "project1")
 	require.NoError(err)
 	require.Len(ids, 2)
 	require.Len(warnings, 5) // Both d1 and d2 are going to match here
+	require.Len(singleTaskDistroIDs, 0)
 	assert.Contains(ids, "distro1")
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Contains(aliases, "distro1-alias")
 
 	// Only d2 is going to match here
-	ids, aliases, warnings, err = getDistrosForProject(ctx, "project3")
+	ids, aliases, singleTaskDistroIDs, warnings, err = getDistrosForProject(ctx, "project3")
 	require.NoError(err)
 	require.Len(ids, 1)
 	assert.Len(warnings, 3)
+	require.Len(singleTaskDistroIDs, 1)
 	assert.Contains(ids, "distro2")
 	assert.Contains(aliases, "distro2-alias")
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Equal(warnings[d2.Id], d2.WarningNote)
 	assert.Equal(warnings["distro2-alias"], d2.WarningNote)
 	assert.Equal(warnings["distro1and2-alias"], d2.WarningNote)
+	assert.Equal(singleTaskDistroIDs[0], "distro3")
 }
 
 func TestValidateTaskSyncCommands(t *testing.T) {
@@ -6209,7 +6265,7 @@ func TestValidateTaskGroupsInBV(t *testing.T) {
 	}
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			errs := ensureReferentialIntegrity(&testCase.project, nil, []string{}, []string{}, nil)
+			errs := ensureReferentialIntegrity(&testCase.project, nil, []string{}, []string{}, []string{}, []string{}, nil)
 			if testCase.expectErr {
 				assert.Equal(t, testCase.expectedErrMsg, errs[0].Message)
 			} else {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4766,15 +4766,15 @@ func TestGetDistrosForProject(t *testing.T) {
 	}
 	require.NoError(d1.Insert(ctx))
 	d2 := distro.Distro{
-		Id:          "distro2",
-		Aliases:     []string{"distro2-alias", "distro1and2-alias"},
-		WarningNote: "this is the warning for another distro",
+		Id:               "distro2",
+		Aliases:          []string{"distro2-alias", "distro1and2-alias"},
+		WarningNote:      "this is the warning for another distro",
+		SingleTaskDistro: true,
 	}
 	require.NoError(d2.Insert(ctx))
 	d3 := distro.Distro{
-		Id:               "distro3",
-		ValidProjects:    []string{"project5"},
-		SingleTaskDistro: true,
+		Id:            "distro3",
+		ValidProjects: []string{"project5"},
 	}
 	require.NoError(d3.Insert(ctx))
 
@@ -4797,16 +4797,17 @@ func TestGetDistrosForProject(t *testing.T) {
 	require.NoError(err)
 	require.Len(ids, 2)
 	require.Len(warnings, 5) // Both d1 and d2 are going to match here
-	require.Len(singleTaskDistroIDs, 0)
+	require.Len(singleTaskDistroIDs, 1)
 	assert.Contains(ids, "distro1")
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Contains(aliases, "distro1-alias")
+	assert.Equal(singleTaskDistroIDs[0], "distro2")
 
 	// Only d2 is going to match here
 	ids, aliases, singleTaskDistroIDs, warnings, err = getDistrosForProject(ctx, "project3")
 	require.NoError(err)
 	require.Len(ids, 1)
-	assert.Len(warnings, 3)
+	require.Len(warnings, 3)
 	require.Len(singleTaskDistroIDs, 1)
 	assert.Contains(ids, "distro2")
 	assert.Contains(aliases, "distro2-alias")
@@ -4814,7 +4815,7 @@ func TestGetDistrosForProject(t *testing.T) {
 	assert.Equal(warnings[d2.Id], d2.WarningNote)
 	assert.Equal(warnings["distro2-alias"], d2.WarningNote)
 	assert.Equal(warnings["distro1and2-alias"], d2.WarningNote)
-	assert.Equal(singleTaskDistroIDs[0], "distro3")
+	assert.Equal(singleTaskDistroIDs[0], "distro2")
 }
 
 func TestValidateTaskSyncCommands(t *testing.T) {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3150,7 +3150,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 		distroIds := []string{"rhel55", "singleTaskDistro"}
 		distroAliases := []string{"rhel55-alias"}
 		singleTaskDistroIDs := []string{"singleTaskDistro"}
-		allowedSingleTaskDistroTasks := []string{"allowedSingleTask"}
+		allowedSingleTaskDistroTasks := []string{".*SingleT.*"}
 		distroWarnings := map[string]string{
 			"rhel55":       "55 is not the best number",
 			"rhel55-alias": "and this is not the best alias",
@@ -3251,13 +3251,14 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 			"task is a single task only distro and the task is not allowed", func() {
 			project := &model.Project{
 				Tasks: []model.ProjectTask{
-					{Name: "compile", RunOn: []string{"singleTaskDistro"}},
+					{Name: "compile"},
 				},
 				BuildVariants: []model.BuildVariant{
 					{
-						Name: "linux",
+						Name:  "enterprise",
+						RunOn: []string{"rhel55"},
 						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile", Variant: "linux", RunOn: []string{"rhel55"}},
+							{Name: "compile", RunOn: []string{"singleTaskDistro"}},
 						},
 					},
 				},
@@ -3324,7 +3325,7 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 				BuildVariants: []model.BuildVariant{
 					{
 						Name:  "enterprise",
-						RunOn: distroIds,
+						RunOn: []string{"rhel55"},
 					},
 				},
 			}
@@ -3349,14 +3350,6 @@ func TestEnsureReferentialIntegrity(t *testing.T) {
 			project := &model.Project{
 				Tasks: []model.ProjectTask{
 					{Name: "allowedSingleTask", RunOn: []string{"singleTaskDistro"}},
-				},
-				BuildVariants: []model.BuildVariant{
-					{
-						Name: "linux",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "compile", Variant: "linux", RunOn: []string{"rhel55"}},
-						},
-					},
 				},
 			}
 			So(ensureReferentialIntegrity(project, nil, distroIds, distroAliases, singleTaskDistroIDs, allowedSingleTaskDistroTasks, nil), ShouldResemble, ValidationErrors{})

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4801,7 +4801,7 @@ func TestGetDistrosForProject(t *testing.T) {
 	assert.Contains(ids, "distro1")
 	assert.Contains(aliases, "distro1and2-alias")
 	assert.Contains(aliases, "distro1-alias")
-	assert.Equal(singleTaskDistroIDs[0], "distro2")
+	assert.Equal("distro2", singleTaskDistroIDs[0])
 
 	// Only d2 is going to match here
 	ids, aliases, singleTaskDistroIDs, warnings, err = getDistrosForProject(ctx, "project3")
@@ -4815,7 +4815,7 @@ func TestGetDistrosForProject(t *testing.T) {
 	assert.Equal(warnings[d2.Id], d2.WarningNote)
 	assert.Equal(warnings["distro2-alias"], d2.WarningNote)
 	assert.Equal(warnings["distro1and2-alias"], d2.WarningNote)
-	assert.Equal(singleTaskDistroIDs[0], "distro2")
+	assert.Equal("distro2", singleTaskDistroIDs[0])
 }
 
 func TestValidateTaskSyncCommands(t *testing.T) {


### PR DESCRIPTION
DEVPROD-13370

### Description
during project validation, any tasks that specify a single task distro will need to be on an allowed list or it will error

### Testing
unit testing
(e2e will be done later)