### PR TITLE
DEVPROD-13980 Add project to prefix mappings to buckets config

### DIFF
--- a/config_bucket.go
+++ b/config_bucket.go
@@ -26,6 +26,14 @@ func (b BucketType) validate() error {
 	}
 }
 
+// ProjectToPrefixMapping relates a project to a bucket path prefix.
+type ProjectToPrefixMapping struct {
+	// ProjectID is the project's ID.
+	ProjectID string `yaml:"project_id" bson:"project_id" json:"project_id"`
+	// Prefix is the bucket path prefix that the project should have access to.
+	Prefix string `yaml:"prefix" bson:"prefix" json:"prefix"`
+}
+
 // BucketsConfig represents the admin config section for interally-owned
 // Evergreen data bucket storage.
 type BucketsConfig struct {
@@ -37,12 +45,19 @@ type BucketsConfig struct {
 	// InternalBuckets are the buckets that Evergreen's app servers have access to
 	// via their IRSA role.
 	InternalBuckets []string `yaml:"internal_buckets" bson:"internal_buckets" json:"internal_buckets"`
+
+	// ProjectToPrefixMappings is a list of project to prefix mappings.
+	// This is used to connect cross-project access to the same prefix.
+	// E.g. if project A should have access to project B's prefix, then
+	// project A's ID and project B's prefix should be in this list.
+	ProjectToPrefixMappings []ProjectToPrefixMapping `yaml:"project_to_prefix_mappings" bson:"project_to_prefix_mappings" json:"project_to_prefix_mappings"`
 }
 
 var (
 	bucketsConfigLogBucketKey       = bsonutil.MustHaveTag(BucketsConfig{}, "LogBucket")
 	bucketsConfigCredentialsKey     = bsonutil.MustHaveTag(BucketsConfig{}, "Credentials")
 	bucketsConfigInternalBucketsKey = bsonutil.MustHaveTag(BucketsConfig{}, "InternalBuckets")
+	projectToPrefixMappingsKey      = bsonutil.MustHaveTag(BucketsConfig{}, "ProjectToPrefixMappings")
 )
 
 // BucketConfig represents the admin config for an individual bucket.
@@ -76,6 +91,7 @@ func (c *BucketsConfig) Set(ctx context.Context) error {
 			bucketsConfigLogBucketKey:       c.LogBucket,
 			bucketsConfigCredentialsKey:     c.Credentials,
 			bucketsConfigInternalBucketsKey: c.InternalBuckets,
+			projectToPrefixMappingsKey:      c.ProjectToPrefixMappings,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -991,6 +991,12 @@ func (s *AdminSuite) TestBucketsConfig() {
 			"test-bucket",
 			"test2-bucket",
 		},
+		ProjectToPrefixMappings: []ProjectToPrefixMapping{
+			{
+				ProjectID: "project-A",
+				Prefix:    "project-B",
+			},
+		},
 	}
 
 	err := config.Set(ctx)
@@ -1002,6 +1008,10 @@ func (s *AdminSuite) TestBucketsConfig() {
 
 	config.LogBucket.Name = "logs-2"
 	config.InternalBuckets = []string{"new-bucket"}
+	config.ProjectToPrefixMappings = []ProjectToPrefixMapping{{
+		ProjectID: "project-C",
+		Prefix:    "project-D",
+	}}
 	s.NoError(config.Set(ctx))
 
 	settings, err = GetConfig(ctx)

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -241,6 +241,26 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.invalidSubnet = "";
   }
 
+  $scope.addProjectToPrefixMapping = function () {
+    if ($scope.Settings.buckets == null) {
+      $scope.Settings.buckets = {
+        "project_to_prefix_mappings": []
+      };
+    }
+    if ($scope.Settings.buckets.project_to_prefix_mappings == null) {
+      $scope.Settings.buckets.project_to_prefix_mappings = [];
+    }
+
+    if (!$scope.validProjectToPrefix($scope.new_project_to_prefix_mapping)) {
+      $scope.invalidProjectToPrefixMapping = "Project and prefix are required.";
+      return
+    }
+
+    $scope.Settings.buckets.project_to_prefix_mappings.push($scope.new_project_to_prefix_mapping);
+    $scope.new_project_to_prefix_mapping = {};
+    $scope.invalidProjectToPrefixMapping = "";
+  }
+
   $scope.addInternalBucket = function () {
     if ($scope.Settings.buckets == null) {
       $scope.Settings.buckets = {
@@ -267,6 +287,14 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
 
   $scope.validSubnet = function (subnet) {
     return subnet && subnet.az && subnet.subnet_id;
+  }
+
+  $scope.deleteProjectToPrefixMapping = function (index) {
+    $scope.Settings.buckets.project_to_prefix_mappings.splice(index, 1);
+  }
+
+  $scope.validProjectToPrefixMapping = function (mapping) {
+    return mapping && mapping.project_id && mapping.prefix;
   }
 
   $scope.deleteInternalBucket = function (index) {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -251,7 +251,7 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
       $scope.Settings.buckets.project_to_prefix_mappings = [];
     }
 
-    if (!$scope.validProjectToPrefix($scope.new_project_to_prefix_mapping)) {
+    if (!$scope.validProjectToPrefixMapping($scope.new_project_to_prefix_mapping)) {
       $scope.invalidProjectToPrefixMapping = "Project and prefix are required.";
       return
     }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -626,15 +626,21 @@ func (a *APIAuthConfig) ToService() (any, error) {
 }
 
 type APIBucketsConfig struct {
-	LogBucket       APIBucketConfig  `json:"log_bucket"`
-	InternalBuckets []string         `json:"internal_buckets"`
-	Credentials     APIS3Credentials `json:"credentials"`
+	LogBucket               APIBucketConfig             `json:"log_bucket"`
+	InternalBuckets         []string                    `json:"internal_buckets"`
+	ProjectToPrefixMappings []APIProjectToPrefixMapping `json:"project_to_prefix_mappings"`
+	Credentials             APIS3Credentials            `json:"credentials"`
 }
 
 type APIBucketConfig struct {
 	Name   *string `json:"name"`
 	Type   *string `json:"type"`
 	DBName *string `json:"db_name"`
+}
+
+type APIProjectToPrefixMapping struct {
+	ProjectID *string `json:"project_id"`
+	Prefix    *string `json:"prefix"`
 }
 
 func (a *APIBucketsConfig) BuildFromService(h any) error {
@@ -651,6 +657,16 @@ func (a *APIBucketsConfig) BuildFromService(h any) error {
 			return errors.Wrap(err, "converting S3 credentials to API model")
 		}
 		a.Credentials = creds
+
+		mappings := []APIProjectToPrefixMapping{}
+		for _, mapping := range v.ProjectToPrefixMappings {
+			apiMapping := APIProjectToPrefixMapping{
+				ProjectID: utility.ToStringPtr(mapping.ProjectID),
+				Prefix:    utility.ToStringPtr(mapping.Prefix),
+			}
+			mappings = append(mappings, apiMapping)
+		}
+		a.ProjectToPrefixMappings = mappings
 	default:
 		return errors.Errorf("programmatic error: expected bucket config but got type %T", h)
 	}
@@ -666,6 +682,13 @@ func (a *APIBucketsConfig) ToService() (any, error) {
 	if !ok {
 		return nil, errors.Errorf("programmatic error: expected S3 credentials but got type %T", i)
 	}
+	mappings := []evergreen.ProjectToPrefixMapping{}
+	for _, mapping := range a.ProjectToPrefixMappings {
+		mappings = append(mappings, evergreen.ProjectToPrefixMapping{
+			ProjectID: utility.FromStringPtr(mapping.ProjectID),
+			Prefix:    utility.FromStringPtr(mapping.Prefix),
+		})
+	}
 
 	return evergreen.BucketsConfig{
 		LogBucket: evergreen.BucketConfig{
@@ -673,8 +696,9 @@ func (a *APIBucketsConfig) ToService() (any, error) {
 			Type:   evergreen.BucketType(utility.FromStringPtr(a.LogBucket.Type)),
 			DBName: utility.FromStringPtr(a.LogBucket.DBName),
 		},
-		InternalBuckets: a.InternalBuckets,
-		Credentials:     creds,
+		InternalBuckets:         a.InternalBuckets,
+		ProjectToPrefixMappings: mappings,
+		Credentials:             creds,
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2249,6 +2249,53 @@ Admin Settings
 											</section>
 										</md-card-content>
 									</md-card>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Project to prefix mappings</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="project-to-prefix-mappings" class="form-group"
+												ng-repeat="(index, mapping) in Settings.buckets.project_to_prefix_mappings">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.project_id"
+															placeholder="Project ID">
+													</md-input-container>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.prefix"
+															placeholder="Bucket prefix">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteProjectToPrefixMapping(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=25>
+													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.project_id"
+														placeholder="Project ID">
+												</md-input-container>
+
+												<md-input-container class="control" flex=50>
+													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.prefix"
+														placeholder="Bucket Prefix">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!validProjectToPrefixMapping(new_project_to_prefix_mapping)" type="button"
+														style="float: left" ng-click="addProjectToPrefixMapping()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidProjectToPrefixMapping ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
 								</md-card-content>
 							</md-card>
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2276,12 +2276,12 @@ Admin Settings
 												</section>
 											</div>
 											<section layout="row" flex>
-												<md-input-container class="control" flex=25>
+												<md-input-container class="control" flex=30>
 													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.project_id"
 														placeholder="Project ID">
 												</md-input-container>
 
-												<md-input-container class="control" flex=50>
+												<md-input-container class="control" flex=30>
 													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.prefix"
 														placeholder="Bucket Prefix">
 												</md-input-container>


### PR DESCRIPTION
DEVPROD-13980

### Description
This adds project to prefix mappings to the buckets config.

For context, this is specifically for the `mciuploads` bucket. This config will give access to projects for a prefix. This is to enable a lot of developer workflows like the master mongo project's prefix being used in branch projects (e.g. 8.1, etc)

### Testing
Deployed to staging, set the fields, refreshed, removed some, refreshed. This is how it looks:

This is with some that I added, clicked saved, then refreshed:
<img width="555" alt="Screenshot 2025-03-11 at 1 27 24 PM" src="https://github.com/user-attachments/assets/206dd344-72df-46bb-802d-841392c95b82" />

This is after I deleted two (first and third, left the 2nd), clicked saved, then refreshed:
<img width="547" alt="Screenshot 2025-03-11 at 1 28 05 PM" src="https://github.com/user-attachments/assets/883b3d4a-d3f1-4f46-bed0-5c9f081f926f" />