### PR TITLE
DEVPROD-14778 Flush logger after running check run

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1047,13 +1047,6 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 
 	a.killProcs(ctx, tc, false, "task is ending")
 
-	if tc.logger != nil {
-		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
-		flushCtx, cancel := context.WithTimeout(ctx, time.Minute)
-		defer cancel()
-		grip.Error(errors.Wrap(tc.logger.Flush(flushCtx), "flushing logs"))
-	}
-
 	grip.Infof("Sending final task status: '%s'.", detail.Status)
 	resp, err := a.comm.EndTask(ctx, detail, tc.task)
 	if err != nil {
@@ -1065,6 +1058,13 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	if err != nil {
 		grip.Error(errors.Wrap(err, "upserting check run"))
 		tc.logger.Task().Errorf("Error upserting check run: '%s'", err.Error())
+	}
+
+	if tc.logger != nil {
+		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
+		flushCtx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+		grip.Error(errors.Wrap(tc.logger.Flush(flushCtx), "flushing logs"))
 	}
 
 	span := trace.SpanFromContext(ctx)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1047,6 +1047,13 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 
 	a.killProcs(ctx, tc, false, "task is ending")
 
+	if tc.logger != nil {
+		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
+		flushCtx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+		grip.Error(errors.Wrap(tc.logger.Flush(flushCtx), "flushing logs"))
+	}
+
 	grip.Infof("Sending final task status: '%s'.", detail.Status)
 	resp, err := a.comm.EndTask(ctx, detail, tc.task)
 	if err != nil {
@@ -1061,7 +1068,6 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	}
 
 	if tc.logger != nil {
-		tc.logger.Execution().Infof("Sending final task status: '%s'.", detail.Status)
 		flushCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 		grip.Error(errors.Wrap(tc.logger.Flush(flushCtx), "flushing logs"))

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-25"
+	AgentVersion = "2025-02-27"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14778

### Description
the logger needs to flush to show check run errors so I moved the flush to after we run the check run

