### PR TITLE
DEVPROD-14912: remove Splunk token file

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -286,11 +286,11 @@ func (h *Host) FetchAndReinstallJasperCommands(settings *evergreen.Settings) str
 
 // removeSplunkTokenFileCommand returns commands to clean up the Splunk token
 // file from file a host.
-// DEVPROD-14912: this removes the Splunk token file when Jasper is reinstalled
-// on the host. The file is not used anymore, but still exists on long-lived
-// static hosts. The intent of this is to remove the file from static hosts as
-// they're re-added to the host pool.
-// TODO (DEVPROD-XXX): remove this cleanup function after a few months.
+// DEVPROD-14912: this is a best-effort attempt to clean up the Splunk token
+// file when Jasper is reinstalled on the host (e.g. when static hosts are
+// re-added to the host pool). The file is not used anymore, but still exists on
+// long-lived static hosts.
+// TODO (DEVPROD-XXX): remove this cleanup function after some time has passed.
 func (h *Host) removeSplunkTokenFileCommand() string {
 	return fmt.Sprintf("rm -f %s", h.splunkTokenFilePath())
 }

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -290,7 +290,8 @@ func (h *Host) FetchAndReinstallJasperCommands(settings *evergreen.Settings) str
 // file when Jasper is reinstalled on the host (e.g. when static hosts are
 // re-added to the host pool). The file is not used anymore, but still exists on
 // long-lived static hosts.
-// TODO (DEVPROD-XXX): remove this cleanup function after some time has passed.
+// TODO (DEVPROD-15116): remove this cleanup function after some time has
+// passed.
 func (h *Host) removeSplunkTokenFileCommand() string {
 	return fmt.Sprintf("rm -f %s", h.splunkTokenFilePath())
 }

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -23,7 +23,6 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper"
 	jcli "github.com/mongodb/jasper/cli"
 	"github.com/mongodb/jasper/options"
@@ -304,16 +303,6 @@ func (h *Host) ForceReinstallJasperCommand(settings *evergreen.Settings) string 
 		params = append(params, fmt.Sprintf("--user=%s", h.User))
 	}
 
-	if settings.Splunk.SplunkConnectionInfo.Populated() && h.StartedBy == evergreen.User {
-		params = append(params,
-			fmt.Sprintf("--splunk_url=%s", settings.Splunk.SplunkConnectionInfo.ServerURL),
-			fmt.Sprintf("--splunk_token_path=%s", h.Distro.AbsPathNotCygwinCompatible(h.splunkTokenFilePath())),
-		)
-		if settings.Splunk.SplunkConnectionInfo.Channel != "" {
-			params = append(params, fmt.Sprintf("--splunk_channel=%s", settings.Splunk.SplunkConnectionInfo.Channel))
-		}
-	}
-
 	for _, envVar := range h.Distro.BootstrapSettings.Env {
 		params = append(params, fmt.Sprintf("--env '%s=%s'", envVar.Key, envVar.Value))
 	}
@@ -481,7 +470,7 @@ func (h *Host) GenerateUserDataProvisioningScript(ctx context.Context, settings 
 		return "", errors.Wrap(err, "creating setup script")
 	}
 
-	writeCredentialsCmds, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk.SplunkConnectionInfo, creds)
+	writeCredentialsCmds, err := h.WriteJasperCredentialsFilesCommands(creds)
 	if err != nil {
 		return "", errors.Wrap(err, "creating commands to write Jasper credentials file")
 	}
@@ -669,8 +658,8 @@ func (h *Host) buildLocalJasperClientRequest(config evergreen.HostJasperConfig, 
 }
 
 // WriteJasperCredentialsFilesCommands builds the command to write the Jasper
