### PR TITLE
DEVPROD-15048: Sort waterfall tasks alphabetically by display name

### DIFF
--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -44,9 +44,7 @@
         "build_variant": "enterprise-ubuntu1604-64",
         "display_name": "01 Ubuntu 16.04"
       },
-      "builds": [
-        "evergreen_version1_build"
-      ]
+      "builds": ["evergreen_version1_build"]
     },
     {
       "_id": "evergreen_version2",
@@ -65,9 +63,7 @@
         "build_id": "evergreen_version2_build",
         "build_variant": "enterprise-ubuntu1604-64"
       },
-      "builds": [
-        "evergreen_version2_build"
-      ]
+      "builds": ["evergreen_version2_build"]
     },
     {
       "_id": "evergreen_version3",
@@ -112,9 +108,7 @@
       "create_time": {
         "$date": "2020-01-05T12:00:00Z"
       },
-      "builds": [
-        "evergreen_version3_build"
-      ]
+      "builds": ["evergreen_version3_build"]
     },
     {
       "_id": "inactive1",
@@ -186,7 +180,7 @@
       "version": "evergreen_version1",
       "status": "success",
       "display_status_cache": "success",
-      "display_name": "Some Task",
+      "display_name": "Task A",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
       "build_variant_display_name": "Ubuntu 16.04",
@@ -203,7 +197,7 @@
       "version": "evergreen_version1",
       "status": "success",
       "display_status_cache": "success",
-      "display_name": "Some Other Task",
+      "display_name": "Task B",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
       "build_variant_display_name": "Ubuntu 16.04",
@@ -223,7 +217,7 @@
       "details": {
         "type": "setup"
       },
-      "display_name": "Some Task",
+      "display_name": "Task A",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
       "build_variant_display_name": "Ubuntu 16.04",
@@ -240,7 +234,7 @@
       "version": "evergreen_version2",
       "status": "success",
       "display_status_cache": "success",
-      "display_name": "Some Other Task",
+      "display_name": "Task B",
       "activated": true,
       "build_variant": "enterprise-ubuntu1604-64",
       "build_variant_display_name": "Ubuntu 16.04",
@@ -257,7 +251,7 @@
       "version": "evergreen_version5",
       "status": "success",
       "display_status_cache": "success",
-      "display_name": "Task Number 5",
+      "display_name": "Task C",
       "activated": true,
       "build_variant": "lint",
       "build_variant_display_name": "Linter",

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -14,14 +14,14 @@
                     "id": "evergreen_version1_build",
                     "tasks": [
                       {
-                        "displayName": "Some Task",
+                        "displayName": "Task A",
                         "displayStatusCache": "success",
                         "execution": 0,
                         "id": "task_1",
                         "status": "success"
                       },
                       {
-                        "displayName": "Some Other Task",
+                        "displayName": "Task B",
                         "displayStatusCache": "success",
                         "execution": 1,
                         "id": "task_2",
@@ -34,14 +34,14 @@
                     "id": "evergreen_version2_build",
                     "tasks": [
                       {
-                        "displayName": "Some Task",
+                        "displayName": "Task A",
                         "displayStatusCache": "setup-failed",
                         "execution": 0,
                         "id": "task_3",
                         "status": "failed"
                       },
                       {
-                        "displayName": "Some Other Task",
+                        "displayName": "Task B",
                         "displayStatusCache": "success",
                         "execution": 0,
                         "id": "task_4",
@@ -58,7 +58,7 @@
                     "id": "evergreen_version3_build",
                     "tasks": [
                       {
-                        "displayName": "Task Number 5",
+                        "displayName": "Task C",
                         "displayStatusCache": "success",
                         "execution": 0,
                         "id": "task_5",
@@ -669,7 +669,7 @@
                     "tasks": [
                       {
                         "id": "task_5",
-                        "displayName": "Task Number 5"
+                        "displayName": "Task C"
                       }
                     ],
                     "version": "evergreen_version5"
@@ -694,11 +694,11 @@
                     "tasks": [
                       {
                         "id": "task_3",
-                        "displayName": "Some Task"
+                        "displayName": "Task A"
                       },
                       {
                         "id": "task_4",
-                        "displayName": "Some Other Task"
+                        "displayName": "Task B"
                       }
                     ],
                     "version": "evergreen_version2"
@@ -715,11 +715,11 @@
                     "tasks": [
                       {
                         "id": "task_1",
-                        "displayName": "Some Task"
+                        "displayName": "Task A"
                       },
                       {
                         "id": "task_2",
-                        "displayName": "Some Other Task"
+                        "displayName": "Task B"
                       }
                     ],
                     "version": "evergreen_version1"

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -248,9 +248,6 @@ func getVersionTasksPipeline() []bson.M {
 							},
 						},
 					},
-					{
-						"$sort": bson.M{task.IdKey: 1},
-					},
 					// The following projection should exactly match the index on the tasks collection in order to function as a covered query
 					{
 						"$project": bson.M{
@@ -260,6 +257,9 @@ func getVersionTasksPipeline() []bson.M {
 							task.ExecutionKey:          1,
 							task.StatusKey:             1,
 						},
+					},
+					{
+						"$sort": bson.M{task.DisplayNameKey: 1},
 					},
 				},
 				"as": bsonutil.GetDottedKeyName(buildsKey, build.TasksKey),


### PR DESCRIPTION
DEVPROD-15048

### Description
Right now, we are sorting by task IDs, which can lead to inconsistent results. 

Consider the following case:
* `build-and-push-darwin-unsigned` 
  * `evg_build_and_push_display_build_and_push_darwin_unsigned_e2289911f2d07f303e220fd32627eb41c7517a7e_25_02_27_21_09_07`
* `build-and-push`
  * `evg_build_and_push_display_build_and_push_e2289911f2d07f303e220fd32627eb41c7517a7e_25_02_27_21_09_07`

Even though `build-and-push` should come alphabetically before `build-and-push-darwin-unsigned`, the IDs dictate otherwise due to the randomly determined version hash. We should sort by display name instead.

### Testing
On staging. 

Before:
<img width="478" alt="incorrect" src="https://github.com/user-attachments/assets/4d213da8-00a2-4a46-86da-eb02367d5224" />

After:
<img width="478" alt="correct" src="https://github.com/user-attachments/assets/b0356b0a-f7bb-479b-b11c-83dca3d0bc70" />

Also added unit tests.
