### PR TITLE
DEVPROD-15595 extend github org/repo expansion

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -763,58 +763,57 @@ file a ticket or issues. That's a bug.
 
 Every task has some expansions available by default:
 
--   `${is_patch}` is "true" if the running task is in a patch build and
-    undefined if it is not.
--   `${is_stepback}` is "true" if the running task was stepped back.
+
 -   `${author}` is the patch author's username for patch tasks or the
     git commit author for git tasks
 -   `${author_email}` is the patch or the git commit authors email
--   `${task_id}` is the task's unique id
--   `${task_name}` is the name of the task
--   `${execution}` is the execution number of the task (how many times
-    it has been reset)
 -   `${build_id}` is the id of the build the task belongs to
--   `${build_variant}` is the name of the build variant the task belongs
-    to
--   `${version_id}` is the id of the task's version
--   `${workdir}` is the task's working directory
--   `${revision}` is the commit hash of the base commit that a patch's changes
-    are being applied to, or of the commit for a mainline build. For PR patches,
-    this is the merge base of the PR branch and the target branch.
--   `${github_commit}` is the commit hash of the commit that triggered
-    the patch run
 -   `${branch_name}` is the name of the branch tracked by the
     project
--   `${distro_id}` is name of the distro the task is running on
+-   `${build_variant}` is the name of the build variant the task belongs
+    to
 -   `${created_at}` is the time the version was created
--   `${revision_order_id}` is Evergreen's internal revision order
-    number, which increments on each commit, and includes the patch
-    author name in patches
--   `${github_pr_number}` is the Github PR number associated with PR
-    patches and PR triggered merge queue items
--   `${github_org}` is the GitHub organization for the repo in which
-    a PR or PR triggered merge queue item appears
--   `${github_repo}` is the GitHub repo in which a PR or PR triggered
-    merge queue item appears
+-   `${distro_id}` is name of the distro the task is running on
+-   `${execution}` is the execution number of the task (how many times
+    it has been reset)
 -   `${github_author}` is the GitHub username of the creator of a PR
     or PR triggered merge queue item
+-   `${github_commit}` is the commit hash of the commit that triggered
+    the patch run
 -   `${github_known_hosts}` is GitHub's SSH key fingerprint
--   `${triggered_by_git_tag}` is the name of the tag that triggered this
-    version, if applicable
+-   `${github_org}` is the GitHub organization for the repo for the project
+-   `${github_pr_number}` is the Github PR number associated with PR
+    patches and PR triggered merge queue items
+-   `${github_repo}` is the GitHub repo for the project
 -   `${is_commit_queue}` is the string "true" if this is a merge
     queue task
--   `${requester}` is what triggered the task: `patch`, `github_pr`,
-    `github_tag`, `commit`, `trigger`, `github_merge_queue`, or `ad_hoc`
+-   `${is_patch}` is "true" if the running task is in a patch build and
+    undefined if it is not.
+-   `${is_stepback}` is "true" if the running task was stepped back.
 -   `${otel_collector_endpoint}` is the gRPC endpoint for Evergreen's
     OTel collector. Tasks can send traces to this endpoint.
