### PR TITLE
DEVPROD-9733 Add OpenAPI version to generated spec

### DIFF
--- a/scripts/prepare-swagger-push.sh
+++ b/scripts/prepare-swagger-push.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 
-# This script generates a sum of the swagger.json file for the OpenAPI spec.
+# This script prepares the swagger.json to be published. The version
+# is calculated by hashing the file and comparing it to the previous
+# version. If the file has changed, the version number is incremented.
+
+# An example usage of this script is:
+# SWAGGER_OLD_SUM_FILE=bin/swagger.sum OUTPUT_SUM_FILE=bin/swagger.sum sh prepare-swagger-push.sh
+# Note that this isn't syncing with the deployed version of our swagger generated file. This means
+# it will increment the version number if you haven't ran this script after a while and the version
+# has since been incremented.
+
 set -o errexit
 
 # Default to local development swagger.json file.
@@ -19,20 +28,21 @@ version_number=1
 # Check if the old sum file exists and read values if it does.
 if [[ -f "${SWAGGER_OLD_SUM_FILE}" ]]; then
     read old_sum old_version_number < "${SWAGGER_OLD_SUM_FILE}"
-    # Use the old version number if it exists.
     version_number="${old_version_number}"
 fi
 
-# A temporary copy is used to avoid modifying the original swagger.json file.
+# Use a temp copy to avoid modifying the original file.
 temp_swagger_json=$(mktemp)
 cp "${SWAGGER_JSON_FILE}" "${temp_swagger_json}"
+
 # Replace the version placeholder with the current version number.
-sed -i "s/{OPENAPI_VERSION}/${version_number}/g" "${temp_swagger_json}"
+perl -pi -e 's/\{OPENAPI_VERSION\}/'$version_number'/' "${temp_swagger_json}"
+
 # Generate the sum of the temporary swagger.json file.
-new_sum=$(shasum -a 256 "${temp_swagger_json}" | cut -d ' ' -f 1)
+temp_sha=$(shasum -a 256 "${temp_swagger_json}" | cut -d ' ' -f 1)
 
 # Compare checksum and update the version number if needed.
-if [[ -f "${SWAGGER_OLD_SUM_FILE}" && "${new_sum}" == "${old_sum}" ]]; then
+if [[ -f "${SWAGGER_OLD_SUM_FILE}" && "${temp_sha}" == "${old_sum}" ]]; then
     echo "The swagger.json file has not changed. Using version number ${version_number}."
 else
     # Increment the version number if sums don't match.
@@ -41,8 +51,11 @@ else
 fi
 
 # Replace the version placeholder with the new version number.
-sed -i "s/{OPENAPI_VERSION}/${version_number}/g" "${SWAGGER_JSON_FILE}"
+perl -pi -e 's/\{OPENAPI_VERSION\}/'$version_number'/' "${SWAGGER_JSON_FILE}"
+
+# Compute a new SHA with the latest version number.
+new_sha=$(shasum -a 256 "${SWAGGER_JSON_FILE}" | cut -d ' ' -f 1)
 
 # Write the new SHA and version number to the output sum file.
-echo "${new_sum} ${version_number}" > "${OUTPUT_SUM_FILE}"
+echo "${new_sha} ${version_number}" > "${OUTPUT_SUM_FILE}"
 echo "New SHA and version number saved to ${OUTPUT_SUM_FILE}."

