### PR TITLE
DEVPROD-14235 Reset remote to ssh for app tokens

### DIFF
--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -315,7 +315,10 @@ func clone(opts cloneOptions) error {
 
 		c = exec.Command("git", checkoutRetryArgs...)
 		c.Stdout, c.Stderr, c.Dir = os.Stdout, os.Stderr, opts.rootDir
-		return c.Run()
+		err = c.Run()
+		if err != nil {
+			return err
+		}
 	}
 	// Reset Git remote URL to SSH after source has been fetched
 	// because the token in the https URL will be revoked.

--- a/operations/fetch_test.go
+++ b/operations/fetch_test.go
@@ -124,7 +124,6 @@ func TestFileNameWithIndex(t *testing.T) {
 }
 
 func TestResetGitRemoteToSSH(t *testing.T) {
-
 	opts := cloneOptions{
 		owner:      "evergreen-ci",
 		repository: "sample",
@@ -135,7 +134,7 @@ func TestResetGitRemoteToSSH(t *testing.T) {
 		isAppToken: true,
 	}
 
-	assert.NoError(t, clone(opts))
+	require.NoError(t, clone(opts))
 
 	// check that the remote is reset to SSH
 	cmd := exec.Command("git", "-C", opts.rootDir, "remote", "-v")
@@ -143,6 +142,4 @@ func TestResetGitRemoteToSSH(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(output), "git@github.com:")
 	assert.NotContains(t, string(output), "https:")
-	assert.NoError(t, err)
-
 }


### PR DESCRIPTION
DEVPROD-14235

### Description
It looks like an edge case where a flaky command failing would trigger a set of commands, and then the final statement in that if block always returned the final command- ignoring the rest of the function (which just resets the remote)

### Testing
Unit test (ran [this](https://spruce.mongodb.com/version/6797d9b397a70c0007b9da19/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)). It's difficult to reproduce this, I wasn't able to. I ran a bit of windows tasks. It isn't high risk and it looks like the token that was leaked was separate from the task that it somehow picked up from somewhere else- so the task could have known to leak it. Our redaction logic doesn't extend to tokens created in tests.

I could see a ticket for adding redaction to tests but it wouldn't have prevented this and we don't have that many e2e tests. The tokens created in our tests target repositories that are public anyways- so it's not a concern.
