### PR TITLE
DEVPROD-8740 Use newer version of Go for verify-mod-tidy task

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -684,8 +684,13 @@ tasks:
         params:
           directory: evergreen
           token: ${github_token}
-      - func: run-make
-        vars: { target: "${task_name}" }
+      - command: subprocess.exec
+        params:
+          working_dir: evergreen
+          binary: make
+          args: ["verify-mod-tidy"]
+          env:
+            GOROOT: /opt/golang/go1.23 # We use a newer version of Go to catch toolchain updates. This should be reverted in DEVPROD-3611.
   - name: verify-merge-function-update
     tags: ["linter"]
     patch_only: true


### PR DESCRIPTION
DEVPROD-8740

### Description
Because [go toolchains were added in go 1.21](https://go.dev/doc/toolchain), when our `verify-mod-tidy` task ran on `go 1.20`, it wouldn't catch PRs that update our go modfile to use packages past go version 1.20 (which would be an error in any go version).

This PR makes our mod tidy run on 1.23, to account for toolchain updates. This can be removed once we update our go version in this ticket [DEVPROD-3611](https://jira.mongodb.org/browse/DEVPROD-3611).

I created [DEVPROD-14092](https://jira.mongodb.org/browse/DEVPROD-14092) to revert this once we upgrade our go version.

### Testing
I went back to a dependabot PR that had to be reverted and ran a [patch](https://spruce.mongodb.com/version/6786b3f412a3c20007d922df/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) confirming it falsely passes. Then I ran with these changes and it correctly [fails](https://spruce.mongodb.com/version/6786b2c04ad33b00070b1490/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).
