### PR TITLE
DEVPROD-14995: remove check for number of task directories that fail to clean up

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -60,12 +60,9 @@ type Agent struct {
 	// completion.
 	addMetadataTagResp  func(*triggerAddMetadataTagResp)
 	addMetadataTagMutex sync.RWMutex
-	// numTaskDirCleanupFailures is the number of times the agent has tried and
-	// failed to clean up the task directory.
-	numTaskDirCleanupFailures int
-	tracer                    trace.Tracer
-	otelGrpcConn              *grpc.ClientConn
-	closers                   []closerOp
+	tracer              trace.Tracer
+	otelGrpcConn        *grpc.ClientConn
+	closers             []closerOp
 }
 
 // Options contains startup options for an Agent.

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -97,8 +97,6 @@ func (a *Agent) removeAllAndCheck(ctx context.Context, dir string) error {
 		return nil
 	}
 
-	a.numTaskDirCleanupFailures++
-
 	checkCtx, checkCancel := context.WithTimeout(ctx, time.Minute)
 	defer checkCancel()
 	if err := a.checkDataDirectoryHealth(checkCtx); err != nil {
@@ -211,15 +209,6 @@ func (a *Agent) tryCleanupDirectory(ctx context.Context, dir string) {
 }
 
 func (a *Agent) checkDataDirectoryHealth(ctx context.Context) error {
-	if a.numTaskDirCleanupFailures >= globals.MaxTaskDirCleanupFailures {
-		err := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{
-			Reason: fmt.Sprintf("agent has tried and failed to clean up task directories %d times", a.numTaskDirCleanupFailures),
-		})
-		if err != nil {
-			return err
-		}
-	}
-
 	usage, err := disk.UsageWithContext(ctx, a.opts.WorkingDirectory)
 	if err != nil {
 		return errors.Wrap(err, "getting disk usage")

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-08"
+	AgentVersion = "2025-03-10"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-14995

### Description
After looking at some hosts in prod, it seems like the agent unfortunately [fails to clean up task directories pretty often on static hosts](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20macos-14-arm64%20%22host%20has%20been%20decommissioned%20or%20quarantined%22%20%22clean%20up%20task%20directories%22&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=1741406400&latest=1741615200&sid=1741615599.348925). While failing to clean up the task directory a few times should warrant a quarantine, it's more work to manage the more frequent quarantines (and I believe fixing the underlying task directory cleanup issue isn't that easy).

To make quarantines less frequent, I reduced the data directory health check to just see how much disk space is remaining, which is the most important thing when deciding whether or not to run the next task.

### Testing
Existing tests pass.
