### PR TITLE
DEVPROD-12041: stop skip_existing retries in s3.put

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -497,6 +497,7 @@ retryLoop:
 								skippedFilesCount++
 
 								logger.Task().Infof("Not uploading file '%s' because remote file '%s' already exists. Continuing to upload other files.", fpath, remoteName)
+								continue uploadLoop
 							}
 						}
 					}

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-07a"
+	AgentVersion = "2025-03-08"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-12041

### Description
This commit prevents the retry loop from running when we are using skip_existing: true in s3.put. This doesn't cause anything to fail, but the logging and extra API calls are unnecessary.