### PR TITLE
DEVPROD-10178 (2): Only match waterfall on active build variants

### DIFF
--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -73,9 +73,10 @@ func getBuildDisplayNames(match bson.M) bson.M {
 						"pipeline": []bson.M{
 							bson.M{
 								"$project": bson.M{
-									build.DisplayNameKey:    1,
-									VersionBuildStatusIdKey: build.IdKey,
-									build.BuildVariantKey:   1,
+									build.DisplayNameKey:           1,
+									VersionBuildStatusActivatedKey: 1,
+									VersionBuildStatusIdKey:        build.IdKey,
+									build.BuildVariantKey:          1,
 								},
 							},
 						},
@@ -102,8 +103,12 @@ func getBuildVariantFilterPipeline(variants []string, match bson.M) []bson.M {
 	pipeline = append(pipeline, bson.M{
 		"$match": bson.M{
 			"$or": []bson.M{
-				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusVariantKey): bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusDisplayNameKey): bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusVariantKey): bson.M{"$regex": variantsAsRegex, "$options": "i"},
+					bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusActivatedKey): true,
+				},
+				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusDisplayNameKey): bson.M{"$regex": variantsAsRegex, "$options": "i"},
+					bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusActivatedKey): true,
+				},
 			},
 		},
 	})

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -31,6 +31,7 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 	b := build.Build{
 		Id:          "b_1",
 		DisplayName: "Build Variant 1",
+		Activated:   true,
 	}
 	assert.NoError(t, b.Insert())
 
@@ -64,6 +65,15 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 		RevisionOrderNumber: 8,
 		CreateTime:          start.Add(-2 * time.Minute),
 		Activated:           utility.TruePtr(),
+		BuildVariants: []VersionBuildStatus{
+			{
+				BuildId:     "b_2",
+				DisplayName: "Build Variant 2",
+				ActivationStatus: ActivationStatus{
+					Activated: false,
+				},
+			},
+		},
 	}
 	assert.NoError(t, v.Insert())
 	v = Version{
@@ -77,6 +87,9 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 			{
 				BuildId:     "b_1",
 				DisplayName: "Build Variant 1",
+				ActivationStatus: ActivationStatus{
+					Activated: true,
+				},
 			},
 		},
 	}
@@ -141,6 +154,15 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 	require.Len(t, versions, 2)
 	assert.EqualValues(t, "v_1", versions[0].Id)
 	assert.EqualValues(t, "v_4", versions[1].Id)
+
+	versions, err = GetActiveWaterfallVersions(ctx, p.Id,
+		WaterfallOptions{
+			Limit:      4,
+			Requesters: evergreen.SystemVersionRequesterTypes,
+			Variants:   []string{"Build Variant 2"},
+		})
+	assert.NoError(t, err)
+	require.Len(t, versions, 0)
 }
 
 func TestGetAllWaterfallVersions(t *testing.T) {


### PR DESCRIPTION
DEVPROD-10178

### Description
Brief followup to https://github.com/evergreen-ci/evergreen/pull/8731

We only want to match on build variants that have actually been activated. This information is also available in the version document.

### Testing
Updated tests to ensure we match on active builds and not on inactive builds