### PR TITLE
DEVPROD-11206 Remove the provider key and secret

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -113,10 +113,8 @@ type BatchManager interface {
 // ManagerOpts is a struct containing the fields needed to get a new cloud manager
 // of the proper type.
 type ManagerOpts struct {
-	Provider       string
-	Region         string
-	ProviderKey    string
-	ProviderSecret string
+	Provider string
+	Region   string
 }
 
 // GetSettings returns an uninitialized ProviderSettings based on the given
@@ -145,20 +143,16 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 		provider = &ec2Manager{
 			env: env,
 			EC2ManagerOptions: &EC2ManagerOptions{
-				client:         &awsClientImpl{},
-				region:         mgrOpts.Region,
-				providerKey:    mgrOpts.ProviderKey,
-				providerSecret: mgrOpts.ProviderSecret,
+				client: &awsClientImpl{},
+				region: mgrOpts.Region,
 			},
 		}
 	case evergreen.ProviderNameEc2Fleet:
 		provider = &ec2FleetManager{
 			env: env,
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
-				client:         &awsClientImpl{},
-				region:         mgrOpts.Region,
-				providerKey:    mgrOpts.ProviderKey,
-				providerSecret: mgrOpts.ProviderSecret,
+				client: &awsClientImpl{},
+				region: mgrOpts.Region,
 			},
 		}
 	case evergreen.ProviderNameStatic:

--- a/cloud/cloud_test.go
+++ b/cloud/cloud_test.go
@@ -18,7 +18,7 @@ func TestGetManager(t *testing.T) {
 	Convey("GetManager() should return non-nil for all valid provider names", t, func() {
 
 		Convey("EC2OnDemand should be returned for ec2-ondemand provider name", func() {
-			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2OnDemand, ProviderKey: "key", ProviderSecret: "secret"}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameEc2OnDemand}
 			cloudMgr, err := GetManager(ctx, env, mgrOpts)
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -26,7 +26,7 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("Static should be returned for static provider name", func() {
-			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameStatic, ProviderKey: "key", ProviderSecret: "secret"}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameStatic}
 			cloudMgr, err := GetManager(ctx, env, mgrOpts)
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -34,7 +34,7 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("Mock should be returned for mock provider name", func() {
-			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameMock, ProviderKey: "key", ProviderSecret: "secret"}
+			mgrOpts := ManagerOpts{Provider: evergreen.ProviderNameMock}
 			cloudMgr, err := GetManager(ctx, env, mgrOpts)
 			So(cloudMgr, ShouldNotBeNil)
 			So(err, ShouldBeNil)
@@ -42,7 +42,7 @@ func TestGetManager(t *testing.T) {
 		})
 
 		Convey("Invalid provider names should return nil with err", func() {
-			mgrOpts := ManagerOpts{Provider: "bogus", ProviderKey: "key", ProviderSecret: "secret"}
+			mgrOpts := ManagerOpts{Provider: "bogus"}
 			cloudMgr, err := GetManager(ctx, env, mgrOpts)
 			So(cloudMgr, ShouldBeNil)
 			So(err, ShouldNotBeNil)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -228,12 +228,6 @@ type EC2ManagerOptions struct {
 
 	// region is the AWS region specified by distro
 	region string
-
-	// providerKey is the AWS credential key
-	providerKey string
-
-	// providerSecret is the AWS credential secret
-	providerSecret string
 }
 
 // ec2Manager starts and configures instances in EC2.

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -78,10 +78,8 @@ func (c instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen
 }
 
 type EC2FleetManagerOptions struct {
-	client         AWSClient
-	region         string
-	providerKey    string
-	providerSecret string
+	client AWSClient
+	region string
 }
 
 type ec2FleetManager struct {

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1290,8 +1290,6 @@ func findVolumes(q bson.M) ([]Volume, error) {
 type ClientOptions struct {
 	Provider string `bson:"provider"`
 	Region   string `bson:"region"`
-	Key      string `bson:"key"`
-	Secret   string `bson:"secret"`
 }
 
 type EC2ProviderSettings struct {

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -308,8 +308,6 @@ func TestFindStartingHostsByClient(t *testing.T) {
 				case ClientOptions{
 					Provider: evergreen.ProviderNameEc2Fleet,
 					Region:   "us-west-1",
-					Key:      "key1",
-					Secret:   "secret1",
 				}:
 					require.Len(t, foundHosts, 1)
 					compareHosts(t, hosts[1], foundHosts[0])

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -88,10 +88,8 @@ clientsLoop:
 			continue
 		}
 		mgrOpts := cloud.ManagerOpts{
-			Provider:       clientOpts.Provider,
-			Region:         clientOpts.Region,
-			ProviderKey:    clientOpts.Key,
-			ProviderSecret: clientOpts.Secret,
+			Provider: clientOpts.Provider,
+			Region:   clientOpts.Region,
 		}
 		m, err := cloud.GetManager(ctx, j.env, mgrOpts)
 		if err != nil {


### PR DESCRIPTION
DEVPROD-11206

### Description
This removes the provider key and secret that we pass around but don't actually use.

### Testing
Unit tests.
