### PR TITLE
DEVPROD-13207: set EC2 hostname during host provisioning

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -20,7 +20,6 @@ import (
 )
 
 type TaskConfig struct {
-	// kim: TODO: add hostname as data to fetch for task.
 	Distro       *apimodels.DistroView
 	ProjectRef   model.ProjectRef
 	Project      model.Project
@@ -230,19 +229,18 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 
 func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 	attributes := map[string]string{
-		evergreen.TaskIDOtelAttribute:            tc.Task.Id,
-		evergreen.TaskNameOtelAttribute:          tc.Task.DisplayName,
-		evergreen.TaskExecutionOtelAttribute:     strconv.Itoa(tc.Task.Execution),
-		evergreen.VersionIDOtelAttribute:         tc.Task.Version,
-		evergreen.VersionRequesterOtelAttribute:  tc.Task.Requester,
-		evergreen.BuildIDOtelAttribute:           tc.Task.BuildId,
-		evergreen.BuildNameOtelAttribute:         tc.Task.BuildVariant,
-		evergreen.ProjectIdentifierOtelAttribute: tc.ProjectRef.Identifier,
-		evergreen.ProjectOrgOtelAttribute:        tc.ProjectRef.Owner,
-		evergreen.ProjectRepoOtelAttribute:       tc.ProjectRef.Repo,
-		evergreen.ProjectIDOtelAttribute:         tc.ProjectRef.Id,
-		evergreen.DistroIDOtelAttribute:          tc.Task.DistroId,
-		// kim: TODO: add hostname attribute fetched from Evergreen.
+		evergreen.TaskIDOtelAttribute:             tc.Task.Id,
+		evergreen.TaskNameOtelAttribute:           tc.Task.DisplayName,
+		evergreen.TaskExecutionOtelAttribute:      strconv.Itoa(tc.Task.Execution),
+		evergreen.VersionIDOtelAttribute:          tc.Task.Version,
+		evergreen.VersionRequesterOtelAttribute:   tc.Task.Requester,
+		evergreen.BuildIDOtelAttribute:            tc.Task.BuildId,
+		evergreen.BuildNameOtelAttribute:          tc.Task.BuildVariant,
+		evergreen.ProjectIdentifierOtelAttribute:  tc.ProjectRef.Identifier,
+		evergreen.ProjectOrgOtelAttribute:         tc.ProjectRef.Owner,
+		evergreen.ProjectRepoOtelAttribute:        tc.ProjectRef.Repo,
+		evergreen.ProjectIDOtelAttribute:          tc.ProjectRef.Id,
+		evergreen.DistroIDOtelAttribute:           tc.Task.DistroId,
 		evergreen.VersionDescriptionOtelAttribute: tc.PatchOrVersionDescription,
 	}
 	if tc.GithubPatchData.PRNumber != 0 {

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -20,6 +20,7 @@ import (
 )
 
 type TaskConfig struct {
+	// kim: TODO: add hostname as data to fetch for task.
 	Distro       *apimodels.DistroView
 	ProjectRef   model.ProjectRef
 	Project      model.Project
@@ -229,18 +230,19 @@ func NewTaskConfig(workDir string, d *apimodels.DistroView, p *model.Project, t 
 
 func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 	attributes := map[string]string{
-		evergreen.TaskIDOtelAttribute:             tc.Task.Id,
-		evergreen.TaskNameOtelAttribute:           tc.Task.DisplayName,
-		evergreen.TaskExecutionOtelAttribute:      strconv.Itoa(tc.Task.Execution),
-		evergreen.VersionIDOtelAttribute:          tc.Task.Version,
-		evergreen.VersionRequesterOtelAttribute:   tc.Task.Requester,
-		evergreen.BuildIDOtelAttribute:            tc.Task.BuildId,
-		evergreen.BuildNameOtelAttribute:          tc.Task.BuildVariant,
-		evergreen.ProjectIdentifierOtelAttribute:  tc.ProjectRef.Identifier,
-		evergreen.ProjectOrgOtelAttribute:         tc.ProjectRef.Owner,
-		evergreen.ProjectRepoOtelAttribute:        tc.ProjectRef.Repo,
-		evergreen.ProjectIDOtelAttribute:          tc.ProjectRef.Id,
-		evergreen.DistroIDOtelAttribute:           tc.Task.DistroId,
+		evergreen.TaskIDOtelAttribute:            tc.Task.Id,
+		evergreen.TaskNameOtelAttribute:          tc.Task.DisplayName,
+		evergreen.TaskExecutionOtelAttribute:     strconv.Itoa(tc.Task.Execution),
+		evergreen.VersionIDOtelAttribute:         tc.Task.Version,
+		evergreen.VersionRequesterOtelAttribute:  tc.Task.Requester,
+		evergreen.BuildIDOtelAttribute:           tc.Task.BuildId,
+		evergreen.BuildNameOtelAttribute:         tc.Task.BuildVariant,
+		evergreen.ProjectIdentifierOtelAttribute: tc.ProjectRef.Identifier,
+		evergreen.ProjectOrgOtelAttribute:        tc.ProjectRef.Owner,
+		evergreen.ProjectRepoOtelAttribute:       tc.ProjectRef.Repo,
+		evergreen.ProjectIDOtelAttribute:         tc.ProjectRef.Id,
+		evergreen.DistroIDOtelAttribute:          tc.Task.DistroId,
+		// kim: TODO: add hostname attribute fetched from Evergreen.
 		evergreen.VersionDescriptionOtelAttribute: tc.PatchOrVersionDescription,
 	}
 	if tc.GithubPatchData.PRNumber != 0 {

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -28,7 +28,7 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 		if instanceID == "" {
 			return "", errors.New("instance ID from response is empty")
 		}
-		return string(instanceID), nil
+		return instanceID, nil
 	})
 }
 
@@ -45,7 +45,7 @@ func GetEC2HostName(ctx context.Context) (string, error) {
 		if hostName == "" {
 			return "", errors.New("host name from response is empty")
 		}
-		return string(hostName), nil
+		return hostName, nil
 	})
 }
 

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -30,7 +30,6 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 
 // GetEC2Hostname returns the public hostname from the metadata endpoint if it's
 // an EC2 instance.
