### PR TITLE
DEVPROD-14546: change Windows service user password to env var

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -298,11 +298,6 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 			user = `.\\` + user
 		}
 		params = append(params, fmt.Sprintf("--user=%s", user))
-		// kim: TODO: move to env var if possible. I believe this is always a
-		// bash script, so it may work to just prepend the env to the command.
-		// if h.ServicePassword != "" {
-		//     params = append(params, fmt.Sprintf("--password='%s'", h.ServicePassword))
-		// }
 	} else if h.User != "" {
 		params = append(params, fmt.Sprintf("--user=%s", h.User))
 	}
@@ -363,8 +358,6 @@ func (h *Host) QuietUninstallJasperCommand(config evergreen.HostJasperConfig) st
 	return h.jasperServiceCommand(config, nil, jcli.ServiceUninstallCommand, "--quiet")
 }
 
-// kim: TODO: test that command looks as expected (with and without service
-// password) in hostutil tests.
 func (h *Host) jasperServiceCommand(config evergreen.HostJasperConfig, env map[string]string, subCmd string, args ...string) string {
 	var cmd []string
 	for k, v := range env {

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -284,6 +284,8 @@ func (h *Host) FetchAndReinstallJasperCommands(settings *evergreen.Settings) str
 	}, " && ")
 }
 
+const jasperServicePasswordEnvVarName = "JASPER_USER_PASSWORD"
+
 // ForceReinstallJasperCommand returns the command to stop the Jasper service
 // (if it's running), delete the current Jasper service configuration (if it
 // exists), install the new configuration, and restart the service.
@@ -340,7 +342,7 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 
 	cmdEnv := map[string]string{}
 	if h.Distro.BootstrapSettings.ServiceUser != "" && h.ServicePassword != "" {
-		cmdEnv["JASPER_USER_PASSWORD"] = h.ServicePassword
+		cmdEnv[jasperServicePasswordEnvVarName] = h.ServicePassword
 	}
 
 	return h.jasperServiceCommand(settings.HostJasper, cmdEnv, jcli.ServiceForceReinstallCommand, params...)

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -525,12 +525,11 @@ func TestJasperCommandsWindows(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			require.NoError(t, h.CreateServicePassword(ctx))
 			cmd := h.ForceReinstallJasperCommand(settings)
-			assert.True(t, strings.HasPrefix(cmd, "/foo/jasper_cli.exe jasper service force-reinstall rpc"))
+			assert.True(t, strings.HasPrefix(cmd, fmt.Sprintf("JASPER_USER_PASSWORD=%s /foo/jasper_cli.exe jasper service force-reinstall rpc", h.ServicePassword)))
 			assert.Contains(t, cmd, "--host=0.0.0.0")
 			assert.Contains(t, cmd, fmt.Sprintf("--port=%d", settings.HostJasper.Port))
 			assert.Contains(t, cmd, fmt.Sprintf("--creds_path=%s", h.Distro.BootstrapSettings.JasperCredentialsPath))
 			assert.Contains(t, cmd, fmt.Sprintf(`--user=.\\%s`, h.Distro.BootstrapSettings.ServiceUser))
-			assert.Contains(t, cmd, fmt.Sprintf("--password='%s'", h.ServicePassword))
 		},
 		"WriteJasperCredentialsFileCommand": func(t *testing.T, h *Host, settings *evergreen.Settings) {
 			creds, err := newMockCredentials()


### PR DESCRIPTION
DEVPROD-14546

### Description
This is the first PR to improve the overall security of the service user auth in Windows. Evergreen has a special service user on Windows hosts to give it elevated permissions to run Windows background services, and it currently passes the user/password auth via command line arguments. However, it's better practice to pass them via env vars since it's harder to access a process's env compared to the process's command line arguments (e.g. from `ps` output). After this change, the service user's password should not appear in the system logs for Windows.

I'm going to post a follow-up PR to fix the original issue that the redaction logic exposes the password as an expansion.

### Testing
Tested in my staging that a Windows host could still start when using an env var for the service user's password.
