### PR TITLE
DEVPROD-14162 Pass context in to GitHub app auth database functions

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -349,12 +349,8 @@ func UpsertContext(ctx context.Context, collection string, query interface{}, up
 		update,
 		options.Update().SetUpsert(true),
 	)
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "updating task")
-	}
-	if res.MatchedCount == 0 {
-		return nil, db.ErrNotFound
 	}
 
 	return &db.ChangeInfo{Updated: int(res.UpsertedCount) + int(res.ModifiedCount), UpsertedId: res.UpsertedID}, nil

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -350,7 +350,7 @@ func UpsertContext(ctx context.Context, collection string, query interface{}, up
 		options.Update().SetUpsert(true),
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "updating task")
+		return nil, errors.Wrapf(err, "updating")
 	}
 
 	return &db.ChangeInfo{Updated: int(res.UpsertedCount) + int(res.ModifiedCount), UpsertedId: res.UpsertedID}, nil

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -342,6 +342,24 @@ func Upsert(collection string, query interface{}, update interface{}) (*db.Chang
 	return db.C(collection).Upsert(query, update)
 }
 
+// UpsertContext run the specified update against the collection as an upsert operation.
+func UpsertContext(ctx context.Context, collection string, query interface{}, update interface{}) (*db.ChangeInfo, error) {
+	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,
+		query,
+		update,
+		options.Update().SetUpsert(true),
+	)
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "updating task")
+	}
+	if res.MatchedCount == 0 {
+		return nil, db.ErrNotFound
+	}
+
+	return &db.ChangeInfo{Updated: int(res.UpsertedCount) + int(res.ModifiedCount), UpsertedId: res.UpsertedID}, nil
+}
+
 // Count run a count command with the specified query against the collection.
 func Count(collection string, query interface{}) (int, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()

--- a/graphql/project_settings_resolver.go
+++ b/graphql/project_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *projectSettingsResolver) Aliases(ctx context.Context, obj *restModel.AP
 
 // GithubAppAuth is the resolver for the githubAppAuth field.
 func (r *projectSettingsResolver) GithubAppAuth(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIGithubAppAuth, error) {
-	app, err := githubapp.FindOneGitHubAppAuth(utility.FromStringPtr(obj.ProjectRef.Id))
+	app, err := githubapp.FindOneGitHubAppAuth(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
 	}

--- a/graphql/repo_settings_resolver.go
+++ b/graphql/repo_settings_resolver.go
@@ -20,7 +20,7 @@ func (r *repoSettingsResolver) Aliases(ctx context.Context, obj *restModel.APIPr
 
 // GithubAppAuth is the resolver for the githubAppAuth field.
 func (r *repoSettingsResolver) GithubAppAuth(ctx context.Context, obj *restModel.APIProjectSettings) (*restModel.APIGithubAppAuth, error) {
-	app, err := githubapp.FindOneGitHubAppAuth(utility.FromStringPtr(obj.ProjectRef.Id))
+	app, err := githubapp.FindOneGitHubAppAuth(ctx, utility.FromStringPtr(obj.ProjectRef.Id))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding GitHub app for project '%s': %s", utility.FromStringPtr(obj.ProjectRef.Id), err.Error()))
 	}

--- a/model/githubapp/github_app_auth_db.go
+++ b/model/githubapp/github_app_auth_db.go
@@ -33,11 +33,11 @@ func byGithubAppAuthID(projectId string) db.Q {
 }
 
 // GetGitHubAppID returns the app id for the given project id
-func GetGitHubAppID(projectId string) (*int64, error) {
+func GetGitHubAppID(ctx context.Context, projectId string) (*int64, error) {
 	githubAppAuth := &GithubAppAuth{}
 
 	q := byGithubAppAuthID(projectId).WithFields(GhAuthAppIdKey)
-	err := db.FindOneQ(GitHubAppAuthCollection, q, githubAppAuth)
+	err := db.FindOneQContext(ctx, GitHubAppAuthCollection, q, githubAppAuth)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
 	}
@@ -54,8 +54,8 @@ const defaultParameterStoreAccessTimeout = 30 * time.Second
 
 // FindOneGitHubAppAuth finds the GitHub app auth and retrieves the private key
 // from Parameter Store if enabled.
-func FindOneGitHubAppAuth(id string) (*GithubAppAuth, error) {
-	appAuth, err := findOneGitHubAppAuthDB(id)
+func FindOneGitHubAppAuth(ctx context.Context, id string) (*GithubAppAuth, error) {
+	appAuth, err := findOneGitHubAppAuthDB(ctx, id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding GitHub app auth for project '%s'", id)
 	}
@@ -63,7 +63,7 @@ func FindOneGitHubAppAuth(id string) (*GithubAppAuth, error) {
 		return nil, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+	ctx, cancel := context.WithTimeout(ctx, defaultParameterStoreAccessTimeout)
 	defer cancel()
 
 	if err := findPrivateKeyParameterStore(ctx, appAuth); err != nil {
@@ -74,9 +74,9 @@ func FindOneGitHubAppAuth(id string) (*GithubAppAuth, error) {
 }
 
 // findOneGitHubAppAuthDB finds the GitHub app auth in the database.
-func findOneGitHubAppAuthDB(id string) (*GithubAppAuth, error) {
+func findOneGitHubAppAuthDB(ctx context.Context, id string) (*GithubAppAuth, error) {
 	appAuth := &GithubAppAuth{}
-	err := db.FindOneQ(GitHubAppAuthCollection, byGithubAppAuthID(id), appAuth)
+	err := db.FindOneQContext(ctx, GitHubAppAuthCollection, byGithubAppAuthID(id), appAuth)
 	if adb.ResultsNotFound(err) {
 		return nil, nil
 	}
@@ -104,8 +104,8 @@ func findPrivateKeyParameterStore(ctx context.Context, appAuth *GithubAppAuth) e
 
 // UpsertGitHubAppAuth upserts the GitHub app auth into the database and upserts
 // the private key to Parameter Store if enabled.
-func UpsertGitHubAppAuth(appAuth *GithubAppAuth) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+func UpsertGitHubAppAuth(ctx context.Context, appAuth *GithubAppAuth) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultParameterStoreAccessTimeout)
 	defer cancel()
 
 	paramName, err := upsertPrivateKeyParameterStore(ctx, appAuth)
@@ -114,12 +114,12 @@ func UpsertGitHubAppAuth(appAuth *GithubAppAuth) error {
 	}
 	appAuth.PrivateKeyParameter = paramName
 
-	return upsertGitHubAppAuthDB(appAuth)
+	return upsertGitHubAppAuthDB(ctx, appAuth)
 }
 
 // upsertGitHubAppAuthDB upserts the GitHub app auth into the database.
-func upsertGitHubAppAuthDB(appAuth *GithubAppAuth) error {
-	_, err := db.Upsert(
+func upsertGitHubAppAuthDB(ctx context.Context, appAuth *GithubAppAuth) error {
+	_, err := db.UpsertContext(ctx,
 		GitHubAppAuthCollection,
 		bson.M{
 			GhAuthIdKey: appAuth.Id,
@@ -161,20 +161,21 @@ func upsertPrivateKeyParameterStore(ctx context.Context, appAuth *GithubAppAuth)
 
 // RemoveGitHubAppAuth removes the GitHub app private key from the database and
 // from Parameter Store if enabled.
-func RemoveGitHubAppAuth(appAuth *GithubAppAuth) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+func RemoveGitHubAppAuth(ctx context.Context, appAuth *GithubAppAuth) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultParameterStoreAccessTimeout)
 	defer cancel()
 
 	if err := removePrivateKeyParameterStore(ctx, appAuth); err != nil {
 		return errors.Wrap(err, "removing GitHub app private key from Parameter Store")
 	}
 
-	return removeGitHubAppAuthDB(appAuth.Id)
+	return removeGitHubAppAuthDB(ctx, appAuth.Id)
 }
 
 // removeGitHubAppAuthDB removes the GitHub app auth from the database.
-func removeGitHubAppAuthDB(id string) error {
-	return db.Remove(
+func removeGitHubAppAuthDB(ctx context.Context, id string) error {
+	return db.RemoveContext(
+		ctx,
 		GitHubAppAuthCollection,
 		bson.M{GhAuthIdKey: id},
 	)

--- a/model/githubapp/github_app_auth_db_test.go
+++ b/model/githubapp/github_app_auth_db_test.go
@@ -23,18 +23,18 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, UpsertGitHubAppAuth(appAuth))
+	require.NoError(t, UpsertGitHubAppAuth(ctx, appAuth))
 
-	dbAppAuth, err := FindOneGitHubAppAuth(projectID)
+	dbAppAuth, err := FindOneGitHubAppAuth(ctx, projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
 	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
 	paramName := appAuth.PrivateKeyParameter
 
 	appAuth.PrivateKey = []byte("new_private_key")
-	require.NoError(t, UpsertGitHubAppAuth(appAuth))
+	require.NoError(t, UpsertGitHubAppAuth(ctx, appAuth))
 
-	dbAppAuth, err = FindOneGitHubAppAuth(projectID)
+	dbAppAuth, err = FindOneGitHubAppAuth(ctx, projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
 	checkParameterMatchesPrivateKey(ctx, t, dbAppAuth)
@@ -42,8 +42,6 @@ func TestUpsertGitHubAppAuth(t *testing.T) {
 }
 
 func TestRemoveGitHubAppAuth(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	require.NoError(t, db.ClearCollections(GitHubAppAuthCollection, fakeparameter.Collection))
 
 	const projectID = "mongodb"
@@ -53,21 +51,21 @@ func TestRemoveGitHubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	require.NoError(t, UpsertGitHubAppAuth(appAuth))
+	require.NoError(t, UpsertGitHubAppAuth(t.Context(), appAuth))
 
-	dbAppAuth, err := FindOneGitHubAppAuth(projectID)
+	dbAppAuth, err := FindOneGitHubAppAuth(t.Context(), projectID)
 	require.NoError(t, err)
 	require.NotZero(t, dbAppAuth)
-	checkParameterMatchesPrivateKey(ctx, t, appAuth)
+	checkParameterMatchesPrivateKey(t.Context(), t, appAuth)
 	paramName := appAuth.PrivateKeyParameter
 
-	require.NoError(t, RemoveGitHubAppAuth(dbAppAuth))
+	require.NoError(t, RemoveGitHubAppAuth(t.Context(), dbAppAuth))
 
-	dbAppAuth, err = FindOneGitHubAppAuth(projectID)
+	dbAppAuth, err = FindOneGitHubAppAuth(t.Context(), projectID)
 	assert.NoError(t, err)
 	assert.Zero(t, dbAppAuth)
 
-	fakeParams, err := fakeparameter.FindByIDs(ctx, paramName)
+	fakeParams, err := fakeparameter.FindByIDs(t.Context(), paramName)
 	assert.NoError(t, err)
 	assert.Empty(t, fakeParams, "private key parameter should be deleted")
 }

--- a/model/githubapp/github_app_auth_test.go
+++ b/model/githubapp/github_app_auth_test.go
@@ -21,10 +21,10 @@ func TestFindOneGithubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	err := UpsertGitHubAppAuth(&githubAppAuth)
+	err := UpsertGitHubAppAuth(t.Context(), &githubAppAuth)
 	require.NoError(t, err)
 
-	githubAppAuthFromDB, err := FindOneGitHubAppAuth("mongodb")
+	githubAppAuthFromDB, err := FindOneGitHubAppAuth(t.Context(), "mongodb")
 	require.NoError(t, err)
 
 	assert.Equal("mongodb", githubAppAuthFromDB.Id)
@@ -44,10 +44,10 @@ func TestGetGitHubAppID(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	err := UpsertGitHubAppAuth(&githubAppAuth)
+	err := UpsertGitHubAppAuth(t.Context(), &githubAppAuth)
 	require.NoError(t, err)
 
-	appIDFromDB, err := GetGitHubAppID("mongodb")
+	appIDFromDB, err := GetGitHubAppID(t.Context(), "mongodb")
 	require.NoError(t, err)
 	assert.Equal(int64(1234), utility.FromInt64Ptr(appIDFromDB))
 }
@@ -63,17 +63,17 @@ func TestRemoveGithubAppAuth(t *testing.T) {
 		AppID:      1234,
 		PrivateKey: key,
 	}
-	err := UpsertGitHubAppAuth(&githubAppAuth)
+	err := UpsertGitHubAppAuth(t.Context(), &githubAppAuth)
 	require.NoError(t, err)
 
-	githubAppAuthFromDB, err := FindOneGitHubAppAuth("mongodb")
+	githubAppAuthFromDB, err := FindOneGitHubAppAuth(t.Context(), "mongodb")
 	require.NoError(t, err)
 	assert.NotNil(githubAppAuthFromDB)
 
-	err = RemoveGitHubAppAuth(&githubAppAuth)
+	err = RemoveGitHubAppAuth(t.Context(), &githubAppAuth)
 	require.NoError(t, err)
 
-	githubAppAuthFromDB, err = FindOneGitHubAppAuth("mongodb")
+	githubAppAuthFromDB, err = FindOneGitHubAppAuth(t.Context(), "mongodb")
 	require.NoError(t, err)
 	assert.Nil(githubAppAuthFromDB)
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"time"
 
@@ -364,8 +365,8 @@ func LogProjectAdded(projectId, username string) error {
 }
 
 // GetAndLogProjectModified retrieves the project settings before and after some change, and logs an event for the modification.
-func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSettings) error {
-	after, err := GetProjectSettingsById(id, isRepo)
+func GetAndLogProjectModified(ctx context.Context, id, userId string, isRepo bool, before *ProjectSettings) error {
+	after, err := GetProjectSettingsById(ctx, id, isRepo)
 	if err != nil {
 		return errors.Wrap(err, "getting after project settings event")
 	}
@@ -374,8 +375,8 @@ func GetAndLogProjectModified(id, userId string, isRepo bool, before *ProjectSet
 
 // GetAndLogProjectRepoAttachment retrieves the project settings before and after the change, and logs the modification
 // as a repo attachment/detachment event.
-func GetAndLogProjectRepoAttachment(id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
-	after, err := GetProjectSettingsById(id, isRepo)
+func GetAndLogProjectRepoAttachment(ctx context.Context, id, userId, attachmentType string, isRepo bool, before *ProjectSettings) error {
+	after, err := GetProjectSettingsById(ctx, id, isRepo)
 	if err != nil {
 		return errors.Wrap(err, "getting after project settings event")
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -836,7 +836,7 @@ func TestAttachToNewRepo(t *testing.T) {
 
 	// Can't attach to repo with an invalid owner
 	pRef.Owner = "invalid"
-	assert.Error(t, pRef.AttachToNewRepo(u))
+	assert.Error(t, pRef.AttachToNewRepo(t.Context(), u))
 
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
@@ -847,7 +847,7 @@ func TestAttachToNewRepo(t *testing.T) {
 		InstallationID: 5678,
 	}
 	assert.NoError(t, newInstallation.Upsert(ctx))
-	assert.NoError(t, pRef.AttachToNewRepo(u))
+	assert.NoError(t, pRef.AttachToNewRepo(t.Context(), u))
 
 	pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 	assert.NoError(t, err)
@@ -891,7 +891,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, pRef.Insert())
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
-	assert.NoError(t, pRef.AttachToNewRepo(u))
+	assert.NoError(t, pRef.AttachToNewRepo(t.Context(), u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
 
@@ -1052,7 +1052,7 @@ func TestDetachFromRepo(t *testing.T) {
 
 	for name, test := range map[string]func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser){
 		"ProjectRefIsUpdatedCorrectly": func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser) {
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			pRefFromDB, err := FindBranchProjectRef(pRef.Id)
 			assert.NoError(t, err)
@@ -1075,7 +1075,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.False(t, hasPermission)
 		},
 		"NewRepoVarsAreMerged": func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser) {
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			vars, err := FindOneProjectVars(pRef.Id)
 			assert.NoError(t, err)
@@ -1091,7 +1091,7 @@ func TestDetachFromRepo(t *testing.T) {
 			expectedVars, err := FindMergedProjectVars(pRef.Id)
 			require.NoError(t, err)
 
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			vars, err := FindOneProjectVars(pRef.Id)
 			require.NoError(t, err)
@@ -1108,7 +1108,7 @@ func TestDetachFromRepo(t *testing.T) {
 			repoAlias := ProjectAlias{Alias: "myRepoAlias", ProjectID: pRef.RepoRefId}
 			assert.NoError(t, repoAlias.Upsert())
 
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
@@ -1121,7 +1121,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.True(t, pRef.UseRepoSettings())
 			assert.NoError(t, RemoveProjectAlias(projectAlias.ID.Hex()))
 
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			aliases, err = FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
@@ -1139,7 +1139,7 @@ func TestDetachFromRepo(t *testing.T) {
 			}
 			assert.NoError(t, UpsertAliasesForProject(repoAliases, pRef.RepoRefId))
 
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
 			assert.NoError(t, err)
@@ -1192,7 +1192,7 @@ func TestDetachFromRepo(t *testing.T) {
 				},
 			}
 			assert.NoError(t, repoSubscription.Upsert())
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 
 			subs, err := event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)
@@ -1204,7 +1204,7 @@ func TestDetachFromRepo(t *testing.T) {
 			// reattach to repo to test without subscription
 			assert.NoError(t, pRef.AttachToRepo(ctx, dbUser))
 			assert.NoError(t, event.RemoveSubscription(projectSubscription.ID))
-			assert.NoError(t, pRef.DetachFromRepo(dbUser))
+			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 
 			subs, err = event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)
 			assert.NoError(t, err)
@@ -1303,7 +1303,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				},
 			}
 			assert.NoError(t, repoRef.Upsert())
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGeneralSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGeneralSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
@@ -1315,7 +1315,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Empty(t, pRefFromDb.RemotePath)
 		},
 		ProjectPageAccessSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageAccessSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageAccessSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
@@ -1324,7 +1324,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.Admins)
 		},
 		ProjectPageVariablesSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageVariablesSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageVariablesSection, "me"))
 
 			varsFromDb, err := FindOneProjectVars(id)
 			assert.NoError(t, err)
@@ -1337,7 +1337,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			aliases, err := FindAliasesForProjectFromDb(id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAndCQSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGithubAndCQSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
@@ -1354,7 +1354,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			}
 		},
 		ProjectPageNotificationsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageNotificationsSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageNotificationsSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1365,7 +1365,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPagePatchAliasSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPagePatchAliasSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1380,14 +1380,14 @@ func TestDefaultRepoBySection(t *testing.T) {
 			}
 		},
 		ProjectPageTriggersSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageTriggersSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageTriggersSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.Triggers)
 		},
 		ProjectPageWorkstationsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageWorkstationsSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageWorkstationsSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1395,7 +1395,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.WorkstationConfig.SetupCommands)
 		},
 		ProjectPagePluginSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPagePluginSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPagePluginSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1404,7 +1404,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.PerfEnabled)
 		},
 		ProjectPagePeriodicBuildsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPagePeriodicBuildsSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPagePeriodicBuildsSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1419,22 +1419,22 @@ func TestDefaultRepoBySection(t *testing.T) {
 				AppID:      9999,
 				PrivateKey: []byte("repo-secret"),
 			}
-			err = githubapp.UpsertGitHubAppAuth(&auth)
+			err = githubapp.UpsertGitHubAppAuth(t.Context(), &auth)
 			assert.NoError(t, err)
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubAppSettingsSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGithubAppSettingsSection, "me"))
 			pRefFromDb, err = FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			require.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.GitHubDynamicTokenPermissionGroups)
 			assert.Nil(t, pRefFromDb.GitHubPermissionGroupByRequester)
 
-			app, err := pRefFromDb.GetGitHubAppAuth()
+			app, err := pRefFromDb.GetGitHubAppAuth(t.Context())
 			require.NoError(t, err)
 			require.NotNil(t, app)
 			assert.Equal(t, pRefFromDb.RepoRefId, app.Id)
 		},
 		ProjectPageGithubPermissionsSection: func(t *testing.T, id string) {
-			assert.NoError(t, DefaultSectionToRepo(id, ProjectPageGithubPermissionsSection, "me"))
+			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGithubPermissionsSection, "me"))
 			pRefFromDb, err := FindBranchProjectRef(id)
 			assert.NoError(t, err)
 			assert.NotNil(t, pRefFromDb)
@@ -1749,74 +1749,74 @@ func TestSetGithubAppCredentials(t *testing.T) {
 	samplePrivateKey := []byte("private_key")
 	for name, test := range map[string]func(t *testing.T, p *ProjectRef){
 		"NoCredentialsWhenNoneExist": func(t *testing.T, p *ProjectRef) {
-			app, err := githubapp.FindOneGitHubAppAuth(p.Id)
+			app, err := githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},
 		"CredentialsCanBeSet": func(t *testing.T, p *ProjectRef) {
-			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGitHubAppAuth(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, samplePrivateKey))
+			app, err := githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
 		},
 		"CredentialsCanBeRemovedByEmptyAppIDAndEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
-			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGitHubAppAuth(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, samplePrivateKey))
+			app, err := githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(0, []byte("")))
-			app, err = githubapp.FindOneGitHubAppAuth(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), 0, []byte("")))
+			app, err = githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},
 		"CredentialsCanBeRemovedByEmptyAppIDAndNilPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
