### PR TITLE
DEVPROD-12696: Parallelize waterfall queries

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1629,6 +1629,7 @@ type ComplexityRoot struct {
 		UpstreamProject          func(childComplexity int) int
 		VersionTiming            func(childComplexity int) int
 		Warnings                 func(childComplexity int) int
+		WaterfallBuilds          func(childComplexity int) int
 	}
 
 	VersionTasks struct {
@@ -1666,7 +1667,6 @@ type ComplexityRoot struct {
 	}
 
 	WaterfallBuild struct {
-		Activated   func(childComplexity int) int
 		DisplayName func(childComplexity int) int
 		Id          func(childComplexity int) int
 		Tasks       func(childComplexity int) int
@@ -2087,6 +2087,7 @@ type VersionResolver interface {
 	UpstreamProject(ctx context.Context, obj *model.APIVersion) (*UpstreamProject, error)
 	VersionTiming(ctx context.Context, obj *model.APIVersion) (*VersionTiming, error)
 	Warnings(ctx context.Context, obj *model.APIVersion) ([]string, error)
+	WaterfallBuilds(ctx context.Context, obj *model.APIVersion) ([]*model1.WaterfallBuild, error)
 }
 type VolumeResolver interface {
 	Host(ctx context.Context, obj *model.APIVolume) (*model.APIHost, error)
@@ -9926,6 +9927,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Version.Warnings(childComplexity), true
 
+	case "Version.waterfallBuilds":
+		if e.complexity.Version.WaterfallBuilds == nil {
+			break
+		}
+
+		return e.complexity.Version.WaterfallBuilds(childComplexity), true
+
 	case "VersionTasks.count":
 		if e.complexity.VersionTasks.Count == nil {
 			break
@@ -10079,13 +10087,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Waterfall.Versions(childComplexity), true
-
-	case "WaterfallBuild.activated":
-		if e.complexity.WaterfallBuild.Activated == nil {
-			break
-		}
-
-		return e.complexity.WaterfallBuild.Activated(childComplexity), true
 
 	case "WaterfallBuild.displayName":
 		if e.complexity.WaterfallBuild.DisplayName == nil {
@@ -28751,6 +28752,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -28872,6 +28875,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(_ context
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -34762,6 +34767,8 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -37994,6 +38001,8 @@ func (ec *executionContext) fieldContext_Patch_versionFull(_ context.Context, fi
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -48892,6 +48901,8 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -58388,6 +58399,8 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(_ context.Context,
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -64193,6 +64206,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(_ context.Conte
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -65853,6 +65868,8 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -66138,6 +66155,8 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -66927,6 +66946,8 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -67733,6 +67754,57 @@ func (ec *executionContext) fieldContext_Version_warnings(_ context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Version_waterfallBuilds(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Version_waterfallBuilds(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Version().WaterfallBuilds(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model1.WaterfallBuild)
+	fc.Result = res
+	return ec.marshalOWaterfallBuild2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuildᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Version_waterfallBuilds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Version",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_WaterfallBuild_id(ctx, field)
+			case "displayName":
+				return ec.fieldContext_WaterfallBuild_displayName(ctx, field)
+			case "version":
+				return ec.fieldContext_WaterfallBuild_version(ctx, field)
+			case "tasks":
+				return ec.fieldContext_WaterfallBuild_tasks(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type WaterfallBuild", field.Name)
 		},
 	}
 	return fc, nil
@@ -68943,6 +69015,8 @@ func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.C
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -69043,47 +69117,6 @@ func (ec *executionContext) fieldContext_WaterfallBuild_id(_ context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _WaterfallBuild_activated(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuild) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_WaterfallBuild_activated(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Activated, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalOBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_WaterfallBuild_activated(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "WaterfallBuild",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -69318,8 +69351,6 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_builds(_ context.
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_WaterfallBuild_id(ctx, field)
-			case "activated":
-				return ec.fieldContext_WaterfallBuild_activated(ctx, field)
 			case "displayName":
 				return ec.fieldContext_WaterfallBuild_displayName(ctx, field)
 			case "version":
@@ -69931,6 +69962,8 @@ func (ec *executionContext) fieldContext_WaterfallVersion_inactiveVersions(_ con
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -70052,6 +70085,8 @@ func (ec *executionContext) fieldContext_WaterfallVersion_version(_ context.Cont
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
 				return ec.fieldContext_Version_warnings(ctx, field)
+			case "waterfallBuilds":
+				return ec.fieldContext_Version_waterfallBuilds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Version", field.Name)
 		},
@@ -93012,6 +93047,39 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "waterfallBuilds":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_waterfallBuilds(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -93310,8 +93378,6 @@ func (ec *executionContext) _WaterfallBuild(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "activated":
-			out.Values[i] = ec._WaterfallBuild_activated(ctx, field, obj)
 		case "displayName":
 			out.Values[i] = ec._WaterfallBuild_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -98838,6 +98904,16 @@ func (ec *executionContext) marshalNWaterfallBuild2ᚕgithubᚗcomᚋevergreen�
 	return ret
 }
 
+func (ec *executionContext) marshalNWaterfallBuild2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuild(ctx context.Context, sel ast.SelectionSet, v *model1.WaterfallBuild) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._WaterfallBuild(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNWaterfallBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.WaterfallBuildVariant) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -101977,6 +102053,53 @@ func (ec *executionContext) marshalOVolume2ᚖgithubᚗcomᚋevergreenᚑciᚋev
 		return graphql.Null
 	}
 	return ec._Volume(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOWaterfallBuild2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuildᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.WaterfallBuild) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNWaterfallBuild2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐWaterfallBuild(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOWebhookInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIWebHook(ctx context.Context, v interface{}) (model.APIWebHook, error) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1667,10 +1667,11 @@ type ComplexityRoot struct {
 	}
 
 	WaterfallBuild struct {
-		DisplayName func(childComplexity int) int
-		Id          func(childComplexity int) int
-		Tasks       func(childComplexity int) int
-		Version     func(childComplexity int) int
+		BuildVariant func(childComplexity int) int
+		DisplayName  func(childComplexity int) int
+		Id           func(childComplexity int) int
+		Tasks        func(childComplexity int) int
+		Version      func(childComplexity int) int
 	}
 
 	WaterfallBuildVariant struct {
@@ -10087,6 +10088,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Waterfall.Versions(childComplexity), true
+
+	case "WaterfallBuild.buildVariant":
+		if e.complexity.WaterfallBuild.BuildVariant == nil {
+			break
+		}
+
+		return e.complexity.WaterfallBuild.BuildVariant(childComplexity), true
 
 	case "WaterfallBuild.displayName":
 		if e.complexity.WaterfallBuild.DisplayName == nil {
@@ -67797,6 +67805,8 @@ func (ec *executionContext) fieldContext_Version_waterfallBuilds(_ context.Conte
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_WaterfallBuild_id(ctx, field)
+			case "buildVariant":
+				return ec.fieldContext_WaterfallBuild_buildVariant(ctx, field)
 			case "displayName":
 				return ec.fieldContext_WaterfallBuild_displayName(ctx, field)
 			case "version":
@@ -69122,6 +69132,50 @@ func (ec *executionContext) fieldContext_WaterfallBuild_id(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _WaterfallBuild_buildVariant(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuild) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WaterfallBuild_buildVariant(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BuildVariant, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WaterfallBuild_buildVariant(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WaterfallBuild",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _WaterfallBuild_displayName(ctx context.Context, field graphql.CollectedField, obj *model1.WaterfallBuild) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_WaterfallBuild_displayName(ctx, field)
 	if err != nil {
@@ -69351,6 +69405,8 @@ func (ec *executionContext) fieldContext_WaterfallBuildVariant_builds(_ context.
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_WaterfallBuild_id(ctx, field)
+			case "buildVariant":
+				return ec.fieldContext_WaterfallBuild_buildVariant(ctx, field)
 			case "displayName":
 				return ec.fieldContext_WaterfallBuild_displayName(ctx, field)
 			case "version":
@@ -93375,6 +93431,11 @@ func (ec *executionContext) _WaterfallBuild(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("WaterfallBuild")
 		case "id":
 			out.Values[i] = ec._WaterfallBuild_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "buildVariant":
+			out.Values[i] = ec._WaterfallBuild_buildVariant(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -74,6 +74,7 @@ type Version {
   upstreamProject: UpstreamProject
   versionTiming: VersionTiming
   warnings: [String!]!
+  waterfallBuilds: [WaterfallBuild!]
 }
 
 type VersionTasks {

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -21,6 +21,7 @@ type WaterfallTask {
 
 type WaterfallBuild {
   id: String!
+  buildVariant: String!
   displayName: String!
   version: String!
   tasks: [WaterfallTask!]!

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -21,7 +21,6 @@ type WaterfallTask {
 
 type WaterfallBuild {
   id: String!
-  activated: Boolean
   displayName: String!
   version: String!
   tasks: [WaterfallTask!]!

--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -24,11 +24,6 @@
       "order": 40,
       "create_time": {
         "$date": "2019-12-31T00:00:03Z"
-      },
-      "build_variants_status": {
-        "activated": false,
-        "build_id": "evergreen_version1_build",
-        "build_variant": "enterprise-ubuntu1604-64"
       }
     },
     {
@@ -47,7 +42,10 @@
         "activated": true,
         "build_id": "evergreen_version1_build",
         "build_variant": "enterprise-ubuntu1604-64"
-      }
+      },
+      "builds": [
+        "evergreen_version1_build"
+      ]
     },
     {
       "_id": "evergreen_version2",
@@ -65,7 +63,10 @@
         "activated": true,
         "build_id": "evergreen_version2_build",
         "build_variant": "enterprise-ubuntu1604-64"
-      }
+      },
+      "builds": [
+        "evergreen_version2_build"
+      ]
     },
     {
       "_id": "evergreen_version3",
@@ -109,7 +110,10 @@
       "order": 45,
       "create_time": {
         "$date": "2020-01-05T12:00:00Z"
-      }
+      },
+      "builds": [
+        "evergreen_version3_build"
+      ]
     },
     {
       "_id": "inactive1",

--- a/graphql/tests/query/waterfall/queries/no_filters.graphql
+++ b/graphql/tests/query/waterfall/queries/no_filters.graphql
@@ -2,7 +2,6 @@
   waterfall(options: { projectIdentifier: "spruce-identifier" }) {
     buildVariants {
       builds {
-        activated
         id
         tasks {
           id

--- a/graphql/tests/query/waterfall/queries/waterfall_builds.graphql
+++ b/graphql/tests/query/waterfall/queries/waterfall_builds.graphql
@@ -1,0 +1,17 @@
+{
+  waterfall(options: { projectIdentifier: "spruce-identifier" }) {
+    flattenedVersions {
+      id
+      waterfallBuilds {
+        buildVariant
+        id
+        displayName
+        version
+        tasks {
+          id
+          displayName
+        }
+      }
+    }
+  }
+}

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -11,7 +11,6 @@
                 "displayName": "01 Ubuntu 16.04",
                 "builds": [
                   {
-                    "activated": true,
                     "id": "evergreen_version1_build",
                     "tasks": [
                       {
@@ -32,7 +31,6 @@
                     "version": "evergreen_version1"
                   },
                   {
-                    "activated": true,
                     "id": "evergreen_version2_build",
                     "tasks": [
                       {
@@ -57,7 +55,6 @@
               {
                 "builds": [
                   {
-                    "activated": true,
                     "id": "evergreen_version3_build",
                     "tasks": [
                       {
@@ -650,6 +647,92 @@
               "nextPageOrder": 0,
               "prevPageOrder": 0
             }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "waterfall_builds.graphql",
+      "result": {
+        "data": {
+          "waterfall": {
+            "flattenedVersions": [
+              {
+                "id": "evergreen_version5",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version3_build",
+                    "buildVariant": "lint",
+                    "displayName": "03 Linter",
+                    "tasks": [
+                      {
+                        "id": "task_5",
+                        "displayName": "Task Number 5"
+                      }
+                    ],
+                    "version": "evergreen_version5"
+                  }
+                ]
+              },
+              {
+                "id": "evergreen_version4",
+                "waterfallBuilds": null
+              },
+              {
+                "id": "evergreen_version3",
+                "waterfallBuilds": []
+              },
+              {
+                "id": "evergreen_version2",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version2_build",
+                    "buildVariant": "enterprise-ubuntu1604-64",
+                    "displayName": "02 Ubuntu 16.04",
+                    "tasks": [
+                      {
+                        "id": "task_3",
+                        "displayName": "Some Task"
+                      },
+                      {
+                        "id": "task_4",
+                        "displayName": "Some Other Task"
+                      }
+                    ],
+                    "version": "evergreen_version2"
+                  }
+                ]
+              },
+              {
+                "id": "evergreen_version1",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version1_build",
+                    "buildVariant": "enterprise-ubuntu1604-64",
+                    "displayName": "01 Ubuntu 16.04",
+                    "tasks": [
+                      {
+                        "id": "task_1",
+                        "displayName": "Some Task"
+                      },
+                      {
+                        "id": "task_2",
+                        "displayName": "Some Other Task"
+                      }
+                    ],
+                    "version": "evergreen_version1"
+                  }
+                ]
+              },
+              {
+                "id": "evergreen_version0",
+                "waterfallBuilds": null
+              },
+              {
+                "id": "evergreen_version39",
+                "waterfallBuilds": []
+              }
+            ]
           }
         }
       }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -521,17 +521,6 @@ func (r *versionResolver) Warnings(ctx context.Context, obj *restModel.APIVersio
 // WaterfallBuilds is the resolver for the waterfallBuilds field.
 func (r *versionResolver) WaterfallBuilds(ctx context.Context, obj *restModel.APIVersion) ([]*model.WaterfallBuild, error) {
 	versionId := utility.FromStringPtr(obj.Id)
-	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
-	if obj.Activated == nil {
-		version, err := model.VersionFindOne(model.VersionById(versionId))
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionId, err.Error()))
-		}
-		if err = setVersionActivationStatus(ctx, version); err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("setting version activation status: %s", err.Error()))
-		}
-		obj.Activated = version.Activated
-	}
 
 	// No need to fetch build variants for unactivated versions
 	if !utility.FromBoolPtr(obj.Activated) {

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -522,7 +522,6 @@ func (r *versionResolver) Warnings(ctx context.Context, obj *restModel.APIVersio
 func (r *versionResolver) WaterfallBuilds(ctx context.Context, obj *restModel.APIVersion) ([]*model.WaterfallBuild, error) {
 	versionId := utility.FromStringPtr(obj.Id)
 	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
-	// TODO: Extract util function for buildVariants resolver to use as well
 	if obj.Activated == nil {
 		version, err := model.VersionFindOne(model.VersionById(versionId))
 		if err != nil {

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -518,6 +518,40 @@ func (r *versionResolver) Warnings(ctx context.Context, obj *restModel.APIVersio
 	return v.Warnings, nil
 }
 
+// WaterfallBuilds is the resolver for the waterfallBuilds field.
+func (r *versionResolver) WaterfallBuilds(ctx context.Context, obj *restModel.APIVersion) ([]*model.WaterfallBuild, error) {
+	versionId := utility.FromStringPtr(obj.Id)
+	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
+	// TODO: Extract util function for buildVariants resolver to use as well
+	if obj.Activated == nil {
+		version, err := model.VersionFindOne(model.VersionById(versionId))
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionId, err.Error()))
+		}
+		if err = setVersionActivationStatus(ctx, version); err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("setting version activation status: %s", err.Error()))
+		}
+		obj.Activated = version.Activated
+	}
+
+	// No need to fetch build variants for unactivated versions
+	if !utility.FromBoolPtr(obj.Activated) {
+		return nil, nil
+	}
+
+	versionBuilds := []*model.WaterfallBuild{}
+	builds, err := model.GetVersionBuilds(ctx, versionId)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting version build variants: %s", err.Error()))
+	}
+
+	for _, b := range builds {
+		bCopy := b
+		versionBuilds = append(versionBuilds, &bCopy)
+	}
+	return versionBuilds, nil
+}
+
 // Version returns VersionResolver implementation.
 func (r *Resolver) Version() VersionResolver { return &versionResolver{r} }
 

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -29,10 +29,11 @@ type WaterfallTask struct {
 }
 
 type WaterfallBuild struct {
-	Id          string          `bson:"_id" json:"_id"`
-	DisplayName string          `bson:"display_name" json:"display_name"`
-	Version     string          `bson:"version" json:"version"`
-	Tasks       []WaterfallTask `bson:"tasks" json:"tasks"`
+	Id           string          `bson:"_id" json:"_id"`
+	BuildVariant string          `bson:"build_variant" json:"build_variant"`
+	DisplayName  string          `bson:"display_name" json:"display_name"`
+	Version      string          `bson:"version" json:"version"`
+	Tasks        []WaterfallTask `bson:"tasks" json:"tasks"`
 }
 
 type WaterfallBuildVariant struct {
@@ -229,6 +230,9 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 		"$project": bson.M{
 			build.VersionKey: bson.M{
 				"$first": "$" + bsonutil.GetDottedKeyName(buildsKey, build.VersionKey),
+			},
+			build.BuildVariantKey: bson.M{
+				"$first": "$" + bsonutil.GetDottedKeyName(buildsKey, build.BuildVariantKey),
 			},
 			build.DisplayNameKey: bson.M{
 				"$first": "$" + bsonutil.GetDottedKeyName(buildsKey, build.DisplayNameKey),

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -10,9 +10,11 @@ import (
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
+	buildsKey                    = "builds"
 	DefaultWaterfallQueryCount   = 20
 	DefaultWaterfallVersionLimit = 5
 	MaxWaterfallVersionLimit     = 300
@@ -28,7 +30,6 @@ type WaterfallTask struct {
 
 type WaterfallBuild struct {
 	Id          string          `bson:"_id" json:"_id"`
-	Activated   bool            `bson:"activated" json:"activated"`
 	DisplayName string          `bson:"display_name" json:"display_name"`
 	Version     string          `bson:"version" json:"version"`
 	Tasks       []WaterfallTask `bson:"tasks" json:"tasks"`
@@ -144,8 +145,59 @@ func GetAllWaterfallVersions(ctx context.Context, projectId string, minOrder int
 	return res, nil
 }
 
+func getVersionTasksPipeline() []bson.M {
+	return []bson.M{
+		bson.M{
+			"$lookup": bson.M{
+				"from":         build.Collection,
+				"localField":   buildsKey,
+				"foreignField": build.IdKey,
+				"as":           buildsKey,
+			},
+		},
+		bson.M{
+			"$unwind": bson.M{
+				"path": "$" + buildsKey,
+			},
+		},
+		// Join all tasks that appear in the build's task cache and overwrite the list of task IDs with partial task documents
+		bson.M{
+			"$lookup": bson.M{
+				"from":         task.Collection,
+				"localField":   bsonutil.GetDottedKeyName(buildsKey, build.TasksKey, build.TaskCacheIdKey),
+				"foreignField": task.IdKey,
+				"pipeline": []bson.M{
+					{
+						"$match": bson.M{
+							task.RequesterKey: bson.M{
+								"$in": evergreen.SystemVersionRequesterTypes,
+							},
+						},
+					},
+					{
+						"$sort": bson.M{task.IdKey: 1},
+					},
+					// The following projection should exactly match the index on the tasks collection in order to function as a covered query
+					{
+						"$project": bson.M{
+							task.IdKey:                 1,
+							task.DisplayNameKey:        1,
+							task.DisplayStatusCacheKey: 1,
+							task.ExecutionKey:          1,
+							task.StatusKey:             1,
+						},
+					},
+				},
+				"as": bsonutil.GetDottedKeyName(buildsKey, build.TasksKey),
+			},
+		},
+	}
+}
+
 // GetWaterfallBuildVariants returns all build variants associated with the specified versions. Each build variant contains an array of builds sorted by revision and their tasks.
 func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]WaterfallBuildVariant, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetWaterfallBuildVariants")})
+
 	if len(versionIds) == 0 {
 		return nil, errors.Errorf("no version IDs specified")
 	}
@@ -154,55 +206,15 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{VersionRevisionOrderNumberKey: -1}})
 
 	pipeline = append(pipeline, bson.M{"$unwind": bson.M{"path": "$" + VersionBuildVariantsKey}})
-	buildsKey := "builds"
 	pipeline = append(pipeline, bson.M{
 		"$group": bson.M{
 			"_id": "$" + bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusVariantKey),
-			buildsKey: bson.M{
+			VersionBuildIdsKey: bson.M{
 				"$push": "$" + bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusIdKey),
 			},
 		},
 	})
-	pipeline = append(pipeline, bson.M{
-		"$lookup": bson.M{
-			"from":         build.Collection,
-			"localField":   buildsKey,
-			"foreignField": build.IdKey,
-			"as":           buildsKey,
-		},
-	})
-	pipeline = append(pipeline, bson.M{"$unwind": bson.M{"path": "$" + buildsKey}})
-
-	// Join all tasks that appear in the build's task cache and overwrite the list of task IDs with partial task documents
-	pipeline = append(pipeline, bson.M{"$lookup": bson.M{
-		"from":         task.Collection,
-		"localField":   bsonutil.GetDottedKeyName(buildsKey, build.TasksKey, build.TaskCacheIdKey),
-		"foreignField": task.IdKey,
-		"pipeline": []bson.M{
-			{
-				"$match": bson.M{
-					task.RequesterKey: bson.M{
-						"$in": evergreen.SystemVersionRequesterTypes,
-					},
-				},
-			},
-			{
-				"$sort": bson.M{task.IdKey: 1},
-			},
-			// The following projection should exactly match the index on the tasks collection in order to function as a covered query
-			{
-				"$project": bson.M{
-					task.IdKey:                 1,
-					task.DisplayNameKey:        1,
-					task.DisplayStatusCacheKey: 1,
-					task.ExecutionKey:          1,
-					task.StatusKey:             1,
-				},
-			},
-		},
-		"as": bsonutil.GetDottedKeyName(buildsKey, build.TasksKey),
-	},
-	})
+	pipeline = append(pipeline, getVersionTasksPipeline()...)
 	// Sorting builds here guarantees a consistent order in the subsequent $group stage
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{bsonutil.GetDottedKeyName(buildsKey, build.RevisionOrderNumberKey): -1}})
 	pipeline = append(pipeline, bson.M{
@@ -231,6 +243,36 @@ func GetWaterfallBuildVariants(ctx context.Context, versionIds []string) ([]Wate
 	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating versions")
+	}
+	if err = cursor.All(ctx, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// GetVersionBuilds returns a list of builds with populated tasks for a given version.
+func GetVersionBuilds(ctx context.Context, versionId string) ([]WaterfallBuild, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetVersionBuilds")})
+
+	pipeline := []bson.M{{"$match": bson.M{VersionIdKey: versionId}}}
+	pipeline = append(pipeline, getVersionTasksPipeline()...)
+	pipeline = append(pipeline, bson.M{
+		"$replaceRoot": bson.M{
+			"newRoot": "$" + buildsKey,
+		},
+	})
+	pipeline = append(pipeline, bson.M{
+		"$sort": bson.M{
+			build.DisplayNameKey: 1,
+		},
+	})
+
+	res := []WaterfallBuild{}
+	env := evergreen.GetEnvironment()
+	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "aggregating version builds")
 	}
 	if err = cursor.All(ctx, &res); err != nil {
 		return nil, err


### PR DESCRIPTION
DEVPROD-12696

### Description
The waterfall schema currently returns versions separately from the page's build variants. This was a helpful schema for rendering the page easily, but limited how much we could leverage parallelization and Apollo caching.

I've added a field within the `Version` type that returns all of the builds and tasks for that version. This means that instead of one large query, there are several that run in parallel. The new pipeline reuses a large chunk of the old one so it's pretty well tested. Though organizing the builds into build variants now needs to be done on the client side, performance overall should be faster.

### Testing
Added unit tests

On [Honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/jx958rsSD2s/trace/cLbdAWcWwAB?fields[]=s_name&fields[]=s_serviceName&span=bc6d15b05cd7cadc), you can see that `Version/waterfallBuilds` runs a lot faster than the existing `Version/buildVariants` query. I'm excited to see how this scales on prod data vs the current aggregation.