### PR TITLE
DEVPROD-15353: replace empty interface with `any`

### DIFF
--- a/agent/command/archive_auto_create.go
+++ b/agent/command/archive_auto_create.go
@@ -37,7 +37,7 @@ func autoArchiveCreateFactory() Command { return &autoArchiveCreate{} }
 
 func (c *autoArchiveCreate) Name() string { return "archive.auto_pack" }
 
-func (c *autoArchiveCreate) ParseParams(params map[string]interface{}) error {
+func (c *autoArchiveCreate) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_auto_create_test.go
+++ b/agent/command/archive_auto_create_test.go
@@ -27,10 +27,10 @@ func TestArchiveAutoPackParseParams(t *testing.T) {
 			assert.Error(t, cmd.ParseParams(nil))
 		},
 		"FailsWithEmptyParams": func(t *testing.T, cmd Command) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{}))
+			assert.Error(t, cmd.ParseParams(map[string]any{}))
 		},
 		"FailsWithInvalidParamTypes": func(t *testing.T, cmd Command) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"target":        1,
 				"source_dir":    2,
 				"include":       3,
@@ -38,11 +38,11 @@ func TestArchiveAutoPackParseParams(t *testing.T) {
 			}))
 		},
 		"SucceedsWithValidParams": func(t *testing.T, cmd Command) {
-			assert.NoError(t, cmd.ParseParams(map[string]interface{}{
+			assert.NoError(t, cmd.ParseParams(map[string]any{
 				"target":     "some_target",
 				"source_dir": "some_source_dir",
 			}))
-			assert.NoError(t, cmd.ParseParams(map[string]interface{}{
+			assert.NoError(t, cmd.ParseParams(map[string]any{
 				"target":        "some_target",
 				"source_dir":    "some_source_dir",
 				"include":       []string{"included_file"},
@@ -50,21 +50,21 @@ func TestArchiveAutoPackParseParams(t *testing.T) {
 			}))
 		},
 		"FailsWithoutSource": func(t *testing.T, cmd Command) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"target":  "some_target",
 				"include": []string{"included_file"},
 				"exclude": []string{"excluded_file"},
 			}))
 		},
 		"FailsWithoutTarget": func(t *testing.T, cmd Command) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"source_dir": "some_source_dir",
 				"include":    []string{"included_file"},
 				"exclude":    []string{"excluded_file"},
 			}))
 		},
 		"FailsWithExcludedFilesButNoIncludedFiles": func(t *testing.T, cmd Command) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"target":        "some_target",
 				"source_dir":    "some_source_dir",
 				"exclude_files": []string{"excluded_file"},

