### PR TITLE
DEVPROD-12800 Omit no-op generate.tasks from CLI estimation

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-02-07"
+	ClientVersion = "2025-02-20"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/model/project.go
+++ b/model/project.go
@@ -1840,31 +1840,31 @@ func (p *Project) GetAllVariantTasks() []patch.VariantTasks {
 
 // TasksThatCallCommand returns a map of tasks that call a given command to the
 // number of times the command is called in the task.
-func (p *Project) TasksThatCallCommand(find string) map[string]int {
+func (p *Project) TasksThatCallCommand(find string) map[string][]PluginCommandConf {
 	// get all functions that call the command.
-	fs := map[string]int{}
+	fs := map[string][]PluginCommandConf{}
 	for f, cmds := range p.Functions {
 		if cmds == nil {
 			continue
 		}
 		for _, c := range cmds.List() {
 			if c.Command == find {
-				fs[f] = fs[f] + 1
+				fs[f] = append(fs[f], c)
 			}
 		}
 	}
 
 	// get all tasks that call the command.
-	ts := map[string]int{}
+	ts := map[string][]PluginCommandConf{}
 	for _, t := range p.Tasks {
 		for _, c := range t.Commands {
 			if c.Function != "" {
-				if times, ok := fs[c.Function]; ok {
-					ts[t.Name] = ts[t.Name] + times
+				if functionCommands, ok := fs[c.Function]; ok {
+					ts[t.Name] = append(ts[t.Name], functionCommands...)
 				}
 			}
 			if c.Command == find {
-				ts[t.Name] = ts[t.Name] + 1
+				ts[t.Name] = append(ts[t.Name], c)
 			}
 		}
 	}


### PR DESCRIPTION
DEVPROD-12800

### Description
Some server builds now have no-op generate.tasks commands ([SERVER-100202](https://jira.mongodb.org/browse/SERVER-100202)). Changed the estimated generate tasks count CLI operation to not include these tasks in the payload because it's making the route slow.
### Testing
Existing tests and _____
