### PR TITLE
DEVPROD-14314 Fix cached tokens giving incorrect permissions

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -158,7 +158,8 @@ func getProjectMethodAndToken(ctx context.Context, comm client.Communicator, td 
 
 	owner := conf.ProjectRef.Owner
 	repo := conf.ProjectRef.Repo
-	appToken, err := comm.CreateInstallationToken(ctx, td, owner, repo)
+	// chaya
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, td, owner, repo)
 	if err != nil {
 		return "", "", errors.Wrap(err, "creating app token")
 	}
@@ -650,7 +651,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		opts.token = projectToken
 	} else {
 		// Otherwise, create an installation token for to clone the module.
-		appToken, err := comm.CreateInstallationToken(ctx, td, opts.owner, opts.repo)
+		appToken, err := comm.CreateInstallationTokenForClone(ctx, td, opts.owner, opts.repo)
 		if err != nil {
 			return errors.Wrap(err, "creating app token")
 		}

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -913,7 +913,7 @@ func (c *baseCommunicator) GetAdditionalPatches(ctx context.Context, patchId str
 	return patches, nil
 }
 
-func (c *baseCommunicator) CreateInstallationToken(ctx context.Context, td TaskData, owner, repo string) (string, error) {
+func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("task/%s/installation_token/%s/%s", td.ID, owner, repo),

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -921,11 +921,11 @@ func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, 
 	}
 	resp, err := c.request(ctx, info, nil)
 	if err != nil {
-		return "", errors.Wrapf(err, "creating installation token for '%s/%s'", owner, repo)
+		return "", errors.Wrapf(err, "creating installation token to clone '%s/%s'", owner, repo)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", util.RespErrorf(resp, "creating installation token for '%s/%s'", owner, repo)
+		return "", util.RespErrorf(resp, "creating installation token to clone '%s/%s'", owner, repo)
 	}
 	token := apimodels.Token{}
 	if err := utility.ReadJSON(resp.Body, &token); err != nil {

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -117,8 +117,8 @@ type SharedCommunicator interface {
 
 	SetDownstreamParams(ctx context.Context, downstreamParams []patchmodel.Parameter, taskData TaskData) error
 
-	// CreateInstallationToken creates an installation token for the given owner and repo if there is a GitHub app installed.
-	CreateInstallationToken(ctx context.Context, td TaskData, owner, repo string) (string, error)
+	// CreateInstallationTokenForClone creates an installation token for the given owner and repo if there is a GitHub app installed.
+	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error)
 
 	// CreateGitHubDynamicAccessToken creates a dynamic access token using the task's project's GitHub app.
 	// It intersects the permissions requested with the permissions set in the project settings for the requester

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -546,7 +546,7 @@ func (c *Mock) GetAdditionalPatches(ctx context.Context, patchId string, td Task
 	return []string{"555555555555555555555555"}, nil
 }
 
-func (c *Mock) CreateInstallationToken(ctx context.Context, td TaskData, owner, repo string) (string, error) {
+func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error) {
 	if c.CreateInstallationTokenFail {
 		return "", errors.New("failed to create token")
 	}

--- a/config.go
+++ b/config.go
@@ -37,11 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-<<<<<<< HEAD
 	AgentVersion = "2025-02-25"
-=======
-	AgentVersion = "2025-02-24"
->>>>>>> main
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-18-a"
+	AgentVersion = "2025-02-25"
 )
 
 const (

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -111,7 +111,7 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 		return "", errors.Wrapf(err, "getting installation id for '%s/%s'", owner, repo)
 	}
 
-	if cachedToken := ghInstallationTokenCache.get(installationID, lifetime); cachedToken != "" {
+	if cachedToken := ghInstallationTokenCache.get(installationID, opts.GetPermissions(), lifetime); cachedToken != "" {
 		return cachedToken, nil
 	}
 
@@ -121,7 +121,7 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 		return "", errors.Wrap(err, "creating installation token")
 	}
 
-	ghInstallationTokenCache.put(installationID, token, createdAt)
+	ghInstallationTokenCache.put(installationID, token, opts.GetPermissions(), createdAt)
 
 	return token, errors.Wrapf(err, "getting installation token for '%s/%s'", owner, repo)
 }

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -112,6 +112,7 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 	}
 
 	if cachedToken := ghInstallationTokenCache.get(installationID, opts.GetPermissions(), lifetime); cachedToken != "" {
+
 		return cachedToken, nil
 	}
 

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -112,7 +112,6 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 	}
 
 	if cachedToken := ghInstallationTokenCache.get(installationID, opts.GetPermissions(), lifetime); cachedToken != "" {
-
 		return cachedToken, nil
 	}
 

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -269,7 +269,7 @@ var ghInstallationTokenCache = installationTokenCache{
 	mu:    sync.RWMutex{},
 }
 