--- a/scripts/prepare-swagger-push.sh
+++ b/scripts/prepare-swagger-push.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This script generates a sum of the swagger.json file for the OpenAPI spec.
+set -o errexit
+
+# Default to local development swagger.json file.
+if [[ "${SWAGGER_JSON_FILE}" == "" ]]; then
+    SWAGGER_JSON_FILE="bin/swagger.json"
+fi
+
+# Check if SWAGGER_JSON_FILE exists
+if [[ ! -f "${SWAGGER_JSON_FILE}" ]]; then
+    echo "Error: swagger.json file '${SWAGGER_JSON_FILE}' does not exist."
+    exit 1
+fi
+
+version_number=1
+
+# Check if the old sum file exists and read values if it does.
+if [[ -f "${SWAGGER_OLD_SUM_FILE}" ]]; then
+    read old_sum old_version_number < "${SWAGGER_OLD_SUM_FILE}"
+    # Use the old version number if it exists.
+    version_number="${old_version_number}"
+fi
+
+# A temporary copy is used to avoid modifying the original swagger.json file.
+temp_swagger_json=$(mktemp)
+cp "${SWAGGER_JSON_FILE}" "${temp_swagger_json}"
+# Replace the version placeholder with the current version number.
+sed -i "s/{OPENAPI_VERSION}/${version_number}/g" "${temp_swagger_json}"
+# Generate the sum of the temporary swagger.json file.
+new_sum=$(shasum -a 256 "${temp_swagger_json}" | cut -d ' ' -f 1)
+
+# Compare checksum and update the version number if needed.
+if [[ -f "${SWAGGER_OLD_SUM_FILE}" && "${new_sum}" == "${old_sum}" ]]; then
+    echo "The swagger.json file has not changed. Using version number ${version_number}."
+else
+    # Increment the version number if sums don't match.
+    version_number=$((version_number + 1))
+    echo "The swagger.json file has changed. Incrementing version number to ${version_number}."
+fi
+
+# Replace the version placeholder with the new version number.
+sed -i "s/{OPENAPI_VERSION}/${version_number}/g" "${SWAGGER_JSON_FILE}"
+
+# Write the new SHA and version number to the output sum file.
+echo "${new_sum} ${version_number}" > "${OUTPUT_SUM_FILE}"
+echo "New SHA and version number saved to ${OUTPUT_SUM_FILE}."

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -208,6 +208,38 @@ functions:
             make mod-tidy;
             [[ $? -eq 0 ]] && break;
           done
+  
+  generate-api-docs:
+    - command: subprocess.exec
+      params:
+        binary: make
+        args: ["swaggo-install"]
+        working_dir: evergreen
+        env:
+          GOPATH: ${workdir}/gopath
+        include_expansions_in_env:
+          - GOROOT
+    - command: shell.exec
+      params:
+        shell: bash
+        working_dir: evergreen
+        env:
+          GOPATH: ${workdir}/gopath
+        script: |
+          set -o verbose
+          set -o errexit
+          $GOPATH/bin/swag init -g service/service.go
+    - command: s3.put
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: evergreen/docs/swagger.json
+        remote_file: evergreen/${task_id}/${execution}/swagger.json
+        bucket: mciuploads
+        content_type: application/json
+        permissions: public-read
+        display_name: swagger.json
 
   assume-role:
     command: ec2.assume_role
@@ -695,38 +727,33 @@ tasks:
       - func: get-project-and-modules
       - func: verify-merge-function-update
   - name: generate-api-docs
+    patch_only: true
     commands:
       - func: get-project-and-modules
-      - command: subprocess.exec
-        params:
-          binary: make
-          args: ["swaggo-install"]
-          working_dir: evergreen
-          env:
-            GOPATH: ${workdir}/gopath
-          include_expansions_in_env:
-            - GOROOT
-      - command: shell.exec
-        params:
-          shell: bash
-          working_dir: evergreen
-          env:
-            GOPATH: ${workdir}/gopath
-          script: |
-            set -o verbose
-            set -o errexit
-            $GOPATH/bin/swag init -g service/service.go
-      - command: s3.put
+      - func: generate-api-docs
+  - name: push-api-docs
+    commands:
+      - func: get-project-and-modules
+      - func: generate-api-docs
+      - command: s3.get
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}
           aws_secret: ${AWS_SECRET_ACCESS_KEY}
           aws_session_token: ${AWS_SESSION_TOKEN}
-          local_file: evergreen/docs/swagger.json
-          remote_file: evergreen/${task_id}/${execution}/swagger.json
+          local_file: evergreen/docs/swagger.old.sum
+          remote_file: evergreen/latest/swagger.sum
           bucket: mciuploads
