### PR TITLE
DEVPROD-10558: include dependencies in activated generated tasks count

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -332,16 +332,12 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		ActivatedTasksAreEssentialToSucceed: g.Task.IsEssentialToSucceed,
 	}
 
-	// kim: NOTE: activatedTasksInExistingBuilds does not include dependencies
-	// that get activated. Could return it from the result though.
 	activatedTasksInExistingBuilds, activatedDependenciesFromTasksInExistingBuilds, err := addNewTasksToExistingBuilds(ctx, creationInfo, existingBuilds, evergreen.GenerateTasksActivator)
 	if err != nil {
 		return errors.Wrap(err, "adding new tasks")
 	}
 
 	creationInfo.Pairs = newTVPairsForNewVariants
-	// kim: NOTE: activatedTasksInNewBUilds does not include dependencies that
-	// get activated. Could return it from the result though.
 	activatedTasksInNewBuilds, activatedDependenciesFromTasksInNewBuilds, err := addNewBuilds(ctx, creationInfo, existingBuilds)
 	if err != nil {
 		return errors.Wrap(err, "adding new builds")
@@ -353,11 +349,6 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 
 	numActivatedGenerateTasks := len(activatedTasksInExistingBuilds) + len(activatedTasksInNewBuilds) + len(activatedDependenciesFromTasksInExistingBuilds) + len(activatedDependenciesFromTasksInNewBuilds)
 	span.SetAttributes(attribute.Int(numActivatedGenerateTasksAttribute, numActivatedGenerateTasks))
-	// kim: NOTE: rather than return the number of activated tasks and
-	// dependencies all over the place, we could absorb this as an $inc into
-	// addNewBuilds and addNewTasksToExistingBuilds so they add up the activated
-	// generated tasks as they go. Can set the span attribute using
-	// SpanFromContext.
 	if err = g.Task.SetNumActivatedGeneratedTasks(ctx, numActivatedGenerateTasks); err != nil {
 		return errors.Wrapf(err, "setting number of tasks generated and activated by '%s'", g.Task.Id)
 	}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1249,7 +1249,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	generatorTask, err := task.FindOneId(ctx, tasksThatExist[0].Id)
 	s.NoError(err)
 	s.Require().NotNil(generatorTask)
-	s.Equal(1, generatorTask.NumActivatedGeneratedTasks)
+	s.Equal(3, generatorTask.NumActivatedGeneratedTasks)
 	s.Equal(4, generatorTask.NumGeneratedTasks)
 }
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1606,9 +1606,6 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		return nil, nil, errors.Wrap(err, "inserting tasks")
 	}
 	numTasksModified := numEstimatedActivatedGeneratedTasks + len(newActivatedTaskIds)
-	// kim: NOTE: this scheduling limit appears to exclude dependencies
-	// activated indirectly. Dependencies are added to the scheduling limit in
-	// ActivateTasks below.
 	if err = task.UpdateSchedulingLimit(creationInfo.Version.Author, creationInfo.Version.Requester, numTasksModified, true); err != nil {
 		return nil, nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
 	}
@@ -1636,9 +1633,6 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		return nil, nil, errors.Wrap(err, "getting dependencies for activated tasks")
 	}
 
-	// kim: NOTE: ActivateTasks already updates the scheduling limit internally.
-	// However, we don't know how many tasks it actually activates. That could
-	// be returned as the result from task.ActivateTasks.
 	activatedDependencyIDs, err := task.ActivateTasks(ctx, activatedTaskDependencies, time.Now(), true, evergreen.User)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "activating dependencies for new tasks")
@@ -1747,8 +1741,6 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			return nil, nil, errors.Wrapf(err, "updating task cache for '%s'", b.Id)
 		}
 	}
-	// kim: NOTE: internally, this calls UpdateSchedulingLimit, so it does add
-	// them to the user's task scheduling limit.
 	if err = task.CheckUsersPatchTaskLimit(ctx, creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
 		return nil, nil, errors.Wrap(err, "updating patch task limit for user")
 	}
@@ -1771,9 +1763,6 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting dependencies for activated tasks")
 	}
