### PR TITLE
DEVPROD-11707: Set build variant display name more widely

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -724,6 +724,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			VersionBuildStatus{
 				BuildVariant:     vt.Variant,
 				BuildId:          build.Id,
+				DisplayName:      build.DisplayName,
 				ActivationStatus: ActivationStatus{Activated: true},
 			},
 		)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -971,6 +971,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		v.BuildVariants = append(v.BuildVariants, model.VersionBuildStatus{
 			BuildVariant:   buildvariant.Name,
 			BuildId:        b.Id,
+			DisplayName:    b.DisplayName,
 			BatchTimeTasks: taskStatuses,
 			ActivationStatus: model.ActivationStatus{
 				ActivateAt: activateVariantAt,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -787,6 +787,7 @@ func TestBatchTimes(t *testing.T) {
 			So(found, ShouldBeTrue)
 			So(bv2, ShouldNotBeNil)
 			So(bv2.Activated, ShouldBeTrue)
+			So(bv2.DisplayName, ShouldEqual, "bv2")
 			So(bv2.ActivateAt, ShouldResemble, bv1.ActivateAt)
 		})
 
@@ -1274,6 +1275,7 @@ tasks:
 	s.Len(v.BuildVariants, 2)
 	for _, bv := range v.BuildVariants {
 		if bv.BuildVariant == "bv" {
+			s.Equal(bv.DisplayName, "bv_display")
 			s.InDelta(bv.ActivateAt.Unix(), now.Unix(), 1)
 			s.Require().Len(bv.BatchTimeTasks, 2)
 			for _, t := range bv.BatchTimeTasks {
@@ -1290,6 +1292,7 @@ tasks:
 			}
 		}
 		if bv.BuildVariant == "bv2" {
+			s.Equal(bv.DisplayName, "bv2_display")
 			s.False(bv.Activated)
 			s.Empty(bv.BatchTimeTasks)
 		}


### PR DESCRIPTION
DEVPROD-11707

### Description
I missed some places where a build variant's display name should be set for a version in my original PR #8663.

### Testing
Add additional tests that fail without changes

Created version [on staging](https://spruce-staging.corp.mongodb.com/version/67a504ca81f295000714c4d7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) that includes display names in the DB document