### PR TITLE
DEVPROD-13207: add hostname to OTel attributes

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -145,10 +145,22 @@ func (s *AgentSuite) SetupTest() {
 		},
 		BuildVariants: []model.BuildVariant{{Name: bvName}},
 	}
-	taskConfig, err := internal.NewTaskConfig(s.testTmpDirName, &apimodels.DistroView{}, project, &s.task, &model.ProjectRef{
-		Id:         "project_id",
-		Identifier: "project_identifier",
-	}, &patch.Patch{}, nil, &apimodels.ExpansionsAndVars{Expansions: util.Expansions{}})
+	tcOpts := internal.TaskConfigOptions{
+		WorkDir: s.testTmpDirName,
+		Distro:  &apimodels.DistroView{},
+		Host:    &apimodels.HostView{},
+		Project: project,
+		Task:    &s.task,
+		ProjectRef: &model.ProjectRef{
+			Id:         "project_id",
+			Identifier: "project_identifier",
+		},
+		Patch: &patch.Patch{},
+		ExpansionsAndVars: &apimodels.ExpansionsAndVars{
+			Expansions: util.Expansions{},
+		},
+	}
+	taskConfig, err := internal.NewTaskConfig(tcOpts)
 	s.Require().NoError(err)
 
 	s.tc = &taskContext{

--- a/agent/command/archive_auto_create_test.go
+++ b/agent/command/archive_auto_create_test.go
@@ -238,15 +238,21 @@ func TestArchiveAutoPackExecute(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			conf, err := internal.NewTaskConfig(t.TempDir(),
-				&apimodels.DistroView{},
-				&model.Project{BuildVariants: []model.BuildVariant{{Name: "bv"}}},
-				&task.Task{BuildVariant: "bv"},
-				&model.ProjectRef{},
-				&patch.Patch{},
-				nil,
-				&apimodels.ExpansionsAndVars{},
-			)
+			tcOpts := internal.TaskConfigOptions{
+				WorkDir: t.TempDir(),
+				Distro:  &apimodels.DistroView{},
+				Host:    &apimodels.HostView{},
+				Project: &model.Project{
+					BuildVariants: []model.BuildVariant{{Name: "bv"}},
+				},
+				ProjectRef: &model.ProjectRef{},
+				Task: &task.Task{
+					BuildVariant: "bv",
+				},
+				Patch:             &patch.Patch{},
+				ExpansionsAndVars: &apimodels.ExpansionsAndVars{},
+			}
+			conf, err := internal.NewTaskConfig(tcOpts)
 			require.NoError(t, err)
 			comm := client.NewMock("url")
 			logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -239,6 +239,23 @@ func (c *baseCommunicator) GetDistroView(ctx context.Context, taskData TaskData)
 	return &dv, nil
 }
 
+func (c *baseCommunicator) GetHostView(ctx context.Context, taskData TaskData) (*apimodels.HostView, error) {
+	info := requestInfo{
+		method:   http.MethodGet,
+		taskData: &taskData,
+	}
+	info.setTaskPathSuffix("host_view")
+	resp, err := c.retryRequest(ctx, info, nil)
+	if err != nil {
+		return nil, util.RespError(resp, errors.Wrap(err, "getting host view").Error())
+	}
+	var hv apimodels.HostView
+	if err = utility.ReadJSON(resp.Body, &hv); err != nil {
+		return nil, errors.Wrap(err, "reading host view from response")
+	}
+	return &hv, nil
+}
+
 // GetDistroAMI returns the distro for the task.
 func (c *baseCommunicator) GetDistroAMI(ctx context.Context, distro, region string, taskData TaskData) (string, error) {
 	info := requestInfo{

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -57,6 +57,8 @@ type SharedCommunicator interface {
 	GetProjectRef(context.Context, TaskData) (*model.ProjectRef, error)
 	// GetDistroView returns the view of the distro information for the task.
 	GetDistroView(context.Context, TaskData) (*apimodels.DistroView, error)
+	// GetHostView returns the view of host information for the task.
+	GetHostView(context.Context, TaskData) (*apimodels.HostView, error)
 	// GetDistroAMI gets the AMI for the given distro/region
 	GetDistroAMI(context.Context, string, string, TaskData) (string, error)
 	// GetProject loads the project using the task's version ID.

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -212,6 +212,10 @@ func (c *Mock) GetDistroView(context.Context, TaskData) (*apimodels.DistroView, 
 	return &apimodels.DistroView{}, nil
 }
 
+func (c *Mock) GetHostView(context.Context, TaskData) (*apimodels.HostView, error) {
+	return &apimodels.HostView{}, nil
+}
+
 func (c *Mock) GetDistroAMI(context.Context, string, string, TaskData) (string, error) {
 	return "ami-mock", nil
 }

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -20,7 +20,6 @@ import (
 )
 
 type TaskConfig struct {
-	// kim: TODO: add hostname as data to fetch for task.
 	Distro       *apimodels.DistroView
 	Host         *apimodels.HostView
 	ProjectRef   model.ProjectRef
@@ -262,7 +261,6 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 		attributes[evergreen.VersionPRNumOtelAttribute] = strconv.Itoa(tc.GithubPatchData.PRNumber)
 	}
 	if tc.Host != nil && tc.Host.Hostname != "" {
-		// kim: TODO: test this attribute appears in staging.
 		attributes[evergreen.HostnameOtelAttribute] = tc.Host.Hostname
 	}
 	return attributes

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -261,7 +261,7 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 	if tc.GithubPatchData.PRNumber != 0 {
 		attributes[evergreen.VersionPRNumOtelAttribute] = strconv.Itoa(tc.GithubPatchData.PRNumber)
 	}
-	if tc.Host != nil {
+	if tc.Host != nil && tc.Host.Hostname != "" {
 		// kim: TODO: test this attribute appears in staging.
 		attributes[evergreen.HostnameOtelAttribute] = tc.Host.Hostname
 	}

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -30,29 +30,46 @@ func TestNewTaskConfig(t *testing.T) {
 		Version:      "v1",
 	}
 
-	taskConfig, err := NewTaskConfig(curdir, &apimodels.DistroView{}, p, task, &model.ProjectRef{
-		Id:         "project_id",
-		Identifier: "project_identifier",
-	}, &patch.Patch{}, nil, &apimodels.ExpansionsAndVars{
-		Vars: map[string]string{
-			"num_hosts":      "",
-			"aws_token":      "",
-			"my_pass_secret": "",
-			"myPASSWORD":     "",
-			"mySecret":       "",
-			"git_token":      "",
+	d := &apimodels.DistroView{
+		Mountpoints: []string{"/dev/sdb"},
+	}
+	h := &apimodels.HostView{
+		Hostname: "hostname",
+	}
+	tcOpts := TaskConfigOptions{
+		WorkDir: curdir,
+		Distro:  d,
+		Host:    h,
+		Project: p,
+		Task:    task,
+		ProjectRef: &model.ProjectRef{
+			Id:         "project_id",
+			Identifier: "project_identifier",
 		},
-		PrivateVars: map[string]bool{
-			"aws_token": true,
+		Patch: &patch.Patch{},
+		ExpansionsAndVars: &apimodels.ExpansionsAndVars{
+			Vars: map[string]string{
+				"num_hosts":      "",
+				"aws_token":      "",
+				"my_pass_secret": "",
+				"myPASSWORD":     "",
+				"mySecret":       "",
+				"git_token":      "",
+			},
+			PrivateVars: map[string]bool{
+				"aws_token": true,
+			},
+			RedactKeys: []string{"pass", "secret", "token"},
 		},
-		RedactKeys: []string{"pass", "secret", "token"},
-	})
+	}
+	taskConfig, err := NewTaskConfig(tcOpts)
 	assert.NoError(t, err)
 
 	assert.Empty(t, taskConfig.DynamicExpansions)
 	assert.Empty(t, taskConfig.Expansions)
 	assert.ElementsMatch(t, []string{"aws_token", "my_pass_secret", "myPASSWORD", "mySecret", "git_token"}, taskConfig.Redacted)
-	assert.Equal(t, &apimodels.DistroView{}, taskConfig.Distro)
+	assert.Equal(t, d, taskConfig.Distro)
+	assert.Equal(t, h, taskConfig.Host)
 	assert.Equal(t, p, &taskConfig.Project)
 	assert.Equal(t, task, &taskConfig.Task)
 }

--- a/agent/internal/testutil/task_config.go
+++ b/agent/internal/testutil/task_config.go
@@ -19,7 +19,16 @@ func MakeTaskConfigFromModelData(ctx context.Context, settings *evergreen.Settin
 	if err != nil {
 		return nil, errors.Wrap(err, "populating expansions")
 	}
-	config, err := internal.NewTaskConfig(data.Host.Distro.WorkDir, &apimodels.DistroView{}, data.Project, data.Task, data.ProjectRef, nil, nil, &apimodels.ExpansionsAndVars{Expansions: exp})
+	tcOpts := internal.TaskConfigOptions{
+		WorkDir:           data.Host.Distro.WorkDir,
+		Distro:            &apimodels.DistroView{},
+		Host:              &apimodels.HostView{},
+		Project:           data.Project,
+		ProjectRef:        data.ProjectRef,
+		Task:              data.Task,
+		ExpansionsAndVars: &apimodels.ExpansionsAndVars{Expansions: exp},
+	}
+	config, err := internal.NewTaskConfig(tcOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "making task config from test model data")
 	}

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -379,8 +379,6 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	}
 
 	grip.Info("Constructing task config.")
-	// kim: TODO: manually test that hostview is set with hostname in staging.
-	// Can just log to task log.
 	tcOpts := internal.TaskConfigOptions{
 		WorkDir:           a.opts.WorkingDirectory,
 		Distro:            confDistro,

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -337,11 +337,16 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 
 	grip.Info("Fetching distro configuration.")
 	confDistro := &apimodels.DistroView{}
+	confHost := &apimodels.HostView{}
 	if a.opts.Mode == globals.HostMode {
 		var err error
 		confDistro, err = a.comm.GetDistroView(ctx, tc.task)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching distro view")
+		}
+		confHost, err = a.comm.GetHostView(ctx, tc.task)
+		if err != nil {
+			return nil, errors.Wrap(err, "fetching host view")
 		}
 	}
 
@@ -374,7 +379,20 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	}
 
 	grip.Info("Constructing task config.")
-	taskConfig, err := internal.NewTaskConfig(a.opts.WorkingDirectory, confDistro, project, tsk, confRef, confPatch, versionDoc, expansionsAndVars)
+	// kim: TODO: manually test that hostview is set with hostname in staging.
+	// Can just log to task log.
+	tcOpts := internal.TaskConfigOptions{
+		WorkDir:           a.opts.WorkingDirectory,
+		Distro:            confDistro,
+		Host:              confHost,
+		Project:           project,
+		Task:              tsk,
+		ProjectRef:        confRef,
+		Patch:             confPatch,
+		Version:           versionDoc,
+		ExpansionsAndVars: expansionsAndVars,
+	}
+	taskConfig, err := internal.NewTaskConfig(tcOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -31,20 +31,20 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 	})
 }
 
-// GetEC2HostName returns the public host name from the metadata endpoint if
+// GetEC2Hostname returns the public host name from the metadata endpoint if
 // it's an EC2 instance.
-func GetEC2HostName(ctx context.Context) (string, error) {
+func GetEC2Hostname(ctx context.Context) (string, error) {
 	return getEC2Metadata(ctx, "public-hostname", func(resp *http.Response) (string, error) {
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "reading response body")
 		}
 
-		hostName := string(b)
-		if hostName == "" {
-			return "", errors.New("host name from response is empty")
+		hostname := string(b)
+		if hostname == "" {
+			return "", errors.New("hostname from response is empty")
 		}
-		return hostName, nil
+		return hostname, nil
 	})
 }
 

--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -23,7 +23,6 @@ func GetEC2InstanceID(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", errors.Wrap(err, "reading response body")
 		}
-
 		instanceID := string(b)
 		if instanceID == "" {
 			return "", errors.New("instance ID from response is empty")

--- a/agent/util/ec2_test.go
+++ b/agent/util/ec2_test.go
@@ -22,7 +22,7 @@ func TestGetEC2InstanceID(t *testing.T) {
 func TestGetEC2Hostname(t *testing.T) {
 	skipEC2TestOnNonEC2Instance(t)
 
-	hostname, err := GetEC2HostName(t.Context())
+	hostname, err := GetEC2Hostname(t.Context())
 	require.NoError(t, err)
 	assert.NotZero(t, hostname)
 	assert.Contains(t, hostname, "amazonaws.com")

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -393,6 +393,11 @@ type DistroView struct {
 	ExecUser            string   `json:"exec_user"`
 }
 
+// HostView includes a relevant subset of information the agent's own host.
+type HostView struct {
+	Hostname string `json:"hostname"`
+}
+
 // ExpansionsAndVars represents expansions, project variables, and parameters
 // used when running a task.
 type ExpansionsAndVars struct {

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-03"
+	AgentVersion = "2025-03-05"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-02-28"
+	AgentVersion = "2025-03-03"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -515,6 +515,7 @@ const (
 	ProjectIDOtelAttribute         = "evergreen.project.id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
 	HostIDOtelAttribute            = "evergreen.host.id"
+	HostnameOtelAttribute          = "evergreen.host.hostname"
 	HostStartedByOtelAttribute     = "evergreen.host.started_by"
 	HostNoExpirationOtelAttribute  = "evergreen.host.no_expiration"
 	HostInstanceTypeOtelAttribute  = "evergreen.host.instance_type"

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -134,7 +134,7 @@ func postHostIsUp(ctx context.Context, comm client.Communicator, hostID, cloudPr
 			"host_id":        hostID,
 			"cloud_provider": cloudProvider,
 		}))
-		hostname, err = agentutil.GetEC2HostName(fetchEC2InfoCtx)
+		hostname, err = agentutil.GetEC2Hostname(fetchEC2InfoCtx)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":        "could not fetch EC2 hostname dynamically",
 			"host_id":        hostID,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -577,6 +577,44 @@ func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
 	return gimlet.NewJSONResponse(dv)
 }
 
+// GET /task/{task_id}/host_view
+type getHostViewHandler struct {
+	hostID string
+}
+
+func makeGetHostView() gimlet.RouteHandler {
+	return &getHostViewHandler{}
+}
+
+func (rh *getHostViewHandler) Factory() gimlet.RouteHandler {
+	return &getHostViewHandler{}
+}
+
+func (rh *getHostViewHandler) Parse(ctx context.Context, r *http.Request) error {
+	if rh.hostID = r.Header.Get(evergreen.HostHeader); rh.hostID == "" {
+		return errors.New("missing host ID")
+	}
+	return nil
+}
+
+func (rh *getHostViewHandler) Run(ctx context.Context) gimlet.Responder {
+	h, err := host.FindOneId(ctx, rh.hostID)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting host"))
+	}
+	if h == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("host '%s' not found", rh.hostID)},
+		)
+	}
+
+	hv := apimodels.HostView{
+		Hostname: h.Host,
+	}
+	return gimlet.NewJSONResponse(hv)
+}
+
 // POST /task/{task_id}/files
 type attachFilesHandler struct {
 	taskID string

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -87,6 +87,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/task/{task_id}/").Version(2).Get().Wrap(requireTask).RouteHandler(makeFetchTask())
 	app.AddRoute("/task/{task_id}/display_task").Version(2).Get().Wrap(requireTask).RouteHandler(makeGetDisplayTaskHandler())
 	app.AddRoute("/task/{task_id}/distro_view").Version(2).Get().Wrap(requireTask, requirePodOrHost).RouteHandler(makeGetDistroView())
+	app.AddRoute("/task/{task_id}/host_view").Version(2).Get().Wrap(requireTask, requirePodOrHost).RouteHandler(makeGetHostView())
 	app.AddRoute("/task/{task_id}/downstreamParams").Version(2).Post().Wrap(requireTask).RouteHandler(makeSetDownstreamParams())
 	app.AddRoute("/task/{task_id}/expansions_and_vars").Version(2).Get().Wrap(requireTask, requirePodOrHost).RouteHandler(makeGetExpansionsAndVars(settings))
 	app.AddRoute("/task/{task_id}/files").Version(2).Post().Wrap(requireTask, requirePodOrHost).RouteHandler(makeAttachFiles())


### PR DESCRIPTION
DEVPROD-13207

### Description
Follow-up to #8775, which set the EC2 hostname is set before the agent starts running tasks. This change sets the hostname as one of the task's OTel attributes.

* Set hostname on task OTel attributes.
* Rename "host name" from #8775 to "hostname" because most of the software world has seemingly agreed to call it "hostname" as one word.
* Refactor `NewTaskConfig` to take an options struct because the parameter list is getting out of hand.

### Testing
Tested in staging that the hostname attribute appears in Honeycomb traces for Ubuntu/Windows hosts.