### PR TITLE
DEVPROD-14995: disable host after multiple failures cleaning up task directory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1246,8 +1246,6 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 		if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, tc.taskConfig.Distro.ExecUser, logger); err != nil {
 			// If the host is in a state where ps is timing out we need human intervention.
 			if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
-				// kim: NOTE: can reuse DisableHost if num cleanup failures
-				// exceeds limit.
 				disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})
 				logger.CriticalWhen(disableErr != nil, errors.Wrap(err, "disabling host due to ps timeout"))
 			}

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -78,7 +78,6 @@ func (a *Agent) removeTaskDirectory(ctx context.Context, tc *taskContext) {
 		return
 	}
 	if err := a.removeAllAndCheck(ctx, abs); err != nil {
-		a.numTaskDirCleanupFailures++
 		grip.Critical(errors.Wrapf(err, "removing task directory '%s'", dir))
 	} else {
 		grip.Info(message.Fields{

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -56,10 +56,11 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 	return taskDir, nil
 }
 
-// removeTaskDirectory removes the folder the agent created for the task it
-// was executing. It does not return an error because it is executed at the end of
-// a task run, and the agent loop will start another task regardless of how this
-// exits.
+// removeTaskDirectory removes the folder the agent created for the task it was
+// executing. It does not return an error because it is executed at the end of a
+// task run, and the agent loop will start another task regardless of how this
+// exits. If it cannot remove the task directory, the agent may disable the host
+// because leaving the task directory behind could impact later tasks.
 func (a *Agent) removeTaskDirectory(ctx context.Context, tc *taskContext) {
 	if tc.taskConfig == nil || tc.taskConfig.WorkDir == "" {
 		grip.Info("Task directory is not set, not removing.")
@@ -208,7 +209,6 @@ func (a *Agent) tryCleanupDirectory(ctx context.Context, dir string) {
 	}
 }
 
-// kim: TODO: test in staging
 func (a *Agent) checkDataDirectoryHealth(ctx context.Context) error {
 	if a.numTaskDirCleanupFailures >= globals.MaxTaskDirCleanupFailures {
 		err := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{

--- a/agent/directory_test.go
+++ b/agent/directory_test.go
@@ -47,7 +47,7 @@ func TestRemoveTaskDirectory(t *testing.T) {
 		oomTracker: &mock.OOMTracker{},
 	}
 
-	agent.removeTaskDirectory(tc)
+	agent.removeTaskDirectory(t.Context(), tc)
 	_, err = os.Stat(tmpDir)
 	require.True(os.IsNotExist(err), "directory should have been deleted")
 }
@@ -67,13 +67,13 @@ func TestDirectoryCleanup(t *testing.T) {
 	// cannot run the operation on a file, and it will not delete
 	// that file
 	a := Agent{}
-	a.tryCleanupDirectory(fn)
+	a.tryCleanupDirectory(t.Context(), fn)
 	_, err = os.Stat(fn)
 	assert.True(osExists(err))
 
 	// running the operation on the top level directory does not
 	// delete that directory but does delete the files within it
-	a.tryCleanupDirectory(dir)
+	a.tryCleanupDirectory(t.Context(), dir)
 	_, err = os.Stat(dir)
 	assert.True(osExists(err))
 
@@ -83,7 +83,7 @@ func TestDirectoryCleanup(t *testing.T) {
 	readOnlyFileToDelete := filepath.Join(toDelete, "read-only")
 	assert.NoError(os.WriteFile(readOnlyFileToDelete, []byte("cookies"), 0644))
 	assert.NoError(os.Chmod(readOnlyFileToDelete, 0444))
-	a.tryCleanupDirectory(dir)
+	a.tryCleanupDirectory(t.Context(), dir)
 	_, err = os.Stat(readOnlyFileToDelete)
 	assert.True(os.IsNotExist(err))
 	_, err = os.Stat(toDelete)
@@ -94,7 +94,7 @@ func TestDirectoryCleanup(t *testing.T) {
 	assert.NoError(os.MkdirAll(gitDir, 0777))
 	shouldNotDelete := filepath.Join(dir, "dir1", "delete-me")
 	assert.NoError(os.MkdirAll(shouldNotDelete, 0777))
-	a.tryCleanupDirectory(dir)
+	a.tryCleanupDirectory(t.Context(), dir)
 	_, err = os.Stat(gitDir)
 	assert.False(os.IsNotExist(err))
 	_, err = os.Stat(shouldNotDelete)

--- a/agent/globals/globals.go
+++ b/agent/globals/globals.go
@@ -66,6 +66,12 @@ const (
 
 	// EndTaskMessageLimit is the length limit of a user-defined end task response.
 	EndTaskMessageLimit = 500
+
+	// MaxTaskDirCleanupFailures is the maximum number of times the agent can
+	// fail to clean up the task directory before the host is declared
+	// unhealthy. This is to reduce the likelihood of later tasks failing due to
+	// lack of disk space from task directories that were left behind.
+	MaxTaskDirCleanupFailures = 3
 )
 
 // TimeoutType indicates the type of task timeout.

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -80,7 +80,7 @@ type SharedCommunicator interface {
 	SetResultsInfo(context.Context, TaskData, string, bool) error
 
 	// DisableHost signals to the app server that the host should be disabled.
-	DisableHost(context.Context, string, apimodels.DisableInfo) error
+	DisableHost(ctx context.Context, hostID string, info apimodels.DisableInfo) error
 
 	// GetLoggerProducer constructs a new LogProducer instance for use by tasks.
 	GetLoggerProducer(context.Context, *task.Task, *LoggerConfig) (LoggerProducer, error)

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-05"
+	AgentVersion = "2025-03-06"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14995

### Description
This is part of the change for DEVPROD-14995. The overall goal is that if the agent fails to clean up the task directory, it should determine if it should take on another task, otherwise it should decommission/quarantine. I added a basic check to decommission/quarantine a host (static or ephemeral) if it fails to clean up 3 task directories, since that would be a sign that the data volume is filling up with too much leftover task state.

I'm going to make a follow-up PR to make it a little smarter so it can make decisions based on the disk space left. For example, if it fails to clean up one task directory but that task directory uses up 90% of the data volume's available space, quarantine immediately.

### Testing
Tested in staging that it decommissioned an ephemeral host.
