### PR TITLE
DEVPROD-12984 Replace Walk with WalkDir

### DIFF
--- a/agent/command/archive_auto_create_test.go
+++ b/agent/command/archive_auto_create_test.go
@@ -95,7 +95,7 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 		},
 		"SucceedsAndCreatesArchive": func(ctx context.Context, t *testing.T, cmd *autoArchiveCreate, client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) {
 			expectedEntriesInArchive := map[string]bool{}
-			require.NoError(t, filepath.Walk(cmd.SourceDir, func(path string, info fs.FileInfo, err error) error {
+			require.NoError(t, filepath.WalkDir(cmd.SourceDir, func(path string, di fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -114,7 +114,7 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 			unarchiveDir := t.TempDir()
 			require.NoError(t, archiver.NewTarGz().Unarchive(cmd.Target, unarchiveDir))
 
-			require.NoError(t, filepath.Walk(unarchiveDir, func(path string, info fs.FileInfo, err error) error {
+			require.NoError(t, filepath.WalkDir(unarchiveDir, func(path string, di fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -157,7 +157,7 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 			unarchiveDir := t.TempDir()
 			require.NoError(t, archiver.NewTarGz().Unarchive(cmd.Target, unarchiveDir))
 
-			require.NoError(t, filepath.Walk(unarchiveDir, func(path string, info fs.FileInfo, err error) error {
+			require.NoError(t, filepath.WalkDir(unarchiveDir, func(path string, di fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
@@ -211,7 +211,7 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 			unarchiveDir := t.TempDir()
 			require.NoError(t, archiver.NewTarGz().Unarchive(cmd.Target, unarchiveDir))
 
-			require.NoError(t, filepath.Walk(unarchiveDir, func(path string, info fs.FileInfo, err error) error {
+			require.NoError(t, filepath.WalkDir(unarchiveDir, func(path string, di fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}

--- a/agent/command/archive_auto_extract_test.go
+++ b/agent/command/archive_auto_extract_test.go
@@ -2,7 +2,7 @@ package command
 
 import (
 	"context"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -150,7 +150,7 @@ func checkCommonExtractedArchiveContents(t *testing.T, targetDirectory string) {
 
 	// Check that the proper directory structure is created and contains the one
 	// extracted file.
-	err := filepath.Walk(targetDirectory, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(targetDirectory, func(path string, di fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -85,7 +86,7 @@ func (a *Agent) removeTaskDirectory(tc *taskContext) {
 // an issue where some files may be marked read-only, which prevents
 // os.RemoveAll from deleting them.
 func (a *Agent) removeAll(dir string) error {
-	grip.Error(errors.Wrapf(filepath.Walk(dir, func(path string, _ os.FileInfo, err error) error {
+	grip.Error(errors.Wrapf(filepath.WalkDir(dir, func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
@@ -147,7 +148,7 @@ func (a *Agent) tryCleanupDirectory(dir string) {
 
 	paths := []string{}
 
-	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.WalkDir(dir, func(path string, di fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -156,11 +157,11 @@ func (a *Agent) tryCleanupDirectory(dir string) {
 			return nil
 		}
 
-		if strings.HasPrefix(info.Name(), ".") {
+		if strings.HasPrefix(di.Name(), ".") {
 			return nil
 		}
 
-		if info.IsDir() {
+		if di.IsDir() {
 			paths = append(paths, path)
 		}
 

--- a/cmd/load-smoke-data/load-smoke-data.go
+++ b/cmd/load-smoke-data/load-smoke-data.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"flag"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,7 +29,7 @@ const gridFSFileID = "5e4ff3ab850e6136624eaf95"
 
 func getFiles(root string) ([]string, error) {
 	out := []string{}
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, di fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/make-tarball/make-tarball.go
+++ b/cmd/make-tarball/make-tarball.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -38,7 +39,12 @@ func getContents(paths []string, exclusions []string) <-chan archiveWorkUnit {
 
 	go func() {
 		for _, path := range paths {
-			err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+			err := filepath.WalkDir(path, func(p string, di fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				info, err := di.Info()
 				if err != nil {
 					return err
 				}

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-12"
+	AgentVersion = "2025-02-14"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-12984

### Description
walkdir was added in a more recent go version and is more efficient than walk (since we dont need stats) 

### Testing
existing tests should pass
