### PR TITLE
DEVPROD-15278 add project creator to admin list

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -660,6 +660,10 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 	if p.Id == "" {
 		p.Id = mgobson.NewObjectId().Hex()
 	}
+	// Default to adding the creator as the admin; the permissions themselves will be handled in the add function.
+	if creator != nil {
+		p.Admins = []string{creator.Id}
+	}
 	// Ensure that any new project is originally explicitly disabled and set to private.
 	p.Enabled = false
 
@@ -675,11 +679,8 @@ func (p *ProjectRef) Add(creator *user.DBUser) error {
 			if err != nil {
 				return errors.Wrapf(err, "upserting project ref '%s'", hidden.Id)
 			}
-			if creator != nil {
-				_, err = p.UpdateAdminRoles([]string{creator.Id}, nil)
-				return err
-			}
-			return nil
+			_, err = p.UpdateAdminRoles(p.Admins, nil)
+			return err
 		}
 	}
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3125,6 +3125,7 @@ func TestAddEmptyBranch(t *testing.T) {
 	assert.NoError(t, p.Add(&u))
 	assert.NotEmpty(t, p.Id)
 	assert.Empty(t, p.Branch)
+	assert.Equal(t, []string{u.Id}, p.Admins)
 }
 
 func TestAddPermissions(t *testing.T) {
@@ -3147,6 +3148,7 @@ func TestAddPermissions(t *testing.T) {
 	}
 	assert.NoError(p.Add(&u))
 	assert.NotEmpty(p.Id)
+	assert.Equal(t, []string{u.Id}, p.Admins)
 	assert.True(mgobson.IsObjectIdHex(p.Id))
 
 	rm := env.RoleManager()
@@ -3173,6 +3175,7 @@ func TestAddPermissions(t *testing.T) {
 	p.Id = ""
 	assert.NoError(p.Add(&u))
 	assert.NotEmpty(p.Id)
+	assert.Equal(t, []string{u.Id}, p.Admins)
 	assert.True(mgobson.IsObjectIdHex(p.Id))
 	assert.Equal(projectId, p.Id)
 


### PR DESCRIPTION
DEVPROD-15278 

### Description
We aren't setting the admin string list explicitly, although we are correctly creating permissions in the backend (verified this in the code and the ticket that set this off). This likely prevents Mana from correctly setting the owners. 

### Testing
Added a unit test (this failed before changes).