--   `${otel_trace_id}` is the OTel trace ID this task is running under.
-    Include the trace ID in your task's spans so they'll be hooked
-    in under the task's trace.
-    See [Hooking tests into command spans](Task_Traces#hooking-tests-into-command-spans) for more information.
 -   `${otel_parent_id}` is the OTel span ID of the current command.
     Include this ID in your test's root spans so it'll be hooked
     in under the command's trace.
+    Include the trace ID in your task's spans so they'll be hooked
+    in under the task's trace.
     See [Hooking tests into command spans](Task_Traces#hooking-tests-into-command-spans) for more information.
+    See [Hooking tests into command spans](Task_Traces#hooking-tests-into-command-spans) for more information.
+-   `${otel_trace_id}` is the OTel trace ID this task is running under.
+-   `${requester}` is what triggered the task: `patch`, `github_pr`,
+    `github_tag`, `commit`, `trigger`, `github_merge_queue`, or `ad_hoc`
+-   `${revision}` is the commit hash of the base commit that a patch's changes
+    are being applied to, or of the commit for a mainline build. For PR patches,
+    this is the merge base of the PR branch and the target branch.
+-   `${revision_order_id}` is Evergreen's internal revision order
+    number, which increments on each commit, and includes the patch
+    author name in patches
+-   `${task_id}` is the task's unique id
+-   `${task_name}` is the name of the task
+-   `${triggered_by_git_tag}` is the name of the tag that triggered this
+    version, if applicable
+-   `${version_id}` is the id of the task's version
+-   `${workdir}` is the task's working directory
 -   `${__project_aws_ssh_key_name}` is the unique key name for the ssh key 
     pair generated by Evergreen. 
 -   `${__project_aws_ssh_key_value}` is the unencrypted PEM encoded PKCS#1 private key 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -782,9 +782,9 @@ Every task has some expansions available by default:
     the patch run
 -   `${github_known_hosts}` is GitHub's SSH key fingerprint
 -   `${github_org}` is the GitHub organization for the repo for the project
+-   `${github_repo}` is the GitHub repo for the project
 -   `${github_pr_number}` is the Github PR number associated with PR
     patches and PR triggered merge queue items
--   `${github_repo}` is the GitHub repo for the project
 -   `${is_commit_queue}` is the string "true" if this is a merge
     queue task
 -   `${is_patch}` is "true" if the running task is in a patch build and

--- a/model/project.go
+++ b/model/project.go
@@ -1035,8 +1035,10 @@ func PopulateExpansions(ctx context.Context, t *task.Task, h *host.Host, appToke
 	expansions.Put("github_commit", t.Revision)
 	expansions.Put(evergreen.GithubKnownHosts, knownHosts)
 	expansions.Put("project", projectRef.Identifier)
-	expansions.Put("project_identifier", projectRef.Identifier) // TODO: deprecate
+	expansions.Put("project_identifier", projectRef.Identifier)
 	expansions.Put("project_id", projectRef.Id)
+	expansions.Put("github_org", projectRef.Owner)
+	expansions.Put("github_repo", projectRef.Repo)
 	if h != nil {
 		expansions.Put("distro_id", h.Distro.Id)
 	}
@@ -1121,20 +1123,13 @@ func PopulateExpansions(ctx context.Context, t *task.Task, h *host.Host, appToke
 		expansions.Put("revision_order_id", fmt.Sprintf("%s_%d", v.Author, v.RevisionOrderNumber))
 		expansions.Put("alias", p.Alias)
 
-		if v.Requester == evergreen.GithubMergeRequester {
-			expansions.Put("is_commit_queue", "true")
-		}
-
 		if v.Requester == evergreen.GithubPRRequester {
 			expansions.Put("github_pr_number", fmt.Sprintf("%d", p.GithubPatchData.PRNumber))
-			expansions.Put("github_org", p.GithubPatchData.BaseOwner)
-			expansions.Put("github_repo", p.GithubPatchData.BaseRepo)
 			expansions.Put("github_author", p.GithubPatchData.Author)
 			expansions.Put("github_commit", p.GithubPatchData.HeadHash)
 		}
 		if p.IsMergeQueuePatch() {
-			expansions.Put("github_org", p.GithubMergeData.Org)
-			expansions.Put("github_repo", p.GithubMergeData.Repo)
+			expansions.Put("is_commit_queue", "true")
 			// this looks like "gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
 			expansions.Put("github_head_branch", p.GithubMergeData.HeadBranch)
 		}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -396,6 +396,8 @@ func TestPopulateExpansions(t *testing.T) {
 	projectRef := &ProjectRef{
 		Id:         "mci",
 		Identifier: "mci-favorite",
+		Owner:      "my_org",
+		Repo:       "my_repo",
 	}
 	assert.NoError(projectRef.Insert())
 	v := &Version{
@@ -423,7 +425,7 @@ func TestPopulateExpansions(t *testing.T) {
 
 	expansions, err := PopulateExpansions(ctx, taskDoc, &h, "appToken", "")
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 23)
+	assert.Len(map[string]string(expansions), 25)
 	assert.Equal("0", expansions.Get("execution"))
 	assert.Equal("v1", expansions.Get("version_id"))
 	assert.Equal("t1", expansions.Get("task_id"))
@@ -435,6 +437,8 @@ func TestPopulateExpansions(t *testing.T) {
 	assert.Equal("mci-favorite", expansions.Get("project"))
 	assert.Equal("mci", expansions.Get("project_id"))
 	assert.Equal("mci-favorite", expansions.Get("project_identifier"))
+	assert.Equal("my_org", expansions.Get("github_org"))
+	assert.Equal("my_repo", expansions.Get("github_repo"))
 	assert.Equal("main", expansions.Get("branch_name"))
 	assert.Equal("somebody", expansions.Get("author"))
 	assert.Equal("somebody@somewhere.com", expansions.Get("author_email"))
@@ -446,7 +450,6 @@ func TestPopulateExpansions(t *testing.T) {
 	assert.False(expansions.Exists("is_commit_queue"))
 	assert.Equal("github_tag", expansions.Get("requester"))
 	assert.False(expansions.Exists("github_pr_number"))
-	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
 
 	assert.NoError(VersionUpdateOne(ctx, bson.M{VersionIdKey: v.Id}, bson.M{
@@ -459,12 +462,12 @@ func TestPopulateExpansions(t *testing.T) {
 
 	expansions, err = PopulateExpansions(ctx, taskDoc, &h, "", "")
 	assert.NoError(err)
-	assert.Len(map[string]string(expansions), 23)
+	assert.Len(map[string]string(expansions), 25)
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("patch", expansions.Get("requester"))
+	assert.Equal("my_repo", expansions.Get("github_repo"))
 	assert.False(expansions.Exists("is_commit_queue"))
 	assert.False(expansions.Exists("github_pr_number"))
-	assert.False(expansions.Exists("github_repo"))
 	assert.False(expansions.Exists("github_author"))
 	assert.False(expansions.Exists("triggered_by_git_tag"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
@@ -475,8 +478,8 @@ func TestPopulateExpansions(t *testing.T) {
 	p = patch.Patch{
 		Version: v.Id,
 		GithubMergeData: thirdparty.GithubMergeGroup{
-			Org:        "my_merge_org",
-			Repo:       "my_merge_repo",
+			Org:        "my_org",
+			Repo:       "my_repo",
 			HeadBranch: "merge_head_branch",
 			HeadSHA:    "merge_head_sha",
 			HeadCommit: "merge_head_commit",
@@ -489,8 +492,8 @@ func TestPopulateExpansions(t *testing.T) {
 	assert.Equal("true", expansions.Get("is_patch"))
 	assert.Equal("true", expansions.Get("is_commit_queue"))
 	assert.Equal("github_merge_queue", expansions.Get("requester"))
-	assert.Equal("my_merge_org", expansions.Get("github_org"))
-	assert.Equal("my_merge_repo", expansions.Get("github_repo"))
+	assert.Equal("my_org", expansions.Get("github_org"))
+	assert.Equal("my_repo", expansions.Get("github_repo"))
 	assert.Equal("merge_head_branch", expansions.Get("github_head_branch"))
 	require.NoError(t, db.ClearCollections(patch.Collection))
 
@@ -518,8 +521,8 @@ func TestPopulateExpansions(t *testing.T) {
 		Version: v.Id,
 		GithubPatchData: thirdparty.GithubPatch{
 			PRNumber:  42,
-			BaseOwner: "evergreen-ci",
-			BaseRepo:  "evergreen",
+			BaseOwner: "my_org",
+			BaseRepo:  "my_repo",
 			Author:    "octocat",
 			HeadHash:  "abc123",
 		},
@@ -531,11 +534,11 @@ func TestPopulateExpansions(t *testing.T) {
 	assert.Len(map[string]string(expansions), 27)
 	assert.Equal("github_pr", expansions.Get("requester"))
 	assert.Equal("true", expansions.Get("is_patch"))
-	assert.Equal("evergreen", expansions.Get("github_repo"))
+	assert.Equal("my_repo", expansions.Get("github_repo"))
 	assert.Equal("octocat", expansions.Get("github_author"))
 	assert.Equal("42", expansions.Get("github_pr_number"))
 	assert.Equal("abc123", expansions.Get("github_commit"))
-	assert.Equal("evergreen-ci", expansions.Get("github_org"))
+	assert.Equal("my_org", expansions.Get("github_org"))
 
 	upstreamTask := task.Task{
 		Id:       "upstreamTask",


### PR DESCRIPTION
DEVPROD-15595
### Description
There's no reason for this to be owner/repo only; we can just use this in general.

### Testing
Updated expansion test.

### Documentation
Updated documentation text for these two fields. (I also alphabetized this list because i found it helpful?? but if you hate it i'll undo that) 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
