### PR TITLE
DEVPROD-14857 Remove evrg-bot-webhook from tests

### DIFF
--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -330,11 +330,7 @@ func (s *githubSuite) TestGithubUserInOrganization() {
 }
 
 func (s *githubSuite) TestGitHubUserPermissionLevel() {
-	hasPermission, err := GitHubUserHasWritePermission(s.ctx, "evergreen-ci", "evergreen", "evrg-bot-webhook")
-	s.NoError(err)
-	s.True(hasPermission)
-
-	hasPermission, err = GitHubUserHasWritePermission(s.ctx, "evergreen-ci", "evergreen", "octocat")
+	hasPermission, err := GitHubUserHasWritePermission(s.ctx, "evergreen-ci", "evergreen", "octocat")
 	s.NoError(err)
 	s.False(hasPermission)
 }


### PR DESCRIPTION
DEVPROD-14857

### Description
This account was deleted so it is no longer available for testing write permissions. There is no suitable user to add without risk of it breaking again and I don't think it's an important enough test to take that risk. 

