### PR TITLE
DEVPROD-13567: retry GitHub token request internally

### DIFF
--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -168,6 +168,8 @@ func githubClientShouldRetry() utility.HTTPRetryFunction {
 			}
 
 			if strings.Contains(err.Error(), "connection reset by peer") {
+				// This has happened in the past when GitHub was having an
+				// outage, so it's worth retrying.
 				return true
 			}
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1648,7 +1648,11 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		Permissions: permissions,
 	})
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
+		// This intentionally returns a 4xx error to prevent the agent from
+		// retrying because CreateInstallationToken already retries internally.
+		// It's assumed that if the token can't be created after retries, it's
+		// not a transient issue.
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
 	}
 	if token == "" {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))


### PR DESCRIPTION
DEVPROD-13567

### Description
* Add more retry conditions for transient GitHub app token generation errors. I used [Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20%2Frest%2Fv2%2F*%2Fgithub_dynamic_access_token%20AND%20%22request%20encountered%20internal%20error%22%20AND%20method%20!%3D%20DELETE%20AND%20%22secondary%20rate%20limit%22%0A%7C%20stats%20count%20by%20error.message&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1737608400&latest=1739250000&display.page.search.tab=statistics&display.general.type=statistics&sid=1739216669.49319) to find errors generating tokens over the past few weeks. Unsure if this is a comprehensive list of errors from that route, but we can always add more retry cases if we discover more.
* Do not have the agent retry the request if creating the installation token fails on the Evergreen app side. Evergreen already retries the request to GitHub, so it shouldn't be necessary for the agent to also retry its request.

### Testing
Tested in [staging patch](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_test_util_patch_4cf80c9c2b76d75b9332a7bcc47cd0d3833146cc_67aa6970faaa310007a4188a_25_02_10_21_02_41/logs?execution=2) that using invalid GitHub app credentials stopped the patch from retrying and immediately returned the Evergreen error. Before, it would just return a vague timeout error.
