### PR TITLE
DEVPROD-11462 Stop git.clone on invalid GitHub merge queue ref

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -541,15 +541,11 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 			}
 			if err := fetch(opts); err != nil {
 				attemptNum++
-				if isSource {
-					switch attemptNum {
-					case 1:
-						logger.Execution().Warning("git source clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
-					case 2:
-						if strings.Contains(err.Error(), githubMergeQueueInvalidRefError) {
-							return false, errors.Wrap(err, githubMergeQueueInvalidRefExternalError)
-						}
-					}
+				if isSource && attemptNum == 1 {
+					logger.Execution().Warning("git source clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
+				}
+				if strings.Contains(err.Error(), githubMergeQueueInvalidRefError) {
+					return false, errors.Wrap(err, githubMergeQueueInvalidRefExternalError)
 				}
 				return true, errors.Wrapf(err, "attempt %d", attemptNum)
 			}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -45,6 +45,9 @@ const (
 	cloneMethodAccessToken = "access-token"
 
 	generatedTokenKey = "EVERGREEN_GENERATED_GITHUB_TOKEN"
+
+	githubMergeQueueInvalidRefError         = "couldn't find remote ref gh-readonly-queue"
+	githubMergeQueueInvalidRefExternalError = "the GitHub merge SHA is not available most likely because the merge completed or was aborted"
 )
 
 var (
@@ -543,8 +546,8 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 					case 1:
 						logger.Execution().Warning("git source clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
 					case 2:
-						if strings.Contains(err.Error(), "couldn't find remote ref gh-readonly-queue") {
-							return false, errors.Wrap(err, "the GitHub merge SHA is not available most likely because the merge completed or was aborted")
+						if strings.Contains(err.Error(), githubMergeQueueInvalidRefError) {
+							return false, errors.Wrap(err, githubMergeQueueInvalidRefExternalError)
 						}
 					}
 				}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -45,9 +45,6 @@ const (
 	cloneMethodAccessToken = "access-token"
 
 	generatedTokenKey = "EVERGREEN_GENERATED_GITHUB_TOKEN"
-
-	githubMergeQueueInvalidRefError         = "couldn't find remote ref gh-readonly-queue"
-	githubMergeQueueInvalidRefExternalError = "the GitHub merge SHA is not available most likely because the merge completed or was aborted"
 )
 
 var (
@@ -544,8 +541,8 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 				if isSource && attemptNum == 1 {
 					logger.Execution().Warning("git source clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
 				}
-				if strings.Contains(err.Error(), githubMergeQueueInvalidRefError) {
-					return false, errors.Wrap(err, githubMergeQueueInvalidRefExternalError)
+				if strings.Contains(err.Error(), "couldn't find remote ref gh-readonly-queue") {
+					return false, errors.Wrap(err, "the GitHub merge SHA is not available most likely because the merge completed or was aborted")
 				}
 				return true, errors.Wrapf(err, "attempt %d", attemptNum)
 			}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -45,6 +45,10 @@ const (
 	cloneMethodAccessToken = "access-token"
 
 	generatedTokenKey = "EVERGREEN_GENERATED_GITHUB_TOKEN"
+
+	// githubMergeQueueInvalidRefError is the error message returned by Git when it fails to find
+	// a GitHub merge queue reference.
+	githubMergeQueueInvalidRefError = "couldn't find remote ref gh-readonly-queue"
 )
 
 var (
@@ -541,7 +545,7 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 				if isSource && attemptNum == 1 {
 					logger.Execution().Warning("git source clone failed with cached merge SHA; re-requesting merge SHA from GitHub")
 				}
-				if strings.Contains(err.Error(), "couldn't find remote ref gh-readonly-queue") {
+				if strings.Contains(err.Error(), githubMergeQueueInvalidRefError) {
 					return false, errors.Wrap(err, "the GitHub merge SHA is not available most likely because the merge completed or was aborted")
 				}
 				return true, errors.Wrapf(err, "attempt %d", attemptNum)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -244,11 +244,11 @@ func (s *GitGetProjectSuite) TestRetryFetchStopsOnInvalidGitHubMergeQueueRef() {
 	attempt := 0
 	err = c.retryFetch(s.ctx, logger, true, opts, func(o cloneOpts) error {
 		attempt++
-		return errors.Errorf("fatel: %s", githubMergeQueueInvalidRefError)
+		return errors.Errorf("fatel: %s", "couldn't find remote ref gh-readonly-queue")
 	})
 
 	s.Equal(1, attempt)
-	s.Require().ErrorContains(err, githubMergeQueueInvalidRefExternalError)
+	s.Require().ErrorContains(err, "the GitHub merge SHA is not available most likely because the merge completed or was aborted")
 }
 
 func (s *GitGetProjectSuite) TestBuildSourceCommandCloneDepth() {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -244,7 +244,7 @@ func (s *GitGetProjectSuite) TestRetryFetchStopsOnInvalidGitHubMergeQueueRef() {
 	attempt := 0
 	err = c.retryFetch(s.ctx, logger, true, opts, func(o cloneOpts) error {
 		attempt++
-		return errors.Errorf("fatel: %s", "couldn't find remote ref gh-readonly-queue")
+		return errors.Errorf("fatel: %s", githubMergeQueueInvalidRefError)
 	})
 
 	s.Equal(1, attempt)

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-21"
+	AgentVersion = "2025-02-24"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-11462

### Description
When a merge queue task fails because the version has been kicked out of the merge queue because another task in it failed, the error message while cloning is a bit confusing for the other ongoing tasks. This is more of a QOL improvement rather than a needed feature. I made the error message very explicit and user-friendly on purpose, as well as stopping retries as they will not do anything.

### Testing
Unit test. I grabbed the exact verbiage from failures like [this](https://parsley.mongodb.com/evergreen/mms_unit_go_UNIT_GO_GO_patch_712620e0fe53d8576a6fe300f0781e21e28dd790_66ec12a0945d7e000754cecc_24_09_19_12_01_41/0/agent?bookmarks=0,267&selectedLineRange=L84&shareLine=84)