### PR TITLE
DEVPROD-10230 avoid asking for CLI module paths repeatedly

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-02-27"
+	ClientVersion = "2025-02-27b"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -271,12 +271,9 @@ func (s *ClientSettings) getModulePath(project, moduleName string) string {
 	return modulePath
 }
 
+// setModulePath updates the given client settings to include the new module path. It does this
+// regardless of whether auto updating is disabled, so that the path is cached locally in case of include files.
 func (s *ClientSettings) setModulePath(project, moduleName, modulePath string) {
-	if s.DisableAutoDefaulting {
-		return
-	}
-	grip.Infof("Project module '%s' will be set to use path '%s'. "+
-		"To disable automatic defaulting, set 'disable_auto_defaulting' to true.", moduleName, modulePath)
 	for i, p := range s.Projects {
 		if p.Name == project {
 			if s.Projects[i].ModulePaths == nil {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -503,13 +503,18 @@ func (p *patchParams) getModulePath(conf *ClientSettings, module string) (string
 	if modulePath == "" {
 		return "", errors.Errorf("no module path given")
 	}
+	// Set path locally regardless of auto defaulting, so that its cached for the rest of the command.
+	conf.setModulePath(p.Project, module, modulePath)
 
 	if !conf.DisableAutoDefaulting {
 		// Verify that the path is correct before auto defaulting
 		if _, err := gitUncommittedChanges(modulePath); err != nil {
 			return "", errors.Wrapf(err, "verifying module '%s''", module)
 		}
-		conf.setModulePath(p.Project, module, modulePath)
+
+		grip.Infof("Project module '%s' will be set to use path '%s'. "+
+			"To disable automatic defaulting, set 'disable_auto_defaulting' to true.", module, modulePath)
+
 		if err := conf.Write(""); err != nil {
 			grip.Errorf("problem setting module '%s' path in config: %s", module, err.Error())
 		}


### PR DESCRIPTION
DEVPROD-10230
### Description
Discovered that if we're using the module include feature, and disable_auto_defaulting is set, then we don't cache the file so we ask for it for every included file (from a module).    

### Testing
Tested it by adding two included files from module. Simplified output:

```
ui [DEVPROD-11928] $evergreen patch --include-modules -p evergreen-ui -u
Enter absolute path to module 'commit_queue' to include changes (optional): 
Enter absolute path to module 'commit_queue' to include changes (optional): 

ui [DEVPROD-11928] $evergreen-with-changes patch --include-modules -p evergreen-ui -u
Enter absolute path to module 'commit_queue' to include changes (optional): 
```
