### PR TITLE
DEVPROD-12270 support unschedule old tasks at build variant level

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -269,8 +269,8 @@ Fields:
     non-module related build variant fields ([context](../decisions/2024-07-18_allow_module_expansions)).
 -   `tasks`: a list of tasks to run, referenced either by task name or by tags.
     Tasks listed here can also include other task-level fields, such as
-    `batchtime`, `cron`, `activate`, `depends_on`, and `run_on`. We can also
-    [define when a task will run](#limiting-when-a-task-or-variant-will-run). If there are
+    `batchtime`, `cron`, `activate`, `depends_on`, `stepback`, and `run_on`. 
+    We can also [define when a task will run](#limiting-when-a-task-or-variant-will-run). If there are
     conflicting settings definitions at different levels, the order of priority
     is defined [here](#task-fields-override-hierarchy).
 -   `activate`: by default, we'll activate if the whole version is
@@ -278,6 +278,10 @@ Fields:
     we instead want to activate immediately, then set activate to true.
     If this should only activate when manually scheduled or by
     stepback/dependencies, set activate to false.
+-   `stepback`: indicate if this variant should opt-in or out of stepback. 
+    (If disabled at the project-level, this value will be ignored.)
+-   `deactivate_previous`: indicate if this variant should unschedule older 
+    mainline tasks on success (if disabled at the project-level, this value will be ignored.)
 -   `batchtime`: interval of time in minutes that Evergreen should wait
     before activating this variant. The default is set on the project
     settings page. This cannot be set for individual tasks. 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -279,9 +279,9 @@ Fields:
     If this should only activate when manually scheduled or by
     stepback/dependencies, set activate to false.
 -   `stepback`: indicate if this variant should opt-in or out of stepback. 
-    (If disabled at the project-level, this value will be ignored.)
+    (If disabled at the project-level, this value will be ignored, otherwise it will override.)
 -   `deactivate_previous`: indicate if this variant should unschedule older 
-    mainline tasks on success (if disabled at the project-level, this value will be ignored.)
+    mainline tasks on success (if disabled at the project-level, this value will be ignored, otherwise it will override.)
 -   `batchtime`: interval of time in minutes that Evergreen should wait
     before activating this variant. The default is set on the project
     settings page. This cannot be set for individual tasks. 

--- a/model/generate.go
+++ b/model/generate.go
@@ -839,7 +839,7 @@ func isNonZeroBV(bv parserBV) bool {
 		bv.Disable != nil || len(bv.Tags) > 0 ||
 		bv.BatchTime != nil || bv.Patchable != nil || bv.PatchOnly != nil ||
 		bv.AllowForGitTag != nil || bv.GitTagOnly != nil || len(bv.AllowedRequesters) > 0 ||
-		bv.Stepback != nil || len(bv.RunOn) > 0 {
+		bv.Stepback != nil || bv.DeactivatePrevious != nil || len(bv.RunOn) > 0 {
 		return true
 	}
 	return false

--- a/model/project.go
+++ b/model/project.go
@@ -394,7 +394,9 @@ type BuildVariant struct {
 	//   1. nil   = not overriding the project setting (default)
 	//   2. true  = overriding the project setting with true
 	//   3. false = overriding the project setting with false
-	Stepback           *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	// Stepback indicates if previous mainline tasks should be run in case of a failure.
+	Stepback *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	// DeactivatePrevious indicates if previous mainline tasks should be deactivated in case of success.
 	DeactivatePrevious *bool `yaml:"deactivate_previous,omitempty" bson:"deactivate_previous,omitempty"`
 
 	// the default distros.  will be used to run a task if no distro field is

--- a/model/project.go
+++ b/model/project.go
@@ -394,7 +394,8 @@ type BuildVariant struct {
 	//   1. nil   = not overriding the project setting (default)
 	//   2. true  = overriding the project setting with true
 	//   3. false = overriding the project setting with false
-	Stepback *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	Stepback           *bool `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	DeactivatePrevious *bool `yaml:"deactivate_previous,omitempty" bson:"deactivate_previous,omitempty"`
 
 	// the default distros.  will be used to run a task if no distro field is
 	// provided for the task

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -319,19 +319,21 @@ func (ts *taskSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // parserBV is a helper type storing intermediary variant definitions.
 type parserBV struct {
-	Name          string             `yaml:"name,omitempty" bson:"name,omitempty"`
-	DisplayName   string             `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
-	Expansions    util.Expansions    `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
-	Tags          parserStringSlice  `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
-	Modules       parserStringSlice  `yaml:"modules,omitempty" bson:"modules,omitempty"`
-	Disable       *bool              `yaml:"disable,omitempty" bson:"disable,omitempty"`
-	BatchTime     *int               `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
-	CronBatchTime string             `yaml:"cron,omitempty" bson:"cron,omitempty"`
-	Stepback      *bool              `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
-	RunOn         parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
-	Tasks         parserBVTaskUnits  `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
-	DisplayTasks  []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
-	DependsOn     parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
+	Name               string            `yaml:"name,omitempty" bson:"name,omitempty"`
+	DisplayName        string            `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+	Expansions         util.Expansions   `yaml:"expansions,omitempty" bson:"expansions,omitempty"`
+	Tags               parserStringSlice `yaml:"tags,omitempty,omitempty" bson:"tags,omitempty"`
+	Modules            parserStringSlice `yaml:"modules,omitempty" bson:"modules,omitempty"`
+	Disable            *bool             `yaml:"disable,omitempty" bson:"disable,omitempty"`
+	BatchTime          *int              `yaml:"batchtime,omitempty" bson:"batchtime,omitempty"`
+	CronBatchTime      string            `yaml:"cron,omitempty" bson:"cron,omitempty"`
+	Stepback           *bool             `yaml:"stepback,omitempty" bson:"stepback,omitempty"`
+	DeactivatePrevious *bool             `yaml:"deactivate_previous,omitempty" bson:"deactivate_previous,omitempty"`
+
+	RunOn        parserStringSlice  `yaml:"run_on,omitempty" bson:"run_on,omitempty"`
+	Tasks        parserBVTaskUnits  `yaml:"tasks,omitempty" bson:"tasks,omitempty"`
+	DisplayTasks []displayTask      `yaml:"display_tasks,omitempty" bson:"display_tasks,omitempty"`
+	DependsOn    parserDependencies `yaml:"depends_on,omitempty" bson:"depends_on,omitempty"`
 	// If Activate is set to false, then we don't initially activate the build variant.
 	Activate          *bool                     `yaml:"activate,omitempty" bson:"activate,omitempty"`
 	Patchable         *bool                     `yaml:"patchable,omitempty" bson:"patchable,omitempty"`
@@ -399,6 +401,7 @@ func (pbv *parserBV) canMerge() bool {
 		pbv.BatchTime == nil &&
 		pbv.CronBatchTime == "" &&
 		pbv.Stepback == nil &&
+		pbv.DeactivatePrevious == nil &&
 		pbv.RunOn == nil &&
 		pbv.DependsOn == nil &&
 		pbv.Activate == nil &&
@@ -1191,21 +1194,22 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 	var evalErrs, errs []error
 	for _, pbv := range pbvs {
 		bv := BuildVariant{
-			DisplayName:    pbv.DisplayName,
-			Name:           pbv.Name,
-			Expansions:     pbv.Expansions,
-			Modules:        pbv.Modules,
-			Disable:        pbv.Disable,
-			BatchTime:      pbv.BatchTime,
-			CronBatchTime:  pbv.CronBatchTime,
-			Activate:       pbv.Activate,
-			Patchable:      pbv.Patchable,
-			PatchOnly:      pbv.PatchOnly,
-			AllowForGitTag: pbv.AllowForGitTag,
-			GitTagOnly:     pbv.GitTagOnly,
-			Stepback:       pbv.Stepback,
-			RunOn:          pbv.RunOn,
-			Tags:           pbv.Tags,
+			DisplayName:        pbv.DisplayName,
+			Name:               pbv.Name,
+			Expansions:         pbv.Expansions,
+			Modules:            pbv.Modules,
+			Disable:            pbv.Disable,
+			BatchTime:          pbv.BatchTime,
+			CronBatchTime:      pbv.CronBatchTime,
+			Activate:           pbv.Activate,
+			Patchable:          pbv.Patchable,
+			PatchOnly:          pbv.PatchOnly,
+			AllowForGitTag:     pbv.AllowForGitTag,
+			GitTagOnly:         pbv.GitTagOnly,
+			Stepback:           pbv.Stepback,
+			DeactivatePrevious: pbv.DeactivatePrevious,
+			RunOn:              pbv.RunOn,
+			Tags:               pbv.Tags,
 		}
 		bv.AllowedRequesters = pbv.AllowedRequesters
 		bv.Tasks, unmatchedSelectors, unmatchedCriteria, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -568,7 +568,6 @@ func (p *ProjectRef) ShouldDeactivatePrevious() bool {
 	return utility.FromBoolPtr(p.DeactivatePrevious)
 }
 
-// TODO: How does stepback work???
 // IsDeactivatePreviousDisabled returns true if this was purposefully disabled.
 func (p *ProjectRef) IsDeactivatePreviousDisabled() bool {
 	return !utility.FromBoolTPtr(p.DeactivatePrevious)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -568,6 +568,12 @@ func (p *ProjectRef) ShouldDeactivatePrevious() bool {
 	return utility.FromBoolPtr(p.DeactivatePrevious)
 }
 
+// TODO: How does stepback work???
+// IsDeactivatePreviousDisabled returns true if this was purposefully disabled.
+func (p *ProjectRef) IsDeactivatePreviousDisabled() bool {
+	return !utility.FromBoolTPtr(p.DeactivatePrevious)
+}
+
 func (p *ProjectRef) ShouldNotifyOnBuildFailure() bool {
 	return utility.FromBoolPtr(p.NotifyOnBuildFailure)
 }

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -924,11 +924,9 @@ func attemptStepbackAndDeactivatePrevious(ctx context.Context, t *task.Task, sta
 		catcher.Add(err)
 	}
 
-	fmt.Printf("TASK STATUS: %s, REQUESTER: %s, ACTIVATOR: %s\n", t.Status, t.Requester, t.ActivatedBy)
 	// Deactivate previous occurrences of the same task only if this one passed on mainline commits.
 	if t.Status == evergreen.TaskSucceeded && t.Requester == evergreen.RepotrackerVersionRequester && t.ActivatedBy != evergreen.StepbackTaskActivator {
 		shouldDeactivatePrevious := getDeactivatePrevious(t, pRef, project)
-		fmt.Printf("SHOULD DEACTIVATE PREVIOUS")
 		if shouldDeactivatePrevious {
 			catcher.Add(DeactivatePreviousTasks(ctx, t, caller))
 		}

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -492,8 +492,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "clearing running task '%s' for pod '%s'", t.Id, p.ID))
 	}
 
-	deactivatePrevious := utility.FromBoolPtr(projectRef.DeactivatePrevious)
-	err = model.MarkEnd(ctx, h.env.Settings(), t, evergreen.APIServerTaskActivator, finishTime, &h.details, deactivatePrevious)
+	err = model.MarkEnd(ctx, h.env.Settings(), t, evergreen.APIServerTaskActivator, finishTime, &h.details)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "calling mark finish on task '%s'", t.Id))
 	}


### PR DESCRIPTION
DEVPROD-12270
### Description
Allow setting deactivate previous from the build variant level. 

This uses the same logic for when to default as stepback. I didn't implement for the task level to keep the PR lighter, and it's not requested so we could just do it in the future. 

I refactored MarkEnd and attemptStepback a bit so that we're still only pulling parser project and projectRef once. Passing in deactivatePrevious was likely to save a project ref call (it doesn't really do anything else, as evidenced by the unit tests passing), so I removed that as well. 

Didn't add to matrices since this is deprecated (although it's honestly not complicated so I _could_... if anyone feels strongly i'll put up a PR after this one)

### Testing
Ensured existing unit tests work when updated, and added an additional test for getting deactivate previous.

### Documentation
Added documentation, and also documented stepback 🙃

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
