### PR TITLE
DEVPROD-11707: Save build variant display name with version

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1584,6 +1584,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		newBuildStatuses = append(newBuildStatuses,
 			VersionBuildStatus{
 				BuildVariant:   pair.Variant,
+				DisplayName:    build.DisplayName,
 				BuildId:        build.Id,
 				BatchTimeTasks: batchTimeTaskStatuses,
 				ActivationStatus: ActivationStatus{

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -802,7 +802,8 @@ func TestAddNewPatch(t *testing.T) {
 		Identifier: "project",
 		BuildVariants: []BuildVariant{
 			{
-				Name: "variant",
+				Name:        "variant",
+				DisplayName: "My Variant Display",
 				Tasks: []BuildVariantTaskUnit{
 					{Name: "task1", Variant: "variant"}, {Name: "task2", Variant: "variant"}, {Name: "task3", Variant: "variant"},
 				},
@@ -844,6 +845,12 @@ func TestAddNewPatch(t *testing.T) {
 	assert.NoError(err)
 	require.NotNil(t, dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
+	dbVersion, err := VersionFindOne(db.Q{})
+	assert.NoError(err)
+	require.NotNil(t, dbVersion)
+	assert.Len(dbVersion.BuildVariants, 1)
+	assert.Equal("variant", dbVersion.BuildVariants[0].BuildVariant)
+	assert.Equal("My Variant Display", dbVersion.BuildVariants[0].DisplayName)
 
 	_, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
 	assert.NoError(err)

--- a/model/version.go
+++ b/model/version.go
@@ -280,6 +280,7 @@ func (v *Version) UpdatePreGenerationProjectStorageMethod(method evergreen.Parse
 // VersionBuildStatus stores metadata relating to each build
 type VersionBuildStatus struct {
 	BuildVariant     string                `bson:"build_variant" json:"id"`
+	DisplayName      string                `bson:"display_name,omitempty" json:"display_name,omitempty"`
 	BuildId          string                `bson:"build_id,omitempty" json:"build_id,omitempty"`
 	BatchTimeTasks   []BatchTimeTaskStatus `bson:"batchtime_tasks,omitempty" json:"batchtime_tasks,omitempty"`
 	ActivationStatus `bson:",inline"`


### PR DESCRIPTION
DEVPROD-11707

### Description
To make the waterfall more functional when filters are applied that match no versions currently on the page, we'll perform a server-side query to fetch additional versions (these GraphQL query updates will be added in an upcoming PR).

This change will allow us to support querying versions by build variants without having to examine any build or task documents by adding the build variant's display name when the build variant is saved to a version's `BuildVariants` field.

### Testing
Update unit test