### PR TITLE
DEVPROD-9444: stop storing GitHub app private key in the DB

### DIFF
--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -21,7 +21,7 @@ type GithubAppAuth struct {
 	// PrivateKey is the GitHub app's private key and is intentionally not
 	// stored in the database for security reasons. The private key can be
 	// fetched from Parameter Store using PrivateKeyParameter.
-	PrivateKey []byte `bson:"-" json:"-"`
+	PrivateKey []byte `bson:"-" json:"private_key"`
 	// PrivateKeyParameter is the name of the parameter that holds the
 	// GitHub app's private key.
 	PrivateKeyParameter string `bson:"private_key_parameter" json:"private_key_parameter"`

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -17,8 +17,11 @@ type GithubAppAuth struct {
 	// Should match the identifier of the project it refers to
 	Id string `bson:"_id" json:"_id"`
 
-	AppID      int64  `bson:"app_id" json:"app_id"`
-	PrivateKey []byte `bson:"private_key" json:"private_key"`
+	AppID int64 `bson:"app_id" json:"app_id"`
+	// PrivateKey is the GitHub app's private key and is intentionally not
+	// stored in the database for security reasons. The private key can be
+	// fetched from Parameter Store using PrivateKeyParameter.
+	PrivateKey []byte `bson:"-" json:"-"`
 	// PrivateKeyParameter is the name of the parameter that holds the
 	// GitHub app's private key.
 	PrivateKeyParameter string `bson:"private_key_parameter" json:"private_key_parameter"`

--- a/model/githubapp/github_app_auth_db.go
+++ b/model/githubapp/github_app_auth_db.go
@@ -25,7 +25,6 @@ const (
 var (
 	GhAuthIdKey                  = bsonutil.MustHaveTag(GithubAppAuth{}, "Id")
 	GhAuthAppIdKey               = bsonutil.MustHaveTag(GithubAppAuth{}, "AppID")
-	GhAuthPrivateKeyKey          = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKey")
 	GhAuthPrivateKeyParameterKey = bsonutil.MustHaveTag(GithubAppAuth{}, "PrivateKeyParameter")
 )
 
@@ -165,7 +164,6 @@ func upsertGitHubAppAuthDB(appAuth *GithubAppAuth) error {
 		bson.M{
 			"$set": bson.M{
 				GhAuthAppIdKey:               appAuth.AppID,
-				GhAuthPrivateKeyKey:          appAuth.PrivateKey,
 				GhAuthPrivateKeyParameterKey: appAuth.PrivateKeyParameter,
 			},
 		},


### PR DESCRIPTION
DEVPROD-9444

### Description
Now that all projects are using Parameter Store for GitHub app private keys, remove the BSON tags and remaining logic that sets the private key in the DB.

### Testing
Existing tests pass.