--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -23,7 +23,7 @@ type autoExtract struct {
 
 func autoExtractFactory() Command   { return &autoExtract{} }
 func (e *autoExtract) Name() string { return "archive.auto_extract" }
-func (e *autoExtract) ParseParams(params map[string]interface{}) error {
+func (e *autoExtract) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, e); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_auto_extract_test.go
+++ b/agent/command/archive_auto_extract_test.go
@@ -28,7 +28,7 @@ type AutoExtractSuite struct {
 
 	cmd            *autoExtract
 	targetLocation string
-	params         map[string]interface{}
+	params         map[string]any
 
 	suite.Suite
 }
@@ -53,7 +53,7 @@ func (s *AutoExtractSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.cmd = &autoExtract{}
-	s.params = map[string]interface{}{}
+	s.params = map[string]any{}
 }
 
 func (s *AutoExtractSuite) TearDownTest() {

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -48,7 +48,7 @@ func tarballCreateFactory() Command   { return &tarballCreate{} }
 func (c *tarballCreate) Name() string { return "archive.targz_pack" }
 
 // ParseParams reads in the given parameters for the command.
-func (c *tarballCreate) ParseParams(params map[string]interface{}) error {
+func (c *tarballCreate) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -33,7 +33,7 @@ func TestTarGzPackParseParams(t *testing.T) {
 
 			Convey("a missing target should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"source_dir": "s",
 					"include":    []string{"i"},
 				}
@@ -43,7 +43,7 @@ func TestTarGzPackParseParams(t *testing.T) {
 
 			Convey("a missing source_dir should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"target":  "t",
 					"include": []string{"i"},
 				}
@@ -53,7 +53,7 @@ func TestTarGzPackParseParams(t *testing.T) {
 
 			Convey("an empty include field should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"target":     "t",
 					"source_dir": "s",
 				}
@@ -64,7 +64,7 @@ func TestTarGzPackParseParams(t *testing.T) {
 			Convey("a valid set of params should be parsed into the"+
 				" corresponding fields of the targz pack command", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"target":        "t",
 					"source_dir":    "s",
 					"include":       []string{"i", "j"},
@@ -108,7 +108,7 @@ func TestTarGzCommandMakeArchive(t *testing.T) {
 				require.NoError(t, target.Close())
 				outputDir := t.TempDir()
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"target":        target.Name(),
 					"source_dir":    testDataDir,
 					"include":       []string{"targz_me/dir1/**"},

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -28,7 +28,7 @@ type tarballExtract struct {
 func tarballExtractFactory() Command   { return &tarballExtract{} }
 func (e *tarballExtract) Name() string { return "archive.targz_extract" }
 
-func (e *tarballExtract) ParseParams(params map[string]interface{}) error {
+func (e *tarballExtract) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, e); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_tarball_extract_test.go
+++ b/agent/command/archive_tarball_extract_test.go
@@ -19,19 +19,19 @@ import (
 func TestArchiveTarballExtractParseParams(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T, cmd *tarballExtract){
 		"ArchivePathMustBeDefined": func(t *testing.T, cmd *tarballExtract) {
-			assert.ErrorContains(t, cmd.ParseParams(map[string]interface{}{
+			assert.ErrorContains(t, cmd.ParseParams(map[string]any{
 				"path":        "",
 				"destination": "bar",
 			}), "archive path")
 		},
 		"DestinationMustBeDefined": func(t *testing.T, cmd *tarballExtract) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"path":        "foo",
 				"destination": "",
 			}), "target directory")
 		},
 		"SucceedsWithValidParams": func(t *testing.T, cmd *tarballExtract) {
-			params := map[string]interface{}{
+			params := map[string]any{
 				"path":        "foo",
 				"destination": "bar",
 			}

--- a/agent/command/archive_zip_create.go
+++ b/agent/command/archive_zip_create.go
@@ -34,7 +34,7 @@ type zipArchiveCreate struct {
 func zipArchiveCreateFactory() Command   { return &zipArchiveCreate{} }
 func (c *zipArchiveCreate) Name() string { return "archive.zip_pack" }
 
-func (c *zipArchiveCreate) ParseParams(params map[string]interface{}) error {
+func (c *zipArchiveCreate) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_zip_create_test.go
+++ b/agent/command/archive_zip_create_test.go
@@ -26,7 +26,7 @@ type ZipCreateSuite struct {
 
 	cmd            *zipArchiveCreate
 	targetLocation string
-	params         map[string]interface{}
+	params         map[string]any
 
 	suite.Suite
 }
@@ -46,7 +46,7 @@ func (s *ZipCreateSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.cmd = &zipArchiveCreate{}
-	s.params = map[string]interface{}{}
+	s.params = map[string]any{}
 }
 
 func (s *ZipCreateSuite) TearDownTest() {

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -23,7 +23,7 @@ type zipExtract struct {
 
 func zipExtractFactory() Command   { return &zipExtract{} }
 func (e *zipExtract) Name() string { return "archive.zip_extract" }
-func (e *zipExtract) ParseParams(params map[string]interface{}) error {
+func (e *zipExtract) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, e); err != nil {
 		return errors.Wrapf(err, "decoding mapstructure params")
 	}

--- a/agent/command/archive_zip_extract_test.go
+++ b/agent/command/archive_zip_extract_test.go
@@ -24,7 +24,7 @@ type ZipExtractSuite struct {
 
 	cmd            *zipExtract
 	targetLocation string
-	params         map[string]interface{}
+	params         map[string]any
 
 	suite.Suite
 }
@@ -49,7 +49,7 @@ func (s *ZipExtractSuite) SetupTest() {
 	s.NoError(err)
 
 	s.cmd = &zipExtract{}
-	s.params = map[string]interface{}{}
+	s.params = map[string]any{}
 }
 
 func (s *ZipExtractSuite) TearDownTest() {

--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -32,7 +32,7 @@ type ec2AssumeRole struct {
 func ec2AssumeRoleFactory() Command   { return &ec2AssumeRole{} }
 func (r *ec2AssumeRole) Name() string { return "ec2.assume_role" }
 
-func (r *ec2AssumeRole) ParseParams(params map[string]interface{}) error {
+func (r *ec2AssumeRole) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, r); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -20,21 +20,21 @@ func TestEC2AssumeRoleParse(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"FailsWithNoARN": func(t *testing.T) {
 			c := &ec2AssumeRole{}
-			assert.Error(t, c.ParseParams(map[string]interface{}{}))
+			assert.Error(t, c.ParseParams(map[string]any{}))
 		},
 		"FailsWithInvalidDuration": func(t *testing.T) {
 			c := &ec2AssumeRole{
 				RoleARN:         "randomRoleArn1234567890",
 				DurationSeconds: -10,
 			}
-			assert.Error(t, c.ParseParams(map[string]interface{}{}))
+			assert.Error(t, c.ParseParams(map[string]any{}))
 		},
 		"SucceedsWithValidParams": func(t *testing.T) {
 			c := &ec2AssumeRole{
 				RoleARN:         "randomRoleArn1234567890",
 				DurationSeconds: 10,
 			}
-			assert.NoError(t, c.ParseParams(map[string]interface{}{}))
+			assert.NoError(t, c.ParseParams(map[string]any{}))
 		},
 	} {
 		t.Run(tName, tCase)

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -38,7 +38,7 @@ type attachArtifacts struct {
 func attachArtifactsFactory() Command   { return &attachArtifacts{} }
 func (c *attachArtifacts) Name() string { return evergreen.AttachArtifactsCommandName }
 
-func (c *attachArtifacts) ParseParams(params map[string]interface{}) error {
+func (c *attachArtifacts) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/attach_artifacts_test.go
+++ b/agent/command/attach_artifacts_test.go
@@ -78,27 +78,27 @@ func (s *ArtifactsSuite) TearDownTest() {
 func (s *ArtifactsSuite) TestParseErrorWorks() {
 	s.cmd.Files = []string{"foo"}
 
-	s.NoError(s.cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(s.cmd.ParseParams(map[string]any{}))
 }
 
 func (s *ArtifactsSuite) TestParseErrorsIfTypesDoNotMatch() {
-	s.Error(s.cmd.ParseParams(map[string]interface{}{
+	s.Error(s.cmd.ParseParams(map[string]any{
 		"files": 1,
 	}))
 
-	s.Error(s.cmd.ParseParams(map[string]interface{}{
+	s.Error(s.cmd.ParseParams(map[string]any{
 		"files": []int{1, 3, 7},
 	}))
 }
 
 func (s *ArtifactsSuite) TestParseErrorIfNothingIsSet() {
 	s.Empty(s.cmd.Files)
-	s.Error(s.cmd.ParseParams(map[string]interface{}{}))
+	s.Error(s.cmd.ParseParams(map[string]any{}))
 }
 
 func (s *ArtifactsSuite) TestArtifactErrorsWithInvalidExpansions() {
 	s.Empty(s.cmd.Files)
-	s.NoError(s.cmd.ParseParams(map[string]interface{}{
+	s.NoError(s.cmd.ParseParams(map[string]any{
 		"files": []string{
 			"fo${bar",
 		},

--- a/agent/command/deprecated.go
+++ b/agent/command/deprecated.go
@@ -10,9 +10,9 @@ import (
 // gitApplyPatch is deprecated. Its functionality is now a part of GitGetProjectCommand.
 type gitApplyPatch struct{ base }
 
-func gitApplyPatchFactory() Command                                    { return &gitApplyPatch{} }
-func (*gitApplyPatch) Name() string                                    { return "git.apply_patch" }
-func (*gitApplyPatch) ParseParams(params map[string]interface{}) error { return nil }
+func gitApplyPatchFactory() Command                            { return &gitApplyPatch{} }
+func (*gitApplyPatch) Name() string                            { return "git.apply_patch" }
+func (*gitApplyPatch) ParseParams(params map[string]any) error { return nil }
 func (*gitApplyPatch) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 
@@ -22,9 +22,9 @@ func (*gitApplyPatch) Execute(ctx context.Context,
 
 type manifestLoad struct{ base }
 
-func manifestLoadFactory() Command                                      { return &manifestLoad{} }
-func (c *manifestLoad) Name() string                                    { return "manifest.load" }
-func (c *manifestLoad) ParseParams(params map[string]interface{}) error { return nil }
+func manifestLoadFactory() Command                              { return &manifestLoad{} }
+func (c *manifestLoad) Name() string                            { return "manifest.load" }
+func (c *manifestLoad) ParseParams(params map[string]any) error { return nil }
 func (c *manifestLoad) Execute(ctx context.Context,
 	comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 

--- a/agent/command/downstream_expansions_set.go
+++ b/agent/command/downstream_expansions_set.go
@@ -30,7 +30,7 @@ func (c *setDownstream) Name() string { return "downstream_expansions.set" }
 
 // ParseParams validates the input to setDownstream, returning and error
 // if something is incorrect. Fulfills Command interface.
-func (c *setDownstream) ParseParams(params map[string]interface{}) error {
+func (c *setDownstream) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -82,7 +82,7 @@ type subprocessExec struct {
 func subprocessExecFactory() Command   { return &subprocessExec{} }
 func (c *subprocessExec) Name() string { return "subprocess.exec" }
 
-func (c *subprocessExec) ParseParams(params map[string]interface{}) error {
+func (c *subprocessExec) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -124,22 +124,22 @@ func (s *execCmdSuite) TestWeirdAndBadExpansions() {
 func (s *execCmdSuite) TestParseParamsInitializesEnvMap() {
 	cmd := &subprocessExec{}
 	s.Nil(cmd.Env)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NotNil(cmd.Env)
 }
 
 func (s *execCmdSuite) TestErrorToIgnoreAndRedirectToStdOut() {
 	cmd := &subprocessExec{}
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	cmd.IgnoreStandardOutput = true
 	cmd.RedirectStandardErrorToOutput = true
-	s.Error(cmd.ParseParams(map[string]interface{}{}))
+	s.Error(cmd.ParseParams(map[string]any{}))
 
 	cmd = &subprocessExec{}
 	cmd.Silent = true
 	cmd.RedirectStandardErrorToOutput = true
-	s.Error(cmd.ParseParams(map[string]interface{}{}))
+	s.Error(cmd.ParseParams(map[string]any{}))
 }
 
 func (s *execCmdSuite) TestCommandParsing() {
@@ -148,7 +148,7 @@ func (s *execCmdSuite) TestCommandParsing() {
 	}
 	s.Zero(cmd.Binary)
 	s.Zero(cmd.Args)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.Len(cmd.Args, 2)
 	s.NotZero(cmd.Binary)
 	s.Equal("/bin/bash", cmd.Binary)
@@ -158,7 +158,7 @@ func (s *execCmdSuite) TestCommandParsing() {
 
 func (s *execCmdSuite) TestParseErrorIfTypeMismatch() {
 	cmd := &subprocessExec{}
-	s.Error(cmd.ParseParams(map[string]interface{}{"args": 1, "silent": "false"}))
+	s.Error(cmd.ParseParams(map[string]any{"args": 1, "silent": "false"}))
 	s.False(cmd.Background)
 }
 
@@ -171,7 +171,7 @@ func (s *execCmdSuite) TestInvalidToSpecifyCommandInMultipleWays() {
 			"echo foo",
 		},
 	}
-	s.Error(cmd.ParseParams(map[string]interface{}{}))
+	s.Error(cmd.ParseParams(map[string]any{}))
 }
 
 func (s *execCmdSuite) TestRunCommand() {
@@ -179,7 +179,7 @@ func (s *execCmdSuite) TestRunCommand() {
 		Binary: "bash",
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	exec := cmd.getProc(s.ctx, cmd.Binary, &internal.TaskConfig{Task: task.Task{Id: "foo"}, Distro: &apimodels.DistroView{}}, s.logger)
 	s.NoError(cmd.runCommand(s.ctx, exec, s.logger))
 }
@@ -189,7 +189,7 @@ func (s *execCmdSuite) TestRunCommandPropagatesError() {
 		Command: "bash -c 'exit 1'",
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	exec := cmd.getProc(s.ctx, cmd.Binary, &internal.TaskConfig{Task: task.Task{Id: "foo"}, Distro: &apimodels.DistroView{}}, s.logger)
 	err := cmd.runCommand(s.ctx, exec, s.logger)
 	s.Require().Error(err)
@@ -203,7 +203,7 @@ func (s *execCmdSuite) TestRunCommandContinueOnErrorNoError() {
 		ContinueOnError: true,
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	exec := cmd.getProc(s.ctx, cmd.Binary, &internal.TaskConfig{Task: task.Task{Id: "foo"}, Distro: &apimodels.DistroView{}}, s.logger)
 	s.NoError(cmd.runCommand(s.ctx, exec, s.logger))
 }
@@ -215,7 +215,7 @@ func (s *execCmdSuite) TestRunCommandBackgroundAlwaysNil() {
 		Silent:     true,
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	exec := cmd.getProc(s.ctx, cmd.Binary, &internal.TaskConfig{Task: task.Task{Id: "foo"}, Distro: &apimodels.DistroView{}}, s.logger)
 	s.NoError(cmd.runCommand(s.ctx, exec, s.logger))
 }
@@ -229,7 +229,7 @@ func (s *execCmdSuite) TestCommandFailsWithoutWorkingDirectorySet() {
 		Command: "bash -c 'echo hello world!'",
 	}
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 }
 
@@ -240,7 +240,7 @@ func (s *execCmdSuite) TestCommandIntegrationSimple() {
 	}
 	cmd.SetJasperManager(s.jasper)
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 }
 
@@ -250,7 +250,7 @@ func (s *execCmdSuite) TestCommandIntegrationFailureExpansion() {
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	if s.Error(err) {
 		s.Contains(err.Error(), "expanding")
@@ -264,7 +264,7 @@ func (s *execCmdSuite) TestCommandIntegrationFailureCase() {
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 }
 
@@ -277,7 +277,7 @@ func (s *execCmdSuite) TestExecuteErrorsIfCommandAborts() {
 
 	s.cancel()
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	if s.Error(err) {
 		s.True(utility.IsContextError(errors.Cause(err)))
@@ -291,7 +291,7 @@ func (s *execCmdSuite) TestKeepEmptyArgs() {
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(cmd.Args, 1)
 
@@ -302,7 +302,7 @@ func (s *execCmdSuite) TestKeepEmptyArgs() {
 		KeepEmptyArgs: true,
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Len(cmd.Args, 2)
 }
@@ -313,7 +313,7 @@ func (s *execCmdSuite) TestCommandFailsForExecutableNotFound() {
 		WorkingDir: testutil.GetDirectoryOfFile(),
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should not be able to run because executable does not exist in PATH")
 }
 
@@ -334,7 +334,7 @@ func (s *execCmdSuite) TestCommandFallsBackToSearchingPathFromEnvForBinaryExecut
 		AddToPath:  []string{filepath.Join(workingDir, "clients", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))},
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should be able to run locally compiled evergreen executable from PATH")
 }
 
@@ -358,7 +358,7 @@ func (s *execCmdSuite) TestCommandUsesFilePathExecutable() {
 		WorkingDir: workingDir,
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should be able to run locally compiled file path to evergreen executable")
 }
 
@@ -379,7 +379,7 @@ func (s *execCmdSuite) TestCommandDoesNotFallBackToSearchingPathFromEnvWhenBinar
 		AddToPath:  []string{filepath.Join(workingDir, "clients", fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH))},
 	}
 	cmd.SetJasperManager(s.jasper)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.Error(cmd.Execute(s.ctx, s.comm, s.logger, s.conf), "command should not be able to run because evergreen executable should not be available in the current working directory")
 }
 

--- a/agent/command/expansion_test.go
+++ b/agent/command/expansion_test.go
@@ -20,16 +20,16 @@ import (
 func TestExpansionUpdate(t *testing.T) {
 	t.Run("ParseParams", func(t *testing.T) {
 		for tName, tCase := range map[string]struct {
-			params map[string]interface{}
+			params map[string]any
 			update []updateParams
 			err    string
 		}{
 			"EmptyParams": {
-				params: map[string]interface{}{},
+				params: map[string]any{},
 			},
 			"MissingKey": {
-				params: map[string]interface{}{
-					"updates": []map[string]interface{}{
+				params: map[string]any{
+					"updates": []map[string]any{
 						{
 							"value": "value",
 						},
@@ -38,8 +38,8 @@ func TestExpansionUpdate(t *testing.T) {
 				err: "expansion key at index 0 must not be a blank string",
 			},
 			"EmptyKey": {
-				params: map[string]interface{}{
-					"updates": []map[string]interface{}{
+				params: map[string]any{
+					"updates": []map[string]any{
 						{
 							"key":   "",
 							"value": "value",
@@ -49,8 +49,8 @@ func TestExpansionUpdate(t *testing.T) {
 				err: "expansion key at index 0 must not be a blank string",
 			},
 			"ConcatAndValuePresent": {
-				params: map[string]interface{}{
-					"updates": []map[string]interface{}{
+				params: map[string]any{
+					"updates": []map[string]any{
 						{
 							"key":    "key",
 							"value":  "value",
@@ -61,14 +61,14 @@ func TestExpansionUpdate(t *testing.T) {
 				err: "expansion 'key' at index 0 must not have both a value and a concat",
 			},
 			"InvalidRedactFileWithNoFile": {
-				params: map[string]interface{}{
+				params: map[string]any{
 					"redact_file_expansions": true,
 				},
 				err: "redact_file_expansions is true but no file was provided",
 			},
 			"ValidParams": {
-				params: map[string]interface{}{
-					"updates": []map[string]interface{}{
+				params: map[string]any{
+					"updates": []map[string]any{
 						{
 							"key":   "key-1",
 							"value": "value",
@@ -111,12 +111,12 @@ func TestExpansionUpdate(t *testing.T) {
 				},
 			},
 			"ValidFile": {
-				params: map[string]interface{}{
+				params: map[string]any{
 					"file": "file.yaml",
 				},
 			},
 			"ValidFileWithRedact": {
-				params: map[string]interface{}{
+				params: map[string]any{
 					"file":                   "file.yaml",
 					"redact_file_expansions": true,
 				},

--- a/agent/command/expansion_update.go
+++ b/agent/command/expansion_update.go
@@ -51,7 +51,7 @@ func (c *update) Name() string         { return "expansions.update" }
 
 // ParseParams validates the input to the update, returning and error
 // if something is incorrect. Fulfills Command interface.
-func (c *update) ParseParams(params map[string]interface{}) error {
+func (c *update) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/expansion_write.go
+++ b/agent/command/expansion_write.go
@@ -23,7 +23,7 @@ type expansionsWriter struct {
 func writeExpansionsFactory() Command    { return &expansionsWriter{} }
 func (c *expansionsWriter) Name() string { return "expansions.write" }
 
-func (c *expansionsWriter) ParseParams(params map[string]interface{}) error {
+func (c *expansionsWriter) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/generate.go
+++ b/agent/command/generate.go
@@ -31,7 +31,7 @@ type generateTask struct {
 func generateTaskFactory() Command   { return &generateTask{} }
 func (c *generateTask) Name() string { return "generate.tasks" }
 
-func (c *generateTask) ParseParams(params map[string]interface{}) error {
+func (c *generateTask) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/generate_test.go
+++ b/agent/command/generate_test.go
@@ -75,11 +75,11 @@ func (s *generateSuite) TearDownTest() {
 }
 
 func (s *generateSuite) TestParseParamsWithNoFiles() {
-	s.Error(s.g.ParseParams(map[string]interface{}{}))
+	s.Error(s.g.ParseParams(map[string]any{}))
 }
 
 func (s *generateSuite) TestParseParamsWithFiles() {
-	s.NoError(s.g.ParseParams(map[string]interface{}{
+	s.NoError(s.g.ParseParams(map[string]any{
 		"files": []string{"foo", "bar", "baz"},
 	}))
 	s.Equal([]string{"foo", "bar", "baz"}, s.g.Files)
@@ -148,7 +148,7 @@ func (s *generateSuite) TestExecuteSuccessWithValidGlobbing() {
 
 func (s *generateSuite) TestErrorWithInvalidExpansions() {
 	s.Empty(s.g.Files)
-	s.NoError(s.g.ParseParams(map[string]interface{}{
+	s.NoError(s.g.ParseParams(map[string]any{
 		"files": []string{
 			"fo${bar",
 		},
@@ -174,7 +174,7 @@ func (s *generateSuite) TestNoErrorWithValidExpansions() {
 	s.NoError(f.Close())
 
 	s.Empty(s.g.Files)
-	s.NoError(s.g.ParseParams(map[string]interface{}{
+	s.NoError(s.g.ParseParams(map[string]any{
 		"files": []string{
 			"${bar}",
 		},

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -288,7 +288,7 @@ func (c *gitFetchProject) Name() string { return "git.get_project" }
 
 // ParseParams parses the command's configuration.
 // Fulfills the Command interface.
-func (c *gitFetchProject) ParseParams(params map[string]interface{}) error {
+func (c *gitFetchProject) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -32,7 +32,7 @@ type gitPush struct {
 func gitPushFactory() Command   { return &gitPush{} }
 func (c *gitPush) Name() string { return "git.push" }
 
-func (c *gitPush) ParseParams(params map[string]interface{}) error {
+func (c *gitPush) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/github_generate_token.go
+++ b/agent/command/github_generate_token.go
@@ -47,7 +47,7 @@ type githubGenerateToken struct {
 func githubGenerateTokenFactory() Command   { return &githubGenerateToken{} }
 func (r *githubGenerateToken) Name() string { return "github.generate_token" }
 
-func (r *githubGenerateToken) ParseParams(params map[string]interface{}) error {
+func (r *githubGenerateToken) ParseParams(params map[string]any) error {
 	// Extract permissions and remove it before decoding.
 	permissions := params["permissions"]
 	delete(params, "permissions")

--- a/agent/command/github_generate_token_test.go
+++ b/agent/command/github_generate_token_test.go
@@ -20,29 +20,29 @@ func TestGitHubGenerateTokenParseParams(t *testing.T) {
 			assert.Error(t, cmd.ParseParams(nil))
 		},
 		"FailsWithEmptyParams": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{}))
+			assert.Error(t, cmd.ParseParams(map[string]any{}))
 		},
 		"FailsWithInvalidParamTypes": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"owner": 1,
 			}))
 		},
 		"FailsWithInvalidPermissions": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"expansion_name": "expansion_name",
-				"permissions": map[string]interface{}{
+				"permissions": map[string]any{
 					"invalid": "test",
 				},
 			}))
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"expansion_name": "expansion_name",
-				"permissions": map[string]interface{}{
+				"permissions": map[string]any{
 					"invalid": 1,
 				},
 			}))
 		},
 		"SucceedsWithValidParamsNoPermissions": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.NoError(t, cmd.ParseParams(map[string]interface{}{
+			assert.NoError(t, cmd.ParseParams(map[string]any{
 				"owner":          "owner",
 				"repo":           "repo",
 				"expansion_name": "expansion_name",
@@ -50,20 +50,20 @@ func TestGitHubGenerateTokenParseParams(t *testing.T) {
 			assert.Nil(t, cmd.Permissions)
 		},
 		"SucceedsWithValidParamsEmptyPermissions": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.NoError(t, cmd.ParseParams(map[string]interface{}{
+			assert.NoError(t, cmd.ParseParams(map[string]any{
 				"owner":          "owner",
 				"repo":           "repo",
 				"expansion_name": "expansion_name",
-				"permissions":    map[string]interface{}{},
+				"permissions":    map[string]any{},
 			}))
 			assert.Nil(t, cmd.Permissions)
 		},
 		"SucceedsWithValidParamsSomePermissions": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.NoError(t, cmd.ParseParams(map[string]interface{}{
+			assert.NoError(t, cmd.ParseParams(map[string]any{
 				"owner":          "owner",
 				"repo":           "repo",
 				"expansion_name": "expansion_name",
-				"permissions": map[string]interface{}{
+				"permissions": map[string]any{
 					"actions": "actions",
 					"checks":  "checks",
 				},
@@ -74,7 +74,7 @@ func TestGitHubGenerateTokenParseParams(t *testing.T) {
 			assert.Nil(t, cmd.Permissions.Administration)
 		},
 		"FailsWithoutExpansionName": func(t *testing.T, cmd *githubGenerateToken) {
-			assert.Error(t, cmd.ParseParams(map[string]interface{}{
+			assert.Error(t, cmd.ParseParams(map[string]any{
 				"owner": "owner",
 				"repo":  "repo",
 			}))

--- a/agent/command/host_create.go
+++ b/agent/command/host_create.go
@@ -26,7 +26,7 @@ func createHostFactory() Command { return &createHost{} }
 
 func (c *createHost) Name() string { return "host.create" }
 
-func (c *createHost) ParseParams(params map[string]interface{}) error {
+func (c *createHost) ParseParams(params map[string]any) error {
 	c.CreateHost = &apimodels.CreateHost{}
 
 	// background default is true

--- a/agent/command/host_create_test.go
+++ b/agent/command/host_create_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 type createHostSuite struct {
-	params map[string]interface{}
+	params map[string]any
 	cmd    createHost
 	conf   *internal.TaskConfig
 	comm   client.Communicator
@@ -46,7 +46,7 @@ func (s *createHostSuite) SetupSuite() {
 }
 
 func (s *createHostSuite) SetupTest() {
-	s.params = map[string]interface{}{
+	s.params = map[string]any{
 		"distro":    "myDistro",
 		"scope":     "task",
 		"subnet_id": "${subnet_id}",
@@ -80,14 +80,14 @@ func (s *createHostSuite) TestParseFromFile() {
 
 	//file for testing parsing from a json file
 	tmpdir := s.T().TempDir()
-	ebsDevice := []map[string]interface{}{
+	ebsDevice := []map[string]any{
 		{
 			"device_name": "myDevice",
 			"ebs_size":    1,
 		},
 	}
 	path := filepath.Join(tmpdir, "example.json")
-	fileContent := map[string]interface{}{
+	fileContent := map[string]any{
 		"distro":           "myDistro",
 		"scope":            "task",
 		"subnet_id":        "${subnet_id}",
@@ -98,7 +98,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.NoError(utility.WriteJSONFile(path, fileContent))
 	_, err := os.Stat(path)
 	s.Require().False(os.IsNotExist(err))
-	s.params = map[string]interface{}{
+	s.params = map[string]any{
 		"file": path,
 	}
 
@@ -116,7 +116,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.NoError(utility.WriteYAMLFile(path, fileContent))
 	_, err = os.Stat(path)
 	s.Require().False(os.IsNotExist(err))
-	s.params = map[string]interface{}{
+	s.params = map[string]any{
 		"file": path,
 	}
 
@@ -130,7 +130,7 @@ func (s *createHostSuite) TestParseFromFile() {
 	s.Equal("myDevice", s.cmd.CreateHost.EBSDevices[0].DeviceName)
 
 	//test with both file and other params
-	s.params = map[string]interface{}{
+	s.params = map[string]any{
 		"file":   path,
 		"distro": "myDistro",
 	}

--- a/agent/command/host_list.go
+++ b/agent/command/host_list.go
@@ -27,7 +27,7 @@ type listHosts struct {
 
 func listHostFactory() Command  { return &listHosts{} }
 func (*listHosts) Name() string { return "host.list" }
-func (c *listHosts) ParseParams(params map[string]interface{}) error {
+func (c *listHosts) ParseParams(params map[string]any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           c,

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -90,7 +90,7 @@ func (s *HostListSuite) TestMockExecuteWithWait() {
 
 func (s *HostListSuite) TestExpansions() {
 	s.NoError(s.cmd.ParseParams(
-		map[string]interface{}{
+		map[string]any{
 			"num_hosts": 2,
 		},
 	))
@@ -98,7 +98,7 @@ func (s *HostListSuite) TestExpansions() {
 	s.Equal("2", s.cmd.NumHosts)
 
 	s.NoError(s.cmd.ParseParams(
-		map[string]interface{}{
+		map[string]any{
 			"num_hosts": "${foo}",
 		},
 	))

--- a/agent/command/initial_setup.go
+++ b/agent/command/initial_setup.go
@@ -15,21 +15,21 @@ import (
 // invoked by end users.
 type initialSetup struct{}
 
-func initialSetupFactory() Command                                    { return &initialSetup{} }
-func (*initialSetup) Type() string                                    { return evergreen.CommandTypeSystem }
-func (*initialSetup) SetType(s string)                                {}
-func (*initialSetup) FullDisplayName() string                         { return "initial task setup" }
-func (*initialSetup) SetFullDisplayName(s string)                     {}
-func (*initialSetup) Name() string                                    { return "setup.initial" }
-func (*initialSetup) SetIdleTimeout(d time.Duration)                  {}
-func (*initialSetup) IdleTimeout() time.Duration                      { return 0 }
-func (*initialSetup) ParseParams(params map[string]interface{}) error { return nil }
-func (*initialSetup) JasperManager() jasper.Manager                   { return nil }
-func (*initialSetup) SetJasperManager(_ jasper.Manager)               {}
-func (*initialSetup) RetryOnFailure() bool                            { return false }
-func (*initialSetup) SetRetryOnFailure(bool)                          {}
-func (*initialSetup) FailureMetadataTags() []string                   { return nil }
-func (*initialSetup) SetFailureMetadataTags([]string)                 {}
+func initialSetupFactory() Command                            { return &initialSetup{} }
+func (*initialSetup) Type() string                            { return evergreen.CommandTypeSystem }
+func (*initialSetup) SetType(s string)                        {}
+func (*initialSetup) FullDisplayName() string                 { return "initial task setup" }
+func (*initialSetup) SetFullDisplayName(s string)             {}
+func (*initialSetup) Name() string                            { return "setup.initial" }
+func (*initialSetup) SetIdleTimeout(d time.Duration)          {}
+func (*initialSetup) IdleTimeout() time.Duration              { return 0 }
+func (*initialSetup) ParseParams(params map[string]any) error { return nil }
+func (*initialSetup) JasperManager() jasper.Manager           { return nil }
+func (*initialSetup) SetJasperManager(_ jasper.Manager)       {}
+func (*initialSetup) RetryOnFailure() bool                    { return false }
+func (*initialSetup) SetRetryOnFailure(bool)                  {}
+func (*initialSetup) FailureMetadataTags() []string           { return nil }
+func (*initialSetup) SetFailureMetadataTags([]string)         {}
 func (*initialSetup) Execute(ctx context.Context,
 	client client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
 

--- a/agent/command/interface.go
+++ b/agent/command/interface.go
@@ -17,7 +17,7 @@ type Command interface {
 	// ParseParams takes a map of fields to values extracted from
 	// the project config and passes them to the command. Any
 	// errors parsing the information are returned.
-	ParseParams(map[string]interface{}) error
+	ParseParams(map[string]any) error
 
 	// Execute runs the command using the agent's logger, communicator,
 	// task config, and a channel for interrupting long-running commands.

--- a/agent/command/keyval.go
+++ b/agent/command/keyval.go
@@ -23,7 +23,7 @@ func (c *keyValInc) Name() string { return "keyval.inc" }
 
 // ParseParams validates the input to the keyValInc, returning an error
 // if something is incorrect. Fulfills Command interface.
-func (c *keyValInc) ParseParams(params map[string]interface{}) error {
+func (c *keyValInc) ParseParams(params map[string]any) error {
 	err := mapstructure.Decode(params, c)
 	if err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/mock.go
+++ b/agent/command/mock.go
@@ -33,7 +33,7 @@ func (c *mockCommand) Execute(context.Context, client.Communicator, client.Logge
 func (c *mockCommand) Name() string { return "command.mock" }
 
 // ParseParams parses the parameters to the mock command, if any.
-func (c *mockCommand) ParseParams(params map[string]interface{}) error {
+func (c *mockCommand) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -42,7 +42,7 @@ type perfSend struct {
 func perfSendFactory() Command { return &perfSend{} }
 func (*perfSend) Name() string { return "perf.send" }
 
-func (c *perfSend) ParseParams(params map[string]interface{}) error {
+func (c *perfSend) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding params")
 	}

--- a/agent/command/perf_send_test.go
+++ b/agent/command/perf_send_test.go
@@ -13,17 +13,17 @@ import (
 func TestPerfSendParseParams(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		params map[string]interface{}
+		params map[string]any
 		hasErr bool
 	}{
 		{
 			name:   "MissingFile",
-			params: map[string]interface{}{},
+			params: map[string]any{},
 			hasErr: true,
 		},
 		{
 			name:   "FileOnly",
-			params: map[string]interface{}{"file": "fn"},
+			params: map[string]any{"file": "fn"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/agent/command/results_gotest.go
+++ b/agent/command/results_gotest.go
@@ -37,7 +37,7 @@ func (c *goTestResults) Name() string { return "gotest.parse_files" }
 
 // ParseParams reads the specified map of parameters into the goTestResults struct, and
 // validates that at least one file pattern is specified.
-func (c *goTestResults) ParseParams(params map[string]interface{}) error {
+func (c *goTestResults) ParseParams(params map[string]any) error {
 	var err error
 	if err = mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")

--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -70,7 +70,7 @@ type attachResults struct {
 func attachResultsFactory() Command   { return &attachResults{} }
 func (c *attachResults) Name() string { return evergreen.AttachResultsCommandName }
 
-func (c *attachResults) ParseParams(params map[string]interface{}) error {
+func (c *attachResults) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -39,7 +39,7 @@ func (c *xunitResults) Name() string { return evergreen.AttachXUnitResultsComman
 
 // ParseParams reads and validates the command parameters. This is required
 // to satisfy the 'Command' interface
-func (c *xunitResults) ParseParams(params map[string]interface{}) error {
+func (c *xunitResults) ParseParams(params map[string]any) error {
 	if err := mapstructure.Decode(params, c); err != nil {
 		return errors.Wrap(err, "decoding mapstructure params")
 	}

--- a/agent/command/s3_copy.go
+++ b/agent/command/s3_copy.go
@@ -100,7 +100,7 @@ type s3Loc struct {
 func s3CopyFactory() Command   { return &s3copy{} }
 func (c *s3copy) Name() string { return "s3Copy.copy" }
 
-func (c *s3copy) ParseParams(params map[string]interface{}) error {
+func (c *s3copy) ParseParams(params map[string]any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           c,

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -92,7 +92,7 @@ func s3GetFactory() Command   { return &s3get{} }
 func (c *s3get) Name() string { return "s3.get" }
 
 // s3get implementation of ParseParams.
-func (c *s3get) ParseParams(params map[string]interface{}) error {
+func (c *s3get) ParseParams(params map[string]any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           c,

--- a/agent/command/s3_get_test.go
+++ b/agent/command/s3_get_test.go
@@ -20,7 +20,7 @@ func TestS3GetValidateParams(t *testing.T) {
 
 			Convey("a missing aws key should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_secret":  "secret",
 					"remote_file": "remote",
 					"bucket":      "bck",
@@ -32,7 +32,7 @@ func TestS3GetValidateParams(t *testing.T) {
 
 			Convey("a missing aws secret should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":     "key",
 					"remote_file": "remote",
 					"bucket":      "bck",
@@ -45,7 +45,7 @@ func TestS3GetValidateParams(t *testing.T) {
 
 			Convey("a missing remote file should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":    "key",
 					"aws_secret": "secret",
 					"bucket":     "bck",
@@ -58,7 +58,7 @@ func TestS3GetValidateParams(t *testing.T) {
 
 			Convey("a missing bucket should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":     "key",
 					"aws_secret":  "secret",
 					"remote_file": "remote",
@@ -72,7 +72,7 @@ func TestS3GetValidateParams(t *testing.T) {
 			Convey("having neither a local file nor extract-to specified"+
 				" should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":     "key",
 					"aws_secret":  "secret",
 					"remote_file": "remote",
@@ -86,7 +86,7 @@ func TestS3GetValidateParams(t *testing.T) {
 			Convey("having both a local file and an extract-to specified"+
 				" should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":     "key",
 					"aws_secret":  "secret",
 					"remote_file": "remote",
@@ -101,7 +101,7 @@ func TestS3GetValidateParams(t *testing.T) {
 
 			Convey("a valid set of params should not cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":     "key",
 					"aws_secret":  "secret",
 					"remote_file": "remote",

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -149,7 +149,7 @@ func s3PutFactory() Command      { return &s3put{} }
 func (s3pc *s3put) Name() string { return "s3.put" }
 
 // s3put-specific implementation of ParseParams.
-func (s3pc *s3put) ParseParams(params map[string]interface{}) error {
+func (s3pc *s3put) ParseParams(params map[string]any) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,
 		Result:           s3pc,

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -38,7 +38,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing aws key should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_secret":   "secret",
 					"local_file":   "local",
 					"remote_file":  "remote",
@@ -53,7 +53,7 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 			Convey("a defined local file and inclusion filter should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_secret":                 "secret",
 					"aws_key":                    "key",
 					"local_file":                 "local",
@@ -70,7 +70,7 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 			Convey("a defined inclusion filter with optional upload should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_secret":                 "secret",
 					"aws_key":                    "key",
 					"local_files_include_filter": []string{"local"},
@@ -101,7 +101,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing aws secret should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"local_file":   "local",
 					"remote_file":  "remote",
@@ -117,7 +117,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing local file should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"remote_file":  "remote",
@@ -133,7 +133,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing remote file should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -149,7 +149,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing bucket should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -165,7 +165,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing s3 permission should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -181,7 +181,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("an invalid s3 permission should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -198,7 +198,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a missing content type should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -214,7 +214,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("an invalid visibility type should cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -232,7 +232,7 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			Convey("a valid set of params should not cause an error", func() {
 
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -253,7 +253,7 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("combining temporary credentials with signed visibility should cause an error", func() {
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":           "key",
 					"aws_secret":        "secret",
 					"aws_session_token": "temporary_token",

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -84,7 +84,7 @@ func shellExecFactory() Command { return &shellExec{} }
 func (*shellExec) Name() string { return evergreen.ShellExecCommandName }
 
 // ParseParams reads in the command's parameters.
-func (c *shellExec) ParseParams(params map[string]interface{}) error {
+func (c *shellExec) ParseParams(params map[string]any) error {
 	if params == nil {
 		return errors.New("params cannot be nil")
 	}

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -73,7 +73,7 @@ func (s *shellExecuteCommandSuite) TestWorksWithEmptyShell() {
 	}
 	cmd.SetJasperManager(s.jasper)
 	s.Empty(cmd.Shell)
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.NotEmpty(cmd.Shell)
 	s.NoError(cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 }
@@ -83,12 +83,12 @@ func (s *shellExecuteCommandSuite) TestSilentAndRedirectToStdOutError() {
 		Script: "exit 0",
 	}
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.False(cmd.IgnoreStandardError)
 	s.False(cmd.IgnoreStandardOutput)
 	cmd.Silent = true
 
-	s.NoError(cmd.ParseParams(map[string]interface{}{}))
+	s.NoError(cmd.ParseParams(map[string]any{}))
 	s.True(cmd.IgnoreStandardError)
 	s.True(cmd.IgnoreStandardOutput)
 }

--- a/agent/command/timeout.go
+++ b/agent/command/timeout.go
@@ -16,7 +16,7 @@ type timeout struct {
 	TimeoutSecs     int `mapstructure:"timeout_secs"`
 	ExecTimeoutSecs int `mapstructure:"exec_timeout_secs"`
 
-	params map[string]interface{}
+	params map[string]any
 
 	base
 }
@@ -33,7 +33,7 @@ func timeoutUpdateFactory() Command { return &timeout{} }
 func (c *timeout) Name() string     { return "timeout.update" }
 
 // ParseParams parses the params into the the timeout struct.
-func (c *timeout) ParseParams(params map[string]interface{}) error {
+func (c *timeout) ParseParams(params map[string]any) error {
 	c.params = params
 	return nil
 }

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -337,7 +337,7 @@ func (c *baseCommunicator) GetExpansionsAndVars(ctx context.Context, taskData Ta
 }
 
 func (c *baseCommunicator) Heartbeat(ctx context.Context, taskData TaskData) (string, error) {
-	data := interface{}("heartbeat")
+	data := any("heartbeat")
 	ctx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
 	defer cancel()
 	info := requestInfo{

--- a/agent/internal/client/request.go
+++ b/agent/internal/client/request.go
@@ -26,7 +26,7 @@ type requestInfo struct {
 	retryOnInvalidBody bool
 }
 
-func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret string, data interface{}) (*http.Request, error) {
+func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret string, data any) (*http.Request, error) {
 	url := c.getPath(path, evergreen.APIRoutePrefixV2)
 	r, err := http.NewRequest(method, url, nil)
 	if err != nil {
@@ -60,7 +60,7 @@ func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret string, d
 	return r, nil
 }
 
-func (c *baseCommunicator) createRequest(info requestInfo, data interface{}) (*http.Request, error) {
+func (c *baseCommunicator) createRequest(info requestInfo, data any) (*http.Request, error) {
 	if info.method == http.MethodPost && data == nil {
 		return nil, errors.Errorf("cannot send '%s' request with a nil body", http.MethodPost)
 	}
@@ -81,7 +81,7 @@ func (c *baseCommunicator) createRequest(info requestInfo, data interface{}) (*h
 	return r, nil
 }
 
-func (c *baseCommunicator) request(ctx context.Context, info requestInfo, data interface{}) (*http.Response, error) {
+func (c *baseCommunicator) request(ctx context.Context, info requestInfo, data any) (*http.Response, error) {
 	r, err := c.createRequest(info, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
@@ -120,7 +120,7 @@ func (c *baseCommunicator) doRequest(ctx context.Context, r *http.Request) (*htt
 	return response, nil
 }
 
-func (c *baseCommunicator) retryRequest(ctx context.Context, info requestInfo, data interface{}) (*http.Response, error) {
+func (c *baseCommunicator) retryRequest(ctx context.Context, info requestInfo, data any) (*http.Response, error) {
 	var err error
 	if info.taskData != nil && !info.taskData.OverrideValidation && info.taskData.Secret == "" {
 		err = errors.New("no task secret provided")

--- a/agent/internal/taskoutput/test_log_test.go
+++ b/agent/internal/taskoutput/test_log_test.go
@@ -231,7 +231,7 @@ func TestTestLogDirectoryHandlerGetSpecFile(t *testing.T) {
 
 	for _, test := range []struct {
 		name     string
-		specData interface{}
+		specData any
 	}{
 		{
 			name:     "InvalidYAML",

--- a/apimodels/runtime_models.go
+++ b/apimodels/runtime_models.go
@@ -2,8 +2,8 @@ package apimodels
 
 // Struct for reporting process timeouts
 type ProcessTimeoutResponse struct {
-	Status        string      `json:"status"`
-	LateProcesses interface{} `json:"late_mci_processes,omitempty"`
+	Status        string `json:"status"`
+	LateProcesses any    `json:"late_mci_processes,omitempty"`
 }
 
 type WorkstationSetupCommandOptions struct {

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -569,7 +569,7 @@ func (c *dockerClientImpl) AttachToContainer(ctx context.Context, h *host.Host, 
 	return &stream, nil
 }
 
-func makeDockerLogMessage(name, parent string, data interface{}) message.Fields {
+func makeDockerLogMessage(name, parent string, data any) message.Fields {
 	return message.Fields{
 		"message":  "Docker API call",
 		"api_name": name,

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1372,14 +1372,14 @@ func (c *awsClientMock) GetCallerIdentity(ctx context.Context, input *sts.GetCal
 	}, nil
 }
 
-func makeAWSLogMessage(name, client string, args interface{}) message.Fields {
+func makeAWSLogMessage(name, client string, args any) message.Fields {
 	msg := message.Fields{
 		"message":  "AWS API call",
 		"api_name": name,
 		"client":   client,
 	}
 
-	argMap := make(map[string]interface{})
+	argMap := make(map[string]any)
 	if err := mapstructure.Decode(args, &argMap); err == nil {
 		msg["args"] = argMap
 	} else {

--- a/cloud/parameterstore/ssm_client.go
+++ b/cloud/parameterstore/ssm_client.go
@@ -129,7 +129,7 @@ func (c *ssmClientImpl) GetParameters(ctx context.Context, input *ssm.GetParamet
 // retryBatchSSMClientOp runs an SSM operation with retries and handles batching for
 // SSM API methods that have a limit on the number of parameters that can be
 // queried at once.
-func retryBatchSSMClientOp[Input interface{}, Output interface{}](ctx context.Context, paramNames []string, client *ssm.Client, input Input, makeBatchInput func(paramNames []string, input Input) Input, op func(ctx context.Context, client *ssm.Client, input Input) (Output, error), opName string) ([]Output, error) {
+func retryBatchSSMClientOp[Input any, Output any](ctx context.Context, paramNames []string, client *ssm.Client, input Input, makeBatchInput func(paramNames []string, input Input) Input, op func(ctx context.Context, client *ssm.Client, input Input) (Output, error), opName string) ([]Output, error) {
 	// This limitation comes from the SSM docs.
 	const maxParamsPerRequest = 10
 	batches := utility.MakeSliceBatches(paramNames, maxParamsPerRequest)
@@ -147,7 +147,7 @@ func retryBatchSSMClientOp[Input interface{}, Output interface{}](ctx context.Co
 }
 
 // retrySSMClientOp runs a single SSM operation with retries.
-func retrySSMClientOp[Input interface{}, Output interface{}](ctx context.Context, client *ssm.Client, input Input, clientOp func(ctx context.Context, client *ssm.Client, input Input) (Output, error), opName string) (Output, error) {
+func retrySSMClientOp[Input any, Output any](ctx context.Context, client *ssm.Client, input Input, clientOp func(ctx context.Context, client *ssm.Client, input Input) (Output, error), opName string) (Output, error) {
 	var output Output
 	var err error
 
@@ -181,14 +181,14 @@ func ssmDefaultRetryOptions() utility.RetryOptions {
 // trace API call inputs/outputs, callers must take extra precaution to ensure
 // that this does not log any sensitive values (e.g. the parameter value in
 // plaintext).
-func makeAWSLogMessage(name, client string, args interface{}) message.Fields {
+func makeAWSLogMessage(name, client string, args any) message.Fields {
 	msg := message.Fields{
 		"message":  "AWS API call",
 		"api_name": name,
 		"client":   client,
 	}
 
-	argMap := make(map[string]interface{})
+	argMap := make(map[string]any)
 	if err := mapstructure.Decode(args, &argMap); err == nil {
 		// Avoid logging the plaintext value of the parameter for PutParameter's
 		// input. This is not a comprehensive solution to redacting sensitive

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-07"
+	AgentVersion = "2025-03-07a"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-03-05"
+	ClientVersion = "2025-03-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
@@ -171,9 +171,9 @@ func (c *Settings) ValidateAndDefault() error {
 		if err != nil {
 			catcher.Add(errors.Wrap(err, "parsing plugins"))
 		}
-		c.Plugins = map[string]map[string]interface{}{}
+		c.Plugins = map[string]map[string]any{}
 		for k1, v1 := range tempPlugins {
-			c.Plugins[k1] = map[string]interface{}{}
+			c.Plugins[k1] = map[string]any{}
 			for k2, v2 := range v1 {
 				c.Plugins[k1][k2] = v2
 			}
@@ -548,7 +548,7 @@ func (s *Settings) makeSplunkSender(ctx context.Context, client *http.Client, le
 
 // PluginConfig holds plugin-specific settings, which are handled.
 // manually by their respective plugins
-type PluginConfig map[string]map[string]interface{}
+type PluginConfig map[string]map[string]any
 
 // SSHKeyPair represents a public and private SSH key pair.
 type SSHKeyPair struct {

--- a/config_overrides.go
+++ b/config_overrides.go
@@ -24,7 +24,7 @@ type Override struct {
 	// Field is the name of the field being overridden. A nested field is indicated with dot notation.
 	Field string `bson:"field" json:"field" yaml:"field"`
 	// Value is the new value to set the field to.
-	Value interface{} `bson:"value" json:"value" yaml:"value"`
+	Value any `bson:"value" json:"value" yaml:"value"`
 }
 
 func (c *OverridesConfig) SectionId() string { return overridesSectionID }

--- a/config_test.go
+++ b/config_test.go
@@ -143,7 +143,7 @@ func (s *AdminSuite) TestBaseConfig() {
 		GithubPRCreatorOrg:  "org",
 		GithubOrgs:          []string{"evergreen-ci"},
 		LogPath:             "logpath",
-		Plugins:             map[string]map[string]interface{}{"k4": {"k5": "v5"}},
+		Plugins:             map[string]map[string]any{"k4": {"k5": "v5"}},
 		PprofPort:           "port",
 		SSHKeyDirectory:     "/ssh_key_directory",
 		SSHKeyPairs:         []SSHKeyPair{{Name: "key", Public: "public", Private: "private"}},

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	NoProjection             = bson.M{}
-	NoSort                   = []string{}
-	NoSkip                   = 0
-	NoLimit                  = 0
-	NoHint       interface{} = nil
+	NoProjection     = bson.M{}
+	NoSort           = []string{}
+	NoSkip           = 0
+	NoLimit          = 0
+	NoHint       any = nil
 )
 
 type SessionFactory interface {
@@ -79,7 +79,7 @@ func (s *shimFactoryImpl) GetContextSession(ctx context.Context) (db.Session, db
 }
 
 // Insert inserts the specified item into the specified collection.
-func Insert(collection string, item interface{}) error {
+func Insert(collection string, item any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		return errors.WithStack(err)
@@ -89,7 +89,7 @@ func Insert(collection string, item interface{}) error {
 	return db.C(collection).Insert(item)
 }
 
-func InsertMany(collection string, items ...interface{}) error {
+func InsertMany(collection string, items ...any) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -102,7 +102,7 @@ func InsertMany(collection string, items ...interface{}) error {
 	return db.C(collection).Insert(items...)
 }
 
-func InsertManyUnordered(c string, items ...interface{}) error {
+func InsertManyUnordered(c string, items ...any) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -199,7 +199,7 @@ func EnsureIndex(collection string, index mongo.IndexModel) error {
 }
 
 // Remove removes one item matching the query from the specified collection.
-func Remove(collection string, query interface{}) error {
+func Remove(collection string, query any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		return err
@@ -209,7 +209,7 @@ func Remove(collection string, query interface{}) error {
 	return db.C(collection).Remove(query)
 }
 
-func RemoveContext(ctx context.Context, collection string, query interface{}) error {
+func RemoveContext(ctx context.Context, collection string, query any) error {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		return err
@@ -220,7 +220,7 @@ func RemoveContext(ctx context.Context, collection string, query interface{}) er
 }
 
 // RemoveAll removes all items matching the query from the specified collection.
-func RemoveAll(collection string, query interface{}) error {
+func RemoveAll(collection string, query any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		return err
@@ -232,7 +232,7 @@ func RemoveAll(collection string, query interface{}) error {
 }
 
 // Update updates one matching document in the collection.
-func Update(collection string, query interface{}, update interface{}) error {
+func Update(collection string, query any, update any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -245,7 +245,7 @@ func Update(collection string, query interface{}, update interface{}) error {
 }
 
 // UpdateContext updates one matching document in the collection.
-func UpdateContext(ctx context.Context, collection string, query interface{}, update interface{}) error {
+func UpdateContext(ctx context.Context, collection string, query any, update any) error {
 	// Temporarily, we check if the document has a key beginning with '$', this would
 	// indicate a proper update operation. If not, it's a document intended for replacement.
 	// If the document is unable to be transformed (aka err != nil, e.g. a pipeline), we
@@ -266,7 +266,7 @@ func UpdateContext(ctx context.Context, collection string, query interface{}, up
 	return ReplaceContext(ctx, collection, query, update)
 }
 
-func updateContext(ctx context.Context, collection string, query interface{}, update interface{}) error {
+func updateContext(ctx context.Context, collection string, query any, update any) error {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,
 		query,
 		update,
@@ -282,7 +282,7 @@ func updateContext(ctx context.Context, collection string, query interface{}, up
 }
 
 // ReplaceContext replaces one matching document in the collection.
-func ReplaceContext(ctx context.Context, collection string, query interface{}, replacement interface{}) error {
+func ReplaceContext(ctx context.Context, collection string, query any, replacement any) error {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).ReplaceOne(ctx,
 		query,
 		replacement,
@@ -298,7 +298,7 @@ func ReplaceContext(ctx context.Context, collection string, query interface{}, r
 }
 
 // UpdateAllContext updates all matching documents in the collection.
-func UpdateAllContext(ctx context.Context, collection string, query interface{}, update interface{}) (*db.ChangeInfo, error) {
+func UpdateAllContext(ctx context.Context, collection string, query any, update any) (*db.ChangeInfo, error) {
 	switch query.(type) {
 	case *Q, Q:
 		grip.EmergencyPanic(message.Fields{
@@ -327,7 +327,7 @@ func UpdateAllContext(ctx context.Context, collection string, query interface{},
 }
 
 // UpdateId updates one _id-matching document in the collection.
-func UpdateId(collection string, id, update interface{}) error {
+func UpdateId(collection string, id, update any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -340,7 +340,7 @@ func UpdateId(collection string, id, update interface{}) error {
 }
 
 // UpdateIdContext updates one _id-matching document in the collection.
-func UpdateIdContext(ctx context.Context, collection string, id, update interface{}) error {
+func UpdateIdContext(ctx context.Context, collection string, id, update any) error {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,
 		bson.D{{Key: "_id", Value: id}},
 		update,
@@ -356,7 +356,7 @@ func UpdateIdContext(ctx context.Context, collection string, id, update interfac
 }
 
 // UpdateAll updates all matching documents in the collection.
-func UpdateAll(collection string, query interface{}, update interface{}) (*db.ChangeInfo, error) {
+func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error) {
 	switch query.(type) {
 	case *Q, Q:
 		grip.EmergencyPanic(message.Fields{
@@ -385,7 +385,7 @@ func UpdateAll(collection string, query interface{}, update interface{}) (*db.Ch
 }
 
 // Upsert run the specified update against the collection as an upsert operation.
-func Upsert(collection string, query interface{}, update interface{}) (*db.ChangeInfo, error) {
+func Upsert(collection string, query any, update any) (*db.ChangeInfo, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -398,7 +398,7 @@ func Upsert(collection string, query interface{}, update interface{}) (*db.Chang
 }
 
 // UpsertContext run the specified update against the collection as an upsert operation.
-func UpsertContext(ctx context.Context, collection string, query interface{}, update interface{}) (*db.ChangeInfo, error) {
+func UpsertContext(ctx context.Context, collection string, query any, update any) (*db.ChangeInfo, error) {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,
 		query,
 		update,
@@ -412,7 +412,7 @@ func UpsertContext(ctx context.Context, collection string, query interface{}, up
 }
 
 // Count run a count command with the specified query against the collection.
-func Count(collection string, query interface{}) (int, error) {
+func Count(collection string, query any) (int, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -425,7 +425,7 @@ func Count(collection string, query interface{}) (int, error) {
 }
 
 // Count run a count command with the specified query against the collection.
-func CountContext(ctx context.Context, collection string, query interface{}) (int, error) {
+func CountContext(ctx context.Context, collection string, query any) (int, error) {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -439,7 +439,7 @@ func CountContext(ctx context.Context, collection string, query interface{}) (in
 
 // FindAndModify runs the specified query and change against the collection,
 // unmarshaling the result into the specified interface.
-func FindAndModify(collection string, query interface{}, sort []string, change db.Change, out interface{}) (*db.ChangeInfo, error) {
+func FindAndModify(collection string, query any, sort []string, change db.Change, out any) (*db.ChangeInfo, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -491,7 +491,7 @@ func ClearGridCollections(fsPrefix string) error {
 // Aggregate runs an aggregation pipeline on a collection and unmarshals
 // the results to the given "out" interface (usually a pointer
 // to an array of structs/bson.M)
-func Aggregate(collection string, pipeline interface{}, out interface{}) error {
+func Aggregate(collection string, pipeline any, out any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		err = errors.Wrap(err, "establishing db connection")
@@ -508,7 +508,7 @@ func Aggregate(collection string, pipeline interface{}, out interface{}) error {
 // AggregateContext runs an aggregation pipeline on a collection and unmarshals
 // the results to the given "out" interface (usually a pointer
 // to an array of structs/bson.M)
-func AggregateContext(ctx context.Context, collection string, pipeline interface{}, out interface{}) error {
+func AggregateContext(ctx context.Context, collection string, pipeline any, out any) error {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		err = errors.Wrap(err, "establishing db connection")
@@ -524,7 +524,7 @@ func AggregateContext(ctx context.Context, collection string, pipeline interface
 
 // AggregateWithMaxTime runs aggregate and specifies a max query time which
 // ensures the query won't go on indefinitely when the request is cancelled.
-func AggregateWithMaxTime(collection string, pipeline interface{}, out interface{}, maxTime time.Duration) error {
+func AggregateWithMaxTime(collection string, pipeline any, out any, maxTime time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), maxTime)
 	defer cancel()
 
@@ -539,7 +539,7 @@ func AggregateWithMaxTime(collection string, pipeline interface{}, out interface
 	return database.C(collection).Pipe(pipeline).All(out)
 }
 
-func transformDocument(val interface{}) (bson.Raw, error) {
+func transformDocument(val any) (bson.Raw, error) {
 	if val == nil {
 		return nil, errors.WithStack(mongo.ErrNilDocument)
 	}

--- a/db/mgo/bson/bson.go
+++ b/db/mgo/bson/bson.go
@@ -64,7 +64,7 @@ import (
 // If GetBSON returns return a non-nil error, the marshalling procedure
 // will stop and error out with the provided value.
 type Getter interface {
-	GetBSON() (interface{}, error)
+	GetBSON() (any, error)
 }
 
 // A value implementing the bson.Setter interface will receive the BSON
@@ -110,7 +110,7 @@ var SetZero = errors.New("set to zero")
 // There's no special handling for this type in addition to what's done anyway
 // for an equivalent map type.  Elements in the map will be dumped in an
 // undefined ordered. See also the bson.D type for an ordered alternative.
-type M map[string]interface{}
+type M map[string]any
 
 // D represents a BSON document containing ordered elements. For example:
 //
@@ -124,7 +124,7 @@ type D []DocElem
 // DocElem is an element of the bson.D document representation.
 type DocElem struct {
 	Name  string
-	Value interface{}
+	Value any
 }
 
 // Map returns a map out of the ordered element name/value pairs in d.
@@ -420,7 +420,7 @@ type RegEx struct {
 // used when evaluating the provided Code.
 type JavaScript struct {
 	Code  string
-	Scope interface{}
+	Scope any
 }
 
 // DBPointer refers to a document id in a namespace.
@@ -485,7 +485,7 @@ func handleErr(err *error) {
 //	    E int64  ",minsize"
 //	    F int64  "myf,omitempty,minsize"
 //	}
-func Marshal(in interface{}) (out []byte, err error) {
+func Marshal(in any) (out []byte, err error) {
 	defer handleErr(&err)
 	e := &encoder{make([]byte, 0, initialBufferSize)}
 	e.addDoc(reflect.ValueOf(in))
@@ -527,7 +527,7 @@ func Marshal(in interface{}) (out []byte, err error) {
 // silently skipped.
 //
 // Pointer values are initialized when necessary.
-func Unmarshal(in []byte, out interface{}) (err error) {
+func Unmarshal(in []byte, out any) (err error) {
 	if raw, ok := out.(*Raw); ok {
 		raw.Kind = 3
 		raw.Data = in
@@ -557,7 +557,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 //
 // See the Unmarshal function documentation for more details on the
 // unmarshalling process.
-func (raw Raw) Unmarshal(out interface{}) (err error) {
+func (raw Raw) Unmarshal(out any) (err error) {
 	defer handleErr(&err)
 	v := reflect.ValueOf(out)
 	switch v.Kind() {

--- a/db/mgo/bson/decode.go
+++ b/db/mgo/bson/decode.go
@@ -56,7 +56,7 @@ func corrupted() {
 	panic("Document is corrupted")
 }
 
-func settableValueOf(i interface{}) reflect.Value {
+func settableValueOf(i any) reflect.Value {
 	v := reflect.ValueOf(i)
 	sv := reflect.New(v.Type()).Elem()
 	sv.Set(v)
@@ -326,7 +326,7 @@ func (d *decoder) readArrayDocTo(out reflect.Value) {
 	}
 }
 
-func (d *decoder) readSliceDoc(t reflect.Type) interface{} {
+func (d *decoder) readSliceDoc(t reflect.Type) any {
 	tmp := make([]reflect.Value, 0, 8)
 	elemType := t.Elem()
 	if elemType == typeRawDocElem {
@@ -369,7 +369,7 @@ func (d *decoder) readSliceDoc(t reflect.Type) interface{} {
 	return slice.Interface()
 }
 
-var typeSlice = reflect.TypeOf([]interface{}{})
+var typeSlice = reflect.TypeOf([]any{})
 var typeIface = typeSlice.Elem()
 
 func (d *decoder) readDocElems(typ reflect.Type) reflect.Value {
@@ -528,7 +528,7 @@ func (d *decoder) readElemTo(out reflect.Value, kind byte) (good bool) {
 		return true
 	}
 
-	var in interface{}
+	var in any
 
 	switch kind {
 	case 0x01: // Float64

--- a/db/mgo/internal/json/decode.go
+++ b/db/mgo/internal/json/decode.go
@@ -82,7 +82,7 @@ import (
 // invalid UTF-16 surrogate pairs are not treated as an error.
 // Instead, they are replaced by the Unicode replacement
 // character U+FFFD.
-func Unmarshal(data []byte, v interface{}) error {
+func Unmarshal(data []byte, v any) error {
 	// Check for well-formedness.
 	// Avoids filling out half a data structure
 	// before discovering a JSON syntax error.
@@ -147,7 +147,7 @@ func (e *InvalidUnmarshalError) Error() string {
 	return "json: Unmarshal(nil " + e.Type.String() + ")"
 }
 
-func (d *decodeState) unmarshal(v interface{}) (err error) {
+func (d *decodeState) unmarshal(v any) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -385,7 +385,7 @@ type unquotedValue struct{}
 // quoted string literal or literal null into an interface value.
 // If it finds anything other than a quoted string literal or null,
 // valueQuoted returns unquotedValue{}.
-func (d *decodeState) valueQuoted() interface{} {
+func (d *decodeState) valueQuoted() any {
 	switch op := d.scanWhile(scanSkipSpace); op {
 	default:
 		d.error(errPhase)
@@ -1013,7 +1013,7 @@ func (d *decodeState) name(v reflect.Value) {
 
 // keyed attempts to decode an object or function using a keyed doc extension,
 // and returns the value and true on success, or nil and false otherwise.
-func (d *decodeState) keyed() (interface{}, bool) {
+func (d *decodeState) keyed() (any, bool) {
 	if len(d.ext.keyed) == 0 {
 		return nil, false
 	}
@@ -1082,7 +1082,7 @@ var (
 	nullBytes  = []byte("null")
 )
 
-func (d *decodeState) storeValue(v reflect.Value, from interface{}) {
+func (d *decodeState) storeValue(v reflect.Value, from any) {
 	switch from {
 	case nil:
 		d.literalStore(nullBytes, v, false)
@@ -1112,7 +1112,7 @@ func (d *decodeState) storeValue(v reflect.Value, from interface{}) {
 	}
 }
 
-func (d *decodeState) convertLiteral(name []byte) (interface{}, bool) {
+func (d *decodeState) convertLiteral(name []byte) (any, bool) {
 	if len(name) == 0 {
 		return nil, false
 	}
@@ -1153,7 +1153,7 @@ func (d *decodeState) literal(v reflect.Value) {
 
 // convertNumber converts the number literal s to a float64 or a Number
 // depending on the setting of d.useNumber.
-func (d *decodeState) convertNumber(s string) (interface{}, error) {
+func (d *decodeState) convertNumber(s string) (any, error) {
 	if d.useNumber {
 		return Number(s), nil
 	}
@@ -1340,7 +1340,7 @@ func (d *decodeState) literalStore(item []byte, v reflect.Value, fromQuoted bool
 // but they avoid the weight of reflection in this common case.
 
 // valueInterface is like value but returns interface{}
-func (d *decodeState) valueInterface() interface{} {
+func (d *decodeState) valueInterface() any {
 	switch d.scanWhile(scanSkipSpace) {
 	default:
 		d.error(errPhase)
@@ -1362,8 +1362,8 @@ func (d *decodeState) syntaxError(expected string) {
 }
 
 // arrayInterface is like array but returns []interface{}.
-func (d *decodeState) arrayInterface() []interface{} {
-	var v = make([]interface{}, 0)
+func (d *decodeState) arrayInterface() []any {
+	var v = make([]any, 0)
 	for {
 		// Look ahead for ] - can only happen on first iteration.
 		op := d.scanWhile(scanSkipSpace)
@@ -1393,13 +1393,13 @@ func (d *decodeState) arrayInterface() []interface{} {
 }
 
 // objectInterface is like object but returns map[string]interface{}.
-func (d *decodeState) objectInterface() interface{} {
+func (d *decodeState) objectInterface() any {
 	v, ok := d.keyed()
 	if ok {
 		return v
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	for {
 		// Read opening " of string key or closing }.
 		op := d.scanWhile(scanSkipSpace)
@@ -1457,7 +1457,7 @@ func (d *decodeState) objectInterface() interface{} {
 }
 
 // literalInterface is like literal but returns an interface value.
-func (d *decodeState) literalInterface() interface{} {
+func (d *decodeState) literalInterface() any {
 	// All bytes inside literal return scanContinue op code.
 	start := d.off - 1
 	op := d.scanWhile(scanContinue)
@@ -1494,7 +1494,7 @@ func (d *decodeState) literalInterface() interface{} {
 }
 
 // nameInterface is like function but returns map[string]interface{}.
-func (d *decodeState) nameInterface() interface{} {
+func (d *decodeState) nameInterface() any {
 	v, ok := d.keyed()
 	if ok {
 		return v
@@ -1521,7 +1521,7 @@ func (d *decodeState) nameInterface() interface{} {
 		d.error(fmt.Errorf("json: unknown function %q", funcName))
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	for i := 0; ; i++ {
 		// Look ahead for ) - can only happen on first iteration.
 		op := d.scanWhile(scanSkipSpace)
@@ -1547,7 +1547,7 @@ func (d *decodeState) nameInterface() interface{} {
 			d.error(errPhase)
 		}
 	}
-	return map[string]interface{}{funcData.key: m}
+	return map[string]any{funcData.key: m}
 }
 
 // getu4 decodes \uXXXX from the beginning of s, returning the hex value,

--- a/db/mgo/internal/json/encode.go
+++ b/db/mgo/internal/json/encode.go
@@ -135,7 +135,7 @@ import (
 // JSON cannot represent cyclic data structures and Marshal does not
 // handle them. Passing cyclic structures to Marshal will result in
 // an infinite recursion.
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	e := &encodeState{}
 	err := e.marshal(v, encOpts{escapeHTML: true})
 	if err != nil {
@@ -212,7 +212,7 @@ func newEncodeState() *encodeState {
 	return new(encodeState)
 }
 
-func (e *encodeState) marshal(v interface{}, opts encOpts) (err error) {
+func (e *encodeState) marshal(v any, opts encOpts) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {

--- a/db/mgo/internal/json/extension.go
+++ b/db/mgo/internal/json/extension.go
@@ -8,9 +8,9 @@ import (
 // strict JSON or JSON-like content.
 type Extension struct {
 	funcs  map[string]funcExt
-	consts map[string]interface{}
-	keyed  map[string]func([]byte) (interface{}, error)
-	encode map[reflect.Type]func(v interface{}) ([]byte, error)
+	consts map[string]any
+	keyed  map[string]func([]byte) (any, error)
+	encode map[reflect.Type]func(v any) ([]byte, error)
 
 	unquotedKeys   bool
 	trailingCommas bool
@@ -40,7 +40,7 @@ func (e *Extension) Extend(ext *Extension) {
 	}
 	for typ, encode := range ext.encode {
 		if e.encode == nil {
-			e.encode = make(map[reflect.Type]func(v interface{}) ([]byte, error))
+			e.encode = make(map[reflect.Type]func(v any) ([]byte, error))
 		}
 		e.encode[typ] = encode
 	}
@@ -58,9 +58,9 @@ func (e *Extension) DecodeFunc(name string, key string, args ...string) {
 
 // DecodeConst defines a constant name that may be observed inside JSON content
 // and will be decoded with the provided value.
-func (e *Extension) DecodeConst(name string, value interface{}) {
+func (e *Extension) DecodeConst(name string, value any) {
 	if e.consts == nil {
-		e.consts = make(map[string]interface{})
+		e.consts = make(map[string]any)
 	}
 	e.consts[name] = value
 }
@@ -68,9 +68,9 @@ func (e *Extension) DecodeConst(name string, value interface{}) {
 // DecodeKeyed defines a key that when observed as the first element inside a
 // JSON document triggers the decoding of that document via the provided
 // decode function.
-func (e *Extension) DecodeKeyed(key string, decode func(data []byte) (interface{}, error)) {
+func (e *Extension) DecodeKeyed(key string, decode func(data []byte) (any, error)) {
 	if e.keyed == nil {
-		e.keyed = make(map[string]func([]byte) (interface{}, error))
+		e.keyed = make(map[string]func([]byte) (any, error))
 	}
 	e.keyed[key] = decode
 }
@@ -87,9 +87,9 @@ func (e *Extension) DecodeTrailingCommas(accept bool) {
 
 // EncodeType registers a function to encode values with the same type of the
 // provided sample.
-func (e *Extension) EncodeType(sample interface{}, encode func(v interface{}) ([]byte, error)) {
+func (e *Extension) EncodeType(sample any, encode func(v any) ([]byte, error)) {
 	if e.encode == nil {
-		e.encode = make(map[reflect.Type]func(v interface{}) ([]byte, error))
+		e.encode = make(map[reflect.Type]func(v any) ([]byte, error))
 	}
 	e.encode[reflect.TypeOf(sample)] = encode
 }

--- a/db/mgo/internal/json/stream.go
+++ b/db/mgo/internal/json/stream.go
@@ -40,7 +40,7 @@ func (dec *Decoder) UseNumber() { dec.d.useNumber = true }
 //
 // See the documentation for Unmarshal for details about
 // the conversion of JSON into a Go value.
-func (dec *Decoder) Decode(v interface{}) error {
+func (dec *Decoder) Decode(v any) error {
 	if dec.err != nil {
 		return dec.err
 	}
@@ -182,7 +182,7 @@ type Encoder struct {
 //
 // See the documentation for Marshal for details about the
 // conversion of Go values to JSON.
-func (enc *Encoder) Encode(v interface{}) error {
+func (enc *Encoder) Encode(v any) error {
 	if enc.err != nil {
 		return enc.err
 	}
@@ -260,7 +260,7 @@ var _ Unmarshaler = (*RawMessage)(nil)
 //	Number, for JSON numbers
 //	string, for JSON string literals
 //	nil, for JSON null
-type Token interface{}
+type Token any
 
 const (
 	tokenTopValue = iota
@@ -425,7 +425,7 @@ func (dec *Decoder) Token() (Token, error) {
 			if !dec.tokenValueAllowed() {
 				return dec.tokenError(c)
 			}
-			var x interface{}
+			var x any
 			if err := dec.Decode(&x); err != nil {
 				clearOffset(err)
 				return nil, err

--- a/db/mgo/session.go
+++ b/db/mgo/session.go
@@ -35,8 +35,8 @@ type LastError struct {
 	Code, N, Waited int
 	FSyncFiles      int `bson:"fsyncFiles"`
 	WTimeout        bool
-	UpdatedExisting bool        `bson:"updatedExisting"`
-	UpsertedId      interface{} `bson:"upserted"`
+	UpdatedExisting bool `bson:"updatedExisting"`
+	UpsertedId      any  `bson:"upserted"`
 }
 
 func (err *LastError) Error() string {

--- a/db/query.go
+++ b/db/query.go
@@ -9,27 +9,27 @@ import (
 
 // Q holds all information necessary to execute a query
 type Q struct {
-	filter     interface{} // should be bson.D or bson.M
-	projection interface{} // should be bson.D or bson.M
+	filter     any // should be bson.D or bson.M
+	projection any // should be bson.D or bson.M
 	sort       []string
 	skip       int
 	limit      int
-	hint       interface{} // should be bson.D of the index keys or string name of the hint
+	hint       any // should be bson.D of the index keys or string name of the hint
 	maxTime    time.Duration
 }
 
 // Query creates a db.Q for the given MongoDB query. The filter
 // can be a struct, bson.D, bson.M, nil, etc.
-func Query(filter interface{}) Q {
+func Query(filter any) Q {
 	return Q{filter: filter}
 }
 
-func (q Q) Filter(filter interface{}) Q {
+func (q Q) Filter(filter any) Q {
 	q.filter = filter
 	return q
 }
 
-func (q Q) Project(projection interface{}) Q {
+func (q Q) Project(projection any) Q {
 	q.projection = projection
 	return q
 }
@@ -75,20 +75,20 @@ func (q Q) MaxTime(maxTime time.Duration) Q {
 
 // Hint sets the hint for a query to determine what index will be used. The hint
 // can be either the index as an ordered document of the keys or a
-func (q Q) Hint(hint interface{}) Q {
+func (q Q) Hint(hint any) Q {
 	q.hint = hint
 	return q
 }
 
 // FindOneQ runs a Q query against the given collection, applying the results to "out."
 // Only reads one document from the DB.
-func FindOneQ(collection string, q Q, out interface{}) error {
+func FindOneQ(collection string, q Q, out any) error {
 	return FindOneQContext(context.Background(), collection, q, out)
 }
 
 // FindOneQContext runs a Q query against the given collection, applying the results to "out."
 // Only reads one document from the DB.
-func FindOneQContext(ctx context.Context, collection string, q Q, out interface{}) error {
+func FindOneQContext(ctx context.Context, collection string, q Q, out any) error {
 	if q.maxTime > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, q.maxTime)
@@ -112,11 +112,11 @@ func FindOneQContext(ctx context.Context, collection string, q Q, out interface{
 }
 
 // FindAllQ runs a Q query against the given collection, applying the results to "out."
-func FindAllQ(collection string, q Q, out interface{}) error {
+func FindAllQ(collection string, q Q, out any) error {
 	return FindAllQContext(context.Background(), collection, q, out)
 }
 
-func FindAllQContext(ctx context.Context, collection string, q Q, out interface{}) error {
+func FindAllQContext(ctx context.Context, collection string, q Q, out any) error {
 	if q.maxTime > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, q.maxTime)
@@ -158,7 +158,7 @@ func RemoveAllQ(collection string, q Q) error {
 // pass a db.Q instead of a bson document, leading to great
 // sadness. The real solution is to get rid of db.Q objects entirely.
 
-func (q Q) SetBSON(_ bson.Raw) error      { panic("should never marshal db.Q objects to bson") }
-func (q Q) GetBSON() (interface{}, error) { panic("should never marshal db.Q objects to bson") }
-func (q Q) UnmarshalBSON(_ []byte) error  { panic("should never marshal db.Q objects to bson") }
-func (q Q) MarshalBSON() ([]byte, error)  { panic("should never marshal db.Q objects to bson") }
+func (q Q) SetBSON(_ bson.Raw) error     { panic("should never marshal db.Q objects to bson") }
+func (q Q) GetBSON() (any, error)        { panic("should never marshal db.Q objects to bson") }
+func (q Q) UnmarshalBSON(_ []byte) error { panic("should never marshal db.Q objects to bson") }
+func (q Q) MarshalBSON() ([]byte, error) { panic("should never marshal db.Q objects to bson") }

--- a/graphql/custom_scalars.go
+++ b/graphql/custom_scalars.go
@@ -23,9 +23,9 @@ func MarshalStringMap(val map[string]string) graphql.Marshaler {
 }
 
 // UnmarshalStringMap handles unmarshaling StringMap
-func UnmarshalStringMap(v interface{}) (map[string]string, error) {
+func UnmarshalStringMap(v any) (map[string]string, error) {
 	stringMap := make(map[string]string)
-	stringInterface, ok := v.(map[string]interface{})
+	stringInterface, ok := v.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a StringMap", v)
 	}

--- a/graphql/directive_project_test.go
+++ b/graphql/directive_project_test.go
@@ -47,28 +47,28 @@ func TestRequireProjectAccess(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
 	}
 
 	// error if input is invalid
-	obj := interface{}(nil)
+	obj := any(nil)
 	res, err := config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.EqualError(t, err, "input: converting args into map")
 	require.Nil(t, res)
 	require.Equal(t, 0, callCount)
 
 	// error if no valid parameters
-	obj = interface{}(map[string]interface{}(nil))
+	obj = any(map[string]any(nil))
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.EqualError(t, err, "input: params map is empty")
 	require.Nil(t, res)
 	require.Equal(t, 0, callCount)
 
 	// error if invalid permission and access combination
-	obj = interface{}(map[string]interface{}(nil))
+	obj = any(map[string]any(nil))
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionAnnotations, AccessLevelAdmin)
 	require.EqualError(t, err, "input: invalid permission and access level configuration: invalid access level for project_task_annotations")
 	require.Nil(t, res)
@@ -89,7 +89,7 @@ func TestRequireProjectAccessForSettings(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -109,13 +109,13 @@ func TestRequireProjectAccessForSettings(t *testing.T) {
 	err = repoRef.Upsert()
 	require.NoError(t, err)
 
-	obj := interface{}(map[string]interface{}{"projectIdentifier": "invalid_identifier"})
+	obj := any(map[string]any{"projectIdentifier": "invalid_identifier"})
 	res, err := config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.EqualError(t, err, "input: project 'invalid_identifier' not found")
 	require.Nil(t, res)
 	require.Equal(t, 0, callCount)
 
-	obj = interface{}(map[string]interface{}{"projectIdentifier": projectRef.Identifier})
+	obj = any(map[string]any{"projectIdentifier": projectRef.Identifier})
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.EqualError(t, err, "input: user 'test_user' does not have permission to 'edit project settings' for the project 'project_id'")
 	require.Nil(t, res)
@@ -142,20 +142,20 @@ func TestRequireProjectAccessForSettings(t *testing.T) {
 	require.Nil(t, res)
 	require.Equal(t, 2, callCount)
 
-	obj = interface{}(map[string]interface{}{"projectIdentifier": projectRef.Identifier})
+	obj = any(map[string]any{"projectIdentifier": projectRef.Identifier})
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.NoError(t, err)
 	require.Nil(t, res)
 	require.Equal(t, 3, callCount)
 
 	// Verify that user with only branch permission can view the repo page but not edit.
-	obj = interface{}(map[string]interface{}{"repoId": repoRef.ProjectRef.Id})
+	obj = any(map[string]any{"repoId": repoRef.ProjectRef.Id})
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelEdit)
 	require.EqualError(t, err, "input: user 'test_user' does not have permission to 'edit project settings' for the project 'repo_id'")
 	require.Nil(t, res)
 	require.Equal(t, 3, callCount)
 
-	obj = interface{}(map[string]interface{}{"repoId": repoRef.ProjectRef.Id})
+	obj = any(map[string]any{"repoId": repoRef.ProjectRef.Id})
 	res, err = config.Directives.RequireProjectAccess(ctx, obj, next, ProjectPermissionSettings, AccessLevelView)
 	require.NoError(t, err)
 	require.Nil(t, res)
@@ -191,7 +191,7 @@ func TestRequireProjectAccessForTasks(t *testing.T) {
 	const refreshToken = "refresh_token"
 	config := New("/graphql")
 	require.NotNil(t, config)
-	obj := interface{}(map[string]interface{}{"taskId": task.Id})
+	obj := any(map[string]any{"taskId": task.Id})
 
 	usr, err := user.GetOrCreateUser(testUser, "User Name", email, accessToken, refreshToken, []string{})
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestRequireProjectAccessForTasks(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -321,7 +321,7 @@ func TestRequireProjectAccessForAnnotations(t *testing.T) {
 	const refreshToken = "refresh_token"
 	config := New("/graphql")
 	require.NotNil(t, config)
-	obj := interface{}(map[string]interface{}{"taskId": task.Id})
+	obj := any(map[string]any{"taskId": task.Id})
 
 	usr, err := user.GetOrCreateUser(testUser, "User Name", email, accessToken, refreshToken, []string{})
 	require.NoError(t, err)
@@ -332,7 +332,7 @@ func TestRequireProjectAccessForAnnotations(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -415,7 +415,7 @@ func TestRequireProjectAccessForPatches(t *testing.T) {
 	const refreshToken = "refresh_token"
 	config := New("/graphql")
 	require.NotNil(t, config)
-	obj := interface{}(map[string]interface{}{"patchId": patch.Id.Hex()})
+	obj := any(map[string]any{"patchId": patch.Id.Hex()})
 
 	usr, err := user.GetOrCreateUser(testUser, "User Name", email, accessToken, refreshToken, []string{})
 	require.NoError(t, err)
@@ -426,7 +426,7 @@ func TestRequireProjectAccessForPatches(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -503,7 +503,7 @@ func TestRequireProjectAccessForLogs(t *testing.T) {
 	const refreshToken = "refresh_token"
 	config := New("/graphql")
 	require.NotNil(t, config)
-	obj := interface{}(map[string]interface{}{"projectId": project.Id})
+	obj := any(map[string]any{"projectId": project.Id})
 
 	usr, err := user.GetOrCreateUser(testUser, "User Name", email, accessToken, refreshToken, []string{})
 	require.NoError(t, err)
@@ -514,7 +514,7 @@ func TestRequireProjectAccessForLogs(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil

--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -236,11 +236,11 @@ func TestRequireDistroAccess(t *testing.T) {
 	config := New("/graphql")
 	require.NotNil(t, config)
 	ctx := context.Background()
-	obj := interface{}(nil)
+	obj := any(nil)
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -273,7 +273,7 @@ func TestRequireDistroAccess(t *testing.T) {
 	// superuser_distro_access is successful for admin, edit, view
 	require.NoError(t, usr.AddRole(t.Context(), "superuser_distro_access"))
 
-	obj = interface{}(map[string]interface{}{"distroId": "distro-id"})
+	obj = any(map[string]any{"distroId": "distro-id"})
 	res, err = config.Directives.RequireDistroAccess(ctx, obj, next, DistroSettingsAccessAdmin)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
@@ -382,11 +382,11 @@ func TestRequireProjectAdmin(t *testing.T) {
 	config := New("/graphql")
 	require.NotNil(t, config)
 	ctx := context.Background()
-	obj := interface{}(nil)
+	obj := any(nil)
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -423,8 +423,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: CreateProjectMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{
-		"project": map[string]interface{}{
+	obj = map[string]any{
+		"project": map[string]any{
 			"identifier": "anything",
 		},
 	}
@@ -446,8 +446,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: CopyProjectMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{
-		"project": map[string]interface{}{
+	obj = map[string]any{
+		"project": map[string]any{
 			"projectIdToCopy": "anything",
 		},
 	}
@@ -457,8 +457,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 	assert.Equal(t, 2, callCount)
 
 	// CopyProject - successful
-	obj = map[string]interface{}{
-		"project": map[string]interface{}{
+	obj = map[string]any{
+		"project": map[string]any{
 			"projectIdToCopy": "project_id",
 		},
 	}
@@ -472,14 +472,14 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: DeleteProjectMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{"projectId": "anything"}
+	obj = map[string]any{"projectId": "anything"}
 	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
 	assert.EqualError(t, err, "input: user test_user does not have permission to access the DeleteProject resolver")
 	assert.Nil(t, res)
 	assert.Equal(t, 3, callCount)
 
 	// DeleteProject - successful
-	obj = map[string]interface{}{"projectId": "project_id"}
+	obj = map[string]any{"projectId": "project_id"}
 	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
@@ -490,8 +490,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: SetLastRevisionMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{
-		"opts": map[string]interface{}{
+	obj = map[string]any{
+		"opts": map[string]any{
 			"projectIdentifier": "project_identifier",
 		},
 	}
@@ -505,8 +505,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: SetLastRevisionMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{
-		"opts": map[string]interface{}{
+	obj = map[string]any{
+		"opts": map[string]any{
 			"projectIdentifier": "project_whatever",
 		},
 	}
@@ -520,8 +520,8 @@ func TestRequireProjectAdmin(t *testing.T) {
 		OperationName: SetLastRevisionMutation,
 	}
 	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]interface{}{
-		"opts": map[string]interface{}{
+	obj = map[string]any{
+		"opts": map[string]any{
 			"projectIdentifier": "project_identifier",
 		},
 	}
@@ -565,7 +565,7 @@ func TestRequireProjectSettingsAccess(t *testing.T) {
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
-	next := func(rctx context.Context) (interface{}, error) {
+	next := func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
 		callCount++
 		return nil, nil
@@ -594,7 +594,7 @@ func TestRequireProjectSettingsAccess(t *testing.T) {
 	}
 	ctx = graphql.WithFieldContext(ctx, fieldCtx)
 
-	res, err := config.Directives.RequireProjectSettingsAccess(ctx, interface{}(nil), next)
+	res, err := config.Directives.RequireProjectSettingsAccess(ctx, any(nil), next)
 	assert.EqualError(t, err, "input: project not valid")
 	assert.Nil(t, res)
 	assert.Equal(t, 0, callCount)

--- a/graphql/distro_resolver.go
+++ b/graphql/distro_resolver.go
@@ -111,7 +111,7 @@ func (r *distroResolver) Provider(ctx context.Context, obj *model.APIDistro) (Pr
 
 // ProviderSettingsList is the resolver for the providerSettingsList field.
 func (r *distroResolver) ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]any, error) {
-	settings := []map[string]interface{}{}
+	settings := []map[string]any{}
 	for _, entry := range obj.ProviderSettingsList {
 		settings = append(settings, entry.ExportMap())
 	}

--- a/graphql/errors.go
+++ b/graphql/errors.go
@@ -51,7 +51,7 @@ func (err GqlError) Send(ctx context.Context, message string) *gqlerror.Error {
 func formError(_ context.Context, msg string, code GqlError) *gqlerror.Error {
 	return &gqlerror.Error{
 		Message: msg,
-		Extensions: map[string]interface{}{
+		Extensions: map[string]any{
 			"code": code,
 		},
 	}

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -28,7 +28,7 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 			return fieldCtx.IsMethod
 		}),
 		otelgqlgen.WithRequestVariablesAttributesBuilder(
-			otelgqlgen.RequestVariablesBuilderFunc(func(requestVariables map[string]interface{}) []attribute.KeyValue {
+			otelgqlgen.RequestVariablesBuilderFunc(func(requestVariables map[string]any) []attribute.KeyValue {
 				redactedRequestVariables := RedactFieldsInMap(requestVariables, redactedFields)
 				flattenedVariables := flattenOtelVariables(redactedRequestVariables)
 
@@ -44,7 +44,7 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv.Use(DisableQuery{})
 
 	// Handler to log graphql panics to splunk
-	srv.SetRecoverFunc(func(ctx context.Context, err interface{}) error {
+	srv.SetRecoverFunc(func(ctx context.Context, err any) error {
 		queryPath := graphql.GetFieldContext(ctx).Path()
 
 		grip.Critical(message.Fields{
@@ -61,7 +61,7 @@ func Handler(apiURL string) func(w http.ResponseWriter, r *http.Request) {
 	srv.SetErrorPresenter(func(ctx context.Context, err error) *gqlerror.Error {
 		fieldCtx := graphql.GetFieldContext(ctx)
 		queryPath := ""
-		args := map[string]interface{}{}
+		args := map[string]any{}
 		if fieldCtx != nil {
 			queryPath = fieldCtx.Path().String()
 			args = fieldCtx.Args

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -513,7 +513,7 @@ func setupDBData(ctx context.Context, env evergreen.Environment, data map[string
 		// The docs to insert as part of setup need to be deserialized
 		// as extended JSON, whereas the rest of the test spec is
 		// normal JSON.
-		var docs []interface{}
+		var docs []any
 		catcher.Add(bson.UnmarshalExtJSON(d, false, &docs))
 		_, err := env.DB().Collection(coll).InsertMany(ctx, docs)
 		catcher.Add(err)

--- a/graphql/redact_secrets_plugin.go
+++ b/graphql/redact_secrets_plugin.go
@@ -74,21 +74,21 @@ func isFieldRedacted(fieldName string, fieldsToRedact map[string]bool) bool {
 
 // RedactFieldsInMap recursively searches for and redacts fields in a map.
 // Assumes map structure like map[string]interface{} where interface{} can be another map, a slice, or a basic datatype.
-func RedactFieldsInMap(data map[string]interface{}, fieldsToRedact map[string]bool) map[string]interface{} {
-	dataCopy := map[string]interface{}{}
+func RedactFieldsInMap(data map[string]any, fieldsToRedact map[string]bool) map[string]any {
+	dataCopy := map[string]any{}
 	if err := util.DeepCopy(data, &dataCopy); err != nil {
 		// If theres an error copying the data, log it and return an empty map.
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "failed to deep copy request variables",
 		}))
-		return map[string]interface{}{}
+		return map[string]any{}
 	}
 	recursivelyRedactFieldsInMap(dataCopy, fieldsToRedact)
 
 	return dataCopy
 }
 
-func recursivelyRedactFieldsInMap(data map[string]interface{}, fieldsToRedact map[string]bool) {
+func recursivelyRedactFieldsInMap(data map[string]any, fieldsToRedact map[string]bool) {
 	for key, value := range data {
 		// If the current key matches a field that should be redacted, redact it.
 		if isFieldRedacted(key, fieldsToRedact) {
@@ -102,7 +102,7 @@ func recursivelyRedactFieldsInMap(data map[string]interface{}, fieldsToRedact ma
 		}
 		// If the value is a map, recursively redact fields within it.
 		if reflect.TypeOf(value).Kind() == reflect.Map {
-			if subMap, ok := value.(map[string]interface{}); ok {
+			if subMap, ok := value.(map[string]any); ok {
 				recursivelyRedactFieldsInMap(subMap, fieldsToRedact)
 			}
 		}
@@ -113,7 +113,7 @@ func recursivelyRedactFieldsInMap(data map[string]interface{}, fieldsToRedact ma
 			for i := 0; i < sliceVal.Len(); i++ {
 				elem := sliceVal.Index(i).Interface()
 				if reflect.TypeOf(elem).Kind() == reflect.Map {
-					if elemMap, ok := elem.(map[string]interface{}); ok {
+					if elemMap, ok := elem.(map[string]any); ok {
 						recursivelyRedactFieldsInMap(elemMap, fieldsToRedact)
 					}
 				}

--- a/graphql/redact_secrets_plugin_test.go
+++ b/graphql/redact_secrets_plugin_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRedactFieldsInMap(t *testing.T) {
 	t.Run("NoRedactedFields", func(t *testing.T) {
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"publicKey":       "public",
 			"secret":          "secret",
 			"servicePassword": "servicePassword",
@@ -20,7 +20,7 @@ func TestRedactFieldsInMap(t *testing.T) {
 		}
 	})
 	t.Run("RedactedFields", func(t *testing.T) {
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"publicKey":       "somePublicKey",
 			"secret":          "someSecret",
 			"servicePassword": "someServicePassword",
@@ -37,9 +37,9 @@ func TestRedactFieldsInMap(t *testing.T) {
 		require.Equal(t, "someOtherField", redactedFields["someOtherField"], "Expected someOtherField to be unchanged")
 	})
 	t.Run("RedactedFieldsInNestedMap", func(t *testing.T) {
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"publicKey": "somePublicKey",
-			"someInnerStruct": map[string]interface{}{
+			"someInnerStruct": map[string]any{
 				"secret":  "someSecret",
 				"service": "someService",
 			},
@@ -48,19 +48,19 @@ func TestRedactFieldsInMap(t *testing.T) {
 			"secret": true,
 		})
 		require.Equal(t, "somePublicKey", redactedFields["publicKey"], "Expected publicKey to be unchanged")
-		innerStruct := redactedFields["someInnerStruct"].(map[string]interface{})
+		innerStruct := redactedFields["someInnerStruct"].(map[string]any)
 		require.NotNil(t, innerStruct, "Expected someInnerStruct to be not nil")
 		require.Equal(t, "REDACTED", innerStruct["secret"], "Expected secret to be redacted")
 		require.Equal(t, "someService", innerStruct["service"], "Expected service to be unchanged")
 	})
 	t.Run("RedactsValuesInASlice", func(t *testing.T) {
-		fields := map[string]interface{}{
+		fields := map[string]any{
 			"publicKey": "somePublicKey",
-			"someSlice": []interface{}{
-				map[string]interface{}{
+			"someSlice": []any{
+				map[string]any{
 					"secret": "someSecret",
 				},
-				map[string]interface{}{
+				map[string]any{
 					"service": "someService",
 				},
 			},
@@ -69,11 +69,11 @@ func TestRedactFieldsInMap(t *testing.T) {
 			"secret": true,
 		})
 		require.Equal(t, "somePublicKey", redactedFields["publicKey"], "Expected publicKey to be unchanged")
-		someSlice := redactedFields["someSlice"].([]interface{})
+		someSlice := redactedFields["someSlice"].([]any)
 		require.NotNil(t, someSlice, "Expected someSlice to be not nil")
-		value1 := someSlice[0].(map[string]interface{})
+		value1 := someSlice[0].(map[string]any)
 		require.Equal(t, "REDACTED", value1["secret"], "Expected secret to be redacted")
-		value2 := someSlice[1].(map[string]interface{})
+		value2 := someSlice[1].(map[string]any)
 		require.Equal(t, "someService", value2["service"], "Expected service to be unchanged")
 	})
 }

--- a/graphql/redacted_fields_gen.go
+++ b/graphql/redacted_fields_gen.go
@@ -2,9 +2,9 @@
 package graphql
 
 var redactedFields = map[string]bool{
-	"githubAppAuth": true,
-	"publicKey": true,
-	"secret": true,
+	"githubAppAuth":   true,
+	"publicKey":       true,
+	"secret":          true,
 	"servicePassword": true,
-	"vars": true,
+	"vars":            true,
 }

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -35,7 +35,7 @@ func New(apiURL string) Config {
 			sc: dbConnector,
 		},
 	}
-	c.Directives.RequireDistroAccess = func(ctx context.Context, obj interface{}, next graphql.Resolver, access DistroSettingsAccess) (interface{}, error) {
+	c.Directives.RequireDistroAccess = func(ctx context.Context, obj any, next graphql.Resolver, access DistroSettingsAccess) (any, error) {
 		user := mustHaveUser(ctx)
 
 		// If directive is checking for create permissions, no distro ID is required.
@@ -46,7 +46,7 @@ func New(apiURL string) Config {
 			return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have create distro permissions", user.Username()))
 		}
 
-		args, isStringMap := obj.(map[string]interface{})
+		args, isStringMap := obj.(map[string]any)
 		if !isStringMap {
 			return nil, ResourceNotFound.Send(ctx, "distro not specified")
 		}
@@ -76,7 +76,7 @@ func New(apiURL string) Config {
 		}
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have permission to access settings for the distro '%s'", user.Username(), distroId))
 	}
-	c.Directives.RequireProjectAdmin = func(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
+	c.Directives.RequireProjectAdmin = func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
 		// Allow if user is superuser.
 		user := mustHaveUser(ctx)
 		opts := gimlet.PermissionOpts{
@@ -110,13 +110,13 @@ func New(apiURL string) Config {
 			}
 		}
 
-		args, isStringMap := obj.(map[string]interface{})
+		args, isStringMap := obj.(map[string]any)
 		if !isStringMap {
 			return nil, ResourceNotFound.Send(ctx, "Project not specified")
 		}
 
 		if operationContext == CopyProjectMutation {
-			projectIdToCopy, ok := args["project"].(map[string]interface{})["projectIdToCopy"].(string)
+			projectIdToCopy, ok := args["project"].(map[string]any)["projectIdToCopy"].(string)
 			if !ok {
 				return nil, InternalServerError.Send(ctx, "finding projectIdToCopy for copy project operation")
 			}
@@ -138,7 +138,7 @@ func New(apiURL string) Config {
 		}
 
 		if operationContext == SetLastRevisionMutation {
-			projectIdentifier, ok := args["opts"].(map[string]interface{})["projectIdentifier"].(string)
+			projectIdentifier, ok := args["opts"].(map[string]any)["projectIdentifier"].(string)
 			if !ok {
 				return nil, InternalServerError.Send(ctx, "finding projectIdentifier for set last revision operation")
 			}
@@ -157,10 +157,10 @@ func New(apiURL string) Config {
 
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user %s does not have permission to access the %s resolver", user.Username(), operationContext))
 	}
-	c.Directives.RequireProjectAccess = func(ctx context.Context, obj interface{}, next graphql.Resolver, permission ProjectPermission, access AccessLevel) (interface{}, error) {
+	c.Directives.RequireProjectAccess = func(ctx context.Context, obj any, next graphql.Resolver, permission ProjectPermission, access AccessLevel) (any, error) {
 		usr := mustHaveUser(ctx)
 
-		args, isMap := obj.(map[string]interface{})
+		args, isMap := obj.(map[string]any)
 		if !isMap {
 			return nil, InternalServerError.Send(ctx, "converting args into map")
 		}
@@ -203,7 +203,7 @@ func New(apiURL string) Config {
 
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have permission to '%s' for the project '%s'", usr.Username(), strings.ToLower(permissionInfo.Description), projectId))
 	}
-	c.Directives.RequireProjectSettingsAccess = func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+	c.Directives.RequireProjectSettingsAccess = func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 		usr := mustHaveUser(ctx)
 
 		projectSettings, isProjectSettings := obj.(*restModel.APIProjectSettings)
@@ -238,7 +238,7 @@ func New(apiURL string) Config {
 
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user does not have permission to access the field '%s' for project with ID '%s'", graphql.GetFieldContext(ctx).Path(), projectId))
 	}
-	c.Directives.RedactSecrets = func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error) {
+	c.Directives.RedactSecrets = func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error) {
 		return next(ctx)
 	}
 	return c

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1120,12 +1120,12 @@ func makeDistroEvent(ctx context.Context, entry event.EventLogEntry) (*DistroEve
 	}, nil
 }
 
-func interfaceToMap(ctx context.Context, data interface{}) (map[string]interface{}, error) {
+func interfaceToMap(ctx context.Context, data any) (map[string]any, error) {
 	if data == nil {
 		return nil, nil
 	}
 
-	mapField := map[string]interface{}{}
+	mapField := map[string]any{}
 	marshalledData, err := bson.Marshal(data)
 	if err != nil {
 		return nil, errors.Wrapf(err, "marshalling data")
@@ -1345,10 +1345,10 @@ func groupInactiveVersions(versions []model.Version) []*WaterfallVersion {
 }
 
 // flattenOtelVariables "flattens" one level of a string map. Any maps that are found as a value within the map are moved to the top level of the map, with "topkey.nestedkey" as their new key, in line with Honeycomb best practices.
-func flattenOtelVariables(vars map[string]interface{}) map[string]interface{} {
-	flattenedVars := map[string]interface{}{}
+func flattenOtelVariables(vars map[string]any) map[string]any {
+	flattenedVars := map[string]any{}
 	for k, v := range vars {
-		if valueMap, isMap := v.(map[string]interface{}); isMap {
+		if valueMap, isMap := v.(map[string]any); isMap {
 			for nestedKey, nestedValue := range valueMap {
 				flattenedVars[k+"."+nestedKey] = nestedValue
 			}

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -551,14 +551,14 @@ func TestGroupInactiveVersions(t *testing.T) {
 }
 
 func TestFlattenOtelVariables(t *testing.T) {
-	nestedVars := map[string]interface{}{
+	nestedVars := map[string]any{
 		"k1": "v1",
-		"k2": map[string]interface{}{
+		"k2": map[string]any{
 			"nested_k3": "v3",
 			"nested_k4": "v4",
 		},
 		"k5": "v5",
-		"k6": map[string]interface{}{
+		"k6": map[string]any{
 			"nested_k7": "v7",
 		},
 	}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -212,7 +212,7 @@ func (r *versionResolver) Manifest(ctx context.Context, obj *restModel.APIVersio
 		IsBase:          m.IsBase,
 		ModuleOverrides: m.ModuleOverrides,
 	}
-	modules := map[string]interface{}{}
+	modules := map[string]any{}
 	for key, module := range m.Modules {
 		modules[key] = module
 	}

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -311,10 +311,10 @@ func (b *Build) Insert() error {
 
 type Builds []*Build
 
-func (b Builds) getPayload() []interface{} {
-	payload := make([]interface{}, len(b))
+func (b Builds) getPayload() []any {
+	payload := make([]any, len(b))
 	for idx := range b {
-		payload[idx] = interface{}(b[idx])
+		payload[idx] = any(b[idx])
 	}
 
 	return payload

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -209,7 +209,7 @@ func Find(query db.Q) ([]Build, error) {
 }
 
 // UpdateOne updates one build.
-func UpdateOne(ctx context.Context, query interface{}, update interface{}) error {
+func UpdateOne(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		Collection,
@@ -218,7 +218,7 @@ func UpdateOne(ctx context.Context, query interface{}, update interface{}) error
 	)
 }
 
-func UpdateAllBuilds(query interface{}, update interface{}) error {
+func UpdateAllBuilds(query any, update any) error {
 	_, err := db.UpdateAll(
 		Collection,
 		query,

--- a/model/dependency_test.go
+++ b/model/dependency_test.go
@@ -22,7 +22,7 @@ type depTask struct {
 func TestDependencyBSON(t *testing.T) {
 	Convey("With BSON bytes", t, func() {
 		Convey("representing legacy dependency format (i.e. just strings)", func() {
-			bytes, err := mgobson.Marshal(map[string]interface{}{
+			bytes, err := mgobson.Marshal(map[string]any{
 				"depends_on": []string{"t1", "t2", "t3"},
 			})
 			require.NoError(t, err, "failed to marshal test BSON")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -66,14 +66,14 @@ type Distro struct {
 // DistroData is the same as a distro, with the only difference being that all
 // the provider settings are stored as maps instead of Birch BSON documents.
 type DistroData struct {
-	Distro              Distro                   `bson:",inline"`
-	ProviderSettingsMap []map[string]interface{} `bson:"provider_settings_list" json:"provider_settings_list"`
+	Distro              Distro           `bson:",inline"`
+	ProviderSettingsMap []map[string]any `bson:"provider_settings_list" json:"provider_settings_list"`
 }
 
 // DistroData creates distro data from this distro. The provider settings are
 // converted into maps instead of Birch BSON documents.
 func (d *Distro) DistroData() DistroData {
-	res := DistroData{ProviderSettingsMap: []map[string]interface{}{}}
+	res := DistroData{ProviderSettingsMap: []map[string]any{}}
 	res.Distro = *d
 	for _, each := range d.ProviderSettingsList {
 		res.ProviderSettingsMap = append(res.ProviderSettingsMap, each.ExportMap())
@@ -527,7 +527,7 @@ func (d *Distro) GetPoolSize() int {
 	switch d.Provider {
 	case evergreen.ProviderNameStatic:
 		if len(d.ProviderSettingsList) > 0 {
-			hosts, ok := d.ProviderSettingsList[0].Lookup("hosts").Interface().([]interface{})
+			hosts, ok := d.ProviderSettingsList[0].Lookup("hosts").Interface().([]any)
 			if !ok {
 				return 0
 			}

--- a/model/event/admin_event.go
+++ b/model/event/admin_event.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeAdmin, func() interface{} { return &rawAdminEventData{} })
+	registry.AddType(ResourceTypeAdmin, func() any { return &rawAdminEventData{} })
 	registry.setUnexpirable(ResourceTypeAdmin, EventTypeValueChanged)
 }
 

--- a/model/event/auth_event.go
+++ b/model/event/auth_event.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeUser, func() interface{} { return &userData{} })
+	registry.AddType(ResourceTypeUser, func() any { return &userData{} })
 }
 
 const (
@@ -34,13 +34,13 @@ func (e UserEventType) validate() error {
 }
 
 type userData struct {
-	User   string      `bson:"user" json:"user"`
-	Before interface{} `bson:"before" json:"before"`
-	After  interface{} `bson:"after" json:"after"`
+	User   string `bson:"user" json:"user"`
+	Before any    `bson:"before" json:"before"`
+	After  any    `bson:"after" json:"after"`
 }
 
 // LogUserEvent logs a DB User change to the event log collection.
-func LogUserEvent(user string, eventType UserEventType, before, after interface{}) error {
+func LogUserEvent(user string, eventType UserEventType, before, after any) error {
 	if err := eventType.validate(); err != nil {
 		return errors.Wrapf(err, "invalid user event for user '%s'", user)
 	}

--- a/model/event/build_event.go
+++ b/model/event/build_event.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeBuild, func() interface{} { return &BuildEventData{} })
+	registry.AddType(ResourceTypeBuild, func() any { return &BuildEventData{} })
 
 	registry.AllowSubscription(ResourceTypeBuild, BuildStateChange)
 	registry.AllowSubscription(ResourceTypeBuild, BuildGithubCheckFinished)

--- a/model/event/distro_event.go
+++ b/model/event/distro_event.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeDistro, func() interface{} { return &DistroEventData{} })
+	registry.AddType(ResourceTypeDistro, func() any { return &DistroEventData{} })
 	registry.setUnexpirable(ResourceTypeDistro, EventDistroAdded)
 	registry.setUnexpirable(ResourceTypeDistro, EventDistroModified)
 	registry.setUnexpirable(ResourceTypeDistro, EventDistroAMIModfied)
@@ -29,14 +29,14 @@ const (
 
 // DistroEventData implements EventData.
 type DistroEventData struct {
-	DistroId string      `bson:"d_id,omitempty" json:"d_id,omitempty"`
-	User     string      `bson:"user,omitempty" json:"user,omitempty"`
-	Before   interface{} `bson:"before" json:"before"`
-	After    interface{} `bson:"after" json:"after"`
+	DistroId string `bson:"d_id,omitempty" json:"d_id,omitempty"`
+	User     string `bson:"user,omitempty" json:"user,omitempty"`
+	Before   any    `bson:"before" json:"before"`
+	After    any    `bson:"after" json:"after"`
 
 	// Fields used by legacy UI
-	Data   interface{} `bson:"dstr,omitempty" json:"dstr,omitempty"`
-	UserId string      `bson:"u_id,omitempty" json:"u_id,omitempty"`
+	Data   any    `bson:"dstr,omitempty" json:"dstr,omitempty"`
+	UserId string `bson:"u_id,omitempty" json:"u_id,omitempty"`
 }
 
 func LogDistroEvent(distroId string, eventType string, eventData DistroEventData) {
@@ -58,12 +58,12 @@ func LogDistroEvent(distroId string, eventType string, eventData DistroEventData
 }
 
 // LogDistroAdded should take in DistroData in order to preserve the ProviderSettingsList
-func LogDistroAdded(distroId, userId string, data interface{}) {
+func LogDistroAdded(distroId, userId string, data any) {
 	LogDistroEvent(distroId, EventDistroAdded, DistroEventData{UserId: userId, Data: data})
 }
 
 // LogDistroModified should take in DistroData in order to preserve the ProviderSettingsList
-func LogDistroModified(distroId, userId string, before, after interface{}) {
+func LogDistroModified(distroId, userId string, before, after any) {
 	// Stop if there are no changes
 	if reflect.DeepEqual(before, after) {
 		grip.Info(message.Fields{
@@ -85,7 +85,7 @@ func LogDistroModified(distroId, userId string, before, after interface{}) {
 }
 
 // LogDistroRemoved should take in DistroData in order to preserve the ProviderSettingsList
-func LogDistroRemoved(distroId, userId string, data interface{}) {
+func LogDistroRemoved(distroId, userId string, data any) {
 	LogDistroEvent(distroId, EventDistroRemoved, DistroEventData{UserId: userId, Data: data})
 }
 

--- a/model/event/event.go
+++ b/model/event/event.go
@@ -18,11 +18,11 @@ type EventLogEntry struct {
 	ResourceType string    `bson:"r_type,omitempty" json:"resource_type,omitempty"`
 	ProcessedAt  time.Time `bson:"processed_at" json:"processed_at"`
 
-	Timestamp  time.Time   `bson:"ts" json:"timestamp"`
-	Expirable  bool        `bson:"expirable,omitempty" json:"expirable,omitempty"`
-	ResourceId string      `bson:"r_id" json:"resource_id"`
-	EventType  string      `bson:"e_type" json:"event_type"`
-	Data       interface{} `bson:"data" json:"data"`
+	Timestamp  time.Time `bson:"ts" json:"timestamp"`
+	Expirable  bool      `bson:"expirable,omitempty" json:"expirable,omitempty"`
+	ResourceId string    `bson:"r_id" json:"resource_id"`
+	EventType  string    `bson:"e_type" json:"event_type"`
+	Data       any       `bson:"data" json:"data"`
 }
 
 // Processed is whether or not this event has been processed. An event
@@ -36,9 +36,9 @@ func (e *EventLogEntry) Processed() (bool, time.Time) {
 }
 
 type UnmarshalEventLogEntry struct {
-	ID           interface{} `bson:"_id" json:"-"`
-	ResourceType string      `bson:"r_type,omitempty" json:"resource_type,omitempty"`
-	ProcessedAt  time.Time   `bson:"processed_at" json:"processed_at"`
+	ID           any       `bson:"_id" json:"-"`
+	ResourceType string    `bson:"r_type,omitempty" json:"resource_type,omitempty"`
+	ProcessedAt  time.Time `bson:"processed_at" json:"processed_at"`
 
 	Timestamp  time.Time   `bson:"ts" json:"timestamp"`
 	Expirable  bool        `bson:"expirable,omitempty" json:"expirable,omitempty"`

--- a/model/event/event_logger.go
+++ b/model/event/event_logger.go
@@ -48,7 +48,7 @@ func (e *EventLogEntry) MarkProcessed(ctx context.Context) error {
 
 func LogManyEvents(events []EventLogEntry) error {
 	catcher := grip.NewBasicCatcher()
-	interfaces := make([]interface{}, len(events))
+	interfaces := make([]any, len(events))
 	for i := range events {
 		e := &events[i]
 		if err := e.validateEvent(); err != nil {
@@ -68,7 +68,7 @@ func LogManyEvents(events []EventLogEntry) error {
 // insertion. Do not use this if the events must be inserted in order.
 func LogManyUnorderedEventsWithContext(ctx context.Context, events []EventLogEntry) error {
 	catcher := grip.NewBasicCatcher()
-	interfaces := make([]interface{}, len(events))
+	interfaces := make([]any, len(events))
 	for i := range events {
 		e := &events[i]
 		if err := e.validateEvent(); err != nil {

--- a/model/event/event_registry.go
+++ b/model/event/event_registry.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-type eventDataFactory func() interface{}
+type eventDataFactory func() any
 
 type eventRegistry struct {
 	lock sync.RWMutex
@@ -99,7 +99,7 @@ func (r *eventRegistry) isExpirable(resourceType, eventType string) bool {
 	return !r.unexpirable[e]
 }
 
-func (r *eventRegistry) newEventFromType(resourceType string) interface{} {
+func (r *eventRegistry) newEventFromType(resourceType string) any {
 	registry.lock.RLock()
 	defer registry.lock.RUnlock()
 

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -445,7 +445,7 @@ func (s *eventSuite) TestCountUnprocessedEvents() {
 // If not, this function returns false. If it the struct had "r_type" (without
 // omitempty), it will return that field's value, otherwise it returns an
 // empty string
-func findResourceTypeIn(data interface{}) (bool, string) {
+func findResourceTypeIn(data any) (bool, string) {
 	const resourceTypeKeyWithOmitEmpty = resourceTypeKey + ",omitempty"
 
 	if data == nil {

--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeHost, func() interface{} { return &HostEventData{} })
+	registry.AddType(ResourceTypeHost, func() any { return &HostEventData{} })
 	registry.AllowSubscription(ResourceTypeHost, EventHostExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventHostTemporaryExemptionExpirationWarningSent)
 	registry.AllowSubscription(ResourceTypeHost, EventVolumeExpirationWarningSent)

--- a/model/event/patch_event.go
+++ b/model/event/patch_event.go
@@ -13,7 +13,7 @@ func init() {
 	registry.AllowSubscription(ResourceTypePatch, PatchChildrenCompletion)
 }
 
-func patchEventDataFactory() interface{} {
+func patchEventDataFactory() any {
 	return &PatchEventData{}
 }
 

--- a/model/event/pod.go
+++ b/model/event/pod.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypePod, func() interface{} { return &PodData{} })
+	registry.AddType(ResourceTypePod, func() any { return &PodData{} })
 }
 
 // PodEventType represents a type of event related to a pod.

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -41,7 +41,7 @@ var SubscriberTypes = []string{
 type Subscriber struct {
 	Type string `bson:"type"`
 	// sad violin
-	Target interface{} `bson:"target"`
+	Target any `bson:"target"`
 }
 
 type unmarshalSubscriber struct {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -174,7 +174,7 @@ type Attributes struct {
 }
 
 func (a *Attributes) filterQuery() bson.M {
-	filterForAttribute := func(values []string) interface{} {
+	filterForAttribute := func(values []string) any {
 		if len(values) > 0 {
 			in := bson.A{nil}
 			for _, attribute := range values {

--- a/model/event/task_event.go
+++ b/model/event/task_event.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registry.AddType(ResourceTypeTask, func() interface{} { return &TaskEventData{} })
+	registry.AddType(ResourceTypeTask, func() any { return &TaskEventData{} })
 	registry.AllowSubscription(ResourceTypeTask, TaskStarted)
 	registry.AllowSubscription(ResourceTypeTask, TaskFinished)
 	registry.AllowSubscription(ResourceTypeTask, TaskBlocked)

--- a/model/event/version_event.go
+++ b/model/event/version_event.go
@@ -14,7 +14,7 @@ func init() {
 	registry.AllowSubscription(ResourceTypeVersion, VersionChildrenCompletion)
 }
 
-func versionEventDataFactory() interface{} {
+func versionEventDataFactory() any {
 	return &VersionEventData{}
 }
 

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -213,7 +213,7 @@ func IdleEphemeralGroupedByDistroID(ctx context.Context, env evergreen.Environme
 			"$group": bson.M{
 				"_id":                             "$" + bsonutil.GetDottedKeyName(DistroKey, distro.IdKey),
 				HostsByDistroRunningHostsCountKey: bson.M{"$sum": 1},
-				HostsByDistroIdleHostsKey:         bson.M{"$push": bson.M{"$cond": []interface{}{bson.M{"$eq": []interface{}{"$running_task", bson.Undefined{}}}, "$$ROOT", bson.Undefined{}}}},
+				HostsByDistroIdleHostsKey:         bson.M{"$push": bson.M{"$cond": []any{bson.M{"$eq": []any{"$running_task", bson.Undefined{}}}, "$$ROOT", bson.Undefined{}}}},
 			},
 		},
 		{
@@ -981,7 +981,7 @@ func InsertMany(ctx context.Context, hosts []Host) error {
 		return nil
 	}
 
-	docs := make([]interface{}, len(hosts))
+	docs := make([]any, len(hosts))
 	for idx := range hosts {
 		docs[idx] = &hosts[idx]
 	}
@@ -1007,7 +1007,7 @@ func DeleteMany(ctx context.Context, filter bson.M, options ...options.Lister[op
 }
 
 func GetHostsByFromIDWithStatus(ctx context.Context, id, status, user string, limit int) ([]Host, error) {
-	var statusMatch interface{}
+	var statusMatch any
 	if status != "" {
 		statusMatch = status
 	} else {
@@ -1042,7 +1042,7 @@ type HostsInRangeParams struct {
 
 // FindHostsInRange is a method to find a filtered list of hosts
 func FindHostsInRange(ctx context.Context, params HostsInRangeParams) ([]Host, error) {
-	var statusMatch interface{}
+	var statusMatch any
 	if params.Status != "" {
 		statusMatch = params.Status
 	} else {
@@ -1149,9 +1149,9 @@ func lastContainerFinishTimePipeline() []bson.M {
 				output: bson.M{
 					// computes last container finish time for each host
 					"$max": bson.M{
-						"$add": []interface{}{bsonutil.GetDottedKeyName("$task", "start_time"),
+						"$add": []any{bsonutil.GetDottedKeyName("$task", "start_time"),
 							// divide by 1000000 to treat duration as milliseconds rather than as nanoseconds
-							bson.M{"$divide": []interface{}{bsonutil.GetDottedKeyName("$task", "duration_prediction", "value"), 1000000}},
+							bson.M{"$divide": []any{bsonutil.GetDottedKeyName("$task", "duration_prediction", "value"), 1000000}},
 						},
 					},
 				},
@@ -1255,7 +1255,7 @@ func (h *Host) RemoveVolumeFromHost(ctx context.Context, volumeId string) error 
 }
 
 // FindOne gets one Volume for the given query.
-func FindOneVolume(ctx context.Context, query interface{}) (*Volume, error) {
+func FindOneVolume(ctx context.Context, query any) (*Volume, error) {
 	v := &Volume{}
 	err := db.FindOneQContext(ctx, VolumesCollection, db.Query(query), v)
 	if adb.ResultsNotFound(err) {
@@ -1427,7 +1427,7 @@ func UnsafeReplace(ctx context.Context, env evergreen.Environment, idToRemove st
 	}
 	defer sess.EndSession(ctx)
 
-	replaceHost := func(sessCtx context.Context) (interface{}, error) {
+	replaceHost := func(sessCtx context.Context) (any, error) {
 		if err := RemoveStrict(sessCtx, env, idToRemove); err != nil {
 			return nil, errors.Wrapf(err, "removing old host '%s'", idToRemove)
 		}
@@ -1569,7 +1569,7 @@ func isSleepScheduleEnabledQuery(q bson.M, now time.Time) bson.M {
 		},
 	}
 
-	andClauses := []interface{}{bson.M{"$or": notTemporarilyExempt}}
+	andClauses := []any{bson.M{"$or": notTemporarilyExempt}}
 	if andClause, ok := q["$and"]; ok {
 		// Combine $and/$or clauses in case $and is already defined.
 		andClauses = append(andClauses, andClause)

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3028,8 +3028,8 @@ func AggregateSpawnhostData(ctx context.Context) (*SpawnHostUsage, error) {
 		{"$group": bson.M{
 			"_id":         nil,
 			"hosts":       bson.M{"$sum": 1},
-			"stopped":     bson.M{"$sum": bson.M{"$cond": []interface{}{bson.M{"$eq": []string{"$" + StatusKey, evergreen.HostStopped}}, 1, 0}}},
-			"unexpirable": bson.M{"$sum": bson.M{"$cond": []interface{}{"$" + NoExpirationKey, 1, 0}}},
+			"stopped":     bson.M{"$sum": bson.M{"$cond": []any{bson.M{"$eq": []string{"$" + StatusKey, evergreen.HostStopped}}, 1, 0}}},
+			"unexpirable": bson.M{"$sum": bson.M{"$cond": []any{"$" + NoExpirationKey, 1, 0}}},
 			"users":       bson.M{"$addToSet": "$" + StartedByKey},
 		}},
 		{"$project": bson.M{

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -653,7 +653,7 @@ func ValidateRDPPassword(password string) bool {
 // assuming the CLI is on the same local machine as the Jasper service. To make
 // requests to a remote Jasper service using RPC, make the request through
 // JasperClient instead.
-func (h *Host) buildLocalJasperClientRequest(config evergreen.HostJasperConfig, subCmd string, input interface{}) (string, error) {
+func (h *Host) buildLocalJasperClientRequest(config evergreen.HostJasperConfig, subCmd string, input any) (string, error) {
 	inputBytes, err := json.Marshal(input)
 	if err != nil {
 		return "", errors.Wrap(err, "marshalling input as JSON")

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func insertTestDocuments() error {
-	input := []interface{}{
+	input := []any{
 		Host{
 			Id:     "one",
 			Status: evergreen.HostRunning,

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1040,7 +1040,7 @@ func getAllNodesInDepGraph(startTaskId, startKey, linkKey string) []bson.M {
 		{
 			"$addFields": bson.M{
 				"dep_graph": bson.M{
-					"$concatArrays": []interface{}{"$dep_graph", []string{"$$ROOT"}},
+					"$concatArrays": []any{"$dep_graph", []string{"$$ROOT"}},
 				},
 			},
 		},

--- a/model/log/merging_iterator.go
+++ b/model/log/merging_iterator.go
@@ -136,7 +136,7 @@ func (h logIteratorHeap) Swap(i, j int) { h.its[i], h.its[j] = h.its[j], h.its[i
 
 // Push appends a new object of type LogIterator to the heap. Note that if x is
 // not a LogIterator nothing happens.
-func (h *logIteratorHeap) Push(x interface{}) {
+func (h *logIteratorHeap) Push(x any) {
 	it, ok := x.(LogIterator)
 	if !ok {
 		return
@@ -147,7 +147,7 @@ func (h *logIteratorHeap) Push(x interface{}) {
 
 // Pop returns the next object (as an empty interface) from the heap. Note that
 // if the heap is empty this will panic.
-func (h *logIteratorHeap) Pop() interface{} {
+func (h *logIteratorHeap) Pop() any {
 	old := h.its
 	n := len(old)
 	x := old[n-1]

--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -88,7 +88,7 @@ func InsertMany(items ...Notification) error {
 		return nil
 	}
 
-	interfaces := make([]interface{}, len(items))
+	interfaces := make([]any, len(items))
 	for i := range items {
 		interfaces[i] = &items[i]
 	}

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -27,7 +27,7 @@ func makeNotificationID(eventID, trigger string, subscriber *event.Subscriber) s
 }
 
 // New returns a new Notification, with a correctly initialised ID
-func New(eventID, trigger string, subscriber *event.Subscriber, payload interface{}) (*Notification, error) {
+func New(eventID, trigger string, subscriber *event.Subscriber, payload any) (*Notification, error) {
 	if len(trigger) == 0 {
 		return nil, errors.New("cannot create notification from nil trigger")
 	}
@@ -48,7 +48,7 @@ func New(eventID, trigger string, subscriber *event.Subscriber, payload interfac
 type Notification struct {
 	ID         string           `bson:"_id"`
 	Subscriber event.Subscriber `bson:"subscriber"`
-	Payload    interface{}      `bson:"payload"`
+	Payload    any              `bson:"payload"`
 
 	SentAt   time.Time            `bson:"sent_at,omitempty"`
 	Error    string               `bson:"error,omitempty"`

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -278,7 +278,7 @@ func (s *notificationSuite) TestJIRAIssuePayload() {
 		Assignee:    "4",
 		Components:  []string{"6"},
 		Labels:      []string{"7"},
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"8":  "9",
 			"10": "11",
 		},

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -153,7 +153,7 @@ var requesterExpression = bson.M{
 			{
 				"case": bson.M{
 					"$and": []bson.M{
-						{"$ifNull": []interface{}{"$" + githubPatchDataKey, false}},
+						{"$ifNull": []any{"$" + githubPatchDataKey, false}},
 						{"$ne": []string{"$" + bsonutil.GetDottedKeyName(githubPatchDataKey, githubPatchHeadOwnerKey), ""}},
 					},
 				},
@@ -162,7 +162,7 @@ var requesterExpression = bson.M{
 			{
 				"case": bson.M{
 					"$and": []bson.M{
-						{"$ifNull": []interface{}{"$" + githubMergeDataKey, false}},
+						{"$ifNull": []any{"$" + githubMergeDataKey, false}},
 						{"$ne": []string{"$" + bsonutil.GetDottedKeyName(githubMergeDataKey, githubMergeGroupHeadSHAKey), ""}},
 					},
 				},
@@ -336,12 +336,12 @@ func Remove(query db.Q) error {
 }
 
 // UpdateAll runs an update on all patch documents.
-func UpdateAll(query interface{}, update interface{}) (info *adb.ChangeInfo, err error) {
+func UpdateAll(query any, update any) (info *adb.ChangeInfo, err error) {
 	return db.UpdateAll(Collection, query, update)
 }
 
 // UpdateOne runs an update on a single patch document.
-func UpdateOne(ctx context.Context, query interface{}, update interface{}) error {
+func UpdateOne(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(ctx, Collection, query, update)
 }
 

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -209,7 +209,7 @@ func (g *githubIntent) SetProcessed(ctx context.Context) error {
 }
 
 // updateOne updates one patch intent.
-func updateOneIntent(ctx context.Context, query interface{}, update interface{}) error {
+func updateOneIntent(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		IntentCollection,

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -749,7 +749,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	}
 	defer session.EndSession(ctx)
 
-	txFunc := func(ctx context.Context) (interface{}, error) {
+	txFunc := func(ctx context.Context) (any, error) {
 		db := env.DB()
 		_, err = db.Collection(VersionCollection).InsertOne(ctx, patchVersion)
 		if err != nil {

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -714,7 +714,7 @@ index 748e345..7e70f15 100644
 
 // shouldContainPair returns a blank string if its arguments resemble each other, and returns a
 // list of pretty-printed diffs between the objects if they do not match.
-func shouldContainPair(actual interface{}, expected ...interface{}) string {
+func shouldContainPair(actual any, expected ...any) string {
 	actualPairsList, ok := actual.([]TVPair)
 
 	if !ok {

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -98,7 +98,7 @@ func FindOneByID(id string) (*Pod, error) {
 }
 
 // UpdateOne updates one pod.
-func UpdateOne(ctx context.Context, query interface{}, update interface{}) error {
+func UpdateOne(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		Collection,

--- a/model/pod/definition/db.go
+++ b/model/pod/definition/db.go
@@ -38,12 +38,12 @@ func FindOne(q db.Q) (*PodDefinition, error) {
 
 // UpsertOne updates an existing pod definition if it exists based on the
 // query; otherwise, it inserts a new pod definition.
-func UpsertOne(ctx context.Context, query, update interface{}) (*adb.ChangeInfo, error) {
+func UpsertOne(ctx context.Context, query, update any) (*adb.ChangeInfo, error) {
 	return db.UpsertContext(ctx, Collection, query, update)
 }
 
 // UpdateOne updates an existing pod definition.
-func UpdateOne(ctx context.Context, query, update interface{}) error {
+func UpdateOne(ctx context.Context, query, update any) error {
 	return db.UpdateContext(ctx, Collection, query, update)
 }
 

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -46,7 +46,7 @@ func Find(q db.Q) ([]PodDispatcher, error) {
 
 // UpsertOne updates an existing pod dispatcher if it exists based on the
 // query; otherwise, it inserts a new pod dispatcher.
-func UpsertOne(query, update interface{}) (*adb.ChangeInfo, error) {
+func UpsertOne(query, update any) (*adb.ChangeInfo, error) {
 	return db.Upsert(Collection, query, update)
 }
 
@@ -90,7 +90,7 @@ func Allocate(ctx context.Context, env evergreen.Environment, t *task.Task, p *p
 	defer session.EndSession(ctx)
 
 	pd := &PodDispatcher{}
-	allocateDispatcher := func(ctx context.Context) (interface{}, error) {
+	allocateDispatcher := func(ctx context.Context) (any, error) {
 		groupID := GetGroupID(t)
 		if err := env.DB().Collection(Collection).FindOne(ctx, ByGroupID(groupID)).Decode(pd); err != nil && !adb.ResultsNotFound(err) {
 			return nil, errors.Wrap(err, "checking for existing pod dispatcher")

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -180,8 +180,8 @@ func (pd *PodDispatcher) dispatchTaskAtomically(ctx context.Context, env evergre
 	return nil
 }
 
-func (pd *PodDispatcher) dispatchTask(env evergreen.Environment, p *pod.Pod, t *task.Task) func(ctx context.Context) (interface{}, error) {
-	return func(ctx context.Context) (interface{}, error) {
+func (pd *PodDispatcher) dispatchTask(env evergreen.Environment, p *pod.Pod, t *task.Task) func(ctx context.Context) (any, error) {
+	return func(ctx context.Context) (any, error) {
 		if err := p.SetRunningTask(ctx, env, t.Id, t.Execution); err != nil {
 			return nil, errors.Wrapf(err, "setting pod's running task")
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -264,7 +264,7 @@ func (tg TaskGroupsByName) Less(i, j int) bool { return tg[i].Name < tg[j].Name 
 // UnmarshalYAML allows tasks to be referenced as single selector strings.
 // This works by first attempting to unmarshal the YAML into a string
 // and then falling back to the BuildVariantTaskUnit struct.
-func (bvt *BuildVariantTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (bvt *BuildVariantTaskUnit) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	var onlySelector string
 	if err := unmarshal(&onlySelector); err == nil {
@@ -528,7 +528,7 @@ type PluginCommandConf struct {
 
 	// Params is used to define params in the yaml and parser project,
 	// but is not stored in the DB (instead see ParamsYAML).
-	Params map[string]interface{} `yaml:"params,omitempty" bson:"-"`
+	Params map[string]any `yaml:"params,omitempty" bson:"-"`
 
 	// ParamsYAML is the marshalled Params to store in the database, to preserve nested interfaces.
 	ParamsYAML string `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
@@ -548,7 +548,7 @@ type PluginCommandConf struct {
 }
 
 func (c *PluginCommandConf) resolveParams() error {
-	out := map[string]interface{}{}
+	out := map[string]any{}
 	if c == nil {
 		return nil
 	}
@@ -561,19 +561,19 @@ func (c *PluginCommandConf) resolveParams() error {
 	return nil
 }
 
-func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(any) error) error {
 	temp := struct {
-		Function            string                 `yaml:"func,omitempty" bson:"func,omitempty"`
-		Type                string                 `yaml:"type,omitempty" bson:"type,omitempty"`
-		DisplayName         string                 `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
-		Command             string                 `yaml:"command,omitempty" bson:"command,omitempty"`
-		Variants            []string               `yaml:"variants,omitempty" bson:"variants,omitempty"`
-		TimeoutSecs         int                    `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
-		Params              map[string]interface{} `yaml:"params,omitempty" bson:"params,omitempty"`
-		ParamsYAML          string                 `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
-		Vars                map[string]string      `yaml:"vars,omitempty" bson:"vars,omitempty"`
-		RetryOnFailure      bool                   `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
-		FailureMetadataTags []string               `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
+		Function            string            `yaml:"func,omitempty" bson:"func,omitempty"`
+		Type                string            `yaml:"type,omitempty" bson:"type,omitempty"`
+		DisplayName         string            `yaml:"display_name,omitempty" bson:"display_name,omitempty"`
+		Command             string            `yaml:"command,omitempty" bson:"command,omitempty"`
+		Variants            []string          `yaml:"variants,omitempty" bson:"variants,omitempty"`
+		TimeoutSecs         int               `yaml:"timeout_secs,omitempty" bson:"timeout_secs,omitempty"`
+		Params              map[string]any    `yaml:"params,omitempty" bson:"params,omitempty"`
+		ParamsYAML          string            `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
+		Vars                map[string]string `yaml:"vars,omitempty" bson:"vars,omitempty"`
+		RetryOnFailure      bool              `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
+		FailureMetadataTags []string          `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
 	}{}
 
 	if err := unmarshal(&temp); err != nil {
@@ -604,7 +604,7 @@ func (c *PluginCommandConf) UnmarshalBSON(in []byte) error {
 // If params is passed, then it means that we haven't yet stored this in the DB.
 func (c *PluginCommandConf) unmarshalParams() error {
 	if c.ParamsYAML != "" {
-		out := map[string]interface{}{}
+		out := map[string]any{}
 		if err := yaml.Unmarshal([]byte(c.ParamsYAML), &out); err != nil {
 			return errors.Wrap(err, "unmarshalling params from YAML")
 		}
@@ -636,7 +636,7 @@ func (c *YAMLCommandSet) List() []PluginCommandConf {
 	return []PluginCommandConf{}
 }
 
-func (c *YAMLCommandSet) MarshalYAML() (interface{}, error) {
+func (c *YAMLCommandSet) MarshalYAML() (any, error) {
 	if c == nil {
 		return nil, nil
 	}
@@ -649,7 +649,7 @@ func (c *YAMLCommandSet) MarshalYAML() (interface{}, error) {
 	return res, nil
 }
 
-func (c *YAMLCommandSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *YAMLCommandSet) UnmarshalYAML(unmarshal func(any) error) error {
 	err1 := unmarshal(&(c.MultiCommand))
 	err2 := unmarshal(&(c.SingleCommand))
 	if err1 == nil || err2 == nil {
@@ -671,7 +671,7 @@ type TaskUnitDependency struct {
 // UnmarshalYAML allows tasks to be referenced as single selector strings.
 // This works by first attempting to unmarshal the YAML into a string
 // and then falling back to the TaskUnitDependency struct.
-func (td *TaskUnitDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (td *TaskUnitDependency) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	var onlySelector string
 	if err := unmarshal(&onlySelector); err == nil {

--- a/model/project_matrix.go
+++ b/model/project_matrix.go
@@ -190,7 +190,7 @@ type matrixDefinitions []matrixDefinition
 
 // UnmarshalYAML allows the YAML parser to read both a single def or
 // an array of them into a slice.
-func (mds *matrixDefinitions) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (mds *matrixDefinitions) UnmarshalYAML(unmarshal func(any) error) error {
 	var single matrixDefinition
 	if err := unmarshal(&single); err == nil {
 		*mds = matrixDefinitions{single}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -163,7 +163,7 @@ func (pp *ParserProject) MarshalBSON() ([]byte, error) {
 	return mgobson.Marshal(pp)
 }
 
-func (pp *ParserProject) MarshalYAML() (interface{}, error) {
+func (pp *ParserProject) MarshalYAML() (any, error) {
 	for i, pt := range pp.Tasks {
 		for j := range pt.Commands {
 			if err := pp.Tasks[i].Commands[j].resolveParams(); err != nil {
@@ -199,7 +199,7 @@ type parserDependencies []parserDependency
 
 // UnmarshalYAML reads YAML into an array of parserDependency. It will
 // successfully unmarshal arrays of dependency entries or single dependency entry.
-func (pds *parserDependencies) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pds *parserDependencies) UnmarshalYAML(unmarshal func(any) error) error {
 	// first check if we are handling a single dep that is not in an array.
 	pd := parserDependency{}
 	if err := unmarshal(&pd); err == nil {
@@ -216,7 +216,7 @@ func (pds *parserDependencies) UnmarshalYAML(unmarshal func(interface{}) error) 
 
 // UnmarshalYAML reads YAML into a parserDependency. A single selector string
 // will be also be accepted.
-func (pd *parserDependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pd *parserDependency) UnmarshalYAML(unmarshal func(any) error) error {
 	type copyType parserDependency
 	var copy copyType
 	if err := unmarshal(&copy); err != nil {
@@ -263,7 +263,7 @@ type variantSelector struct {
 // UnmarshalYAML allows variants to be referenced as single selector strings or
 // as a matrix definition. This works by first attempting to unmarshal the YAML
 // into a string and then falling back to the matrix.
-func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (vs *variantSelector) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	// ignore errors here, because there may be other fields that are valid with single-string selectors
 	var onlySelector string
@@ -284,7 +284,7 @@ func (vs *variantSelector) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	return nil
 }
 
-func (vs *variantSelector) MarshalYAML() (interface{}, error) {
+func (vs *variantSelector) MarshalYAML() (any, error) {
 	if vs == nil || vs.StringSelector == "" {
 		return nil, nil
 	}
@@ -296,7 +296,7 @@ func (vs *variantSelector) MarshalYAML() (interface{}, error) {
 // UnmarshalYAML allows tasks to be referenced as single selector strings.
 // This works by first attempting to unmarshal the YAML into a string
 // and then falling back to the TaskSelector struct.
-func (ts *taskSelector) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ts *taskSelector) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	var onlySelector string
 	if _ = unmarshal(&onlySelector); onlySelector != "" {
@@ -354,7 +354,7 @@ type parserBV struct {
 func (pbv *parserBV) name() string   { return pbv.Name }
 func (pbv *parserBV) tags() []string { return pbv.Tags }
 
-func (pbv *parserBV) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pbv *parserBV) UnmarshalYAML(unmarshal func(any) error) error {
 	// first attempt to unmarshal into a matrix
 	m := matrix{}
 	merr := unmarshal(&m)
@@ -446,7 +446,7 @@ type parserBVTaskUnit struct {
 
 // UnmarshalYAML allows the YAML parser to read both a single selector string or
 // a fully defined parserBVTaskUnit.
-func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pbvt *parserBVTaskUnit) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	var onlySelector string
 	if err := unmarshal(&onlySelector); err == nil {
@@ -481,7 +481,7 @@ type parserBVTaskUnits []parserBVTaskUnit
 
 // UnmarshalYAML allows the YAML parser to read both a single parserBVTaskUnit or
 // an array of them into a slice.
-func (pbvts *parserBVTaskUnits) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pbvts *parserBVTaskUnits) UnmarshalYAML(unmarshal func(any) error) error {
 	// first, attempt to unmarshal just a selector string
 	var single parserBVTaskUnit
 	if err := unmarshal(&single); err == nil {
@@ -502,7 +502,7 @@ type parserStringSlice []string
 
 // UnmarshalYAML allows the YAML parser to read both a single string or
 // an array of them into a slice.
-func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (pss *parserStringSlice) UnmarshalYAML(unmarshal func(any) error) error {
 	var single string
 	if err := unmarshal(&single); err == nil {
 		*pss = []string{single}
@@ -997,7 +997,7 @@ func createIntermediateProject(yml []byte, unmarshalStrict bool) (*ParserProject
 			ProjectConfigFields `yaml:"pc,inline"`
 			// Variables is only used to suppress yaml unmarshalling errors related
 			// to a non-existent variables field.
-			Variables interface{} `yaml:"variables,omitempty" bson:"-"`
+			Variables any `yaml:"variables,omitempty" bson:"-"`
 		}{}
 		if err := util.UnmarshalYAMLStrictWithFallback(yml, &strictProjectWithVariables); err != nil {
 			return nil, err

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -65,7 +65,7 @@ func parserProjectById(id string) db.Q {
 }
 
 // parserProjectUpsertOne updates one parser project in the DB.
-func parserProjectUpsertOne(query interface{}, update interface{}) error {
+func parserProjectUpsertOne(query any, update any) error {
 	_, err := db.Upsert(
 		ParserProjectCollection,
 		query,

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -29,7 +29,7 @@ import (
 
 // ShouldContainResembling tests whether a slice contains an element that DeepEquals
 // the expected input.
-func ShouldContainResembling(actual interface{}, expected ...interface{}) string {
+func ShouldContainResembling(actual any, expected ...any) string {
 	if len(expected) != 1 || expected == nil {
 		return "ShouldContainResembling takes 1 argument"
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3429,7 +3429,7 @@ func (c ContainerSecretCache) Put(ctx context.Context, sc cocoa.SecretCacheItem)
 	return db.UpdateContext(ctx, ProjectRefCollection, bson.M{
 		externalNameKey: sc.Name,
 		externalIDKey: bson.M{
-			"$in": []interface{}{"", sc.ID},
+			"$in": []any{"", sc.ID},
 		},
 	}, bson.M{
 		"$set": bson.M{

--- a/model/push.go
+++ b/model/push.go
@@ -74,7 +74,7 @@ func (pl *PushLog) UpdateStatus(ctx context.Context, newStatus string) error {
 	)
 }
 
-func FindOnePushLog(query interface{}, projection interface{},
+func FindOnePushLog(query any, projection any,
 	sort []string) (*PushLog, error) {
 	pushLog := &PushLog{}
 	q := db.Query(query).Project(projection).Sort(sort)

--- a/model/reliability/db.go
+++ b/model/reliability/db.go
@@ -57,7 +57,7 @@ func (filter TaskReliabilityFilter) dateBoundaries() []time.Time {
 // BuildTaskPaginationOrBranches builds an expression for the conditions imposed by the filter StartAt field.
 func (filter TaskReliabilityFilter) buildTaskPaginationOrBranches() []bson.M {
 	var dateDescending = filter.Sort == taskstats.SortLatestFirst
-	var nextDate interface{}
+	var nextDate any
 
 	if filter.GroupNumDays > 1 {
 		nextDate = filter.StartAt.Date
@@ -122,7 +122,7 @@ func (filter TaskReliabilityFilter) buildMatchStageForTask() bson.M {
 
 // buildDateStageGroupID builds the date of the grouped
 // period the stats document belongs in.
-func (filter TaskReliabilityFilter) buildDateStageGroupID(inputDateFieldName string) interface{} {
+func (filter TaskReliabilityFilter) buildDateStageGroupID(inputDateFieldName string) any {
 	numDays := filter.GroupNumDays
 	inputDateFieldRef := "$" + inputDateFieldName
 	if numDays <= 1 {

--- a/model/reliability/query_test.go
+++ b/model/reliability/query_test.go
@@ -165,7 +165,7 @@ func clearCollection() error {
 	return db.Clear(taskstats.DailyTaskStatsCollection)
 }
 
-func InsertDailyTaskStats(taskStats ...interface{}) error {
+func InsertDailyTaskStats(taskStats ...any) error {
 	err := db.InsertManyUnordered(taskstats.DailyTaskStatsCollection, taskStats...)
 	return err
 }
@@ -180,7 +180,7 @@ func handleNoFormat(format string, i int) string {
 
 func InsertManyDailyTaskStats(many int, prototype taskstats.DBTaskStats, projectFmt string, requesterFmt string, taskNameFmt string, variantFmt string, distroFmt string) error {
 
-	items := make([]interface{}, many)
+	items := make([]any, many)
 	for i := 0; i < many; i++ {
 		item := prototype
 		item.Id.Project = handleNoFormat(projectFmt, i)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -178,7 +178,7 @@ var (
 		"$reduce": bson.M{
 			"input":        "$" + DependsOnKey,
 			"initialValue": false,
-			"in":           bson.M{"$or": []interface{}{"$$value", bsonutil.GetDottedKeyName("$$this", DependencyUnattainableKey)}},
+			"in":           bson.M{"$or": []any{"$$value", bsonutil.GetDottedKeyName("$$this", DependencyUnattainableKey)}},
 		},
 	}
 
@@ -214,13 +214,13 @@ var (
 			"branches": []bson.M{
 				{
 					"case": bson.M{
-						"$eq": []interface{}{"$" + HasAnnotationsKey, true},
+						"$eq": []any{"$" + HasAnnotationsKey, true},
 					},
 					"then": evergreen.TaskKnownIssue,
 				},
 				{
 					"case": bson.M{
-						"$eq": []interface{}{"$" + AbortedKey, true},
+						"$eq": []any{"$" + AbortedKey, true},
 					},
 					"then": evergreen.TaskAborted,
 				},
@@ -240,7 +240,7 @@ var (
 					"case": bson.M{
 						"$and": []bson.M{
 							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
-							{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
+							{"$eq": []any{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
 							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailDescription), evergreen.TaskDescriptionHeartbeat}},
 						},
 					},
@@ -250,7 +250,7 @@ var (
 					"case": bson.M{
 						"$and": []bson.M{
 							{"$eq": []string{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailType), evergreen.CommandTypeSystem}},
-							{"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
+							{"$eq": []any{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true}},
 						},
 					},
 					"then": evergreen.TaskSystemTimedOut,
@@ -263,7 +263,7 @@ var (
 				},
 				{
 					"case": bson.M{
-						"$eq": []interface{}{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true},
+						"$eq": []any{"$" + bsonutil.GetDottedKeyName(DetailsKey, TaskEndDetailTimedOut), true},
 					},
 					"then": evergreen.TaskTimedOut,
 				},
@@ -271,7 +271,7 @@ var (
 				{
 					"case": bson.M{
 						"$and": []bson.M{
-							{"$eq": []interface{}{"$" + ActivatedKey, false}},
+							{"$eq": []any{"$" + ActivatedKey, false}},
 							{"$eq": []string{"$" + StatusKey, evergreen.TaskUndispatched}},
 						},
 					},
@@ -282,7 +282,7 @@ var (
 					"case": bson.M{
 						"$and": []bson.M{
 							{"$eq": []string{"$" + StatusKey, evergreen.TaskUndispatched}},
-							{"$ne": []interface{}{"$" + OverrideDependenciesKey, true}},
+							{"$ne": []any{"$" + OverrideDependenciesKey, true}},
 							isUnattainable,
 						},
 					},
@@ -293,7 +293,7 @@ var (
 					"case": bson.M{
 						"$and": []bson.M{
 							{"$eq": []string{"$" + StatusKey, evergreen.TaskUndispatched}},
-							{"$eq": []interface{}{"$" + ActivatedKey, true}},
+							{"$eq": []any{"$" + ActivatedKey, true}},
 						},
 					},
 					"then": evergreen.TaskWillRun,
@@ -1647,7 +1647,7 @@ func FindAllOld(ctx context.Context, query db.Q) ([]Task, error) {
 }
 
 // UpdateOne updates one task.
-func UpdateOne(ctx context.Context, query interface{}, update interface{}) error {
+func UpdateOne(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		Collection,
@@ -1656,7 +1656,7 @@ func UpdateOne(ctx context.Context, query interface{}, update interface{}) error
 	)
 }
 
-func UpdateAll(ctx context.Context, query interface{}, update interface{}) (*adb.ChangeInfo, error) {
+func UpdateAll(ctx context.Context, query any, update any) (*adb.ChangeInfo, error) {
 	return db.UpdateAllContext(
 		ctx,
 		Collection,
@@ -1665,7 +1665,7 @@ func UpdateAll(ctx context.Context, query interface{}, update interface{}) (*adb
 	)
 }
 
-func UpdateAllWithHint(ctx context.Context, query interface{}, update interface{}, hint interface{}) (*adb.ChangeInfo, error) {
+func UpdateAllWithHint(ctx context.Context, query any, update any, hint any) (*adb.ChangeInfo, error) {
 	res, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateMany(ctx, query, update, options.UpdateMany().SetHint(hint))
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -1683,7 +1683,7 @@ func Remove(ctx context.Context, id string) error {
 	)
 }
 
-func Aggregate(ctx context.Context, pipeline []bson.M, results interface{}) error {
+func Aggregate(ctx context.Context, pipeline []bson.M, results any) error {
 	return db.AggregateContext(ctx,
 		Collection,
 		pipeline,
@@ -1825,13 +1825,13 @@ func addStatusColorSort(key string) bson.M {
 					"branches": []bson.M{
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, []string{evergreen.TaskFailed, evergreen.TaskTestTimedOut, evergreen.TaskTimedOut}},
+								"$in": []any{"$" + key, []string{evergreen.TaskFailed, evergreen.TaskTestTimedOut, evergreen.TaskTimedOut}},
 							},
 							"then": 1, // red
 						},
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, []string{evergreen.TaskKnownIssue}},
+								"$in": []any{"$" + key, []string{evergreen.TaskKnownIssue}},
 							},
 							"then": 2,
 						},
@@ -1843,13 +1843,13 @@ func addStatusColorSort(key string) bson.M {
 						},
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, evergreen.TaskSystemFailureStatuses},
+								"$in": []any{"$" + key, evergreen.TaskSystemFailureStatuses},
 							},
 							"then": 4, // purple
 						},
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, []string{evergreen.TaskStarted, evergreen.TaskDispatched}},
+								"$in": []any{"$" + key, []string{evergreen.TaskStarted, evergreen.TaskDispatched}},
 							},
 							"then": 5, // yellow
 						},
@@ -1861,7 +1861,7 @@ func addStatusColorSort(key string) bson.M {
 						},
 						{
 							"case": bson.M{
-								"$in": []interface{}{"$" + key, []string{evergreen.TaskUnscheduled, evergreen.TaskInactive, evergreen.TaskStatusBlocked, evergreen.TaskAborted}},
+								"$in": []any{"$" + key, []string{evergreen.TaskUnscheduled, evergreen.TaskInactive, evergreen.TaskStatusBlocked, evergreen.TaskAborted}},
 							},
 							"then": 11, // light grey
 						},
@@ -1883,7 +1883,7 @@ func recalculateTimeTaken() bson.M {
 					},
 					// Time taken for a task is in nanoseconds. Since subtracting two dates in MongoDB yields milliseconds, we have
 					// to multiply by time.Millisecond (1000000) to keep time taken consistently in nanoseconds.
-					"then": bson.M{"$multiply": []interface{}{time.Millisecond, bson.M{"$subtract": []interface{}{"$$NOW", "$" + StartTimeKey}}}},
+					"then": bson.M{"$multiply": []any{time.Millisecond, bson.M{"$subtract": []any{"$$NOW", "$" + StartTimeKey}}}},
 					"else": "$" + TimeTakenKey,
 				},
 			},
@@ -2094,8 +2094,8 @@ func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksB
 		{
 			"$project": bson.M{
 				"eta": bson.M{
-					"$add": []interface{}{
-						bson.M{"$divide": []interface{}{"$" + ExpectedDurationKey, time.Millisecond}},
+					"$add": []any{
+						bson.M{"$divide": []any{"$" + ExpectedDurationKey, time.Millisecond}},
 						"$" + StartTimeKey,
 					},
 				},

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1212,7 +1212,7 @@ func TestGetTasksByVersionErrorHandling(t *testing.T) {
 	}
 
 	for i := 0; i < 40; i++ {
-		tasksToInsert := []interface{}{}
+		tasksToInsert := []any{}
 		for j := 0; j < 1000; j++ {
 			task.Id = fmt.Sprintf("t_%d_%d", i, j)
 			task.BuildVariant = fmt.Sprintf("bv_%d", j)

--- a/model/task/results.go
+++ b/model/task/results.go
@@ -99,8 +99,8 @@ func GetResultCounts(tasks []Task) *ResultCounts {
 	return &out
 }
 
-func (c *ResultCounts) Raw() interface{} { _ = c.Collect(true); return c }
-func (c *ResultCounts) Loggable() bool   { return c.loggable }
+func (c *ResultCounts) Raw() any       { _ = c.Collect(true); return c }
+func (c *ResultCounts) Loggable() bool { return c.loggable }
 func (c *ResultCounts) String() string {
 	if !c.Loggable() {
 		return ""

--- a/model/task/sorter.go
+++ b/model/task/sorter.go
@@ -14,10 +14,10 @@ func (t Tasks) Len() int           { return len(t) }
 func (t Tasks) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 func (t Tasks) Less(i, j int) bool { return t[i].Id < t[j].Id }
 
-func (t Tasks) getPayload() []interface{} {
-	payload := make([]interface{}, len(t))
+func (t Tasks) getPayload() []any {
+	payload := make([]any, len(t))
 	for idx := range t {
-		payload[idx] = interface{}(t[idx])
+		payload[idx] = any(t[idx])
 	}
 
 	return payload

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -925,7 +925,7 @@ func (t *Task) MarkDependenciesFinished(ctx context.Context, finished bool) erro
 				bsonutil.GetDottedKeyName(DependsOnKey, "$[elem]", DependencyFinishedAtKey): finishedAt,
 			},
 		},
-		options.UpdateMany().SetArrayFilters([]interface{}{
+		options.UpdateMany().SetArrayFilters([]any{
 			bson.M{bsonutil.GetDottedKeyName("elem", DependencyTaskIdKey): t.Id},
 		}),
 	)
@@ -1726,7 +1726,7 @@ func SetGeneratedStepbackInfoForGenerator(ctx context.Context, taskId string, s 
 				bsonutil.GetDottedKeyName(StepbackInfoKey, GeneratedStepbackInfoKey, "$[elem]", PreviousStepbackTaskIdKey):    s.PreviousStepbackTaskId,
 			},
 		},
-		options.UpdateOne().SetArrayFilters([]interface{}{
+		options.UpdateOne().SetArrayFilters([]any{
 			bson.M{
 				bsonutil.GetDottedKeyName("elem", DisplayNameKey):  s.DisplayName,
 				bsonutil.GetDottedKeyName("elem", BuildVariantKey): s.BuildVariant,
@@ -3049,7 +3049,7 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 	allTaskIds := []string{}          // Contains all tasks and display tasks IDs
 	execTaskIds := []string{}         // Contains all exec tasks IDs
 	toUpdateExecTaskIds := []string{} // Contains all exec tasks IDs that should update and have new execution
-	archivedTasks := []interface{}{}  // Contains all archived tasks (task, display, and execution). Created by Task.makeArchivedTask()
+	archivedTasks := []any{}          // Contains all archived tasks (task, display, and execution). Created by Task.makeArchivedTask()
 
 	for _, t := range tasks {
 		if !utility.StringSliceContains(evergreen.TaskCompletedStatuses, t.Status) {
@@ -3095,7 +3095,7 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 // - execTaskIds            : All execution task IDs
 // - toRestartExecTaskIds   : All execution task IDs for execution tasks that will be archived/restarted
 // - archivedTasks          : All archived tasks created by Task.makeArchivedTask()
-func archiveAll(ctx context.Context, taskIds, execTaskIds, toRestartExecTaskIds []string, archivedTasks []interface{}) error {
+func archiveAll(ctx context.Context, taskIds, execTaskIds, toRestartExecTaskIds []string, archivedTasks []any) error {
 	mongoClient := evergreen.GetEnvironment().Client()
 	session, err := mongoClient.StartSession()
 	if err != nil {
@@ -3103,7 +3103,7 @@ func archiveAll(ctx context.Context, taskIds, execTaskIds, toRestartExecTaskIds 
 	}
 	defer session.EndSession(ctx)
 
-	txFunc := func(ctx context.Context) (interface{}, error) {
+	txFunc := func(ctx context.Context) (any, error) {
 		var err error
 		if len(archivedTasks) > 0 {
 			oldTaskColl := evergreen.GetEnvironment().DB().Collection(OldCollection)
@@ -4004,7 +4004,7 @@ func (t *Task) UpdateDependsOn(ctx context.Context, status string, newDependency
 		[]bson.M{
 			bson.M{"$set": bson.M{
 				DependsOnKey: bson.M{
-					"$concatArrays": []interface{}{"$" + DependsOnKey, newDependencies},
+					"$concatArrays": []any{"$" + DependsOnKey, newDependencies},
 				},
 			}},
 			addDisplayStatusCache,

--- a/model/taskstats/db.go
+++ b/model/taskstats/db.go
@@ -73,7 +73,7 @@ var (
 )
 
 // Convenient type to use for arrays in pipeline definitions.
-type Array []interface{}
+type Array []any
 
 //////////////////
 // Stats Status //
@@ -320,7 +320,7 @@ func buildGroupId(groupBy GroupBy) bson.M {
 }
 
 // BuildMatchArrayExpression builds an expression to match any of the values in the array argument.
-func BuildMatchArrayExpression(values []string) interface{} {
+func BuildMatchArrayExpression(values []string) any {
 	if len(values) == 1 {
 		return values[0]
 	} else if len(values) > 1 {
@@ -428,7 +428,7 @@ func (filter StatsFilter) buildMatchStageForTask() bson.M {
 // BuildTaskPaginationOrBranches builds an expression for the conditions imposed by the filter StartAt field.
 func (filter StatsFilter) buildTaskPaginationOrBranches() []bson.M {
 	var dateDescending = filter.Sort == SortLatestFirst
-	var nextDate interface{}
+	var nextDate any
 
 	if filter.GroupNumDays > 1 {
 		nextDate = filter.getNextDate()
@@ -515,13 +515,13 @@ type PaginationField struct {
 	Field      string
 	Descending bool
 	Strict     bool
-	Value      interface{}
-	NextValue  interface{}
+	Value      any
+	NextValue  any
 }
 
 // GetEqExpression returns an expression that can be used to match the documents which have the same field value or
 // are in the same range as this PaginationField.
-func (pf PaginationField) GetEqExpression() interface{} {
+func (pf PaginationField) GetEqExpression() any {
 	if pf.NextValue == nil {
 		return pf.Value
 	}
@@ -542,7 +542,7 @@ func (pf PaginationField) GetEqExpression() interface{} {
 // greater or smaller than the this PaginationField.
 func (pf PaginationField) GetNextExpression() bson.M {
 	var operator string
-	var value interface{}
+	var value any
 	var strict bool
 
 	if pf.NextValue != nil {

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -102,7 +102,7 @@ func Find(query db.Q) ([]DBUser, error) {
 }
 
 // UpdateOne updates one user.
-func UpdateOne(query interface{}, update interface{}) error {
+func UpdateOne(query any, update any) error {
 	return db.Update(
 		Collection,
 		query,
@@ -110,7 +110,7 @@ func UpdateOne(query interface{}, update interface{}) error {
 	)
 }
 
-func UpdateOneContext(ctx context.Context, query interface{}, update interface{}) error {
+func UpdateOneContext(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		Collection,
@@ -120,7 +120,7 @@ func UpdateOneContext(ctx context.Context, query interface{}, update interface{}
 }
 
 // UpdateAll updates all users.
-func UpdateAll(query interface{}, update interface{}) error {
+func UpdateAll(query any, update any) error {
 	_, err := db.UpdateAll(
 		Collection,
 		query,
@@ -130,7 +130,7 @@ func UpdateAll(query interface{}, update interface{}) error {
 }
 
 // UpsertOne upserts a user.
-func UpsertOne(query interface{}, update interface{}) (*adb.ChangeInfo, error) {
+func UpsertOne(query any, update any) (*adb.ChangeInfo, error) {
 	return db.Upsert(
 		Collection,
 		query,

--- a/model/version.go
+++ b/model/version.go
@@ -646,7 +646,7 @@ func GetVersionsWithOptions(projectName string, opts GetVersionsOptions) ([]Vers
 		if opts.IncludeTasks {
 			taskMatch := []bson.M{
 				{"$eq": []string{"$build_id", "$$temp_build_id"}},
-				{"$eq": []interface{}{"$activated", true}},
+				{"$eq": []any{"$activated", true}},
 			}
 			if opts.ByTask != "" {
 				taskMatch = append(taskMatch, bson.M{"$eq": []string{"$display_name", opts.ByTask}})
@@ -664,7 +664,7 @@ func GetVersionsWithOptions(projectName string, opts GetVersionsOptions) ([]Vers
 
 			// filter out builds that don't have any tasks included
 			matchTasksExist := bson.M{
-				"tasks": bson.M{"$exists": true, "$ne": []interface{}{}},
+				"tasks": bson.M{"$exists": true, "$ne": []any{}},
 			}
 			innerPipeline = append(innerPipeline, bson.M{"$match": matchTasksExist})
 		}
@@ -678,7 +678,7 @@ func GetVersionsWithOptions(projectName string, opts GetVersionsOptions) ([]Vers
 		//
 		// filter out versions that don't have any activated builds
 		matchBuildsExist := bson.M{
-			"build_variants": bson.M{"$exists": true, "$ne": []interface{}{}},
+			"build_variants": bson.M{"$exists": true, "$ne": []any{}},
 		}
 		pipeline = append(pipeline, bson.M{"$match": matchBuildsExist})
 	}

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -329,7 +329,7 @@ func VersionCount(query db.Q) (int, error) {
 }
 
 // UpdateOne updates one version.
-func VersionUpdateOne(ctx context.Context, query interface{}, update interface{}) error {
+func VersionUpdateOne(ctx context.Context, query any, update any) error {
 	return db.UpdateContext(
 		ctx,
 		VersionCollection,

--- a/operations/admin_from_mdb.go
+++ b/operations/admin_from_mdb.go
@@ -104,7 +104,7 @@ func toMdbForLocal() cli.Command {
 					_, _ = io.Copy(buf, tr)
 				}
 
-				docs := []interface{}{}
+				docs := []any{}
 				for {
 					doc := &birch.Document{}
 					if _, err := doc.ReadFrom(buf); err != nil {

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -67,12 +67,12 @@ func Evaluate() cli.Command {
 				p.BuildVariants = model.BuildVariants(sortBuildVariantsByName)
 			}
 
-			var out interface{}
+			var out any
 			if showTasks || showVariants {
 				tmp := struct {
-					Functions interface{} `yaml:"functions,omitempty"`
-					Tasks     interface{} `yaml:"tasks,omitempty"`
-					Variants  interface{} `yaml:"buildvariants,omitempty"`
+					Functions any `yaml:"functions,omitempty"`
+					Tasks     any `yaml:"tasks,omitempty"`
+					Variants  any `yaml:"buildvariants,omitempty"`
 				}{}
 				if showTasks {
 					tmp.Functions = p.Functions

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -24,8 +24,8 @@ type displayTaskFiles struct {
 
 // Name returns the name of this plugin - it serves to satisfy
 // the 'Plugin' interface
-func (ap *AttachPlugin) Name() string                           { return AttachPluginName }
-func (ap *AttachPlugin) Configure(map[string]interface{}) error { return nil }
+func (ap *AttachPlugin) Name() string                   { return AttachPluginName }
+func (ap *AttachPlugin) Configure(map[string]any) error { return nil }
 
 // GetPanelConfig returns a plugin.PanelConfig struct representing panels
 // that will be added to the Task and Build pages.
@@ -37,7 +37,7 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Position: PageLeft,
 				PanelHTML: "<div ng-include=\"'/static/plugins/attach/partials/task_files_panel.html'\" " +
 					"ng-init='entries=plugins.attach' ng-show='plugins.attach.length'></div>",
-				DataFunc: func(uiCtx UIContext) (interface{}, error) {
+				DataFunc: func(uiCtx UIContext) (any, error) {
 					if uiCtx.Task == nil {
 						return nil, nil
 					}
@@ -104,7 +104,7 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Position: PageLeft,
 				PanelHTML: "<div ng-include=\"'/static/plugins/attach/partials/build_files_panel.html'\" " +
 					"ng-init='filesByTask=plugins.attach' ng-show='plugins.attach.length'></div>",
-				DataFunc: func(uiCtx UIContext) (interface{}, error) {
+				DataFunc: func(uiCtx UIContext) (any, error) {
 					if uiCtx.Build == nil {
 						return nil, nil
 					}

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -14,7 +14,7 @@ type BuildBaronPlugin struct{}
 
 func (bbp *BuildBaronPlugin) Name() string { return "buildbaron" }
 
-func (bbp *BuildBaronPlugin) Configure(map[string]interface{}) error { return nil }
+func (bbp *BuildBaronPlugin) Configure(map[string]any) error { return nil }
 
 func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 	return &PanelConfig{
@@ -27,7 +27,7 @@ func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 					template.HTML(`<link href="/static/plugins/buildbaron/css/task_build_baron.css" rel="stylesheet"/>`),
 					template.HTML(`<script type="text/javascript" src="/static/plugins/buildbaron/js/task_build_baron.js"></script>`),
 				},
-				DataFunc: func(context UIContext) (interface{}, error) {
+				DataFunc: func(context UIContext) (any, error) {
 					bbSettings, ok := model.GetBuildBaronSettings(context.ProjectRef.Id, "")
 					enabled := ok && len(bbSettings.TicketSearchProjects) > 0
 					return struct {

--- a/plugin/manifest_plugin.go
+++ b/plugin/manifest_plugin.go
@@ -14,8 +14,8 @@ func init() {
 }
 
 // Name returns the name of this plugin - satisfies 'Plugin' interface
-func (m *ManifestPlugin) Name() string                           { return "manifest" }
-func (m *ManifestPlugin) Configure(map[string]interface{}) error { return nil }
+func (m *ManifestPlugin) Name() string                   { return "manifest" }
+func (m *ManifestPlugin) Configure(map[string]any) error { return nil }
 
 // GetPanelConfig returns a pointer to a plugin's UI configuration.
 // or an error, if an error occur while trying to generate the config
@@ -30,7 +30,7 @@ func (m *ManifestPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Page:      VersionPage,
 				Position:  PageRight,
 				PanelHTML: "<div ng-include=\"'/static/plugins/manifest/partials/version_manifest_panel.html'\"></div>",
-				DataFunc: func(context UIContext) (interface{}, error) {
+				DataFunc: func(context UIContext) (any, error) {
 					if context.Version == nil {
 						return nil, nil
 					}

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -19,7 +19,7 @@ type PerfPlugin struct{}
 // Name implements Plugin Interface.
 func (pp *PerfPlugin) Name() string { return "perf" }
 
-func (pp *PerfPlugin) Configure(map[string]interface{}) error { return nil }
+func (pp *PerfPlugin) Configure(map[string]any) error { return nil }
 
 func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 	panelHTML, err := os.ReadFile(filepath.Join(TemplateRoot(), "task_perf_data.html"))
@@ -39,7 +39,7 @@ func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Page:      TaskPage,
 				Position:  PageCenter,
 				PanelHTML: template.HTML(panelHTML),
-				DataFunc: func(context UIContext) (interface{}, error) {
+				DataFunc: func(context UIContext) (any, error) {
 					enabled := model.IsPerfEnabledForProject(context.ProjectRef.Id)
 					return struct {
 						Enabled bool `json:"enabled"`

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,7 +18,7 @@ type Plugin interface {
 	GetPanelConfig() (*PanelConfig, error)
 
 	// Configure reads in a settings map from the Evergreen config file.
-	Configure(conf map[string]interface{}) error
+	Configure(conf map[string]any) error
 }
 
 // Publish is called in a plugin's "init" func to

--- a/plugin/plugin_ui.go
+++ b/plugin/plugin_ui.go
@@ -47,7 +47,7 @@ const (
 
 // UIDataFunction is a function which is called to populate panels
 // which are injected into Task/Build/Version pages at runtime.
-type UIDataFunction func(context UIContext) (interface{}, error)
+type UIDataFunction func(context UIContext) (any, error)
 
 // UIPage represents the information to be sent over to the ui server
 // in order to render a page for an app level plugin.
@@ -107,7 +107,7 @@ type PanelManager interface {
 	RegisterPlugins([]Plugin) error
 	Includes(PageScope) ([]template.HTML, error)
 	Panels(PageScope) (PanelLayout, error)
-	UIData(UIContext, PageScope) (map[string]interface{}, error)
+	UIData(UIContext, PageScope) (map[string]any, error)
 }
 
 // private type for sorting alphabetically,
@@ -258,12 +258,12 @@ func (spm *SimplePanelManager) Panels(page PageScope) (PanelLayout, error) {
 
 // UIData returns a map of plugin name -> data for inclusion
 // in the view's javascript.
-func (spm *SimplePanelManager) UIData(context UIContext, page PageScope) (map[string]interface{}, error) {
-	pluginUIData := map[string]interface{}{}
+func (spm *SimplePanelManager) UIData(context UIContext, page PageScope) (map[string]any, error) {
+	pluginUIData := map[string]any{}
 	errs := &UIDataFunctionError{}
 	for plName, dataFunc := range spm.uiDataFuncs[page] {
 		// run the data function, catching all sorts of errors
-		plData, err := func() (data interface{}, err error) {
+		plData, err := func() (data any, err error) {
 			defer func() {
 				if r := recover(); r != nil {
 					err = errors.Errorf("plugin function panicked: %v", r)

--- a/plugin/plugin_ui_test.go
+++ b/plugin/plugin_ui_test.go
@@ -26,7 +26,7 @@ func (mp *MockPlugin) GetUIHandler() http.Handler {
 	return nil
 }
 
-func (mp *MockPlugin) Configure(conf map[string]interface{}) error {
+func (mp *MockPlugin) Configure(conf map[string]any) error {
 	return nil
 }
 
@@ -112,12 +112,12 @@ func TestPanelManagerRegistration(t *testing.T) {
 						Panels: []UIPanel{
 							{
 								Page: TaskPage,
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return 100, nil
 								}},
 							{
 								Page: TaskPage,
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return nil, errors.New("this function just errors")
 								}},
 						},
@@ -156,7 +156,7 @@ func TestPanelManagerRetrieval(t *testing.T) {
 									"1",
 								},
 								PanelHTML: "0",
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return 1000, nil
 								},
 							},
@@ -192,7 +192,7 @@ func TestPanelManagerRetrieval(t *testing.T) {
 									"8",
 								},
 								PanelHTML: "3",
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return 2112, nil
 								},
 							},
@@ -210,7 +210,7 @@ func TestPanelManagerRetrieval(t *testing.T) {
 									"5",
 								},
 								PanelHTML: "2",
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return 1776, nil
 								},
 							},
@@ -284,7 +284,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return nil, errors.New("Error #1")
 								},
 							},
@@ -298,7 +298,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(context UIContext) (interface{}, error) {
+								DataFunc: func(context UIContext) (any, error) {
 									return nil, errors.New("Error #2")
 								},
 							},
@@ -312,7 +312,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(_ UIContext) (interface{}, error) {
+								DataFunc: func(_ UIContext) (any, error) {
 									return nil, errors.New("Error")
 								},
 							},
@@ -326,7 +326,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(_ UIContext) (interface{}, error) {
+								DataFunc: func(_ UIContext) (any, error) {
 									return "fine", nil
 								},
 							},
@@ -360,7 +360,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(_ UIContext) (interface{}, error) {
+								DataFunc: func(_ UIContext) (any, error) {
 									panic("BOOM")
 								},
 							},
@@ -374,7 +374,7 @@ func TestPluginUIDataFunctionErrorHandling(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(_ UIContext) (interface{}, error) {
+								DataFunc: func(_ UIContext) (any, error) {
 									return "still fine", nil
 								},
 							},
@@ -412,7 +412,7 @@ func TestUIDataInjection(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(ctx UIContext) (interface{}, error) {
+								DataFunc: func(ctx UIContext) (any, error) {
 									return ctx.Task.Id + ctx.Build.Id + ctx.Version.Id, nil
 								},
 							},
@@ -426,7 +426,7 @@ func TestUIDataInjection(t *testing.T) {
 							{
 								Page:     TaskPage,
 								Position: PageCenter,
-								DataFunc: func(ctx UIContext) (interface{}, error) {
+								DataFunc: func(ctx UIContext) (any, error) {
 									return fmt.Sprintf("%v.%v@%v", ctx.User.Email(), ctx.Settings.Api.URL, nil), nil
 								},
 							},

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -812,7 +812,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 	}
 
 	// create all builds for the version
-	buildsToCreate := []interface{}{}
+	buildsToCreate := []any{}
 	tasksToCreate := task.Tasks{}
 	pairsToCreate := model.TVPairSet{}
 	// build all pairsToCreate before creating builds, to handle dependencies (if applicable)

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -828,7 +828,7 @@ func createTestProject(override1, override2 *int) *model.ParserProject {
 
 	pp.AddTask("t1", []model.PluginCommandConf{{
 		Command: "shell.exec",
-		Params: map[string]interface{}{
+		Params: map[string]any{
 			"script": "echo hi",
 		},
 	}})

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -43,7 +43,7 @@ type Communicator interface {
 	RestartRecentTasks(context.Context, time.Time, time.Time) error
 	GetSettings(context.Context) (*evergreen.Settings, error)
 	UpdateSettings(context.Context, *restmodel.APIAdminSettings) (*restmodel.APIAdminSettings, error)
-	GetEvents(context.Context, time.Time, int) ([]interface{}, error)
+	GetEvents(context.Context, time.Time, int) ([]any, error)
 	RevertSettings(context.Context, string) error
 	GetServiceUsers(ctx context.Context) ([]restmodel.APIDBUser, error)
 	UpdateServiceUser(context.Context, string, string, []string) error
@@ -98,7 +98,7 @@ type Communicator interface {
 	GetSubscriptions(context.Context) ([]event.Subscription, error)
 
 	// Notifications
-	SendNotification(ctx context.Context, notificationType string, data interface{}) error
+	SendNotification(ctx context.Context, notificationType string, data any) error
 
 	// GetManifestByTask returns the manifest corresponding to the given task
 	GetManifestByTask(ctx context.Context, taskId string) (*manifest.Manifest, error)

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -683,7 +683,7 @@ func (c *communicatorImpl) UpdateSettings(ctx context.Context, update *model.API
 	return newSettings, nil
 }
 
-func (c *communicatorImpl) GetEvents(ctx context.Context, ts time.Time, limit int) ([]interface{}, error) {
+func (c *communicatorImpl) GetEvents(ctx context.Context, ts time.Time, limit int) ([]any, error) {
 	info := requestInfo{
 		method: http.MethodGet,
 		path:   fmt.Sprintf("admin/events?ts=%s&limit=%d", ts.Format(time.RFC3339), limit),
@@ -694,7 +694,7 @@ func (c *communicatorImpl) GetEvents(ctx context.Context, ts time.Time, limit in
 	}
 	defer resp.Body.Close()
 
-	events := []interface{}{}
+	events := []any{}
 	err = utility.ReadJSON(resp.Body, &events)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading JSON response body")
@@ -1062,7 +1062,7 @@ func (c *communicatorImpl) GetSubscriptions(ctx context.Context) ([]event.Subscr
 	return subs, nil
 }
 
-func (c *communicatorImpl) SendNotification(ctx context.Context, notificationType string, data interface{}) error {
+func (c *communicatorImpl) SendNotification(ctx context.Context, notificationType string, data any) error {
 	info := requestInfo{
 		method: http.MethodPost,
 		path:   "notifications/" + notificationType,

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -143,7 +143,7 @@ func (c *Mock) GetSettings(ctx context.Context) (*evergreen.Settings, error)    
 func (c *Mock) UpdateSettings(ctx context.Context, update *model.APIAdminSettings) (*model.APIAdminSettings, error) {
 	return nil, nil
 }
-func (c *Mock) GetEvents(ctx context.Context, ts time.Time, limit int) ([]interface{}, error) {
+func (c *Mock) GetEvents(ctx context.Context, ts time.Time, limit int) ([]any, error) {
 	return nil, nil
 }
 func (c *Mock) RevertSettings(ctx context.Context, guid string) error { return nil }
@@ -232,7 +232,7 @@ func (c *Mock) GetSubscriptions(_ context.Context) ([]event.Subscription, error)
 	}, nil
 }
 
-func (c *Mock) SendNotification(_ context.Context, _ string, _ interface{}) error {
+func (c *Mock) SendNotification(_ context.Context, _ string, _ any) error {
 	return nil
 }
 

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -26,7 +26,7 @@ type requestInfo struct {
 // suggest logging in again as a possible solution to the error.
 var AuthError = "Possibly user credentials are expired, try logging in again via the Evergreen web UI."
 
-func (c *communicatorImpl) newRequest(method, path string, data interface{}) (*http.Request, error) {
+func (c *communicatorImpl) newRequest(method, path string, data any) (*http.Request, error) {
 	url := c.getPath(path)
 	r, err := http.NewRequest(method, url, nil)
 	if err != nil {
@@ -61,7 +61,7 @@ func (c *communicatorImpl) newRequest(method, path string, data interface{}) (*h
 	return r, nil
 }
 
-func (c *communicatorImpl) createRequest(info requestInfo, data interface{}) (*http.Request, error) {
+func (c *communicatorImpl) createRequest(info requestInfo, data any) (*http.Request, error) {
 	if info.method == http.MethodPost && data == nil {
 		return nil, errors.New("cannot make a POST request without a body")
 	}
@@ -77,7 +77,7 @@ func (c *communicatorImpl) createRequest(info requestInfo, data interface{}) (*h
 	return r, nil
 }
 
-func (c *communicatorImpl) request(ctx context.Context, info requestInfo, data interface{}) (*http.Response, error) {
+func (c *communicatorImpl) request(ctx context.Context, info requestInfo, data any) (*http.Response, error) {
 	r, err := c.createRequest(info, data)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -107,7 +107,7 @@ func (c *communicatorImpl) doRequest(ctx context.Context, r *http.Request) (*htt
 	return response, nil
 }
 
-func (c *communicatorImpl) retryRequest(ctx context.Context, info requestInfo, data interface{}) (*http.Response, error) {
+func (c *communicatorImpl) retryRequest(ctx context.Context, info requestInfo, data any) (*http.Response, error) {
 	var err error
 
 	var out []byte

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -126,7 +126,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 
 // BuildProjectParameterMapForGraphQL builds the parameters map that can be used as an input to GetProjectIdFromParams.
 // It is used by the GraphQL @requireProjectAccess directive.
-func BuildProjectParameterMapForGraphQL(args map[string]interface{}) (map[string]string, error) {
+func BuildProjectParameterMapForGraphQL(args map[string]any) (map[string]string, error) {
 	paramsMap := map[string]string{}
 
 	if projectIdentifier, hasProjectIdentifier := args[projectIdentifierKey].(string); hasProjectIdentifier {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -74,7 +74,7 @@ func RequestS3Creds(ctx context.Context, projectIdentifier, userEmail string) er
 		Summary:     summary,
 		Description: description,
 		Reporter:    userEmail,
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			evergreen.DevProdServiceFieldName: evergreen.DevProdJiraServiceField,
 		},
 	}

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -545,7 +545,7 @@ func TestGetLegacyProjectEvents(t *testing.T) {
 		ResourceType: event.EventResourceTypeProject,
 		EventType:    event.EventTypeProjectModified,
 		ResourceId:   projectId,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"user":   username,
 			"before": model.NewProjectSettingsEvent(before),
 			"after":  model.NewProjectSettingsEvent(after),

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -30,7 +30,7 @@ func NewConfigModel() *APIAdminSettings {
 		Notify:              &APINotifyConfig{},
 		Overrides:           &APIOverridesConfig{},
 		ParameterStore:      &APIParameterStoreConfig{},
-		Plugins:             map[string]map[string]interface{}{},
+		Plugins:             map[string]map[string]any{},
 		PodLifecycle:        &APIPodLifecycleConfig{},
 		ProjectCreation:     &APIProjectCreationConfig{},
 		Providers:           &APICloudProviders{},
@@ -54,61 +54,61 @@ func NewConfigModel() *APIAdminSettings {
 
 // APIAdminSettings is the structure of a response to the admin route
 type APIAdminSettings struct {
-	Amboy               *APIAmboyConfig                   `json:"amboy,omitempty"`
-	AmboyDB             *APIAmboyDBConfig                 `json:"amboy_db,omitempty"`
-	Api                 *APIapiConfig                     `json:"api,omitempty"`
-	AWSInstanceRole     *string                           `json:"aws_instance_role,omitempty"`
-	AuthConfig          *APIAuthConfig                    `json:"auth,omitempty"`
-	Banner              *string                           `json:"banner,omitempty"`
-	BannerTheme         *string                           `json:"banner_theme,omitempty"`
-	Buckets             *APIBucketsConfig                 `json:"buckets,omitempty"`
-	Cedar               *APICedarConfig                   `json:"cedar,omitempty"`
-	ConfigDir           *string                           `json:"configdir,omitempty"`
-	ContainerPools      *APIContainerPoolsConfig          `json:"container_pools,omitempty"`
-	DomainName          *string                           `json:"domain_name,omitempty"`
-	Expansions          map[string]string                 `json:"expansions,omitempty"`
-	GithubPRCreatorOrg  *string                           `json:"github_pr_creator_org,omitempty"`
-	GithubOrgs          []string                          `json:"github_orgs,omitempty"`
-	GithubWebhookSecret *string                           `json:"github_webhook_secret,omitempty"`
-	DisabledGQLQueries  []string                          `json:"disabled_gql_queries"`
-	HostInit            *APIHostInitConfig                `json:"hostinit,omitempty"`
-	HostJasper          *APIHostJasperConfig              `json:"host_jasper,omitempty"`
-	Jira                *APIJiraConfig                    `json:"jira,omitempty"`
-	JIRANotifications   *APIJIRANotificationsConfig       `json:"jira_notifications,omitempty"`
-	KanopySSHKeyPath    *string                           `json:"kanopy_ssh_key_path,omitempty"`
-	LoggerConfig        *APILoggerConfig                  `json:"logger_config,omitempty"`
-	LogPath             *string                           `json:"log_path,omitempty"`
-	NewRelic            *APINewRelicConfig                `json:"newrelic,omitempty"`
-	Notify              *APINotifyConfig                  `json:"notify,omitempty"`
-	Overrides           *APIOverridesConfig               `json:"overrides,omitempty"`
-	ParameterStore      *APIParameterStoreConfig          `json:"parameter_store,omitempty"`
-	Plugins             map[string]map[string]interface{} `json:"plugins,omitempty"`
-	PodLifecycle        *APIPodLifecycleConfig            `json:"pod_lifecycle,omitempty"`
-	PprofPort           *string                           `json:"pprof_port,omitempty"`
-	ProjectCreation     *APIProjectCreationConfig         `json:"project_creation,omitempty"`
-	Providers           *APICloudProviders                `json:"providers,omitempty"`
-	RepoTracker         *APIRepoTrackerConfig             `json:"repotracker,omitempty"`
-	RuntimeEnvironments *APIRuntimeEnvironmentsConfig     `json:"runtime_environments,omitempty"`
-	Scheduler           *APISchedulerConfig               `json:"scheduler,omitempty"`
-	ServiceFlags        *APIServiceFlags                  `json:"service_flags,omitempty"`
-	SingleTaskDistro    *APISingleTaskDistroConfig        `json:"single_task_distro,omitempty"`
-	Slack               *APISlackConfig                   `json:"slack,omitempty"`
-	SleepSchedule       *APISleepScheduleConfig           `json:"sleep_schedule,omitempty"`
-	SSHKeyDirectory     *string                           `json:"ssh_key_directory,omitempty"`
-	SSHKeyPairs         []APISSHKeyPair                   `json:"ssh_key_pairs,omitempty"`
-	Splunk              *APISplunkConfig                  `json:"splunk,omitempty"`
-	TaskLimits          *APITaskLimitsConfig              `json:"task_limits,omitempty"`
-	TestSelection       *APITestSelectionConfig           `json:"test_selection,omitempty"`
-	Triggers            *APITriggerConfig                 `json:"triggers,omitempty"`
-	Ui                  *APIUIConfig                      `json:"ui,omitempty"`
-	Spawnhost           *APISpawnHostConfig               `json:"spawnhost,omitempty"`
-	Tracer              *APITracerSettings                `json:"tracer,omitempty"`
-	GitHubCheckRun      *APIGitHubCheckRunConfig          `json:"github_check_run,omitempty"`
-	ShutdownWaitSeconds *int                              `json:"shutdown_wait_seconds,omitempty"`
+	Amboy               *APIAmboyConfig               `json:"amboy,omitempty"`
+	AmboyDB             *APIAmboyDBConfig             `json:"amboy_db,omitempty"`
+	Api                 *APIapiConfig                 `json:"api,omitempty"`
+	AWSInstanceRole     *string                       `json:"aws_instance_role,omitempty"`
+	AuthConfig          *APIAuthConfig                `json:"auth,omitempty"`
+	Banner              *string                       `json:"banner,omitempty"`
+	BannerTheme         *string                       `json:"banner_theme,omitempty"`
+	Buckets             *APIBucketsConfig             `json:"buckets,omitempty"`
+	Cedar               *APICedarConfig               `json:"cedar,omitempty"`
+	ConfigDir           *string                       `json:"configdir,omitempty"`
+	ContainerPools      *APIContainerPoolsConfig      `json:"container_pools,omitempty"`
+	DomainName          *string                       `json:"domain_name,omitempty"`
+	Expansions          map[string]string             `json:"expansions,omitempty"`
+	GithubPRCreatorOrg  *string                       `json:"github_pr_creator_org,omitempty"`
+	GithubOrgs          []string                      `json:"github_orgs,omitempty"`
+	GithubWebhookSecret *string                       `json:"github_webhook_secret,omitempty"`
+	DisabledGQLQueries  []string                      `json:"disabled_gql_queries"`
+	HostInit            *APIHostInitConfig            `json:"hostinit,omitempty"`
+	HostJasper          *APIHostJasperConfig          `json:"host_jasper,omitempty"`
+	Jira                *APIJiraConfig                `json:"jira,omitempty"`
+	JIRANotifications   *APIJIRANotificationsConfig   `json:"jira_notifications,omitempty"`
+	KanopySSHKeyPath    *string                       `json:"kanopy_ssh_key_path,omitempty"`
+	LoggerConfig        *APILoggerConfig              `json:"logger_config,omitempty"`
+	LogPath             *string                       `json:"log_path,omitempty"`
+	NewRelic            *APINewRelicConfig            `json:"newrelic,omitempty"`
+	Notify              *APINotifyConfig              `json:"notify,omitempty"`
+	Overrides           *APIOverridesConfig           `json:"overrides,omitempty"`
+	ParameterStore      *APIParameterStoreConfig      `json:"parameter_store,omitempty"`
+	Plugins             map[string]map[string]any     `json:"plugins,omitempty"`
+	PodLifecycle        *APIPodLifecycleConfig        `json:"pod_lifecycle,omitempty"`
+	PprofPort           *string                       `json:"pprof_port,omitempty"`
+	ProjectCreation     *APIProjectCreationConfig     `json:"project_creation,omitempty"`
+	Providers           *APICloudProviders            `json:"providers,omitempty"`
+	RepoTracker         *APIRepoTrackerConfig         `json:"repotracker,omitempty"`
+	RuntimeEnvironments *APIRuntimeEnvironmentsConfig `json:"runtime_environments,omitempty"`
+	Scheduler           *APISchedulerConfig           `json:"scheduler,omitempty"`
+	ServiceFlags        *APIServiceFlags              `json:"service_flags,omitempty"`
+	SingleTaskDistro    *APISingleTaskDistroConfig    `json:"single_task_distro,omitempty"`
+	Slack               *APISlackConfig               `json:"slack,omitempty"`
+	SleepSchedule       *APISleepScheduleConfig       `json:"sleep_schedule,omitempty"`
+	SSHKeyDirectory     *string                       `json:"ssh_key_directory,omitempty"`
+	SSHKeyPairs         []APISSHKeyPair               `json:"ssh_key_pairs,omitempty"`
+	Splunk              *APISplunkConfig              `json:"splunk,omitempty"`
+	TaskLimits          *APITaskLimitsConfig          `json:"task_limits,omitempty"`
+	TestSelection       *APITestSelectionConfig       `json:"test_selection,omitempty"`
+	Triggers            *APITriggerConfig             `json:"triggers,omitempty"`
+	Ui                  *APIUIConfig                  `json:"ui,omitempty"`
+	Spawnhost           *APISpawnHostConfig           `json:"spawnhost,omitempty"`
+	Tracer              *APITracerSettings            `json:"tracer,omitempty"`
+	GitHubCheckRun      *APIGitHubCheckRunConfig      `json:"github_check_run,omitempty"`
+	ShutdownWaitSeconds *int                          `json:"shutdown_wait_seconds,omitempty"`
 }
 
 // BuildFromService builds a model from the service layer
-func (as *APIAdminSettings) BuildFromService(h interface{}) error {
+func (as *APIAdminSettings) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.Settings:
 		if v == nil {
@@ -209,7 +209,7 @@ func (as *APIAdminSettings) BuildFromService(h interface{}) error {
 }
 
 // ToService returns a service model from an API model
-func (as *APIAdminSettings) ToService() (interface{}, error) {
+func (as *APIAdminSettings) ToService() (any, error) {
 	settings := evergreen.Settings{
 		Expansions:         map[string]string{},
 		Plugins:            evergreen.PluginConfig{},
@@ -269,7 +269,7 @@ func (as *APIAdminSettings) ToService() (interface{}, error) {
 	}
 	settings.KanopySSHKeyPath = utility.FromStringPtr(as.KanopySSHKeyPath)
 	for k, v := range as.Plugins {
-		settings.Plugins[k] = map[string]interface{}{}
+		settings.Plugins[k] = map[string]any{}
 		for k2, v2 := range v {
 			settings.Plugins[k][k2] = v2
 		}
@@ -294,7 +294,7 @@ type APISESConfig struct {
 	SenderAddress *string `json:"sender_address"`
 }
 
-func (a *APISESConfig) BuildFromService(h interface{}) error {
+func (a *APISESConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SESConfig:
 		a.SenderAddress = utility.ToStringPtr(v.SenderAddress)
@@ -304,7 +304,7 @@ func (a *APISESConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISESConfig) ToService() (interface{}, error) {
+func (a *APISESConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -330,7 +330,7 @@ type APIAmboyConfig struct {
 	NamedQueues                           []APIAmboyNamedQueueConfig `json:"named_queues,omitempty"`
 }
 
-func (a *APIAmboyConfig) BuildFromService(h interface{}) error {
+func (a *APIAmboyConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AmboyConfig:
 		a.Name = utility.ToStringPtr(v.Name)
@@ -358,7 +358,7 @@ func (a *APIAmboyConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIAmboyConfig) ToService() (interface{}, error) {
+func (a *APIAmboyConfig) ToService() (any, error) {
 	i, err := a.Retry.ToService()
 	if err != nil {
 		return nil, errors.Wrap(err, "converting Amboy retry settings to service model")
@@ -394,7 +394,7 @@ type APIAmboyDBConfig struct {
 	Database *string `json:"database"`
 }
 
-func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
+func (a *APIAmboyDBConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AmboyDBConfig:
 		a.URL = utility.ToStringPtr(v.URL)
@@ -405,7 +405,7 @@ func (a *APIAmboyDBConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIAmboyDBConfig) ToService() (interface{}, error) {
+func (a *APIAmboyDBConfig) ToService() (any, error) {
 	return evergreen.AmboyDBConfig{
 		URL:      utility.FromStringPtr(a.URL),
 		Database: utility.FromStringPtr(a.Database),
@@ -421,7 +421,7 @@ type APIAmboyRetryConfig struct {
 	StaleRetryingMonitorIntervalSeconds int `json:"stale_retrying_monitor_interval_seconds,omitempty"`
 }
 
-func (a *APIAmboyRetryConfig) BuildFromService(h interface{}) error {
+func (a *APIAmboyRetryConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AmboyRetryConfig:
 		a.NumWorkers = v.NumWorkers
@@ -436,7 +436,7 @@ func (a *APIAmboyRetryConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIAmboyRetryConfig) ToService() (interface{}, error) {
+func (a *APIAmboyRetryConfig) ToService() (any, error) {
 	return evergreen.AmboyRetryConfig{
 		NumWorkers:                          a.NumWorkers,
 		MaxCapacity:                         a.MaxCapacity,
@@ -479,7 +479,7 @@ type APIapiConfig struct {
 	URL            *string `json:"url"`
 }
 
-func (a *APIapiConfig) BuildFromService(h interface{}) error {
+func (a *APIapiConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.APIConfig:
 		a.HttpListenAddr = utility.ToStringPtr(v.HttpListenAddr)
@@ -490,7 +490,7 @@ func (a *APIapiConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIapiConfig) ToService() (interface{}, error) {
+func (a *APIapiConfig) ToService() (any, error) {
 	return evergreen.APIConfig{
 		HttpListenAddr: utility.FromStringPtr(a.HttpListenAddr),
 		URL:            utility.FromStringPtr(a.URL),
@@ -508,7 +508,7 @@ type APIAuthConfig struct {
 	AllowServiceUsers       bool                 `json:"allow_service_users"`
 }
 
-func (a *APIAuthConfig) BuildFromService(h interface{}) error {
+func (a *APIAuthConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AuthConfig:
 		if v.Okta != nil {
@@ -550,7 +550,7 @@ func (a *APIAuthConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIAuthConfig) ToService() (interface{}, error) {
+func (a *APIAuthConfig) ToService() (any, error) {
 	var okta *evergreen.OktaConfig
 	var naive *evergreen.NaiveAuthConfig
 	var github *evergreen.GithubAuthConfig
@@ -637,7 +637,7 @@ type APIBucketConfig struct {
 	DBName *string `json:"db_name"`
 }
 
-func (a *APIBucketsConfig) BuildFromService(h interface{}) error {
+func (a *APIBucketsConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.BucketsConfig:
 		a.LogBucket.Name = utility.ToStringPtr(v.LogBucket.Name)
@@ -657,7 +657,7 @@ func (a *APIBucketsConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIBucketsConfig) ToService() (interface{}, error) {
+func (a *APIBucketsConfig) ToService() (any, error) {
 	i, err := a.Credentials.ToService()
 	if err != nil {
 		return nil, errors.Wrap(err, "converting S3 credentials to service model")
@@ -688,7 +688,7 @@ type APICedarConfig struct {
 	SPSKanopyURL *string `json:"sps_kanopy_url"`
 }
 
-func (a *APICedarConfig) BuildFromService(h interface{}) error {
+func (a *APICedarConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.CedarConfig:
 		a.BaseURL = utility.ToStringPtr(v.BaseURL)
@@ -704,7 +704,7 @@ func (a *APICedarConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APICedarConfig) ToService() (interface{}, error) {
+func (a *APICedarConfig) ToService() (any, error) {
 	return evergreen.CedarConfig{
 		BaseURL:      utility.FromStringPtr(a.BaseURL),
 		GRPCBaseURL:  utility.FromStringPtr(a.GRPCBaseURL),
@@ -725,7 +725,7 @@ type APIOktaConfig struct {
 	ExpireAfterMinutes int      `json:"expire_after_minutes"`
 }
 
-func (a *APIOktaConfig) BuildFromService(h interface{}) error {
+func (a *APIOktaConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.OktaConfig:
 		if v == nil {
@@ -743,7 +743,7 @@ func (a *APIOktaConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIOktaConfig) ToService() (interface{}, error) {
+func (a *APIOktaConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -761,7 +761,7 @@ type APINaiveAuthConfig struct {
 	Users []APIAuthUser `json:"users"`
 }
 
-func (a *APINaiveAuthConfig) BuildFromService(h interface{}) error {
+func (a *APINaiveAuthConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.NaiveAuthConfig:
 		if v == nil {
@@ -780,7 +780,7 @@ func (a *APINaiveAuthConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APINaiveAuthConfig) ToService() (interface{}, error) {
+func (a *APINaiveAuthConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -806,7 +806,7 @@ type APIAuthUser struct {
 	Email       *string `json:"email"`
 }
 
-func (a *APIAuthUser) BuildFromService(h interface{}) error {
+func (a *APIAuthUser) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AuthUser:
 		a.Username = utility.ToStringPtr(v.Username)
@@ -819,7 +819,7 @@ func (a *APIAuthUser) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIAuthUser) ToService() (interface{}, error) {
+func (a *APIAuthUser) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -841,7 +841,7 @@ type APIGithubAuthConfig struct {
 	Users        []*string `json:"users"`
 }
 
-func (a *APIGithubAuthConfig) BuildFromService(h interface{}) error {
+func (a *APIGithubAuthConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.GithubAuthConfig:
 		if v == nil {
@@ -862,7 +862,7 @@ func (a *APIGithubAuthConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIGithubAuthConfig) ToService() (interface{}, error) {
+func (a *APIGithubAuthConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -885,7 +885,7 @@ type APIMultiAuthConfig struct {
 	ReadOnly  []string `json:"read_only"`
 }
 
-func (a *APIMultiAuthConfig) BuildFromService(h interface{}) error {
+func (a *APIMultiAuthConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.MultiAuthConfig:
 		if v == nil {
@@ -899,7 +899,7 @@ func (a *APIMultiAuthConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIMultiAuthConfig) ToService() (interface{}, error) {
+func (a *APIMultiAuthConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -915,7 +915,7 @@ type APIKanopyAuthConfig struct {
 	KeysetURL  *string `json:"keyset_url"`
 }
 
-func (a *APIKanopyAuthConfig) BuildFromService(h interface{}) error {
+func (a *APIKanopyAuthConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *evergreen.KanopyAuthConfig:
 		if v == nil {
@@ -930,7 +930,7 @@ func (a *APIKanopyAuthConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIKanopyAuthConfig) ToService() (interface{}, error) {
+func (a *APIKanopyAuthConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -959,7 +959,7 @@ type APIHostInitConfig struct {
 	MaxTotalDynamicHosts int `json:"max_total_dynamic_hosts"`
 }
 
-func (a *APIHostInitConfig) BuildFromService(h interface{}) error {
+func (a *APIHostInitConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.HostInitConfig:
 		a.HostThrottle = v.HostThrottle
@@ -972,7 +972,7 @@ func (a *APIHostInitConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIHostInitConfig) ToService() (interface{}, error) {
+func (a *APIHostInitConfig) ToService() (any, error) {
 	return evergreen.HostInitConfig{
 		HostThrottle:         a.HostThrottle,
 		ProvisioningThrottle: a.ProvisioningThrottle,
@@ -987,7 +987,7 @@ type APIPodLifecycleConfig struct {
 	MaxSecretCleanupRate        int `json:"max_secret_cleanup_rate"`
 }
 
-func (a *APIPodLifecycleConfig) BuildFromService(h interface{}) error {
+func (a *APIPodLifecycleConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.PodLifecycleConfig:
 		a.MaxParallelPodRequests = v.MaxParallelPodRequests
@@ -999,7 +999,7 @@ func (a *APIPodLifecycleConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIPodLifecycleConfig) ToService() (interface{}, error) {
+func (a *APIPodLifecycleConfig) ToService() (any, error) {
 	return evergreen.PodLifecycleConfig{
 		MaxParallelPodRequests:      a.MaxParallelPodRequests,
 		MaxPodDefinitionCleanupRate: a.MaxPodDefinitionCleanupRate,
@@ -1015,7 +1015,7 @@ type APIJiraConfig struct {
 	OAuth1Config    *APIJiraOAuth1    `json:"oauth1"`
 }
 
-func (a *APIJiraConfig) BuildFromService(h interface{}) error {
+func (a *APIJiraConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.JiraConfig:
 		a.Host = utility.ToStringPtr(v.Host)
@@ -1030,7 +1030,7 @@ func (a *APIJiraConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIJiraConfig) ToService() (interface{}, error) {
+func (a *APIJiraConfig) ToService() (any, error) {
 	c := evergreen.JiraConfig{
 		Host:  utility.FromStringPtr(a.Host),
 		Email: utility.FromStringPtr(a.Email),
@@ -1092,7 +1092,7 @@ type APILoggerConfig struct {
 	RedactKeys     []*string        `json:"redact_keys"`
 }
 
-func (a *APILoggerConfig) BuildFromService(h interface{}) error {
+func (a *APILoggerConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.LoggerConfig:
 		a.DefaultLevel = utility.ToStringPtr(v.DefaultLevel)
@@ -1109,7 +1109,7 @@ func (a *APILoggerConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APILoggerConfig) ToService() (interface{}, error) {
+func (a *APILoggerConfig) ToService() (any, error) {
 	config := evergreen.LoggerConfig{
 		DefaultLevel:   utility.FromStringPtr(a.DefaultLevel),
 		ThresholdLevel: utility.FromStringPtr(a.ThresholdLevel),
@@ -1132,7 +1132,7 @@ type APILogBuffering struct {
 	IncomingBufferFactor int  `json:"incoming_buffer_factor"`
 }
 
-func (a *APILogBuffering) BuildFromService(h interface{}) error {
+func (a *APILogBuffering) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.LogBuffering:
 		a.UseAsync = v.UseAsync
@@ -1145,7 +1145,7 @@ func (a *APILogBuffering) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APILogBuffering) ToService() (interface{}, error) {
+func (a *APILogBuffering) ToService() (any, error) {
 	return evergreen.LogBuffering{
 		UseAsync:             a.UseAsync,
 		DurationSeconds:      a.DurationSeconds,
@@ -1160,7 +1160,7 @@ type APINotifyConfig struct {
 	SES                     APISESConfig `json:"ses"`
 }
 
-func (a *APINotifyConfig) BuildFromService(h interface{}) error {
+func (a *APINotifyConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.NotifyConfig:
 		a.SES = APISESConfig{}
@@ -1175,7 +1175,7 @@ func (a *APINotifyConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APINotifyConfig) ToService() (interface{}, error) {
+func (a *APINotifyConfig) ToService() (any, error) {
 	ses, err := a.SES.ToService()
 	if err != nil {
 		return nil, err
@@ -1192,7 +1192,7 @@ type APIOverridesConfig struct {
 	Overrides []APIOverride `json:"overrides"`
 }
 
-func (a *APIOverridesConfig) BuildFromService(h interface{}) error {
+func (a *APIOverridesConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.OverridesConfig:
 		var overrides []APIOverride
@@ -1210,7 +1210,7 @@ func (a *APIOverridesConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIOverridesConfig) ToService() (interface{}, error) {
+func (a *APIOverridesConfig) ToService() (any, error) {
 	var overrides []evergreen.Override
 	for _, apiOverride := range a.Overrides {
 		overrideInterface, err := apiOverride.ToService()
@@ -1229,9 +1229,9 @@ func (a *APIOverridesConfig) ToService() (interface{}, error) {
 }
 
 type APIOverride struct {
-	SectionID *string     `bson:"section_id" json:"section_id"`
-	Field     *string     `bson:"field" json:"field"`
-	Value     interface{} `bson:"value" json:"value"`
+	SectionID *string `bson:"section_id" json:"section_id"`
+	Field     *string `bson:"field" json:"field"`
+	Value     any     `bson:"value" json:"value"`
 }
 
 // MarshalJSON is a custom JSON marshaler function to satisfy the [json.Marshaler] interface.
@@ -1246,7 +1246,7 @@ func (a *APIOverride) UnmarshalJSON(data []byte) error {
 	return bson.UnmarshalExtJSON(data, false, a)
 }
 
-func (a *APIOverride) BuildFromService(h interface{}) error {
+func (a *APIOverride) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.Override:
 		a.SectionID = utility.ToStringPtr(v.SectionID)
@@ -1258,7 +1258,7 @@ func (a *APIOverride) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIOverride) ToService() (interface{}, error) {
+func (a *APIOverride) ToService() (any, error) {
 	override := evergreen.Override{
 		SectionID: utility.FromStringPtr(a.SectionID),
 		Field:     utility.FromStringPtr(a.Field),
@@ -1271,7 +1271,7 @@ type APIParameterStoreConfig struct {
 	Prefix *string `json:"prefix"`
 }
 
-func (a *APIParameterStoreConfig) BuildFromService(h interface{}) error {
+func (a *APIParameterStoreConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ParameterStoreConfig:
 		a.Prefix = utility.ToStringPtr(v.Prefix)
@@ -1281,7 +1281,7 @@ func (a *APIParameterStoreConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIParameterStoreConfig) ToService() (interface{}, error) {
+func (a *APIParameterStoreConfig) ToService() (any, error) {
 	return evergreen.ParameterStoreConfig{
 		Prefix: utility.FromStringPtr(a.Prefix),
 	}, nil
@@ -1292,7 +1292,7 @@ type APIOwnerRepo struct {
 	Repo  *string `json:"repo"`
 }
 
-func (a *APIOwnerRepo) BuildFromService(h interface{}) error {
+func (a *APIOwnerRepo) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.OwnerRepo:
 		a.Owner = utility.ToStringPtr(v.Owner)
@@ -1303,7 +1303,7 @@ func (a *APIOwnerRepo) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIOwnerRepo) ToService() (interface{}, error) {
+func (a *APIOwnerRepo) ToService() (any, error) {
 	res := evergreen.OwnerRepo{}
 	res.Owner = utility.FromStringPtr(a.Owner)
 	res.Repo = utility.FromStringPtr(a.Repo)
@@ -1317,7 +1317,7 @@ type APIProjectCreationConfig struct {
 	JiraProject       string         `json:"jira_project"`
 }
 
-func (a *APIProjectCreationConfig) BuildFromService(h interface{}) error {
+func (a *APIProjectCreationConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ProjectCreationConfig:
 		for _, ownerRepo := range v.RepoExceptions {
@@ -1337,7 +1337,7 @@ func (a *APIProjectCreationConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIProjectCreationConfig) ToService() (interface{}, error) {
+func (a *APIProjectCreationConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1368,7 +1368,7 @@ type APICloudProviders struct {
 	Docker *APIDockerConfig `json:"docker"`
 }
 
-func (a *APICloudProviders) BuildFromService(h interface{}) error {
+func (a *APICloudProviders) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.CloudProviders:
 		a.AWS = &APIAWSConfig{}
@@ -1385,7 +1385,7 @@ func (a *APICloudProviders) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APICloudProviders) ToService() (interface{}, error) {
+func (a *APICloudProviders) ToService() (any, error) {
 	aws, err := a.AWS.ToService()
 	if err != nil {
 		return nil, err
@@ -1404,7 +1404,7 @@ type APIContainerPoolsConfig struct {
 	Pools []APIContainerPool `json:"pools"`
 }
 
-func (a *APIContainerPoolsConfig) BuildFromService(h interface{}) error {
+func (a *APIContainerPoolsConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ContainerPoolsConfig:
 		for _, pool := range v.Pools {
@@ -1420,7 +1420,7 @@ func (a *APIContainerPoolsConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIContainerPoolsConfig) ToService() (interface{}, error) {
+func (a *APIContainerPoolsConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1443,7 +1443,7 @@ type APIContainerPool struct {
 	Port          uint16  `json:"port"`
 }
 
-func (a *APIContainerPool) BuildFromService(h interface{}) error {
+func (a *APIContainerPool) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ContainerPool:
 		a.Distro = utility.ToStringPtr(v.Distro)
@@ -1456,7 +1456,7 @@ func (a *APIContainerPool) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIContainerPool) ToService() (interface{}, error) {
+func (a *APIContainerPool) ToService() (any, error) {
 	return evergreen.ContainerPool{
 		Distro:        utility.FromStringPtr(a.Distro),
 		Id:            utility.FromStringPtr(a.Id),
@@ -1472,7 +1472,7 @@ type APIEC2Key struct {
 	Secret *string `json:"secret"`
 }
 
-func (a *APIEC2Key) BuildFromService(h interface{}) error {
+func (a *APIEC2Key) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.EC2Key:
 		a.Name = utility.ToStringPtr(v.Name)
@@ -1485,7 +1485,7 @@ func (a *APIEC2Key) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIEC2Key) ToService() (interface{}, error) {
+func (a *APIEC2Key) ToService() (any, error) {
 	res := evergreen.EC2Key{}
 	res.Name = utility.FromStringPtr(a.Name)
 	res.Region = utility.FromStringPtr(a.Region)
@@ -1499,7 +1499,7 @@ type APISubnet struct {
 	SubnetID *string `json:"subnet_id"`
 }
 
-func (a *APISubnet) BuildFromService(h interface{}) error {
+func (a *APISubnet) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.Subnet:
 		a.AZ = utility.ToStringPtr(v.AZ)
@@ -1510,7 +1510,7 @@ func (a *APISubnet) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISubnet) ToService() (interface{}, error) {
+func (a *APISubnet) ToService() (any, error) {
 	res := evergreen.Subnet{}
 	res.AZ = utility.FromStringPtr(a.AZ)
 	res.SubnetID = utility.FromStringPtr(a.SubnetID)
@@ -1529,7 +1529,7 @@ type APIAWSConfig struct {
 	Pod                  *APIAWSPodConfig          `json:"pod"`
 }
 
-func (a *APIAWSConfig) BuildFromService(h interface{}) error {
+func (a *APIAWSConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.AWSConfig:
 		for _, key := range v.EC2Keys {
@@ -1574,7 +1574,7 @@ func (a *APIAWSConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIAWSConfig) ToService() (interface{}, error) {
+func (a *APIAWSConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1583,7 +1583,7 @@ func (a *APIAWSConfig) ToService() (interface{}, error) {
 		MaxVolumeSizePerUser: evergreen.DefaultMaxVolumeSizePerUser,
 	}
 
-	var i interface{}
+	var i any
 	var err error
 	var ok bool
 
@@ -1659,7 +1659,7 @@ type APIS3Credentials struct {
 	Bucket *string `json:"bucket"`
 }
 
-func (a *APIS3Credentials) BuildFromService(h interface{}) error {
+func (a *APIS3Credentials) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.S3Credentials:
 		a.Key = utility.ToStringPtr(v.Key)
@@ -1671,7 +1671,7 @@ func (a *APIS3Credentials) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIS3Credentials) ToService() (interface{}, error) {
+func (a *APIS3Credentials) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1690,7 +1690,7 @@ type APIParserProjectS3Config struct {
 	GeneratedJSONPrefix *string `json:"generated_json_prefix"`
 }
 
-func (a *APIParserProjectS3Config) BuildFromService(h interface{}) error {
+func (a *APIParserProjectS3Config) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ParserProjectS3Config:
 		a.Key = utility.ToStringPtr(v.Key)
@@ -1704,7 +1704,7 @@ func (a *APIParserProjectS3Config) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIParserProjectS3Config) ToService() (interface{}, error) {
+func (a *APIParserProjectS3Config) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1726,7 +1726,7 @@ type APIPersistentDNSConfig struct {
 	Domain       *string `json:"domain"`
 }
 
-func (a *APIPersistentDNSConfig) BuildFromService(h interface{}) error {
+func (a *APIPersistentDNSConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.PersistentDNSConfig:
 		a.HostedZoneID = utility.ToStringPtr(v.HostedZoneID)
@@ -1737,7 +1737,7 @@ func (a *APIPersistentDNSConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (a *APIPersistentDNSConfig) ToService() (interface{}, error) {
+func (a *APIPersistentDNSConfig) ToService() (any, error) {
 	if a == nil {
 		return nil, nil
 	}
@@ -1975,7 +1975,7 @@ type APIDockerConfig struct {
 	APIVersion *string `json:"api_version"`
 }
 
-func (a *APIDockerConfig) BuildFromService(h interface{}) error {
+func (a *APIDockerConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.DockerConfig:
 		a.APIVersion = utility.ToStringPtr(v.APIVersion)
@@ -1985,7 +1985,7 @@ func (a *APIDockerConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIDockerConfig) ToService() (interface{}, error) {
+func (a *APIDockerConfig) ToService() (any, error) {
 	return evergreen.DockerConfig{
 		APIVersion: utility.FromStringPtr(a.APIVersion),
 	}, nil
@@ -1997,7 +1997,7 @@ type APIRepoTrackerConfig struct {
 	MaxConcurrentRequests      int `json:"max_con_requests"`
 }
 
-func (a *APIRepoTrackerConfig) BuildFromService(h interface{}) error {
+func (a *APIRepoTrackerConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.RepoTrackerConfig:
 		a.NumNewRepoRevisionsToFetch = v.NumNewRepoRevisionsToFetch
@@ -2009,7 +2009,7 @@ func (a *APIRepoTrackerConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIRepoTrackerConfig) ToService() (interface{}, error) {
+func (a *APIRepoTrackerConfig) ToService() (any, error) {
 	return evergreen.RepoTrackerConfig{
 		NumNewRepoRevisionsToFetch: a.NumNewRepoRevisionsToFetch,
 		MaxConcurrentRequests:      a.MaxConcurrentRequests,
@@ -2038,7 +2038,7 @@ type APISchedulerConfig struct {
 	StepbackTaskFactor            int64   `json:"stepback_task_factor"`
 }
 
-func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
+func (a *APISchedulerConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SchedulerConfig:
 		a.TaskFinder = utility.ToStringPtr(v.TaskFinder)
@@ -2064,7 +2064,7 @@ func (a *APISchedulerConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISchedulerConfig) ToService() (interface{}, error) {
+func (a *APISchedulerConfig) ToService() (any, error) {
 	return evergreen.SchedulerConfig{
 		TaskFinder:                    utility.FromStringPtr(a.TaskFinder),
 		HostAllocator:                 utility.FromStringPtr(a.HostAllocator),
@@ -2130,7 +2130,7 @@ type APIProjectTasksPair struct {
 	AllowedTasks []string `json:"allowed_tasks"`
 }
 
-func (a *APIProjectTasksPair) BuildFromService(h interface{}) error {
+func (a *APIProjectTasksPair) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ProjectTasksPair:
 		a.ProjectID = v.ProjectID
@@ -2141,7 +2141,7 @@ func (a *APIProjectTasksPair) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIProjectTasksPair) ToService() (interface{}, error) {
+func (a *APIProjectTasksPair) ToService() (any, error) {
 	return evergreen.ProjectTasksPair{
 		ProjectID:    a.ProjectID,
 		AllowedTasks: a.AllowedTasks,
@@ -2152,7 +2152,7 @@ type APISingleTaskDistroConfig struct {
 	ProjectTasksPairs []APIProjectTasksPair `json:"project_tasks_pair"`
 }
 
-func (a *APISingleTaskDistroConfig) BuildFromService(h interface{}) error {
+func (a *APISingleTaskDistroConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SingleTaskDistroConfig:
 		apiPairs := []APIProjectTasksPair{}
@@ -2170,7 +2170,7 @@ func (a *APISingleTaskDistroConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISingleTaskDistroConfig) ToService() (interface{}, error) {
+func (a *APISingleTaskDistroConfig) ToService() (any, error) {
 	pairs := []evergreen.ProjectTasksPair{}
 	for _, pair := range a.ProjectTasksPairs {
 		p, err := pair.ToService()
@@ -2197,7 +2197,7 @@ type APISlackConfig struct {
 	Name    *string          `json:"name"`
 }
 
-func (a *APISlackConfig) BuildFromService(h interface{}) error {
+func (a *APISlackConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SlackConfig:
 		a.Token = utility.ToStringPtr(v.Token)
@@ -2215,7 +2215,7 @@ func (a *APISlackConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISlackConfig) ToService() (interface{}, error) {
+func (a *APISlackConfig) ToService() (any, error) {
 	i, err := a.Options.ToService()
 	if err != nil {
 		return nil, err
@@ -2240,7 +2240,7 @@ type APISlackOptions struct {
 	FieldsSet     map[string]bool `json:"fields"`
 }
 
-func (a *APISlackOptions) BuildFromService(h interface{}) error {
+func (a *APISlackOptions) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case send.SlackOptions:
 		a.Channel = utility.ToStringPtr(v.Channel)
@@ -2257,7 +2257,7 @@ func (a *APISlackOptions) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISlackOptions) ToService() (interface{}, error) {
+func (a *APISlackOptions) ToService() (any, error) {
 	if a == nil {
 		return send.SlackOptions{}, nil
 	}
@@ -2277,7 +2277,7 @@ type APISleepScheduleConfig struct {
 	PermanentlyExemptHosts []string `json:"permanently_exempt_hosts"`
 }
 
-func (a *APISleepScheduleConfig) BuildFromService(h interface{}) error {
+func (a *APISleepScheduleConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SleepScheduleConfig:
 		a.PermanentlyExemptHosts = v.PermanentlyExemptHosts
@@ -2287,7 +2287,7 @@ func (a *APISleepScheduleConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISleepScheduleConfig) ToService() (interface{}, error) {
+func (a *APISleepScheduleConfig) ToService() (any, error) {
 	if a == nil {
 		return evergreen.SleepScheduleConfig{}, nil
 	}
@@ -2300,7 +2300,7 @@ type APISplunkConfig struct {
 	SplunkConnectionInfo *APISplunkConnectionInfo `json:"splunk_connection_info"`
 }
 
-func (a *APISplunkConfig) BuildFromService(h interface{}) error {
+func (a *APISplunkConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SplunkConfig:
 		a.SplunkConnectionInfo = &APISplunkConnectionInfo{}
@@ -2311,7 +2311,7 @@ func (a *APISplunkConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APISplunkConfig) ToService() (interface{}, error) {
+func (a *APISplunkConfig) ToService() (any, error) {
 	c := evergreen.SplunkConfig{}
 	if a.SplunkConnectionInfo != nil {
 		c.SplunkConnectionInfo = a.SplunkConnectionInfo.ToService()
@@ -2357,7 +2357,7 @@ type APIUIConfig struct {
 	StagingEnvironment        *string         `json:"staging_environment"`
 }
 
-func (a *APIUIConfig) BuildFromService(h interface{}) error {
+func (a *APIUIConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.UIConfig:
 		a.Url = utility.ToStringPtr(v.Url)
@@ -2384,7 +2384,7 @@ func (a *APIUIConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIUIConfig) ToService() (interface{}, error) {
+func (a *APIUIConfig) ToService() (any, error) {
 	return evergreen.UIConfig{
 		Url:                       utility.FromStringPtr(a.Url),
 		HelpUrl:                   utility.FromStringPtr(a.HelpUrl),
@@ -2413,7 +2413,7 @@ type APINewRelicConfig struct {
 }
 
 // BuildFromService builds a model from the service layer
-func (a *APINewRelicConfig) BuildFromService(h interface{}) error {
+func (a *APINewRelicConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.NewRelicConfig:
 		a.AccountID = utility.ToStringPtr(v.AccountID)
@@ -2428,7 +2428,7 @@ func (a *APINewRelicConfig) BuildFromService(h interface{}) error {
 }
 
 // ToService returns a service model from an API model
-func (a *APINewRelicConfig) ToService() (interface{}, error) {
+func (a *APINewRelicConfig) ToService() (any, error) {
 	return evergreen.NewRelicConfig{
 		AccountID:     utility.FromStringPtr(a.AccountID),
 		TrustKey:      utility.FromStringPtr(a.TrustKey),
@@ -2445,7 +2445,7 @@ type RestartResponse struct {
 }
 
 // BuildFromService builds a model from the service layer
-func (ab *APIBanner) BuildFromService(h interface{}) error {
+func (ab *APIBanner) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case APIBanner:
 		ab.Text = v.Text
@@ -2457,12 +2457,12 @@ func (ab *APIBanner) BuildFromService(h interface{}) error {
 }
 
 // ToService is not yet implemented
-func (ab *APIBanner) ToService() (interface{}, error) {
+func (ab *APIBanner) ToService() (any, error) {
 	return ab, nil
 }
 
 // BuildFromService builds a model from the service layer
-func (as *APIServiceFlags) BuildFromService(h interface{}) error {
+func (as *APIServiceFlags) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.ServiceFlags:
 		as.TaskDispatchDisabled = v.TaskDispatchDisabled
@@ -2505,7 +2505,7 @@ func (as *APIServiceFlags) BuildFromService(h interface{}) error {
 }
 
 // ToService returns a service model from an API model
-func (as *APIServiceFlags) ToService() (interface{}, error) {
+func (as *APIServiceFlags) ToService() (any, error) {
 	return evergreen.ServiceFlags{
 		TaskDispatchDisabled:            as.TaskDispatchDisabled,
 		HostInitDisabled:                as.HostInitDisabled,
@@ -2544,7 +2544,7 @@ func (as *APIServiceFlags) ToService() (interface{}, error) {
 }
 
 // BuildFromService builds a model from the service layer
-func (rtr *RestartResponse) BuildFromService(h interface{}) error {
+func (rtr *RestartResponse) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *RestartResponse:
 		rtr.ItemsRestarted = v.ItemsRestarted
@@ -2556,7 +2556,7 @@ func (rtr *RestartResponse) BuildFromService(h interface{}) error {
 }
 
 // ToService is not implemented for /admin/restart
-func (rtr *RestartResponse) ToService() (interface{}, error) {
+func (rtr *RestartResponse) ToService() (any, error) {
 	return nil, errors.New("ToService not implemented for RestartTasksResponse")
 }
 
@@ -2609,7 +2609,7 @@ type APIJIRANotificationsProject struct {
 	Labels     []string          `json:"labels,omitempty"`
 }
 
-func (j *APIJIRANotificationsConfig) BuildFromService(h interface{}) error {
+func (j *APIJIRANotificationsConfig) BuildFromService(h any) error {
 	var config *evergreen.JIRANotificationsConfig
 	switch v := h.(type) {
 	case *evergreen.JIRANotificationsConfig:
@@ -2633,7 +2633,7 @@ func (j *APIJIRANotificationsConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (j *APIJIRANotificationsConfig) ToService() (interface{}, error) {
+func (j *APIJIRANotificationsConfig) ToService() (any, error) {
 	service := evergreen.JIRANotificationsConfig{}
 	if len(j.CustomFields) == 0 {
 		return service, nil
@@ -2653,7 +2653,7 @@ func (j *APIJIRANotificationsConfig) ToService() (interface{}, error) {
 	return service, nil
 }
 
-func (j *APIJIRANotificationsProject) BuildFromService(h interface{}) error {
+func (j *APIJIRANotificationsProject) BuildFromService(h any) error {
 	serviceProject, ok := h.(evergreen.JIRANotificationsProject)
 	if !ok {
 		return errors.Errorf("programmatic error: expected Jira project notifications config but got type %T", h)
@@ -2670,7 +2670,7 @@ func (j *APIJIRANotificationsProject) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (j *APIJIRANotificationsProject) ToService() (interface{}, error) {
+func (j *APIJIRANotificationsProject) ToService() (any, error) {
 	service := evergreen.JIRANotificationsProject{}
 	for field, template := range j.Fields {
 		service.Fields = append(service.Fields, evergreen.JIRANotificationsCustomField{Field: field, Template: template})
@@ -2685,7 +2685,7 @@ type APITriggerConfig struct {
 	GenerateTaskDistro *string `json:"generate_distro"`
 }
 
-func (c *APITriggerConfig) BuildFromService(h interface{}) error {
+func (c *APITriggerConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.TriggerConfig:
 		c.GenerateTaskDistro = utility.ToStringPtr(v.GenerateTaskDistro)
@@ -2694,7 +2694,7 @@ func (c *APITriggerConfig) BuildFromService(h interface{}) error {
 	}
 	return nil
 }
-func (c *APITriggerConfig) ToService() (interface{}, error) {
+func (c *APITriggerConfig) ToService() (any, error) {
 	return evergreen.TriggerConfig{
 		GenerateTaskDistro: utility.FromStringPtr(c.GenerateTaskDistro),
 	}, nil
@@ -2708,7 +2708,7 @@ type APIHostJasperConfig struct {
 	Version          *string `json:"version,omitempty"`
 }
 
-func (c *APIHostJasperConfig) BuildFromService(h interface{}) error {
+func (c *APIHostJasperConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.HostJasperConfig:
 		c.BinaryName = utility.ToStringPtr(v.BinaryName)
@@ -2722,7 +2722,7 @@ func (c *APIHostJasperConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (c *APIHostJasperConfig) ToService() (interface{}, error) {
+func (c *APIHostJasperConfig) ToService() (any, error) {
 	return evergreen.HostJasperConfig{
 		BinaryName:       utility.FromStringPtr(c.BinaryName),
 		DownloadFileName: utility.FromStringPtr(c.DownloadFileName),
@@ -2738,7 +2738,7 @@ type APISpawnHostConfig struct {
 	SpawnHostsPerUser         *int `json:"spawn_hosts_per_user"`
 }
 
-func (c *APISpawnHostConfig) BuildFromService(h interface{}) error {
+func (c *APISpawnHostConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.SpawnHostConfig:
 		c.UnexpirableHostsPerUser = &v.UnexpirableHostsPerUser
@@ -2750,7 +2750,7 @@ func (c *APISpawnHostConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (c *APISpawnHostConfig) ToService() (interface{}, error) {
+func (c *APISpawnHostConfig) ToService() (any, error) {
 	config := evergreen.SpawnHostConfig{
 		UnexpirableHostsPerUser:   evergreen.DefaultUnexpirableHostsPerUser,
 		UnexpirableVolumesPerUser: evergreen.DefaultUnexpirableVolumesPerUser,
@@ -2776,7 +2776,7 @@ type APITracerSettings struct {
 	CollectorAPIKey           *string `json:"collector_api_key"`
 }
 
-func (c *APITracerSettings) BuildFromService(h interface{}) error {
+func (c *APITracerSettings) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.TracerConfig:
 		c.Enabled = &v.Enabled
@@ -2789,7 +2789,7 @@ func (c *APITracerSettings) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (c *APITracerSettings) ToService() (interface{}, error) {
+func (c *APITracerSettings) ToService() (any, error) {
 	config := evergreen.TracerConfig{
 		Enabled:                   utility.FromBoolPtr(c.Enabled),
 		CollectorEndpoint:         utility.FromStringPtr(c.CollectorEndpoint),
@@ -2804,7 +2804,7 @@ type APIGitHubCheckRunConfig struct {
 	CheckRunLimit *int `json:"check_run_limit"`
 }
 
-func (c *APIGitHubCheckRunConfig) BuildFromService(h interface{}) error {
+func (c *APIGitHubCheckRunConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.GitHubCheckRunConfig:
 		c.CheckRunLimit = utility.ToIntPtr(v.CheckRunLimit)
@@ -2814,7 +2814,7 @@ func (c *APIGitHubCheckRunConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (c *APIGitHubCheckRunConfig) ToService() (interface{}, error) {
+func (c *APIGitHubCheckRunConfig) ToService() (any, error) {
 	config := evergreen.GitHubCheckRunConfig{
 		CheckRunLimit: utility.FromIntPtr(c.CheckRunLimit),
 	}
@@ -2853,7 +2853,7 @@ type APITaskLimitsConfig struct {
 	MaxDailyAutomaticRestarts *int `json:"max_daily_automatic_restarts"`
 }
 
-func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
+func (c *APITaskLimitsConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.TaskLimitsConfig:
 		c.MaxTasksPerVersion = utility.ToIntPtr(v.MaxTasksPerVersion)
@@ -2874,7 +2874,7 @@ func (c *APITaskLimitsConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (c *APITaskLimitsConfig) ToService() (interface{}, error) {
+func (c *APITaskLimitsConfig) ToService() (any, error) {
 	return evergreen.TaskLimitsConfig{
 		MaxTasksPerVersion:                               utility.FromIntPtr(c.MaxTasksPerVersion),
 		MaxIncludesPerVersion:                            utility.FromIntPtr(c.MaxIncludesPerVersion),
@@ -2895,7 +2895,7 @@ type APITestSelectionConfig struct {
 	URL *string `json:"url"`
 }
 
-func (c *APITestSelectionConfig) BuildFromService(h interface{}) error {
+func (c *APITestSelectionConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.TestSelectionConfig:
 		c.URL = utility.ToStringPtr(v.URL)
@@ -2905,7 +2905,7 @@ func (c *APITestSelectionConfig) BuildFromService(h interface{}) error {
 	}
 }
 
-func (c *APITestSelectionConfig) ToService() (interface{}, error) {
+func (c *APITestSelectionConfig) ToService() (any, error) {
 	return evergreen.TestSelectionConfig{
 		URL: utility.FromStringPtr(c.URL),
 	}, nil
@@ -2916,7 +2916,7 @@ type APIRuntimeEnvironmentsConfig struct {
 	APIKey  *string `json:"api_key"`
 }
 
-func (a *APIRuntimeEnvironmentsConfig) BuildFromService(h interface{}) error {
+func (a *APIRuntimeEnvironmentsConfig) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case evergreen.RuntimeEnvironmentsConfig:
 		a.BaseURL = utility.ToStringPtr(v.BaseURL)
@@ -2927,7 +2927,7 @@ func (a *APIRuntimeEnvironmentsConfig) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (a *APIRuntimeEnvironmentsConfig) ToService() (interface{}, error) {
+func (a *APIRuntimeEnvironmentsConfig) ToService() (any, error) {
 	return evergreen.RuntimeEnvironmentsConfig{
 		BaseURL: utility.FromStringPtr(a.BaseURL),
 		APIKey:  utility.FromStringPtr(a.APIKey),

--- a/rest/model/admin_event.go
+++ b/rest/model/admin_event.go
@@ -16,7 +16,7 @@ type APIAdminEvent struct {
 	Guid      string     `json:"guid"`
 }
 
-func (e *APIAdminEvent) BuildFromService(h interface{}) error {
+func (e *APIAdminEvent) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case event.EventLogEntry:
 		e.Timestamp = ToTimePtr(v.Timestamp)
@@ -44,6 +44,6 @@ func (e *APIAdminEvent) BuildFromService(h interface{}) error {
 	return nil
 }
 
-func (e *APIAdminEvent) ToService() (interface{}, error) {
+func (e *APIAdminEvent) ToService() (any, error) {
 	return nil, errors.New("ToService not implemented for APIAdminEvent")
 }

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -395,7 +395,7 @@ func TestAPIServiceFlagsModelInterface(t *testing.T) {
 	allStructFieldsTrue(t, &newFlags)
 }
 
-func allStructFieldsTrue(t *testing.T, s interface{}) {
+func allStructFieldsTrue(t *testing.T, s any) {
 	elem := reflect.ValueOf(s).Elem()
 	for i := 0; i < elem.NumField(); i++ {
 		f := elem.Field(i)

--- a/rest/model/listhost.go
+++ b/rest/model/listhost.go
@@ -16,7 +16,7 @@ type APIHostCreateDetail struct {
 	Error  *string `bson:"error" json:"error"`
 }
 
-func (a *APIHostCreateDetail) BuildFromService(t interface{}) error {
+func (a *APIHostCreateDetail) BuildFromService(t any) error {
 	switch v := t.(type) {
 	case task.HostCreateDetail:
 		a.HostId = utility.ToStringPtr(v.HostId)
@@ -27,6 +27,6 @@ func (a *APIHostCreateDetail) BuildFromService(t interface{}) error {
 	return nil
 }
 
-func (a *APIHostCreateDetail) ToService() (interface{}, error) {
+func (a *APIHostCreateDetail) ToService() (any, error) {
 	return nil, errors.New("ToService() is not implemented for APIHostCreateDetail")
 }

--- a/rest/model/mocks.go
+++ b/rest/model/mocks.go
@@ -15,18 +15,18 @@ type MockSubStruct struct {
 	SubInt int
 }
 
-func (m *MockModel) ToService() (interface{}, error) {
+func (m *MockModel) ToService() (any, error) {
 	return nil, nil
 }
 
-func (m *MockModel) BuildFromService(in interface{}) error {
+func (m *MockModel) BuildFromService(in any) error {
 	return nil
 }
 
 type MockScalars struct {
 	TimeType time.Time
-	MapType  map[string]interface{}
-	AnyType  interface{}
+	MapType  map[string]any
+	AnyType  any
 }
 
 type MockEmbedded struct {

--- a/rest/model/model.go
+++ b/rest/model/model.go
@@ -8,6 +8,6 @@ package model
 // interface{}; instead, pass in and return the actual service model that
 // corresponds to the REST model.
 type Model interface {
-	BuildFromService(interface{}) error
-	ToService() (interface{}, error)
+	BuildFromService(any) error
+	ToService() (any, error)
 }

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -108,7 +108,7 @@ func (e *APIProjectEvent) BuildFromService(entry model.ProjectChangeEventEntry) 
 	return nil
 }
 
-func (e *APIProjectEvent) ToService() (interface{}, error) {
+func (e *APIProjectEvent) ToService() (any, error) {
 	return nil, errors.New("ToService not implemented for APIProjectEvent")
 }
 

--- a/rest/model/project_event_test.go
+++ b/rest/model/project_event_test.go
@@ -202,7 +202,7 @@ func checkSubscriptions(suite *ProjectEventSuite, in []event.Subscription, out [
 	}
 }
 
-func checkSubscriptionTarget(suite *ProjectEventSuite, inTarget interface{}, outTarget interface{}) {
+func checkSubscriptionTarget(suite *ProjectEventSuite, inTarget any, outTarget any) {
 	switch v := inTarget.(type) {
 	case *event.GithubPullRequestSubscriber:
 		outTargetGithub, ok := outTarget.(APIGithubPRSubscriber)

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -17,7 +17,7 @@ type APISubscriber struct {
 	// Target can be either a slice or a string. However, since swaggo does not
 	// support the OpenAPI `oneOf` keyword, we set `swaggerignore` and document
 	// the field manually in the "Fetch all projects" endpoint.
-	Target              interface{}             `json:"target" swaggerignore:"true"`
+	Target              any                     `json:"target" swaggerignore:"true"`
 	WebhookSubscriber   *APIWebhookSubscriber   `json:"-"`
 	JiraIssueSubscriber *APIJIRAIssueSubscriber `json:"-"`
 }
@@ -58,7 +58,7 @@ type APIWebhookHeader struct {
 // BuildFromService for APISubscriber needs to return an error so that we can validate the target interface type.
 func (s *APISubscriber) BuildFromService(in event.Subscriber) error {
 	s.Type = utility.ToStringPtr(in.Type)
-	var target interface{}
+	var target any
 
 	switch in.Type {
 	case event.GithubPullRequestSubscriberType:
@@ -116,7 +116,7 @@ func (s *APISubscriber) BuildFromService(in event.Subscriber) error {
 }
 
 func (s *APISubscriber) ToService() (event.Subscriber, error) {
-	var target interface{}
+	var target any
 	var err error
 	out := event.Subscriber{
 		Type: utility.FromStringPtr(s.Type),
@@ -195,7 +195,7 @@ func (s *APISubscriber) ToService() (event.Subscriber, error) {
 	return out, nil
 }
 
-func (s *APIGithubPRSubscriber) BuildFromService(h interface{}) error {
+func (s *APIGithubPRSubscriber) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *event.GithubPullRequestSubscriber:
 		s.Owner = utility.ToStringPtr(v.Owner)
@@ -218,7 +218,7 @@ func (s *APIGithubCheckSubscriber) ToService() event.GithubCheckSubscriber {
 	}
 }
 
-func (s *APIGithubCheckSubscriber) BuildFromService(h interface{}) error {
+func (s *APIGithubCheckSubscriber) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *event.GithubCheckSubscriber:
 		s.Owner = utility.ToStringPtr(v.Owner)
@@ -240,7 +240,7 @@ func (s *APIGithubMergeSubscriber) ToService() event.GithubMergeSubscriber {
 	}
 }
 
-func (s *APIGithubMergeSubscriber) BuildFromService(h interface{}) error {
+func (s *APIGithubMergeSubscriber) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *event.GithubMergeSubscriber:
 		s.Owner = utility.ToStringPtr(v.Owner)
@@ -263,7 +263,7 @@ func (s *APIGithubPRSubscriber) ToService() event.GithubPullRequestSubscriber {
 	}
 }
 
-func (s *APIWebhookSubscriber) BuildFromService(h interface{}) error {
+func (s *APIWebhookSubscriber) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *event.WebhookSubscriber:
 		s.URL = utility.ToStringPtr(v.URL)
@@ -321,7 +321,7 @@ type APIJIRAIssueSubscriber struct {
 	IssueType *string `json:"issue_type" mapstructure:"issue_type"`
 }
 
-func (s *APIJIRAIssueSubscriber) BuildFromService(h interface{}) error {
+func (s *APIJIRAIssueSubscriber) BuildFromService(h any) error {
 	switch v := h.(type) {
 	case *event.JIRAIssueSubscriber:
 		s.Project = utility.ToStringPtr(v.Project)

--- a/rest/model/subscriber_test.go
+++ b/rest/model/subscriber_test.go
@@ -35,7 +35,7 @@ func TestSubscriberModelsGithubStatusAPI(t *testing.T) {
 	// incoming subscribers have target serialized as a map
 	incoming := APISubscriber{
 		Type: utility.ToStringPtr(event.GithubPullRequestSubscriberType),
-		Target: map[string]interface{}{
+		Target: map[string]any{
 			"owner":     "me",
 			"repo":      "mine",
 			"pr_number": 5,
@@ -78,7 +78,7 @@ func TestSubscriberModelsWebhook(t *testing.T) {
 	// incoming subscribers have target serialized as a map
 	incoming := APISubscriber{
 		Type: utility.ToStringPtr(event.EvergreenWebhookSubscriberType),
-		Target: map[string]interface{}{
+		Target: map[string]any{
 			"url":          "foo",
 			"secret":       evergreen.RedactedValue,
 			"retries":      3,
@@ -116,7 +116,7 @@ func TestSubscriberModelsJIRAIssue(t *testing.T) {
 	// incoming subscribers have target serialized as a map
 	incoming := APISubscriber{
 		Type: utility.ToStringPtr(event.JIRAIssueSubscriberType),
-		Target: map[string]interface{}{
+		Target: map[string]any{
 			"project":    "ABC",
 			"issue_type": "123",
 		},

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -47,7 +47,7 @@ type TestLogs struct {
 	Version       int32   `json:"version"`
 }
 
-func (at *APITest) BuildFromService(st interface{}) error {
+func (at *APITest) BuildFromService(st any) error {
 	env := evergreen.GetEnvironment()
 
 	switch v := st.(type) {
@@ -88,7 +88,7 @@ func (at *APITest) BuildFromService(st interface{}) error {
 	return nil
 }
 
-func (at *APITest) ToService() (interface{}, error) {
+func (at *APITest) ToService() (any, error) {
 	// It is not valid translate an APITest object to a TestResult object
 	// due to data loss.
 	return nil, errors.New("not implemented")

--- a/rest/model/test_test.go
+++ b/rest/model/test_test.go
@@ -19,12 +19,12 @@ func TestTestBuildFromService(t *testing.T) {
 
 	for _, test := range []struct {
 		name   string
-		io     func() (interface{}, *APITest)
+		io     func() (any, *APITest)
 		hasErr bool
 	}{
 		{
 			name: "NoOptionals",
-			io: func() (interface{}, *APITest) {
+			io: func() (any, *APITest) {
 				input := &testresult.TestResult{
 					TaskID:        "task",
 					Execution:     1,
@@ -56,7 +56,7 @@ func TestTestBuildFromService(t *testing.T) {
 		},
 		{
 			name: "Optionals",
-			io: func() (interface{}, *APITest) {
+			io: func() (any, *APITest) {
 				input := &testresult.TestResult{
 					TaskID:          "task",
 					Execution:       1,
@@ -98,7 +98,7 @@ func TestTestBuildFromService(t *testing.T) {
 		},
 		{
 			name: "TaskID",
-			io: func() (interface{}, *APITest) {
+			io: func() (any, *APITest) {
 				output := &APITest{
 					TaskID: utility.ToStringPtr("task"),
 				}
@@ -108,7 +108,7 @@ func TestTestBuildFromService(t *testing.T) {
 		},
 		{
 			name: "InvalidType",
-			io: func() (interface{}, *APITest) {
+			io: func() (any, *APITest) {
 				return &task.Task{}, &APITest{}
 			},
 			hasErr: true,

--- a/rest/model/time.go
+++ b/rest/model/time.go
@@ -45,7 +45,7 @@ func MarshalAPIDuration(b APIDuration) graphql.Marshaler {
 	})
 }
 
-func UnmarshalAPIDuration(v interface{}) (APIDuration, error) {
+func UnmarshalAPIDuration(v any) (APIDuration, error) {
 	switch v := v.(type) {
 	case int:
 		return APIDuration(v), nil

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -375,7 +375,7 @@ func (s *AdminRouteSuite) TestAdminEventRoute() {
 	s.NotNil(resp)
 	count := 0
 
-	data := response.Data().([]interface{})
+	data := response.Data().([]any)
 	for _, model := range data {
 		evt, ok := model.(*restModel.APIAdminEvent)
 		s.True(ok)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1869,9 +1869,9 @@ func (h *awsS3Credentials) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 	// TODO (DEVPROD-13978): Create correct session policy based off of provided task.
-	sessionPolicy := map[string]interface{}{
+	sessionPolicy := map[string]any{
 		"Version": "2012-10-17",
-		"Statement": []map[string]interface{}{
+		"Statement": []map[string]any{
 			{
 				"Effect":   "Deny",
 				"Action":   "*",

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -23,7 +23,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			resp := h.Run(ctx)
 			assert.Equal(t, http.StatusOK, resp.Status())
 
-			payload := resp.Data().([]interface{})
+			payload := resp.Data().([]any)
 			require.Len(t, payload, 1)
 			foundAlias := payload[0].(model.APIProjectAlias)
 			assert.Equal(t, "project_alias", utility.FromStringPtr(foundAlias.Alias))
@@ -41,7 +41,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			resp := h.Run(ctx)
 			assert.Equal(t, http.StatusOK, resp.Status())
 
-			payload := resp.Data().([]interface{})
+			payload := resp.Data().([]any)
 			require.Len(t, payload, 1)
 			foundAlias := payload[0].(model.APIProjectAlias)
 			assert.Equal(t, "repo_alias", utility.FromStringPtr(foundAlias.Alias))
@@ -56,7 +56,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			resp := h.Run(ctx)
 			assert.Equal(t, http.StatusOK, resp.Status())
 
-			payload := resp.Data().([]interface{})
+			payload := resp.Data().([]any)
 			require.Empty(t, payload)
 		},
 		"ReturnsConfigLevelAliases": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
@@ -69,7 +69,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			resp := h.Run(ctx)
 			assert.Equal(t, http.StatusOK, resp.Status())
 
-			payload := resp.Data().([]interface{})
+			payload := resp.Data().([]any)
 			require.Len(t, payload, 1)
 			foundAlias := payload[0].(model.APIProjectAlias)
 			assert.Equal(t, "project_config_alias", utility.FromStringPtr(foundAlias.Alias))

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1353,7 +1353,7 @@ func getMockDistrosdata() error {
 						birch.EC.String("virtual_name", "ephemeral0"),
 					)),
 				)),
-				birch.EC.Interface("mount_points", map[string]interface{}{
+				birch.EC.Interface("mount_points", map[string]any{
 					"device_name":  "/dev/xvdb",
 					"virtual_name": "ephemeral0"}),
 			)},

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -63,7 +63,7 @@ type githubHookApi struct {
 	queue  amboy.Queue
 	secret []byte
 
-	event     interface{}
+	event     any
 	eventType string
 	msgID     string
 	sc        data.Connector

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -744,8 +744,8 @@ func dispatchHostTaskAtomically(ctx context.Context, env evergreen.Environment, 
 	return nil
 }
 
-func dispatchHostTask(env evergreen.Environment, h *host.Host, t *task.Task) func(context.Context) (interface{}, error) {
-	return func(ctx context.Context) (interface{}, error) {
+func dispatchHostTask(env evergreen.Environment, h *host.Host, t *task.Task) func(context.Context) (any, error) {
+	return func(ctx context.Context) (any, error) {
 		if err := h.UpdateRunningTaskWithContext(ctx, env, t); err != nil {
 			return nil, errors.Wrapf(err, "updating running task for host '%s' to '%s'", h.Id, t.Id)
 		}
@@ -798,8 +798,8 @@ func undoHostTaskDispatchAtomically(ctx context.Context, env evergreen.Environme
 	return nil
 }
 
-func undoHostTaskDispatch(env evergreen.Environment, h *host.Host, t *task.Task) func(context.Context) (interface{}, error) {
-	return func(ctx context.Context) (interface{}, error) {
+func undoHostTaskDispatch(env evergreen.Environment, h *host.Host, t *task.Task) func(context.Context) (any, error) {
+	return func(ctx context.Context) (any, error) {
 		if err := h.ClearRunningTaskWithContext(ctx, env); err != nil {
 			return nil, errors.Wrapf(err, "clearing running task '%s' execution '%d' from host '%s'", h.RunningTask, h.RunningTaskExecution, h.Id)
 		}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1002,7 +1002,7 @@ func TestHostFilterGetHandler(t *testing.T) {
 	}
 	resp := handler.Run(gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user0"}))
 	assert.Equal(t, http.StatusOK, resp.Status())
-	hosts := resp.Data().([]interface{})
+	hosts := resp.Data().([]any)
 	require.Len(t, hosts, 1)
 	assert.Equal(t, "h0", utility.FromStringPtr(hosts[0].(*restmodel.APIHost).Id))
 
@@ -1011,7 +1011,7 @@ func TestHostFilterGetHandler(t *testing.T) {
 	}
 	resp = handler.Run(gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user0"}))
 	assert.Equal(t, http.StatusOK, resp.Status())
-	hosts = resp.Data().([]interface{})
+	hosts = resp.Data().([]any)
 	require.Len(t, hosts, 1)
 	assert.Equal(t, "h1", utility.FromStringPtr(hosts[0].(*restmodel.APIHost).Id))
 
@@ -1020,7 +1020,7 @@ func TestHostFilterGetHandler(t *testing.T) {
 	}
 	resp = handler.Run(gimlet.AttachUser(context.Background(), &user.DBUser{Id: "user1"}))
 	assert.Equal(t, http.StatusOK, resp.Status())
-	hosts = resp.Data().([]interface{})
+	hosts = resp.Data().([]any)
 	require.Len(t, hosts, 1)
 	assert.Equal(t, "h2", utility.FromStringPtr(hosts[0].(*restmodel.APIHost).Id))
 }

--- a/rest/route/keys_test.go
+++ b/rest/route/keys_test.go
@@ -69,7 +69,7 @@ func (s *UserConnectorSuite) TestGetSSHKeys() {
 	resp := s.get.Run(ctx)
 
 	s.Equal(http.StatusOK, resp.Status())
-	payload := resp.Data().([]interface{})
+	payload := resp.Data().([]any)
 	s.Len(payload, 2)
 	for i, result := range payload {
 		s.IsType(new(model.APIPubKey), result)

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -175,7 +175,7 @@ func (s *PatchesByProjectSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 	resp := s.route.Run(context.Background())
 	s.NotNil(resp)
 
-	payload := resp.Data().([]interface{})
+	payload := resp.Data().([]any)
 	s.NotNil(payload)
 
 	s.Len(payload, 2)
@@ -197,7 +197,7 @@ func (s *PatchesByProjectSuite) TestPaginatorShouldReturnEmptyResultsIfDataIsEmp
 	s.route.limit = 100
 
 	resp := s.route.Run(context.Background())
-	s.Len(resp.Data().([]interface{}), 2)
+	s.Len(resp.Data().([]any), 2)
 
 	s.Nil(resp.Pages())
 }
@@ -541,7 +541,7 @@ func (s *PatchesByUserSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 
 	resp := s.route.Run(context.Background())
 	s.Equal(http.StatusOK, resp.Status())
-	payload := resp.Data().([]interface{})
+	payload := resp.Data().([]any)
 
 	s.Len(payload, 2)
 	s.Equal(s.now.Add(time.Second*6), *(payload[0]).(restModel.APIPatch).CreateTime)
@@ -565,7 +565,7 @@ func (s *PatchesByUserSuite) TestPaginatorShouldReturnEmptyResultsIfDataIsEmpty(
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
 
-	s.Len(resp.Data().([]interface{}), 2)
+	s.Len(resp.Data().([]any), 2)
 
 	s.Nil(resp.Pages())
 }

--- a/rest/route/project_events_test.go
+++ b/rest/route/project_events_test.go
@@ -86,7 +86,7 @@ func (s *ProjectEventsTestSuite) TestGetProjectEvents() {
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
 
-	responseData, ok := resp.Data().([]interface{})
+	responseData, ok := resp.Data().([]any)
 	s.Require().True(ok)
 	apiEvent := responseData[0].(*restModel.APIProjectEvent)
 	s.Equal(s.event.Before.ProjectRef.Identifier, *apiEvent.Before.ProjectRef.Identifier)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -799,7 +799,7 @@ func (s *ProjectGetSuite) TestPaginatorShouldReturnResultsIfDataExists() {
 
 	resp := s.route.Run(ctx)
 	s.NotNil(resp)
-	payload := resp.Data().([]interface{})
+	payload := resp.Data().([]any)
 
 	s.Len(payload, 1)
 	s.Equal(utility.ToStringPtr("projectC"), (payload[0]).(*model.APIProjectRef).Id)
@@ -819,7 +819,7 @@ func (s *ProjectGetSuite) TestPaginatorShouldReturnEmptyResultsIfDataIsEmpty() {
 
 	resp := s.route.Run(ctx)
 	s.NotNil(resp)
-	payload := resp.Data().([]interface{})
+	payload := resp.Data().([]any)
 
 	s.Len(payload, 6)
 	s.Equal(utility.ToStringPtr("projectA"), (payload[0]).(*model.APIProjectRef).Id, payload[0])

--- a/rest/route/reliability_test.go
+++ b/rest/route/reliability_test.go
@@ -59,7 +59,7 @@ func truncatedTime(deltaHours time.Duration) time.Time {
 	return time.Now().UTC().Add(deltaHours).Truncate(24 * time.Hour)
 }
 
-func getURL(projectID string, parameters map[string]interface{}) string {
+func getURL(projectID string, parameters map[string]any) string {
 	url := fmt.Sprintf("https://example.net/api/rest/v2/projects/%s/logs/task_reliability", projectID)
 	params := []string{}
 	for key, value := range parameters {
@@ -438,7 +438,7 @@ func TestReliabilityParse(t *testing.T) {
 					err := setupTest(t)
 					require.NoError(t, err)
 
-					url := getURL(projectID, map[string]interface{}{
+					url := getURL(projectID, map[string]any{
 						"tasks":         "aggregation_expression_multiversion_fuzzer",
 						"after_date":    "2019-01-02",
 						"group_by_days": "10",
@@ -521,7 +521,7 @@ func TestReliabilityRun(t *testing.T) {
 
 					require.NotNil(t, resp)
 					require.Equal(t, http.StatusOK, resp.Status())
-					data := resp.Data().([]interface{})
+					data := resp.Data().([]any)
 					require.Empty(t, data)
 					require.Nil(t, resp.Pages())
 				},
@@ -565,7 +565,7 @@ func TestReliabilityRun(t *testing.T) {
 
 					require.NotNil(t, resp)
 					require.Equal(t, http.StatusOK, resp.Status())
-					data := resp.Data().([]interface{})
+					data := resp.Data().([]any)
 					require.Len(t, data, 1)
 					require.NotNil(t, resp.Pages())
 				},
@@ -609,7 +609,7 @@ func TestReliabilityRun(t *testing.T) {
 
 					require.NotNil(t, resp)
 					require.Equal(t, http.StatusOK, resp.Status())
-					data := resp.Data().([]interface{})
+					data := resp.Data().([]any)
 					require.Len(t, data, handler.filter.StatsFilter.Limit)
 					require.NotNil(t, resp.Pages())
 				},
@@ -658,7 +658,7 @@ func TestReliabilityRun(t *testing.T) {
 
 					require.NotNil(t, resp)
 					require.Equal(t, http.StatusOK, resp.Status())
-					data := resp.Data().([]interface{})
+					data := resp.Data().([]any)
 					require.Len(t, data, handler.filter.StatsFilter.Limit-1)
 					require.Nil(t, resp.Pages())
 				},
@@ -707,7 +707,7 @@ func TestReliabilityRun(t *testing.T) {
 
 					require.NotNil(t, resp)
 					require.Equal(t, http.StatusOK, resp.Status())
-					respData := resp.Data().([]interface{})
+					respData := resp.Data().([]any)
 					require.Len(t, respData, handler.filter.StatsFilter.Limit)
 					require.NotNil(t, resp.Pages())
 					docs, err := data.GetTaskReliabilityScores(handler.filter)
@@ -772,7 +772,7 @@ func TestReliability(t *testing.T) {
 				"Less Than One Page": func(ctx context.Context, t *testing.T) {
 					err := setupTest(t)
 					require.NoError(t, err)
-					url := getURL(projectID, map[string]interface{}{
+					url := getURL(projectID, map[string]any{
 						"tasks":         "aggregation_expression_multiversion_fuzzer",
 						"after_date":    "2019-01-02",
 						"group_by_days": "10",
@@ -821,7 +821,7 @@ func TestReliability(t *testing.T) {
 				"Exactly One Page": func(ctx context.Context, t *testing.T) {
 					err := setupTest(t)
 					require.NoError(t, err)
-					url := getURL(projectID, map[string]interface{}{
+					url := getURL(projectID, map[string]any{
 						"tasks":         "aggregation_expression_multiversion_fuzzer",
 						"after_date":    "2019-01-02",
 						"group_by_days": "10",
@@ -874,7 +874,7 @@ func TestReliability(t *testing.T) {
 				"More Than One Page": func(ctx context.Context, t *testing.T) {
 					err := setupTest(t)
 					require.NoError(t, err)
-					url := getURL(projectID, map[string]interface{}{
+					url := getURL(projectID, map[string]any{
 						"tasks":         "aggregation_expression_multiversion_fuzzer",
 						"after_date":    "2019-01-02",
 						"group_by_days": "10",

--- a/rest/route/service_test.go
+++ b/rest/route/service_test.go
@@ -91,7 +91,7 @@ func TestHostPaginator(t *testing.T) {
 				" a full next and previous page and a full set of models", func() {
 				hostToStartAt := 100
 				limit := 100
-				expectedHosts := []interface{}{}
+				expectedHosts := []any{}
 				for i := hostToStartAt; i < hostToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -146,7 +146,7 @@ func TestHostPaginator(t *testing.T) {
 				" a limited next and full previous page and a full set of models", func() {
 				hostToStartAt := 150
 				limit := 100
-				expectedHosts := []interface{}{}
+				expectedHosts := []any{}
 				for i := hostToStartAt; i < hostToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -202,7 +202,7 @@ func TestHostPaginator(t *testing.T) {
 				" a full next and a limited previous page and a full set of models", func() {
 				hostToStartAt := 50
 				limit := 100
-				expectedHosts := []interface{}{}
+				expectedHosts := []any{}
 				for i := hostToStartAt; i < hostToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -257,7 +257,7 @@ func TestHostPaginator(t *testing.T) {
 				" page and a full set of models", func() {
 				hostToStartAt := 0
 				limit := 100
-				expectedHosts := []interface{}{}
+				expectedHosts := []any{}
 				for i := hostToStartAt; i < hostToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -350,7 +350,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				" a full next and previous page and a full set of models", func() {
 				taskToStartAt := 100
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -392,7 +392,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				" a limited next and full previous page and a full set of models", func() {
 				taskToStartAt := 150
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -439,7 +439,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				" a full next and a limited previous page and a full set of models", func() {
 				taskToStartAt := 50
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -482,7 +482,7 @@ func TestTasksByProjectAndCommitPaginator(t *testing.T) {
 				" page and a full set of models", func() {
 				taskToStartAt := 0
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -604,7 +604,7 @@ func TestTaskByBuildPaginator(t *testing.T) {
 				" a full next and previous page and a full set of models", func() {
 				taskToStartAt := 100
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -648,7 +648,7 @@ func TestTaskByBuildPaginator(t *testing.T) {
 				" a limited next and full previous page and a full set of models", func() {
 				taskToStartAt := 150
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -692,7 +692,7 @@ func TestTaskByBuildPaginator(t *testing.T) {
 				" a full next and a limited previous page and a full set of models", func() {
 				taskToStartAt := 50
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -736,7 +736,7 @@ func TestTaskByBuildPaginator(t *testing.T) {
 				" page and a full set of models", func() {
 				taskToStartAt := 0
 				limit := 100
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				for i := taskToStartAt; i < taskToStartAt+limit; i++ {
 					prefix := int(math.Log10(float64(i)))
 					if i == 0 {
@@ -776,7 +776,7 @@ func TestTaskByBuildPaginator(t *testing.T) {
 			})
 
 			Convey("pagination with tasks with previous executions", func() {
-				expectedTasks := []interface{}{}
+				expectedTasks := []any{}
 				serviceModel := &task.Task{
 					Id: "0build0",
 				}
@@ -1276,7 +1276,7 @@ func TestParentTaskInfo(t *testing.T) {
 	assert.True(t, tbh.fetchParentIds)
 
 	resp := tbh.Run(ctx)
-	data, ok := resp.Data().([]interface{})
+	data, ok := resp.Data().([]any)
 	assert.True(t, ok)
 	assert.Len(t, data, 3)
 
@@ -1305,7 +1305,7 @@ func TestOptionsRequest(t *testing.T) {
 
 }
 
-func validatePaginatedResponse(t *testing.T, h gimlet.RouteHandler, expected []interface{}, pages *gimlet.ResponsePages) {
+func validatePaginatedResponse(t *testing.T, h gimlet.RouteHandler, expected []any, pages *gimlet.ResponsePages) {
 	require.NotNil(t, h)
 	require.NotNil(t, pages)
 
@@ -1332,7 +1332,7 @@ func validatePaginatedResponse(t *testing.T, h gimlet.RouteHandler, expected []i
 
 	assert.EqualValues(t, pages, rpg)
 
-	data, ok := resp.Data().([]interface{})
+	data, ok := resp.Data().([]any)
 	assert.True(t, ok)
 
 	if !assert.Equal(t, len(expected), len(data)) {

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -185,7 +185,7 @@ func TestECSSNSHandleNotification(t *testing.T) {
 		taskARN = "external_id"
 	)
 
-	makeJSON := func(t *testing.T, i interface{}) json.RawMessage {
+	makeJSON := func(t *testing.T, i any) json.RawMessage {
 		b, err := json.Marshal(i)
 		require.NoError(t, err)
 		return json.RawMessage(b)

--- a/rest/route/status_test.go
+++ b/rest/route/status_test.go
@@ -215,29 +215,29 @@ func (s *StatusSuite) TaskTaskType() {
 	resp := s.h.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
-	found := resp.Data().([]interface{})[0].(*model.APITask)
+	found := resp.Data().([]any)[0].(*model.APITask)
 	s.Equal(utility.ToStringPtr("task1"), found.Id)
 
 	s.h.taskType = evergreen.TaskStarted
 	resp = s.h.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
-	found = resp.Data().([]interface{})[0].(*model.APITask)
+	found = resp.Data().([]any)[0].(*model.APITask)
 	s.Equal(utility.ToStringPtr("task2"), found.Id)
 
 	s.h.taskType = evergreen.TaskSucceeded
 	resp = s.h.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
-	found = resp.Data().([]interface{})[0].(*model.APITask)
+	found = resp.Data().([]any)[0].(*model.APITask)
 	s.Equal(utility.ToStringPtr("task3"), found.Id)
-	found = resp.Data().([]interface{})[1].(*model.APITask)
+	found = resp.Data().([]any)[1].(*model.APITask)
 	s.Equal(utility.ToStringPtr("task4"), found.Id)
 
 	s.h.taskType = evergreen.TaskSystemTimedOut
 	resp = s.h.Run(context.Background())
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
-	found = resp.Data().([]interface{})[0].(*model.APITask)
+	found = resp.Data().([]any)[0].(*model.APITask)
 	s.Equal(utility.ToStringPtr("task5"), found.Id)
 }

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -38,7 +38,7 @@ func (s *SubscriptionRouteSuite) SetupTest() {
 func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -74,7 +74,7 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 
 	// test updating the same subscription
 	id := dbSubscriptions[0].ID
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"id":            id,
 		"resource_type": event.ResourceTypePatch,
 		"trigger":       "outcome",
@@ -109,7 +109,7 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "myproj",
@@ -144,7 +144,7 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 
 	// test updating the same subscription
 	id := dbSubscriptions[0].ID
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"id":            id,
 		"resource_type": event.ResourceTypePatch,
 		"trigger":       "outcome",
@@ -192,7 +192,7 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 func (s *SubscriptionRouteSuite) TestPostUnauthorizedUser() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "not_me",
@@ -281,7 +281,7 @@ func (s *SubscriptionRouteSuite) TestGetWithoutUser() {
 func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -290,7 +290,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 			"type": event.SelectorObject,
 			"data": "version",
 		}},
-		"subscriber": map[string]interface{}{
+		"subscriber": map[string]any{
 			"type": "jira-issue",
 			"target": map[string]string{
 				"project":    "ABC",
@@ -311,7 +311,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 	s.Contains(respErr.Message, "cannot notify by subscriber type 'jira-issue' for selector 'version'")
 
 	//test that project-level subscriptions are allowed
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -320,7 +320,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 			"type": event.SelectorProject,
 			"data": "mci",
 		}},
-		"subscriber": map[string]interface{}{
+		"subscriber": map[string]any{
 			"type": "jira-issue",
 			"target": map[string]string{
 				"project":    "ABC",
@@ -339,7 +339,7 @@ func (s *SubscriptionRouteSuite) TestDisallowedSubscription() {
 func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -368,7 +368,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 	s.True(ok)
 	s.Contains(respErr.Message, "invalid task duration")
 
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -397,7 +397,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 	s.True(ok)
 	s.Contains(respErr.Message, "cannot be negative")
 
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -426,7 +426,7 @@ func (s *SubscriptionRouteSuite) TestInvalidTriggerData() {
 	s.True(ok)
 	s.Contains(respErr.Message, "parsing 'a' as float")
 
-	body = []map[string]interface{}{{
+	body = []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -459,7 +459,7 @@ func (s *SubscriptionRouteSuite) TestInvalidRegexSelectors() {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -510,7 +510,7 @@ func (s *SubscriptionRouteSuite) TestRejectSubscriptionWithoutSelectors() {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",
@@ -538,7 +538,7 @@ func (s *SubscriptionRouteSuite) TestAcceptSubscriptionWithOnlyRegexSelectors() 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	body := []map[string]interface{}{{
+	body := []map[string]any{{
 		"resource_type": event.ResourceTypeTask,
 		"trigger":       "outcome",
 		"owner":         "me",

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -184,7 +184,7 @@ func (tgh *testGetHandler) buildResponse(results []testresult.TestResult, key st
 	return resp
 }
 
-func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, result interface{}) error {
+func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, result any) error {
 	at := &model.APITest{}
 	if err := at.BuildFromService(tgh.taskID); err != nil {
 		return gimlet.ErrorResponse{

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -53,7 +53,7 @@ func (s *UserRouteSuite) TestUpdateNotifications() {
 	s.NoError(err)
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := map[string]interface{}{
+	body := map[string]any{
 		"slack_username":  "@test",
 		"slack_member_id": "NOTES25BA",
 		"notifications": map[string]string{
@@ -92,7 +92,7 @@ func (s *UserRouteSuite) TestUndefinedInput() {
 	}
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me", Settings: settings})
-	body := map[string]interface{}{
+	body := map[string]any{
 		"notifications": map[string]string{
 			"build_break": "slack",
 		},
@@ -121,10 +121,10 @@ func (s *UserRouteSuite) TestSaveFeedback() {
 	s.NoError(err)
 	ctx := context.Background()
 	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	body := map[string]interface{}{
-		"spruce_feedback": map[string]interface{}{
+	body := map[string]any{
+		"spruce_feedback": map[string]any{
 			"type": "someType",
-			"questions": []map[string]interface{}{
+			"questions": []map[string]any{
 				{"id": "1", "prompt": "this is a question", "answer": "this is an answer"},
 			},
 		},

--- a/service/flash.go
+++ b/service/flash.go
@@ -33,7 +33,7 @@ func NewErrorFlash(message string) flashMessage {
 	return flashMessage{Severity: FlashSeverityError, Message: message}
 }
 
-func PopFlashes(store *sessions.CookieStore, r *http.Request, w http.ResponseWriter) []interface{} {
+func PopFlashes(store *sessions.CookieStore, r *http.Request, w http.ResponseWriter) []any {
 	session, _ := store.Get(r, FlashSession)
 	flashes := session.Flashes()
 	grip.Warning(session.Save(r, w))

--- a/service/models.go
+++ b/service/models.go
@@ -25,7 +25,7 @@ type hostsData struct {
 type pluginData struct {
 	Includes []template.HTML
 	Panels   plugin.PanelLayout
-	Data     map[string]interface{}
+	Data     map[string]any
 }
 
 type uiVersion struct {
@@ -51,7 +51,7 @@ type uiUpstreamData struct {
 
 type uiPatch struct {
 	Patch       patch.Patch
-	StatusDiffs interface{}
+	StatusDiffs any
 
 	// only used on task pages
 	BaseTimeTaken time.Duration `json:"base_time_taken"`

--- a/service/plugin.go
+++ b/service/plugin.go
@@ -28,7 +28,7 @@ func (uis *UIServer) GetPluginHandler(uiPage *plugin.UIPage) func(http.ResponseW
 			return
 		}
 		data := struct {
-			Data interface{}
+			Data any
 			ViewData
 		}{pluginData, uis.GetCommonViewData(w, r, false, true)}
 

--- a/service/rest_build_test.go
+++ b/service/rest_build_test.go
@@ -91,7 +91,7 @@ func TestGetBuildInfo(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -132,13 +132,13 @@ func TestGetBuildInfo(t *testing.T) {
 
 			_jsonTasks, ok := jsonBody["tasks"]
 			So(ok, ShouldBeTrue)
-			jsonTasks, ok := _jsonTasks.(map[string]interface{})
+			jsonTasks, ok := _jsonTasks.(map[string]any)
 			So(ok, ShouldBeTrue)
 			So(len(jsonTasks), ShouldEqual, 1)
 
 			_jsonTask, ok := jsonTasks[task.DisplayName]
 			So(ok, ShouldBeTrue)
-			jsonTask, ok := _jsonTask.(map[string]interface{})
+			jsonTask, ok := _jsonTask.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(jsonTask["task_id"], ShouldEqual, task.Id)
@@ -168,7 +168,7 @@ func TestGetBuildInfo(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -223,7 +223,7 @@ func TestGetBuildStatus(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -236,13 +236,13 @@ func TestGetBuildStatus(t *testing.T) {
 
 			_jsonTasks, ok := jsonBody["tasks"]
 			So(ok, ShouldBeTrue)
-			jsonTasks, ok := _jsonTasks.(map[string]interface{})
+			jsonTasks, ok := _jsonTasks.(map[string]any)
 			So(ok, ShouldBeTrue)
 			So(len(jsonTasks), ShouldEqual, 1)
 
 			_jsonTask, ok := jsonTasks[task.DisplayName]
 			So(ok, ShouldBeTrue)
-			jsonTask, ok := _jsonTask.(map[string]interface{})
+			jsonTask, ok := _jsonTask.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(jsonTask["task_id"], ShouldEqual, task.Id)
@@ -268,7 +268,7 @@ func TestGetBuildStatus(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)

--- a/service/rest_project_test.go
+++ b/service/rest_project_test.go
@@ -153,7 +153,7 @@ func TestProjectRoutes(t *testing.T) {
 			Convey("for a public user", func() {
 				router.ServeHTTP(response, request)
 				So(response.Code, ShouldEqual, http.StatusNotFound)
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 				So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -162,7 +162,7 @@ func TestProjectRoutes(t *testing.T) {
 				request.AddCookie(&http.Cookie{Name: evergreen.AuthTokenCookie, Value: "token"})
 				router.ServeHTTP(response, request)
 				So(response.Code, ShouldEqual, http.StatusNotFound)
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 				So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -69,7 +69,7 @@ type taskStatusDetails struct {
 type taskTestResult struct {
 	Status    string        `json:"status"`
 	TimeTaken time.Duration `json:"time_taken"`
-	Logs      interface{}   `json:"logs"`
+	Logs      any           `json:"logs"`
 }
 
 type taskTestLogURL struct {

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -133,7 +133,7 @@ func TestGetTaskInfo(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database and should omit hidden artifacts", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -199,7 +199,7 @@ func TestGetTaskInfo(t *testing.T) {
 
 			jsonStatusDetails, ok := jsonBody["status_details"]
 			So(ok, ShouldBeTrue)
-			statusDetails, ok := jsonStatusDetails.(map[string]interface{})
+			statusDetails, ok := jsonStatusDetails.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(statusDetails["timed_out"], ShouldEqual, testTask.Details.TimedOut)
@@ -211,13 +211,13 @@ func TestGetTaskInfo(t *testing.T) {
 
 			jsonTestResults, ok := jsonBody["test_results"]
 			So(ok, ShouldBeTrue)
-			testResults, ok := jsonTestResults.(map[string]interface{})
+			testResults, ok := jsonTestResults.(map[string]any)
 			So(ok, ShouldBeTrue)
 			So(len(testResults), ShouldEqual, 1)
 
 			jsonTestResult, ok := testResults[testResult.TestName]
 			So(ok, ShouldBeTrue)
-			testResultForTestName, ok := jsonTestResult.(map[string]interface{})
+			testResultForTestName, ok := jsonTestResult.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(testResultForTestName["status"], ShouldEqual, testResult.Status)
@@ -225,12 +225,12 @@ func TestGetTaskInfo(t *testing.T) {
 
 			jsonTestResultLogs, ok := testResultForTestName["logs"]
 			So(ok, ShouldBeTrue)
-			testResultLogs, ok := jsonTestResultLogs.(map[string]interface{})
+			testResultLogs, ok := jsonTestResultLogs.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(testResultLogs["url"], ShouldEqual, testResult.LogURL)
 
-			var jsonFiles []map[string]interface{}
+			var jsonFiles []map[string]any
 			err = json.Unmarshal(*rawJSONBody["files"], &jsonFiles)
 			So(err, ShouldBeNil)
 			So(len(jsonFiles), ShouldEqual, 1)
@@ -258,7 +258,7 @@ func TestGetTaskInfo(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -316,7 +316,7 @@ func TestGetTaskStatus(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -330,7 +330,7 @@ func TestGetTaskStatus(t *testing.T) {
 
 			jsonStatusDetails, ok := jsonBody["status_details"]
 			So(ok, ShouldBeTrue)
-			statusDetails, ok := jsonStatusDetails.(map[string]interface{})
+			statusDetails, ok := jsonStatusDetails.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(statusDetails["timed_out"], ShouldEqual, testTask.Details.TimedOut)
@@ -338,13 +338,13 @@ func TestGetTaskStatus(t *testing.T) {
 
 			jsonTestResults, ok := jsonBody["tests"]
 			So(ok, ShouldBeTrue)
-			testResults, ok := jsonTestResults.(map[string]interface{})
+			testResults, ok := jsonTestResults.(map[string]any)
 			So(ok, ShouldBeTrue)
 			So(len(testResults), ShouldEqual, 1)
 
 			jsonTestResult, ok := testResults[testResult.TestName]
 			So(ok, ShouldBeTrue)
-			testResultForTestName, ok := jsonTestResult.(map[string]interface{})
+			testResultForTestName, ok := jsonTestResult.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(testResultForTestName["status"], ShouldEqual, testResult.Status)
@@ -352,7 +352,7 @@ func TestGetTaskStatus(t *testing.T) {
 
 			jsonTestResultLogs, ok := testResultForTestName["logs"]
 			So(ok, ShouldBeTrue)
-			testResultLogs, ok := jsonTestResultLogs.(map[string]interface{})
+			testResultLogs, ok := jsonTestResultLogs.(map[string]any)
 			So(ok, ShouldBeTrue)
 
 			So(testResultLogs["url"], ShouldEqual, testResult.LogURL)
@@ -376,7 +376,7 @@ func TestGetTaskStatus(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -437,12 +437,12 @@ func TestGetDisplayTaskInfo(t *testing.T) {
 
 	assert.Equal(http.StatusOK, response.Code)
 
-	var jsonBody map[string]interface{}
+	var jsonBody map[string]any
 	err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 
 	assert.NoError(err)
 	assert.Equal(displayTask.Id, jsonBody["id"])
-	found, ok := jsonBody["test_results"].(map[string]interface{})
+	found, ok := jsonBody["test_results"].(map[string]any)
 	assert.True(ok)
 	assert.Contains(found, "some-test")
 }

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -135,7 +135,7 @@ func TestGetRecentVersions(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should match contents of database", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			link := response.Header().Get("Link")
@@ -149,7 +149,7 @@ func TestGetRecentVersions(t *testing.T) {
 
 			So(jsonBody["project"], ShouldEqual, projectName)
 
-			var jsonVersions []map[string]interface{}
+			var jsonVersions []map[string]any
 			err = json.Unmarshal(*rawJsonBody["versions"], &jsonVersions)
 			So(err, ShouldBeNil)
 			So(len(jsonVersions), ShouldEqual, len(versions))
@@ -164,13 +164,13 @@ func TestGetRecentVersions(t *testing.T) {
 
 				_jsonBuilds, ok := jsonVersion["builds"]
 				So(ok, ShouldBeTrue)
-				jsonBuilds, ok := _jsonBuilds.(map[string]interface{})
+				jsonBuilds, ok := _jsonBuilds.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(len(jsonBuilds), ShouldEqual, 1)
 
 				_jsonBuild, ok := jsonBuilds[builds[i].BuildVariant]
 				So(ok, ShouldBeTrue)
-				jsonBuild, ok := _jsonBuild.(map[string]interface{})
+				jsonBuild, ok := _jsonBuild.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				So(jsonBuild["build_id"], ShouldEqual, builds[i].Id)
@@ -178,13 +178,13 @@ func TestGetRecentVersions(t *testing.T) {
 
 				_jsonTasks, ok := jsonBuild["tasks"]
 				So(ok, ShouldBeTrue)
-				jsonTasks, ok := _jsonTasks.(map[string]interface{})
+				jsonTasks, ok := _jsonTasks.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(len(jsonTasks), ShouldEqual, 1)
 
 				_jsonTask, ok := jsonTasks[tasks[i].DisplayName]
 				So(ok, ShouldBeTrue)
-				jsonTask, ok := _jsonTask.(map[string]interface{})
+				jsonTask, ok := _jsonTask.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				So(jsonTask["task_id"], ShouldEqual, tasks[i].Id)
@@ -211,7 +211,7 @@ func TestGetRecentVersions(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusOK)
 
 		Convey("response should contain no versions", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -221,7 +221,7 @@ func TestGetRecentVersions(t *testing.T) {
 
 			So(jsonBody["project"], ShouldEqual, projectName)
 
-			var jsonVersions []map[string]interface{}
+			var jsonVersions []map[string]any
 			err = json.Unmarshal(*rawJsonBody["versions"], &jsonVersions)
 			So(err, ShouldBeNil)
 			So(jsonVersions, ShouldBeEmpty)
@@ -314,7 +314,7 @@ func TestGetVersionInfo(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -400,7 +400,7 @@ func TestGetVersionInfoViaRevision(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -462,7 +462,7 @@ func TestActivateVersion(t *testing.T) {
 
 		url := "/rest/v1/versions/" + versionId
 
-		var body = map[string]interface{}{
+		var body = map[string]any{
 			"activated": true,
 		}
 		jsonBytes, err := json.Marshal(body)
@@ -489,7 +489,7 @@ func TestActivateVersion(t *testing.T) {
 
 		url := "/rest/v1/versions/" + versionId
 
-		var body = map[string]interface{}{
+		var body = map[string]any{
 			"activated": true,
 		}
 		jsonBytes, err := json.Marshal(body)
@@ -507,7 +507,7 @@ func TestActivateVersion(t *testing.T) {
 		So(response.Code, ShouldEqual, http.StatusNotFound)
 
 		Convey("response should contain a sensible error message", func() {
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 			So(len(jsonBody["message"].(string)), ShouldBeGreaterThan, 0)
@@ -519,7 +519,7 @@ func TestActivateVersion(t *testing.T) {
 
 		url := "/rest/v1/versions/" + versionId
 
-		var body = map[string]interface{}{
+		var body = map[string]any{
 			"activated": true,
 		}
 		jsonBytes, err := json.Marshal(body)
@@ -587,7 +587,7 @@ func TestGetVersionStatus(t *testing.T) {
 			So(response.Code, ShouldEqual, http.StatusOK)
 
 			Convey("response should match contents of database", func() {
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 
@@ -595,18 +595,18 @@ func TestGetVersionStatus(t *testing.T) {
 
 				_jsonTasks, ok := jsonBody["tasks"]
 				So(ok, ShouldBeTrue)
-				jsonTasks, ok := _jsonTasks.(map[string]interface{})
+				jsonTasks, ok := _jsonTasks.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(len(jsonTasks), ShouldEqual, 1)
 
 				_jsonTask, ok := jsonTasks[task.DisplayName]
 				So(ok, ShouldBeTrue)
-				jsonTask, ok := _jsonTask.(map[string]interface{})
+				jsonTask, ok := _jsonTask.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				_jsonBuild, ok := jsonTask[task.BuildVariant]
 				So(ok, ShouldBeTrue)
-				jsonBuild, ok := _jsonBuild.(map[string]interface{})
+				jsonBuild, ok := _jsonBuild.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				So(jsonBuild["task_id"], ShouldEqual, task.Id)
@@ -648,7 +648,7 @@ func TestGetVersionStatus(t *testing.T) {
 			So(response.Code, ShouldEqual, http.StatusOK)
 
 			Convey("response should match contents of database", func() {
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 
@@ -656,18 +656,18 @@ func TestGetVersionStatus(t *testing.T) {
 
 				_jsonBuilds, ok := jsonBody["builds"]
 				So(ok, ShouldBeTrue)
-				jsonBuilds, ok := _jsonBuilds.(map[string]interface{})
+				jsonBuilds, ok := _jsonBuilds.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(len(jsonBuilds), ShouldEqual, 1)
 
 				_jsonBuild, ok := jsonBuilds[build.BuildVariant]
 				So(ok, ShouldBeTrue)
-				jsonBuild, ok := _jsonBuild.(map[string]interface{})
+				jsonBuild, ok := _jsonBuild.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				_jsonTask, ok := jsonBuild[task.DisplayName]
 				So(ok, ShouldBeTrue)
-				jsonTask, ok := _jsonTask.(map[string]interface{})
+				jsonTask, ok := _jsonTask.(map[string]any)
 				So(ok, ShouldBeTrue)
 
 				So(jsonTask["task_id"], ShouldEqual, task.Id)
@@ -692,7 +692,7 @@ func TestGetVersionStatus(t *testing.T) {
 
 			So(response.Code, ShouldEqual, http.StatusBadRequest)
 
-			var jsonBody map[string]interface{}
+			var jsonBody map[string]any
 			err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 			So(err, ShouldBeNil)
 
@@ -721,13 +721,13 @@ func TestGetVersionStatus(t *testing.T) {
 			So(response.Code, ShouldEqual, http.StatusOK)
 
 			Convey("response should contain a sensible error message", func() {
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 
 				_jsonTasks, ok := jsonBody["tasks"]
 				So(ok, ShouldBeTrue)
-				jsonTasks, ok := _jsonTasks.(map[string]interface{})
+				jsonTasks, ok := _jsonTasks.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(jsonTasks, ShouldBeEmpty)
 			})
@@ -751,13 +751,13 @@ func TestGetVersionStatus(t *testing.T) {
 			So(response.Code, ShouldEqual, http.StatusOK)
 
 			Convey("response should contain a sensible error message", func() {
-				var jsonBody map[string]interface{}
+				var jsonBody map[string]any
 				err = json.Unmarshal(response.Body.Bytes(), &jsonBody)
 				So(err, ShouldBeNil)
 
 				_jsonBuilds, ok := jsonBody["builds"]
 				So(ok, ShouldBeTrue)
-				jsonBuilds, ok := _jsonBuilds.(map[string]interface{})
+				jsonBuilds, ok := _jsonBuilds.(map[string]any)
 				So(ok, ShouldBeTrue)
 				So(jsonBuilds, ShouldBeEmpty)
 			})
@@ -767,7 +767,7 @@ func TestGetVersionStatus(t *testing.T) {
 
 func validateVersionInfo(v *model.Version, response *httptest.ResponseRecorder) {
 	Convey("response should match contents of database", func() {
-		var jsonBody map[string]interface{}
+		var jsonBody map[string]any
 		err := json.Unmarshal(response.Body.Bytes(), &jsonBody)
 		So(err, ShouldBeNil)
 

--- a/service/spawn.go
+++ b/service/spawn.go
@@ -202,10 +202,10 @@ func (uis *UIServer) listSpawnableDistros(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	distroList := []map[string]interface{}{}
+	distroList := []map[string]any{}
 	for _, d := range distros {
 		regions := d.GetRegionsList(uis.Settings.Providers.AWS.AllowedRegions)
-		distroList = append(distroList, map[string]interface{}{
+		distroList = append(distroList, map[string]any{
 			"name":                        d.Id,
 			"virtual_workstation_allowed": d.IsVirtualWorkstation,
 			"is_cluster":                  d.IsCluster,

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -213,7 +213,7 @@ func (uis *UIServer) variantHistory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uis.render.WriteResponse(w, http.StatusOK, struct {
-		Data interface{}
+		Data any
 		ViewData
 	}{data, uis.GetCommonViewData(w, r, false, true)}, "base",
 		"build_variant_history.html", "base_angular.html", "menu.html")

--- a/service/templatefuncs.go
+++ b/service/templatefuncs.go
@@ -18,8 +18,8 @@ type TemplateFunctionOptions struct {
 }
 
 // MakeTemplateFuncs creates and registers all of our built-in template functions.
-func MakeTemplateFuncs(fo TemplateFunctionOptions) map[string]interface{} {
-	r := map[string]interface{}{
+func MakeTemplateFuncs(fo TemplateFunctionOptions) map[string]any {
+	r := map[string]any{
 		// DateFormat returns a time Formatted to the given layout and
 		// time zone. If the time zone is unset, it defaults to
 		// `America/New_York`.

--- a/service/ui.go
+++ b/service/ui.go
@@ -58,7 +58,7 @@ type ViewData struct {
 	User        *user.DBUser
 	ProjectData projectContext
 	Project     model.Project
-	Flashes     []interface{}
+	Flashes     []any
 	Banner      string
 	BannerTheme string
 	Csrf        htmlTemplate.HTML

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -266,7 +266,7 @@ func MockConfig() *evergreen.Settings {
 		ParameterStore: evergreen.ParameterStoreConfig{
 			Prefix: "/prefix",
 		},
-		Plugins: map[string]map[string]interface{}{"k4": {"k5": "v5"}},
+		Plugins: map[string]map[string]any{"k4": {"k5": "v5"}},
 		PodLifecycle: evergreen.PodLifecycleConfig{
 			MaxParallelPodRequests:      2000,
 			MaxPodDefinitionCleanupRate: 100,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -757,7 +757,7 @@ func GetBranchEvent(ctx context.Context, owner, repo, branch string) (*github.Br
 }
 
 // githubRequest performs the specified http request. If the oauth token field is empty it will not use oauth
-func githubRequest(ctx context.Context, method string, url string, oauthToken string, data interface{}) (*http.Response, error) {
+func githubRequest(ctx context.Context, method string, url string, oauthToken string, data any) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
@@ -790,7 +790,7 @@ func githubRequest(ctx context.Context, method string, url string, oauthToken st
 }
 
 // tryGithubPost posts the data to the Github api endpoint with the url given
-func tryGithubPost(ctx context.Context, url string, oauthToken string, data interface{}) (resp *http.Response, err error) {
+func tryGithubPost(ctx context.Context, url string, oauthToken string, data any) (resp *http.Response, err error) {
 	err = utility.Retry(ctx, func() (bool, error) {
 		grip.Info(message.Fields{
 			"message": "Attempting GitHub API POST",

--- a/thirdparty/jira.go
+++ b/thirdparty/jira.go
@@ -120,9 +120,9 @@ func (jiraHandler *JiraHandler) JiraHost() string { return jiraHandler.opts.Base
 
 // CreateTicket takes a map of fields to initialize a JIRA ticket with. Returns a response containing the
 // new ticket's key, id, and API URL. See the JIRA API documentation for help.
-func (jiraHandler *JiraHandler) CreateTicket(fields map[string]interface{}) (*JiraCreateTicketResponse, error) {
+func (jiraHandler *JiraHandler) CreateTicket(fields map[string]any) (*JiraCreateTicketResponse, error) {
 	postArgs := struct {
-		Fields map[string]interface{} `json:"fields"`
+		Fields map[string]any `json:"fields"`
 	}{fields}
 	apiEndpoint := fmt.Sprintf("%s/rest/api/2/issue", jiraHandler.JiraHost())
 	body := &bytes.Buffer{}
@@ -157,10 +157,10 @@ func (jiraHandler *JiraHandler) CreateTicket(fields map[string]interface{}) (*Ji
 }
 
 // UpdateTicket sets the given fields of the ticket with the given key. Returns any errors JIRA returns.
-func (jiraHandler *JiraHandler) UpdateTicket(key string, fields map[string]interface{}) error {
+func (jiraHandler *JiraHandler) UpdateTicket(key string, fields map[string]any) error {
 	apiEndpoint := fmt.Sprintf("%s/rest/api/2/issue/%v", jiraHandler.JiraHost(), url.QueryEscape(key))
 	putArgs := struct {
-		Fields map[string]interface{} `json:"fields"`
+		Fields map[string]any `json:"fields"`
 	}{fields}
 	body := &bytes.Buffer{}
 	if err := json.NewEncoder(body).Encode(putArgs); err != nil {

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -126,7 +126,7 @@ func (t *hostTriggers) Fetch(ctx context.Context, e *event.EventLogEntry) error 
 }
 
 func (t *hostTriggers) generateExpiration(sub *event.Subscription) (*notification.Notification, error) {
-	var payload interface{}
+	var payload any
 	var err error
 	switch sub.Subscriber.Type {
 	case event.EmailSubscriberType:
@@ -144,7 +144,7 @@ func (t *hostTriggers) generateExpiration(sub *event.Subscription) (*notificatio
 }
 
 func (t *hostTriggers) generateTemporaryExemptionExpiration(sub *event.Subscription) (*notification.Notification, error) {
-	var payload interface{}
+	var payload any
 	var err error
 	switch sub.Subscriber.Type {
 	case event.EmailSubscriberType:

--- a/trigger/host_spawn.go
+++ b/trigger/host_spawn.go
@@ -127,7 +127,7 @@ func (t *spawnHostProvisioningTriggers) email() *message.Email {
 	}
 }
 
-func (t *spawnHostProvisioningTriggers) makePayload(sub *event.Subscription) interface{} {
+func (t *spawnHostProvisioningTriggers) makePayload(sub *event.Subscription) any {
 	switch sub.Subscriber.Type {
 	case event.SlackSubscriberType:
 		return t.slack()
@@ -203,7 +203,7 @@ func (t *spawnHostStateChangeTriggers) spawnHostStateChangeOutcome(ctx context.C
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
 
-func (t *spawnHostStateChangeTriggers) makePayload(sub *event.Subscription) (interface{}, error) {
+func (t *spawnHostStateChangeTriggers) makePayload(sub *event.Subscription) (any, error) {
 	var action string
 	switch t.event.EventType {
 	case event.EventSpawnHostCreatedError, event.EventHostCreatedError:
@@ -300,7 +300,7 @@ func (t *spawnHostSetupScriptTriggers) spawnHostSetupScriptOutcome(ctx context.C
 	return notification.New(t.event.ID, sub.Trigger, &sub.Subscriber, payload)
 }
 
-func (t *spawnHostSetupScriptTriggers) makePayload(ctx context.Context, sub *event.Subscription) (interface{}, error) {
+func (t *spawnHostSetupScriptTriggers) makePayload(ctx context.Context, sub *event.Subscription) (any, error) {
 	var result string
 	switch t.event.EventType {
 	case event.EventHostScriptExecuted:

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -53,7 +53,7 @@ type commonTemplateData struct {
 	ProjectRef *model.ProjectRef
 	Build      *build.Build
 
-	apiModel interface{}
+	apiModel any
 	slack    []message.SlackAttachment
 
 	githubContext     string
@@ -297,7 +297,7 @@ func emailPayload(t *commonTemplateData) (*message.Email, error) {
 	return &m, nil
 }
 
-func webhookPayload(api interface{}, headers http.Header) (*util.EvergreenWebhook, error) {
+func webhookPayload(api any, headers http.Header) (*util.EvergreenWebhook, error) {
 	bytes, err := json.Marshal(api)
 	if err != nil {
 		return nil, errors.Wrap(err, "building JSON model")
@@ -397,7 +397,7 @@ func truncateString(s string, capacity int) (string, string) {
 }
 
 func makeCommonPayload(sub *event.Subscription, eventAttributes event.Attributes,
-	data *commonTemplateData) (interface{}, error) {
+	data *commonTemplateData) (any, error) {
 	var err error
 	headerMap := eventAttributes.ToSelectorMap()
 	headerMap["trigger"] = append(headerMap["trigger"], sub.Trigger)

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -124,7 +124,7 @@ func getShouldExecuteError(t, previousTask *task.Task) message.Fields {
 	}
 
 	if previousTask != nil {
-		m["previous"] = map[string]interface{}{
+		m["previous"] = map[string]any{
 			"id":          previousTask.Id,
 			"variant":     previousTask.BuildVariant,
 			"project":     previousTask.Project,
@@ -333,7 +333,7 @@ func (t *taskTriggers) makeData(sub *event.Subscription, pastTenseOverride, test
 }
 
 func (t *taskTriggers) generate(ctx context.Context, sub *event.Subscription, pastTenseOverride, testNames string) (*notification.Notification, error) {
-	var payload interface{}
+	var payload any
 	if sub.Subscriber.Type == event.JIRAIssueSubscriberType {
 		issueSub, ok := sub.Subscriber.Target.(*event.JIRAIssueSubscriber)
 		if !ok {

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -238,7 +238,7 @@ func (j *jiraBuilder) build(ctx context.Context) (*message.JiraIssue, error) {
 		return nil, errors.Wrap(err, "creating summary")
 	}
 
-	fields := map[string]interface{}{}
+	fields := map[string]any{}
 	components := []string{}
 	labels := []string{}
 	for _, project := range j.mappings.CustomFields {
@@ -333,8 +333,8 @@ func (j *jiraBuilder) getSummary() (string, error) {
 	return subj.String(), catcher.Resolve()
 }
 
-func (j *jiraBuilder) makeCustomFields(customFields []evergreen.JIRANotificationsCustomField) map[string]interface{} {
-	fields := map[string]interface{}{}
+func (j *jiraBuilder) makeCustomFields(customFields []evergreen.JIRANotificationsCustomField) map[string]any {
+	fields := map[string]any{}
 	for i := range j.data.Task.LocalTestResults {
 		if j.data.Task.LocalTestResults[i].Status == evergreen.TestFailedStatus {
 			j.data.FailedTests = append(j.data.FailedTests, j.data.Task.LocalTestResults[i])

--- a/trigger/volume.go
+++ b/trigger/volume.go
@@ -77,7 +77,7 @@ func makeVolumeTriggers() eventHandler {
 }
 
 func (t *volumeTriggers) generate(sub *event.Subscription) (*notification.Notification, error) {
-	var payload interface{}
+	var payload any
 	var err error
 	switch sub.Subscriber.Type {
 	case event.EmailSubscriberType:

--- a/util/copy.go
+++ b/util/copy.go
@@ -10,7 +10,7 @@ import (
 // It uses json marshalling to do so, so the src and copy params must be
 // json encodable and decodable.
 // It only works with public fields.
-func DeepCopy(src, copy interface{}) error {
+func DeepCopy(src, copy any) error {
 	b, err := json.Marshal(src)
 	if err != nil {
 		return errors.Wrap(err, "marshalling source")

--- a/util/expand_params.go
+++ b/util/expand_params.go
@@ -18,7 +18,7 @@ const (
 // Taking in the input and expansions map, apply the expansions to any
 // appropriate fields in the input.  The input must be a pointer to a struct
 // so that the underlying struct can be modified.
-func ExpandValues(input interface{}, expansions *Expansions) error {
+func ExpandValues(input any, expansions *Expansions) error {
 
 	// make sure the input is a pointer to a map or struct
 	if reflect.ValueOf(input).Type().Kind() != reflect.Ptr {

--- a/util/http.go
+++ b/util/http.go
@@ -28,7 +28,7 @@ func GetIntValue(r *http.Request, valueKey string, defaultValue int) (int, error
 // JSON. If successful, it returns the gimlet.ErrorResponse wrapped with the
 // HTTP status code and the formatted error message. Otherwise, it returns an
 // error message with the HTTP status and raw response body.
-func RespErrorf(resp *http.Response, format string, args ...interface{}) error {
+func RespErrorf(resp *http.Response, format string, args ...any) error {
 	return RespError(resp, fmt.Sprintf(format, args...))
 }
 

--- a/util/key_val_pair.go
+++ b/util/key_val_pair.go
@@ -7,8 +7,8 @@ import (
 )
 
 type KeyValuePair struct {
-	Key   string      `bson:"key" json:"key" yaml:"key"`
-	Value interface{} `bson:"value" json:"value" yaml:"value"`
+	Key   string `bson:"key" json:"key" yaml:"key"`
+	Value any    `bson:"value" json:"value" yaml:"value"`
 }
 
 type KeyValuePairSlice []KeyValuePair

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -73,7 +73,7 @@ func (w *evergreenWebhookMessage) Loggable() bool {
 	return err == nil
 }
 
-func (w *evergreenWebhookMessage) Raw() interface{} {
+func (w *evergreenWebhookMessage) Raw() any {
 	return &w.raw
 }
 

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -13,7 +13,7 @@ const UnmarshalStrictError = "error unmarshalling yaml strict"
 // UnmarshalYAMLWithFallback attempts to use yaml v3 to unmarshal, but on failure attempts yaml v2. If this
 // succeeds then we can assume in is outdated yaml and requires v2, otherwise we only return the error relevant to the
 // current yaml version. This should only be used for cases where we expect v3 to fail for legacy cases.
-func UnmarshalYAMLWithFallback(in []byte, out interface{}) error {
+func UnmarshalYAMLWithFallback(in []byte, out any) error {
 	err := yaml.Unmarshal(in, out)
 	if err != nil {
 		// try the older version of yaml before erroring, in case it's just an outdated yaml
@@ -27,7 +27,7 @@ func UnmarshalYAMLWithFallback(in []byte, out interface{}) error {
 // UnmarshalYAMLStrictWithFallback attempts to use yaml v3 to unmarshal strict, but on failure attempts yaml v2. If this
 // succeeds then we can assume in is outdated yaml and requires v2, otherwise we only return the error relevant to the
 // current yaml version. This should only be used for cases where we expect v3 to fail for legacy cases.
-func UnmarshalYAMLStrictWithFallback(in []byte, out interface{}) error {
+func UnmarshalYAMLStrictWithFallback(in []byte, out any) error {
 	d := yaml.NewDecoder(bytes.NewReader(in))
 	d.KnownFields(true)
 	if err := d.Decode(out); err != nil {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -69,7 +69,7 @@ type ValidationError struct {
 
 type ValidationErrors []ValidationError
 
-func (v ValidationErrors) Raw() interface{} {
+func (v ValidationErrors) Raw() any {
 	return v
 }
 func (v ValidationErrors) Loggable() bool {
@@ -86,7 +86,7 @@ func (v ValidationErrors) String() string {
 
 	return out
 }
-func (v ValidationErrors) Annotate(key string, value interface{}) error {
+func (v ValidationErrors) Annotate(key string, value any) error {
 	return nil
 }
 func (v ValidationErrors) Priority() level.Priority {
@@ -1925,7 +1925,7 @@ func validateDuplicateBVTasks(p *model.Project) ValidationErrors {
 	errors := []ValidationError{}
 
 	for _, bv := range p.BuildVariants {
-		tasksFound := map[string]interface{}{}
+		tasksFound := map[string]any{}
 		for _, t := range bv.Tasks {
 
 			if t.IsGroup {
@@ -1952,7 +1952,7 @@ func validateDuplicateBVTasks(p *model.Project) ValidationErrors {
 	return errors
 }
 
-func checkOrAddTask(task, variant string, tasksFound map[string]interface{}) *ValidationError {
+func checkOrAddTask(task, variant string, tasksFound map[string]any) *ValidationError {
 	if _, found := tasksFound[task]; found {
 		return &ValidationError{
 			Level:   Error,

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3112,8 +3112,8 @@ func TestCheckTaskCommands(t *testing.T) {
 							Commands: []model.PluginCommandConf{
 								{
 									Command: "gotest.parse_files",
-									Params: map[string]interface{}{
-										"files": []interface{}{"test"},
+									Params: map[string]any{
+										"files": []any{"test"},
 									},
 								},
 							},
@@ -3132,8 +3132,8 @@ func TestCheckTaskCommands(t *testing.T) {
 								{
 									Command: "gotest.parse_files",
 									Type:    "setup",
-									Params: map[string]interface{}{
-										"files": []interface{}{"test"},
+									Params: map[string]any{
+										"files": []any{"test"},
 									},
 								},
 							},
@@ -3463,7 +3463,7 @@ func TestValidatePluginCommands(t *testing.T) {
 							{
 								Function: "",
 								Command:  "a.b",
-								Params:   map[string]interface{}{},
+								Params:   map[string]any{},
 							},
 						},
 					},
@@ -3478,8 +3478,8 @@ func TestValidatePluginCommands(t *testing.T) {
 					"funcOne": {
 						SingleCommand: &model.PluginCommandConf{
 							Command: "gotest.parse_files",
-							Params: map[string]interface{}{
-								"blah": []interface{}{"test"},
+							Params: map[string]any{
+								"blah": []any{"test"},
 							},
 						},
 					},
@@ -3516,8 +3516,8 @@ tasks:
 						SingleCommand: &model.PluginCommandConf{
 							Command: "shell.exec",
 							Type:    "system",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3535,7 +3535,7 @@ tasks:
 						SingleCommand: &model.PluginCommandConf{
 							Command: "shell.exec",
 							Type:    "system",
-							Params: map[string]interface{}{
+							Params: map[string]any{
 								"script": "echo hi",
 							},
 						},
@@ -3568,8 +3568,8 @@ tasks:
 					"funcOne": {
 						SingleCommand: &model.PluginCommandConf{
 							Command: "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3581,8 +3581,8 @@ tasks:
 							{
 								Function: "funcOne",
 								Command:  "gotest.parse_files",
-								Params: map[string]interface{}{
-									"files": []interface{}{"test"},
+								Params: map[string]any{
+									"files": []any{"test"},
 								},
 							},
 						},
@@ -3598,8 +3598,8 @@ tasks:
 				Functions: map[string]*model.YAMLCommandSet{
 					"funcOne": {
 						SingleCommand: &model.PluginCommandConf{
-							Params: map[string]interface{}{
-								"blah": []interface{}{"test"},
+							Params: map[string]any{
+								"blah": []any{"test"},
 							},
 						},
 					},
@@ -3614,8 +3614,8 @@ tasks:
 					"funcOne": {
 						SingleCommand: &model.PluginCommandConf{
 							Command: "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3631,16 +3631,16 @@ tasks:
 						SingleCommand: &model.PluginCommandConf{
 							Function: "b",
 							Command:  "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
 					"b": {
 						SingleCommand: &model.PluginCommandConf{
 							Command: "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3657,8 +3657,8 @@ tasks:
 						SingleCommand: &model.PluginCommandConf{
 							Function: "b",
 							Command:  "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3674,7 +3674,7 @@ tasks:
 					MultiCommand: []model.PluginCommandConf{
 						{
 							Command: "gotest.parse_files",
-							Params:  map[string]interface{}{},
+							Params:  map[string]any{},
 						},
 					},
 				},
@@ -3689,8 +3689,8 @@ tasks:
 						{
 							Function: "",
 							Command:  "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3705,7 +3705,7 @@ tasks:
 						{
 							Function: "",
 							Command:  "gotest.parse_files",
-							Params:   map[string]interface{}{},
+							Params:   map[string]any{},
 						},
 					},
 				},
@@ -3720,8 +3720,8 @@ tasks:
 						{
 							Function: "",
 							Command:  "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3736,7 +3736,7 @@ tasks:
 						{
 							Function: "",
 							Command:  "gotest.parse_files",
-							Params:   map[string]interface{}{},
+							Params:   map[string]any{},
 						},
 					},
 				},
@@ -3751,8 +3751,8 @@ tasks:
 						{
 							Function: "",
 							Command:  "gotest.parse_files",
-							Params: map[string]interface{}{
-								"files": []interface{}{"test"},
+							Params: map[string]any{
+								"files": []any{"test"},
 							},
 						},
 					},
@@ -3770,7 +3770,7 @@ tasks:
 							{
 								Function: "",
 								Command:  "archive.targz_pack",
-								Params: map[string]interface{}{
+								Params: map[string]any{
 									"target":     "tgz",
 									"source_dir": "src",
 									"include":    []string{":"},
@@ -3791,7 +3791,7 @@ tasks:
 							{
 								Function: "",
 								Command:  "archive.targz_pack",
-								Params: map[string]interface{}{
+								Params: map[string]any{
 									"target":     "tgz",
 									"source_dir": "src",
 									"include":    []string{":"},
@@ -3805,16 +3805,16 @@ tasks:
 			So(validatePluginCommands(project), ShouldResemble, ValidationErrors{})
 		})
 		Convey("an error should be thrown if a referenced plugin contains invalid parameters", func() {
-			params := map[string]interface{}{
+			params := map[string]any{
 				"aws_key":    "key",
 				"aws_secret": "sec",
-				"s3_copy_files": []interface{}{
-					map[string]interface{}{
-						"source": map[string]interface{}{
+				"s3_copy_files": []any{
+					map[string]any{
+						"source": map[string]any{
 							"bucket": "long3nough",
 							"path":   "fghij",
 						},
-						"destination": map[string]interface{}{
+						"destination": map[string]any{
 							"bucket": "..long-but-invalid",
 							"path":   "fghij",
 						},
@@ -3841,16 +3841,16 @@ tasks:
 		Convey("no error should be thrown if a referenced plugin that "+
 			"exists contains params that appear invalid but are in expansions",
 			func() {
-				params := map[string]interface{}{
+				params := map[string]any{
 					"aws_key":    "key",
 					"aws_secret": "sec",
-					"s3_copy_files": []interface{}{
-						map[string]interface{}{
-							"source": map[string]interface{}{
+					"s3_copy_files": []any{
+						map[string]any{
+							"source": map[string]any{
 								"bucket": "long3nough",
 								"path":   "fghij",
 							},
-							"destination": map[string]interface{}{
+							"destination": map[string]any{
 								"bucket": "${..longButInvalid}",
 								"path":   "fghij",
 							},
@@ -3875,16 +3875,16 @@ tasks:
 			})
 		Convey("no error should be thrown if a referenced plugin contains all "+
 			"the necessary and valid parameters", func() {
-			params := map[string]interface{}{
+			params := map[string]any{
 				"aws_key":    "key",
 				"aws_secret": "sec",
-				"s3_copy_files": []interface{}{
-					map[string]interface{}{
-						"source": map[string]interface{}{
+				"s3_copy_files": []any{
+					map[string]any{
+						"source": map[string]any{
 							"bucket": "abcde",
 							"path":   "fghij",
 						},
-						"destination": map[string]interface{}{
+						"destination": map[string]any{
 							"bucket": "abcde",
 							"path":   "fghij",
 						},


### PR DESCRIPTION
DEVPROD-15353

### Description
Ran
```
gofmt -r 'interface{} -> any' -w .
```