-	// kim: NOTE: ActivateTasks already updates the scheduling limit internally.
-	// However, we don't know how many tasks it actually activates. That could
-	// be returned as the result from task.ActivateTasks.
 	activatedDependencyIDs, err := task.ActivateTasks(ctx, activatedTaskDependencies, time.Now(), true, evergreen.User)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "activating existing dependencies for new tasks")

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2946,7 +2946,7 @@ func TestAddNewTasks(t *testing.T) {
 				ActivationInfo: testCase.activationInfo,
 				GeneratedBy:    "",
 			}
-			_, err := addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{b}, "")
+			_, _, err := addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{b}, "")
 			assert.NoError(t, err)
 			buildTasks, err := task.FindAll(ctx, db.Query(bson.M{task.BuildIdKey: "b0"}))
 			assert.NoError(t, err)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -91,11 +91,11 @@ func addNewTasksAndBuildsForPatch(ctx context.Context, creationInfo TaskCreation
 	if err != nil {
 		return err
 	}
-	_, err = addNewBuilds(ctx, creationInfo, existingBuilds)
+	_, _, err = addNewBuilds(ctx, creationInfo, existingBuilds)
 	if err != nil {
 		return errors.Wrap(err, "adding new builds")
 	}
-	_, err = addNewTasksToExistingBuilds(ctx, creationInfo, existingBuilds, caller)
+	_, _, err = addNewTasksToExistingBuilds(ctx, creationInfo, existingBuilds, caller)
 	if err != nil {
 		return errors.Wrap(err, "adding new tasks")
 	}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -842,7 +842,7 @@ func TestAddNewPatch(t *testing.T) {
 		ActivationInfo: specificActivationInfo{},
 		GeneratedBy:    "",
 	}
-	_, _, err := addNewBuilds(context.Background(), creationInfo, nil)
+	_, _, err := addNewBuilds(ctx, creationInfo, nil)
 	assert.NoError(err)
 	dbBuild, err := build.FindOne(db.Q{})
 	assert.NoError(err)
@@ -855,7 +855,7 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal("variant", dbVersion.BuildVariants[0].BuildVariant)
 	assert.Equal("My Variant Display", dbVersion.BuildVariants[0].DisplayName)
 
-	_, _, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
+	_, _, err = addNewTasksToExistingBuilds(ctx, creationInfo, []build.Build{*dbBuild}, "")
 	assert.NoError(err)
 	dbUser, err := user.FindOneById(u.Id)
 	assert.NoError(err)

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -842,7 +842,7 @@ func TestAddNewPatch(t *testing.T) {
 		ActivationInfo: specificActivationInfo{},
 		GeneratedBy:    "",
 	}
-	_, err := addNewBuilds(context.Background(), creationInfo, nil)
+	_, _, err := addNewBuilds(context.Background(), creationInfo, nil)
 	assert.NoError(err)
 	dbBuild, err := build.FindOne(db.Q{})
 	assert.NoError(err)
@@ -855,7 +855,7 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal("variant", dbVersion.BuildVariants[0].BuildVariant)
 	assert.Equal("My Variant Display", dbVersion.BuildVariants[0].DisplayName)
 
-	_, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
+	_, _, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
 	assert.NoError(err)
 	dbUser, err := user.FindOneById(u.Id)
 	assert.NoError(err)
@@ -943,14 +943,14 @@ func TestAddNewPatchWithMissingBaseVersion(t *testing.T) {
 		ActivationInfo: specificActivationInfo{},
 		GeneratedBy:    "",
 	}
-	_, err := addNewBuilds(context.Background(), creationInfo, nil)
+	_, _, err := addNewBuilds(context.Background(), creationInfo, nil)
 	assert.NoError(err)
 	dbBuild, err := build.FindOne(db.Q{})
 	assert.NoError(err)
 	assert.NotNil(dbBuild)
 	assert.Len(dbBuild.Tasks, 2)
 
-	_, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
+	_, _, err = addNewTasksToExistingBuilds(context.Background(), creationInfo, []build.Build{*dbBuild}, "")
 	assert.NoError(err)
 	dbTasks, err := task.FindAll(ctx, db.Query(task.ByBuildId(dbBuild.Id)))
 	assert.NoError(err)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1910,10 +1910,15 @@ func (t *Task) HasResults(ctx context.Context) bool {
 	return t.ResultsService != "" || t.HasCedarResults
 }
 
-// ActivateTasks sets all given tasks to active, logs them as activated, and proceeds to activate any dependencies that were deactivated.
-func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, updateDependencies bool, caller string) error {
+// ActivateTasks sets all given tasks to active, logs them as activated, and
+// proceeds to activate any dependencies that were deactivated. This returns the
+// task IDs that were activated.
+// kim: NOTE: may be best to have this return the task IDs of the activated
+// dependencies. That way, the caller can correctly account for them in the
+// generate.task task count.
+func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, updateDependencies bool, caller string) ([]string, error) {
 	if len(tasks) == 0 {
-		return nil
+		return nil, nil
 	}
 	tasksToActivate := make([]Task, 0, len(tasks))
 	taskIDs := make([]string, 0, len(tasks))
@@ -1925,11 +1930,16 @@ func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, 
 		}
 		tasksToActivate = append(tasksToActivate, t)
 		taskIDs = append(taskIDs, t.Id)
