### PR TITLE
DEVPROD-14544: remove host secret from expansions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -486,7 +486,12 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 
 	// Set up a new task output directory regardless if the task is part of
 	// a task group.
-	tc.taskConfig.TaskOutputDir = taskoutput.NewDirectory(tc.taskConfig.WorkDir, &tc.taskConfig.Task, redactor.RedactionOptions{Expansions: tc.taskConfig.NewExpansions, Redacted: tc.taskConfig.Redacted}, tc.logger)
+	redactorOpts := redactor.RedactionOptions{
+		Expansions:           tc.taskConfig.NewExpansions,
+		Redacted:             tc.taskConfig.Redacted,
+		AdditionalRedactions: tc.taskConfig.InternalRedactions,
+	}
+	tc.taskConfig.TaskOutputDir = taskoutput.NewDirectory(tc.taskConfig.WorkDir, &tc.taskConfig.Task, redactorOpts, tc.logger)
 	if err := tc.taskConfig.TaskOutputDir.Setup(); err != nil {
 		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task output directory"))
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -487,9 +487,9 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 	// Set up a new task output directory regardless if the task is part of
 	// a task group.
 	redactorOpts := redactor.RedactionOptions{
-		Expansions:           tc.taskConfig.NewExpansions,
-		Redacted:             tc.taskConfig.Redacted,
-		AdditionalRedactions: tc.taskConfig.InternalRedactions,
+		Expansions:         tc.taskConfig.NewExpansions,
+		Redacted:           tc.taskConfig.Redacted,
+		InternalRedactions: tc.taskConfig.InternalRedactions,
 	}
 	tc.taskConfig.TaskOutputDir = taskoutput.NewDirectory(tc.taskConfig.WorkDir, &tc.taskConfig.Task, redactorOpts, tc.logger)
 	if err := tc.taskConfig.TaskOutputDir.Setup(); err != nil {

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -47,7 +47,7 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 		if err := taskoutput.AppendTestLog(ctx, &conf.Task, redactor.RedactionOptions{
 			Expansions:           conf.NewExpansions,
 			Redacted:             conf.Redacted,
-			AdditionalRedactions: conf.InternalRedactions,
+			InternalRedactions: conf.InternalRedactions,
 		}, &log); err != nil {
 			// Continue on error to let the other logs get posted.
 			logger.Task().Error(errors.Wrap(err, "sending test log"))

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -45,8 +45,8 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 		}
 
 		if err := taskoutput.AppendTestLog(ctx, &conf.Task, redactor.RedactionOptions{
-			Expansions:           conf.NewExpansions,
-			Redacted:             conf.Redacted,
+			Expansions:         conf.NewExpansions,
+			Redacted:           conf.Redacted,
 			InternalRedactions: conf.InternalRedactions,
 		}, &log); err != nil {
 			// Continue on error to let the other logs get posted.

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -44,7 +44,11 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 			return errors.Wrap(err, "canceled while sending test logs")
 		}
 
-		if err := taskoutput.AppendTestLog(ctx, &conf.Task, redactor.RedactionOptions{Expansions: conf.NewExpansions, Redacted: conf.Redacted}, &log); err != nil {
+		if err := taskoutput.AppendTestLog(ctx, &conf.Task, redactor.RedactionOptions{
+			Expansions:           conf.NewExpansions,
+			Redacted:             conf.Redacted,
+			AdditionalRedactions: conf.InternalRedactions,
+		}, &log); err != nil {
 			// Continue on error to let the other logs get posted.
 			logger.Task().Error(errors.Wrap(err, "sending test log"))
 		}

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -193,9 +193,9 @@ func (c *xunitResults) parseAndUploadResults(ctx context.Context, conf *internal
 		}
 
 		opts := redactor.RedactionOptions{
-			Expansions:           conf.NewExpansions,
-			Redacted:             conf.Redacted,
-			AdditionalRedactions: conf.InternalRedactions,
+			Expansions:         conf.NewExpansions,
+			Redacted:           conf.Redacted,
+			InternalRedactions: conf.InternalRedactions,
 		}
 		if err := taskoutput.AppendTestLog(ctx, &conf.Task, opts, log); err != nil {
 			logger.Task().Error(errors.Wrap(err, "sending test log"))

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -192,7 +192,12 @@ func (c *xunitResults) parseAndUploadResults(ctx context.Context, conf *internal
 			return errors.Wrap(err, "canceled while sending test logs")
 		}
 
-		if err := taskoutput.AppendTestLog(ctx, &conf.Task, redactor.RedactionOptions{Expansions: conf.NewExpansions, Redacted: conf.Redacted}, log); err != nil {
+		opts := redactor.RedactionOptions{
+			Expansions:           conf.NewExpansions,
+			Redacted:             conf.Redacted,
+			AdditionalRedactions: conf.InternalRedactions,
+		}
+		if err := taskoutput.AppendTestLog(ctx, &conf.Task, opts, log); err != nil {
 			logger.Task().Error(errors.Wrap(err, "sending test log"))
 			continue
 		} else {

--- a/agent/globals/globals.go
+++ b/agent/globals/globals.go
@@ -114,7 +114,10 @@ const (
 	AWSSessionToken = "AWS_SESSION_TOKEN"
 	// AWSRoleExpiration is the expansion name for the expiration of a temporary AWS access key.
 	AWSRoleExpiration = "AWS_ROLE_EXPIRATION"
-	// HostSecret is the expansion name within the agent that is the host's unique secret.
+
+	// HostSecret is the placeholder name within the agent for the host's
+	// secret. The host secret is not an expansion, but is still a sensitive
+	// Evergreen-internal value that should be redacted.
 	HostSecret = "HOST_SECRET"
 )
 
@@ -128,6 +131,5 @@ var (
 		AWSAccessKeyId,
 		AWSSecretAccessKey,
 		AWSSessionToken,
-		HostSecret,
 	}
 )

--- a/agent/internal/redactor/redacting_sender.go
+++ b/agent/internal/redactor/redacting_sender.go
@@ -49,9 +49,10 @@ func (r *redactingSender) Send(m message.Composer) {
 			allRedacted = append(allRedacted, util.RedactInfo{Key: expansion, Value: val})
 		}
 	}
-	for k, v := range r.additionalRedactions.Map() {
+	r.additionalRedactions.Range(func(k, v string) bool {
 		allRedacted = append(allRedacted, util.RedactInfo{Key: k, Value: v})
-	}
+		return true
+	})
 
 	// Sort redacted info based on value length to ensure we're redacting longer values first.
 	sort.Slice(allRedacted, func(i, j int) bool {

--- a/agent/internal/redactor/redacting_sender.go
+++ b/agent/internal/redactor/redacting_sender.go
@@ -13,10 +13,12 @@ import (
 
 const redactedVariableTemplate = "<REDACTED:%s>"
 
-// redactingSender wraps a sender for redacting sensitive expansion values.
+// redactingSender wraps a sender for redacting sensitive expansion values and
+// other Evergreen-internal values.
 type redactingSender struct {
-	expansions         *util.DynamicExpansions
-	expansionsToRedact []string
+	expansions           *util.DynamicExpansions
+	expansionsToRedact   []string
+	additionalRedactions *util.DynamicExpansions
 
 	send.Sender
 }
@@ -28,6 +30,11 @@ type RedactionOptions struct {
 	// Redacted specifies the names of expansions to redact the values for.
 	// [globals.ExpansionsToRedact] are always redacted.
 	Redacted []string
+	// AdditionalRedactions specifies an additional set of strings that are not
+	// expansions that should be redacted from the logs (e.g. agent-internal
+	// secrets).
+	// kim: TODO: use this where needed to redact strings.
+	AdditionalRedactions *util.DynamicExpansions
 }
 
 func (r *redactingSender) Send(m message.Composer) {
@@ -42,6 +49,9 @@ func (r *redactingSender) Send(m message.Composer) {
 			allRedacted = append(allRedacted, util.RedactInfo{Key: expansion, Value: val})
 		}
 	}
+	// kim: TODO: verify that this is correct when combined with PutAndRedact.
+	allRedacted = append(allRedacted, r.additionalRedactions.GetRedacted()...)
+
 	// Sort redacted info based on value length to ensure we're redacting longer values first.
 	sort.Slice(allRedacted, func(i, j int) bool {
 		return len(allRedacted[i].Value) > len(allRedacted[j].Value)
@@ -49,18 +59,24 @@ func (r *redactingSender) Send(m message.Composer) {
 	for _, info := range allRedacted {
 		msg = strings.ReplaceAll(msg, info.Value, fmt.Sprintf(redactedVariableTemplate, info.Key))
 	}
+
 	r.Sender.Send(message.NewDefaultMessage(m.Priority(), msg))
 }
 
 // NewRedactingSender wraps the provided sender with a sender that redacts
 // expansions in accordance with the reaction options.
+// kim: TODO: ensure all usages of redacting sender pass in internal redactions.
 func NewRedactingSender(sender send.Sender, opts RedactionOptions) send.Sender {
 	if opts.Expansions == nil {
 		opts.Expansions = &util.DynamicExpansions{}
 	}
+	if opts.AdditionalRedactions == nil {
+		opts.AdditionalRedactions = &util.DynamicExpansions{}
+	}
 	return &redactingSender{
-		expansions:         opts.Expansions,
-		expansionsToRedact: append(opts.Redacted, globals.ExpansionsToRedact...),
-		Sender:             sender,
+		expansions:           opts.Expansions,
+		expansionsToRedact:   append(opts.Redacted, globals.ExpansionsToRedact...),
+		additionalRedactions: opts.AdditionalRedactions,
+		Sender:               sender,
 	}
 }

--- a/agent/internal/redactor/redacting_sender_test.go
+++ b/agent/internal/redactor/redacting_sender_test.go
@@ -14,28 +14,34 @@ import (
 
 func TestRedactingSender(t *testing.T) {
 	for name, test := range map[string]struct {
-		expansions         map[string]string
-		expansionsToRedact []string
-		internalRedactions map[string]string
-		inputString        string
-		expected           string
+		expansions           map[string]string
+		expansionsToRedact   []string
+		additionalRedactions map[string]string
+		inputString          string
+		expected             string
 	}{
 		"MultipleSubstitutions": {
 			expansions: map[string]string{
 				"secret_key": "secret_val",
 			},
+			additionalRedactions: map[string]string{
+				"another_secret_key": "another_secret_val",
+			},
 			expansionsToRedact: []string{"secret_key"},
-			inputString:        "secret_val secret_val",
-			expected:           fmt.Sprintf("%s %s", fmt.Sprintf(redactedVariableTemplate, "secret_key"), fmt.Sprintf(redactedVariableTemplate, "secret_key")),
+			inputString:        "secret_val secret_val another_secret_val",
+			expected:           fmt.Sprintf("%s %s %s", fmt.Sprintf(redactedVariableTemplate, "secret_key"), fmt.Sprintf(redactedVariableTemplate, "secret_key"), fmt.Sprintf(redactedVariableTemplate, "another_secret_key")),
 		},
 		"MultipleValues": {
 			expansions: map[string]string{
 				"secret_key1": "secret_val1",
 				"secret_key2": "secret_val2",
 			},
+			additionalRedactions: map[string]string{
+				"secret_key3": "secret_val3",
+			},
 			expansionsToRedact: []string{"secret_key1", "secret_key2"},
-			inputString:        "secret_val2 secret_val1",
-			expected:           fmt.Sprintf("%s %s", fmt.Sprintf(redactedVariableTemplate, "secret_key2"), fmt.Sprintf(redactedVariableTemplate, "secret_key1")),
+			inputString:        "secret_val2 secret_val1 secret_val3",
+			expected:           fmt.Sprintf("%s %s %s", fmt.Sprintf(redactedVariableTemplate, "secret_key2"), fmt.Sprintf(redactedVariableTemplate, "secret_key1"), fmt.Sprintf(redactedVariableTemplate, "secret_key3")),
 		},
 		"OverlappingSubstitutions": {
 			expansions: map[string]string{
@@ -75,6 +81,9 @@ func TestRedactingSender(t *testing.T) {
 			expansions: map[string]string{
 				"secret_key": "secret_val",
 			},
+			additionalRedactions: map[string]string{
+				"another_secret_key": "another_secret_val",
+			},
 			expansionsToRedact: []string{"secret_key"},
 			inputString:        "nothing to see here",
 			expected:           "nothing to see here",
@@ -85,9 +94,9 @@ func TestRedactingSender(t *testing.T) {
 			require.NoError(t, err)
 
 			opts := RedactionOptions{
-				Expansions: util.NewDynamicExpansions(test.expansions),
-				Redacted:   test.expansionsToRedact,
-				// kim: TODO: test additional redactions
+				Expansions:           util.NewDynamicExpansions(test.expansions),
+				Redacted:             test.expansionsToRedact,
+				AdditionalRedactions: util.NewDynamicExpansions(test.additionalRedactions),
 			}
 			s := NewRedactingSender(wrappedSender, opts)
 			s.Send(message.NewDefaultMessage(level.Info, test.inputString))

--- a/agent/internal/redactor/redacting_sender_test.go
+++ b/agent/internal/redactor/redacting_sender_test.go
@@ -14,17 +14,17 @@ import (
 
 func TestRedactingSender(t *testing.T) {
 	for name, test := range map[string]struct {
-		expansions           map[string]string
-		expansionsToRedact   []string
-		additionalRedactions map[string]string
-		inputString          string
-		expected             string
+		expansions         map[string]string
+		expansionsToRedact []string
+		internalRedactions map[string]string
+		inputString        string
+		expected           string
 	}{
 		"MultipleSubstitutions": {
 			expansions: map[string]string{
 				"secret_key": "secret_val",
 			},
-			additionalRedactions: map[string]string{
+			internalRedactions: map[string]string{
 				"another_secret_key": "another_secret_val",
 			},
 			expansionsToRedact: []string{"secret_key"},
@@ -36,7 +36,7 @@ func TestRedactingSender(t *testing.T) {
 				"secret_key1": "secret_val1",
 				"secret_key2": "secret_val2",
 			},
-			additionalRedactions: map[string]string{
+			internalRedactions: map[string]string{
 				"secret_key3": "secret_val3",
 			},
 			expansionsToRedact: []string{"secret_key1", "secret_key2"},
@@ -81,7 +81,7 @@ func TestRedactingSender(t *testing.T) {
 			expansions: map[string]string{
 				"secret_key": "secret_val",
 			},
-			additionalRedactions: map[string]string{
+			internalRedactions: map[string]string{
 				"another_secret_key": "another_secret_val",
 			},
 			expansionsToRedact: []string{"secret_key"},
@@ -94,9 +94,9 @@ func TestRedactingSender(t *testing.T) {
 			require.NoError(t, err)
 
 			opts := RedactionOptions{
-				Expansions:           util.NewDynamicExpansions(test.expansions),
-				Redacted:             test.expansionsToRedact,
-				AdditionalRedactions: util.NewDynamicExpansions(test.additionalRedactions),
+				Expansions:         util.NewDynamicExpansions(test.expansions),
+				Redacted:           test.expansionsToRedact,
+				InternalRedactions: util.NewDynamicExpansions(test.internalRedactions),
 			}
 			s := NewRedactingSender(wrappedSender, opts)
 			s.Send(message.NewDefaultMessage(level.Info, test.inputString))

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -47,8 +47,6 @@ type TaskConfig struct {
 	// expansions available to tasks. Having this allows redaction of strings
 	// that cannot be exposed to tasks as expansions.
 	// This only reuses agentutil.DynamicExpansions for thread safety.
-	// kim: TODO: set internal redactions
-	// kim: TODO: double-check safety of concurrent access.
 	InternalRedactions *agentutil.DynamicExpansions
 	WorkDir            string
 	TaskOutputDir      *taskoutput.Directory
@@ -207,7 +205,7 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 		Expansions:         e.Expansions,
 		NewExpansions:      agentutil.NewDynamicExpansions(e.Expansions),
 		DynamicExpansions:  util.Expansions{},
-		InternalRedactions: agentutil.NewDynamicExpansions(*util.NewExpansions(map[string]string{})),
+		InternalRedactions: agentutil.NewDynamicExpansions(map[string]string{}),
 		ProjectVars:        e.Vars,
 		Redacted:           redacted,
 		WorkDir:            workDir,

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -64,12 +64,12 @@ func TestAppendTestLog(t *testing.T) {
 		},
 		{
 			name:           "Redacted",
-			input:          []string{"the secret is: DEADBEEF"},
-			expectedOutput: []string{"the secret is: <REDACTED:secret_name>"},
+			input:          []string{"the secret is: DEADBEEF, and the second secret is: DEADC0DE"},
+			expectedOutput: []string{"the secret is: <REDACTED:secret_name>, and the second secret is: <REDACTED:another_secret>"},
 			redactOpts: redactor.RedactionOptions{
-				Expansions: &util.DynamicExpansions{Expansions: map[string]string{"secret_name": "DEADBEEF"}},
-				Redacted:   []string{"secret_name"},
-				// kim: TODO: add AdditionalRedactions tests here
+				Expansions:           util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
+				Redacted:             []string{"secret_name"},
+				AdditionalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
 			},
 		},
 	} {
@@ -161,17 +161,17 @@ func TestTestLogDirectoryHandlerRun(t *testing.T) {
 				{
 					logPath: "secret.log",
 					inputLines: []string{
-						"This log contains a big secret: DEADBEEF",
+						"This log contains a big secret: DEADBEEF, and another bigger secret: DEADC0DE",
 					},
 					expectedLines: []string{
-						"This log contains a big secret: <REDACTED:secret_name>",
+						"This log contains a big secret: <REDACTED:secret_name>, and another bigger secret: <REDACTED:another_secret>",
 					},
 				},
 			},
 			redactOpts: redactor.RedactionOptions{
-				Expansions: &util.DynamicExpansions{Expansions: map[string]string{"secret_name": "DEADBEEF"}},
-				Redacted:   []string{"secret_name"},
-				// kim: TODO: add AdditionalRedactions tests here
+				Expansions:           util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
+				Redacted:             []string{"secret_name"},
+				AdditionalRedactions: util.NewDynamicExpansions(Expansions: map[string]string{"another_secret": "DEADC0DE"}),
 			},
 		},
 	} {

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -171,7 +171,7 @@ func TestTestLogDirectoryHandlerRun(t *testing.T) {
 			redactOpts: redactor.RedactionOptions{
 				Expansions:           util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
 				Redacted:             []string{"secret_name"},
-				AdditionalRedactions: util.NewDynamicExpansions(Expansions: map[string]string{"another_secret": "DEADC0DE"}),
+				AdditionalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
 			},
 		},
 	} {

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -67,9 +67,9 @@ func TestAppendTestLog(t *testing.T) {
 			input:          []string{"the secret is: DEADBEEF, and the second secret is: DEADC0DE"},
 			expectedOutput: []string{"the secret is: <REDACTED:secret_name>, and the second secret is: <REDACTED:another_secret>"},
 			redactOpts: redactor.RedactionOptions{
-				Expansions:           util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
-				Redacted:             []string{"secret_name"},
-				AdditionalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
+				Expansions:         util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
+				Redacted:           []string{"secret_name"},
+				InternalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
 			},
 		},
 	} {
@@ -169,9 +169,9 @@ func TestTestLogDirectoryHandlerRun(t *testing.T) {
 				},
 			},
 			redactOpts: redactor.RedactionOptions{
-				Expansions:           util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
-				Redacted:             []string{"secret_name"},
-				AdditionalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
+				Expansions:         util.NewDynamicExpansions(map[string]string{"secret_name": "DEADBEEF"}),
+				Redacted:           []string{"secret_name"},
+				InternalRedactions: util.NewDynamicExpansions(map[string]string{"another_secret": "DEADC0DE"}),
 			},
 		},
 	} {

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -69,6 +69,7 @@ func TestAppendTestLog(t *testing.T) {
 			redactOpts: redactor.RedactionOptions{
 				Expansions: &util.DynamicExpansions{Expansions: map[string]string{"secret_name": "DEADBEEF"}},
 				Redacted:   []string{"secret_name"},
+				// kim: TODO: add AdditionalRedactions tests here
 			},
 		},
 	} {
@@ -170,6 +171,7 @@ func TestTestLogDirectoryHandlerRun(t *testing.T) {
 			redactOpts: redactor.RedactionOptions{
 				Expansions: &util.DynamicExpansions{Expansions: map[string]string{"secret_name": "DEADBEEF"}},
 				Redacted:   []string{"secret_name"},
+				// kim: TODO: add AdditionalRedactions tests here
 			},
 		},
 	} {

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -114,10 +114,6 @@ func (a *Agent) prepLogger(tc *taskContext, commandName string) client.LoggerCon
 		logDir = filepath.Join(logDir, commandName)
 		grip.Error(errors.Wrapf(os.MkdirAll(logDir, os.ModeDir|os.ModePerm), "making log directory '%s' for command '%s'", logDir, commandName))
 	}
-	// kim: TODO: remove
-	// redactorExpansions := tc.taskConfig.NewExpansions
-	// Add the host's secret to the internal agent expansions, so it can be redacted by our redacting logger later.
-	// redactorExpansions.Put(globals.HostSecret, a.opts.HostSecret)
 	config := client.LoggerConfig{
 		SendToGlobalSender: a.opts.SendTaskLogsToGlobalSender,
 		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskOutput.Key, tc.taskConfig.TaskOutput.Secret, ""),

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -114,15 +114,17 @@ func (a *Agent) prepLogger(tc *taskContext, commandName string) client.LoggerCon
 		logDir = filepath.Join(logDir, commandName)
 		grip.Error(errors.Wrapf(os.MkdirAll(logDir, os.ModeDir|os.ModePerm), "making log directory '%s' for command '%s'", logDir, commandName))
 	}
-	redactorExpansions := tc.taskConfig.NewExpansions
+	// kim: TODO: remove
+	// redactorExpansions := tc.taskConfig.NewExpansions
 	// Add the host's secret to the internal agent expansions, so it can be redacted by our redacting logger later.
-	redactorExpansions.Put(globals.HostSecret, a.opts.HostSecret)
+	// redactorExpansions.Put(globals.HostSecret, a.opts.HostSecret)
 	config := client.LoggerConfig{
 		SendToGlobalSender: a.opts.SendTaskLogsToGlobalSender,
 		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskOutput.Key, tc.taskConfig.TaskOutput.Secret, ""),
 		RedactorOpts: redactor.RedactionOptions{
-			Expansions: redactorExpansions,
-			Redacted:   tc.taskConfig.Redacted,
+			Expansions:           tc.taskConfig.NewExpansions,
+			Redacted:             tc.taskConfig.Redacted,
+			AdditionalRedactions: tc.taskConfig.InternalRedactions,
 		},
 	}
 	agentLog := client.LogOpts{

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -118,9 +118,9 @@ func (a *Agent) prepLogger(tc *taskContext, commandName string) client.LoggerCon
 		SendToGlobalSender: a.opts.SendTaskLogsToGlobalSender,
 		AWSCredentials:     pail.CreateAWSCredentials(tc.taskConfig.TaskOutput.Key, tc.taskConfig.TaskOutput.Secret, ""),
 		RedactorOpts: redactor.RedactionOptions{
-			Expansions:           tc.taskConfig.NewExpansions,
-			Redacted:             tc.taskConfig.Redacted,
-			AdditionalRedactions: tc.taskConfig.InternalRedactions,
+			Expansions:         tc.taskConfig.NewExpansions,
+			Redacted:           tc.taskConfig.Redacted,
+			InternalRedactions: tc.taskConfig.InternalRedactions,
 		},
 	}
 	agentLog := client.LogOpts{

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -386,6 +386,12 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.Task.TaskOutputInfo.TaskLogs.AWSCredentials = awsCreds
 	taskConfig.Task.TaskOutputInfo.TestLogs.AWSCredentials = awsCreds
 
+	if a.opts.HostSecret != "" {
+		// kim: NOTE: check if this makes sense. The host secret should already
+		// be set when the agent is initialized with opts.
+		taskConfig.InternalRedactions.PutAndRedact(globals.HostSecret, a.opts.HostSecret)
+	}
+
 	return taskConfig, nil
 }
 

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -387,8 +387,6 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.Task.TaskOutputInfo.TestLogs.AWSCredentials = awsCreds
 
 	if a.opts.HostSecret != "" {
-		// kim: NOTE: check if this makes sense. The host secret should already
-		// be set when the agent is initialized with opts.
 		taskConfig.InternalRedactions.PutAndRedact(globals.HostSecret, a.opts.HostSecret)
 	}
 

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -387,6 +387,10 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	taskConfig.Task.TaskOutputInfo.TestLogs.AWSCredentials = awsCreds
 
 	if a.opts.HostSecret != "" {
+		// Redact the host secret from the logs. While the host secret isn't
+		// supposed to be logged anywhere nor is it accessible by the task, this
+		// is additional protection against leaking the secret due to situations
+		// like a bug that unintentionally logs it.
 		taskConfig.InternalRedactions.PutAndRedact(globals.HostSecret, a.opts.HostSecret)
 	}
 

--- a/agent/util/expansions.go
+++ b/agent/util/expansions.go
@@ -9,9 +9,6 @@ import (
 // DynamicExpansions wraps expansions for safe concurrent access as they are
 // dynamically updated.
 // It also contains logic to redact values that should not be exposed.
-//
-// This should be expanded to support better expansion handling during a task
-// run.
 type DynamicExpansions struct {
 	util.Expansions
 	mu sync.RWMutex

--- a/agent/util/expansions.go
+++ b/agent/util/expansions.go
@@ -127,3 +127,18 @@ func (e *DynamicExpansions) Remove(expansion string) {
 
 	e.Expansions.Remove(expansion)
 }
+
+// Range iterates over all the expansions and calls the given function op for
+// each expansion key and value. op returns a boolean indicating whether to
+// continue iteration or not for each key-value pair. This is safe for
+// concurrent access and has no guaranteed iteration order.
+func (e *DynamicExpansions) Range(op func(key, value string) bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for k, v := range e.Expansions {
+		if !op(k, v) {
+			return
+		}
+	}
+}

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-06"
+	AgentVersion = "2025-02-12"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14544

### Description
The current implementation of redaction for the host secret also exposes the secret as an expansion that users can access because [it puts the host secret in the task's expansion map](https://github.com/evergreen-ci/evergreen/blob/440e66d6447986af9701d8f3ea3ef9654caac72f/agent/logging.go#L119). I changed the redacting sender so that it accepts a second, separate map that holds Evergreen-internal secrets. That way, secret strings can be redacted if they somehow accidentally appear in the logs, but they won't be accessible to the task as expansions.

### Testing
* Updated unit tests for redaction.
* Tested in staging patches that 1. [if the host secret is logged in plaintext, it's redacted from the task log](https://evergreen-multi.staging.corp.mongodb.com/kimberly-tao/task_log_raw/playground_ubuntu_test_archive_patch_18a445c1364c2bc21ff62f63561ef4331b6b6250_67abd3b4ab659800077d598f_25_02_11_22_48_21/0?type=T#L4) and 2. [the `${HOST_SECRET}` expansion is no longer defined for tasks to use](https://evergreen-multi.staging.corp.mongodb.com/kimberly-tao/task_log_raw/playground_ubuntu_test_archive_patch_18a445c1364c2bc21ff62f63561ef4331b6b6250_67abd416ab659800077d59a1_25_02_11_22_49_58/0?type=T#L4). (Sorry, the links likely won't work if you click them because personal stagings don't give access to other users by default.)