### PR TITLE
DEVPROD-8409: remove host auth CLI arguments

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-01-29"
+	AgentVersion = "2025-02-03"
 )
 
 const (

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1019,11 +1019,6 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		"agent",
 		fmt.Sprintf("--api_server=%s", settings.Api.URL),
 		"--mode=host",
-		// TODO (DEVPROD-8409): delete the host ID and secret from the CLI args
-		// once the agent monitor and agent on all static/dynamic hosts have
-		// rolled over to newer versions.
-		fmt.Sprintf("--host_id=%s", h.Id),
-		fmt.Sprintf("--host_secret=%s", h.Secret),
 		fmt.Sprintf("--provider=%s", h.Distro.Provider),
 		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent")),


### PR DESCRIPTION
DEVPROD-8409

### Description
Now that #8680 has been deployed, new agents and agent monitors should accept the host auth env vars for host auth. To ensure this for static hosts in prod, I reprovisioned all of the running ones.

This requires the static hosts to roll over one more time to ensure the agent uses only env vars for host auth. Once this is deployed, I'm going to reprovision all the static hosts.

### Testing
Tested same provisioning methods as in #8680 and they still worked.

### Documentation
N/A
