### PR TITLE
DEVPROD-15633: finish host termination after setting intent host status

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -167,6 +167,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 			if err := j.host.Terminate(ctx, evergreen.User, j.TerminationReason); err != nil {
 				j.AddError(errors.Wrapf(err, "terminating intent host '%s' in DB", j.host.Id))
 			}
+			return
 		}
 	case evergreen.HostTerminated:
 		if host.IsIntentHostId(j.host.Id) {


### PR DESCRIPTION
DEVPROD-15633

### Description
I accidentally removed a return in [this commit](https://github.com/evergreen-ci/evergreen/commit/936f965fb3e7124df303043bff58dae06c3092d3#diff-6dd488a00c797fb521cd37e03c8869d4fb82c17ee75a9c79eec5648ed8f7a05bL164-L169). For intent hosts, there's no need to do any further cleanup once the host status is set to terminated in the DB.

### Testing
Existing tests pass.