-// credentials and Splunk credentials to files.
-func (h *Host) WriteJasperCredentialsFilesCommands(splunk send.SplunkConnectionInfo, creds *certdepot.Credentials) (string, error) {
+// credentials to a file.
+func (h *Host) WriteJasperCredentialsFilesCommands(creds *certdepot.Credentials) (string, error) {
 	exportedCreds, err := creds.Export()
 	if err != nil {
 		return "", errors.Wrap(err, "exporting host Jasper credentials to file format")
@@ -682,11 +671,6 @@ func (h *Host) WriteJasperCredentialsFilesCommands(splunk send.SplunkConnectionI
 	cmds := []string{
 		writeFileContentCmd(h.Distro.BootstrapSettings.JasperCredentialsPath, string(exportedCreds)),
 		fmt.Sprintf("chmod 666 %s", h.Distro.BootstrapSettings.JasperCredentialsPath),
-	}
-
-	if splunk.Populated() && h.StartedBy == evergreen.User {
-		cmds = append(cmds, writeFileContentCmd(h.splunkTokenFilePath(), splunk.Token))
-		cmds = append(cmds, fmt.Sprintf("chmod 666 %s", h.splunkTokenFilePath()))
 	}
 
 	return strings.Join(cmds, " && "), nil
@@ -701,13 +685,6 @@ func (h *Host) WriteJasperPreconditionScriptsCommands() string {
 		cmds = append(cmds, fmt.Sprintf("chmod 755 %s", ps.Path))
 	}
 	return strings.Join(cmds, "\n")
-}
-
-func (h *Host) splunkTokenFilePath() string {
-	if h.Distro.BootstrapSettings.JasperCredentialsPath == "" {
-		return ""
-	}
-	return filepath.Join(filepath.Dir(h.Distro.BootstrapSettings.JasperCredentialsPath), "splunk.txt")
 }
 
 // RunJasperProcess makes a request to the host's Jasper service to create the

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -239,6 +239,7 @@ func TestJasperCommands(t *testing.T) {
 				setupScript,
 				h.MakeJasperDirsCommand(),
 				h.FetchJasperCommand(settings.HostJasper),
+				h.removeSplunkTokenFileCommand(),
 				h.ForceReinstallJasperCommand(settings),
 				h.ChangeJasperDirsOwnerCommand(),
 				startAgentMonitor,
@@ -285,6 +286,7 @@ func TestJasperCommands(t *testing.T) {
 				setupScript,
 				h.MakeJasperDirsCommand(),
 				h.FetchJasperCommand(settings.HostJasper),
+				h.removeSplunkTokenFileCommand(),
 				h.ForceReinstallJasperCommand(settings),
 				h.ChangeJasperDirsOwnerCommand(),
 				setupSpawnHost,
@@ -444,6 +446,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript, writeCredentialsCmd)
 			expectedCmds = append(expectedCmds,
 				h.FetchJasperCommand(settings.HostJasper),
+				h.removeSplunkTokenFileCommand(),
 				h.ForceReinstallJasperCommand(settings),
 				h.ChangeJasperDirsOwnerCommand(),
 				startAgentMonitor,
@@ -492,6 +495,7 @@ func TestJasperCommandsWindows(t *testing.T) {
 			expectedCmds = append(expectedCmds, checkRerun, setupUser, setupScript, writeCredentialsCmd)
 			expectedCmds = append(expectedCmds,
 				h.FetchJasperCommand(settings.HostJasper),
+				h.removeSplunkTokenFileCommand(),
 				h.ForceReinstallJasperCommand(settings),
 				h.ChangeJasperDirsOwnerCommand(),
 				setupSpawnHost,

--- a/units/provisioning_restart_jasper.go
+++ b/units/provisioning_restart_jasper.go
@@ -123,7 +123,7 @@ func (j *restartJasperJob) Run(ctx context.Context) {
 		return
 	}
 
-	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFilesCommands(j.settings.Splunk.SplunkConnectionInfo, creds)
+	writeCredentialsCmd, err := j.host.WriteJasperCredentialsFilesCommands(creds)
 	if err != nil {
 		j.AddRetryableError(errors.Wrap(err, "building command to write Jasper credentials file"))
 		return

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -241,7 +241,7 @@ func setupJasper(ctx context.Context, env evergreen.Environment, settings *everg
 		return errors.Wrapf(err, "creating Jasper directories: command returned: %s", logs)
 	}
 
-	if err := putJasperCredentials(ctx, env, settings, h); err != nil {
+	if err := putJasperCredentials(ctx, env, h); err != nil {
 		return errors.Wrap(err, "putting Jasper credentials on remote host")
 	}
 
@@ -258,13 +258,13 @@ func setupJasper(ctx context.Context, env evergreen.Environment, settings *everg
 
 // putJasperCredentials creates Jasper credentials for the host and puts the
 // credentials file on the host.
-func putJasperCredentials(ctx context.Context, env evergreen.Environment, settings *evergreen.Settings, h *host.Host) error {
+func putJasperCredentials(ctx context.Context, env evergreen.Environment, h *host.Host) error {
 	creds, err := h.GenerateJasperCredentials(ctx, env)
 	if err != nil {
 		return errors.Wrap(err, "generating credentials for host")
 	}
 
-	writeCmds, err := h.WriteJasperCredentialsFilesCommands(settings.Splunk.SplunkConnectionInfo, creds)
+	writeCmds, err := h.WriteJasperCredentialsFilesCommands(creds)
 	if err != nil {
 		return errors.Wrap(err, "getting command to write Jasper credentials file")
 	}


### PR DESCRIPTION
DEVPROD-14912

### Description
* Remove logic that puts the Splunk token file on task hosts.
* Add temporary logic to try cleaning up the Splunk token file on long-lived static hosts.

Once this is deployed, I'm going to reprovision all the running static hosts to remove the file and remove the Splunk token file parameter.

### Testing
* Updated unit tests.
* Tested in staging that a host provisioned with SSH could run tasks.