### PR TITLE
DEVPROD-14795 Log when agent cannot find task in parser project

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -833,11 +833,15 @@ func (a *Agent) runTaskCommands(ctx context.Context, tc *taskContext) error {
 	task := tc.taskConfig.Project.FindProjectTask(tc.taskConfig.Task.DisplayName)
 
 	if task == nil {
-		return errors.Errorf("unable to find task '%s' in project '%s'", tc.taskConfig.Task.DisplayName, tc.taskConfig.Task.Project)
+		err := errors.Errorf("unable to find task '%s' in project '%s'", tc.taskConfig.Task.DisplayName, tc.taskConfig.Task.Project)
+		tc.logger.Execution().Error(err)
+		return err
 	}
 
 	if err := ctx.Err(); err != nil {
-		return errors.Wrap(err, "canceled while running task commands")
+		err = errors.Wrap(err, "canceled before running task commands")
+		tc.logger.Execution().Error(err)
+		return err
 	}
 
 	mainTask := commandBlock{

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-25"
+	AgentVersion = "2025-02-27"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14795 

### Description
Log when the agent cannot find a task so that the user can see what went wrong. 