-			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			app, err := githubapp.FindOneGitHubAppAuth(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, samplePrivateKey))
+			app, err := githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Equal(t, sampleAppId, app.AppID)
 			assert.Equal(t, samplePrivateKey, app.PrivateKey)
 
 			// Remove credentials.
-			require.NoError(t, p.SetGithubAppCredentials(0, nil))
-			app, err = githubapp.FindOneGitHubAppAuth(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), 0, nil))
+			app, err = githubapp.FindOneGitHubAppAuth(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.Nil(t, app)
 		},
 		"CredentialsCannotBeRemovedByOnlyEmptyPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
-			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			appID, err := githubapp.GetGitHubAppID(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, samplePrivateKey))
+			appID, err := githubapp.GetGitHubAppID(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.NotNil(t, appID)
 
 			// Remove credentials.
-			require.Error(t, p.SetGithubAppCredentials(sampleAppId, []byte("")), "both app ID and private key must be provided")
+			require.Error(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, []byte("")), "both app ID and private key must be provided")
 		},
 		"CredentialsCannotBeRemovedByOnlyNilPrivateKey": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
-			require.NoError(t, p.SetGithubAppCredentials(10, samplePrivateKey))
-			appID, err := githubapp.GetGitHubAppID(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), 10, samplePrivateKey))
+			appID, err := githubapp.GetGitHubAppID(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.NotNil(t, appID)
 
 			// Remove credentials.
-			require.Error(t, p.SetGithubAppCredentials(sampleAppId, nil), "both app ID and private key must be provided")
+			require.Error(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, nil), "both app ID and private key must be provided")
 		},
 		"CredentialsCannotBeRemovedByOnlyEmptyAppID": func(t *testing.T, p *ProjectRef) {
 			// Add credentials.
-			require.NoError(t, p.SetGithubAppCredentials(sampleAppId, samplePrivateKey))
-			appID, err := githubapp.GetGitHubAppID(p.Id)
+			require.NoError(t, p.SetGithubAppCredentials(t.Context(), sampleAppId, samplePrivateKey))
+			appID, err := githubapp.GetGitHubAppID(t.Context(), p.Id)
 			require.NoError(t, err)
 			assert.NotNil(t, appID)
 
 			// Remove credentials.
-			require.Error(t, p.SetGithubAppCredentials(0, samplePrivateKey), "both app ID and private key must be provided")
+			require.Error(t, p.SetGithubAppCredentials(t.Context(), 0, samplePrivateKey), "both app ID and private key must be provided")
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1800,7 +1800,7 @@ func (s *FindProjectsSuite) TestGetProjectSettings() {
 		Admins:  []string{},
 		Repo:    "SomeRepo",
 	}
-	projectSettingsEvent, err := GetProjectSettings(projRef)
+	projectSettingsEvent, err := GetProjectSettings(s.T().Context(), projRef)
 	s.NoError(err)
 	s.NotNil(projectSettingsEvent)
 }
