### PR TITLE
DEVPROD-13396 Grip for all aws errors

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -944,6 +944,7 @@ func (c *awsClientImpl) AssumeRole(ctx context.Context, input *sts.AssumeRoleInp
 			msg := makeAWSLogMessage("AssumeRole", fmt.Sprintf("%T", c), input)
 			output, err = c.stsClient.AssumeRole(ctx, input)
 			if err != nil {
+				grip.Debug(message.WrapError(err, msg))
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
 					if strings.Contains(apiErr.ErrorCode(), stsErrorAccessDenied) ||
@@ -951,7 +952,6 @@ func (c *awsClientImpl) AssumeRole(ctx context.Context, input *sts.AssumeRoleInp
 						// This means the role does not exist or our role does not have permission to assume it.
 						return false, err
 					}
-					grip.Debug(message.WrapError(apiErr, msg))
 				}
 				return true, err
 			}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -938,13 +938,12 @@ func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *rou
 func (c *awsClientImpl) AssumeRole(ctx context.Context, input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
 	var output *sts.AssumeRoleOutput
 	var err error
+	msg := makeAWSLogMessage("AssumeRole", fmt.Sprintf("%T", c), input)
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
-			msg := makeAWSLogMessage("AssumeRole", fmt.Sprintf("%T", c), input)
 			output, err = c.stsClient.AssumeRole(ctx, input)
 			if err != nil {
-				grip.Debug(message.WrapError(err, msg))
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
 					if strings.Contains(apiErr.ErrorCode(), stsErrorAccessDenied) ||
@@ -959,6 +958,7 @@ func (c *awsClientImpl) AssumeRole(ctx context.Context, input *sts.AssumeRoleInp
 			return false, nil
 		}, awsClientDefaultRetryOptions())
 	if err != nil {
+		grip.Debug(message.WrapError(err, msg))
 		return nil, err
 	}
 	return output, nil


### PR DESCRIPTION
DEVPROD-13396

### Description
we were only gripping for a certain case but we should be gripping all the aws errors 

ticket had an idea to put custom messages for certain errors but the error codes returned by aws should cover that and this makes the code simpler 