### PR TITLE
DEVPROD-12123 Update update host API to use existing logic

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -85,7 +85,7 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding host '%s' with owner '%s'", id, user.Id))
 		}
-		_, _, err = api.ModifyHostStatus(ctx, h.env, foundHost, status.Status, "", user)
+		_, _, err = api.ModifyHostStatus(ctx, h.env, foundHost, status.Status, "modified by REST API", user)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "modifying host '%s' status to '%s' from API", id, status.Status))
 		}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/api"
 	"github.com/evergreen-ci/evergreen/apimodels"
-	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -30,10 +30,13 @@ type hostStatus struct {
 
 type hostsChangeStatusesHandler struct {
 	HostToStatus map[string]hostStatus
+	env          evergreen.Environment
 }
 
-func makeChangeHostsStatuses() gimlet.RouteHandler {
-	return &hostsChangeStatusesHandler{}
+func makeChangeHostsStatuses(env evergreen.Environment) gimlet.RouteHandler {
+	return &hostsChangeStatusesHandler{
+		env: env,
+	}
 }
 
 // Factory creates an instance of the handler.
@@ -48,7 +51,9 @@ func makeChangeHostsStatuses() gimlet.RouteHandler {
 //	@Param			status		query		string	false	"A status of host to limit the results to"
 //	@Success		200			{object}	model.APIHost
 func (h *hostsChangeStatusesHandler) Factory() gimlet.RouteHandler {
-	return &hostsChangeStatusesHandler{}
+	return &hostsChangeStatusesHandler{
+		env: h.env,
+	}
 }
 
 func (h *hostsChangeStatusesHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -80,16 +85,9 @@ func (h *hostsChangeStatusesHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding host '%s' with owner '%s'", id, user.Id))
 		}
-		switch status.Status {
-		case evergreen.HostTerminated:
-			err = errors.WithStack(cloud.TerminateSpawnHost(ctx, evergreen.GetEnvironment(), foundHost, user.Id, "terminated via REST API"))
-		case evergreen.HostQuarantined:
-			err = units.DisableAndNotifyPoisonedHost(ctx, evergreen.GetEnvironment(), foundHost, false, fmt.Sprintf("quarantined via REST API by user '%s'", user.Id), user.Id)
-		default:
-			err = foundHost.SetStatus(ctx, status.Status, user.Id, fmt.Sprintf("changed by %s from API", user.Id))
-		}
+		_, _, err = api.ModifyHostStatus(ctx, h.env, foundHost, status.Status, "", user)
 		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(err)
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "modifying host '%s' status to '%s' from API", id, status.Status))
 		}
 
 		h := &model.APIHost{}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -56,7 +56,7 @@ func (s *HostsChangeStatusesSuite) SetupTest() {
 	s.Require().NoError(db.ClearCollections(task.Collection, build.Collection, model.VersionCollection))
 	setupMockHostsConnector(s.T(), s.env)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
-	s.route = makeChangeHostsStatuses().(*hostsChangeStatusesHandler)
+	s.route = makeChangeHostsStatuses(s.env).(*hostsChangeStatusesHandler)
 }
 
 func (s *HostsChangeStatusesSuite) TearDownTest() {
@@ -179,17 +179,6 @@ func (s *HostsChangeStatusesSuite) TestRunSuperUserSetStatusAnyHost() {
 	ctx := gimlet.AttachUser(s.ctx, &user.DBUser{Id: "root", SystemRoles: []string{"root"}})
 	res := h.Run(ctx)
 	s.Equal(http.StatusOK, res.Status())
-}
-
-func (s *HostsChangeStatusesSuite) TestRunTerminatedOnTerminatedHost() {
-	h := s.route.Factory().(*hostsChangeStatusesHandler)
-	h.HostToStatus = map[string]hostStatus{
-		"host1": {Status: evergreen.HostTerminated},
-	}
-
-	ctx := gimlet.AttachUser(s.ctx, &user.DBUser{Id: "user0"})
-	res := h.Run(ctx)
-	s.Equal(http.StatusInternalServerError, res.Status())
 }
 
 func (s *HostsChangeStatusesSuite) TestRunHostRunningOnTerminatedHost() {

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -157,7 +157,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/host/get_processes").Version(2).Get().Wrap(requireUser).RouteHandler(makeHostGetProcesses(env))
 	app.AddRoute("/hosts").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchHosts(opts.URL))
 	app.AddRoute("/hosts").Version(2).Post().Wrap(requireUser).RouteHandler(makeSpawnHostCreateRoute(env))
-	app.AddRoute("/hosts").Version(2).Patch().Wrap(requireUser).RouteHandler(makeChangeHostsStatuses())
+	app.AddRoute("/hosts").Version(2).Patch().Wrap(requireUser).RouteHandler(makeChangeHostsStatuses(env))
 	app.AddRoute("/hosts/{host_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetHostByID())
 	app.AddRoute("/hosts/{host_id}").Version(2).Patch().Wrap(requireUser).RouteHandler(makeHostModifyRouteManager(env))
 	app.AddRoute("/hosts/{host_id}/stop").Version(2).Post().Wrap(requireUser).RouteHandler(makeHostStopManager(env))


### PR DESCRIPTION
DEVPROD-12123

### Description
update hosts api should use the existing modify hosts function and not use custom function

### Testing
existing tests should pass 
removed one test that we do not case on anymore 