### PR TITLE
DEVPROD-13572 Update agent to end after running single task host task

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -304,6 +304,17 @@ func (s *AgentSuite) TestAgentEndTaskShouldExit() {
 	s.Empty(endDetail.FailingCommand, "should not include end task failing command for successful task")
 }
 
+func (s *AgentSuite) TestAgentExitsSingleTaskDistros() {
+	s.setupRunTask(defaultProjYml)
+	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
+	s.a.opts.SingleTaskDistro = true
+	ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+	defer cancel()
+
+	// The loop should exit after one execution because it is on a single host distro
+	s.NoError(s.a.loop(ctx))
+}
+
 func (s *AgentSuite) TestFinishTaskWithNormalCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-11-b"
+	AgentVersion = "2025-03-11-c"
 )
 
 const (

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1076,9 +1076,6 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent.monitor")),
 	)
-	if h.Distro.SingleTaskDistro {
-		args = append(args, "--single_task_distro")
-	}
 
 	return &options.Create{
 		Args:        args,

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1022,7 +1022,7 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 	if executablePath == "" {
 		executablePath = h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName())
 	}
-	return []string{
+	args := []string{
 		executablePath,
 		"agent",
 		fmt.Sprintf("--api_server=%s", settings.Api.URL),
@@ -1033,6 +1033,11 @@ func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string)
 		fmt.Sprintf("--working_directory=%s", h.Distro.WorkDir),
 		"--cleanup",
 	}
+
+	if h.Distro.SingleTaskDistro {
+		args = append(args, "--single_task_distro")
+	}
+	return args
 }
 
 // AgentEnv returns the environment variables required to start the agent.
@@ -1071,6 +1076,9 @@ func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create
 		"--log_output=file",
 		fmt.Sprintf("--log_prefix=%s", filepath.Join(h.Distro.WorkDir, "agent.monitor")),
 	)
+	if h.Distro.SingleTaskDistro {
+		args = append(args, "--single_task_distro")
+	}
 
 	return &options.Create{
 		Args:        args,

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -25,6 +25,7 @@ const (
 	agentCloudProviderFlagName = "provider"
 	agentHostIDFlagName        = "host_id"
 	agentHostSecretFlagName    = "host_secret"
+	singleTaskDistroFlagName   = "single_task_distro"
 )
 
 func Agent() cli.Command {
@@ -112,6 +113,10 @@ func Agent() cli.Command {
 				Name:  joinFlagNames(versionFlagName, "v"),
 				Usage: "print the agent revision of the current binary and exit",
 			},
+			cli.BoolFlag{
+				Name:  singleTaskDistroFlagName,
+				Usage: "marks the agent as running in single task distro",
+			},
 		},
 		Before: mergeBeforeFuncs(
 			func(c *cli.Context) error {
@@ -159,6 +164,7 @@ func Agent() cli.Command {
 				Cleanup:                    c.Bool(cleanupFlagName),
 				CloudProvider:              c.String(agentCloudProviderFlagName),
 				SendTaskLogsToGlobalSender: c.Bool(sendTaskLogsToGlobalSenderFlagName),
+				SingleTaskDistro:           c.Bool(singleTaskDistroFlagName),
 			}
 
 			// Once the agent has retrieved the host ID and secret, unset those
@@ -180,6 +186,7 @@ func Agent() cli.Command {
 				"commands": command.RegisteredCommandNames(),
 				"dir":      opts.WorkingDirectory,
 				"host_id":  opts.HostID,
+				"single":   opts.SingleTaskDistro,
 			})
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -182,11 +182,11 @@ func Agent() cli.Command {
 			}
 
 			grip.Info(message.Fields{
-				"message":  "starting agent",
-				"commands": command.RegisteredCommandNames(),
-				"dir":      opts.WorkingDirectory,
-				"host_id":  opts.HostID,
-				"single":   opts.SingleTaskDistro,
+				"message":            "starting agent",
+				"commands":           command.RegisteredCommandNames(),
+				"dir":                opts.WorkingDirectory,
+				"host_id":            opts.HostID,
+				"single_task_distro": opts.SingleTaskDistro,
 			})
 
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
DEVPROD-13572

### Description
agent exits after looping once if the task is a single task distro task
it does not currently exit if the task is a single host task but does not fully handle the single host task group case which will be covered later 

### Testing
added a unit test for agent ending the loop

will do a full end to end test with some logging next ticket

tested on staging that each task starts a new host and terminates it at the end