-          content_type: application/json
-          permissions: public-read
-          display_name: swagger.json
+          content_type: text/plain
+          optional: true
+      - command: subprocess.exec
+        params:
+          working_dir: evergreen
+          binary: bash
+          args: ["scripts/prepare-swagger-push.sh"]
+          env:
+            SWAGGER_JSON_FILE: docs/swagger.json
+            SWAGGER_OLD_SUM_FILE: docs/swagger.old.sum
+            OUTPUT_SUM_FILE: docs/swagger.sum
       - command: s3.put
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}
@@ -738,6 +765,18 @@ tasks:
           content_type: application/json
           permissions: public-read
           display_name: swagger.json (latest)
+          patchable: false
+      - command: s3.put
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_file: evergreen/docs/swagger.sum
+          remote_file: evergreen/latest/swagger.sum
+          bucket: mciuploads
+          content_type: text/plain
+          permissions: public-read
+          display_name: swagger.sum (latest)
           patchable: false
   - name: write-downstream-expansions-for-pine
     commands:
@@ -812,6 +851,7 @@ buildvariants:
       - name: test-cloud
       - name: "js-test"
       - name: generate-api-docs
+      - name: push-api-docs
       - name: write-downstream-expansions-for-pine
 
   - name: race-detector

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -209,27 +209,6 @@ functions:
             [[ $? -eq 0 ]] && break;
           done
   
-  generate-api-docs:
-    - command: subprocess.exec
-      params:
-        binary: make
-        args: ["swaggo-install"]
-        working_dir: evergreen
-        env:
-          GOPATH: ${workdir}/gopath
-        include_expansions_in_env:
-          - GOROOT
-    - command: shell.exec
-      params:
-        shell: bash
-        working_dir: evergreen
-        env:
-          GOPATH: ${workdir}/gopath
-        script: |
-          set -o verbose
-          set -o errexit
-          $GOPATH/bin/swag init -g service/service.go
-  
   assume-role:
     command: ec2.assume_role
     type: setup
@@ -718,7 +697,25 @@ tasks:
   - name: generate-api-docs
     commands:
       - func: get-project-and-modules
-      - func: generate-api-docs
+      - command: subprocess.exec
+        params:
+          binary: make
+          args: ["swaggo-install"]
+          working_dir: evergreen
+          env:
+            GOPATH: ${workdir}/gopath
+          include_expansions_in_env:
+            - GOROOT
+      - command: shell.exec
+        params:
+          shell: bash
+          working_dir: evergreen
+          env:
+            GOPATH: ${workdir}/gopath
+          script: |
+            set -o verbose
+            set -o errexit
+            $GOPATH/bin/swag init -g service/service.go
       - command: s3.get
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -230,19 +230,6 @@ functions:
           set -o errexit
           $GOPATH/bin/swag init -g service/service.go
   
-  push-api-docs-task:
-    - command: s3.put
-      params:
-        aws_key: ${AWS_ACCESS_KEY_ID}
-        aws_secret: ${AWS_SECRET_ACCESS_KEY}
-        aws_session_token: ${AWS_SESSION_TOKEN}
-        local_file: evergreen/docs/swagger.json
-        remote_file: evergreen/${task_id}/${execution}/swagger.json
-        bucket: mciuploads
-        content_type: application/json
-        permissions: public-read
-        display_name: swagger.json
-
   assume-role:
     command: ec2.assume_role
     type: setup
@@ -729,12 +716,6 @@ tasks:
       - func: get-project-and-modules
       - func: verify-merge-function-update
   - name: generate-api-docs
-    patch_only: true
-    commands:
-      - func: get-project-and-modules
-      - func: generate-api-docs
-      - func: push-api-docs-task
-  - name: push-api-docs
     commands:
       - func: get-project-and-modules
       - func: generate-api-docs
@@ -757,7 +738,17 @@ tasks:
             SWAGGER_JSON_FILE: docs/swagger.json
             SWAGGER_OLD_SUM_FILE: docs/swagger.old.sum
             OUTPUT_SUM_FILE: docs/swagger.sum
