### PR TITLE
DEVPROD-13571 Allocate hosts for single task distro hosts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -223,6 +223,8 @@ func (a *Agent) Start(ctx context.Context) error {
 		a.tryCleanupDirectory(a.opts.WorkingDirectory)
 	}
 
+	a.opts
+
 	return errors.Wrap(a.loop(ctx), "executing main agent loop")
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -223,8 +223,6 @@ func (a *Agent) Start(ctx context.Context) error {
 		a.tryCleanupDirectory(a.opts.WorkingDirectory)
 	}
 
-	a.opts
-
 	return errors.Wrap(a.loop(ctx), "executing main agent loop")
 }
 

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -54,7 +54,8 @@ type Distro struct {
 	HomeVolumeSettings    HomeVolumeSettings    `bson:"home_volume_settings" json:"home_volume_settings" mapstructure:"home_volume_settings"`
 	IceCreamSettings      IceCreamSettings      `bson:"icecream_settings,omitempty" json:"icecream_settings,omitempty" mapstructure:"icecream_settings,omitempty"`
 	Mountpoints           []string              `bson:"mountpoints,omitempty" json:"mountpoints,omitempty" mapstructure:"mountpoints,omitempty"`
-	SingleTaskDistro      bool                  `bson:"single_task_distro,omitempty" json:"single_task_distro,omitempty" mapstructure:"single_task_distro,omitempty"`
+	// SingleTaskDistro is a bool that indicates whether the hosts with this distro will only be allowed to run one task.
+	SingleTaskDistro bool `bson:"single_task_distro,omitempty" json:"single_task_distro,omitempty" mapstructure:"single_task_distro,omitempty"`
 	// ImageID is not equivalent to AMI. It is the identifier of the base image for the distro.
 	ImageID string `bson:"image_id,omitempty" json:"image_id,omitempty" mapstructure:"image_id,omitempty"`
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2738,6 +2738,8 @@ func (hosts HostGroup) Uphosts() HostGroup {
 	return out
 }
 
+// ProvisioningHosts return a subset of the host group that contains hosts
+// that have started, but not have not yet completed the provisioning process.
 func (hosts HostGroup) ProvisioningHosts() HostGroup {
 	out := HostGroup{}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2738,6 +2738,17 @@ func (hosts HostGroup) Uphosts() HostGroup {
 	return out
 }
 
+func (hosts HostGroup) ProvisioningHosts() HostGroup {
+	out := HostGroup{}
+
+	for _, h := range hosts {
+		if utility.StringSliceContains(evergreen.ProvisioningHostStatus, h.Status) {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
 // getNumContainersOnParents returns a slice of running parents and their respective
 // number of current containers currently running in order of longest expected
 // finish time

--- a/units/host_allocator_test.go
+++ b/units/host_allocator_test.go
@@ -1,0 +1,78 @@
+package units
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleTaskDistroHostAllocatorJob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = testutil.TestSpan(ctx, t)
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	env := &mock.Environment{}
+	require.NoError(env.Configure(ctx))
+
+	require.NoError(db.ClearCollections(distro.Collection, model.TaskQueuesCollection, host.Collection))
+	defer func() {
+		assert.NoError(db.ClearCollections(distro.Collection, model.TaskQueuesCollection, host.Collection))
+	}()
+
+	d := distro.Distro{
+		Id:               "d",
+		SingleTaskDistro: true,
+	}
+	require.NoError(d.Insert(ctx))
+
+	tq := model.TaskQueue{
+		Distro: d.Id,
+		Queue: []model.TaskQueueItem{
+			{
+				Id: "t1",
+			},
+			{
+				Id: "t2",
+			},
+			{
+				Id: "t3",
+			},
+		},
+		DistroQueueInfo: model.DistroQueueInfo{
+			Length:                    3,
+			LengthWithDependenciesMet: 2,
+		},
+	}
+	require.NoError(tq.Save())
+
+	h := host.Host{
+		Id:     "h1",
+		Distro: d,
+		Status: evergreen.HostProvisioning,
+	}
+	require.NoError(h.Insert(ctx))
+
+	j := NewHostAllocatorJob(env, d.Id, time.Now())
+
+	j.Run(ctx)
+
+	assert.NoError(j.Error())
+	assert.True(j.Status().Completed)
+
+	hosts, err := host.AllActiveHosts(ctx, d.Id)
+	require.NoError(err)
+	require.Len(hosts, 2)
+}


### PR DESCRIPTION
DEVPROD-13571

### Description
This new logic should figure out how many new hosts we would need for the new single task hosts 
This is only half the logic (the other half being termination) so it cannot be tested e2e until that work is done (scheduled in project) but I decided to split them and added a unit test to verify that this logic works as expected

### Testing
added a unit test specifically for the new logic and created a new ticket for adding tests for the rest of host allocator jobs