+		// kim: NOTE: should not include this because it would double count the
+		// estimated generated tasks. The function needs to return the total
+		// number of tasks it activated, and should not include the estimated
+		// tasks that those task could generate. The scheduling limits will be
+		// re-checked if/when those tasks actually generate tasks.
 		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 	}
 	depTasksToUpdate, depTaskIDsToUpdate, err := getDependencyTaskIdsToActivate(ctx, taskIDs, updateDependencies)
 	if err != nil {
-		return errors.Wrap(err, "getting dependency tasks to activate")
+		return nil, errors.Wrap(err, "getting dependency tasks to activate")
 	}
 	for _, depTask := range depTasksToUpdate {
 		numEstimatedActivatedGeneratedTasks += utility.FromIntPtr(depTask.EstimatedNumActivatedGeneratedTasks)
@@ -1938,11 +1948,11 @@ func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, 
 	// all tasks also share the same requester field.
 	numTasksModified := len(taskIDs) + len(depTaskIDsToUpdate) + numEstimatedActivatedGeneratedTasks
 	if err = UpdateSchedulingLimit(caller, tasks[0].Requester, numTasksModified, true); err != nil {
-		return err
+		return nil, err
 	}
 	err = activateTasks(ctx, taskIDs, caller, activationTime)
 	if err != nil {
-		return errors.Wrap(err, "activating tasks")
+		return nil, errors.Wrap(err, "activating tasks")
 	}
 	logs := []event.EventLogEntry{}
 	for _, t := range tasksToActivate {
@@ -1954,10 +1964,15 @@ func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, 
 		"caller":   caller,
 	}))
 
+	activatedTaskIDs := make([]string, 0, len(taskIDs)+len(depTaskIDsToUpdate))
+	activatedTaskIDs = append(activatedTaskIDs, taskIDs...)
+	activatedTaskIDs = append(activatedTaskIDs, depTaskIDsToUpdate...)
+
 	if len(depTaskIDsToUpdate) > 0 {
-		return activateDeactivatedDependencies(ctx, depTasksToUpdate, depTaskIDsToUpdate, caller)
+		return activatedTaskIDs, activateDeactivatedDependencies(ctx, depTasksToUpdate, depTaskIDsToUpdate, caller)
 	}
-	return nil
+
+	return activatedTaskIDs, nil
 }
 
 // UpdateSchedulingLimit retrieves a user from the DB and updates their hourly scheduling limit info
@@ -1997,7 +2012,7 @@ func ActivateTasksByIdsWithDependencies(ctx context.Context, ids []string, calle
 		return errors.Wrap(err, "getting recursive dependencies")
 	}
 
-	if err = ActivateTasks(ctx, append(tasks, dependOn...), time.Now(), true, caller); err != nil {
+	if _, err = ActivateTasks(ctx, append(tasks, dependOn...), time.Now(), true, caller); err != nil {
 		return errors.Wrap(err, "updating tasks for activation")
 	}
 	return nil
@@ -2597,6 +2612,7 @@ func (t *Task) SetNumGeneratedTasks(ctx context.Context, numGeneratedTasks int) 
 }
 
 // SetNumActivatedGeneratedTasks sets the number of activated generated tasks to the given value.