-      - func: push-api-docs-task
+      - command: s3.put
+        params:
+          aws_key: ${AWS_ACCESS_KEY_ID}
+          aws_secret: ${AWS_SECRET_ACCESS_KEY}
+          aws_session_token: ${AWS_SESSION_TOKEN}
+          local_file: evergreen/docs/swagger.json
+          remote_file: evergreen/${task_id}/${execution}/swagger.json
+          bucket: mciuploads
+          content_type: application/json
+          permissions: public-read
+          display_name: swagger.json
       - command: s3.put
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -229,6 +229,8 @@ functions:
           set -o verbose
           set -o errexit
           $GOPATH/bin/swag init -g service/service.go
+  
+  push-api-docs-task:
     - command: s3.put
       params:
         aws_key: ${AWS_ACCESS_KEY_ID}
@@ -731,6 +733,7 @@ tasks:
     commands:
       - func: get-project-and-modules
       - func: generate-api-docs
+      - func: push-api-docs-task
   - name: push-api-docs
     commands:
       - func: get-project-and-modules
@@ -754,6 +757,7 @@ tasks:
             SWAGGER_JSON_FILE: docs/swagger.json
             SWAGGER_OLD_SUM_FILE: docs/swagger.old.sum
             OUTPUT_SUM_FILE: docs/swagger.sum
+      - func: push-api-docs-task
       - command: s3.put
         params:
           aws_key: ${AWS_ACCESS_KEY_ID}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -208,7 +208,7 @@ functions:
             make mod-tidy;
             [[ $? -eq 0 ]] && break;
           done
-  
+
   assume-role:
     command: ec2.assume_role
     type: setup

--- a/service/service.go
+++ b/service/service.go
@@ -75,7 +75,8 @@ func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler,
 	// and UI endpoints. While there were no users of restv1 in
 	// with the "api" prefix, there are many users of restv2, so
 	// we will continue to publish these routes in these
-	// endpoints.
+	// endpoints. The version uses a placeholder that's computed
+	// and replaced during publishing.
 	//
 	//	@title						Evergreen REST v2 API
 	//	@version					{OPENAPI_VERSION}

--- a/service/service.go
+++ b/service/service.go
@@ -78,6 +78,7 @@ func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler,
 	// endpoints.
 	//
 	//	@title						Evergreen REST v2 API
+	//	@version					{OPENAPI_VERSION}
 	//	@host						evergreen.mongodb.com
 	//	@BasePath					/rest/v2
 	//	@accept						json


### PR DESCRIPTION
DEVPROD-9733

### Description
S&I wanted some consistent versioning for our openapi generated spec (we use swaggo/swagger). This adds a second file that keeps track of the sha256 of the swagger.json and the current version number. If the sha256 changes, the version number gets incremented by one. This means we don't use semantic versioning for our swagger.json which goes against openapi specifications- but I don't think that's worrisome since the depending service seemingly only uses the version number for reliable historic builds.

### Testing
I ran [this](https://spruce.mongodb.com/task/evergreen_ubuntu2204_push_api_docs_patch_b6d5c387fd0017ff8d0c4eee73056423cdf0cc13_67868af052e2b50007cf1822_25_01_14_16_04_08/files?execution=0) which started the versioning at 2. I ran a duplicate task [here](https://spruce.mongodb.com/task/evergreen_ubuntu2204_push_api_docs_patch_b6d5c387fd0017ff8d0c4eee73056423cdf0cc13_67868afd414a9b0007f8d524_25_01_14_16_10_11/files?execution=0) and it generated a swagger.json with `version=2` again. Then I ran a third [task](https://spruce.mongodb.com/task/evergreen_ubuntu2204_push_api_docs_patch_b6d5c387fd0017ff8d0c4eee73056423cdf0cc13_67868b1a404c4a00072996f1_25_01_14_16_11_19/files?execution=0) that changes the swagger docs to a new title, and it generated a swagger.json with `version=3`.

I also ran the script locally with simulated envs to confirm the behavior.
