### PR TITLE
DEVPROD-14942: Exclude already generated tasks from max tasks error

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -311,7 +311,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		return errors.Wrap(err, "creating task ID table for new variant-tasks to create")
 	}
 	tasksToBeGenerated := allTasksToBeCreatedIncludingDeps.Length()
-	if err = validateGeneratedProjectMaxTasks(ctx, v, tasksToBeGenerated); err != nil {
+	if err = validateGeneratedProjectMaxTasks(ctx, v, g.Task.Id, tasksToBeGenerated); err != nil {
 		return errors.Wrapf(err, "validating the number of tasks to be added by '%s'", g.Task.Id)
 	}
 	span.SetAttributes(attribute.Int(numGenerateTasksAttribute, tasksToBeGenerated))
@@ -400,9 +400,10 @@ func getBuildVariantsFromPairs(pairs TaskVariantPairs) []string {
 	return uniqueBVs
 }
 
-func validateGeneratedProjectMaxTasks(ctx context.Context, v *Version, tasksToBeCreated int) error {
+func validateGeneratedProjectMaxTasks(ctx context.Context, v *Version, taskID string, tasksToBeCreated int) error {
 	numExistingTasks, err := task.Count(ctx, db.Query(bson.M{
-		task.VersionKey: v.Id,
+		task.VersionKey:     v.Id,
+		task.GeneratedByKey: bson.M{"$ne": taskID},
 	}))
 	if err != nil {
 		return errors.Wrapf(err, "counting tasks for version '%s'", v.Id)


### PR DESCRIPTION
DEVPROD-14942

### Description
The error described in the ticket was caused by an app pod terminating while a generate tasks job was already inflight, causing only half of the tasks to be generated ([trace](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/C2JnL5XNLm/trace/yXHFFcmhgBQ?fields[]=s_name&fields[]=s_serviceName&span=22ae61f2678c7cbb)).

When the job was re-attempted on another app pod ([trace](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/C2JnL5XNLm/trace/AEnscnMYovf?fields[]=s_name&fields[]=s_serviceName&span=903f00ffd291378f)), the tasks that were already generated counted on top of the tasks that were to be generated according to the input JSON, causing some double counting and triggering the max tasks per version error.

Note that in cases like this one, a generate tasks job terminating halfway through creating its tasks will always manifest itself in a system failure because we don't currently have a way to recover from that sort of bad state. This change serves to not show a "max tasks" error in this case because it's not accurate as to what happened.

### Testing
Existing tests. Tested that the query is not slow for larger server patches.