### PR TITLE
DEVPROD-9149 Create manifest in periodic build job

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -416,7 +416,7 @@ which git revisions are being used. If no modules have been defined, the
 For mainline commits and [trigger versions](Project-and-Distro-Settings#project-triggers), a new 
 manifest will be created that uses the latest revision available for each module.
 
-For manual patches, GitHub PRs and periodic builds, by default, the git revisions in the
+For manual patches, GitHub PRs, and periodic builds, by default, the git revisions in the
 version manifest will be inherited from its base version (i.e. the mainline commit version of the patch's base git revision). 
 You can change the git revision for modules by setting a module manually with 
 [evergreen set-module](../CLI/#operating-on-existing-patches) or

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -416,7 +416,7 @@ which git revisions are being used. If no modules have been defined, the
 For mainline commits and [trigger versions](Project-and-Distro-Settings#project-triggers), a new 
 manifest will be created that uses the latest revision available for each module.
 
-For manual patches and GitHub PRs, by default, the git revisions in the
+For manual patches, GitHub PRs and periodic builds, by default, the git revisions in the
 version manifest will be inherited from its base version (i.e. the mainline commit version of the patch's base git revision). 
 You can change the git revision for modules by setting a module manually with 
 [evergreen set-module](../CLI/#operating-on-existing-patches) or
@@ -463,7 +463,7 @@ Fields:
     not specified, defaults to the latest revision that existed at the
     time of the Evergreen version creation)
 -   `auto_update`: if true, the latest revision for the module will be
-    dynamically retrieved for each Github PR and CLI patch submission
+    dynamically retrieved for each Github PR, CLI patch, and periodic build submission
 
 ### Pre and Post
 

--- a/model/version.go
+++ b/model/version.go
@@ -842,7 +842,7 @@ func getManifestModule(v *Version, projectRef *ProjectRef, module Module) (*mani
 }
 
 // CreateManifest inserts a newly constructed manifest into the DB.
-func CreateManifest(v *Version, modules ModuleList, projectRef *ProjectRef, settings *evergreen.Settings) (*manifest.Manifest, error) {
+func CreateManifest(v *Version, modules ModuleList, projectRef *ProjectRef) (*manifest.Manifest, error) {
 	newManifest, err := constructManifest(v, projectRef, modules)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing manifest")

--- a/model/version.go
+++ b/model/version.go
@@ -752,7 +752,7 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 
 	var baseManifest *manifest.Manifest
 	isPatch := utility.StringSliceContains(evergreen.PatchRequesters, v.Requester)
-	if isPatch {
+	if isPatch || v.Requester == evergreen.AdHocRequester {
 		baseManifest, err = manifest.FindFromVersion(v.Id, v.Identifier, v.Revision, v.Requester)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting base manifest")

--- a/model/version.go
+++ b/model/version.go
@@ -751,8 +751,8 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 	}
 
 	var baseManifest *manifest.Manifest
-	isPatch := utility.StringSliceContains(evergreen.PatchRequesters, v.Requester)
-	if isPatch || v.Requester == evergreen.AdHocRequester {
+	shouldUseBaseRevision := utility.StringSliceContains(evergreen.PatchRequesters, v.Requester) || v.Requester == evergreen.AdHocRequester
+	if shouldUseBaseRevision {
 		baseManifest, err = manifest.FindFromVersion(v.Id, v.Identifier, v.Revision, v.Requester)
 		if err != nil {
 			return nil, errors.Wrap(err, "getting base manifest")
@@ -761,7 +761,7 @@ func constructManifest(v *Version, projectRef *ProjectRef, moduleList ModuleList
 
 	modules := map[string]*manifest.Module{}
 	for _, module := range moduleList {
-		if isPatch && !module.AutoUpdate && baseManifest != nil {
+		if shouldUseBaseRevision && !module.AutoUpdate && baseManifest != nil {
 			if baseModule, ok := baseManifest.Modules[module.Name]; ok {
 				modules[module.Name] = baseModule
 				continue

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -363,7 +363,7 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			}
 		}
 
-		_, err = model.CreateManifest(v, pInfo.Project.Modules, ref, repoTracker.Settings)
+		_, err = model.CreateManifest(v, pInfo.Project.Modules, ref)
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":            "error creating manifest",

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1630,8 +1630,6 @@ tasks:
 
 func TestCreateManifest(t *testing.T) {
 	assert := assert.New(t)
-	settings := testutil.TestConfig()
-	testutil.ConfigureIntegrationTest(t, settings)
 	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection, model.ProjectVarsCollection), fakeparameter.Collection)
 	// with a revision from 5/31/15
 	v := model.Version{
@@ -1676,7 +1674,7 @@ func TestCreateManifest(t *testing.T) {
 	}
 	require.NoError(t, projVars.Insert())
 
-	manifest, err := model.CreateManifest(&v, proj.Modules, projRef, settings)
+	manifest, err := model.CreateManifest(&v, proj.Modules, projRef)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1689,7 +1687,7 @@ func TestCreateManifest(t *testing.T) {
 	assert.Equal("b27779f856b211ffaf97cbc124b7082a20ea8bc0", module.Revision)
 
 	proj.Modules[0].AutoUpdate = true
-	manifest, err = model.CreateManifest(&patchVersion, proj.Modules, projRef, settings)
+	manifest, err = model.CreateManifest(&patchVersion, proj.Modules, projRef)
 	assert.NoError(err)
 	assert.Equal(patchVersion.Id, manifest.Id)
 	assert.Equal(patchVersion.Revision, manifest.Revision)
@@ -1716,7 +1714,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef)
 	assert.NoError(err)
 	assert.Equal(v.Id, manifest.Id)
 	assert.Equal(v.Revision, manifest.Revision)
@@ -1741,7 +1739,7 @@ func TestCreateManifest(t *testing.T) {
 			},
 		},
 	}
-	manifest, err = model.CreateManifest(&v, proj.Modules, projRef, settings)
+	manifest, err = model.CreateManifest(&v, proj.Modules, projRef)
 	assert.Contains(err.Error(), "No commit found for SHA")
 }
 

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1630,6 +1630,8 @@ tasks:
 
 func TestCreateManifest(t *testing.T) {
 	assert := assert.New(t)
+	settings := testutil.TestConfig()
+	testutil.ConfigureIntegrationTest(t, settings)
 	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection, model.ProjectVarsCollection), fakeparameter.Collection)
 	// with a revision from 5/31/15
 	v := model.Version{

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1246,7 +1246,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// attempt to insert a manifest after making GitHub API calls
-	manifest, err := model.CreateManifest(v, project.Modules, projectRef, h.settings)
+	manifest, err := model.CreateManifest(v, project.Modules, projectRef)
 	if err != nil {
 		if apiErr, ok := errors.Cause(err).(thirdparty.APIRequestError); ok && apiErr.StatusCode == http.StatusNotFound {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "manifest resource not found"))

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -3,7 +3,6 @@ package trigger
 import (
 	"context"
 
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/repotracker"
@@ -46,10 +45,6 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 			return nil, err
 		}
 	}
-	settings, err := evergreen.GetConfig(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting Evergreen settings")
-	}
 	// Since push triggers have no source version (unlike build and task level triggers), we need to
 	// extract the project ID from the trigger definition's project ID, which is populated in the TriggerID field
 	// for push triggers.
@@ -78,7 +73,7 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 			if args.TriggerType == model.ProjectTriggerLevelPush {
 				moduleList[i].Ref = metadata.SourceCommit
 			}
-			_, err = model.CreateManifest(v, moduleList, projectInfo.Ref, settings)
+			_, err = model.CreateManifest(v, moduleList, projectInfo.Ref)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -196,5 +196,18 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, metadata model.Versio
 	if v == nil {
 		return errors.New("no version created")
 	}
+
+	_, err = model.CreateManifest(v, projectInfo.Project.Modules, projectInfo.Ref)
+	if err != nil {
+		grip.Error(message.WrapError(err, message.Fields{
+			"message":               "error creating manifest",
+			"runner":                periodicBuildJobName,
+			"project":               j.project.Id,
+			"project_identifier":    j.project.Identifier,
+			"revision":              metadata.Revision.Revision,
+			"revision_order_number": v.RevisionOrderNumber,
+		}))
+		return errors.Wrap(err, "creating manifest")
+	}
 	return nil
 }


### PR DESCRIPTION
DEVPROD-9149

### Description
A user was reporting an old module revision being used rather than the latest. This is because we don't insert a manifest during our periodic build job and the base commit's manifest is used instead. This inserts a manifest for the periodic build job.

### Testing
I simulated the situation with the commit queue repository and github merge queue repository (which I'll reference as CQ and GM respectively).
1. For the CQ repo, I added GM as a module (via a commit).
2. I added a periodic build in CQ.
3. I did a [fresh commit](https://github.com/evergreen-ci/github-merge-queue-sandbox/commit/1fd3906e41ea4d7283ff5a82e9d2a2b8b12ca960) in GM which is propagated in a log line in a CQ task (which will is now newer than the latest CQ commit).
4. It ran [this](https://spruce-staging.corp.mongodb.com/version/679b9afc7e2fce00074f469b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) version which has the older log line [here](https://parsley-staging.corp.mongodb.com/evergreen/zackary_bisect_variant1_clone_project_679b9afc7e2fce00074f469b_25_01_30_15_30_04/0/all?bookmarks=0,321&shareLine=282).
5. I deployed this PR and it ran [this](https://spruce-staging.corp.mongodb.com/version/679bbe2749b11b0007166b9c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) version which has the new log line [here](https://parsley-staging.corp.mongodb.com/evergreen/zackary_bisect_variant1_clone_project_679bbe2749b11b0007166b9c_25_01_30_18_00_07/0/task?bookmarks=0,49&shareLine=45). You can see the difference in log lines and the difference in the version manifest on the version page.

This is for the version without the update that does not create a manifest and uses the base commit (step 4):
<img width="908" alt="Screenshot 2025-01-30 at 11 06 10 AM" src="https://github.com/user-attachments/assets/a0900344-da77-447b-8170-63fb622f2a70" />

This is for the version with the update that does create a manifest (step 5):
<img width="901" alt="Screenshot 2025-01-30 at 1 11 03 PM" src="https://github.com/user-attachments/assets/512b164e-bcb2-402a-8e7a-6ea60fbb9f57" />

### Documentation
TBA