-// kim: TODO: test on EC2 hosts in staging.
 func GetEC2Hostname(ctx context.Context) (string, error) {
 	return getEC2Metadata(ctx, "public-hostname", func(resp *http.Response) (string, error) {
 		instanceID, err := io.ReadAll(resp.Body)

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -19,25 +19,33 @@ const metadataBaseURL = "http://169.254.169.254/latest/meta-data"
 // an EC2 instance.
 func GetEC2InstanceID(ctx context.Context) (string, error) {
 	return getEC2Metadata(ctx, "instance-id", func(resp *http.Response) (string, error) {
-		instanceID, err := io.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "reading response body")
 		}
 
+		instanceID := string(b)
+		if instanceID == "" {
+			return "", errors.New("instance ID from response is empty")
+		}
 		return string(instanceID), nil
 	})
 }
 
-// GetEC2Hostname returns the public hostname from the metadata endpoint if it's
-// an EC2 instance.
-func GetEC2Hostname(ctx context.Context) (string, error) {
+// GetEC2HostName returns the public host name from the metadata endpoint if
+// it's an EC2 instance.
+func GetEC2HostName(ctx context.Context) (string, error) {
 	return getEC2Metadata(ctx, "public-hostname", func(resp *http.Response) (string, error) {
-		instanceID, err := io.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "reading response body")
 		}
 
-		return string(instanceID), nil
+		hostName := string(b)
+		if hostName == "" {
+			return "", errors.New("host name from response is empty")
+		}
+		return string(hostName), nil
 	})
 }
 

