### PR TITLE
DEVPROD-14546: remove Windows service password from expansions

### DIFF
--- a/agent/globals/globals.go
+++ b/agent/globals/globals.go
@@ -2,8 +2,6 @@ package globals
 
 import (
 	"time"
-
-	"github.com/evergreen-ci/evergreen"
 )
 
 const (
@@ -124,10 +122,6 @@ const (
 var (
 	// ExpansionsToRedact are expansion names that should be redacted from logs and expansion exports.
 	ExpansionsToRedact = []string{
-		// HostServicePasswordExpansion exists to redact the host's ServicePassword in the logs,
-		// which is used for some jasper commands for Windows hosts. It is populated as a default
-		// expansion only for tasks running on Windows hosts.
-		evergreen.HostServicePasswordExpansion,
 		AWSAccessKeyId,
 		AWSSecretAccessKey,
 		AWSSessionToken,

--- a/agent/internal/redactor/redacting_sender.go
+++ b/agent/internal/redactor/redacting_sender.go
@@ -32,8 +32,8 @@ type RedactionOptions struct {
 	Redacted []string
 	// InternalRedactions specifies an additional set of strings that are not
 	// expansions that should be redacted from the logs (e.g. agent-internal
-	// secrets). All key-values in InternalRedactions are assumed to be
-	// sensitive.
+	// secrets). All values in InternalRedactions are assumed to be
+	// sensitive and are replaced by their key.
 	InternalRedactions *util.DynamicExpansions
 }
 

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -202,16 +202,14 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 	}
 
 	taskConfig := &TaskConfig{
-		Distro:            d,
-		ProjectRef:        *r,
-		Project:           *p,
-		Task:              *t,
-		BuildVariant:      *bv,
-		Expansions:        e.Expansions,
-		NewExpansions:     agentutil.NewDynamicExpansions(e.Expansions),
-		DynamicExpansions: util.Expansions{},
-		// kim: TODO: verify manually that service password string is redacted
-		// from task logs.
+		Distro:             d,
+		ProjectRef:         *r,
+		Project:            *p,
+		Task:               *t,
+		BuildVariant:       *bv,
+		Expansions:         e.Expansions,
+		NewExpansions:      agentutil.NewDynamicExpansions(e.Expansions),
+		DynamicExpansions:  util.Expansions{},
 		InternalRedactions: agentutil.NewDynamicExpansions(internalRedactions),
 		ProjectVars:        e.Vars,
 		Redacted:           redacted,

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -196,16 +196,23 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 		redacted = append(redacted, key)
 	}
 
+	internalRedactions := e.InternalRedactions
+	if internalRedactions == nil {
+		internalRedactions = map[string]string{}
+	}
+
 	taskConfig := &TaskConfig{
-		Distro:             d,
-		ProjectRef:         *r,
-		Project:            *p,
-		Task:               *t,
-		BuildVariant:       *bv,
-		Expansions:         e.Expansions,
-		NewExpansions:      agentutil.NewDynamicExpansions(e.Expansions),
-		DynamicExpansions:  util.Expansions{},
-		InternalRedactions: agentutil.NewDynamicExpansions(map[string]string{}),
+		Distro:            d,
+		ProjectRef:        *r,
+		Project:           *p,
+		Task:              *t,
+		BuildVariant:      *bv,
+		Expansions:        e.Expansions,
+		NewExpansions:     agentutil.NewDynamicExpansions(e.Expansions),
+		DynamicExpansions: util.Expansions{},
+		// kim: TODO: verify manually that service password string is redacted
+		// from task logs.
+		InternalRedactions: agentutil.NewDynamicExpansions(internalRedactions),
 		ProjectVars:        e.Vars,
 		Redacted:           redacted,
 		WorkDir:            workDir,

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -407,7 +407,7 @@ type ExpansionsAndVars struct {
 	// RedactKeys contain patterns to match against expansion keys for redaction
 	// in logs.
 	RedactKeys []string `json:"redact_keys"`
-	// InternalRedactions contain Evergreen-internal strings should not be
+	// InternalRedactions contain Evergreen-internal values that should not be
 	// usable by the task but should still be redacted from logs.
 	InternalRedactions map[string]string `json:"internal_redactions"`
 }

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -408,7 +408,7 @@ type ExpansionsAndVars struct {
 	// in logs.
 	RedactKeys []string `json:"redact_keys"`
 	// InternalRedactions contain Evergreen-internal strings should not be
-	// usable by teh task but should still be redacted from logs.
+	// usable by the task but should still be redacted from logs.
 	InternalRedactions map[string]string `json:"internal_redactions"`
 }
 

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -404,9 +404,12 @@ type ExpansionsAndVars struct {
 	Vars map[string]string `json:"vars"`
 	// PrivateVars contain the project private variables.
 	PrivateVars map[string]bool `json:"private_vars"`
-	// Redact keys contain patterns to match against expansion keys for
-	// redaction in logs.
+	// RedactKeys contain patterns to match against expansion keys for redaction
+	// in logs.
 	RedactKeys []string `json:"redact_keys"`
+	// InternalRedactions contain Evergreen-internal strings should not be
+	// usable by teh task but should still be redacted from logs.
+	InternalRedactions map[string]string `json:"internal_redactions"`
 }
 
 // CheckRunOutput represents the output for a CheckRun.

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-12"
+	AgentVersion = "2025-02-13"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -369,9 +369,11 @@ const (
 	// indicating that there are still running tasks.
 	PRTasksRunningDescription = "tasks are running"
 
-	// HostServicePasswordExpansion is the expansion for the service password that is stored on the host,
-	// and is meant to be set as a private variable so that it will be redacted in all logs.
-	HostServicePasswordExpansion = "host_service_password"
+	// HostServicePasswordInternalRedaction is the service user's password on a
+	// host. This is for Evergreen internal use only, and while it should not
+	// typically be accessible, it should be redacted in any logs from the task
+	// if it does happen to appear.
+	HostServicePasswordInternalRedaction = "host_service_password"
 
 	// RedactedValue is the value that is shown in the REST API and UI for redacted values.
 	RedactedValue       = "{REDACTED}"

--- a/globals.go
+++ b/globals.go
@@ -369,12 +369,6 @@ const (
 	// indicating that there are still running tasks.
 	PRTasksRunningDescription = "tasks are running"
 
-	// HostServicePasswordInternalRedaction is the service user's password on a
-	// host. This is for Evergreen internal use only, and while it should not
-	// typically be accessible, it should be redacted in any logs from the task
-	// if it does happen to appear.
-	HostServicePasswordInternalRedaction = "host_service_password"
-
 	// RedactedValue is the value that is shown in the REST API and UI for redacted values.
 	RedactedValue       = "{REDACTED}"
 	RedactedAfterValue  = "{REDACTED_AFTER}"

--- a/model/project.go
+++ b/model/project.go
@@ -1144,9 +1144,6 @@ func PopulateExpansions(ctx context.Context, t *task.Task, h *host.Host, appToke
 		for _, e := range h.Distro.Expansions {
 			expansions.Put(e.Key, e.Value)
 		}
-		if h.Distro.IsWindows() {
-			expansions.Put(evergreen.HostServicePasswordExpansion, h.ServicePassword)
-		}
 	}
 
 	return expansions, nil

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -334,6 +334,11 @@ func (h *getExpansionsAndVarsHandler) Parse(ctx context.Context, r *http.Request
 	return nil
 }
 
+// hostServicePasswordPlaceholder is the placeholder name for a service user's
+// password on a host. If the service user's password is present in any task
+// logs, it will be replaced with this placeholder string.
+const hostServicePasswordPlaceholder = "host_service_password"
+
 func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder {
 	t, err := task.FindOneId(ctx, h.taskID)
 	if err != nil {
@@ -392,7 +397,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 	}
 
 	if foundHost != nil && foundHost.ServicePassword != "" {
-		res.InternalRedactions[evergreen.HostServicePasswordInternalRedaction] = foundHost.ServicePassword
+		res.InternalRedactions[hostServicePasswordPlaceholder] = foundHost.ServicePassword
 	}
 
 	projectVars, err := model.FindMergedProjectVars(t.Project)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -383,11 +383,16 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 	}
 
 	res := apimodels.ExpansionsAndVars{
-		Expansions:  e,
-		Parameters:  map[string]string{},
-		Vars:        map[string]string{},
-		PrivateVars: map[string]bool{},
-		RedactKeys:  h.settings.LoggerConfig.RedactKeys,
+		Expansions:         e,
+		Parameters:         map[string]string{},
+		Vars:               map[string]string{},
+		PrivateVars:        map[string]bool{},
+		RedactKeys:         h.settings.LoggerConfig.RedactKeys,
+		InternalRedactions: map[string]string{},
+	}
+
+	if foundHost != nil && foundHost.ServicePassword != "" {
+		res.InternalRedactions[evergreen.HostServicePasswordInternalRedaction] = foundHost.ServicePassword
 	}
 
 	projectVars, err := model.FindMergedProjectVars(t.Project)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -86,7 +86,7 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, rh.taskID, data.Expansions.Get("task_id"))
 			assert.Equal(t, "distro_expansion_value", data.Expansions.Get("distro_expansion_key"))
-			assert.Equal(t, "password", data.Expansions.Get(evergreen.HostServicePasswordExpansion))
+			assert.Equal(t, "password", data.InternalRedactions[evergreen.HostServicePasswordInternalRedaction])
 			assert.Equal(t, map[string]string{"a": "1", "b": "3"}, data.Vars)
 			assert.Equal(t, map[string]string{"a": "4"}, data.Parameters)
 			assert.Equal(t, map[string]bool{"b": true}, data.PrivateVars)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -86,7 +86,7 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, rh.taskID, data.Expansions.Get("task_id"))
 			assert.Equal(t, "distro_expansion_value", data.Expansions.Get("distro_expansion_key"))
-			assert.Equal(t, "password", data.InternalRedactions[evergreen.HostServicePasswordInternalRedaction])
+			assert.Equal(t, "password", data.InternalRedactions[hostServicePasswordPlaceholder])
 			assert.Equal(t, map[string]string{"a": "1", "b": "3"}, data.Vars)
 			assert.Equal(t, map[string]string{"a": "4"}, data.Parameters)
 			assert.Equal(t, map[string]bool{"b": true}, data.PrivateVars)


### PR DESCRIPTION
DEVPROD-14546

### Description
Related to #8712 and building on #8708 - change the way the service user's password is redacted in task logs. Instead of setting it as an private variable in an expansion (which would allow the task to also access the service password), make it an Evergreen-internal redaction string. That way, the string will be redacted if it happens to appear in task logs, but it won't be usable as an expansion.

### Testing
Tested in staging to verify that [the service password is redacted if it appears](https://evergreen-staging.corp.mongodb.com/task_log_raw/evg_windows_test_agent_patch_ad48caa8037a77d28258c49e28d04a5645d05f12_67ae5bf7ccc2e500074b8695_25_02_13_20_54_16/0?type=T#L6) and [trying to use the `${host_service_password}` as an expansion does not work](https://evergreen-staging.corp.mongodb.com/task_log_raw/evg_windows_test_agent_patch_ad48caa8037a77d28258c49e28d04a5645d05f12_67ae5c51fba6200007ce31ed_25_02_13_20_55_46/0?type=T#L6).