### PR TITLE
DEVPROD-15468: Use $elemMatch operator to search build variants

### DIFF
--- a/graphql/tests/query/waterfall/data.json
+++ b/graphql/tests/query/waterfall/data.json
@@ -38,12 +38,14 @@
       "create_time": {
         "$date": "2020-01-01T00:00:00Z"
       },
-      "build_variants_status": {
-        "activated": true,
-        "build_id": "evergreen_version1_build",
-        "build_variant": "enterprise-ubuntu1604-64",
-        "display_name": "01 Ubuntu 16.04"
-      },
+      "build_variants_status": [
+        {
+          "activated": true,
+          "build_id": "evergreen_version1_build",
+          "build_variant": "enterprise-ubuntu1604-64",
+          "display_name": "01 Ubuntu 16.04"
+        }
+      ],
       "builds": ["evergreen_version1_build"]
     },
     {
@@ -58,11 +60,13 @@
       "create_time": {
         "$date": "2020-01-02T06:43:00Z"
       },
-      "build_variants_status": {
-        "activated": true,
-        "build_id": "evergreen_version2_build",
-        "build_variant": "enterprise-ubuntu1604-64"
-      },
+      "build_variants_status": [
+        {
+          "activated": true,
+          "build_id": "evergreen_version2_build",
+          "build_variant": "enterprise-ubuntu1604-64"
+        }
+      ],
       "builds": ["evergreen_version2_build"]
     },
     {
@@ -77,11 +81,19 @@
       "create_time": {
         "$date": "2020-01-03T13:30:00Z"
       },
-      "build_variants_status": {
-        "activated": true,
-        "build_id": "evergreen_version3_build",
-        "build_variant": "lint"
-      }
+      "build_variants_status": [
+        {
+          "activated": true,
+          "build_id": "evergreen_version3_build",
+          "build_variant": "lint"
+        },
+        {
+          "activated": false,
+          "build_id": "evergreen_version1_build_b",
+          "build_variant": "enterprise-ubuntu1604-64",
+          "display_name": "01 Ubuntu 16.04"
+        }
+      ]
     },
     {
       "_id": "evergreen_version4",

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -121,12 +121,13 @@ func getBuildVariantFilterPipeline(ctx context.Context, variants []string, match
 	variantsAsRegex := strings.Join(variants, "|")
 	pipeline = append(pipeline, bson.M{
 		"$match": bson.M{
-			"$or": []bson.M{
-				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusVariantKey): bson.M{"$regex": variantsAsRegex, "$options": "i"},
-					bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusActivatedKey): true,
-				},
-				{bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusDisplayNameKey): bson.M{"$regex": variantsAsRegex, "$options": "i"},
-					bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusActivatedKey): true,
+			VersionBuildVariantsKey: bson.M{
+				"$elemMatch": bson.M{
+					VersionBuildStatusActivatedKey: true,
+					"$or": []bson.M{
+						bson.M{VersionBuildStatusVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+						bson.M{VersionBuildStatusDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
DEVPROD-15468 - followup to https://github.com/evergreen-ci/evergreen/pull/8785

### Description
I incorrectly wrote the match operators for build variant filtering such that a version would match if it had _any_ active build and _any_ build that matched the string. We need the build that contains the string match to be active, so use `$elemMatch` to accomplish this.

### Testing
Update test data such that tests fail with the old incorrect logic. However, since I added an inactive build to test data, the new query operators correctly don't find a match and the test passes.