### PR TITLE
DEVPROD-13392 add global file cleanup clarification

### DIFF
--- a/docs/Project-Configuration/Task-Runtime-Behavior.md
+++ b/docs/Project-Configuration/Task-Runtime-Behavior.md
@@ -149,7 +149,11 @@ a task group, it will keep the task directory as long as it is running tasks
 in the same task group. Once all the task group tasks have finished, it will
 clean up the task directory.
 
-### Global Git Config and Git Credentials Cleanup
+
+### Global File Cleanup
+
+**Evergreen will only accept requests to clean up global files with clear security implications.**
+
 For tasks not in a task group, the global git config and git credentials will be reset 
 at the end of the task after all commands have finished running. This will be done by 
 deleting the .git-credentials and .gitconfig files from the home directory. 


### PR DESCRIPTION
DEVPROD-13392 
### Description
Add a small caveat about what global files we are willing to clean up, so that we can easily say no to files that don't apply. Also simplified the section header, since we'll want to add to this for [DEVPROD-13248](https://jira.mongodb.org/browse/DEVPROD-13248)