+// kim: TODO: potentially remove if going with $inc
 func (t *Task) SetNumActivatedGeneratedTasks(ctx context.Context, numActivatedGeneratedTasks int) error {
 	return UpdateOne(
 		ctx,
@@ -2606,6 +2622,22 @@ func (t *Task) SetNumActivatedGeneratedTasks(ctx context.Context, numActivatedGe
 		bson.M{
 			"$set": bson.M{
 				NumActivatedGeneratedTasksKey: numActivatedGeneratedTasks,
+			},
+		},
+	)
+}
+
+// IncNumActivatedGeneratedTasks increments the number of activated generated
+// tasks.
+func (t *Task) IncNumActivatedGeneratedTasks(ctx context.Context, numActivatedGeneratedTasksToAdd int) error {
+	return UpdateOne(
+		ctx,
+		bson.M{
+			IdKey: t.Id,
+		},
+		bson.M{
+			"$inc": bson.M{
+				NumActivatedGeneratedTasksKey: numActivatedGeneratedTasksToAdd,
 			},
 		},
 	)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -2376,8 +2376,9 @@ func TestActivateTasks(t *testing.T) {
 		}
 
 		updatedIDs := []string{"t0", "t3", "t4"}
-		err := ActivateTasks(ctx, []Task{tasks[0]}, time.Time{}, true, u.Id)
+		activatedDependencyIDs, err := ActivateTasks(ctx, []Task{tasks[0]}, time.Time{}, true, u.Id)
 		assert.NoError(t, err)
+		assert.ElementsMatch(t, updatedIDs, activatedDependencyIDs)
 
 		u, err = user.FindOne(user.ById(u.Id))
 		require.NoError(t, err)
@@ -2407,9 +2408,10 @@ func TestActivateTasks(t *testing.T) {
 			}
 		}
 
-		err = ActivateTasks(ctx, []Task{tasks[1]}, time.Time{}, true, u.Id)
+		activatedDependencyIDs, err = ActivateTasks(ctx, []Task{tasks[1]}, time.Time{}, true, u.Id)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), fmt.Sprintf("cannot schedule %d tasks, maximum hourly per-user limit is %d", 102, 100))
+		assert.Empty(t, activatedDependencyIDs)
 	})
 
 	t.Run("NoopActivatedTask", func(t *testing.T) {
@@ -2422,8 +2424,9 @@ func TestActivateTasks(t *testing.T) {
 		}
 		require.NoError(t, task.Insert())
 
-		err := ActivateTasks(ctx, []Task{task}, time.Now(), true, "abyssinian")
+		activatedDependencyIDs, err := ActivateTasks(ctx, []Task{task}, time.Now(), true, "abyssinian")
 		assert.NoError(t, err)
+		assert.Empty(t, activatedDependencyIDs)
 
 		events, err := event.FindAllByResourceID(task.Id)
 		require.NoError(t, err)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -84,7 +84,7 @@ func SetActiveState(ctx context.Context, caller string, active bool, tasks ...ta
 	}
 
 	if active {
-		if err := task.ActivateTasks(ctx, tasksToActivate, time.Now(), true, caller); err != nil {
+		if _, err := task.ActivateTasks(ctx, tasksToActivate, time.Now(), true, caller); err != nil {
 			return errors.Wrap(err, "activating tasks")
 		}
 		versionIdsToActivate := []string{}


### PR DESCRIPTION
DEVPROD-10558

### Description
The number of tasks activated by generate.tasks currently only includes tasks that were directly created by generate.tasks. This updates the activated task count to include dependencies that were activated as a result of scheduling a generated task that has dependencies.

### Testing
* Updated existing unit test for activated generated task count.
* Tested in staging patches that the activated generated task count:
    * Included a dependency on an already-existing task when the generated task depended on it.
    * Didn't double-count a dependency when a generated task depended on another generated task.