### PR TITLE
DEVPROD-13613 log and continue on container secret upsert error

### DIFF
--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -189,10 +189,11 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 
 	// Under the hood, this is updating the container secrets in the DB project
 	// ref, but this function's copy of the in-memory project ref won't reflect
-	// those changes.
-	if err := UpsertContainerSecrets(ctx, vault, secrets); err != nil {
-		return errors.Wrapf(err, "upserting container secrets")
-	}
+	// those changes. We log an error here instead of returning, so that this
+	// doesn't prevent the rest of the operations.
+	grip.Error(message.WrapError(UpsertContainerSecrets(ctx, vault, secrets), message.Fields{
+		"message": "problem upserting container secrets",
+	}))
 
 	return nil
 }

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -192,7 +192,9 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	// those changes. We log an error here instead of returning, so that this
 	// doesn't prevent the rest of the operations.
 	grip.Error(message.WrapError(UpsertContainerSecrets(ctx, vault, secrets), message.Fields{
-		"message": "problem upserting container secrets",
+		"message":            "problem upserting container secrets",
+		"project_id":         pRef.Id,
+		"project_identifier": pRef.Identifier,
 	}))
 
 	return nil

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -563,7 +563,9 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	// those changes. We log an error here instead of returning, so that this
 	// doesn't prevent the rest of the operations.
 	grip.Error(message.WrapError(data.UpsertContainerSecrets(ctx, vault, allContainerSecrets), message.Fields{
-		"message": "problem upserting container secrets",
+		"message":            "problem upserting container secrets",
+		"project_id":         h.newProjectRef.Id,
+		"project_identifier": h.newProjectRef.Identifier,
 	}))
 
 	if err = data.UpdateProjectVars(h.newProjectRef.Id, &h.apiNewProjectRef.Variables, false); err != nil { // destructively modifies h.apiNewProjectRef.Variables


### PR DESCRIPTION
DEVPROD-13613 
### Description
As discussed in triage, we want to log and continue on this error so that we aren't prevented from continuing errors. Doing this only for the upsert case rather than tryCopyingContainerSecrets since more of those errors seem valid. 

### Testing
Will ensure existing tests pass.