### PR TITLE
DEVPROD-9990 POC for using  git scalar for git clones 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1228,7 +1228,7 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 
 // clearGitConfig removes cleans up git files that were created in the
 // home directory including the global git config file and credentials file.
-// It also unregisters and repositories that were cloned with scalar to stop
+// It also unregisters any repositories that were cloned with scalar to stop
 // the background maintenance of the repositories.
 func (a *Agent) clearGitConfig(tc *taskContext) {
 	logger := grip.GetDefaultJournaler()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,6 +22,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/thirdparty/docker"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
@@ -1223,6 +1226,10 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 	}
 }
 
+// clearGitConfig removes cleans up git files that were created in the
+// home directory including the global git config file and credentials file.
+// It also unregisters and repositories that were cloned with scalar to stop
+// the background maintenance of the repositories.
 func (a *Agent) clearGitConfig(tc *taskContext) {
 	logger := grip.GetDefaultJournaler()
 	if tc.logger != nil && !tc.logger.Closed() {
@@ -1254,6 +1261,45 @@ func (a *Agent) clearGitConfig(tc *taskContext) {
 		return
 	}
 	logger.Info("Cleared git credentials.")
+
+	if err := unregisterScalar(); err != nil {
+		logger.Error(errors.Wrap(err, "unregistering scalar repositories"))
+		return
+	}
+}
+
+// unregisterScalar unregisters a repository that was cloned (and therefore registered with) Scalar.
+// This should be done for each repository after it is cloned with scalar to stop the background maintenance processes.
+func unregisterScalar() error {
+	isScalarAvailable, err := agentutil.IsGitVersionMinimum(thirdparty.RequiredScalarGitVersion)
+
+	if err != nil {
+		return errors.Wrap(err, "checking git version")
+	}
+	if !isScalarAvailable {
+		return nil
+	}
+
+	// Run scalar list to get all registered repositories
+	cmd := exec.Command("scalar", "list")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "running scalar list")
+	}
+	repoPaths := strings.Split(strings.TrimSpace(out.String()), "\n")
+
+	// Unregister each registered repository
+	for _, repoPath := range repoPaths {
+		c := exec.Command("scalar", "unregister", repoPath)
+		c.Stdout, c.Stderr = os.Stdout, os.Stderr
+		err = c.Run()
+		if err != nil {
+			return errors.Wrapf(err, "unregistering repo from scalar: %s", repoPath)
+		}
+	}
+	return nil
 }
 
 func (a *Agent) shouldKill(tc *taskContext, ignoreTaskGroupCheck bool) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,11 +1,13 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,11 +20,13 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/agent/internal/testutil"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/taskoutput"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -30,6 +34,7 @@ import (
 	"github.com/mongodb/jasper/mock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
 )
@@ -2883,4 +2888,44 @@ func checkMockLogs(t *testing.T, mc *client.Mock, taskID string, logsToFind []st
 	if displayLogs {
 		grip.Infof("Logs for task '%s':\n%s\n", taskID, strings.Join(allLogs, "\n"))
 	}
+}
+
+// TestUnregisterScalar tests the unregisterScalar function without using a mock.
+func TestUnregisterScalar(t *testing.T) {
+	// Check if the Git version meets the minimum required version
+	isScalarAvailable, err := agentutil.IsGitVersionMinimum(thirdparty.RequiredScalarGitVersion)
+	require.NoError(t, err)
+	if !isScalarAvailable {
+		t.Skip("Git version does not meet the minimum required version for Scalar")
+	}
+
+	// Create a temporary directory to act as the repository
+	tempDir, err := os.MkdirTemp("", "scalar-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Clone the repository using Scalar
+	cmd := exec.Command("scalar", "clone", "https://github.com/evergreen-ci/sample", tempDir)
+	err = cmd.Run()
+	require.NoError(t, err)
+
+	// Verify that the repository is registered
+	cmd = exec.Command("scalar", "list")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), tempDir)
+
+	// Call unregisterScalar
+	err = unregisterScalar()
+	require.NoError(t, err)
+
+	// Verify that the repository is unregistered
+	cmd = exec.Command("scalar", "list")
+	out.Reset()
+	cmd.Stdout = &out
+	err = cmd.Run()
+	require.NoError(t, err)
+	assert.NotContains(t, out.String(), tempDir)
 }

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -36,7 +36,8 @@ const (
 	gitFetchProjectRetries = 5
 	defaultCommitterName   = "Evergreen Agent"
 	defaultCommitterEmail  = "no-reply@evergreen.mongodb.com"
-	shallowCloneDepth      = 100
+	//todo: shallow clone doesn't work with scalar
+	shallowCloneDepth = 100
 
 	gitGetProjectAttribute = "evergreen.command.git_get_project"
 
@@ -205,12 +206,12 @@ func (opts cloneOpts) buildHTTPCloneCommand(forApp bool) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "checking git version")
 	}
