### PR TITLE
DEVPROD-13915 Fix json output for patch-file command

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-02-24"
+	ClientVersion = "2025-02-27"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -380,6 +380,7 @@ func PatchFile() cli.Command {
 		),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
+			setPlainLogger,
 			mutuallyExclusiveArgs(false, patchDescriptionFlagName, autoDescriptionFlag),
 			mutuallyExclusiveArgs(false, diffPathFlagName, diffPatchIdFlagName),
 			mutuallyExclusiveArgs(false, allowEmptyFlagName, diffPatchIdFlagName),
@@ -396,12 +397,21 @@ func PatchFile() cli.Command {
 				}
 			}
 			confPath := c.Parent().String(confFlagName)
+			outputJSON := c.Bool(jsonFlagName)
+			if outputJSON {
+				// If outputting the patch data as JSON, suppress any non-error
+				// logs since the logs won't be in JSON format. Errors should
+				// still appear so users can diagnose issues.
+				l := grip.GetSender().Level()
+				l.Threshold = level.Error
+				grip.Error(errors.Wrap(grip.SetLevel(l), "increasing log level to suppress non-errors for JSON output"))
+			}
 			params := &patchParams{
 				Project:          c.String(projectFlagName),
 				Variants:         utility.SplitCommas(c.StringSlice(variantsFlagName)),
 				Tasks:            utility.SplitCommas(c.StringSlice(tasksFlagName)),
 				Alias:            c.String(patchAliasFlagName),
-				SkipConfirm:      c.Bool(skipConfirmFlagName),
+				SkipConfirm:      c.Bool(skipConfirmFlagName) || outputJSON,
 				Description:      c.String(patchDescriptionFlagName),
 				AutoDescription:  c.Bool(autoDescriptionFlag),
 				ShowSummary:      c.Bool(patchVerboseFlagName),
@@ -429,7 +439,7 @@ func PatchFile() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			comm, err := conf.setupRestCommunicator(ctx, true)
+			comm, err := conf.setupRestCommunicator(ctx, !outputJSON)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -509,7 +519,7 @@ func PatchFile() cli.Command {
 			outputParams := outputPatchParams{
 				patches:    []patch.Patch{*newPatch},
 				uiHost:     conf.UIServerHost,
-				outputJSON: c.Bool(jsonFlagName),
+				outputJSON: outputJSON,
 			}
 
 			return params.displayPatch(ac, outputParams)


### PR DESCRIPTION
DEVPROD-13915

### Description
--json was not outputting a full json output for patch-file 

### Testing
verified it was broken previously

tested that the output was what we expected 
`❯ evgs patch-file --diff-patchId 67c0bee74cf228000778d862 -j
{
        "patch_id": "67c0c82567db8800076937a5",
        "description": "DEVPROD-13915: DEVPROD-15025 Switch from Gp2 volume default to Gp3 default (#8752)",
        "project_id": "mci",
        "project_identifier": null,
        "branch": "mci",
        "git_hash": "97c3401b9c5e75d121afce6afe40b04abeb9a06b",
        "patch_number": 808,
        "hidden": false,
        "author": "bynn.lee",`