### PR TITLE
DEVPROD-13555 Return 400 for agent route idempotent errors rather than 500

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1648,7 +1648,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		Permissions: permissions,
 	})
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
 	}
 	if token == "" {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))
@@ -1823,7 +1823,7 @@ func (h *awsS3Credentials) Run(ctx context.Context) gimlet.Responder {
 	}
 	policyJSON, err := json.Marshal(sessionPolicy)
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "marshalling session policy for task '%s'", h.taskID))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "marshalling session policy for task '%s'", h.taskID))
 	}
 	creds, err := h.stsManager.AssumeRole(ctx, h.taskID, cloud.AssumeRoleOptions{
 		RoleARN: h.callerARN,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1616,7 +1616,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		AllPermissions: h.allPermissions,
 	})
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
+		return gimlet.MakeJSONErrorResponder(err)
 	}
 	// If all permissions is true, we want to send an empty permissions object to the GitHub API.
 	permissions := &intersection.Permissions
@@ -1648,10 +1648,10 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		Permissions: permissions,
 	})
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))
 	}
 	if token == "" {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))
+		return gimlet.MakeJSONErrorResponder(errors.Errorf("no installation token returned for '%s/%s'", h.owner, h.repo))
 	}
 
 	return gimlet.NewJSONResponse(&apimodels.Token{
@@ -1694,7 +1694,7 @@ func (h *revokeGitHubDynamicAccessToken) Parse(ctx context.Context, r *http.Requ
 
 func (h *revokeGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Responder {
 	if err := thirdparty.RevokeInstallationToken(ctx, h.body.Token); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "revoking token for task '%s'", h.taskID))
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "revoking token for task '%s'", h.taskID))
 	}
 
 	return gimlet.NewJSONResponse(struct{}{})
@@ -1741,7 +1741,7 @@ func (h *awsAssumeRole) Run(ctx context.Context) gimlet.Responder {
 		DurationSeconds: h.body.DurationSeconds,
 	})
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "assuming role for task '%s'", h.taskID))
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "assuming role for task '%s'", h.taskID))
 	}
 	return gimlet.NewJSONResponse(apimodels.AWSCredentials{
 		AccessKeyID:     creds.AccessKeyID,
@@ -1807,7 +1807,7 @@ func (h *awsS3Credentials) Run(ctx context.Context) gimlet.Responder {
 	if h.callerARN == "" {
 		h.callerARN, err = h.stsManager.GetCallerIdentityARN(ctx)
 		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting caller identity for task '%s'", h.taskID))
+			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "getting caller identity for task '%s'", h.taskID))
 		}
 	}
 	// TODO (DEVPROD-13978): Create correct session policy based off of provided task.
@@ -1823,14 +1823,14 @@ func (h *awsS3Credentials) Run(ctx context.Context) gimlet.Responder {
 	}
 	policyJSON, err := json.Marshal(sessionPolicy)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "marshalling session policy for task '%s'", h.taskID))
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "marshalling session policy for task '%s'", h.taskID))
 	}
 	creds, err := h.stsManager.AssumeRole(ctx, h.taskID, cloud.AssumeRoleOptions{
 		RoleARN: h.callerARN,
 		Policy:  aws.String(string(policyJSON)),
 	})
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating credentials for s3 access for task '%s'", h.taskID))
+		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "creating credentials for s3 access for task '%s'", h.taskID))
 	}
 
 	return gimlet.NewJSONResponse(apimodels.AWSCredentials{

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -938,7 +938,7 @@ func TestAWSAssumeRole(t *testing.T) {
 			t.Run("RunErrorsOnNilTask", func(t *testing.T) {
 				resp := handler.Run(ctx)
 				require.NotNil(t, resp)
-				require.Equal(t, http.StatusInternalServerError, resp.Status(), resp.Data())
+				require.Equal(t, http.StatusBadRequest, resp.Status(), resp.Data())
 			})
 
 			t.Run("RunSucceeds", func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-13555

### Description
Errors returned as a 500 mean that the agent will retry the request. I changed some errors from 500 -> 400.

Who ever reviews, I could add a comment(s) to the ones that are non-obvious why it's 400 rather than 500 (I'm a biased observer as these are mostly routes I've created/modified recently)

### Testing
Unit tests
