### PR TITLE
DEVPROD-12227 filter github links by variant correctly

### DIFF
--- a/service/build.go
+++ b/service/build.go
@@ -53,7 +53,7 @@ func (uis *UIServer) buildPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s/tasks?variant=%s", uis.Settings.Ui.UIv2Url, projCtx.Version.Id, projCtx.Build.BuildVariant)) {
+	if RedirectSpruceUsers(w, r, fmt.Sprintf("%s/version/%s/tasks?variant=^%s$", uis.Settings.Ui.UIv2Url, projCtx.Version.Id, projCtx.Build.BuildVariant)) {
 		return
 	}
 


### PR DESCRIPTION
DEVPROD-12227
### Description
Previously we weren't matching to the exact build variant, so more build variants could show up.
### Testing
Verified that the case in the ticket will work with this (https://spruce.mongodb.com/version/67169fb4f1f5850007ab515b/tasks?variant=^int$ redirects to just the `04a. Int Tests Java [int]` variant, whereas https://spruce.mongodb.com/version/67169fb4f1f5850007ab515b/tasks?variant=int includes an additional variant)
