### PR TITLE
DEVPROD-13976 Add otel to presign file func

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -30,12 +30,13 @@ const (
 )
 
 var (
-	fileNameAttribute       = fmt.Sprintf("%s.file_name", artifactFileAttribute)
-	bucketAttribute         = fmt.Sprintf("%s.bucket", artifactFileAttribute)
-	internalBucketAttribute = fmt.Sprintf("%s.internal_bucket", artifactFileAttribute)
-	fileKeyAttribute        = fmt.Sprintf("%s.file_key", artifactFileAttribute)
-	errorAttribute          = fmt.Sprintf("%s.error", artifactFileAttribute)
-	irsaErrorAttribute      = fmt.Sprintf("%s.irsa_error", artifactFileAttribute)
+	fileNameAttribute         = fmt.Sprintf("%s.file_name", artifactFileAttribute)
+	bucketAttribute           = fmt.Sprintf("%s.bucket", artifactFileAttribute)
+	internalBucketAttribute   = fmt.Sprintf("%s.internal_bucket", artifactFileAttribute)
+	fileKeyAttribute          = fmt.Sprintf("%s.file_key", artifactFileAttribute)
+	errorAttribute            = fmt.Sprintf("%s.error", artifactFileAttribute)
+	irsaErrorAttribute        = fmt.Sprintf("%s.irsa_error", artifactFileAttribute)
+	contextCancelledAttribute = fmt.Sprintf("%s.context_cancelled", artifactFileAttribute)
 )
 
 var ValidVisibilities = []string{Public, Private, None, Signed, ""}
@@ -153,6 +154,7 @@ func presignFile(ctx context.Context, file File) (string, error) {
 			return "", err
 		}
 		if err := verifyPresignURL(ctx, presignURL); err != nil {
+			span.SetAttributes(attribute.Bool(contextCancelledAttribute, errors.Is(err, context.Canceled)))
 			span.SetAttributes(attribute.String(irsaErrorAttribute, err.Error()))
 		} else {
 			return presignURL, nil

--- a/model/artifact/otel.go
+++ b/model/artifact/otel.go
@@ -1,0 +1,12 @@
+package artifact
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/model/artifact")
+
+var tracer = otel.GetTracerProvider().Tracer(packageName)


### PR DESCRIPTION
DEVPROD-13976

### Description
I originally added splunk logs and with the limited logs I got, the error trace is a cancelled context. I thought it might be the get requests taking long on verifying the presigned urls, so I ran a local example with the url- it was extremely fast. This probably means that some code is cancelling the context (or giving a cancelled context). This honeycomb tracing will help diagnose what is doing it.

### Testing
Staging task produced [this honeycomb query](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/ykrKQWUZomX/trace/vo6xFscXm3B?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=1128719cc73cc4e6).
