### PR TITLE
DEVPROD-14181: Set DisplayStatusCache upon task and display task creation

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1190,6 +1190,8 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 		CachedProjectStorageMethod: creationInfo.Version.ProjectStorageMethod,
 	}
 
+	t.DisplayStatusCache = t.DetermineDisplayStatus()
+
 	if err := t.SetGenerateTasksEstimations(ctx); err != nil {
 		return nil, errors.Wrap(err, "setting generate tasks estimations")
 	}
@@ -1370,6 +1372,7 @@ func createDisplayTask(id string, creationInfo TaskCreationInfo, displayName str
 		TriggerEvent:            creationInfo.Version.TriggerEvent,
 		DisplayTaskId:           utility.ToStringPtr(""),
 	}
+	t.DisplayStatusCache = t.DetermineDisplayStatus()
 	return t, nil
 }
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -1295,10 +1295,14 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			// check the display tasks too
 			So(len(tasks), ShouldEqual, 6)
 			So(tasks[0].DisplayName, ShouldEqual, buildVar1.DisplayTasks[0].Name)
+			So(tasks[0].Status, ShouldEqual, evergreen.TaskUndispatched)
+			So(tasks[0].DisplayStatusCache, ShouldEqual, evergreen.TaskUnscheduled)
 			So(tasks[0].DisplayOnly, ShouldBeTrue)
 			So(len(tasks[0].ExecutionTasks), ShouldEqual, 2)
 			So(tasks[1].DisplayName, ShouldEqual, buildVar1.DisplayTasks[1].Name)
 			So(tasks[1].DisplayOnly, ShouldBeTrue)
+			So(tasks[1].Status, ShouldEqual, evergreen.TaskUndispatched)
+			So(tasks[1].DisplayStatusCache, ShouldEqual, evergreen.TaskUnscheduled)
 		})
 		Convey("all of the tasks created should have the dependencies"+
 			"and priorities specified in the project", func() {
@@ -1440,6 +1444,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 			So(tasks[2].BuildVariant, ShouldEqual, buildVar1.Name)
 			So(tasks[2].CreateTime.Equal(creationInfo.TaskCreateTime), ShouldBeTrue)
 			So(tasks[2].Status, ShouldEqual, evergreen.TaskUndispatched)
+			So(tasks[2].DisplayStatusCache, ShouldEqual, evergreen.TaskUnscheduled)
 			So(tasks[2].Activated, ShouldBeFalse)
 			So(tasks[2].ActivatedTime.Equal(utility.ZeroTime), ShouldBeTrue)
 			So(tasks[2].RevisionOrderNumber, ShouldEqual, build.RevisionOrderNumber)


### PR DESCRIPTION
DEVPROD-14181

### Description
Updating a task's display status works properly, but if the task (or display task) was never activated or touched again after being created, its display status is unset. Ensure that it is set upon task creation.

### Testing
Added test cases that fail without the new call to `DetermineDisplayStatus()`