### PR TITLE
DEVPROD-13972 Log error when fallbacking during presigning a file

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -128,16 +128,15 @@ func presignFile(ctx context.Context, file File) (string, error) {
 			return "", errors.Wrap(err, "presigning internal bucket file")
 		}
 
-		if err := verifyPresignURL(ctx, presignURL); err != nil {
-			grip.Debug(message.Fields{
-				"message":    "presigning with IRSA failed",
-				"ticket":     "DEVPROD-13970",
-				"error":      err.Error(),
-				"bucket":     file.Bucket,
-				"presignURL": presignURL,
-				"file_key":   file.FileKey,
-			})
-		} else {
+		err = verifyPresignURL(ctx, presignURL)
+		grip.Debug(message.WrapError(err, message.Fields{
+			"message":    "presigning with IRSA failed",
+			"ticket":     "DEVPROD-13970",
+			"bucket":     file.Bucket,
+			"presignURL": presignURL,
+			"file_key":   file.FileKey,
+		}))
+		if err == nil {
 			return presignURL, nil
 		}
 	}

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -132,7 +132,7 @@ func presignFile(ctx context.Context, file File) (string, error) {
 			grip.Debug(message.Fields{
 				"message":    "presigning with IRSA failed",
 				"ticket":     "DEVPROD-13970",
-				"error":      err,
+				"error":      err.Error(),
 				"bucket":     file.Bucket,
 				"presignURL": presignURL,
 				"file_key":   file.FileKey,


### PR DESCRIPTION
DEVPROD-13972

### Description
Looking at the [splunk logs](https://mongodb.splunkcloud.com/en-US/app/search/search?display.page.search.mode=fast&dispatch.sample_ratio=1&q=search%20index%3D%22evergreen%22%20%20%7C%20spath%20message%20%7C%20search%20message%3D%22presigning%20with%20IRSA%20failed%22&earliest=-15m&latest=now&workload_pool=standard_perf&sid=1738008345.16058254), the error is never printed. I think this is because grip [doesn't handle err inside of its fields](https://github.com/mongodb/grip/blob/main/message/interface.go#L58).

The error should provide a lot of context, because the urls posted in the logs are working for me.

<img width="291" alt="Screenshot 2025-01-27 at 3 10 54 PM" src="https://github.com/user-attachments/assets/85f73d75-d062-49db-9874-eae14f631414" />
