### PR TITLE
DEVPROD-8937 Set a max number of intent hosts

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3137,7 +3137,7 @@ func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (in
 }
 
 // CountIntentHosts counts the number of intent hosts Evergreen will soon
-// attempt to create
+// attempt to create.
 func CountIntentHosts(ctx context.Context) (int, error) {
 	query := bson.M{
 		IdKey:        bson.M{"$regex": "^evg.*"},

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3136,6 +3136,17 @@ func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (in
 	return Count(ctx, query)
 }
 
+// CountIntentHosts counts the number of intent hosts Evergreen will soon
+// attempt to create
+func CountIntentHosts(ctx context.Context) (int, error) {
+	query := bson.M{
+		IdKey:        bson.M{"$regex": "^evg.*"},
+		StartedByKey: evergreen.User,
+		StatusKey:    bson.M{"$in": evergreen.UpHostStatus},
+	}
+	return Count(ctx, query)
+}
+
 // FindSpawnhostsWithNoExpirationToExtend returns all hosts that are set to never
 // expire but have their expiration time within the next day and are still up.
 func FindSpawnhostsWithNoExpirationToExtend(ctx context.Context) ([]Host, error) {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4623,8 +4623,6 @@ func TestCountSpawnhostsWithNoExpirationByUser(t *testing.T) {
 }
 
 func TestCountIntentHosts(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	require.NoError(t, db.ClearCollections(Collection))
 	hosts := []Host{
@@ -4655,9 +4653,9 @@ func TestCountIntentHosts(t *testing.T) {
 		},
 	}
 	for _, h := range hosts {
-		assert.NoError(t, h.Insert(ctx))
+		assert.NoError(t, h.Insert(t.Context()))
 	}
-	count, err := CountIntentHosts(ctx)
+	count, err := CountIntentHosts(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
 }

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4622,6 +4622,46 @@ func TestCountSpawnhostsWithNoExpirationByUser(t *testing.T) {
 	assert.Equal(t, 0, count)
 }
 
+func TestCountIntentHosts(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, db.ClearCollections(Collection))
+	hosts := []Host{
+		{
+			Id:        "evg-host-1",
+			Status:    evergreen.HostRunning,
+			StartedBy: evergreen.User,
+		},
+		{
+			Id:        "evg-host-2",
+			Status:    evergreen.HostRunning,
+			StartedBy: evergreen.User,
+		},
+		{
+			Id:        "evg-host-3",
+			Status:    evergreen.HostTerminated,
+			StartedBy: evergreen.User,
+		},
+		{
+			Id:        "host-4",
+			Status:    evergreen.HostRunning,
+			StartedBy: evergreen.User,
+		},
+		{
+			Id:        "host-5",
+			Status:    evergreen.HostStarting,
+			StartedBy: evergreen.User,
+		},
+	}
+	for _, h := range hosts {
+		assert.NoError(t, h.Insert(ctx))
+	}
+	count, err := CountIntentHosts(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
 func TestFindSpawnhostsWithNoExpirationToExtend(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -27,7 +27,9 @@ const (
 	hostAllocatorJobName         = "host-allocator"
 	hostAllocatorAttributePrefix = "evergreen.host_allocator"
 	maxHostAllocatorJobTime      = 10 * time.Minute
-	maxIntentHosts               = 5000
+	// maxIntentHosts represents the maximum number of intent hosts we can
+	// be processing at once, in order to prevent over-logging
+	maxIntentHosts = 5000
 )
 
 func init() {
@@ -200,20 +202,20 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 	//////////////////////
 
 	numIntentHosts, err := host.CountIntentHosts(ctx)
-	if err != nil {
-		grip.Error(message.WrapError(err, message.Fields{
-			"runner":   hostAllocatorJobName,
-			"instance": j.ID(),
-			"distro":   j.DistroID,
-			"message":  "failed to count intent hosts",
-		}))
-	}
+	grip.Error(message.WrapError(err, message.Fields{
+		"runner":   hostAllocatorJobName,
+		"instance": j.ID(),
+		"distro":   j.DistroID,
+		"message":  "failed to count intent hosts",
+	}))
+
 	if numIntentHosts > maxIntentHosts {
 		grip.Info(message.Fields{
-			"runner":   hostAllocatorJobName,
-			"instance": j.ID(),
-			"distro":   j.DistroID,
-			"message":  "too many intent hosts, skipping host allocation",
+			"runner":    hostAllocatorJobName,
+			"instance":  j.ID(),
+			"distro":    j.DistroID,
+			"message":   "too many intent hosts, skipping host allocation",
+			"max_hosts": maxIntentHosts,
 		})
 		return
 	}


### PR DESCRIPTION
DEVPROD-8937

### Description
Caps the number of intent hosts we can be processing at once to prevent over-logging.
### Testing
Unit test + confirmed the query is not slow.