@@ -1812,7 +1812,7 @@ func (s *FindProjectsSuite) TestGetProjectSettingsNoRepo() {
 		Id:      projectId,
 		Admins:  []string{},
 	}
-	projectSettingsEvent, err := GetProjectSettings(projRef)
+	projectSettingsEvent, err := GetProjectSettings(s.T().Context(), projRef)
 	s.NoError(err)
 	s.NotNil(projectSettingsEvent)
 	s.False(projectSettingsEvent.GithubHooksEnabled)

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -482,7 +482,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err := githubapp.FindOneGitHubAppAuth(ref.Id)
+			githubAppFromDB, err := githubapp.FindOneGitHubAppAuth(t.Context(), ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, int64(12345), githubAppFromDB.AppID)
@@ -499,7 +499,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(ref.Id)
+			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(t.Context(), ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, int64(12345), githubAppFromDB.AppID)
@@ -516,7 +516,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(ref.Id)
+			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(t.Context(), ref.Id)
 			assert.NoError(t, err)
 			require.NotNil(t, githubAppFromDB)
 			assert.Equal(t, int64(12345), githubAppFromDB.AppID)
@@ -533,7 +533,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, settings)
 
-			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(ref.Id)
+			githubAppFromDB, err = githubapp.FindOneGitHubAppAuth(t.Context(), ref.Id)
 			assert.NoError(t, err)
 			assert.Nil(t, githubAppFromDB)
 
