### PR TITLE
DEVPROD-9443: stop storing project vars in the DB

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -617,8 +617,8 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 	// FindAndModify is expected to return all the project's vars. However,
 	// FindAndModify only receives as input the subset of vars to be modified.
 	// Therefore, it's necessary to look up all the vars in Parameter Store
-	// after the update to ensure that the the returned project vars includes
-	// all the unmodified vars.
+	// after the update to ensure that the returned project vars includes all
+	// the unmodified vars.
 	if err := projectVars.checkAndRunParameterStoreOp(ctx, func() error {
 		projectVarsFromPS, err := projectVars.findParameterStore(ctx)
 		if err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -309,9 +309,9 @@ func UpdateProjectVars(projectId string, varsModel *restModel.APIProjectVars, ov
 	vars.Id = projectId
 
 	// Avoid accidentally overwriting private variables, for example if the GET route is used to populate PATCH.
-	for key, val := range varsModel.Vars {
+	for key, val := range vars.Vars {
 		if val == "" {
-			delete(varsModel.Vars, key)
+			delete(vars.Vars, key)
 		}
 	}
 	if overwrite {

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -142,6 +142,7 @@ func DbProjectSettingsToRestModel(settings model.ProjectSettings) (APIProjectSet
 func (p *APIProjectVars) ToService() *model.ProjectVars {
 	privateVars := map[string]bool{}
 	adminOnlyVars := map[string]bool{}
+	vars := map[string]string{}
 	// ignore false inputs
 	for key, val := range p.PrivateVars {
 		if val {
@@ -153,6 +154,9 @@ func (p *APIProjectVars) ToService() *model.ProjectVars {
 			adminOnlyVars[key] = val
 		}
 	}
+	for key, val := range p.Vars {
+		vars[key] = val
+	}
 
 	// handle UI list
 	for _, each := range p.PrivateVarsList {
@@ -162,7 +166,7 @@ func (p *APIProjectVars) ToService() *model.ProjectVars {
 		adminOnlyVars[each] = true
 	}
 	return &model.ProjectVars{
-		Vars:          p.Vars,
+		Vars:          vars,
 		AdminOnlyVars: adminOnlyVars,
 		PrivateVars:   privateVars,
 	}


### PR DESCRIPTION
DEVPROD-9443

### Description
* Stop storing project vars in the DB.
* Look up all project vars after `FindAndModify` to ensure that the project vars is populated with all the project's vars, not just the modified ones.

### Testing
Existing tests pass.
