### PR TITLE
DEVPROD-15126 Respond to OPTIONS requests for GET request routes 

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -257,11 +257,11 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/restart").Version(2).Post().Wrap(requireUser, editTasks).RouteHandler(makeRestartVersion())
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion())
 
-	// Add an options method to every POST request to handle pre-flight Options requests.
+	// Add an options method to every GET, POST request to handle pre-flight Options requests.
 	// These requests must not check for credentials and just validate whether a route exists
 	// And allows requests from a origin.
 	for _, route := range app.Routes() {
-		if route.HasMethod(http.MethodPost) {
+		if route.HasMethod(http.MethodPost) || route.HasMethod(http.MethodGet) {
 			app.AddRoute(route.GetRoute()).Version(2).Options().RouteHandler(makeOptionsHandler())
 		}
 	}


### PR DESCRIPTION
DEVPROD-15126

### Description
This caused an error when Parsley attempted to fetch certain task logs. The server doesn't reply to the OPTIONS request leading to a CORS failure for subsequent requests.

### Testing
https://parsley-staging.corp.mongodb.com/test/evg_race_detector_test_graphql_cb5ecf9d7c3ddcae24605392f68724f6119dbcd2_25_02_19_22_58_03/0/3d27f57abf895ff55c6c69a597437c62?bookmarks=0,142&shareLine=28

This URL works now and doesn't work without this change.