-	gitCommand := "scalar"
+	gitCommand := "scalar clone --no-src"
 	if !scalarAvailable {
-		gitCommand = "git"
+		gitCommand = "git clone"
 	}
 
-	clone := fmt.Sprintf("%s clone %s '%s'", gitCommand, gitURL, opts.dir)
+	clone := fmt.Sprintf("%s %s '%s'", gitCommand, gitURL, opts.dir)
 
 	if opts.recurseSubmodules {
 		clone = fmt.Sprintf("%s --recurse-submodules", clone)
@@ -323,6 +324,7 @@ func (c *gitFetchProject) buildSourceCloneCommand(conf *internal.TaskConfig, opt
 		}
 		gitCommands = append(gitCommands, fmt.Sprintf("git reset --hard %s", conf.Task.Revision))
 	}
+
 	gitCommands = append(gitCommands, "git log --oneline -n 10")
 
 	return gitCommands, nil
@@ -837,6 +839,7 @@ func getPatchCommands(modulePatch patch.ModulePatch, conf *internal.TaskConfig, 
 	if moduleDir != "" {
 		patchCommands = append(patchCommands, fmt.Sprintf("cd '%s'", moduleDir))
 	}
+	// I think it's this one
 	patchCommands = append(patchCommands, fmt.Sprintf("git reset --hard '%s'", modulePatch.Githash))
 
 	if modulePatch.PatchSet.Patch == "" {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -839,7 +839,6 @@ func getPatchCommands(modulePatch patch.ModulePatch, conf *internal.TaskConfig, 
 	if moduleDir != "" {
 		patchCommands = append(patchCommands, fmt.Sprintf("cd '%s'", moduleDir))
 	}
-	// I think it's this one
 	patchCommands = append(patchCommands, fmt.Sprintf("git reset --hard '%s'", modulePatch.Githash))
 
 	if modulePatch.PatchSet.Patch == "" {

--- a/agent/util/git.go
+++ b/agent/util/git.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/pkg/errors"
+)
+
+// getGitVersion retrieves the current Git version installed on the system.
+func getGitVersion() (string, bool, error) {
+	cmd := exec.Command("git", "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", false, errors.Wrap(err, "failed to get git version")
+	}
+
+	return thirdparty.ParseGitVersion(strings.TrimSpace(out.String()))
+}
+
+// IsGitVersionMinimum checks if the installed Git version is later than the specified version.
+func IsGitVersionMinimum(minVersion string) (bool, error) {
+	gitVersion, isApple, err := getGitVersion()
+	if err != nil {
+		return false, err
+	}
+	// scalar is not bundled with Apple's Git version 2.38.0
+	if isApple {
+		return false, nil
+	}
+
+	return !thirdparty.IsVersionMinimum(gitVersion, minVersion), nil
+}

--- a/config.go
+++ b/config.go
@@ -33,11 +33,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-01-28"
+	ClientVersion = "2025-02-05"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-03"
+	AgentVersion = "2025-02-05"
 )
 
 const (

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -277,10 +277,10 @@ func clone(opts cloneOptions) error {
 	cloneArgs = append(cloneArgs, opts.rootDir)
 	grip.Debug(cloneArgs)
 
-	gitCommand := "scalar"
+	gitCommand := "scalar clone --no-src"
 
 	if scalarAvailable, err := isScalarAvailable(); err != nil || !scalarAvailable {
-		gitCommand = "git"
+		gitCommand = "git clone"
 	}
 
 	c := exec.Command(gitCommand, cloneArgs...)
@@ -294,7 +294,7 @@ func clone(opts cloneOptions) error {
 	checkoutArgs := []string{"checkout", opts.revision}
 	grip.Debug(checkoutArgs)
 
-	c = exec.Command(gitCommand, checkoutArgs...)
+	c = exec.Command("git", checkoutArgs...)
 	stdoutBuf, stderrBuf := &bytes.Buffer{}, &bytes.Buffer{}
 	c.Stdout = io.MultiWriter(os.Stdout, stdoutBuf)
 	c.Stderr = io.MultiWriter(os.Stderr, stderrBuf)
@@ -309,7 +309,7 @@ func clone(opts cloneOptions) error {
 		fetchArgs := []string{"fetch", "--unshallow"}
 		grip.Debug(fetchArgs)
 
-		c = exec.Command(gitCommand, fetchArgs...)
+		c = exec.Command("git", fetchArgs...)
 		c.Stdout, c.Stderr, c.Dir = os.Stdout, os.Stderr, opts.rootDir
 		err = c.Run()
 		if err != nil {
@@ -319,7 +319,7 @@ func clone(opts cloneOptions) error {
 		checkoutRetryArgs := []string{"checkout", opts.revision}
 		grip.Debug(checkoutRetryArgs)
 
-		c = exec.Command(gitCommand, checkoutRetryArgs...)
+		c = exec.Command("git", checkoutRetryArgs...)
 		c.Stdout, c.Stderr, c.Dir = os.Stdout, os.Stderr, opts.rootDir
 		err = c.Run()
 		if err != nil {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"text/template"
@@ -18,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/client"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -855,22 +855,9 @@ func getGitVersion() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "getting git version")
 	}
+	version, _, err := thirdparty.ParseGitVersion(strings.TrimSpace(versionString))
 
-	return parseGitVersion(strings.TrimSpace(versionString))
-}
-
-func parseGitVersion(version string) (string, error) {
-	matches := regexp.MustCompile(`^git version ` +
-		// capture the version major.minor(.patch(.build(.etc...)))
-		`(\w+(?:\.\w+)+)` +
-		// match and discard Apple git's addition to the version string
-		`(?: \(Apple Git-[\w\.]+\))?$`,
-	).FindStringSubmatch(version)
-	if len(matches) != 2 {
-		return "", errors.Errorf("could not parse git version number from version string '%s'", version)
-	}
-
-	return matches[1], nil
+	return version, err
 }
 
 func gitCmd(cmdName string, gitArgs ...string) (string, error) {

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -146,21 +146,6 @@ func (s *PatchUtilTestSuite) TestVariantsTasksFromCLI() {
 	s.Contains(pp.Tasks, "mytask2")
 }
 
-func (s *PatchUtilTestSuite) TestParseGitVersionString() {
-	versionStrings := map[string]string{
-		"git version 2.19.1":                   "2.19.1",
-		"git version 2.24.3 (Apple Git-128)":   "2.24.3",
-		"git version 2.21.1 (Apple Git-122.3)": "2.21.1",
-		"git version 2.16.2.windows.1":         "2.16.2.windows.1",
-	}
-
-	for versionString, version := range versionStrings {
-		parsedVersion, err := parseGitVersion(versionString)
-		s.NoError(err)
-		s.Equal(version, parsedVersion)
-	}
-}
-
 func (s *PatchUtilTestSuite) TestNonRepeatedDefaultsLoadsExplicitAlias() {
 	pp := patchParams{
 		Project: "project",

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -242,7 +242,7 @@ func ParseGitVersion(version string) (string, bool, error) {
 		return "", false, errors.Errorf("could not parse git version number from version string '%s'", version)
 	}
 
-	isAppleGit := regexp.MustCompile(appleGitRegex).MatchString(version)
+	isAppleGit := strings.Contains(version, "Apple Git-")
 	return matches[1], isAppleGit, nil
 }
 

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -29,6 +30,8 @@ type Commit struct {
 	Message   string    `bson:"message"`
 	Patch     string    `bson:"patch"`
 }
+
+const RequiredScalarGitVersion = "2.38.0"
 
 // GitApplyNumstat attempts to apply a given patch; it returns the patch's bytes
 // if it is successful
@@ -209,4 +212,66 @@ func FormGitURLForApp(host, owner, repo, token string) string {
 	}
 
 	return fmt.Sprintf("https://%s/%s/%s.git", host, owner, repo)
+}
+
+// ParseGitVersion parses the git version number from the version string.
+func ParseGitVersion2(version string) (string, error) {
+	matches := regexp.MustCompile(`^git version ` +
+		// capture the version major.minor(.patch(.build(.etc...)))
+		`(\w+(?:\.\w+)+)` +
+		// match and discard Apple git's addition to the version string
+		`(?: \(Apple Git-[\w\.]+\))?$`,
+	).FindStringSubmatch(version)
+	if len(matches) != 2 {
+		return "", errors.Errorf("could not parse git version number from version string '%s'", version)
+	}
+
+	return matches[1], nil
+}
+
+// ParseGitVersion parses the git version number from the version string and returns a boolean indicating if it's an Apple Git version.
+func ParseGitVersion(version string) (string, bool, error) {
+	appleGitRegex := `(?: \(Apple Git-[\w\.]+\))?$`
+	matches := regexp.MustCompile(`^git version ` +
+		// capture the version major.minor(.patch(.build(.etc...)))
+		`(\w+(?:\.\w+)+)` +
+		// match and capture Apple git's addition to the version string
+		appleGitRegex,
+	).FindStringSubmatch(version)
+	if len(matches) != 2 {
+		return "", false, errors.Errorf("could not parse git version number from version string '%s'", version)
+	}
+
+	isAppleGit := regexp.MustCompile(appleGitRegex).MatchString(version)
+	return matches[1], isAppleGit, nil
+}
+
+// IsVersionMinimum checks if the version is less or equal to the minVersion.
+func IsVersionMinimum(version, minVersion string) bool {
+	versionParts := strings.Split(version, ".")
+	minVersionParts := strings.Split(minVersion, ".")
+
+	for i := 0; i < len(minVersionParts); i++ {
+		if i >= len(versionParts) {
+			return true
+		}
+
+		versionPart, err := strconv.Atoi(versionParts[i])
+		if err != nil {
+			return true
+		}
+
+		minVersionPart, err := strconv.Atoi(minVersionParts[i])
+		if err != nil {
+			return false
+		}
+
+		if versionPart < minVersionPart {
+			return true
+		} else if versionPart > minVersionPart {
+			return false
+		}
+	}
+
+	return false
 }

--- a/thirdparty/git_test.go
+++ b/thirdparty/git_test.go
@@ -87,3 +87,43 @@ func TestParseGitUrl(t *testing.T) {
 	assert.Equal("evergreen-ci", owner)
 	assert.Equal("sample", repo)
 }
+
+func TestIsVersionMinimum(t *testing.T) {
+	tests := []struct {
+		version    string
+		minVersion string
+		expected   bool
+	}{
+		{"2.37.0", "2.380", true},
+		{"2.38.0", "2.380", true},
+		{"2.38.0", "2.38.1", true},
+		{"2.38.1", "2.38.0", false},
+		{"2.38", "2.37.9", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.version+" < "+test.minVersion, func(t *testing.T) {
+			result := IsVersionMinimum(test.version, test.minVersion)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestParseGitVersionString(t *testing.T) {
+	versionStrings := map[string]struct {
+		expectedVersion string
+		isApple         bool
+	}{
+		"git version 2.19.1":                   {"2.19.1", false},
+		"git version 2.24.3 (Apple Git-128)":   {"2.24.3", true},
+		"git version 2.21.1 (Apple Git-122.3)": {"2.21.1", true},
+		"git version 2.16.2.windows.1":         {"2.16.2.windows.1", false},
+	}
+
+	for versionString, expected := range versionStrings {
+		parsedVersion, isApple, err := ParseGitVersion(versionString)
+		assert.NoError(t, err)
+		assert.Equal(t, expected.expectedVersion, parsedVersion)
+		assert.Equal(t, expected.isApple, isApple)
+	}
+}


### PR DESCRIPTION
DEVPROD-9990

### Description
Scalar is a repository management tool that optimizes Git for use in large repositories and improves performance. This checks to make sure that the git version supports scalar and if it does, use scalar to clone. 

It also unregisters any repositories in teardown that were cloned with scalar to stop the background maintenance of the repositories.

### Testing
Added unit tests for some of it and will test on staging 

