### PR TITLE
DEVPROD-12696: Skip waterfall buildVariants pipeline if not requested

### DIFF
--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1041,19 +1041,6 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	}
 
 	waterfallVersions := groupInactiveVersions(allVersions)
-	bv := []*model.WaterfallBuildVariant{}
-
-	if len(activeVersionIds) > 0 {
-		buildVariants, err := model.GetWaterfallBuildVariants(ctx, activeVersionIds)
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting waterfall build variants: %s", err.Error()))
-		}
-
-		for _, b := range buildVariants {
-			bCopy := b
-			bv = append(bv, &bCopy)
-		}
-	}
 
 	prevPageOrder := 0
 	nextPageOrder := 0
@@ -1083,8 +1070,7 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 		flattenedVersions = append(flattenedVersions, apiVersion)
 	}
 
-	return &Waterfall{
-		BuildVariants:     bv,
+	results := &Waterfall{
 		FlattenedVersions: flattenedVersions,
 		Versions:          waterfallVersions,
 		Pagination: &WaterfallPagination{
@@ -1093,7 +1079,27 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 			HasNextPage:   nextPageOrder > 0,
 			HasPrevPage:   prevPageOrder > 0,
 		},
-	}, nil
+	}
+
+	// If buildVariants its not included in the request, skip that agg pipeline
+	if utility.StringSliceContains(graphql.CollectAllFields(ctx), "buildVariants") {
+		bv := []*model.WaterfallBuildVariant{}
+
+		if len(activeVersionIds) > 0 {
+			buildVariants, err := model.GetWaterfallBuildVariants(ctx, activeVersionIds)
+			if err != nil {
+				return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting waterfall build variants: %s", err.Error()))
+			}
+
+			for _, b := range buildVariants {
+				bCopy := b
+				bv = append(bv, &bCopy)
+			}
+		}
+		results.BuildVariants = bv
+	}
+
+	return results, nil
 }
 
 // HasVersion is the resolver for the hasVersion field.


### PR DESCRIPTION
DEVPROD-12696

### Description
Ahead of further GraphQL cache improvements to the waterfall, skip fetching version build variants and tasks if not requested in the GraphQL schema

### Testing
Existing tests pass; also ensured that negating the `if` condition caused tests to fail which means we're accurately accessing the request's fields.