@@ -1109,7 +1109,7 @@ func TestPromoteVarsToRepo(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T, ref model.ProjectRef){
 		"SuccessfullyPromotesAllVariables": func(t *testing.T, ref model.ProjectRef) {
 			varsToPromote := []string{"a", "b", "c"}
-			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
+			err := PromoteVarsToRepo(t.Context(), ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
 			projectVarsFromDB, err := model.FindOneProjectVars(ref.Id)
@@ -1137,7 +1137,7 @@ func TestPromoteVarsToRepo(t *testing.T) {
 		},
 		"SuccessfullyPromotesSomeVariables": func(t *testing.T, ref model.ProjectRef) {
 			varsToPromote := []string{"a", "b"}
-			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
+			err := PromoteVarsToRepo(t.Context(), ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
 			varsFromDB, err := model.FindOneProjectVars(ref.Id)
@@ -1166,7 +1166,7 @@ func TestPromoteVarsToRepo(t *testing.T) {
 		},
 		"CorrectlyPromotesNoVariables": func(t *testing.T, ref model.ProjectRef) {
 			varsToPromote := []string{}
-			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
+			err := PromoteVarsToRepo(t.Context(), ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
 			varsFromDB, err := model.FindOneProjectVars(ref.Id)
@@ -1196,12 +1196,12 @@ func TestPromoteVarsToRepo(t *testing.T) {
 		},
 		"FailsOnUnattachedRepo": func(t *testing.T, ref model.ProjectRef) {
 			varsToPromote := []string{"test"}
-			err := PromoteVarsToRepo("pUnattached", varsToPromote, "u")
+			err := PromoteVarsToRepo(t.Context(), "pUnattached", varsToPromote, "u")
 			assert.Error(t, err)
 		},
 		"IgnoresNonexistentVars": func(t *testing.T, ref model.ProjectRef) {
 			varsToPromote := []string{"test"}
-			err := PromoteVarsToRepo(ref.Id, varsToPromote, "u")
+			err := PromoteVarsToRepo(t.Context(), ref.Id, varsToPromote, "u")
 			assert.NoError(t, err)
 
 			varsFromDB, err := model.FindOneProjectVars(ref.Id)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1646,7 +1646,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	}
 
 	// The token also should use the project's GitHub app.
-	githubAppAuth, err := p.GetGitHubAppAuth()
+	githubAppAuth, err := p.GetGitHubAppAuth(ctx)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -252,7 +252,7 @@ func (h *detachProjectFromRepoHandler) Parse(ctx context.Context, r *http.Reques
 }
 
 func (h *detachProjectFromRepoHandler) Run(ctx context.Context) gimlet.Responder {
-	if err := h.project.DetachFromRepo(h.user); err != nil {
+	if err := h.project.DetachFromRepo(ctx, h.user); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "detaching repo from project"))
 	}
 
@@ -361,7 +361,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating project repotracker"))
 	}
 
-	before, err := dbModel.GetProjectSettings(h.newProjectRef)
+	before, err := dbModel.GetProjectSettings(ctx, h.newProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting original project settings for project '%s'", h.newProjectRef.Identifier))
 	}
@@ -590,7 +590,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting subscriptions for project '%s'", h.project))
 	}
 
-	after, err := dbModel.GetProjectSettings(h.newProjectRef)
+	after, err := dbModel.GetProjectSettings(ctx, h.newProjectRef)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting project settings after update for project '%s'", h.project))
 	}

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -157,7 +157,7 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONResponse(varsToCopy)
 	}
 
-	projectBefore, err := model.GetProjectSettingsById(copyToProjectId, !copyIdIsProject)
+	projectBefore, err := model.GetProjectSettingsById(ctx, copyToProjectId, !copyIdIsProject)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting settings for project '%s' before copying variables", copyToProjectId))
 	}
@@ -166,7 +166,7 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "copying project vars from source project '%s' to target project '%s'", p.copyFrom, p.opts.CopyTo))
 	}
 
-	if err = model.GetAndLogProjectModified(copyToProjectId, p.usr.Id, !copyIdIsProject, projectBefore); err != nil {
+	if err = model.GetAndLogProjectModified(ctx, copyToProjectId, p.usr.Id, !copyIdIsProject, projectBefore); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "logging project '%s' variables copied", copyToProjectId))
 	}
 


### PR DESCRIPTION
DEVPROD-14162

### Description
This passes context through to the GitHub app auth database functions. This involved some context threading to some higher level functions and the creation of UpsertContext to support an upsert use case.

I didn't go and update all references that could be passed a context from this, as it's out of scope for the ticket

### Testing
Unit tests.
