### PR TITLE
DEVPROD-14838: Add spans for task output handling

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -504,7 +504,7 @@ func (a *Agent) setupTask(agentCtx, setupCtx context.Context, initialTC *taskCon
 		Redacted:           tc.taskConfig.Redacted,
 		InternalRedactions: tc.taskConfig.InternalRedactions,
 	}
-	tc.taskConfig.TaskOutputDir = taskoutput.NewDirectory(tc.taskConfig.WorkDir, &tc.taskConfig.Task, redactorOpts, tc.logger, a.tracer)
+	tc.taskConfig.TaskOutputDir = taskoutput.NewDirectory(tc.taskConfig.WorkDir, &tc.taskConfig.Task, redactorOpts, tc.logger)
 	if err := tc.taskConfig.TaskOutputDir.Setup(); err != nil {
 		return a.handleSetupError(setupCtx, tc, errors.Wrap(err, "creating task output directory"))
 	}

--- a/agent/internal/taskoutput/directory.go
+++ b/agent/internal/taskoutput/directory.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var directoryHandlerFactories = map[string]directoryHandlerFactory{
@@ -45,7 +44,7 @@ type Directory struct {
 
 // NewDirectory returns a new task output directory with the specified root for
 // the given task.
-func NewDirectory(root string, tsk *task.Task, redactorOpts redactor.RedactionOptions, logger client.LoggerProducer, tracer trace.Tracer) *Directory {
+func NewDirectory(root string, tsk *task.Task, redactorOpts redactor.RedactionOptions, logger client.LoggerProducer) *Directory {
 	output := tsk.TaskOutputInfo
 	taskOpts := taskoutput.TaskOptions{
 		ProjectID: tsk.Project,
@@ -57,7 +56,7 @@ func NewDirectory(root string, tsk *task.Task, redactorOpts redactor.RedactionOp
 	handlers := map[string]directoryHandler{}
 	for name, factory := range directoryHandlerFactories {
 		dir := filepath.Join(root, name)
-		handlers[dir] = factory(dir, output, taskOpts, redactorOpts, logger, tracer)
+		handlers[dir] = factory(dir, output, taskOpts, redactorOpts, logger)
 	}
 
 	return &Directory{
@@ -108,4 +107,4 @@ type directoryHandler interface {
 }
 
 // directoryHandlerFactory abstracts the creation of a directory handler.
-type directoryHandlerFactory func(string, *taskoutput.TaskOutput, taskoutput.TaskOptions, redactor.RedactionOptions, client.LoggerProducer, trace.Tracer) directoryHandler
+type directoryHandlerFactory func(string, *taskoutput.TaskOutput, taskoutput.TaskOptions, redactor.RedactionOptions, client.LoggerProducer) directoryHandler

--- a/agent/internal/taskoutput/otel.go
+++ b/agent/internal/taskoutput/otel.go
@@ -1,0 +1,10 @@
+package taskoutput
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var tracer = otel.GetTracerProvider().Tracer(fmt.Sprintf("%s%s", evergreen.PackageName, "/agent/internal/taskoutput"))

--- a/agent/internal/taskoutput/test_log.go
+++ b/agent/internal/taskoutput/test_log.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 	"gopkg.in/yaml.v2"
 )
 
@@ -111,6 +112,8 @@ func (h *testLogDirectoryHandler) run(ctx context.Context) error {
 		return nil
 	})
 	wg.Wait()
+
+	span.SetAttributes(attribute.KeyValue{Key: "test_log_file_count", Value: attribute.IntValue(h.logFileCount)})
 
 	return err
 }

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v2"
 )
 
@@ -417,7 +416,7 @@ func setupTestTestLogDirectoryHandler(t *testing.T, comm *client.Mock, redactOpt
 		ProjectID: tsk.Project,
 		TaskID:    tsk.Id,
 		Execution: tsk.Execution,
-	}, redactOpts, logger, otel.GetTracerProvider().Tracer("noop-tracer"))
+	}, redactOpts, logger)
 
 	return tsk, h.(*testLogDirectoryHandler)
 }

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/grip/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v2"
 )
 
@@ -416,7 +417,7 @@ func setupTestTestLogDirectoryHandler(t *testing.T, comm *client.Mock, redactOpt
 		ProjectID: tsk.Project,
 		TaskID:    tsk.Id,
 		Execution: tsk.Execution,
-	}, redactOpts, logger)
+	}, redactOpts, logger, otel.GetTracerProvider().Tracer("noop-tracer"))
 
 	return tsk, h.(*testLogDirectoryHandler)
 }

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -393,6 +393,9 @@ func addEnvironmentAttributes(ctx context.Context, r *resource.Resource) (*resou
 // [OTel JSON protobuf encoding] https://opentelemetry.io/docs/specs/otel/protocol/otlp/#json-protobuf-encoding
 // [file exporter] https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
 func (a *Agent) uploadTraces(ctx context.Context, taskDir string) error {
+	ctx, span := a.tracer.Start(ctx, "upload-traces")
+	defer span.End()
+
 	if a.otelGrpcConn == nil {
 		return errors.New("OTel gRPC connection has not been configured")
 	}

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-12"
+	AgentVersion = "2025-02-14"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14838

### Description
Add spans to trace task output handling at the end of a task.

### Testing
Updated the unit tests and tested in staging [here](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_js_test_ad48caa8037a77d28258c49e28d04a5645d05f12_25_02_13_16_35_45/logs?execution=1&sortBy=STATUS&sortDir=ASC).

### Documentation
N/A
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
