### PR TITLE
DEVPROD-14089: fix failure metadata tags when user-defined end task response continues

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1200,7 +1200,7 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 			tc.setFailingCommand(currCmd)
 		}
 		detail.Type = failureType
-		detail.FailureMetadataTags = utility.UniqueStrings(append(currCmd.FailureMetadataTags(), failureMetadataTagsToAdd...))
+		detail.FailureMetadataTags = utility.UniqueStrings(append(tc.getFailingCommand().FailureMetadataTags(), failureMetadataTagsToAdd...))
 	}
 
 	detail.OtherFailingCommands = tc.getOtherFailingCommands()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1824,6 +1824,7 @@ tasks:
 	factory, ok := command.GetCommandFactory("command.mock")
 	s.Require().True(ok)
 	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFullDisplayName("command.mock")
 	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
 	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 
@@ -1879,6 +1880,7 @@ tasks:
 	factory, ok := command.GetCommandFactory("command.mock")
 	s.Require().True(ok)
 	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFullDisplayName("command.mock")
 	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
 	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 
@@ -1933,6 +1935,7 @@ tasks:
 	factory, ok := command.GetCommandFactory("command.mock")
 	s.Require().True(ok)
 	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFullDisplayName("command.mock")
 	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
 	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1817,8 +1817,15 @@ tasks:
       - command: shell.exec
         params:
           script: exit 0
+        failure_metadata_tags: ["failure_tag2"]
 `
 	s.setupRunTask(projYml)
+
+	factory, ok := command.GetCommandFactory("command.mock")
+	s.Require().True(ok)
+	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
+	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 
 	resp := &triggerEndTaskResp{
 		Status:                 evergreen.TaskFailed,
@@ -1826,16 +1833,9 @@ tasks:
 		Description:            "task failed",
 		AddFailureMetadataTags: []string{"failure_tag0", "failure_tag1", "failure_tag2"},
 	}
-
-	s.Nil(s.tc.userEndTaskResp)
 	s.tc.setUserEndTaskResponse(resp)
 	s.NotNil(s.tc.userEndTaskRespOriginatingCommand)
-	s.Equal("initial task setup", s.tc.userEndTaskRespOriginatingCommand.FullDisplayName())
-
-	// Set the current command to show that the command containing the user-defined resp has precedence.
-	factory, ok := command.GetCommandFactory("command.mock")
-	s.Require().True(ok)
-	s.tc.setCurrentCommand(factory())
+	s.Equal(userDefinedTaskStatusCmd.FullDisplayName(), s.tc.userEndTaskRespOriginatingCommand.FullDisplayName())
 
 	nextTask := &apimodels.NextTaskResponse{
 		TaskId:     s.tc.task.ID,
@@ -1847,8 +1847,8 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
-	s.Equal("initial task setup", s.mockCommunicator.EndTaskResult.Detail.FailingCommand, "should set the failing command's display name to the user-defined resp's originating command")
-	s.ElementsMatch([]string{"failure_tag0", "failure_tag1", "failure_tag2"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set the failing command's metadata tags along with the additional tags")
+	s.Equal(userDefinedTaskStatusCmd.FullDisplayName(), s.mockCommunicator.EndTaskResult.Detail.FailingCommand, "should set the failing command's display name to the user-defined resp's originating command")
+	s.ElementsMatch(append(userDefinedTaskStatusCmd.FailureMetadataTags(), "failure_tag0", "failure_tag1", "failure_tag2"), s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set the failing command's metadata tags along with the additional tags")
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -1872,8 +1872,15 @@ tasks:
       - command: shell.exec
         params:
           script: exit 1
+        failure_metadata_tags: ["failure_tag0"]
 `
 	s.setupRunTask(projYml)
+
+	factory, ok := command.GetCommandFactory("command.mock")
+	s.Require().True(ok)
+	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
+	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 
 	resp := &triggerEndTaskResp{
 		Status:      evergreen.TaskSucceeded,
@@ -1891,6 +1898,8 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.FailingCommand, "should not set a failing command because the task succeeded")
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should not set the failing command's metadata tags because the task succeeded")
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -1913,13 +1922,19 @@ tasks:
       - command: shell.exec
         params:
           script: exit 0
-        failure_metadata_tags: ["failure_tag1"]
+        failure_metadata_tags: ["failure_tag0"]
       - command: shell.exec
         params:
           script: exit 0
