### PR TITLE
DEVPROD-13972 Fallback to credentials for IRSA presign failures

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -550,13 +550,15 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 		if s3pc.Visibility == artifact.Signed {
 			bucket = s3pc.Bucket
 			fileKey = remoteFileName
+			// TODO (DEVPROD-13973): After verifying all added internal buckets can be signed,
+			// renable the check below.
 			// If the bucket is an internal one, Evergreen does not need the credentials
 			// to sign the URL. If the bucket is not an internal one, Evergreen needs the
 			// credentials to sign the URL.
-			if !utility.StringSliceContains(s3pc.internalBuckets, s3pc.Bucket) {
-				key = s3pc.AwsKey
-				secret = s3pc.AwsSecret
-			}
+			// if !utility.StringSliceContains(s3pc.internalBuckets, s3pc.Bucket) {
+			key = s3pc.AwsKey
+			secret = s3pc.AwsSecret
+			// }
 		}
 
 		files = append(files, &artifact.File{

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -551,7 +551,7 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 			bucket = s3pc.Bucket
 			fileKey = remoteFileName
 			// TODO (DEVPROD-13973): After verifying all added internal buckets can be signed,
-			// renable the check below.
+			// re-enable the check below.
 			// If the bucket is an internal one, Evergreen does not need the credentials
 			// to sign the URL. If the bucket is not an internal one, Evergreen needs the
 			// credentials to sign the URL.

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-22"
+	AgentVersion = "2025-01-23"
 )
 
 const (

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -2,6 +2,7 @@ package artifact
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -113,10 +115,31 @@ func presignFile(ctx context.Context, file File) (string, error) {
 
 	// If this bucket is a devprod owned one, we sign the URL
 	// with the app's server IRSA credentials (which is used
-	// when no credentials are provided).
+	// when no credentials are provided). If it fails,
+	// we fallback to using the provided credentials.
 	if isInternalBucket(file.Bucket) {
-		file.AwsKey = ""
-		file.AwsSecret = ""
+		requestParams := pail.PreSignRequestParams{
+			Bucket:                file.Bucket,
+			FileKey:               file.FileKey,
+			SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
+		}
+		presignURL, err := pail.PreSign(ctx, requestParams)
+		if err != nil {
+			return "", errors.Wrap(err, "presigning internal bucket file")
+		} else if presignURL != "" {
+			resp, err := http.Get(presignURL)
+			if err != nil || resp.StatusCode == http.StatusForbidden {
+				grip.Debug(message.Fields{
+					"message":    "presigning gave a forbidden status",
+					"error":      err,
+					"bucket":     file.Bucket,
+					"presignURL": presignURL,
+					"file_key":   file.FileKey,
+				})
+			} else if resp.StatusCode == http.StatusOK {
+				return presignURL, nil
+			}
+		}
 	}
 
 	requestParams := pail.PreSignRequestParams{


### PR DESCRIPTION
DEVPROD-13972

### Description
This makes presigning internal buckets fallback to using the stored credentials. This is temporary while I add a lot of internal buckets in future project tickets. I added some TODO's and a ticket label in the grip message.

### Testing
I ran [this task](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_s3put_private_s3put_visibility_signed.permissions_private_patch_e912fa78d2522a2bf7f99ee1ba171b36b94ae598_679260e37b3d1e00072f445a_25_01_23_15_31_58/files?execution=0) and then I manually switched the bucket to one that our IRSA doesn't have. I then checked splunk and found the corresponding [log](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3D%22evergreen-staging%22%20%20%7C%20spath%20message%20%7C%20search%20message%3D%22presigning%20gave%20a%20forbidden%20status%22&earliest=1737649343&latest=1737649353.001&workload_pool=standard_perf&sid=1737649359.15070737). It then falls back.

I since then changed it back to mciuploads and removed the keys and the file is presigned (this is checking that if it is valid, it gets used)
<img width="672" alt="Screenshot 2025-01-23 at 11 32 20 AM" src="https://github.com/user-attachments/assets/061f70fc-dc0e-466a-8301-7d753f53f7b4" />
