### PR TITLE
DEVPROD-8409: support host auth using env vars

### DIFF
--- a/agent/globals/globals.go
+++ b/agent/globals/globals.go
@@ -114,7 +114,7 @@ const (
 	AWSSessionToken = "AWS_SESSION_TOKEN"
 	// AWSRoleExpiration is the expansion name for the expiration of a temporary AWS access key.
 	AWSRoleExpiration = "AWS_ROLE_EXPIRATION"
-	// HostSecret is the environment variable within the agent that is unique to its running host.
+	// HostSecret is the expansion name within the agent that is the host's unique secret.
 	HostSecret = "HOST_SECRET"
 )
 

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -366,7 +366,6 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		// Build Evergreen agent command.
 		agentCmdParts = containerHost.AgentCommand(c.evergreenSettings, pathToExecutable)
 		containerHost.DockerOptions.Command = strings.Join(agentCmdParts, "\n")
-		// kim: TODO: need to test that env vars work for Docker containers.
 		containerHost.DockerOptions.EnvironmentVars = append(containerHost.DockerOptions.EnvironmentVars, containerHost.AgentEnvSlice()...)
 	}
 

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -366,6 +366,8 @@ func (c *dockerClientImpl) CreateContainer(ctx context.Context, parentHost, cont
 		// Build Evergreen agent command.
 		agentCmdParts = containerHost.AgentCommand(c.evergreenSettings, pathToExecutable)
 		containerHost.DockerOptions.Command = strings.Join(agentCmdParts, "\n")
+		// kim: TODO: need to test that env vars work for Docker containers.
+		containerHost.DockerOptions.EnvironmentVars = append(containerHost.DockerOptions.EnvironmentVars, containerHost.AgentEnvSlice()...)
 	}
 
 	// Populate container settings with command and new image.

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-23"
+	AgentVersion = "2025-01-29"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -262,6 +262,9 @@ const (
 	AgentMonitorTag = "agent-monitor"
 	HostFetchTag    = "host-fetch"
 
+	HostIDEnvVar     = "HOST_ID"
+	HostSecretEnvVar = "HOST_SECRET"
+
 	DegradedLoggingPercent = 10
 
 	SetupScriptName               = "setup.sh"

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1019,9 +1019,9 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		"agent",
 		fmt.Sprintf("--api_server=%s", settings.Api.URL),
 		"--mode=host",
-		// kim: TODO: this needs to stay for the deploy, but commenting it out
-		// verifies if the env vars get propagated to the agent properly via the
-		// agent monitor.
+		// kim: TODO: this needs to stay for the deploy to ensure a smooth
+		// rollover, but commenting it out verifies if the env vars get
+		// propagated to the agent properly via the agent monitor.
 		// fmt.Sprintf("--host_id=%s", h.Id),
 		// fmt.Sprintf("--host_secret=%s", h.Secret),
 		fmt.Sprintf("--provider=%s", h.Distro.Provider),
@@ -1061,11 +1061,7 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 	credsPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperCredentialsPath)
 	shellPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ShellPath)
 
-	// kim: NOTE: need to pass along host ID and host secret env vars from the
-	// agent monitor to the agent. Potentially, it will just work with no
-	// changes to the agent monitor if the agent inherits the env vars from the
-	// agent monitor, but would have to check. If not, will have to explicitly
-	// set it when invoking the agent.
+	// kim: NOTE: agent monitor already passes on its environment to the agent.
 	args := append(h.AgentCommand(settings, ""), "monitor")
 	args = append(args,
 		fmt.Sprintf("--client_path=%s", clientPath),

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1019,11 +1019,11 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		"agent",
 		fmt.Sprintf("--api_server=%s", settings.Api.URL),
 		"--mode=host",
-		// kim: TODO: this needs to stay for the deploy to ensure a smooth
-		// rollover, but commenting it out verifies if the env vars get
-		// propagated to the agent properly via the agent monitor.
-		// fmt.Sprintf("--host_id=%s", h.Id),
-		// fmt.Sprintf("--host_secret=%s", h.Secret),
+		// TODO (DEVPROD-8409): delete the host ID and secret from the CLI args
+		// once the agent monitor and agent on all static/dynamic hosts have
+		// rolled over to newer versions.
+		fmt.Sprintf("--host_id=%s", h.Id),
+		fmt.Sprintf("--host_secret=%s", h.Secret),
 		fmt.Sprintf("--provider=%s", h.Distro.Provider),
 		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent")),
@@ -1031,9 +1031,6 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		"--cleanup",
 	}
 }