-        failure_metadata_tags: ["failure_tag2"]
+        failure_metadata_tags: ["failure_tag1"]
 `
 	s.setupRunTask(projYml)
+
+	factory, ok := command.GetCommandFactory("command.mock")
+	s.Require().True(ok)
+	userDefinedTaskStatusCmd := factory()
+	userDefinedTaskStatusCmd.SetFailureMetadataTags([]string{"user_defined_end_task_response_tag"})
+	s.tc.setCurrentCommand(userDefinedTaskStatusCmd)
 
 	resp := &triggerEndTaskResp{
 		Status:         evergreen.TaskFailed,
@@ -1927,11 +1942,6 @@ tasks:
 		Description:    "task failed",
 		ShouldContinue: true,
 	}
-	factory, ok := command.GetCommandFactory("command.mock")
-	s.Require().True(ok)
-	cmd := factory()
-	cmd.SetFailureMetadataTags([]string{"failure_tag0"})
-	s.tc.setCurrentCommand(cmd)
 	s.tc.setUserEndTaskResponse(resp)
 
 	nextTask := &apimodels.NextTaskResponse{
@@ -1944,7 +1954,7 @@ tasks:
 	s.Equal(resp.Status, s.mockCommunicator.EndTaskResult.Detail.Status, "should set user-defined task status")
 	s.Equal(resp.Type, s.mockCommunicator.EndTaskResult.Detail.Type, "should set user-defined command failure type")
 	s.Equal(resp.Description, s.mockCommunicator.EndTaskResult.Detail.Description, "should set user-defined task description")
-	s.Equal([]string{"failure_tag0"}, s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set failure metadata tags to the ones associated with the command that triggered a user-defined end task response because it caused the task to fail")
+	s.ElementsMatch(userDefinedTaskStatusCmd.FailureMetadataTags(), s.mockCommunicator.EndTaskResult.Detail.FailureMetadataTags, "should set failure metadata tags to the ones associated with the command that sets the user-defined response")
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{

--- a/agent/command/mock.go
+++ b/agent/command/mock.go
@@ -32,6 +32,8 @@ func (c *mockCommand) Execute(context.Context, client.Communicator, client.Logge
 // Name returns the value of the command's name.
 func (c *mockCommand) Name() string { return "command.mock" }
 
+func (c *mockCommand) FullDisplayName() string { return c.Name() }
+
 // ParseParams parses the parameters to the mock command, if any.
 func (c *mockCommand) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {

--- a/agent/command/mock.go
+++ b/agent/command/mock.go
@@ -32,8 +32,6 @@ func (c *mockCommand) Execute(context.Context, client.Communicator, client.Logge
 // Name returns the value of the command's name.
 func (c *mockCommand) Name() string { return "command.mock" }
 
-func (c *mockCommand) FullDisplayName() string { return c.Name() }
-
 // ParseParams parses the parameters to the mock command, if any.
 func (c *mockCommand) ParseParams(params map[string]interface{}) error {
 	if err := mapstructure.Decode(params, c); err != nil {

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -68,18 +68,6 @@ func (tc *taskContext) setPostErrored(errored bool) {
 	tc.postErrored = errored
 }
 
-func (tc *taskContext) setFailingCommand(cmd command.Command) {
-	tc.Lock()
-	defer tc.Unlock()
-	tc.failingCommand = cmd
-}
-
-func (tc *taskContext) addFailingCommand(cmd command.Command) {
-	tc.Lock()
-	defer tc.Unlock()
-	tc.otherFailingCommands = append(tc.otherFailingCommands, cmd)
-}
-
 func (tc *taskContext) addTaskCommandCleanups(cleanups []internal.CommandCleanup) {
 	tc.Lock()
 	defer tc.Unlock()
@@ -137,6 +125,24 @@ func runCommandCleanups(ctx context.Context, cleanups []internal.CommandCleanup,
 		span.End()
 	}
 	return catcher.Resolve()
+}
+
+func (tc *taskContext) setFailingCommand(cmd command.Command) {
+	tc.Lock()
+	defer tc.Unlock()
+	tc.failingCommand = cmd
+}
+
+func (tc *taskContext) getFailingCommand() command.Command {
+	tc.RLock()
+	defer tc.RUnlock()
+	return tc.failingCommand
+}
+
+func (tc *taskContext) addFailingCommand(cmd command.Command) {
+	tc.Lock()
+	defer tc.Unlock()
+	tc.otherFailingCommands = append(tc.otherFailingCommands, cmd)
 }
 
 func (tc *taskContext) getOtherFailingCommands() []apimodels.FailingCommand {

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-17-a"
+	AgentVersion = "2025-01-22"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14089

### Description
When a command manually sets the end task status to failure, the task should treat that as the failing command and include its failure metadata tags. However, it used the wrong tags if it set the task status to failure and continued on error because the failure metadata tags were taken from the last command that ran before deciding the task status, rather than from the command that set the task status.

### Testing
Improved existing unit tests.