### PR TITLE
DEVPROD-9639: log task restart event for execution tasks

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -409,10 +409,15 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	}
 	for _, t := range allFinishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() { // this will be logged separately if task group is restarted
-			// kim: TODO: figure out if this needs to handle execution tasks as
-			// well. It possibly already handles execution tasks when restarting
-			// an entire version.
 			event.LogTaskRestarted(t.Id, t.Execution, caller)
+		}
+		if t.DisplayOnly {
+			// kim: TODO: add test for execution task restart log
+			grip.Error(message.WrapError(logExecutionTasksRestarted(ctx, &t, t.ExecutionTasks, caller), message.Fields{
+				"message":                      "could not log task restart events for some execution tasks",
+				"display_task_id":              t.Id,
+				"restarted_execution_task_ids": t.ExecutionTasks,
+			}))
 		}
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -412,7 +412,6 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 			event.LogTaskRestarted(t.Id, t.Execution, caller)
 		}
 		if t.DisplayOnly {
-			// kim: TODO: add test for execution task restart log
 			grip.Error(message.WrapError(logExecutionTasksRestarted(ctx, &t, t.ExecutionTasks, caller), message.Fields{
 				"message":                      "could not log task restart events for some execution tasks",
 				"display_task_id":              t.Id,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -409,6 +409,9 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	}
 	for _, t := range allFinishedTasks {
 		if !t.IsPartOfSingleHostTaskGroup() { // this will be logged separately if task group is restarted
+			// kim: TODO: figure out if this needs to handle execution tasks as
+			// well. It possibly already handles execution tasks when restarting
+			// an entire version.
 			event.LogTaskRestarted(t.Id, t.Execution, caller)
 		}
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1817,8 +1817,6 @@ func MarkOneTaskReset(ctx context.Context, t *task.Task, caller string) error {
 			return errors.Wrap(err, "resetting failed execution tasks")
 		}
 
-		// kim: TODO: test in staging with failed_only/all
-		// kim: TODO: add unit tests
 		grip.Error(message.WrapError(logExecutionTasksRestarted(ctx, t, execTaskIdsToRestart, caller), message.Fields{
 			"message":                      "could not log task restart events for some execution tasks",
 			"display_task_id":              t.Id,

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1857,7 +1857,13 @@ func logExecutionTasksRestarted(ctx context.Context, displayTask *task.Task, exe
 			catcher.Errorf("execution task '%s' not found", etID)
 			continue
 		}
-		event.LogTaskRestarted(execTask.Id, execTask.Execution, caller)
+		// Use the previous execution number rather than latest execution
+		// number. The task restart event is supposed to log the previous
+		// execution that was restarted (e.g. if it restarted from execution 2
+		// to execution 3, the restart event should log for execution 2). This
+		// logic always logs after the execution task has already been
+		// restarted, so it needs to use the previous execution number.
+		event.LogTaskRestarted(execTask.Id, execTask.Execution-1, caller)
 	}
 
 	return catcher.Resolve()

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -80,7 +80,6 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 
 // Execute calls the data ResetTask function and returns the refreshed
 // task from the service.
-// kim: TODO: double-check that this logs task restart event.
 func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
 	err := resetTask(ctx, evergreen.GetEnvironment().Settings(), trh.taskId, trh.username, trh.FailedOnly)
 	if err != nil {

--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -80,6 +80,7 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 
 // Execute calls the data ResetTask function and returns the refreshed
 // task from the service.
+// kim: TODO: double-check that this logs task restart event.
 func (trh *taskRestartHandler) Run(ctx context.Context) gimlet.Responder {
 	err := resetTask(ctx, evergreen.GetEnvironment().Settings(), trh.taskId, trh.username, trh.FailedOnly)
 	if err != nil {


### PR DESCRIPTION
DEVPROD-9639

### Description
When a display task is restarted, it only logs a task restart event for the entire display task. On top of this, log a task restart event for each execution task so that users can view which particular execution tasks get restarted in the UI.

### Testing
* Added unit tests.
* Tested in staging that restarting an entire display task and just the failed tasks both show restart events as expected. Tested both via Spruce and the `/tasks/{task_id}/restart` route.