### PR TITLE
DEVPROD-14947 consider requester correctly for batchtime

### DIFF
--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -934,7 +934,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		if v.Requester == evergreen.RepotrackerVersionRequester && evergreen.ShouldConsiderBatchtime(v.Requester) {
+		if evergreen.ShouldConsiderBatchtime(v.Requester) {
 			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(&buildvariant, v.CreateTime, time.Now())
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times


### PR DESCRIPTION
DEVPROD-14947
### Description
We should be considering requester using ShouldConsiderBatchtime rather than casing directly on repotracker version (otherwise, we don't handle push triggers correctly).

It looks like I tried fixing this line in [DEVPROD-5857](https://jira.mongodb.org/browse/DEVPROD-5857) which was reverted; however, I think that this had been more of an inadvertent fix, rather than being the reason that the PR was reverted, so I think it should still be done.

### Testing
Improved existing unit test to consider more requesters.

