### PR TITLE
DEVPROD-12131 Add user data script wait option for host.create

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -761,6 +761,22 @@ func (c *baseCommunicator) CreateHost(ctx context.Context, td TaskData, options 
 	return ids, nil
 }
 
+// IsUserDataScriptFinished checks if the user data script has finished executing
+// for a given host.
+func (c *baseCommunicator) IsUserDataScriptFinished(ctx context.Context, td TaskData, id string) error {
+	info := requestInfo{
+		method:   http.MethodPost,
+		taskData: &td,
+	}
+	info.path = fmt.Sprintf("hosts/%s/is_user_data_script_finished", td.ID)
+	resp, err := c.retryRequest(ctx, info, id)
+	if err != nil {
+		return util.RespError(resp, errors.Wrap(err, "sending host.create request").Error())
+	}
+
+	return nil
+}
+
 func (c *baseCommunicator) ListHosts(ctx context.Context, td TaskData) (restmodel.HostListResults, error) {
 	info := requestInfo{
 		method:   http.MethodGet,

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -108,6 +108,7 @@ type SharedCommunicator interface {
 	// Spawn-hosts for tasks methods
 	CreateHost(context.Context, TaskData, apimodels.CreateHost) ([]string, error)
 	ListHosts(context.Context, TaskData) (restmodel.HostListResults, error)
+	IsUserDataScriptFinished(context.Context, TaskData, string) error
 
 	// GetDockerLogs returns logs for the given docker container
 	GetDockerLogs(ctx context.Context, hostID string, startTime time.Time, endTime time.Time, isError bool) ([]byte, error)

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -530,6 +530,10 @@ func (c *Mock) CreateHost(ctx context.Context, td TaskData, options apimodels.Cr
 	return []string{"id"}, options.Validate(ctx)
 }
 
+func (c *Mock) IsUserDataScriptFinished(ctx context.Context, td TaskData, id string) error {
+	return nil
+}
+
 func (c *Mock) ListHosts(_ context.Context, _ TaskData) (model.HostListResults, error) {
 	return model.HostListResults{}, nil
 }

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -53,6 +53,9 @@ type Manager interface {
 	// GetDNSName returns the DNS name of a host.
 	GetDNSName(context.Context, *host.Host) (string, error)
 
+	// IsUserDataFinished checks if a host's user data script has finished running.
+	IsUserDataFinished(context.Context, *host.Host) (bool, error)
+
 	// AttachVolume attaches a volume to a host.
 	AttachVolume(context.Context, *host.Host, *host.VolumeAttachment) error
 

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -244,6 +244,10 @@ func (m *dockerManager) GetDNSName(ctx context.Context, h *host.Host) (string, e
 	return "", nil
 }
 
+func (m *dockerManager) IsUserDataFinished(_ context.Context, _ *host.Host) (bool, error) {
+	return true, nil
+}
+
 // TerminateInstance destroys a container.
 func (m *dockerManager) TerminateInstance(ctx context.Context, h *host.Host, user, reason string) error {
 	if h.Status == evergreen.HostTerminated {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1311,6 +1311,33 @@ func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, erro
 	return m.client.GetPublicDNSName(ctx, h)
 }
 
+func (m *ec2Manager) IsUserDataFinished(ctx context.Context, host *host.Host) (bool, error) {
+	if err := m.client.Create(ctx, m.region); err != nil {
+		return false, errors.Wrap(err, "creating client")
+	}
+	logs, err := m.client.GetConsoleOutput(ctx, host.Id)
+	if err != nil {
+		return false, errors.Wrap(err, "getting console output")
+	}
+
+	// TODO: Decide if logs has the required things
+	grip.Debug(message.Fields{
+		"message": "checking if user data is finished",
+		"host_id": host.Id,
+		"logs":    logs,
+	})
+	return true, nil
+}
+
+// GetConsoleOutput returns the console output for the host.
+func (m *ec2Manager) GetConsoleOutput(ctx context.Context, hostId string) (string, error) {
+	if err := m.client.Create(ctx, m.region); err != nil {
+		return "", errors.Wrap(err, "creating client")
+	}
+
+	return m.client.GetConsoleOutput(ctx, hostId)
+}
+
 // TimeTilNextPayment returns how long until the next payment is due for a host.
 func (m *ec2Manager) TimeTilNextPayment(host *host.Host) time.Duration {
 	return timeTilNextEC2Payment(host)

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -397,6 +397,24 @@ func (m *ec2FleetManager) GetDNSName(ctx context.Context, h *host.Host) (string,
 	return m.client.GetPublicDNSName(ctx, h)
 }
 
+func (m *ec2FleetManager) IsUserDataFinished(ctx context.Context, host *host.Host) (bool, error) {
+	if err := m.client.Create(ctx, m.region); err != nil {
+		return false, errors.Wrap(err, "creating client")
+	}
+	logs, err := m.client.GetConsoleOutput(ctx, host.Id)
+	if err != nil {
+		return false, errors.Wrap(err, "getting console output")
+	}
+
+	// TODO: Decide if logs has the required things
+	grip.Debug(message.Fields{
+		"message": "checking if user data is finished",
+		"host_id": host.Id,
+		"logs":    logs,
+	})
+	return true, nil
+}
+
 func (m *ec2FleetManager) TimeTilNextPayment(h *host.Host) time.Duration {
 	return timeTilNextEC2Payment(h)
 }

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -262,6 +262,10 @@ func (m *mockManager) GetDNSName(ctx context.Context, host *host.Host) (string, 
 	return instance.DNSName, nil
 }
 
+func (m *mockManager) IsUserDataFinished(ctx context.Context, host *host.Host) (bool, error) {
+	return true, nil
+}
+
 // terminate an instance
 func (m *mockManager) TerminateInstance(ctx context.Context, host *host.Host, user, reason string) error {
 	l := m.mutex

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -76,6 +76,10 @@ func (staticMgr *staticManager) GetDNSName(ctx context.Context, host *host.Host)
 	return host.Id, nil
 }
 
+func (staticMgr *staticManager) IsUserDataFinished(ctx context.Context, host *host.Host) (bool, error) {
+	return true, nil
+}
+
 func (m *staticManager) SetPortMappings(context.Context, *host.Host, *host.Host) error {
 	return errors.New("can't set port mappings with static provider")
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-05"
+	AgentVersion = "2025-03-06"
 )
 
 const (

--- a/rest/route/host_create.go
+++ b/rest/route/host_create.go
@@ -183,23 +183,23 @@ func (h *hostListHandler) Run(ctx context.Context) gimlet.Responder {
 
 // /////////////////////////////////////////////////////////////////////////////
 //
-// POST /hosts/{task_id}/wait_for_user_data_script
-type hostWaitForUserDataScriptHandler struct {
+// POST /hosts/{task_id}/is_user_data_script_finished
+type hostIsUserDataScriptFinished struct {
 	env evergreen.Environment
 
 	taskID string
 	hostID string
 }
 
-func makeHostWaitForUserDataScript(env evergreen.Environment) gimlet.RouteHandler {
-	return &hostWaitForUserDataScriptHandler{env: env}
+func makeHostIsUserDataScriptFinished(env evergreen.Environment) gimlet.RouteHandler {
+	return &hostIsUserDataScriptFinished{env: env}
 }
 
-func (h *hostWaitForUserDataScriptHandler) Factory() gimlet.RouteHandler {
-	return &hostWaitForUserDataScriptHandler{env: h.env}
+func (h *hostIsUserDataScriptFinished) Factory() gimlet.RouteHandler {
+	return &hostIsUserDataScriptFinished{env: h.env}
 }
 
-func (h *hostWaitForUserDataScriptHandler) Parse(ctx context.Context, r *http.Request) error {
+func (h *hostIsUserDataScriptFinished) Parse(ctx context.Context, r *http.Request) error {
 	taskID := gimlet.GetVars(r)["task_id"]
 	if taskID == "" {
 		return errors.New("must provide task ID")
@@ -212,7 +212,7 @@ func (h *hostWaitForUserDataScriptHandler) Parse(ctx context.Context, r *http.Re
 	return nil
 }
 
-func (h *hostWaitForUserDataScriptHandler) Run(ctx context.Context) gimlet.Responder {
+func (h *hostIsUserDataScriptFinished) Run(ctx context.Context) gimlet.Responder {
 	t, err := task.FindOneId(ctx, h.taskID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task '%s'", h.taskID))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -81,6 +81,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostProvisioningOptionsGetHandler(env))
 	app.AddRoute("/hosts/{task_id}/create").Version(2).Post().Wrap(requireTask).RouteHandler(makeHostCreateRouteManager(env))
 	app.AddRoute("/hosts/{task_id}/list").Version(2).Get().Wrap(requireTask).RouteHandler(makeHostListRouteManager())
+	app.AddRoute("/hosts/{task_id}/wait_for_user_data_script").Version(2).Post().Wrap(requireTask).RouteHandler(makeHostWaitForUserDataScript(env))
 	app.AddRoute("/pods/{pod_id}/agent/next_task").Version(2).Get().Wrap(requirePod).RouteHandler(makePodAgentNextTask(env))
 	app.AddRoute("/pods/{pod_id}/task/{task_id}/end").Version(2).Post().Wrap(requirePod, requireTask).RouteHandler(makePodAgentEndTask(env))
 	app.AddRoute("/pods/{pod_id}/provisioning_script").Version(2).Get().Wrap(requirePod).RouteHandler(makePodProvisioningScript(env))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -81,7 +81,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{host_id}/provisioning_options").Version(2).Get().Wrap(requireHost).RouteHandler(makeHostProvisioningOptionsGetHandler(env))
 	app.AddRoute("/hosts/{task_id}/create").Version(2).Post().Wrap(requireTask).RouteHandler(makeHostCreateRouteManager(env))
 	app.AddRoute("/hosts/{task_id}/list").Version(2).Get().Wrap(requireTask).RouteHandler(makeHostListRouteManager())
-	app.AddRoute("/hosts/{task_id}/wait_for_user_data_script").Version(2).Post().Wrap(requireTask).RouteHandler(makeHostWaitForUserDataScript(env))
+	app.AddRoute("/hosts/{task_id}/is_user_data_script_finished").Version(2).Post().Wrap(requireTask).RouteHandler(makeHostIsUserDataScriptFinished(env))
 	app.AddRoute("/pods/{pod_id}/agent/next_task").Version(2).Get().Wrap(requirePod).RouteHandler(makePodAgentNextTask(env))
 	app.AddRoute("/pods/{pod_id}/task/{task_id}/end").Version(2).Post().Wrap(requirePod, requireTask).RouteHandler(makePodAgentEndTask(env))
 	app.AddRoute("/pods/{pod_id}/provisioning_script").Version(2).Get().Wrap(requirePod).RouteHandler(makePodProvisioningScript(env))


### PR DESCRIPTION
DEVPROD-12131

# This is not in review yet.

### Description
This adds an option to `host.create` called `WaitForUserDataScript`. This option will cause host.create to poll Evergreen until the requested hosts are completed with their user data scripts. The underlying implementation of checking if the user data script is complete, is checking if the host recent messages establish if the cloud init process is complete.

### Testing
I spawn a couple hosts that wait for 20 seconds in the user data script:
- The one without *should* error.
- The one with *should not* error.

### Documentation
TODO: Add docs about this.