### PR TITLE
DEVPROD-15078 Require git 2.42.1 for scalar

### DIFF
--- a/agent/util/git.go
+++ b/agent/util/git.go
@@ -24,12 +24,12 @@ func getGitVersion() (string, bool, error) {
 
 // IsGitVersionMinimumForScalar checks if the installed Git version is later than the specified version.
 func IsGitVersionMinimumForScalar(minVersion string) (bool, error) {
-	gitVersion, isApple, err := getGitVersion()
+	gitVersion, isAppleOrWindows, err := getGitVersion()
 	if err != nil {
 		return false, err
 	}
-	// scalar is not bundled with Apple's Git version 2.38.0
-	if isApple {
+	// as of now, scalar is not bundled with Apple's or Windows Git version
+	if isAppleOrWindows {
 		return false, nil
 	}
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-18-a"
+	AgentVersion = "2025-02-21"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -665,7 +665,7 @@ Parameters:
     yaml. This token is *only* used for the source repository, not modules.
 -   `is_oauth`: If a project token is provided and that token is an OAuth token and not a
     GitHub app token, `is_oauth` must be set to true so that the clone command is formatted properly.
--   `use_scalar`: Clone using scalar, a tool that helps optimize clones for large repositories. It cannot be combined with `clone_depth`, `shallow_clone`, or `recurse_submodules`.
+-   `use_scalar`: Clone using scalar, a tool that helps optimize clones for large repositories. It cannot be combined with `clone_depth`, `shallow_clone`, or `recurse_submodules`. Scalar will only be used if the git version is above 2.42.1, and it's not Apple's or Windows' packaged versions of Git. 
 -   `clone_depth`: Clone with `git clone --depth <clone_depth>`. For
     patch builds, Evergreen will `git fetch --unshallow` if the base
     commit is older than `<clone_depth>` commits. `clone_depth` takes precedence over `shallow_clone`. It cannot be combined with `use_scalar`. 

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -31,7 +31,7 @@ type Commit struct {
 	Patch     string    `bson:"patch"`
 }
 
-const RequiredScalarGitVersion = "2.38.0"
+const RequiredScalarGitVersion = "2.42.1"
 
 // GitApplyNumstat attempts to apply a given patch; it returns the patch's bytes
 // if it is successful
@@ -227,8 +227,8 @@ func ParseGitVersion(version string) (string, bool, error) {
 		return "", false, errors.Errorf("could not parse git version number from version string '%s'", version)
 	}
 
-	isAppleGit := strings.Contains(version, "Apple Git-")
-	return matches[1], isAppleGit, nil
+	isAppleOrWindowsGit := strings.Contains(version, "Apple Git-") || strings.Contains(version, ".windows.")
+	return matches[1], isAppleOrWindowsGit, nil
 }
 
 // VersionMeetsMinimum checks if the version is greater than or equal to the minVersion.

--- a/thirdparty/git_test.go
+++ b/thirdparty/git_test.go
@@ -95,8 +95,8 @@ func TestVersionMeetsMinimum(t *testing.T) {
 		minVersion string
 		expected   bool
 	}{
-		{version: "2.37.0", minVersion: "2.38.0", expected: false},
-		{version: "2.38.0", minVersion: "2.38.0", expected: true},
+		{version: "2.41.0", minVersion: "2.42.1", expected: false},
+		{version: "2.42.1", minVersion: "2.42.1", expected: true},
 		{version: "2.38.0", minVersion: "2.38.1", expected: false},
 		{version: "2.38.1", minVersion: "2.38.0", expected: true},
 		{version: "2.38", minVersion: "2.37.9", expected: true},
@@ -112,19 +112,20 @@ func TestVersionMeetsMinimum(t *testing.T) {
 
 func TestParseGitVersionString(t *testing.T) {
 	versionStrings := map[string]struct {
-		expectedVersion string
-		isApple         bool
+		expectedVersion  string
+		isAppleOrWindows bool
 	}{
 		"git version 2.19.1":                   {"2.19.1", false},
 		"git version 2.24.3 (Apple Git-128)":   {"2.24.3", true},
 		"git version 2.21.1 (Apple Git-122.3)": {"2.21.1", true},
-		"git version 2.16.2.windows.1":         {"2.16.2.windows.1", false},
+		"git version 2.16.2.windows.1":         {"2.16.2.windows.1", true},
+		"git version 2.47.1.windows.2":         {"2.47.1.windows.2", true},
 	}
 
 	for versionString, expected := range versionStrings {
-		parsedVersion, isApple, err := ParseGitVersion(versionString)
+		parsedVersion, isAppleOrWindows, err := ParseGitVersion(versionString)
 		require.NoError(t, err)
 		assert.Equal(t, expected.expectedVersion, parsedVersion)
-		assert.Equal(t, expected.isApple, isApple)
+		assert.Equal(t, expected.isAppleOrWindows, isAppleOrWindows)
 	}
 }


### PR DESCRIPTION
DEVPROD-15078

### Description
While scalar was added to git in 2.38, the --no-src option wasn't added until 2.42.1. Since we rely on that, we should require at least2.42.1. before running scalar. 

It also looks like scalar is not bundled with Windows git either, so I added it to the check that makes sure that scalar is available. 

