### PR TITLE
DEVPROD-12696: Only check for upstream project for trigger versions

### DIFF
--- a/graphql/tests/version/upstreamProject/data.json
+++ b/graphql/tests/version/upstreamProject/data.json
@@ -1,6 +1,35 @@
 {
   "versions": [
     {
+      "_id": "5e4ff3abe3c3317e352062e4",
+      "create_time": {
+        "$date": "2020-02-21T15:13:48.801Z"
+      },
+      "start_time": {
+        "$date": "2020-02-21T15:15:38.261Z"
+      },
+      "finish_time": {
+        "$date": "2020-02-21T15:29:54.869Z"
+      },
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "author": "brian.samek",
+      "author_email": "",
+      "message": "'evergreen-ci/evergreen' pull request #3186 by bsamek: EVG-7425 Don't send ShouldExit to unprovisioned hosts (https://github.com/evergreen-ci/evergreen/pull/3186)",
+      "status": "failed",
+      "order": 2567,
+      "config_number": 1,
+      "ignored": false,
+      "owner_name": "",
+      "repo_name": "",
+      "branch_name": "main",
+      "identifier": "spruce",
+      "remote": false,
+      "remote_path": "",
+      "r": "github_pull_request",
+      "author_id": "brian.samek",
+      "activated": true
+    },
+    {
       "_id": "spruce_a7906eed65f88ae436ddb5c19096969f198a9efe",
       "create_time": {
         "$date": "2020-12-22T22:01:40Z"

--- a/graphql/tests/version/upstreamProject/data.json
+++ b/graphql/tests/version/upstreamProject/data.json
@@ -42,7 +42,7 @@
       "identifier": "spruce",
       "remote": false,
       "remote_path": ".evergreen.yml",
-      "r": "gitter_request",
+      "r": "trigger_request",
       "author_id": "arjun.patel",
       "activated": true,
       "trigger_id": "1",

--- a/graphql/tests/version/upstreamProject/queries/no_upstream_project.graphql
+++ b/graphql/tests/version/upstreamProject/queries/no_upstream_project.graphql
@@ -1,0 +1,19 @@
+{
+    version(versionId: "5e4ff3abe3c3317e352062e4"){
+        id
+        upstreamProject {
+            owner
+            repo
+            revision
+            project
+            triggerID
+            triggerType
+            task {
+                id
+            }
+            version {
+                id
+            }
+        }
+    }
+}

--- a/graphql/tests/version/upstreamProject/results.json
+++ b/graphql/tests/version/upstreamProject/results.json
@@ -21,6 +21,17 @@
           }
         }
       }
+    },
+    {
+      "query_file": "no_upstream_project.graphql",
+      "result": {
+        "data": {
+          "version": {
+            "id": "5e4ff3abe3c3317e352062e4",
+            "upstreamProject": null
+          }
+        }
+      }
     }
   ]
 }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -395,6 +395,10 @@ func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.AP
 
 // UpstreamProject is the resolver for the upstreamProject field.
 func (r *versionResolver) UpstreamProject(ctx context.Context, obj *restModel.APIVersion) (*UpstreamProject, error) {
+	if utility.FromStringPtr(obj.Requester) != evergreen.TriggerRequester {
+		return nil, nil
+	}
+
 	v, err := model.VersionFindOneId(utility.FromStringPtr(obj.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding version '%s': %s", utility.FromStringPtr(obj.Id), err.Error()))


### PR DESCRIPTION
DEVPROD-12696

### Description
To minimize the number of requests to the database within the `Version/upstreamProject` resolver, only check for a trigger ID if the version's requester is `trigger_request`

### Testing
- Add test for no upstream project
- Fix inconsistent test data so that test passes