### PR TITLE
DEVPROD-14909: allow intent hosts to be decommissioned

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -159,14 +159,15 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	// nor is the intent host associated with any instance in the cloud that
 	// we're aware of.
 	switch j.host.Status {
-	case evergreen.HostUninitialized, evergreen.HostBuilding, evergreen.HostBuildingFailed:
+	case evergreen.HostUninitialized, evergreen.HostBuilding, evergreen.HostBuildingFailed, evergreen.HostDecommissioned:
 		// If the host never successfully started, this means the host is an
-		// intent host, and should be marked terminated, and not in the cloud
-		// provider.
-		if err := j.host.Terminate(ctx, evergreen.User, j.TerminationReason); err != nil {
-			j.AddError(errors.Wrapf(err, "terminating intent host '%s' in DB", j.host.Id))
+		// intent host, and should be marked terminated. There's no host
+		// associated with it in the cloud provider.
+		if host.IsIntentHostId(j.host.Id) {
+			if err := j.host.Terminate(ctx, evergreen.User, j.TerminationReason); err != nil {
+				j.AddError(errors.Wrapf(err, "terminating intent host '%s' in DB", j.host.Id))
+			}
 		}
-		return
 	case evergreen.HostTerminated:
 		if host.IsIntentHostId(j.host.Id) {
 			return


### PR DESCRIPTION
DEVPROD-14909

### Description
If you decommission an intent host, it'll just stay decommissioned forever, and the host termination job will infinite loop on it because it looks for a host in the cloud provider. I changed the host termination job to just mark the host terminated if it's a decommissioned intent host.

### Testing
* Updated unit test.
* Tested that decommissioning an intent host in my staging eventually led to it being terminated.