--- a/agent/util/ec2_test.go
+++ b/agent/util/ec2_test.go
@@ -22,7 +22,7 @@ func TestGetEC2InstanceID(t *testing.T) {
 func TestGetEC2Hostname(t *testing.T) {
 	skipEC2TestOnNonEC2Instance(t)
 
-	hostname, err := GetEC2Hostname(t.Context())
+	hostname, err := GetEC2HostName(t.Context())
 	require.NoError(t, err)
 	assert.NotZero(t, hostname)
 	assert.Contains(t, hostname, "amazonaws.com")

--- a/agent/util/ec2_test.go
+++ b/agent/util/ec2_test.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"context"
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/stretchr/testify/assert"
@@ -15,13 +13,19 @@ import (
 func TestGetEC2InstanceID(t *testing.T) {
 	skipEC2TestOnNonEC2Instance(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	instanceID, err := GetEC2InstanceID(ctx)
+	instanceID, err := GetEC2InstanceID(t.Context())
 	require.NoError(t, err)
 	assert.NotZero(t, instanceID)
 	assert.True(t, cloud.IsEC2InstanceID(instanceID))
+}
+
+func TestGetEC2Hostname(t *testing.T) {
+	skipEC2TestOnNonEC2Instance(t)
+
+	hostname, err := GetEC2Hostname(t.Context())
+	require.NoError(t, err)
+	assert.NotZero(t, hostname)
+	assert.Contains(t, hostname, "amazonaws.com")
 }
 
 // skipEC2TestOnNonEC2Instance skips a test that can only be run on an EC2

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-27"
+	AgentVersion = "2025-02-28"
 )
 
 const (

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1318,27 +1318,30 @@ func (h *Host) Terminate(ctx context.Context, user, reason string) error {
 	return nil
 }
 
-// SetDNSName updates the DNS name for a given host once
+// SetDNSName updates the DNS name for a given host. If the dnsName is empty,
+// this will no-op and will not unset the existing DNS name.
 func (h *Host) SetDNSName(ctx context.Context, dnsName string) error {
-	err := UpdateOne(
+	if h.Host == dnsName || dnsName == "" {
+		return nil
+	}
+
+	if err := UpdateOne(
 		ctx,
 		bson.M{
-			IdKey:  h.Id,
-			DNSKey: "",
+			IdKey: h.Id,
 		},
 		bson.M{
 			"$set": bson.M{
 				DNSKey: dnsName,
 			},
 		},
-	)
-	if err == nil {
-		h.Host = dnsName
+	); err != nil {
+		return err
 	}
-	if adb.ResultsNotFound(err) {
-		return nil
-	}
-	return err
+
+	h.Host = dnsName
+
+	return nil
 }
 
 // probably don't want to store the port mapping exactly this way

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1334,13 +1334,6 @@ func (h *Host) SetDNSName(ctx context.Context, dnsName string) error {
 	)
 	if err == nil {
 		h.Host = dnsName
-		event.LogHostDNSNameSet(h.Id, dnsName)
-		grip.Info(message.Fields{
-			"message":  "set host DNS name",
-			"host_id":  h.Id,
-			"host_tag": h.Tag,
-			"dns_name": dnsName,
-		})
 	}
 	if adb.ResultsNotFound(err) {
 		return nil

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -531,7 +531,7 @@ type hostHealthCheck struct {
 }
 
 func (m *monitor) getHostHealth(ctx context.Context) (hostHealthCheck, error) {
-	apiHost, err := m.comm.PostHostIsUp(ctx, "")
+	apiHost, err := m.comm.PostHostIsUp(ctx, "", "")
 	if err != nil {
 		return hostHealthCheck{
 			shouldExit: false,

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -134,7 +134,7 @@ func postHostIsUp(ctx context.Context, comm client.Communicator, hostID, cloudPr
 			"host_id":        hostID,
 			"cloud_provider": cloudProvider,
 		}))
-		hostname, err = agentutil.GetEC2Hostname(fetchEC2InfoCtx)
+		hostname, err = agentutil.GetEC2HostName(fetchEC2InfoCtx)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":        "could not fetch EC2 hostname dynamically",
 			"host_id":        hostID,

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -111,7 +111,7 @@ type Communicator interface {
 
 	// PostHostIsUp indicates to the app server that the task host is up and
 	// running.
-	PostHostIsUp(ctx context.Context, instanceID string) (*restmodel.APIHost, error)
+	PostHostIsUp(ctx context.Context, instanceID, hostname string) (*restmodel.APIHost, error)
 	// GetHostProvisioningOptions gets the options to provision a host.
 	GetHostProvisioningOptions(ctx context.Context) (*restmodel.APIHostProvisioningOptions, error)
 

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1327,13 +1327,14 @@ func (c *communicatorImpl) GetClientURLs(ctx context.Context, distroID string) (
 	return urls, nil
 }
 
-func (c *communicatorImpl) PostHostIsUp(ctx context.Context, ec2InstanceID string) (*restmodel.APIHost, error) {
+func (c *communicatorImpl) PostHostIsUp(ctx context.Context, ec2InstanceID, hostname string) (*restmodel.APIHost, error) {
 	info := requestInfo{
 		method: http.MethodPost,
 		path:   fmt.Sprintf("/hosts/%s/is_up", c.hostID),
 	}
 	opts := restmodel.APIHostIsUpOptions{
 		HostID:        c.hostID,
+		Hostname:      hostname,
 		EC2InstanceID: ec2InstanceID,
 	}
 	r, err := c.createRequest(info, opts)

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -313,7 +313,6 @@ func PostHostIsUp(ctx context.Context, env evergreen.Environment, params restmod
 		}
 	}
 
-	// kim: TODO: add unit test for setting hostname.
 	if err := setHostname(ctx, h, params.Hostname); err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -313,7 +313,7 @@ func PostHostIsUp(ctx context.Context, env evergreen.Environment, params restmod
 		}
 	}
 
-	if err := setHostname(ctx, h, params.Hostname); err != nil {
+	if err := h.SetDNSName(ctx, params.Hostname); err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "setting hostname").Error(),
@@ -375,16 +375,6 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 	default:
 		return errors.Errorf("logical error: intent host is in state '%s', which should be impossible when host is up and provisioning", h.Status)
 	}
-}
-
-// setHostname sets the host's self-reported hostname after it's been marked as
-// up. This only applies to hosts that can determine their own hostname.
-func setHostname(ctx context.Context, h *host.Host, hostname string) error {
-	if hostname == "" {
-		return nil
-	}
-
-	return h.SetDNSName(ctx, hostname)
 }
 
 // transitionIntentHostToStarting converts an intent host to a real host because

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -313,6 +313,14 @@ func PostHostIsUp(ctx context.Context, env evergreen.Environment, params restmod
 		}
 	}
 
+	// kim: TODO: add unit test for setting hostname.
+	if err := setHostname(ctx, h, params.Hostname); err != nil {
+		return nil, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    errors.Wrap(err, "setting hostname").Error(),
+		}
+	}
+
 	if err := setReadyForReprovisioning(ctx, env, h); err != nil {
 		// It's okay to continue even if this errors because if the host needs
 		// to reprovision, the agent monitor will eventually shut itself down or
@@ -368,6 +376,16 @@ func fixProvisioningIntentHost(ctx context.Context, h *host.Host, instanceID str
 	default:
 		return errors.Errorf("logical error: intent host is in state '%s', which should be impossible when host is up and provisioning", h.Status)
 	}
+}
+
+// setHostname sets the host's self-reported hostname after it's been marked as
+// up. This only applies to hosts that can determine their own hostname.
+func setHostname(ctx context.Context, h *host.Host, hostname string) error {
+	if hostname == "" {
+		return nil
+	}
+
+	return h.SetDNSName(ctx, hostname)
 }
 
 // transitionIntentHostToStarting converts an intent host to a real host because

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -293,6 +293,7 @@ type APIOffboardUserResults struct {
 
 type APIHostIsUpOptions struct {
 	HostID        string `json:"host_id"`
+	Hostname      string `json:"hostname,omitempty"`
 	EC2InstanceID string `json:"ec2_instance_id,omitempty"`
 }
 

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -421,7 +421,7 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 	return gimlet.NewJSONResponse(apiOpts)
 }
 
-// GET /hosts/{host_id}/is_up
+// POST /hosts/{host_id}/is_up
 
 type hostIsUpPostHandler struct {
 	params model.APIHostIsUpOptions

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1141,6 +1141,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 
 			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        h.Id,
+				Hostname:      "hostname",
 				EC2InstanceID: instanceID,
 			}
 			resp := rh.Run(ctx)
@@ -1162,6 +1163,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NotZero(t, realHost)
 			assert.Equal(t, evergreen.HostStarting, realHost.Status, "intent host should be converted to real host when it's up")
 			assert.False(t, realHost.NeedsNewAgentMonitor)
+			assert.Equal(t, rh.params.Hostname, realHost.Host)
 		},
 		"ConvertsFailedIntentHostToDecommissionedRealHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
 			h.Status = evergreen.HostBuildingFailed
@@ -1171,6 +1173,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 
 			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        h.Id,
+				Hostname:      "hostname",
 				EC2InstanceID: instanceID,
 			}
 
@@ -1193,8 +1196,9 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NotZero(t, realHost)
 			assert.Equal(t, evergreen.HostDecommissioned, realHost.Status, "host that fails to build should be decommissioned when it comes up")
 			assert.False(t, realHost.NeedsNewAgentMonitor)
+			assert.Equal(t, rh.params.Hostname, realHost.Host)
 		},
-		"NoopsForNonIntentHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
+		"SetsHostnameForNonIntentHost": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
 			instanceID := generateFakeEC2InstanceID()
 			h.Id = instanceID
 			h.Status = evergreen.HostStarting
@@ -1202,6 +1206,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 
 			rh.params = restmodel.APIHostIsUpOptions{
 				HostID:        instanceID,
+				Hostname:      "hostname",
 				EC2InstanceID: instanceID,
 			}
 
@@ -1220,6 +1225,7 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostStarting, dbHost.Status, "host should not be modified if it's not an intent host")
 			assert.False(t, dbHost.NeedsNewAgentMonitor)
+			assert.Equal(t, rh.params.Hostname, dbHost.Host)
 		},
 		"MarksHostAsNeedingNewAgentMonitorForReprovisioning": func(ctx context.Context, t *testing.T, rh *hostIsUpPostHandler, h *host.Host) {
 			instanceID := generateFakeEC2InstanceID()


### PR DESCRIPTION
DEVPROD-13207

### Description
This is half of the change for DEVPROD-13207 - this change makes so that the EC2 hostname is set in Evergreen before it runs its first task. Re [this comment](https://jira.mongodb.org/browse/DEVPROD-13207?focusedCommentId=7108350&focusedId=7108350&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-7108350), we can't just get the hostname directly from Evergreen currently, because Evergreen may not have fetched the hostname from EC2 yet. To work around this, EC2 hosts will provide their own hostname from the locally-available EC2 instance metadata on the host. The host will then send that hostname back to Evergreen.

After this is merged, I'll post a follow-up PR to expose the hostname as an OTel attribute for tasks.

### Testing
* Updated unit tests.
* Tested in staging to verify that an EC2 host that started up provided Evergreen with its hostname.