-// get gets an installation token from the cache by its installation ID. It will
+// get gets an installation token from the cache by its installation ID and permissions. It will
 // not return a token if the token will expire before the requested lifetime.
 func (c *installationTokenCache) get(installationID int64, permissions *github.InstallationPermissions, lifetime time.Duration) string {
 	c.mu.RLock()

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -282,6 +282,12 @@ func (c *installationTokenCache) get(installationID int64, permissions *github.I
 	if !ok {
 		return ""
 	}
+	grip.Info(message.Fields{
+		"msg":                                  "ChayaMTesting installationTokenCache.get ",
+		"id":                                   id,
+		"cachedToken.installationToken != '' ": cachedToken.installationToken != "",
+		"permissions == nil":                   permissions == nil,
+	})
 	if cachedToken.isExpired(lifetime) {
 		return ""
 	}
@@ -297,6 +303,11 @@ func (c *installationTokenCache) put(installationID int64, installationToken str
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	id, err := createCacheID(installationID, permissions)
+	grip.Info(message.Fields{
+		"msg":                "ChayaMTesting installationTokenCache.put ",
+		"id":                 id,
+		"permissions == nil": permissions == nil,
+	})
 	if err != nil {
 		return
 	}

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -282,12 +282,6 @@ func (c *installationTokenCache) get(installationID int64, permissions *github.I
 	if !ok {
 		return ""
 	}
-	grip.Info(message.Fields{
-		"msg":                                  "ChayaMTesting installationTokenCache.get ",
-		"id":                                   id,
-		"cachedToken.installationToken != '' ": cachedToken.installationToken != "",
-		"permissions == nil":                   permissions == nil,
-	})
 	if cachedToken.isExpired(lifetime) {
 		return ""
 	}
@@ -303,11 +297,6 @@ func (c *installationTokenCache) put(installationID int64, installationToken str
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	id, err := createCacheID(installationID, permissions)
-	grip.Info(message.Fields{
-		"msg":                "ChayaMTesting installationTokenCache.put ",
-		"id":                 id,
-		"permissions == nil": permissions == nil,
-	})
 	if err != nil {
 		return
 	}

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -206,8 +206,9 @@ func TestCreateCacheID(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			result := createCacheID(tc.installationID, tc.permissions)
+			result, err := createCacheID(tc.installationID, tc.permissions)
 			assert.Equal(t, tc.expected, result)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/google/go-github/v52/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -113,19 +114,36 @@ func (s *installationSuite) TestCreateCachedInstallationToken() {
 	s.NoError(installation.Upsert(s.ctx))
 
 	const (
-		installationToken = "installation_token"
+		unrestrictedToken = "unrestricted_token"
+		restrictedToken   = "restricted_token"
 		lifetime          = time.Minute
 	)
-	ghInstallationTokenCache.put(installation.InstallationID, installationToken, time.Now())
+
+	// Test without permissions
+	ghInstallationTokenCache.put(installation.InstallationID, unrestrictedToken, nil, time.Now())
 
 	authFields := GithubAppAuth{
 		AppID: installation.AppID,
 	}
 	token, err := authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil)
 	s.Require().NoError(err)
-	s.Equal(installationToken, token, "should return cached token since it is still valid for at least %s", lifetime)
-}
+	s.Equal(unrestrictedToken, token, "should return cached token since it is still valid for at least %s", lifetime)
 
+	// Test with permissions
+	p := &github.InstallationPermissions{
+		Contents: github.String("read"),
+		Issues:   github.String("write"),
+	}
+	opts := &github.InstallationTokenOptions{
+		Permissions: p,
+	}
+
+	ghInstallationTokenCache.put(installation.InstallationID, restrictedToken, p, time.Now())
+
+	token, err = authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, opts)
+	s.Require().NoError(err)
+	s.Equal(restrictedToken, token, "should return cached token since it is still valid for at least %s", lifetime)
+}
 func TestCreateGitHubAppAuth(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,4 +169,45 @@ func TestCreateGitHubAppAuth(t *testing.T) {
 	assert.NotNil(t, authFields)
 	assert.Equal(t, int64(1234), authFields.AppID)
 	assert.Equal(t, []byte("key"), authFields.PrivateKey)
+}
+
+func TestCreateCacheID(t *testing.T) {
+	testCases := map[string]struct {
+		installationID int64
+		permissions    *github.InstallationPermissions
+		expected       string
+	}{
+		"NoPermissions": {
+			installationID: 1234,
+			permissions:    nil,
+			expected:       "1234",
+		},
+		"EmptyPermissions": {
+			installationID: 1234,
+			permissions:    &github.InstallationPermissions{},
+			expected:       "1234",
+		},
+		"SinglePermission": {
+			installationID: 1234,
+			permissions: &github.InstallationPermissions{
+				Contents: github.String("read"),
+			},
+			expected: "1234_contents-read",
+		},
+		"MultiplePermissions": {
+			installationID: 1234,
+			permissions: &github.InstallationPermissions{
+				Contents: github.String("read"),
+				Issues:   github.String("write"),
+			},
+			expected: "1234_contents-read_issues-write",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			result := createCacheID(tc.installationID, tc.permissions)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -192,7 +192,7 @@ func TestCreateCacheID(t *testing.T) {
 			permissions: &github.InstallationPermissions{
 				Contents: github.String("read"),
 			},
-			expected: "1234_contents-read",
+			expected: "1234_contents:read",
 		},
 		"MultiplePermissions": {
 			installationID: 1234,
@@ -200,7 +200,7 @@ func TestCreateCacheID(t *testing.T) {
 				Contents: github.String("read"),
 				Issues:   github.String("write"),
 			},
-			expected: "1234_contents-read_issues-write",
+			expected: "1234_contents:read_issues:write",
 		},
 	}
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1350,7 +1350,7 @@ func (h *setDownstreamParamsHandler) Run(ctx context.Context) gimlet.Responder {
 // and only meant for internal use.
 // It returns an installation token that's attached to Evergreen's GitHub app.
 // See createGitHubDynamicAccessToken or tokens created for users using their GitHub app.
-type createInstallationToken struct {
+type createInstallationTokenForClone struct {
 	owner string
 	repo  string
 
@@ -1358,18 +1358,18 @@ type createInstallationToken struct {
 }
 
 func makeCreateInstallationToken(env evergreen.Environment) gimlet.RouteHandler {
-	return &createInstallationToken{
+	return &createInstallationTokenForClone{
 		env: env,
 	}
 }
 
-func (g *createInstallationToken) Factory() gimlet.RouteHandler {
-	return &createInstallationToken{
+func (g *createInstallationTokenForClone) Factory() gimlet.RouteHandler {
+	return &createInstallationTokenForClone{
 		env: g.env,
 	}
 }
 
-func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) error {
+func (g *createInstallationTokenForClone) Parse(ctx context.Context, r *http.Request) error {
 	if g.owner = gimlet.GetVars(r)["owner"]; g.owner == "" {
 		return errors.New("missing owner")
 	}
@@ -1381,9 +1381,15 @@ func (g *createInstallationToken) Parse(ctx context.Context, r *http.Request) er
 	return nil
 }
 
-func (g *createInstallationToken) Run(ctx context.Context) gimlet.Responder {
+func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Responder {
 	const lifetime = 50 * time.Minute
-	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, nil)
+	// because this token will be used for cloning, restrict the token to read only
+	opts := &github.InstallationTokenOptions{
+		Permissions: &github.InstallationPermissions{
+			Contents: utility.ToStringPtr(thirdparty.GithubPermissionRead),
+		},
+	}
+	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -619,8 +619,8 @@ func TestCreateInstallationToken(t *testing.T) {
 	validOwner := "owner"
 	validRepo := "repo"
 
-	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, gh *createInstallationToken){
-		"ParseErrorsOnEmptyOwnerAndRepo": func(ctx context.Context, t *testing.T, handler *createInstallationToken) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, gh *createInstallationTokenForClone){
+		"ParseErrorsOnEmptyOwnerAndRepo": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
 			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", "", "")
 			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
 			assert.NoError(t, err)
@@ -630,7 +630,7 @@ func TestCreateInstallationToken(t *testing.T) {
 
 			assert.Error(t, handler.Parse(ctx, request))
 		},
-		"ParseErrorsOnEmptyOwner": func(ctx context.Context, t *testing.T, handler *createInstallationToken) {
+		"ParseErrorsOnEmptyOwner": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
 			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", "", validRepo)
 			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
 			assert.NoError(t, err)
@@ -640,7 +640,7 @@ func TestCreateInstallationToken(t *testing.T) {
 
 			assert.ErrorContains(t, handler.Parse(ctx, request), "missing owner")
 		},
-		"ParseErrorsOnEmptyRepo": func(ctx context.Context, t *testing.T, handler *createInstallationToken) {
+		"ParseErrorsOnEmptyRepo": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
 			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", validOwner, "")
 			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
 			assert.NoError(t, err)
@@ -650,7 +650,7 @@ func TestCreateInstallationToken(t *testing.T) {
 
 			assert.ErrorContains(t, handler.Parse(ctx, request), "missing repo")
 		},
-		"ParseSucceeds": func(ctx context.Context, t *testing.T, handler *createInstallationToken) {
+		"ParseSucceeds": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
 			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", validOwner, validRepo)
 			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
 			assert.NoError(t, err)
@@ -668,7 +668,7 @@ func TestCreateInstallationToken(t *testing.T) {
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
 
-			r, ok := makeCreateInstallationToken(env).(*createInstallationToken)
+			r, ok := makeCreateInstallationToken(env).(*createInstallationTokenForClone)
 			require.True(t, ok)
 
 			tCase(ctx, t, r)


### PR DESCRIPTION
DEVPROD-14314 

### Description
This edits the token cache to cache tokens based on the permissions they are scoped to. 

### Testing
Added to existing tests 