-
-// kim: TODO: need to test the agent with env vars for legacy SSH, SSH, and user
-// data provisioning. Also need to check reprovisioning works.
 
 // AgentEnv returns the environment variables required to start the agent.
 func (h *Host) AgentEnv() map[string]string {
@@ -1061,7 +1058,6 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 	credsPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperCredentialsPath)
 	shellPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ShellPath)
 
-	// kim: NOTE: agent monitor already passes on its environment to the agent.
 	args := append(h.AgentCommand(settings, ""), "monitor")
 	args = append(args,
 		fmt.Sprintf("--client_path=%s", clientPath),

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -162,8 +162,8 @@ func Agent() cli.Command {
 			}
 
 			// Once the agent has retrieved the host ID and secret, unset those
-			// env vars to prevent them from leaking to task processes such as
-			// shell.exec and subprocess.exec.
+			// env vars to prevent them from being inherited by subprocesses
+			// such as shell.exec and subprocess.exec.
 			if err := os.Unsetenv(evergreen.HostIDEnvVar); err != nil {
 				return errors.Wrapf(err, "unsetting %s env var", evergreen.HostIDEnvVar)
 			}

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -162,8 +162,8 @@ func Agent() cli.Command {
 			}
 
 			// Once the agent has retrieved the host ID and secret, unset those
-			// env vars to prevent them from being inherited by subprocesses
-			// such as shell.exec and subprocess.exec.
+			// env vars to prevent them from being inherited by task
+			// subprocesses (e.g. shell.exec).
 			if err := os.Unsetenv(evergreen.HostIDEnvVar); err != nil {
 				return errors.Wrapf(err, "unsetting %s env var", evergreen.HostIDEnvVar)
 			}

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -157,10 +157,7 @@ func smokeStartEvergreen() cli.Command {
 				var envVars []string
 				switch mode {
 				case string(globals.HostMode):
-					envVars = []string{
-						fmt.Sprintf("%s=%s", evergreen.HostIDEnvVar, execModeID),
-						fmt.Sprintf("%s=%s", evergreen.HostSecretEnvVar, execModeSecret),
-					}
+					envVars = makeHostAuthEnvVars(execModeID, execModeSecret)
 				case string(globals.PodMode):
 					envVars = []string{
 						fmt.Sprintf("POD_ID=%s", execModeID),
@@ -222,10 +219,7 @@ func smokeStartEvergreen() cli.Command {
 					exit,
 					"agent.monitor",
 					wd,
-					[]string{
-						fmt.Sprintf("HOST_ID=%s", execModeID),
-						fmt.Sprintf("HOST_SECRET=%s", execModeSecret),
-					},
+					makeHostAuthEnvVars(execModeID, execModeSecret),
 					binary,
 					"agent",
 					fmt.Sprintf("--mode=%s", globals.HostMode),
@@ -252,6 +246,13 @@ func smokeStartEvergreen() cli.Command {
 			return nil
 
 		},
+	}
+}
+
+func makeHostAuthEnvVars(hostID, secret string) []string {
+	return []string{
+		fmt.Sprintf("%s=%s", evergreen.HostIDEnvVar, hostID),
+		fmt.Sprintf("%s=%s", evergreen.HostSecretEnvVar, secret),
 	}
 }
 

--- a/operations/service_deploy_smoke.go
+++ b/operations/service_deploy_smoke.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/globals"
 	timberutil "github.com/evergreen-ci/timber/testutil"
 	"github.com/mongodb/grip"
@@ -157,8 +158,8 @@ func smokeStartEvergreen() cli.Command {
 				switch mode {
 				case string(globals.HostMode):
 					envVars = []string{
-						fmt.Sprintf("HOST_ID=%s", execModeID),
-						fmt.Sprintf("HOST_SECRET=%s", execModeSecret),
+						fmt.Sprintf("%s=%s", evergreen.HostIDEnvVar, execModeID),
+						fmt.Sprintf("%s=%s", evergreen.HostSecretEnvVar, execModeSecret),
 					}
 				case string(globals.PodMode):
 					envVars = []string{

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -303,7 +303,6 @@ func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *everg
 	defer cancel()
 
 	agentEnvVars := strings.Join(j.host.AgentEnvSlice(), " ")
-	// kim: TODO: test if setting these env vars really works with nohup.
 	startAgentCmd := fmt.Sprintf("%s nohup %s > /tmp/start 2>&1 &", agentEnvVars, remoteCmd)
 	logs, err := j.host.RunSSHCommand(ctx, startAgentCmd)
 	if err != nil {

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -292,7 +292,6 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context) error {
 // Start the agent process on the specified remote host.
 func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings) (string, error) {
 	// build the command to run on the remote machine
-	// kim: NOTE: need to modify this to set the env vars.
 	remoteCmd := strings.Join(j.host.AgentCommand(settings, ""), " ")
 	grip.Info(message.Fields{
 		"message": "starting agent on host",

--- a/units/provisioning_agent_deploy.go
+++ b/units/provisioning_agent_deploy.go
@@ -292,6 +292,7 @@ func (j *agentDeployJob) prepRemoteHost(ctx context.Context) error {
 // Start the agent process on the specified remote host.
 func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *evergreen.Settings) (string, error) {
 	// build the command to run on the remote machine
+	// kim: NOTE: need to modify this to set the env vars.
 	remoteCmd := strings.Join(j.host.AgentCommand(settings, ""), " ")
 	grip.Info(message.Fields{
 		"message": "starting agent on host",
@@ -302,7 +303,9 @@ func (j *agentDeployJob) startAgentOnRemote(ctx context.Context, settings *everg
 	ctx, cancel := context.WithTimeout(ctx, startAgentTimeout)
 	defer cancel()
 
-	startAgentCmd := fmt.Sprintf("nohup %s > /tmp/start 2>&1 &", remoteCmd)
+	agentEnvVars := strings.Join(j.host.AgentEnvSlice(), " ")
+	// kim: TODO: test if setting these env vars really works with nohup.
+	startAgentCmd := fmt.Sprintf("%s nohup %s > /tmp/start 2>&1 &", agentEnvVars, remoteCmd)
 	logs, err := j.host.RunSSHCommand(ctx, startAgentCmd)
 	if err != nil {
 		return logs, errors.Wrapf(err, "starting agent on host '%s'", j.host.Id)


### PR DESCRIPTION
DEVPROD-8409

### Description
The `localhost:2285/status` agent endpoint that's available to tasks currently leaks the host secret in plaintext to tasks because the endpoint returns process command-line arguments such as the agent's host ID/secret (e.g. `evergreen agent --host-id <HOST_ID> --host-secret <HOST_SECRET>`).

To prevent the `/status` endpoint from returning the host secret in plaintext, I changed the way the agent receives its host ID/secret so that they can be set as environment variables for the process instead of command-line arguments. I can't actually remove the command-ine arguments until this is deployed to prod + I do some post-deploy work to update static hosts (see below).

#### Post-Deploy Steps
As I mentioned under testing, staging has drifted pretty far from prod for distros, so it's not possible to test some provisioning scenarios that will appear in prod. Instead, I'm going to monitor the deploy and manually test SSH provisioning and Docker container pool provisioning once the deploy goes out.

In addition, static hosts will not roll over to the new version automatically (in case you're wondering - no, this is not easily fixable). To roll them over to use env vars for auth, I'm going to reprovision all non-quarantined static hosts manually.

### Testing
* Smoke test passes when using env vars for auth.
* Tested in a staging patch that using env vars for host auth prevented the host ID/secret from appearing in the response from the `/status` endpoint.
* Tested user data and legacy SSH provisioning to verify they could start the agent with the host ID/secret set through env vars.
    * I didn't test Docker containers and SSH provisioning because they don't work in staging anymore. Instead, I'm going to verify they work post-deploy (see above).